### PR TITLE
Code style changes in LinearRing::getCentroid()

### DIFF
--- a/lib/OpenLayers/Geometry/LinearRing.js
+++ b/lib/OpenLayers/Geometry/LinearRing.js
@@ -191,38 +191,45 @@ OpenLayers.Geometry.LinearRing = OpenLayers.Class(
      * {<OpenLayers.Geometry.Point>} The centroid of the collection
      */
     getCentroid: function() {
-        if (this.components) {
-            var len = this.components.length;
+        var centroid = null,
+            components = this.components,
+            len;
+            
+        if (components) {
+            len = components.length;
             if (len > 0 && len <= 2) {
-                return this.components[0].clone();
+                centroid = components[0].clone();
             } else if (len > 2) {
-                var sumX = 0.0;
-                var sumY = 0.0;
-                var x0 = this.components[0].x;
-                var y0 = this.components[0].y;
-                var area = -1 * this.getArea();
-                if (area != 0) {
-                    for (var i = 0; i < len - 1; i++) {
-                        var b = this.components[i];
-                        var c = this.components[i+1];
-                        sumX += (b.x + c.x - 2 * x0) * ((b.x - x0) * (c.y - y0) - (c.x - x0) * (b.y - y0));
-                        sumY += (b.y + c.y - 2 * y0) * ((b.x - x0) * (c.y - y0) - (c.x - x0) * (b.y - y0));
+                var sumX = 0.0,
+                    sumY = 0.0,
+                    x0 = components[0].x,
+                    y0 = components[0].y,
+                    area = -1 * this.getArea(),
+                    i, b, c, x, y;
+                    
+                if (area !== 0) {
+                    for (i = 0; i < len - 1; i++) {
+                        b = components[i];
+                        c = components[i+1];
+                        sumX += (b.x + c.x - 2 * x0) * 
+                            ((b.x - x0) * (c.y - y0) - (c.x - x0) * (b.y - y0));
+                        sumY += (b.y + c.y - 2 * y0) * 
+                            ((b.x - x0) * (c.y - y0) - (c.x - x0) * (b.y - y0));
                     }
-                    var x = x0 + sumX / (6 * area);
-                    var y = y0 + sumY / (6 * area);
+                    x = x0 + sumX / (6 * area);
+                    y = y0 + sumY / (6 * area);
                 } else {
-                    for (var i = 0; i < len - 1; i++) {
-                        sumX += this.components[i].x;
-                        sumY += this.components[i].y;
+                    for (i = 0; i < len - 1; i++) {
+                        sumX += components[i].x;
+                        sumY += components[i].y;
                     }
-                    var x = sumX / (len - 1);
-                    var y = sumY / (len - 1);
+                    x = sumX / (len - 1);
+                    y = sumY / (len - 1);
                 }
-                return new OpenLayers.Geometry.Point(x, y);
-            } else {
-                return null;
+                centroid = new OpenLayers.Geometry.Point(x, y);
             }
         }
+        return centroid;
     },
 
     /**


### PR DESCRIPTION
Mainly:

* Not too many var declarations
* line-length
* single return statement

Also added an identity check when compairing to the number 0.

This is mostly cosmetic follow-up to #361.

Relevant tests continue to pass in IE 6, FF 11 and the ancient Chrome 11. 

Please review.