### PR TITLE
getResolutionforzoom

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -220,7 +220,7 @@ ol.Map.prototype.getMaxRes = function() {
  * @return {number} the resolution for the map at the given zoom level
  */
 ol.Map.prototype.getResolutionForZoom = function(zoom) {
-    if (goog.isDefAndNotNull(this.resolutions_)) {
+    if (goog.isDefAndNotNull(this.resolutions_) && goog.isDefAndNotNull(this.resolutions_[zoom])) {
         return this.resolutions_[zoom];
     } else {
         var maxRes = this.getMaxRes();


### PR DESCRIPTION
HI,
shouldn't it also be checked if there is a resolutions entry for the requested zoom?
or should it throw an error if resolutions are defined but not for the requested zoom?

greetings patzi
