### PR TITLE
remove ol.CHECK_KEYS and ol.error.VERBOSE_ERRORS

### DIFF
--- a/main.json
+++ b/main.json
@@ -11,7 +11,10 @@
 
   "define": {
     // "goog.dom.ASSUME_STANDARDS_MODE": true,
-    "goog.DEBUG": false
+
+    // The tests require goog.DEBUG to be true, as some test
+    // that exceptions are thrown on user errors.
+    "goog.DEBUG": true
   },
 
   "externs": [

--- a/src/ol/base.js
+++ b/src/ol/base.js
@@ -2,10 +2,16 @@ goog.provide('ol.base');
 goog.provide('ol.error');
 
 /**
+ * Compilation with public API, let's accept options from external world
+ * @define {boolean}
+ */
+ol.API = true;
+
+/**
  * @param {string} message Message.
  */
 ol.error = function(message) {
-    if (ol.error.VERBOSE_ERRORS) {
+    if (goog.DEBUG) {
         throw new Error(message);
     } else {
         throw null;
@@ -13,28 +19,11 @@ ol.error = function(message) {
 };
 
 /**
- * Compilation with public API, let's accept options from external world
- * @define {boolean}
- */
-ol.API = true;
-
-/**
- * @define {boolean}
- */
-ol.error.VERBOSE_ERRORS = true;
-
-/**
- * Options passed in the API from external world are checked for wrong keys
- * @define {boolean}
- */
-ol.CHECK_KEYS = true;
-
-/**
  * @param {Object} obj Object.
  * @param {!Array.<string>} allowedKeys Allowed keys.
  */
 ol.base.checkKeys = function(obj, allowedKeys) {
-    if (ol.CHECK_KEYS) {
+    if (goog.DEBUG) {
         var keys = goog.object.getKeys(obj);
         goog.array.forEach(allowedKeys, function(allowedKey) {
             goog.array.remove(keys, allowedKey);

--- a/test/spec/ol/layer/TileLayer.test.js
+++ b/test/spec/ol/layer/TileLayer.test.js
@@ -97,16 +97,9 @@ describe('ol.layer.TileLayer', function() {
 
             it('throws an error or return null', function() {
                 var origin;
-                if (ol.error.VERBOSE_ERRORS) {
-                    expect(function() {
-                        origin = layer.getTileOrigin();
-                    }).toThrow();
-                } else {
-                    expect(function() {
-                        origin = layer.getTileOrigin();
-                    }).not.toThrow();
-                    expect(origin).toBeNull();
-                }
+                expect(function() {
+                    origin = layer.getTileOrigin();
+                }).toThrow();
             });
 
         });
@@ -118,15 +111,9 @@ describe('ol.layer.TileLayer', function() {
             });
 
             it('returns the expected origin', function() {
-                if (ol.error.VERBOSE_ERRORS) {
-                    expect(function() {
-                        var origin = layer.getTileOrigin();
-                    }).toThrow();
-                } else {
-                    expect(function() {
-                        var origin = layer.getTileOrigin();
-                    }).not.toThrow();
-                }
+                expect(function() {
+                    var origin = layer.getTileOrigin();
+                }).toThrow();
             });
 
         });


### PR DESCRIPTION
This pull request suggests removing the CHECK_KEYS and VERBOSE_ERRORS @define's, and rely on goog.DEBUG only. In this way by setting goog.DEBUG exceptions are throw on user error and assertions.
