### PR TITLE
Travese the interaction array in reverse order.

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -605,7 +605,7 @@ ol.Map.prototype.handleMapBrowserEvent = function(mapBrowserEvent) {
   var interactionsArray = /** @type {Array.<ol.interaction.Interaction>} */
       interactions.getArray();
   if (this.dispatchEvent(mapBrowserEvent) !== false) {
-    goog.array.every(interactionsArray, function(interaction) {
+    goog.array.every(interactionsArray.reverse(), function(interaction) {
       interaction.handleMapBrowserEvent(mapBrowserEvent);
       return !mapBrowserEvent.defaultPrevented;
     });


### PR DESCRIPTION
The interactions added via getInteractions().push(...) are evaluated first. 
