### PR TITLE
ol.interaction.Drag: ability to draw a drag box.

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -25,7 +25,7 @@
 .ol-attribution li:not(:last-child):after {
   content: " ";
 }
-.ol-dragbox {
+.ol-dragbox, .ol-zoombox {
   position: absolute;
   border: 2px solid red;
 }

--- a/src/ol/interaction/altdragrotate.js
+++ b/src/ol/interaction/altdragrotate.js
@@ -53,8 +53,8 @@ ol.interaction.AltDragRotate.prototype.handleDragStart =
         size.height / 2 - offset.y,
         offset.x - size.width / 2);
     this.startRotation_ = (map.getRotation() || 0) + theta;
-    return true;
+    return {capture: true};
   } else {
-    return false;
+    return {capture: false};
   }
 };

--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -40,8 +40,8 @@ ol.interaction.DragPan.prototype.handleDrag = function(mapBrowserEvent) {
 ol.interaction.DragPan.prototype.handleDragStart = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   if (!browserEvent.shiftKey) {
-    return true;
+    return {capture: true};
   } else {
-    return false;
+    return {capture: false};
   }
 };

--- a/src/ol/interaction/shiftdragrotateandzoom.js
+++ b/src/ol/interaction/shiftdragrotateandzoom.js
@@ -65,8 +65,8 @@ ol.interaction.ShiftDragRotateAndZoom.prototype.handleDragStart =
     var theta = Math.atan2(delta.y, delta.x);
     this.startRotation_ = (map.getRotation() || 0) + theta;
     this.startRatio_ = resolution / delta.magnitude();
-    return true;
+    return {capture: true};
   } else {
-    return false;
+    return {capture: false};
   }
 };

--- a/src/ol/interaction/shiftdragzoom.js
+++ b/src/ol/interaction/shiftdragzoom.js
@@ -1,10 +1,7 @@
-// FIXME draw drag box
-
 goog.provide('ol.interaction.ShiftDragZoom');
 
 goog.require('ol.Extent');
 goog.require('ol.MapBrowserEvent');
-goog.require('ol.control.DragBox');
 goog.require('ol.interaction.Drag');
 
 
@@ -28,16 +25,7 @@ ol.SHIFT_DRAG_ZOOM_HYSTERESIS_PIXELS_SQUARED =
  * @extends {ol.interaction.Drag}
  */
 ol.interaction.ShiftDragZoom = function() {
-
   goog.base(this);
-
-  /**
-   * @type {ol.control.DragBox}
-   * @private
-   */
-  this.dragBox_ = null;
-
-
 };
 goog.inherits(ol.interaction.ShiftDragZoom, ol.interaction.Drag);
 
@@ -47,8 +35,6 @@ goog.inherits(ol.interaction.ShiftDragZoom, ol.interaction.Drag);
  */
 ol.interaction.ShiftDragZoom.prototype.handleDragEnd =
     function(mapBrowserEvent) {
-  this.dragBox_.setMap(null);
-  this.dragBox_ = null;
   if (this.deltaX * this.deltaX + this.deltaY * this.deltaY >=
       ol.SHIFT_DRAG_ZOOM_HYSTERESIS_PIXELS_SQUARED) {
     var map = mapBrowserEvent.map;
@@ -67,12 +53,8 @@ ol.interaction.ShiftDragZoom.prototype.handleDragStart =
     function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   if (browserEvent.isMouseActionButton() && browserEvent.shiftKey) {
-    this.dragBox_ = new ol.control.DragBox({
-      map: mapBrowserEvent.map,
-      startCoordinate: this.startCoordinate
-    });
-    return true;
+    return {capture: true, box: true, boxClass: 'ol-zoombox'};
   } else {
-    return false;
+    return {capture: false};
   }
 };


### PR DESCRIPTION
See new return type for handleDragStart (ol.DragCaptureResponse).
The object can contain an optional 'box' and 'boxClass' option; if
'box' is true, ol.interaction.Drag will create, update and destroy the
box div.
