### PR TITLE
Properly sort numeric strings

### DIFF
--- a/src/ol/renderer/webgl/tilelayer.js
+++ b/src/ol/renderer/webgl/tilelayer.js
@@ -456,7 +456,7 @@ ol.renderer.webgl.TileLayer.prototype.render = function() {
 
     /** @type {Array.<number>} */
     var zs = goog.object.getKeys(tilesToDrawByZ);
-    goog.array.sort(zs);
+    zs.sort(function(a, b) {return a - b});
     var uTileOffset = goog.vec.Vec4.createFloat32();
     goog.array.forEach(zs, function(z) {
       goog.object.forEach(tilesToDrawByZ[z], function(tile) {


### PR DESCRIPTION
Though you're telling the compiler that this is an array of numbers, we
all know it's really an array of strings.  The goog.array.sort method uses
built in < and > operators, which won't return what you want with an array
of numeric strings.
