### PR TITLE
Taking over new template from jsdoc but keep modifications by OpenLayers as much as possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ doc: build/jsdoc-$(BRANCH)-timestamp
 
 build/jsdoc-$(BRANCH)-timestamp: $(SRC) $(shell find doc/template -type f)
 	mkdir -p build/gh-pages/$(BRANCH)/apidoc
-	$(JSDOC) -t doc/template -r src -d build/gh-pages/$(BRANCH)/apidoc
+	$(JSDOC) -t doc/template -r src -d build/gh-pages/$(BRANCH)/apidoc doc/index.md
 	touch $@
 
 .PHONY: hostexamples

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,17 @@
+Finding your way round
+----------------------
+See the class list to the right and especially take a look at {@link ol.Map} and {@link ol.layer.Layer} because those are the central objects.
+
+In general every use of OpenLayers starts by initializing a map, then adding the required layers. Controls and interactions can be added to change the behavior of the map.
+
+Projections
+-----------
+A {@link ol.Projection} defines which point on earth is represented by a pair of coordinates. Coordinates within OpenLayers can be used in various projections where some common projections are always supported, others can be used via Proj4js.
+
+Maps and Layers
+---------------
+A map in OpenLayers is essentially a staple of layers that is viewed from the top. Layers are responsible for retieving data and displaying it.
+
+Contributing
+------------
+See CONTRIBUTING.md for instructions on building and tesing OpenLayers. The file does also describe how to commit your changes to OpenLayers.

--- a/doc/template/static/styles/jsdoc-default.css
+++ b/doc/template/static/styles/jsdoc-default.css
@@ -1,9 +1,11 @@
-html {
+html
+{
     overflow: auto;
     background-color: #fff;
 }
 
-body {
+body
+{
 	font: 14px "DejaVu Sans Condensed", "Liberation Sans", "Nimbus Sans L", Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans serif;
 	line-height: 130%;
 	color: #000;
@@ -22,7 +24,8 @@ a:active {
     color: #444;
 }
 
-header {
+header
+{
 	display: block;
 	padding: 6px 4px;
 }
@@ -41,7 +44,8 @@ header {
     width: 100%;
 }
 
-section {
+section
+{
 	display: block;
 	
 	background-color: #fff;
@@ -62,7 +66,8 @@ section {
 	font-weight: lighter;
 }
 
-nav {
+nav
+{
 	display: block;
 	float: left;
     margin-left: -230px;
@@ -114,21 +119,24 @@ footer {
     font-size: 90%;
 }
 
-h1 {
+h1
+{
 	font-size: 200%;
 	font-weight: bold;
 	letter-spacing: -0.01em;
 	margin: 6px 0 9px 0;
 }
 
-h2 {
+h2
+{
 	font-size: 170%;
 	font-weight: bold;
 	letter-spacing: -0.01em;
 	margin: 6px 0 3px 0;
 }
 
-h3 {
+h3
+{
 	font-size: 150%;
 	font-weight: bold;
 	letter-spacing: -0.01em;
@@ -136,7 +144,8 @@ h3 {
 	margin: 6px 0 3px 0;
 }
 
-h4 {
+h4
+{
 	font-size: 130%;
 	font-weight: bold;
 	letter-spacing: -0.01em;
@@ -145,14 +154,16 @@ h4 {
 	color: #A35A00;
 }
 
-h5, .container-overview .subsection-title {
+h5, .container-overview .subsection-title
+{
 	font-size: 120%;
 	font-weight: bold;
 	letter-spacing: -0.01em;
 	margin: 8px 0 3px -16px;
 }
 
-h6 {
+h6
+{
 	font-size: 100%;
 	letter-spacing: -0.01em;
 	margin: 6px 0 3px 0;
@@ -162,18 +173,19 @@ h6 {
 .protected {
     display: none;
 }
-
 dt.tag-source, dd.tag-source {
     display: none;
 }
 
 .ancestors { color: #999; }
-.ancestors a {
+.ancestors a
+{
     color: #999 !important;
     text-decoration: none;
 }
 
-.important {
+.important
+{
 	font-weight: bold;
 	color: #950B02;
 }
@@ -203,19 +215,22 @@ dt.tag-source, dd.tag-source {
 	margin-top: 1em;
 }
 
-.code-caption {
+.code-caption
+{
 	font-style: italic;
 	font-family: Palatino, 'Palatino Linotype', serif;
 	font-size: 107%;
 	margin: 0;
 }
 
-.prettyprint {
+.prettyprint
+{
 	border: 1px solid #ddd;
 	width: 80%;
 }
 
-.prettyprint code {
+.prettyprint code
+{
 	font-family: Consolas, 'Lucida Console', Monaco, monospace;
 	font-size: 100%;
 	line-height: 18px;
@@ -227,7 +242,8 @@ dt.tag-source, dd.tag-source {
 	border-left: 3px #ddd solid;
 }
 
-.params, .props {
+.params, .props
+{
 	border-spacing: 0;
 	border: 0;
 	border-collapse: collapse;
@@ -239,7 +255,8 @@ dt.tag-source, dd.tag-source {
 	font-size: 100%;
 }
 
-.params td, .params th, .props td, .props th {
+.params td, .params th, .props td, .props th
+{
 	border: 1px solid #ddd;
 	margin: 0px;
 	text-align: left;
@@ -248,12 +265,14 @@ dt.tag-source, dd.tag-source {
 	display: table-cell;
 }
 
-.params thead tr, .props thead tr {
+.params thead tr, .props thead tr
+{
 	background-color: #ddd;
 	font-weight: bold;
 }
 
-.params .params thead tr, .props .props thead tr {
+.params .params thead tr, .props .props thead tr
+{
 	background-color: #fff;
 	font-weight: bold;
 }

--- a/doc/template/tmpl/details.tmpl
+++ b/doc/template/tmpl/details.tmpl
@@ -1,4 +1,7 @@
-<?js var self = this; ?>
+<?js
+var data = obj;
+var self = this;
+?>
 <dl class="details">
     <?js
         var properties = data.properties;

--- a/doc/template/tmpl/example.tmpl
+++ b/doc/template/tmpl/example.tmpl
@@ -1,2 +1,2 @@
-
+<?js var data = obj; ?>
 <pre><code><?js= data ?></code></pre>

--- a/doc/template/tmpl/examples.tmpl
+++ b/doc/template/tmpl/examples.tmpl
@@ -1,4 +1,5 @@
 <?js
+	var data = obj;
     data.forEach(function(example) {
         if (example.caption) {
     ?>

--- a/doc/template/tmpl/exceptions.tmpl
+++ b/doc/template/tmpl/exceptions.tmpl
@@ -1,4 +1,7 @@
-<?js if (data.description) { ?>
+<?js
+	var data = obj;
+	if (data.description) {
+?>
 <div class="param-desc">
     <?js= description ?>
 </div>

--- a/doc/template/tmpl/fires.tmpl
+++ b/doc/template/tmpl/fires.tmpl
@@ -1,3 +1,4 @@
+<?js var data = obj; ?>
 <li>
     <?js= data ?>
 </li>

--- a/doc/template/tmpl/layout.tmpl
+++ b/doc/template/tmpl/layout.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>OpenLayers <?js= title ?></title>
+    <title>OpenLayers: <?js= title ?></title>
     
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>
@@ -10,7 +10,7 @@
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify-jsdoc.css">
-    <link type="text/css" rel="stylesheet" href="styles/apidoc.css">
+    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>

--- a/doc/template/tmpl/mainpage.tmpl
+++ b/doc/template/tmpl/mainpage.tmpl
@@ -1,4 +1,5 @@
 <?js
+var data = obj;
 var self = this;
 ?>
 

--- a/doc/template/tmpl/members.tmpl
+++ b/doc/template/tmpl/members.tmpl
@@ -1,12 +1,12 @@
-
-<dt class="protected">
+<?js var data = obj; ?>
+<dt class="<?js= data.access ?>">
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + name + data.signature ?></h4>
     
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>
 </dt>
-<dd class="protected">
+<dd class="<?js= data.access ?>">
     <?js if (data.description) { ?>
     <div class="description">
         <?js= data.description ?>

--- a/doc/template/tmpl/method.tmpl
+++ b/doc/template/tmpl/method.tmpl
@@ -1,4 +1,7 @@
-<?js var self = this; ?>
+<?js
+var data = obj;
+var self = this;
+?>
 <dt>
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind == 'class'? 'new ':'') + name + data.signature ?></h4>
     

--- a/doc/template/tmpl/params.tmpl
+++ b/doc/template/tmpl/params.tmpl
@@ -1,5 +1,5 @@
 <?js
-    var params = data;
+    var params = obj;
     
     /* sort subparams under their parent params (like opts.classname) */
     var parentParam = null;
@@ -47,6 +47,10 @@
 		
 		<th>Type</th>
 		
+		<?js if (params.hasAttributes) {?>
+		<th>Argument</th>
+		<?js } ?>
+		
 		<?js if (params.hasDefault) {?>
 		<th>Default</th>
 		<?js } ?>
@@ -72,6 +76,18 @@
                 <?js= self.partial('type.tmpl', param.type.names) ?>
             <?js } ?>
             </td>
+            
+            <?js if (params.hasAttributes) {?>
+                <td class="attributes">
+                <?js if (param.optional) { ?>
+                    &lt;optional><br>
+                <?js } ?>
+                    
+                <?js if (param.nullable) { ?>
+                    &lt;nullable><br>
+                <?js } ?>
+                </td>
+            <?js } ?>
             
             <?js if (params.hasDefault) {?>
                 <td class="default">

--- a/doc/template/tmpl/properties.tmpl
+++ b/doc/template/tmpl/properties.tmpl
@@ -1,5 +1,5 @@
 <?js
-    var props = data;
+    var props = obj;
     
     /* sort subprops under their parent props (like opts.classname) */
     var parentProp = null;

--- a/doc/template/tmpl/returns.tmpl
+++ b/doc/template/tmpl/returns.tmpl
@@ -1,4 +1,7 @@
-<?js if (data.description) { ?>
+<?js
+var data = obj;
+if (data.description) {
+?>
 <div class="param-desc">
     <?js= description ?>
 </div>

--- a/doc/template/tmpl/type.tmpl
+++ b/doc/template/tmpl/type.tmpl
@@ -1,4 +1,5 @@
 <?js
+	var data = obj;
     var self = this;
     data.forEach(function(name, i) { ?>
 <span class="param-type"><?js= self.linkto(name, self.htmlsafe(name)) ?></span>


### PR DESCRIPTION
Contains current template from jsdoc to make documentation build again. Additionally changes to their original template by OpenLayers have been done again so the documentation should look the same.

The only noteworthy change is the addition of an index page `doc/index.md` to replace the blank index page that was used previously. Its content does very likely need amendments by someone that is more familiar with OL3.

This pull request is intended to fix issue #68 and replaces the previously suggested pull request #77 in part.
