### PR TITLE
Projection handling improvements

### DIFF
--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -13,11 +13,12 @@ if (goog.DEBUG) {
   goog.debug.Logger.getLogger('ol').setLevel(goog.debug.Logger.Level.INFO);
 }
 
+var epsg21781 = new ol.Projection('EPSG:21781', ol.ProjectionUnits.METERS,
+    // Validity extent from http://spatialreference.org
+    new ol.Extent(485869.5728, 76443.1884, 837076.5648, 299941.7864));
+ol.Projection.addProjection(epsg21781);
+
 var extent = new ol.Extent(420000, 30000, 900000, 350000);
-
-var epsg21781 = new ol.Projection('EPSG:21781',
-    ol.ProjectionUnits.METERS, extent);
-
 var layers = new ol.Collection([
   new ol.layer.TileLayer({
     source: new ol.source.TiledWMS({
@@ -28,7 +29,8 @@ var layers = new ol.Collection([
           'Pixelmap 1:1000000 / geo.admin.ch</a>')],
       crossOrigin: null,
       params: {'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale'},
-      projection: epsg21781
+      projection: epsg21781,
+      extent: extent
     })
   }),
   new ol.layer.TileLayer({
@@ -40,7 +42,8 @@ var layers = new ol.Collection([
           'National parks / geo.admin.ch</a>')],
       crossOrigin: null,
       params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
-      projection: epsg21781
+      projection: epsg21781,
+      extent: extent
     })
   })
 ]);
@@ -49,6 +52,9 @@ var map = new ol.Map({
   renderer: ol.RendererHint.DOM,
   center: new ol.Coordinate(660000, 190000),
   projection: epsg21781,
+  // By setting userProjection to the same as projection, we do not need
+  // proj4js because we do not need any transforms.
+  userProjection: epsg21781,
   layers: layers,
   target: 'map',
   zoom: 9

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -980,7 +980,7 @@ ol.Map.createOptionsInternal = function(mapOptions) {
   values[ol.MapProperty.LAYERS] = goog.isDef(mapOptions.layers) ?
       mapOptions.layers : new ol.Collection();
 
-  values[ol.MapProperty.PROJECTION] = ol.Map.createProjection_(
+  values[ol.MapProperty.PROJECTION] = ol.Projection.createProjection(
       mapOptions.projection, 'EPSG:3857');
 
   if (goog.isDef(mapOptions.resolution)) {
@@ -990,7 +990,7 @@ ol.Map.createOptionsInternal = function(mapOptions) {
         ol.Projection.EPSG_3857_HALF_SIZE / (128 << mapOptions.zoom);
   }
 
-  values[ol.MapProperty.USER_PROJECTION] = ol.Map.createProjection_(
+  values[ol.MapProperty.USER_PROJECTION] = ol.Projection.createProjection(
       mapOptions.userProjection, 'EPSG:4326');
 
   /**
@@ -1182,22 +1182,4 @@ ol.Map.createInteractions_ = function(mapOptions) {
 
   return interactions;
 
-};
-
-
-/**
- * @private
- * @param {ol.Projection|string|undefined} projection Projection.
- * @param {string} defaultCode Default code.
- * @return {ol.Projection} Projection.
- */
-ol.Map.createProjection_ = function(projection, defaultCode) {
-  if (!goog.isDefAndNotNull(projection)) {
-    return ol.Projection.getFromCode(defaultCode);
-  } else if (goog.isString(projection)) {
-    return ol.Projection.getFromCode(projection);
-  } else {
-    goog.asserts.assert(projection instanceof ol.Projection);
-    return projection;
-  }
 };

--- a/src/ol/projection.js
+++ b/src/ol/projection.js
@@ -137,8 +137,10 @@ ol.Projection.addEquivalentProjections_ = function(projections) {
   ol.Projection.addProjections(projections);
   goog.array.forEach(projections, function(source) {
     goog.array.forEach(projections, function(destination) {
-      ol.Projection.addTransform(
-          source, destination, ol.Projection.cloneTransform);
+      if (source !== destination) {
+        ol.Projection.addTransform(
+            source, destination, ol.Projection.cloneTransform);
+      }
     });
   });
 };
@@ -181,6 +183,8 @@ ol.Projection.addProjection = function(projection) {
   var code = projection.getCode();
   goog.asserts.assert(!goog.object.containsKey(projections, code));
   projections[code] = projection;
+  ol.Projection.addTransform(
+      projection, projection, ol.Projection.cloneTransform);
 };
 
 
@@ -191,6 +195,23 @@ ol.Projection.addProjections = function(projections) {
   goog.array.forEach(projections, function(projection) {
     ol.Projection.addProjection(projection);
   });
+};
+
+
+/**
+ * @param {ol.Projection|string|undefined} projection Projection.
+ * @param {string} defaultCode Default code.
+ * @return {ol.Projection} Projection.
+ */
+ol.Projection.createProjection = function(projection, defaultCode) {
+  if (!goog.isDefAndNotNull(projection)) {
+    return ol.Projection.getFromCode(defaultCode);
+  } else if (goog.isString(projection)) {
+    return ol.Projection.getFromCode(projection);
+  } else {
+    goog.asserts.assert(projection instanceof ol.Projection);
+    return projection;
+  }
 };
 
 


### PR DESCRIPTION
- The Map's private createProjection_ method is now a public
  method of the Projection. It is also used by TiledWMSSource
  to calculate the appropriate projection from the user
  configuration.
- ol.Projection.addProjection now adds the transformation for
  the source == target case. This makes it easy for the user
  to create custom projection maps without including proj4js and
  without adding a custom transformation, as long as the
  userProjection equals the projection.
- The TiledWMSSource now uses the same default resolutions as
  the map (i.e. the OSM resolutions)
- The modulo calculation for wrapping extents now works for all
  grid configurations, by not calculating the number of columns
  based on an assumption about the way the zoom levels relate to
  resolutions.
- The wms-custom-proj example now shows how to properly
  configure a custom resolution, i.e. by using the validity
  extent of the projection as its extent.
