### PR TITLE
wms-custom-proj example does not work with the ol build

### DIFF
--- a/src/ol/attribution.exports
+++ b/src/ol/attribution.exports
@@ -1,0 +1,1 @@
+@exportSymbol ol.Attribution

--- a/src/ol/projection.exports
+++ b/src/ol/projection.exports
@@ -1,4 +1,5 @@
 @exportSymbol ol.Projection
+@exportProperty ol.Projection.addProjection
 @exportProperty ol.Projection.getFromCode
 @exportProperty ol.Projection.getTransform
 @exportProperty ol.Projection.getTransformFromCodes
@@ -8,3 +9,6 @@
 @exportProperty ol.Projection.prototype.getExtent
 @exportProperty ol.Projection.prototype.getUnits
 
+@exportSymbol ol.ProjectionUnits
+@exportProperty ol.ProjectionUnits.DEGREES
+@exportProperty ol.ProjectionUnits.METERS

--- a/src/ol/projection.js
+++ b/src/ol/projection.js
@@ -1,4 +1,5 @@
 goog.provide('ol.Projection');
+goog.provide('ol.ProjectionUnits');
 
 goog.require('goog.array');
 goog.require('goog.asserts');


### PR DESCRIPTION
We get this error:

```
TypeError: ol.ProjectionUnits is undefined
```

The issue is that the `ol.ProjectionUnits` and its properties aren't exported.

Patch to come.
