### PR TITLE
Add ol.TileUrlFunction.createBboxParam

### DIFF
--- a/src/ol/source/tiledwmssource.js
+++ b/src/ol/source/tiledwmssource.js
@@ -5,6 +5,7 @@ goog.provide('ol.source.TiledWMS');
 
 goog.require('goog.asserts');
 goog.require('goog.object');
+goog.require('goog.uri.utils');
 goog.require('ol.Attribution');
 goog.require('ol.Projection');
 goog.require('ol.TileCoord');
@@ -68,14 +69,15 @@ ol.source.TiledWMS = function(tiledWMSOptions) {
   if (tiledWMSOptions.urls) {
     var tileUrlFunctions = goog.array.map(
         tiledWMSOptions.urls, function(url) {
-          return ol.TileUrlFunction.createBboxParam(
-              url, baseParams, tileGrid);
+          url = goog.uri.utils.appendParamsFromMap(url, baseParams);
+          return ol.TileUrlFunction.createBboxParam(url, tileGrid);
         });
     tileUrlFunction = ol.TileUrlFunction.createFromTileUrlFunctions(
         tileUrlFunctions);
   } else if (tiledWMSOptions.url) {
-    tileUrlFunction = ol.TileUrlFunction.createBboxParam(
-        tiledWMSOptions.url, baseParams, tileGrid);
+    var url = goog.uri.utils.appendParamsFromMap(
+        tiledWMSOptions.url, baseParams);
+    tileUrlFunction = ol.TileUrlFunction.createBboxParam(url, tileGrid);
   } else {
     tileUrlFunction = ol.TileUrlFunction.nullTileUrlFunction;
   }

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -2,6 +2,7 @@ goog.provide('ol.TileUrlFunction');
 goog.provide('ol.TileUrlFunctionType');
 
 goog.require('goog.math');
+goog.require('goog.uri.utils');
 goog.require('ol.TileCoord');
 goog.require('ol.tilegrid.TileGrid');
 
@@ -69,29 +70,21 @@ ol.TileUrlFunction.createFromTileUrlFunctions = function(tileUrlFunctions) {
 
 
 /**
- * @param {string} baseUrl WMS base URL.
- * @param {Object} baseParams Query string parameters.
+ * @param {string} baseUrl Base URL (may have query data).
  * @param {ol.tilegrid.TileGrid} tileGrid Tile grid.
  * @return {ol.TileUrlFunctionType} Tile URL function.
  */
-ol.TileUrlFunction.createBboxParam = function(baseUrl, baseParams, tileGrid) {
+ol.TileUrlFunction.createBboxParam = function(baseUrl, tileGrid) {
   return function(tileCoord) {
     if (goog.isNull(tileCoord)) {
       return undefined;
     } else {
       var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
-      var params = goog.object.clone(baseParams);
       // FIXME Projection dependant axis order.
       var bboxValue = [
         tileExtent.minX, tileExtent.minY, tileExtent.maxX, tileExtent.maxY
       ].join(',');
-      goog.object.extend(params, {'BBOX': bboxValue});
-      var url = baseUrl;
-      for (var p in params) {
-        url += (~url.indexOf('?') ? '&' : '?') +
-            p + '=' + encodeURIComponent(params[p]);
-      }
-      return url;
+      return goog.uri.utils.appendParam(baseUrl, 'BBOX', bboxValue);
     }
   };
 };

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -69,27 +69,14 @@ describe('ol.TileUrlFunction', function() {
         maxZoom: 10
       });
     });
-    describe('base params in object', function() {
-      it('creates expected URL', function() {
-        var tileUrlFunction = ol.TileUrlFunction.createBboxParam(
-           'http://wms', {'foo': 'bar'}, tileGrid);
-        var tileCoord = new ol.TileCoord(1, 0, 0);
-        var tileUrl = tileUrlFunction(tileCoord);
-        var expected = 'http://wms?foo=bar&BBOX=-20037508.342789244' +
-                       '%2C20037508.342789244%2C0%2C40075016.68557849';
-        expect(tileUrl).toEqual(expected);
-      });
-    });
-    describe('base params in URL', function() {
-      it('creates expected URL', function() {
-        var tileUrlFunction = ol.TileUrlFunction.createBboxParam(
-           'http://wms?foo=bar', {}, tileGrid);
-        var tileCoord = new ol.TileCoord(1, 0, 0);
-        var tileUrl = tileUrlFunction(tileCoord);
-        var expected = 'http://wms?foo=bar&BBOX=-20037508.342789244' +
-                       '%2C20037508.342789244%2C0%2C40075016.68557849';
-        expect(tileUrl).toEqual(expected);
-      });
+    it('creates expected URL', function() {
+      var tileUrlFunction = ol.TileUrlFunction.createBboxParam(
+         'http://wms?foo=bar', tileGrid);
+      var tileCoord = new ol.TileCoord(1, 0, 0);
+      var tileUrl = tileUrlFunction(tileCoord);
+      var expected = 'http://wms?foo=bar&BBOX=-20037508.342789244' +
+                     '%2C20037508.342789244%2C0%2C40075016.68557849';
+      expect(tileUrl).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
This pull request suggests adding `ol.TileUrlFunction.createBboxParam` and using it from `ol.source.TiledWMS`.

`ol.TileUrlFunction.createBboxParam` creates a _tile url function_ that calculates a bbox from the `tileCoord` and the `tileGrid` and adds a `BBOX` parameter to the query string.

With this function `ol.source.TiledWMS`  can use `createFromTileUrlFunctions` and no longer needs to have its own `goog.math.modulo` based calculation.

Unit-testing this function is also possible now.

Also, with this commit the base params are defined once for good, instead of being redefined on each `getTileCoordUrl` call.
