### PR TITLE
Python 2.7 required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,8 @@ Run make:
 
     $ ./build.py
 
+Python 2.7, at least, is required to run this command.
+
 ## Run the examples in debug mode
 
 Run the [Plovr](http://plovr.com/) web server with:


### PR DESCRIPTION
Since subprocess.check_output has been added in python 2.7, this release is the minimal one for the usage of the new build.py script.
