### PR TITLE
Add view abstraction

### DIFF
--- a/examples/full-screen.js
+++ b/examples/full-screen.js
@@ -4,6 +4,7 @@ goog.require('goog.debug.Logger.Level');
 goog.require('ol.Collection');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
+goog.require('ol.View2D');
 goog.require('ol.source.MapQuestOpenAerial');
 
 
@@ -17,8 +18,10 @@ var layer = new ol.layer.TileLayer({
   source: new ol.source.MapQuestOpenAerial()
 });
 var map = new ol.Map({
-  center: new ol.Coordinate(0, 0),
   layers: new ol.Collection([layer]),
   target: 'map',
-  zoom: 2
+  view: new ol.View2D({
+    center: new ol.Coordinate(0, 0),
+    zoom: 0
+  })
 });

--- a/examples/overlay-and-popup.js
+++ b/examples/overlay-and-popup.js
@@ -4,6 +4,7 @@ goog.require('goog.debug.Logger.Level');
 goog.require('ol.Collection');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
+goog.require('ol.View2D');
 goog.require('ol.overlay.Overlay');
 goog.require('ol.source.MapQuestOpenAerial');
 
@@ -17,11 +18,14 @@ if (goog.DEBUG) {
 var layer = new ol.layer.TileLayer({
   source: new ol.source.MapQuestOpenAerial()
 });
+
 var map = new ol.Map({
-  center: new ol.Coordinate(0, 0),
   layers: new ol.Collection([layer]),
   target: 'map',
-  zoom: 2
+  view: new ol.View2D({
+    center: new ol.Coordinate(0, 0),
+    zoom: 2
+  })
 });
 
 // Vienna label

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -4,6 +4,7 @@ goog.require('goog.debug.Logger.Level');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
 goog.require('ol.RendererHint');
+goog.require('ol.View2D');
 goog.require('ol.control.MousePosition');
 goog.require('ol.interaction.Keyboard');
 goog.require('ol.layer.TileLayer');
@@ -20,12 +21,16 @@ var layer = new ol.layer.TileLayer({
   source: new ol.source.MapQuestOpenAerial()
 });
 
-var domMap = new ol.Map({
+var view = new ol.View2D({
   center: new ol.Coordinate(0, 0),
+  zoom: 1
+});
+
+var domMap = new ol.Map({
   layers: new ol.Collection([layer]),
   renderer: ol.RendererHint.DOM,
   target: 'domMap',
-  zoom: 1
+  view: view
 });
 
 domMap.getControls().push(new ol.control.MousePosition({
@@ -40,10 +45,8 @@ var webglMap = new ol.Map({
   target: 'webglMap'
 });
 if (webglMap !== null) {
-  webglMap.bindTo('center', domMap);
   webglMap.bindTo('layers', domMap);
-  webglMap.bindTo('resolution', domMap);
-  webglMap.bindTo('rotation', domMap);
+  webglMap.bindTo('view', domMap);
 }
 
 webglMap.getControls().push(new ol.control.MousePosition({
@@ -88,7 +91,7 @@ keyboardInteraction.addCallback('O', function() {
   layer.setOpacity(layer.getOpacity() + 0.1);
 });
 keyboardInteraction.addCallback('r', function() {
-  webglMap.setRotation(0);
+  view.setRotation(0);
 });
 keyboardInteraction.addCallback('s', function() {
   layer.setSaturation(layer.getSaturation() - 0.1);

--- a/examples/two-layers.js
+++ b/examples/two-layers.js
@@ -3,6 +3,7 @@ goog.require('ol.Coordinate');
 goog.require('ol.Map');
 goog.require('ol.Projection');
 goog.require('ol.RendererHint');
+goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.source.BingMaps');
 goog.require('ol.source.TileJSON');
@@ -23,19 +24,19 @@ var layers = new ol.Collection([
 ]);
 
 var webglMap = new ol.Map({
-  center: ol.Projection.transformWithCodes(
-      new ol.Coordinate(-77.93255, 37.9555), 'EPSG:4326', 'EPSG:3857'),
   layers: layers,
   renderer: ol.RendererHint.WEBGL,
   target: 'webglMap',
-  zoom: 5
+  view: new ol.View2D({
+    center: ol.Projection.transformWithCodes(
+        new ol.Coordinate(-77.93255, 37.9555), 'EPSG:4326', 'EPSG:3857'),
+    zoom: 5
+  })
 });
 
 var domMap = new ol.Map({
   renderer: ol.RendererHint.DOM,
   target: 'domMap'
 });
-domMap.bindTo('center', webglMap);
 domMap.bindTo('layers', webglMap);
-domMap.bindTo('resolution', webglMap);
-domMap.bindTo('rotation', webglMap);
+domMap.bindTo('view', webglMap);

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -5,6 +5,7 @@ goog.require('ol.Collection');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
 goog.require('ol.Projection');
+goog.require('ol.View2D');
 goog.require('ol.source.TiledWMS');
 
 
@@ -50,12 +51,14 @@ var layers = new ol.Collection([
 ]);
 
 var map = new ol.Map({
-  center: new ol.Coordinate(660000, 190000),
   projection: epsg21781,
   // By setting userProjection to the same as projection, we do not need
   // proj4js because we do not need any transforms.
   userProjection: epsg21781,
   layers: layers,
   target: 'map',
-  zoom: 9
+  view: new ol.View2D({
+    center: new ol.Coordinate(660000, 190000),
+    zoom: 9
+  })
 });

--- a/examples/wms.js
+++ b/examples/wms.js
@@ -4,6 +4,7 @@ goog.require('goog.debug.Logger.Level');
 goog.require('ol.Collection');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
+goog.require('ol.View2D');
 goog.require('ol.source.MapQuestOpenAerial');
 goog.require('ol.source.TiledWMS');
 
@@ -31,6 +32,8 @@ var map = new ol.Map({
   renderer: ol.RendererHint.DOM,
   layers: layers,
   target: 'map',
-  center: new ol.Coordinate(-10997148, 4569099),
-  zoom: 4
+  view: new ol.View2D({
+    center: new ol.Coordinate(-10997148, 4569099),
+    zoom: 4
+  })
 });

--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -24,7 +24,6 @@
 @exportObjectLiteralProperty ol.layer.LayerOptions.visible boolean|undefined
 
 @exportObjectLiteral ol.MapOptions
-@exportObjectLiteralProperty ol.MapOptions.center ol.Coordinate|undefined
 @exportObjectLiteralProperty ol.MapOptions.controls ol.Collection|undefined
 @exportObjectLiteralProperty ol.MapOptions.doubleClickZoom boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.dragPan boolean|undefined
@@ -32,22 +31,14 @@
 @exportObjectLiteralProperty ol.MapOptions.keyboard boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.keyboardPanOffset number|undefined
 @exportObjectLiteralProperty ol.MapOptions.layers ol.Collection|undefined
-@exportObjectLiteralProperty ol.MapOptions.maxResolution number|undefined
 @exportObjectLiteralProperty ol.MapOptions.mouseWheelZoom boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.mouseWheelZoomDelta number|undefined
-@exportObjectLiteralProperty ol.MapOptions.numZoomLevels number|undefined
-@exportObjectLiteralProperty ol.MapOptions.projection ol.Projection|string|undefined
 @exportObjectLiteralProperty ol.MapOptions.renderer ol.RendererHint|undefined
 @exportObjectLiteralProperty ol.MapOptions.renderers Array.<ol.RendererHint>|undefined
-@exportObjectLiteralProperty ol.MapOptions.resolution number|undefined
-@exportObjectLiteralProperty ol.MapOptions.resolutions Array.<number>|undefined
-@exportObjectLiteralProperty ol.MapOptions.rotate boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.shiftDragZoom boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.target Element|string
-@exportObjectLiteralProperty ol.MapOptions.userProjection ol.Projection|string|undefined
-@exportObjectLiteralProperty ol.MapOptions.zoom number|undefined
+@exportObjectLiteralProperty ol.MapOptions.view ol.IView|undefined
 @exportObjectLiteralProperty ol.MapOptions.zoomDelta number|undefined
-@exportObjectLiteralProperty ol.MapOptions.zoomFactor number|undefined
 
 @exportObjectLiteral ol.overlay.OverlayOptions
 @exportObjectLiteralProperty ol.overlay.OverlayOptions.coordinate ol.Coordinate|undefined
@@ -71,3 +62,14 @@
 @exportObjectLiteralProperty ol.source.TiledWMSOptions.projection ol.Projection|undefined
 @exportObjectLiteralProperty ol.source.TiledWMSOptions.url string|undefined
 @exportObjectLiteralProperty ol.source.TiledWMSOptions.urls Array.<string>|undefined
+
+@exportObjectLiteral ol.View2DOptions
+@exportObjectLiteralProperty ol.View2DOptions.center ol.Coordinate|undefined
+@exportObjectLiteralProperty ol.View2DOptions.maxResolution number|undefined
+@exportObjectLiteralProperty ol.View2DOptions.numZoomLevels number|undefined
+@exportObjectLiteralProperty ol.View2DOptions.projection ol.Projection|string|undefined
+@exportObjectLiteralProperty ol.View2DOptions.resolution number|undefined
+@exportObjectLiteralProperty ol.View2DOptions.resolutions Array.<number>|undefined
+@exportObjectLiteralProperty ol.View2DOptions.rotation number|undefined
+@exportObjectLiteralProperty ol.View2DOptions.zoom number|undefined
+@exportObjectLiteralProperty ol.View2DOptions.zoomFactor number|undefined

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -1,3 +1,5 @@
+// FIXME works for View2D only
+
 goog.provide('ol.control.Zoom');
 
 goog.require('goog.dom');
@@ -58,7 +60,9 @@ goog.inherits(ol.control.Zoom, ol.control.Control);
 ol.control.Zoom.prototype.handleIn_ = function(browserEvent) {
   // prevent #zoomIn anchor from getting appended to the url
   browserEvent.preventDefault();
-  this.getMap().zoom(this.delta_);
+  var map = this.getMap();
+  // FIXME works for View2D only
+  map.getView().zoom(map, this.delta_);
 };
 
 
@@ -69,5 +73,7 @@ ol.control.Zoom.prototype.handleIn_ = function(browserEvent) {
 ol.control.Zoom.prototype.handleOut_ = function(browserEvent) {
   // prevent #zoomOut anchor from getting appended to the url
   browserEvent.preventDefault();
-  this.getMap().zoom(-this.delta_);
+  var map = this.getMap();
+  // FIXME works for View2D only
+  map.getView().zoom(map, -this.delta_);
 };

--- a/src/ol/interaction/dblclickzoominteraction.js
+++ b/src/ol/interaction/dblclickzoominteraction.js
@@ -1,7 +1,10 @@
+// FIXME works for View2D only
+
 goog.provide('ol.interaction.DblClickZoom');
 
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.MapBrowserEvent.EventType');
+goog.require('ol.View2D');
 goog.require('ol.interaction.Interaction');
 
 
@@ -35,7 +38,10 @@ ol.interaction.DblClickZoom.prototype.handleMapBrowserEvent =
     var anchor = mapBrowserEvent.getCoordinate();
     var delta = mapBrowserEvent.browserEvent.shiftKey ?
         -this.delta_ : this.delta_;
-    map.zoom(delta, anchor);
+    // FIXME works for View2D only
+    var view = map.getView();
+    goog.asserts.assert(view instanceof ol.View2D);
+    view.zoom(map, delta, anchor);
     mapBrowserEvent.preventDefault();
     browserEvent.preventDefault();
   }

--- a/src/ol/interaction/draginteraction.js
+++ b/src/ol/interaction/draginteraction.js
@@ -89,6 +89,7 @@ ol.interaction.Drag.prototype.handleMapBrowserEvent =
   if (!map.isDef()) {
     return;
   }
+  var view = map.getView();
   var browserEvent = mapBrowserEvent.browserEvent;
   if (this.dragging_) {
     if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.DRAG) {
@@ -109,7 +110,7 @@ ol.interaction.Drag.prototype.handleMapBrowserEvent =
     this.startY = browserEvent.clientY;
     this.deltaX = 0;
     this.deltaY = 0;
-    this.startCenter = /** @type {!ol.Coordinate} */ map.getCenter();
+    this.startCenter = /** @type {!ol.Coordinate} */ (view.getCenter());
     this.startCoordinate = /** @type {ol.Coordinate} */
         (mapBrowserEvent.getCoordinate());
     var handled = this.handleDragStart(mapBrowserEvent);

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -1,7 +1,11 @@
+// FIXME works for View2D only
+
 goog.provide('ol.interaction.DragPan');
 
+goog.require('goog.asserts');
 goog.require('ol.Coordinate');
 goog.require('ol.MapBrowserEvent');
+goog.require('ol.View2D');
 goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Drag');
 
@@ -31,8 +35,11 @@ goog.inherits(ol.interaction.DragPan, ol.interaction.Drag);
  */
 ol.interaction.DragPan.prototype.handleDrag = function(mapBrowserEvent) {
   var map = mapBrowserEvent.map;
-  var resolution = map.getResolution();
-  var rotation = map.getRotation();
+  // FIXME works for View2D only
+  var view = map.getView();
+  goog.asserts.assert(view instanceof ol.View2D);
+  var resolution = view.getResolution();
+  var rotation = view.getRotation();
   var delta =
       new ol.Coordinate(-resolution * this.deltaX, resolution * this.deltaY);
   if (map.canRotate() && goog.isDef(rotation)) {
@@ -41,7 +48,7 @@ ol.interaction.DragPan.prototype.handleDrag = function(mapBrowserEvent) {
   var newCenter = new ol.Coordinate(
       this.startCenter.x + delta.x, this.startCenter.y + delta.y);
   map.requestRenderFrame();
-  map.setCenter(newCenter);
+  view.setCenter(newCenter);
 };
 
 

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -1,7 +1,10 @@
+// FIXME works for View2D only
+
 goog.provide('ol.interaction.DragRotateAndZoom');
 
 goog.require('goog.math.Vec2');
 goog.require('ol.MapBrowserEvent');
+goog.require('ol.View2D');
 goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Drag');
 
@@ -50,12 +53,15 @@ ol.interaction.DragRotateAndZoom.prototype.handleDrag =
       browserEvent.offsetX - size.width / 2,
       size.height / 2 - browserEvent.offsetY);
   var theta = Math.atan2(delta.y, delta.x);
+  var resolution = this.startRatio_ * delta.magnitude();
+  // FIXME works for View2D only
+  var view = map.getView();
+  goog.asserts.assert(view instanceof ol.View2D);
   map.requestRenderFrame();
   // FIXME the calls to map.rotate and map.zoomToResolution should use
   // map.withFrozenRendering but an assertion fails :-(
-  map.rotate(this.startRotation_, -theta);
-  var resolution = this.startRatio_ * delta.magnitude();
-  map.zoomToResolution(resolution);
+  view.rotate(map, this.startRotation_, -theta);
+  view.zoomToResolution(map, resolution);
 };
 
 
@@ -66,14 +72,15 @@ ol.interaction.DragRotateAndZoom.prototype.handleDragStart =
     function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   var map = mapBrowserEvent.map;
+  var view = map.getView().getView2D();
   if (map.canRotate() && this.condition_(browserEvent)) {
-    var resolution = map.getResolution();
+    var resolution = view.getResolution();
     var size = map.getSize();
     var delta = new goog.math.Vec2(
         browserEvent.offsetX - size.width / 2,
         size.height / 2 - browserEvent.offsetY);
     var theta = Math.atan2(delta.y, delta.x);
-    this.startRotation_ = (map.getRotation() || 0) + theta;
+    this.startRotation_ = (view.getRotation() || 0) + theta;
     this.startRatio_ = resolution / delta.magnitude();
     map.requestRenderFrame();
     return true;

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -1,6 +1,7 @@
 goog.provide('ol.interaction.DragRotate');
 
 goog.require('ol.MapBrowserEvent');
+goog.require('ol.View2D');
 goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Drag');
 
@@ -42,8 +43,11 @@ ol.interaction.DragRotate.prototype.handleDrag = function(mapBrowserEvent) {
   var theta = Math.atan2(
       size.height / 2 - offset.y,
       offset.x - size.width / 2);
+  // FIXME supports View2D only
+  var view = map.getView();
+  goog.asserts.assert(view instanceof ol.View2D);
   map.requestRenderFrame();
-  map.rotate(this.startRotation_, -theta);
+  view.rotate(map, this.startRotation_, -theta);
 };
 
 
@@ -54,6 +58,9 @@ ol.interaction.DragRotate.prototype.handleDragStart =
     function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   var map = mapBrowserEvent.map;
+  // FIXME supports View2D only
+  var view = map.getView();
+  goog.asserts.assert(view instanceof ol.View2D);
   if (browserEvent.isMouseActionButton() && this.condition_(browserEvent) &&
       map.canRotate()) {
     map.requestRenderFrame();
@@ -62,7 +69,7 @@ ol.interaction.DragRotate.prototype.handleDragStart =
     var theta = Math.atan2(
         size.height / 2 - offset.y,
         offset.x - size.width / 2);
-    this.startRotation_ = (map.getRotation() || 0) + theta;
+    this.startRotation_ = (view.getRotation() || 0) + theta;
     return true;
   } else {
     return false;

--- a/src/ol/interaction/dragzoominteraction.js
+++ b/src/ol/interaction/dragzoominteraction.js
@@ -1,4 +1,5 @@
 // FIXME draw drag box
+// FIXME works for View2D only
 
 goog.provide('ol.interaction.DragZoom');
 
@@ -63,7 +64,19 @@ ol.interaction.DragZoom.prototype.handleDragEnd =
     var extent = ol.Extent.boundingExtent(
         this.startCoordinate,
         mapBrowserEvent.getCoordinate());
-    map.fitExtent(extent);
+    map.withFrozenRendering(function() {
+      // FIXME works for View2D only
+      var view = map.getView();
+      goog.asserts.assert(view instanceof ol.View2D);
+      var mapSize = /** @type {ol.Size} */ (map.getSize());
+      view.fitExtent(extent, mapSize);
+      if (map.canRotate()) {
+        // FIXME we don't set the rotation if the map doesn't
+        // support rotation, this will prevent any map using
+        // that view from rotating, which may not be desired
+        view.setRotation(0);
+      }
+    });
   }
 };
 

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -1,7 +1,10 @@
+// FIXME works for View2D only
+
 goog.provide('ol.interaction.KeyboardPan');
 
 goog.require('goog.events.KeyCodes');
 goog.require('goog.events.KeyHandler.EventType');
+goog.require('ol.View2D');
 goog.require('ol.interaction.Interaction');
 
 
@@ -39,7 +42,10 @@ ol.interaction.KeyboardPan.prototype.handleMapBrowserEvent =
         keyCode == goog.events.KeyCodes.RIGHT ||
         keyCode == goog.events.KeyCodes.UP) {
       var map = mapBrowserEvent.map;
-      var resolution = map.getResolution();
+      // FIXME works for View2D only
+      var view = map.getView();
+      goog.asserts.assert(view instanceof ol.View2D);
+      var resolution = view.getResolution();
       var delta;
       var mapUnitsDelta = resolution * this.pixelDelta_;
       if (keyCode == goog.events.KeyCodes.DOWN) {
@@ -52,10 +58,10 @@ ol.interaction.KeyboardPan.prototype.handleMapBrowserEvent =
         goog.asserts.assert(keyCode == goog.events.KeyCodes.UP);
         delta = new ol.Coordinate(0, mapUnitsDelta);
       }
-      var oldCenter = map.getCenter();
+      var oldCenter = view.getCenter();
       var newCenter = new ol.Coordinate(
           oldCenter.x + delta.x, oldCenter.y + delta.y);
-      map.setCenter(newCenter);
+      view.setCenter(newCenter);
       keyEvent.preventDefault();
       mapBrowserEvent.preventDefault();
     }

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -1,7 +1,10 @@
+// FIXME works for View2D only
+
 goog.provide('ol.interaction.KeyboardZoom');
 
 goog.require('goog.events.KeyCodes');
 goog.require('goog.events.KeyHandler.EventType');
+goog.require('ol.View2D');
 goog.require('ol.interaction.Interaction');
 
 
@@ -28,7 +31,10 @@ ol.interaction.KeyboardZoom.prototype.handleMapBrowserEvent =
     if (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0)) {
       var map = mapBrowserEvent.map;
       var delta = (charCode == '+'.charCodeAt(0)) ? 4 : -4;
-      map.zoom(delta);
+      // FIXME works for View2D only
+      var view = map.getView();
+      goog.asserts.assert(view instanceof ol.View2D);
+      view.zoom(map, delta);
       keyEvent.preventDefault();
       mapBrowserEvent.preventDefault();
     }

--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -1,8 +1,11 @@
+// FIXME works for View2D only
+
 goog.provide('ol.interaction.MouseWheelZoom');
 
 goog.require('goog.events.MouseWheelEvent');
 goog.require('goog.events.MouseWheelHandler.EventType');
 goog.require('ol.MapBrowserEvent');
+goog.require('ol.View2D');
 
 
 
@@ -36,8 +39,11 @@ ol.interaction.MouseWheelZoom.prototype.handleMapBrowserEvent =
     goog.asserts.assert(mouseWheelEvent instanceof goog.events.MouseWheelEvent);
     var anchor = mapBrowserEvent.getCoordinate();
     var delta = mouseWheelEvent.deltaY < 0 ? this.delta_ : -this.delta_;
+    // FIXME works for View2D only
+    var view = map.getView();
+    goog.asserts.assert(view instanceof ol.View2D);
     map.requestRenderFrame();
-    map.zoom(delta, anchor);
+    view.zoom(map, delta, anchor);
     mapBrowserEvent.preventDefault();
     mouseWheelEvent.preventDefault();
   }

--- a/src/ol/iview.js
+++ b/src/ol/iview.js
@@ -1,0 +1,27 @@
+goog.provide('ol.IView');
+
+goog.require('ol.IView2D');
+goog.require('ol.IView3D');
+
+
+
+/**
+ * Interface for views.
+ * @interface
+ */
+ol.IView = function() {
+};
+
+
+/**
+ * @return {ol.IView2D} View2D.
+ */
+ol.IView.prototype.getView2D = function() {
+};
+
+
+/**
+ * @return {ol.IView3D} View3D.
+ */
+ol.IView.prototype.getView3D = function() {
+};

--- a/src/ol/iview2d.js
+++ b/src/ol/iview2d.js
@@ -1,0 +1,38 @@
+goog.provide('ol.IView2D');
+
+
+
+/**
+ * Interface for views.
+ * @interface
+ */
+ol.IView2D = function() {
+};
+
+
+/**
+ * @return {ol.Coordinate|undefined} Map center.
+ */
+ol.IView2D.prototype.getCenter = function() {
+};
+
+
+/**
+ * @return {ol.Projection|undefined} Map projection.
+ */
+ol.IView2D.prototype.getProjection = function() {
+};
+
+
+/**
+ * @return {number|undefined} Map resolution.
+ */
+ol.IView2D.prototype.getResolution = function() {
+};
+
+
+/**
+ * @return {number|undefined} Map rotation.
+ */
+ol.IView2D.prototype.getRotation = function() {
+};

--- a/src/ol/iview3d.js
+++ b/src/ol/iview3d.js
@@ -1,0 +1,12 @@
+goog.provide('ol.IView3D');
+
+
+
+/**
+ * Interface for views.
+ * @interface
+ */
+ol.IView3D = function() {
+};
+
+

--- a/src/ol/renderer/dom/dommaprenderer.js
+++ b/src/ol/renderer/dom/dommaprenderer.js
@@ -133,26 +133,8 @@ ol.renderer.dom.Map.prototype.createLayerRenderer = function(layer) {
 /**
  * @inheritDoc
  */
-ol.renderer.dom.Map.prototype.handleCenterChanged = function() {
-  goog.base(this, 'handleCenterChanged');
-  this.getMap().render();
-};
-
-
-/**
- * @inheritDoc
- */
-ol.renderer.dom.Map.prototype.handleResolutionChanged = function() {
-  goog.base(this, 'handleResolutionChanged');
-  this.getMap().render();
-};
-
-
-/**
- * @inheritDoc
- */
-ol.renderer.dom.Map.prototype.handleRotationChanged = function() {
-  goog.base(this, 'handleRotationChanged');
+ol.renderer.dom.Map.prototype.handleViewPropertyChanged = function() {
+  goog.base(this, 'handleViewPropertyChanged');
   this.getMap().render();
 };
 
@@ -162,6 +144,15 @@ ol.renderer.dom.Map.prototype.handleRotationChanged = function() {
  */
 ol.renderer.dom.Map.prototype.handleSizeChanged = function() {
   goog.base(this, 'handleSizeChanged');
+  this.getMap().render();
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.renderer.dom.Map.prototype.handleViewChanged = function() {
+  goog.base(this, 'handleViewChanged');
   this.getMap().render();
 };
 
@@ -177,10 +168,11 @@ ol.renderer.dom.Map.prototype.renderFrame = function(time) {
     return;
   }
 
-  var mapCenter = map.getCenter();
+  var view = map.getView().getView2D();
+  var mapCenter = view.getCenter();
   var mapSize = map.getSize();
-  var mapResolution = map.getResolution();
-  var mapRotation = map.getRotation();
+  var mapResolution = view.getResolution();
+  var mapRotation = view.getRotation();
 
   goog.asserts.assert(goog.isDefAndNotNull(mapCenter));
   goog.asserts.assert(goog.isDef(mapResolution));
@@ -235,14 +227,15 @@ ol.renderer.dom.Map.prototype.resetLayersPane_ = function() {
   var mapSize = map.getSize();
   var halfWidth = mapSize.width / 2;
   var halfHeight = mapSize.height / 2;
-  var center = map.getCenter();
-  var resolution = map.getResolution();
+  var view = /** @type {ol.View2D} */ (map.getView().getView2D());
+  var center = view.getCenter();
+  var resolution = view.getResolution();
   var origin = new ol.Coordinate(
       center.x - resolution * halfWidth,
       center.y + resolution * halfHeight);
   this.layersPaneOrigin_ = origin;
   this.setTransformOrigin_(halfWidth, halfHeight);
-  this.applyTransform_(0, 0, map.getRotation());
+  this.applyTransform_(0, 0, view.getRotation());
   goog.object.forEach(this.layerRenderers, function(layerRenderer) {
     layerRenderer.setOrigin(origin);
   });
@@ -273,8 +266,9 @@ ol.renderer.dom.Map.prototype.setTransformOrigin_ = function(x, y) {
  */
 ol.renderer.dom.Map.prototype.transformLayersPane_ = function() {
   var map = this.map;
-  var resolution = map.getResolution();
-  var center = map.getCenter();
+  var view = map.getView();
+  var resolution = view.getResolution();
+  var center = view.getCenter();
   var size = map.getSize();
   var origin = this.layersPaneOrigin_;
   var ox = (center.x - origin.x) / resolution;
@@ -282,5 +276,5 @@ ol.renderer.dom.Map.prototype.transformLayersPane_ = function() {
   this.setTransformOrigin_(ox, oy);
   var dx = ox - (size.width / 2);
   var dy = oy - (size.height / 2);
-  this.applyTransform_(-dx, -dy, map.getRotation());
+  this.applyTransform_(-dx, -dy, view.getRotation());
 };

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -95,8 +95,10 @@ ol.renderer.dom.TileLayer.prototype.renderFrame = function(time) {
   if (!map.isDef()) {
     return;
   }
-  var mapExtent = /** @type {!ol.Extent} */ map.getRotatedExtent();
-  var mapResolution = /** @type {number} */ map.getResolution();
+  var mapSize = /** @type {ol.Size} */ (map.getSize());
+  var view = map.getView().getView2D();
+  var mapExtent = /** @type {!ol.Extent} */ (view.getRotatedExtent(mapSize));
+  var mapResolution = /** @type {number} */ (view.getResolution());
   var resolutionChanged = (mapResolution !== this.renderedMapResolution_);
 
   var tileLayer = this.getLayer();

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -386,8 +386,8 @@ ol.renderer.webgl.Map.prototype.handleBackgroundColorChanged = function() {
 /**
  * @inheritDoc
  */
-ol.renderer.webgl.Map.prototype.handleCenterChanged = function() {
-  goog.base(this, 'handleCenterChanged');
+ol.renderer.webgl.Map.prototype.handleViewPropertyChanged = function() {
+  goog.base(this, 'handleViewPropertyChanged');
   this.getMap().render();
 };
 
@@ -404,26 +404,17 @@ ol.renderer.webgl.Map.prototype.handleLayerRendererChange = function(event) {
 /**
  * @inheritDoc
  */
-ol.renderer.webgl.Map.prototype.handleResolutionChanged = function() {
-  goog.base(this, 'handleResolutionChanged');
-  this.getMap().render();
-};
-
-
-/**
- * @inheritDoc
- */
-ol.renderer.webgl.Map.prototype.handleRotationChanged = function() {
-  goog.base(this, 'handleRotationChanged');
-  this.getMap().render();
-};
-
-
-/**
- * @inheritDoc
- */
 ol.renderer.webgl.Map.prototype.handleSizeChanged = function() {
   goog.base(this, 'handleSizeChanged');
+  this.getMap().render();
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.renderer.webgl.Map.prototype.handleViewChanged = function() {
+  goog.base(this, 'handleViewChanged');
   this.getMap().render();
 };
 
@@ -525,7 +516,7 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(time) {
     }
   });
 
-  var size = /** @type {ol.Size} */ this.getMap().getSize();
+  var size = /** @type {ol.Size} */ (this.getMap().getSize());
   if (!this.canvasSize_.equals(size)) {
     this.canvas_.width = size.width;
     this.canvas_.height = size.height;

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -294,13 +294,15 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame = function(time) {
   var mapRenderer = this.getMapRenderer();
   var map = this.getMap();
   var gl = mapRenderer.getGL();
+  var view = map.getView().getView2D();
 
   goog.asserts.assert(map.isDef());
-  var mapCenter = map.getCenter();
-  var mapExtent = map.getExtent();
-  var mapResolution = /** @type {number} */ map.getResolution();
-  var mapRotatedExtent = map.getRotatedExtent();
-  var mapRotation = map.getRotation();
+  var mapSize = map.getSize();
+  var mapCenter = view.getCenter();
+  var mapExtent = view.getExtent(mapSize);
+  var mapResolution = /** @type {number} */ (view.getResolution());
+  var mapRotatedExtent = view.getRotatedExtent(mapSize);
+  var mapRotation = view.getRotation();
 
   var tileLayer = this.getLayer();
   var tileSource = tileLayer.getTileSource();

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -1,0 +1,29 @@
+goog.provide('ol.View');
+
+goog.require('ol.IView');
+goog.require('ol.IView2D');
+goog.require('ol.IView3D');
+
+
+
+/**
+ * @constructor
+ * @implements {ol.IView}
+ * @extends {ol.Object}
+ */
+ol.View = function() {
+};
+goog.inherits(ol.View, ol.Object);
+
+
+/**
+ * @inheritDoc
+ */
+ol.View.prototype.getView2D = goog.abstractMethod;
+
+
+/**
+ * @inheritDoc
+ */
+ol.View.prototype.getView3D = goog.abstractMethod;
+

--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -1,0 +1,344 @@
+// FIXME getView3D has not return type
+
+goog.provide('ol.View2D');
+goog.provide('ol.View2DProperty');
+
+goog.require('ol.Constraints');
+goog.require('ol.Extent');
+goog.require('ol.IView2D');
+goog.require('ol.IView3D');
+goog.require('ol.Projection');
+goog.require('ol.ResolutionConstraint');
+goog.require('ol.RotationConstraint');
+goog.require('ol.View');
+
+
+/**
+ * @enum {string}
+ */
+ol.View2DProperty = {
+  CENTER: 'center',
+  PROJECTION: 'projection',
+  RESOLUTION: 'resolution',
+  ROTATION: 'rotation'
+};
+
+
+
+/**
+ * @constructor
+ * @implements {ol.IView2D}
+ * @implements {ol.IView3D}
+ * @extends {ol.View}
+ * @param {ol.View2DOptions=} opt_view2DOptions View2D options.
+ */
+ol.View2D = function(opt_view2DOptions) {
+  goog.base(this);
+  var view2DOptions = opt_view2DOptions || {};
+
+  /**
+   * @type {Object.<string, *>}
+   */
+  var values = {};
+  values[ol.View2DProperty.CENTER] = goog.isDef(view2DOptions.center) ?
+      view2DOptions.center : null;
+  values[ol.View2DProperty.PROJECTION] = ol.Projection.createProjection(
+      view2DOptions.projection, 'EPSG:3857');
+  if (goog.isDef(view2DOptions.resolution)) {
+    values[ol.View2DProperty.RESOLUTION] = view2DOptions.resolution;
+  } else if (goog.isDef(view2DOptions.zoom)) {
+    values[ol.View2DProperty.RESOLUTION] =
+        ol.Projection.EPSG_3857_HALF_SIZE / (128 << view2DOptions.zoom);
+  }
+  values[ol.View2DProperty.ROTATION] = view2DOptions.rotation;
+  this.setValues(values);
+
+  /**
+   * @private
+   * @type {ol.Constraints}
+   */
+  this.constraints_ = ol.View2D.createConstraints_(view2DOptions);
+
+};
+goog.inherits(ol.View2D, ol.View);
+
+
+/**
+ * @inheritDoc
+ */
+ol.View2D.prototype.getCenter = function() {
+  return /** @type {ol.Coordinate|undefined} */ (
+      this.get(ol.View2DProperty.CENTER));
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'getCenter',
+    ol.View2D.prototype.getCenter);
+
+
+/**
+ * @param {ol.Size} size Box pixel size.
+ * @return {ol.Extent} Extent.
+ */
+ol.View2D.prototype.getExtent = function(size) {
+  goog.asserts.assert(this.isDef());
+  var center = this.getCenter();
+  var resolution = this.getResolution();
+  var minX = center.x - resolution * size.width / 2;
+  var minY = center.y - resolution * size.height / 2;
+  var maxX = center.x + resolution * size.width / 2;
+  var maxY = center.y + resolution * size.height / 2;
+  return new ol.Extent(minX, minY, maxX, maxY);
+};
+
+
+/**
+ * @param {ol.Size} size Box pixel size.
+ * @return {ol.Extent} Rotated extent.
+ */
+ol.View2D.prototype.getRotatedExtent = function(size) {
+  goog.asserts.assert(this.isDef());
+  // FIXME try w/o casting
+  var center = /** @type {!ol.Coordinate} */ (this.getCenter());
+  var resolution = this.getResolution();
+  var rotation = this.getRotation();
+  var xScale = resolution * size.width / 2;
+  var yScale = resolution * size.height / 2;
+  var corners = [
+    new ol.Coordinate(-xScale, -yScale),
+    new ol.Coordinate(-xScale, yScale),
+    new ol.Coordinate(xScale, -yScale),
+    new ol.Coordinate(xScale, yScale)
+  ];
+  goog.array.forEach(corners, function(corner) {
+    corner.rotate(rotation);
+    corner.add(center);
+  });
+  return ol.Extent.boundingExtent.apply(null, corners);
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.View2D.prototype.getProjection = function() {
+  return /** @type {ol.Projection|undefined} */ (
+      this.get(ol.View2DProperty.PROJECTION));
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'getProjection',
+    ol.View2D.prototype.getProjection);
+
+
+/**
+ * @inheritDoc
+ */
+ol.View2D.prototype.getResolution = function() {
+  return /** @type {number|undefined} */ (
+      this.get(ol.View2DProperty.RESOLUTION));
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'getResolution',
+    ol.View2D.prototype.getResolution);
+
+
+/**
+ * @param {ol.Extent} extent Extent.
+ * @param {ol.Size} size Box pixel size.
+ * @return {number} Resolution.
+ */
+ol.View2D.prototype.getResolutionForExtent = function(extent, size) {
+  var xResolution = (extent.maxX - extent.minX) / size.width;
+  var yResolution = (extent.maxY - extent.minY) / size.height;
+  return Math.max(xResolution, yResolution);
+};
+
+
+/**
+ * @return {number} Map rotation.
+ */
+ol.View2D.prototype.getRotation = function() {
+  return /** @type {number|undefined} */ (
+      this.get(ol.View2DProperty.ROTATION)) || 0;
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'getRotation',
+    ol.View2D.prototype.getRotation);
+
+
+/**
+ * @inheritDoc
+ */
+ol.View2D.prototype.getView2D = function() {
+  return this;
+};
+
+
+/**
+ * FIXME return type
+ */
+ol.View2D.prototype.getView3D = function() {
+};
+
+
+/**
+ * @param {ol.Extent} extent Extent.
+ * @param {ol.Size} size Box pixel size.
+ */
+ol.View2D.prototype.fitExtent = function(extent, size) {
+  this.setCenter(extent.getCenter());
+  var resolution = this.getResolutionForExtent(extent, size);
+  resolution = this.constraints_.resolution(resolution, 0);
+  this.setResolution(resolution);
+};
+
+
+/**
+ * @return {boolean} Is defined.
+ */
+ol.View2D.prototype.isDef = function() {
+  return goog.isDefAndNotNull(this.getCenter()) &&
+      goog.isDef(this.getResolution());
+};
+
+
+/**
+ * @param {ol.Coordinate|undefined} center Center.
+ */
+ol.View2D.prototype.setCenter = function(center) {
+  this.set(ol.View2DProperty.CENTER, center);
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'setCenter',
+    ol.View2D.prototype.setCenter);
+
+
+/**
+ * @param {ol.Projection|undefined} projection Projection.
+ */
+ol.View2D.prototype.setProjection = function(projection) {
+  this.set(ol.View2DProperty.PROJECTION, projection);
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'setProjection',
+    ol.View2D.prototype.setProjection);
+
+
+/**
+ * @param {number|undefined} resolution Resolution.
+ */
+ol.View2D.prototype.setResolution = function(resolution) {
+  this.set(ol.View2DProperty.RESOLUTION, resolution);
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'setResolution',
+    ol.View2D.prototype.setResolution);
+
+
+/**
+ * @param {number|undefined} rotation Rotation.
+ */
+ol.View2D.prototype.setRotation = function(rotation) {
+  this.set(ol.View2DProperty.ROTATION, rotation);
+};
+goog.exportProperty(
+    ol.View2D.prototype,
+    'setRotation',
+    ol.View2D.prototype.setRotation);
+
+
+/**
+ * @param {ol.Map} map Map.
+ * @param {number|undefined} rotation Rotation.
+ * @param {number} delta Delta.
+ */
+ol.View2D.prototype.rotate = function(map, rotation, delta) {
+  rotation = this.constraints_.rotation(rotation, delta);
+  this.setRotation(rotation);
+};
+
+
+/**
+ * @private
+ * @param {ol.Map} map Map.
+ * @param {number|undefined} resolution Resolution to go to.
+ * @param {ol.Coordinate=} opt_anchor Anchor coordinate.
+ */
+ol.View2D.prototype.zoom_ = function(map, resolution, opt_anchor) {
+  if (goog.isDefAndNotNull(resolution) && goog.isDefAndNotNull(opt_anchor)) {
+    var anchor = opt_anchor;
+    var oldCenter = /** @type {!ol.Coordinate} */ (this.getCenter());
+    var oldResolution = this.getResolution();
+    var x = anchor.x - resolution * (anchor.x - oldCenter.x) / oldResolution;
+    var y = anchor.y - resolution * (anchor.y - oldCenter.y) / oldResolution;
+    var center = new ol.Coordinate(x, y);
+    map.withFrozenRendering(function() {
+      this.setCenter(center);
+      this.setResolution(resolution);
+    }, this);
+  } else {
+    this.setResolution(resolution);
+  }
+};
+
+
+/**
+ * @param {ol.Map} map Map.
+ * @param {number} delta Delta from previous zoom level.
+ * @param {ol.Coordinate=} opt_anchor Anchor coordinate.
+ */
+ol.View2D.prototype.zoom = function(map, delta, opt_anchor) {
+  var resolution = this.constraints_.resolution(this.getResolution(), delta);
+  this.zoom_(map, resolution, opt_anchor);
+};
+
+
+/**
+ * @param {ol.Map} map Map.
+ * @param {number|undefined} resolution Resolution to go to.
+ * @param {ol.Coordinate=} opt_anchor Anchor coordinate.
+ */
+ol.View2D.prototype.zoomToResolution = function(map, resolution, opt_anchor) {
+  resolution = this.constraints_.resolution(resolution, 0);
+  this.zoom_(map, resolution, opt_anchor);
+};
+
+
+/**
+ * @private
+ * @param {ol.View2DOptions} view2DOptions View2D options.
+ * @return {ol.Constraints} Constraints.
+ */
+ol.View2D.createConstraints_ = function(view2DOptions) {
+  var resolutionConstraint;
+  if (goog.isDef(view2DOptions.resolutions)) {
+    resolutionConstraint = ol.ResolutionConstraint.createSnapToResolutions(
+        view2DOptions.resolutions);
+  } else {
+    var maxResolution, numZoomLevels, zoomFactor;
+    if (goog.isDef(view2DOptions.maxResolution) &&
+        goog.isDef(view2DOptions.numZoomLevels) &&
+        goog.isDef(view2DOptions.zoomFactor)) {
+      maxResolution = view2DOptions.maxResolution;
+      numZoomLevels = view2DOptions.numZoomLevels;
+      zoomFactor = view2DOptions.zoomFactor;
+    } else {
+      maxResolution = ol.Projection.EPSG_3857_HALF_SIZE / 128;
+      // number of steps we want between two data resolutions
+      var numSteps = 4;
+      numZoomLevels = 29 * numSteps;
+      zoomFactor = Math.exp(Math.log(2) / numSteps);
+    }
+    resolutionConstraint = ol.ResolutionConstraint.createSnapToPower(
+        zoomFactor, maxResolution, numZoomLevels - 1);
+  }
+  // FIXME rotation constraint is not configurable at the moment
+  var rotationConstraint = ol.RotationConstraint.none;
+  return new ol.Constraints(resolutionConstraint, rotationConstraint);
+};

--- a/test/ol.html
+++ b/test/ol.html
@@ -78,6 +78,7 @@
   <script type="text/javascript" src="spec/ol/projection.test.js"></script>
   <script type="text/javascript" src="spec/ol/rectangle.test.js"></script>
   <script type="text/javascript" src="spec/ol/resolutionconstraint.test.js"></script>
+  <script type="text/javascript" src="spec/ol/view2d.test.js"></script>
   <script type="text/javascript" src="spec/ol/layer/layer.test.js"></script>
   <script type="text/javascript" src="spec/ol/source/xyz.test.js"></script>
   <script type="text/javascript" src="spec/ol/tilecoord.test.js"></script>

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -4,6 +4,7 @@ goog.require('ol.Collection');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
 goog.require('ol.RendererHint');
+goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.source.XYZ');
 
@@ -21,56 +22,6 @@ describe('ol.Map', function() {
     it('removes the viewport from its parent', function() {
       map.dispose();
       expect(goog.dom.getParentElement(map.getViewport())).toBeNull();
-    });
-  });
-
-  describe('create constraints', function() {
-
-    describe('create resolution constraint', function() {
-
-      describe('with no options', function() {
-        it('gives a correct resolution constraint function', function() {
-          var options = {};
-          var fn = ol.Map.createConstraints_(options).resolution;
-          expect(fn(156543.03392804097, 0))
-              .toRoughlyEqual(156543.03392804097, 1e-9);
-          expect(fn(78271.51696402048, 0))
-              .toRoughlyEqual(78271.51696402048, 1e-10);
-        });
-      });
-
-      describe('with maxResolution, numZoomLevels, and zoomFactor options',
-          function() {
-        it('gives a correct resolution constraint function', function() {
-          var options = {
-            maxResolution: 81,
-            numZoomLevels: 4,
-            zoomFactor: 3
-          };
-          var fn = ol.Map.createConstraints_(options).resolution;
-          expect(fn(82, 0)).toEqual(81);
-          expect(fn(81, 0)).toEqual(81);
-          expect(fn(27, 0)).toEqual(27);
-          expect(fn(9, 0)).toEqual(9);
-          expect(fn(3, 0)).toEqual(3);
-          expect(fn(2, 0)).toEqual(3);
-        });
-      });
-
-      describe('with resolutions', function() {
-        it('gives a correct resolution constraint function', function() {
-          var options = {
-            resolutions: [97, 76, 65, 54, 0.45]
-          };
-          var fn = ol.Map.createConstraints_(options).resolution;
-          expect(fn(97, 0), 97);
-          expect(fn(76, 0), 76);
-          expect(fn(65, 0), 65);
-          expect(fn(54, 0), 54);
-          expect(fn(0.45, 0), 0.45);
-        });
-      });
-
     });
   });
 
@@ -158,11 +109,13 @@ describe('ol.Map', function() {
       });
 
       map = new ol.Map({
-        center: new ol.Coordinate(0, 0),
         layers: new ol.Collection([layer]),
         renderer: ol.RendererHint.DOM,
         target: 'map',
-        zoom: 1
+        view: new ol.View2D({
+          center: new ol.Coordinate(0, 0),
+          zoom: 1
+        })
       });
     });
 
@@ -183,7 +136,7 @@ describe('ol.Map', function() {
       var duration = 500;
       var destination = new ol.Coordinate(1000, 1000);
 
-      var origin = map.getCenter();
+      var origin = map.getView().getCenter();
       var start = new Date().getTime();
       var x0 = origin.x;
       var y0 = origin.y;
@@ -202,7 +155,7 @@ describe('ol.Map', function() {
             x = destination.x;
             y = destination.y;
           }
-          map.setCenter(new ol.Coordinate(x, y));
+          map.getView().setCenter(new ol.Coordinate(x, y));
           if (more) {
             animationDelay.start();
           }
@@ -220,7 +173,7 @@ describe('ol.Map', function() {
       waits(100);
       runs(function() {
         expect(o.callback).toHaveBeenCalled();
-        var loc = map.getCenter();
+        var loc = map.getView().getCenter();
         expect(loc.x).not.toEqual(origin.x);
         expect(loc.y).not.toEqual(origin.y);
         expect(loc.x).not.toEqual(destination.x);
@@ -230,7 +183,7 @@ describe('ol.Map', function() {
       // confirm that the map has reached the destination after the duration
       waits(duration);
       runs(function() {
-        var loc = map.getCenter();
+        var loc = map.getView().getCenter();
         expect(loc.x).toEqual(destination.x);
         expect(loc.y).toEqual(destination.y);
       });

--- a/test/spec/ol/view2d.test.js
+++ b/test/spec/ol/view2d.test.js
@@ -1,0 +1,53 @@
+goog.require('ol.View2D');
+
+describe('ol.View2D', function() {
+  describe('create constraints', function() {
+
+    describe('create resolution constraint', function() {
+
+      describe('with no options', function() {
+        it('gives a correct resolution constraint function', function() {
+          var options = {};
+          var fn = ol.View2D.createConstraints_(options).resolution;
+          expect(fn(156543.03392804097, 0))
+              .toRoughlyEqual(156543.03392804097, 1e-9);
+          expect(fn(78271.51696402048, 0))
+              .toRoughlyEqual(78271.51696402048, 1e-10);
+        });
+      });
+
+      describe('with maxResolution, numZoomLevels, and zoomFactor options',
+          function() {
+        it('gives a correct resolution constraint function', function() {
+          var options = {
+            maxResolution: 81,
+            numZoomLevels: 4,
+            zoomFactor: 3
+          };
+          var fn = ol.View2D.createConstraints_(options).resolution;
+          expect(fn(82, 0)).toEqual(81);
+          expect(fn(81, 0)).toEqual(81);
+          expect(fn(27, 0)).toEqual(27);
+          expect(fn(9, 0)).toEqual(9);
+          expect(fn(3, 0)).toEqual(3);
+          expect(fn(2, 0)).toEqual(3);
+        });
+      });
+
+      describe('with resolutions', function() {
+        it('gives a correct resolution constraint function', function() {
+          var options = {
+            resolutions: [97, 76, 65, 54, 0.45]
+          };
+          var fn = ol.View2D.createConstraints_(options).resolution;
+          expect(fn(97, 0)).toEqual(97);
+          expect(fn(76, 0)).toEqual(76);
+          expect(fn(65, 0)).toEqual(65);
+          expect(fn(54, 0)).toEqual(54);
+          expect(fn(0.45, 0)).toEqual(0.45);
+        });
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
This PR suggests abstracting out the concept of views. This work will enable configuring a map with a 2D view or a 3D view. `View2D` only is supported for now.

The API is the one [I described](https://groups.google.com/forum/#!msg/ol3-dev/B2boA4pG5II/2Rx-2-cyT-kJ) on the ol3-dev mailing list. This is for example how you can create a 2D map:

```
new ol.Map({
  view: new ol.View2D({
    center: new ol.Coordinate(5, 45),
    zoom: 0
  })
)
```

If no view is provided by the user then the `ol.Map` constructor creates an `ol.View2D`. It is then possible to do for example `map.getView().setCenter(...)` to change the map view.

The controls and interactions are currently 2D only. They use things like

```
map.getView().setResolution()
```

and therefore assume that `map.getView()` returns a `View2D` object. Controls are interactions meant to work both in 2D and 3D modes will need to be changed. We may also decide that `View3D` should support 2D operations like `setCenter`. This is to be determined.

The case of renderers is pretty much covered already. 2D renderers use

```
map.getView().getView2D()
```

and get a `View2D` object back, on which they can call `getCenter` or `getResolution`. (Calling `getView2D` on a `View2D` object just returns that `View2D` object.)

Thanks for any review. (I already got a number of review comments from @twpayne. Thank you Tom!)
