### PR TITLE
Fire postrender events

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -3,7 +3,6 @@
 // FIXME add tilt and height?
 
 goog.provide('ol.Map');
-goog.provide('ol.MapEventType');
 goog.provide('ol.MapProperty');
 goog.provide('ol.RendererHint');
 goog.provide('ol.RendererHints');
@@ -664,6 +663,9 @@ ol.Map.prototype.renderFrame_ = function(time) {
   }
   this.frameState_ = frameState;
   this.dirty_ = false;
+
+  this.dispatchEvent(
+      new ol.MapEvent(ol.MapEventType.POSTRENDER, this, frameState));
 
   goog.global.setTimeout(this.handlePostRender_, 0);
 

--- a/src/ol/mapevent.js
+++ b/src/ol/mapevent.js
@@ -1,6 +1,16 @@
 goog.provide('ol.MapEvent');
+goog.provide('ol.MapEventType');
 
 goog.require('goog.events.Event');
+goog.require('ol.FrameState');
+
+
+/**
+ * @enum {string}
+ */
+ol.MapEventType = {
+  POSTRENDER: 'postrender'
+};
 
 
 
@@ -9,8 +19,9 @@ goog.require('goog.events.Event');
  * @extends {goog.events.Event}
  * @param {string} type Event type.
  * @param {ol.Map} map Map.
+ * @param {?ol.FrameState=} opt_frameState Frame state.
  */
-ol.MapEvent = function(type, map) {
+ol.MapEvent = function(type, map, opt_frameState) {
 
   goog.base(this, type);
 
@@ -23,6 +34,11 @@ ol.MapEvent = function(type, map) {
    * @type {boolean}
    */
   this.defaultPrevented = false;
+
+  /**
+   * @type {?ol.FrameState}
+   */
+  this.frameState = goog.isDef(opt_frameState) ? opt_frameState : null;
 
 };
 goog.inherits(ol.MapEvent, goog.events.Event);


### PR DESCRIPTION
This pull request causes the map to fire `postrender` events that include the rendered frame state, as described in the [wiki](https://github.com/openlayers/ol3/wiki/Camera,-Animation-and-Frame-State).
