### PR TITLE
Bing maps key will expire on 15 Jan 2013

### DIFF
--- a/examples/two-layers.js
+++ b/examples/two-layers.js
@@ -12,7 +12,7 @@ goog.require('ol.source.TileJSON');
 var layers = new ol.Collection([
   new ol.layer.TileLayer({
     source: new ol.source.BingMaps({
-      key: 'Ak0kFwyFsvMr0dVwuaURTqKAXytSSN47KOdj4uVpaWBhK-DT6Zo-FeHCiJUL0tYL',
+      key: 'AgtFlPYDnymLEe9zJ5PCkghbNiFZE9aAtTy3mPaEnEBXqLHtFuTcKoZ-miMC3w7R',
       style: ol.BingMapsStyle.AERIAL
     })
   }),


### PR DESCRIPTION
The key is used in the Bing Maps demo. We will need to obtain a new key.
