### PR TITLE
Adjust border-radius of zoom buttons.

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -78,8 +78,8 @@
   }
 }
 .ol-zoom-in {
-  border-radius: 4px 4px 0 0;
+  border-radius: 2px 2px 0 0;
 }
 .ol-zoom-out {
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 2px 2px;
 }


### PR DESCRIPTION
The `border-radius` of the actual zoom buttons currently equals the radius of the container they are in. 

I suggest to have a smaller inner radius that IMO looks more visually appealing.

Compare in the following image: The zoom-in button (on top) is adjusted already and the zoom-out (on the bottom) button shows the current border-radius of `4px`.

![border-radius](https://f.cloud.github.com/assets/227934/89247/2ef8b0f2-652d-11e2-9b16-7084dbd7c36e.png)
