### PR TITLE
Add fixme/todo target to build.py.

### DIFF
--- a/build.py
+++ b/build.py
@@ -85,6 +85,9 @@ virtual('precommit', 'lint', 'build-all', 'test', 'build', 'build-examples', 'do
 virtual('build', 'build/ol.css', 'build/ol.js')
 
 
+virtual('todo', 'fixme')
+
+
 @target('build/ol.css', 'build/ol.js')
 def build_ol_css(t):
     t.touch()
@@ -247,6 +250,27 @@ def hostexamples(t):
 def test(t):
     t.run('%(PHANTOMJS)s', 'test/phantom-jasmine/run_jasmine_test.coffee', 'test/ol.html')
 
+@target('fixme', phony=True)
+def find_fixme(t):
+    regex = re.compile(".(FIXME|TODO).")
+    matches = dict()
+    totalcount = 0
+    for filename in SRC:
+        f = open(filename, 'r')
+        for lineno, line in enumerate(f):
+            if regex.search(line):
+                if (filename not in matches):
+                    matches[filename] = list()
+                matches[filename].append("#" + str(lineno + 1).ljust(10) + line.strip())
+                totalcount += 1
+        f.close()
+
+    for filename in matches:
+        print "  ", filename, "has", len(matches[filename]), "matches:"
+        for match in matches[filename]:
+            print "    ", match
+        print
+    print "A total number of", totalcount, "TODO/FIXME was found"
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Will show a list of lines in sourcefiles that either contains the string `TODO`
or `FIXME`.

Example output:

```
user@host:~/src/ol3 $ ./build.py fixme
  src/ol/source/xyzsource.js has 4 matches:
    #1         // FIXME add minZoom support
    #46        // FIXME use goog.nullFunction ?
    #59        // FIXME factor out common code
    #76        // FIXME we shouldn't need a typecast here

  src/ol/interaction/dragpaninteraction.js has 2 matches:
    #1         // FIXME works for View2D only
    #39        // FIXME works for View2D only
```
