### PR TITLE
Remove ref to userProjection

### DIFF
--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -52,9 +52,6 @@ var layers = new ol.Collection([
 ]);
 
 var map = new ol.Map({
-  // By setting userProjection to the same as projection, we do not need
-  // proj4js because we do not need any transforms.
-  userProjection: epsg21781,
   layers: layers,
   renderers: ol.RendererHints.createFromQueryData(),
   target: 'map',


### PR DESCRIPTION
The wms-custom-proj example sets a userProjection in the map while userProjection is gone for now. It was removed in 927cffb2.
