### PR TITLE
Change class names in DOM renderer

### DIFF
--- a/src/ol/renderer/dom/dommaprenderer.js
+++ b/src/ol/renderer/dom/dommaprenderer.js
@@ -30,7 +30,7 @@ ol.renderer.dom.Map = function(container, map) {
    * @private
    */
   this.layersPane_ = goog.dom.createElement(goog.dom.TagName.DIV);
-  this.layersPane_.className = 'ol-layers-pane ol-unselectable';
+  this.layersPane_.className = 'ol-layers ol-unselectable';
   var style = this.layersPane_.style;
   style.position = 'absolute';
   style.width = '100%';

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -30,7 +30,7 @@ goog.require('ol.tilegrid.TileGrid');
 ol.renderer.dom.TileLayer = function(mapRenderer, tileLayer) {
 
   var target = goog.dom.createElement(goog.dom.TagName.DIV);
-  target.className = 'ol-layer';
+  target.className = 'ol-layer-tile';
   target.style.position = 'absolute';
 
   goog.base(this, mapRenderer, tileLayer, target);


### PR DESCRIPTION
This PR changes class names in the DOM renderer.

We don't use `pane` elsewhere, so the class of the layer container is renamed from `ol-layers-pane` to `ol-layers`.

The class name of the tile layer renderer is changed from `ol-layer` to `ol-layer-tile`.

(I'm currently working on an image layer renderer, which will use `ol-layer-image` as the class name for its DOM element.)
