### PR TITLE
Use namespaces for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /examples/*.combined.js
 /examples/example-list.js
 /examples/example-list.xml
+/test/requireall.js

--- a/build.py
+++ b/build.py
@@ -122,17 +122,26 @@ def build_src_external_src_types_js(t):
     t.output('%(PYTHON)s', 'bin/generate-exports.py', '--typedef', 'src/objectliterals.exports')
 
 
-@target('build/src/internal/src/requireall.js', SRC)
-def build_src_internal_src_requireall_js(t):
-    requires = set(('goog.dom',))
-    for dependency in t.dependencies:
+def _build_require_list(dependencies, output_file_name):
+    requires = set()
+    for dependency in dependencies:
         for line in open(dependency):
             match = re.match(r'goog\.provide\(\'(.*)\'\);', line)
             if match:
                 requires.add(match.group(1))
-    with open(t.name, 'w') as f:
+    with open(output_file_name, 'w') as f:
         for require in sorted(requires):
             f.write('goog.require(\'%s\');\n' % (require,))
+
+
+@target('build/src/internal/src/requireall.js', SRC)
+def build_src_internal_src_requireall_js(t):
+    _build_require_list(t.dependencies, t.name)
+
+
+@target('test/requireall.js', SPEC)
+def build_test_requireall_js(t):
+    _build_require_list(t.dependencies, t.name)
 
 
 @target('build/src/internal/src/types.js', 'bin/generate-exports.py', 'src/objectliterals.exports')
@@ -177,9 +186,9 @@ def examples_star_combined_js(name, match):
     return Target(name, action=action, dependencies=dependencies)
 
 
-@target('serve', PLOVR_JAR, INTERNAL_SRC, 'examples')
+@target('serve', PLOVR_JAR, INTERNAL_SRC, 'test/requireall.js', 'examples')
 def serve(t):
-    t.run('%(JAVA)s', '-jar', PLOVR_JAR, 'serve', glob.glob('build/*.json'), glob.glob('examples/*.json'))
+    t.run('%(JAVA)s', '-jar', PLOVR_JAR, 'serve', glob.glob('build/*.json'), glob.glob('examples/*.json'), glob.glob('test/*.json'))
 
 
 @target('serve-precommit', PLOVR_JAR, INTERNAL_SRC)
@@ -246,9 +255,10 @@ def hostexamples(t):
     t.cp('examples/example-list.js', 'examples/example-list.xml', 'examples/Jugl.js', 'build/gh-pages/%(BRANCH)s/examples/')
 
 
-@target('test', INTERNAL_SRC, phony=True)
+@target('test', INTERNAL_SRC, 'test/requireall.js', phony=True)
 def test(t):
     t.run('%(PHANTOMJS)s', 'test/phantom-jasmine/run_jasmine_test.coffee', 'test/ol.html')
+
 
 @target('fixme', phony=True)
 def find_fixme(t):

--- a/test/ol.html
+++ b/test/ol.html
@@ -37,7 +37,7 @@
 
         // Create the script tag which includes the derived variables from above
         var script = '<sc' + 'ript type="text/javascript" '
-            + 'src="http://' + plovrHost + '/compile?id=ol-all&mode=RAW">'
+            + 'src="http://' + plovrHost + '/compile?id=test&mode=RAW">'
             + '</scr' + 'ipt>';
 
         // this function will fix the links of the result to also include
@@ -68,26 +68,6 @@
     })(document, location);
 
   </script>
-
-  <!-- include spec files here... -->
-  <script type="text/javascript" src="spec/ol/array.test.js"></script>
-  <script type="text/javascript" src="spec/ol/collection.test.js"></script>
-  <script type="text/javascript" src="spec/ol/color.test.js"></script>
-  <script type="text/javascript" src="spec/ol/extent.test.js"></script>
-  <script type="text/javascript" src="spec/ol/map.test.js"></script>
-  <script type="text/javascript" src="spec/ol/object.test.js"></script>
-  <script type="text/javascript" src="spec/ol/projection.test.js"></script>
-  <script type="text/javascript" src="spec/ol/rectangle.test.js"></script>
-  <script type="text/javascript" src="spec/ol/resolutionconstraint.test.js"></script>
-  <script type="text/javascript" src="spec/ol/view2d.test.js"></script>
-  <script type="text/javascript" src="spec/ol/layer/layer.test.js"></script>
-  <script type="text/javascript" src="spec/ol/source/xyz.test.js"></script>
-  <script type="text/javascript" src="spec/ol/tilecoord.test.js"></script>
-  <script type="text/javascript" src="spec/ol/tilegrid.test.js"></script>
-  <script type="text/javascript" src="spec/ol/tilequeue.test.js"></script>
-  <script type="text/javascript" src="spec/ol/tilerange.test.js"></script>
-  <script type="text/javascript" src="spec/ol/tileurlfunction.test.js"></script>
-  <script type="text/javascript" src="spec/ol/control/control.test.js"></script>
 
   <script type="text/javascript">
 

--- a/test/spec/ol/array.test.js
+++ b/test/spec/ol/array.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.array');
+
 describe('ol.array', function() {
 
   describe('binaryFindNearest', function() {

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.Collection');
+
 describe('ol.collection', function() {
   var collection;
 

--- a/test/spec/ol/color.test.js
+++ b/test/spec/ol/color.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.Color');
+
 describe('ol.Color', function() {
 
   describe('constructor', function() {

--- a/test/spec/ol/control/control.test.js
+++ b/test/spec/ol/control/control.test.js
@@ -1,6 +1,4 @@
-goog.require('goog.dom');
-goog.require('ol.Map');
-goog.require('ol.control.Control');
+goog.provide('ol.test.control.Control');
 
 describe('ol.control.Control', function() {
   var map, control;
@@ -25,3 +23,7 @@ describe('ol.control.Control', function() {
     });
   });
 });
+
+goog.require('goog.dom');
+goog.require('ol.Map');
+goog.require('ol.control.Control');

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.Extent');
+
 describe('ol.Extent', function() {
 
   describe('contains', function() {

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.layer.Layer');
+
 describe('ol.layer.Layer', function() {
 
   describe('constructor (defaults)', function() {

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -1,12 +1,5 @@
-goog.require('goog.async.AnimationDelay');
-goog.require('goog.dom');
-goog.require('ol.Collection');
-goog.require('ol.Coordinate');
-goog.require('ol.Map');
-goog.require('ol.RendererHint');
-goog.require('ol.View2D');
-goog.require('ol.layer.TileLayer');
-goog.require('ol.source.XYZ');
+goog.provide('ol.test.Map');
+goog.provide('ol.test.RendererHints');
 
 describe('ol.RendererHints', function() {
 
@@ -241,3 +234,13 @@ describe('ol.Map', function() {
   });
 
 });
+
+goog.require('goog.async.AnimationDelay');
+goog.require('goog.dom');
+goog.require('ol.Collection');
+goog.require('ol.Coordinate');
+goog.require('ol.Map');
+goog.require('ol.RendererHint');
+goog.require('ol.View2D');
+goog.require('ol.layer.TileLayer');
+goog.require('ol.source.XYZ');

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.Object');
+
 describe('ol.Object', function() {
 
   var o;

--- a/test/spec/ol/projection.test.js
+++ b/test/spec/ol/projection.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.Projection');
+
 describe('ol.Projection', function() {
 
   describe('projection equivalence', function() {

--- a/test/spec/ol/rectangle.test.js
+++ b/test/spec/ol/rectangle.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.Rectangle');
+
 describe('ol.Rectangle', function() {
 
   describe('getCenter', function() {

--- a/test/spec/ol/resolutionconstraint.test.js
+++ b/test/spec/ol/resolutionconstraint.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.ResolutionConstraint');
+
 describe('ol.ResolutionConstraint', function() {
 
   describe('SnapToResolution', function() {

--- a/test/spec/ol/source/xyz.test.js
+++ b/test/spec/ol/source/xyz.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.source.XYZ');
+
 describe('ol.source.XYZ', function() {
 
   describe('getTileCoordUrl', function() {

--- a/test/spec/ol/tilecoord.test.js
+++ b/test/spec/ol/tilecoord.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.TileCoord');
+
 describe('ol.TileCoord', function() {
 
   describe('create', function() {

--- a/test/spec/ol/tilegrid.test.js
+++ b/test/spec/ol/tilegrid.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.TileGrid');
+
 describe('ol.tilegrid.TileGrid', function() {
   var extent;
   var resolutions;

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.TileQueue');
+
 describe('ol.TileQueue', function() {
 
   // is the tile queue's array a heap?

--- a/test/spec/ol/tilerange.test.js
+++ b/test/spec/ol/tilerange.test.js
@@ -1,3 +1,5 @@
+goog.provide('ol.test.TileRange');
+
 describe('ol.TileRange', function() {
 
   describe('contains', function() {

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -1,5 +1,4 @@
-goog.require('ol.TileUrlFunction');
-goog.require('ol.tilegrid.XYZ');
+goog.provide('ol.test.TileUrlFunction');
 
 describe('ol.TileUrlFunction', function() {
 
@@ -51,7 +50,7 @@ describe('ol.TileUrlFunction', function() {
 
   describe('createFromTileUrlFunctions', function() {
     it('creates expected URL', function() {
-      tileUrl = ol.TileUrlFunction.createFromTileUrlFunctions([
+      var tileUrl = ol.TileUrlFunction.createFromTileUrlFunctions([
           ol.TileUrlFunction.createFromTemplate('a'),
           ol.TileUrlFunction.createFromTemplate('b')
       ]);
@@ -83,3 +82,4 @@ describe('ol.TileUrlFunction', function() {
 
 goog.require('ol.TileCoord');
 goog.require('ol.TileUrlFunction');
+goog.require('ol.tilegrid.XYZ');

--- a/test/spec/ol/view2d.test.js
+++ b/test/spec/ol/view2d.test.js
@@ -1,4 +1,4 @@
-goog.require('ol.View2D');
+goog.provide('ol.test.View2D');
 
 describe('ol.View2D', function() {
   describe('create constraints', function() {
@@ -51,3 +51,5 @@ describe('ol.View2D', function() {
     });
   });
 });
+
+goog.require('ol.View2D');

--- a/test/test.json
+++ b/test/test.json
@@ -1,0 +1,16 @@
+{
+
+  "id": "test",
+
+  "inherits": "../base.json",
+
+  "inputs": [
+    "test/requireall.js"
+  ],
+
+  "paths": [
+    "src",
+    "test"
+  ]
+
+}


### PR DESCRIPTION
With this commit test files provide namespaces (using goog.provide). This fixes the issue reported by @bartvde where goog objects cannot be used in Jasmine "describe" functions. It also frees us from having to add script tags for the test files in test/ol.html.
