### PR TITLE
Simplify control architecture

### DIFF
--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -42,12 +42,13 @@ var domMap = new ol.Map({
   view: view
 });
 
-domMap.getControls().push(new ol.control.MousePosition({
+var domMousePosition = new ol.control.MousePosition({
   coordinateFormat: ol.Coordinate.toStringHDMS,
   projection: ol.Projection.getFromCode('EPSG:4326'),
   target: document.getElementById('domMousePosition'),
   undefinedHTML: '&nbsp;'
-}));
+});
+domMousePosition.setMap(domMap);
 
 var webglMap = new ol.Map({
   renderer: ol.RendererHint.WEBGL,
@@ -58,12 +59,13 @@ if (webglMap !== null) {
   webglMap.bindTo('view', domMap);
 }
 
-webglMap.getControls().push(new ol.control.MousePosition({
+var webglMousePosition = new ol.control.MousePosition({
   coordinateFormat: ol.Coordinate.toStringHDMS,
   projection: ol.Projection.getFromCode('EPSG:4326'),
   target: document.getElementById('webglMousePosition'),
   undefinedHTML: '&nbsp;'
-}));
+});
+webglMousePosition.setMap(webglMap);
 
 var canvasMap = new ol.Map({
   renderer: ol.RendererHint.CANVAS,
@@ -74,12 +76,13 @@ if (canvasMap !== null) {
   canvasMap.bindTo('view', domMap);
 }
 
-canvasMap.getControls().push(new ol.control.MousePosition({
+var canvasMousePosition = new ol.control.MousePosition({
   coordinateFormat: ol.Coordinate.toStringHDMS,
   projection: ol.Projection.getFromCode('EPSG:4326'),
   target: document.getElementById('canvasMousePosition'),
   undefinedHtml: '&nbsp;'
-}));
+});
+canvasMousePosition.setMap(canvasMap);
 
 var keyboardInteraction = new ol.interaction.Keyboard();
 keyboardInteraction.addCallback('0', function() {

--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -1,5 +1,5 @@
 @exportObjectLiteral ol.MapOptions
-@exportObjectLiteralProperty ol.MapOptions.controls ol.Collection|undefined
+@exportObjectLiteralProperty ol.MapOptions.attributionControl boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.doubleClickZoom boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.dragPan boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.interactions ol.Collection|undefined
@@ -13,6 +13,7 @@
 @exportObjectLiteralProperty ol.MapOptions.shiftDragZoom boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.target Element|string
 @exportObjectLiteralProperty ol.MapOptions.view ol.IView|undefined
+@exportObjectLiteralProperty ol.MapOptions.zoomControl boolean|undefined
 @exportObjectLiteralProperty ol.MapOptions.zoomDelta number|undefined
 
 @exportObjectLiteral ol.View2DOptions

--- a/src/ol/control/attribution.exports
+++ b/src/ol/control/attribution.exports
@@ -1,2 +1,3 @@
 @exportClass ol.control.Attribution ol.control.AttributionOptions
+@exportProperty ol.control.Attribution.prototype.setMap
 

--- a/src/ol/control/mouseposition.exports
+++ b/src/ol/control/mouseposition.exports
@@ -1,2 +1,3 @@
 @exportClass ol.control.MousePosition ol.control.MousePositionOptions
+@exportProperty ol.control.MousePosition.prototype.setMap
 

--- a/src/ol/control/zoom.exports
+++ b/src/ol/control/zoom.exports
@@ -1,2 +1,2 @@
 @exportClass ol.control.Zoom ol.control.ZoomOptions
-
+@exportProperty ol.control.Zoom.prototype.setMap

--- a/src/ol/map.exports
+++ b/src/ol/map.exports
@@ -1,7 +1,6 @@
 @exportClass ol.Map ol.MapOptions
 @exportProperty ol.Map.prototype.addPreRenderFunction
 @exportProperty ol.Map.prototype.addPreRenderFunctions
-@exportProperty ol.Map.prototype.getControls
 @exportProperty ol.Map.prototype.getInteractions
 
 @exportSymbol ol.RendererHint

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -22,8 +22,6 @@ goog.require('goog.events.MouseWheelHandler');
 goog.require('goog.events.MouseWheelHandler.EventType');
 goog.require('ol.BrowserFeature');
 goog.require('ol.Collection');
-goog.require('ol.CollectionEvent');
-goog.require('ol.CollectionEventType');
 goog.require('ol.Color');
 goog.require('ol.Coordinate');
 goog.require('ol.Extent');
@@ -234,17 +232,6 @@ ol.Map = function(mapOptions) {
    * @type {ol.Collection}
    * @private
    */
-  this.controls_ = mapOptionsInternal.controls;
-
-  goog.events.listen(this.controls_, ol.CollectionEventType.ADD,
-      this.handleControlsAdd_, false, this);
-  goog.events.listen(this.controls_, ol.CollectionEventType.REMOVE,
-      this.handleControlsRemove_, false, this);
-
-  /**
-   * @type {ol.Collection}
-   * @private
-   */
   this.interactions_ = mapOptionsInternal.interactions;
 
   /**
@@ -299,7 +286,9 @@ ol.Map = function(mapOptions) {
   // this gives the map an initial size
   this.handleBrowserWindowResize();
 
-  this.controls_.forEach(
+  /** @type {Array.<ol.control.Control>} */
+  var controls = mapOptionsInternal.controls;
+  goog.array.forEach(controls,
       /**
        * @param {ol.control.Control} control Control.
        */
@@ -384,14 +373,6 @@ ol.Map.prototype.getRenderer = function() {
  */
 ol.Map.prototype.getTarget = function() {
   return this.target_;
-};
-
-
-/**
- * @return {ol.Collection} Controls.
- */
-ol.Map.prototype.getControls = function() {
-  return this.controls_;
 };
 
 
@@ -520,26 +501,6 @@ ol.Map.prototype.handleBrowserEvent = function(browserEvent, opt_type) {
   var type = opt_type || browserEvent.type;
   var mapBrowserEvent = new ol.MapBrowserEvent(type, this, browserEvent);
   this.handleMapBrowserEvent(mapBrowserEvent);
-};
-
-
-/**
- * @param {ol.CollectionEvent} collectionEvent Collection event.
- * @private
- */
-ol.Map.prototype.handleControlsAdd_ = function(collectionEvent) {
-  var control = /** @type {ol.control.Control} */ (collectionEvent.elem);
-  control.setMap(this);
-};
-
-
-/**
- * @param {ol.CollectionEvent} collectionEvent Collection event.
- * @private
- */
-ol.Map.prototype.handleControlsRemove_ = function(collectionEvent) {
-  var control = /** @type {ol.control.Control} */ (collectionEvent.elem);
-  control.setMap(null);
 };
 
 
@@ -849,7 +810,7 @@ ol.Map.prototype.withFrozenRendering = function(f, opt_obj) {
 
 
 /**
- * @typedef {{controls: ol.Collection,
+ * @typedef {{controls: Array.<ol.control.Control>,
  *            interactions: ol.Collection,
  *            rendererConstructor:
  *                function(new: ol.renderer.Map, Element, ol.Map),
@@ -915,14 +876,9 @@ ol.Map.createOptionsInternal = function(mapOptions) {
   }
 
   /**
-   * @type {ol.Collection}
+   * @type {Array.<ol.control.Control>}
    */
-  var controls;
-  if (goog.isDef(mapOptions.controls)) {
-    controls = mapOptions.controls;
-  } else {
-    controls = ol.Map.createControls_(mapOptions);
-  }
+  var controls = ol.Map.createControls_(mapOptions);
 
   /**
    * @type {ol.Collection}
@@ -953,22 +909,29 @@ ol.Map.createOptionsInternal = function(mapOptions) {
 /**
  * @private
  * @param {ol.MapOptions} mapOptions Map options.
- * @return {ol.Collection} Controls.
+ * @return {Array.<ol.control.Control>} Controls.
  */
 ol.Map.createControls_ = function(mapOptions) {
+  /** @type {Array.<ol.control.Control>} */
+  var controls = [];
 
-  var controls = new ol.Collection();
+  var attributionControl = goog.isDef(mapOptions.attributionControl) ?
+      mapOptions.attributionControl : true;
+  if (attributionControl) {
+    controls.push(new ol.control.Attribution({}));
+  }
 
-  controls.push(new ol.control.Attribution({}));
-
-  var zoomDelta = goog.isDef(mapOptions.zoomDelta) ?
-      mapOptions.zoomDelta : 4;
-  controls.push(new ol.control.Zoom({
-    delta: zoomDelta
-  }));
+  var zoomControl = goog.isDef(mapOptions.zoomControl) ?
+      mapOptions.zoomControl : true;
+  if (zoomControl) {
+    var zoomDelta = goog.isDef(mapOptions.zoomDelta) ?
+        mapOptions.zoomDelta : 4;
+    controls.push(new ol.control.Zoom({
+      delta: zoomDelta
+    }));
+  }
 
   return controls;
-
 };
 
 


### PR DESCRIPTION
Currently the map has a collection of controls, and provides a `getControls` method for accessing the controls collection. For example adding a control to the map is done as follows:

```
map.getControls().push(aControl);
```

When a control is added to a map's controls collection the map calls `setMap(this)` on that control. This gives the control a reference to the map, and the opportunity to add HTML markup to the map's "overlay container".

With the current design we can easily end up with inconsistent states:
- If we "relocate" a control by calling `setMap(map2)` then we end up with the following state: map1 includes the control, while the control has a reference to map2 (and is effectively rendered in map2).
- If we "relocate" a control by calling `map2.getControls().push(aControl)` we also end up with an inconsistent state: map1 and map2 both include the control, while the control has a reference to map2.

I'm suggesting to fix this by simplifying things a bit. I don't think we need maps to reference controls. For now controls can just be objects with setMap functions. This PR implements this. Also, as a convenience, the map constructor can create controls, based on some options passed to the map constructor.

Please review.
