### PR TITLE
(Re)add a reallyclean target to the build.

### DIFF
--- a/build.py
+++ b/build.py
@@ -348,5 +348,16 @@ def find_fixme(t):
         print
     print "A total number of", totalcount, "TODO/FIXME was found"
 
+@target('reallyclean')
+def reallyclean(t):
+    """Removes untracked files and folders from previous builds."""
+    # -X => only clean up files that are usually ignored e.g.
+    #       through .gitignore
+    # -d => also consider directories for deletion
+    # -f => if git configuration variable clean.requireForce != false,
+    #       git clean will refuse to run unless given -f or -n.
+    t.run('%(GIT)s', 'clean', '-X', '-d', '-f', '.')
+
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previously we had both a `clean` and `reallyclean` in our Makefile; both
got lost when we switched to a python build.

A clean 'target' can be invoked by calling the build script with the '-c' flag:

```
./build.py -c
```

This commit readds the `reallyclean` target and lets it clean up a little more
than the Makefiles `clean` or `reallyclean` did. More files are deleted,
but only if these are being ignored inside of the repository (e.g. through
.gitignore files).

Please review.
