### PR TITLE
More natural names for animations

### DIFF
--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -110,7 +110,7 @@ keyboardInteraction.addCallback('H', function() {
   layer.setHue(layer.getHue() + (Math.PI / 5));
 });
 keyboardInteraction.addCallback('j', function() {
-  var bounce = ol.animation.createBounce({
+  var bounce = ol.animation.bounce({
     resolution: 2 * view.getResolution()
   });
   domMap.addPreRenderFunction(bounce);
@@ -118,69 +118,69 @@ keyboardInteraction.addCallback('j', function() {
   canvasMap.addPreRenderFunction(bounce);
 });
 keyboardInteraction.addCallback('l', function() {
-  var panFrom = ol.animation.createPanFrom({
+  var pan = ol.animation.pan({
     source: view.getCenter(),
     easing: ol.easing.elastic
   });
-  domMap.addPreRenderFunction(panFrom);
-  webglMap.addPreRenderFunction(panFrom);
-  canvasMap.addPreRenderFunction(panFrom);
+  domMap.addPreRenderFunction(pan);
+  webglMap.addPreRenderFunction(pan);
+  canvasMap.addPreRenderFunction(pan);
   view.setCenter(LONDON);
 });
 keyboardInteraction.addCallback('L', function() {
   var start = goog.now();
   var duration = 5000;
-  var bounce = ol.animation.createBounce({
+  var bounce = ol.animation.bounce({
     resolution: 2 * view.getResolution(),
     start: start,
     duration: duration
   });
-  var panFrom = ol.animation.createPanFrom({
+  var pan = ol.animation.pan({
     source: view.getCenter(),
     start: start,
     duration: duration
   });
-  var rotateFrom = ol.animation.createRotateFrom({
+  var rotate = ol.animation.rotate({
     rotation: 4 * Math.PI,
     start: start,
     duration: duration
   });
-  var preRenderFunctions = [bounce, panFrom, rotateFrom];
+  var preRenderFunctions = [bounce, pan, rotate];
   domMap.addPreRenderFunctions(preRenderFunctions);
   webglMap.addPreRenderFunctions(preRenderFunctions);
   canvasMap.addPreRenderFunctions(preRenderFunctions);
   view.setCenter(LONDON);
 });
 keyboardInteraction.addCallback('m', function() {
-  var panFrom = ol.animation.createPanFrom({
+  var pan = ol.animation.pan({
     source: view.getCenter(),
     duration: 1000,
     easing: ol.easing.bounce
   });
-  domMap.addPreRenderFunction(panFrom);
-  webglMap.addPreRenderFunction(panFrom);
-  canvasMap.addPreRenderFunction(panFrom);
+  domMap.addPreRenderFunction(pan);
+  webglMap.addPreRenderFunction(pan);
+  canvasMap.addPreRenderFunction(pan);
   view.setCenter(MOSCOW);
 });
 keyboardInteraction.addCallback('M', function() {
   var start = goog.now();
   var duration = 5000;
-  var bounce = ol.animation.createBounce({
+  var bounce = ol.animation.bounce({
     resolution: 2 * view.getResolution(),
     start: start,
     duration: duration
   });
-  var panFrom = ol.animation.createPanFrom({
+  var pan = ol.animation.pan({
     source: view.getCenter(),
     start: start,
     duration: duration
   });
-  var rotateFrom = ol.animation.createRotateFrom({
+  var rotate = ol.animation.rotate({
     rotation: -4 * Math.PI,
     start: start,
     duration: duration
   });
-  var preRenderFunctions = [bounce, panFrom, rotateFrom];
+  var preRenderFunctions = [bounce, pan, rotate];
   domMap.addPreRenderFunctions(preRenderFunctions);
   webglMap.addPreRenderFunctions(preRenderFunctions);
   canvasMap.addPreRenderFunctions(preRenderFunctions);
@@ -206,21 +206,21 @@ keyboardInteraction.addCallback('vV', function() {
   layer.setVisible(!layer.getVisible());
 });
 keyboardInteraction.addCallback('x', function() {
-  var rotateFrom = ol.animation.createRotateFrom({
+  var rotate = ol.animation.rotate({
     rotation: 4 * Math.PI,
     duration: 2000
   });
-  domMap.addPreRenderFunction(rotateFrom);
-  webglMap.addPreRenderFunction(rotateFrom);
-  canvasMap.addPreRenderFunction(rotateFrom);
+  domMap.addPreRenderFunction(rotate);
+  webglMap.addPreRenderFunction(rotate);
+  canvasMap.addPreRenderFunction(rotate);
 });
 keyboardInteraction.addCallback('X', function() {
-  var rotateFrom = ol.animation.createRotateFrom({
+  var rotate = ol.animation.rotate({
     rotation: -4 * Math.PI,
     duration: 2000
   });
-  domMap.addPreRenderFunction(rotateFrom);
-  webglMap.addPreRenderFunction(rotateFrom);
-  canvasMap.addPreRenderFunction(rotateFrom);
+  domMap.addPreRenderFunction(rotate);
+  webglMap.addPreRenderFunction(rotate);
+  canvasMap.addPreRenderFunction(rotate);
 });
 domMap.getInteractions().push(keyboardInteraction);

--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -32,23 +32,23 @@
 @exportObjectLiteralProperty ol.animation.BounceOptions.duration number|undefined
 @exportObjectLiteralProperty ol.animation.BounceOptions.easing function(number):number|undefined
 
-@exportObjectLiteral ol.animation.PanFromOptions
-@exportObjectLiteralProperty ol.animation.PanFromOptions.source ol.Coordinate
-@exportObjectLiteralProperty ol.animation.PanFromOptions.start number|undefined
-@exportObjectLiteralProperty ol.animation.PanFromOptions.duration number|undefined
-@exportObjectLiteralProperty ol.animation.PanFromOptions.easing function(number):number|undefined
+@exportObjectLiteral ol.animation.PanOptions
+@exportObjectLiteralProperty ol.animation.PanOptions.source ol.Coordinate
+@exportObjectLiteralProperty ol.animation.PanOptions.start number|undefined
+@exportObjectLiteralProperty ol.animation.PanOptions.duration number|undefined
+@exportObjectLiteralProperty ol.animation.PanOptions.easing function(number):number|undefined
 
-@exportObjectLiteral ol.animation.RotateFromOptions
-@exportObjectLiteralProperty ol.animation.RotateFromOptions.rotation number
-@exportObjectLiteralProperty ol.animation.RotateFromOptions.start number|undefined
-@exportObjectLiteralProperty ol.animation.RotateFromOptions.duration number|undefined
-@exportObjectLiteralProperty ol.animation.RotateFromOptions.easing function(number):number|undefined
+@exportObjectLiteral ol.animation.RotateOptions
+@exportObjectLiteralProperty ol.animation.RotateOptions.rotation number
+@exportObjectLiteralProperty ol.animation.RotateOptions.start number|undefined
+@exportObjectLiteralProperty ol.animation.RotateOptions.duration number|undefined
+@exportObjectLiteralProperty ol.animation.RotateOptions.easing function(number):number|undefined
 
-@exportObjectLiteral ol.animation.ZoomFromOptions
-@exportObjectLiteralProperty ol.animation.ZoomFromOptions.resolution number
-@exportObjectLiteralProperty ol.animation.ZoomFromOptions.start number|undefined
-@exportObjectLiteralProperty ol.animation.ZoomFromOptions.duration number|undefined
-@exportObjectLiteralProperty ol.animation.ZoomFromOptions.easing function(number):number|undefined
+@exportObjectLiteral ol.animation.ZoomOptions
+@exportObjectLiteralProperty ol.animation.ZoomOptions.resolution number
+@exportObjectLiteralProperty ol.animation.ZoomOptions.start number|undefined
+@exportObjectLiteralProperty ol.animation.ZoomOptions.duration number|undefined
+@exportObjectLiteralProperty ol.animation.ZoomOptions.easing function(number):number|undefined
 
 @exportObjectLiteral ol.control.AttributionOptions
 @exportObjectLiteralProperty ol.control.AttributionOptions.map ol.Map|undefined

--- a/src/ol/animation.exports
+++ b/src/ol/animation.exports
@@ -1,4 +1,4 @@
 @exportSymbol ol.animation
-@exportProperty ol.animation.createBounce
-@exportProperty ol.animation.createPanFrom
-@exportProperty ol.animation.createRotateFrom
+@exportProperty ol.animation.bounce
+@exportProperty ol.animation.pan
+@exportProperty ol.animation.rotate

--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -12,7 +12,7 @@ goog.require('ol.easing');
  * @param {ol.animation.BounceOptions} options Options.
  * @return {ol.PreRenderFunction} Pre-render function.
  */
-ol.animation.createBounce = function(options) {
+ol.animation.bounce = function(options) {
   var resolution = options.resolution;
   var start = goog.isDef(options.start) ? options.start : goog.now();
   var duration = goog.isDef(options.duration) ? options.duration : 1000;
@@ -38,10 +38,10 @@ ol.animation.createBounce = function(options) {
 
 
 /**
- * @param {ol.animation.PanFromOptions} options Options.
+ * @param {ol.animation.PanOptions} options Options.
  * @return {ol.PreRenderFunction} Pre-render function.
  */
-ol.animation.createPanFrom = function(options) {
+ol.animation.pan = function(options) {
   var source = options.source;
   var start = goog.isDef(options.start) ? options.start : goog.now();
   var sourceX = source.x;
@@ -71,10 +71,10 @@ ol.animation.createPanFrom = function(options) {
 
 
 /**
- * @param {ol.animation.RotateFromOptions} options Options.
+ * @param {ol.animation.RotateOptions} options Options.
  * @return {ol.PreRenderFunction} Pre-render function.
  */
-ol.animation.createRotateFrom = function(options) {
+ol.animation.rotate = function(options) {
   var sourceRotation = options.rotation;
   var start = goog.isDef(options.start) ? options.start : goog.now();
   var duration = goog.isDef(options.duration) ? options.duration : 1000;
@@ -102,10 +102,10 @@ ol.animation.createRotateFrom = function(options) {
 
 
 /**
- * @param {ol.animation.ZoomFromOptions} options Options.
+ * @param {ol.animation.ZoomOptions} options Options.
  * @return {ol.PreRenderFunction} Pre-render function.
  */
-ol.animation.createZoomFrom = function(options) {
+ol.animation.zoom = function(options) {
   var sourceResolution = options.resolution;
   var start = goog.isDef(options.start) ? options.start : goog.now();
   var duration = goog.isDef(options.duration) ? options.duration : 1000;

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -84,7 +84,7 @@ ol.interaction.DragPan.prototype.handleDragEnd = function(mapBrowserEvent) {
     var distance = this.kinetic_.getDistance();
     var angle = this.kinetic_.getAngle();
     var center = view.getCenter();
-    this.kineticPreRenderFn_ = this.kinetic_.createPanFrom(center);
+    this.kineticPreRenderFn_ = this.kinetic_.pan(center);
     map.addPreRenderFunction(this.kineticPreRenderFn_);
 
     var centerpx = map.getPixelFromCoordinate(center);

--- a/src/ol/kinetic.js
+++ b/src/ol/kinetic.js
@@ -112,7 +112,7 @@ ol.Kinetic.prototype.end = function() {
  * @param {ol.Coordinate} source Source coordinate for the animation.
  * @return {ol.PreRenderFunction} Pre-render function for kinetic animation.
  */
-ol.Kinetic.prototype.createPanFrom = function(source) {
+ol.Kinetic.prototype.pan = function(source) {
   var decay = this.decay_;
   var initialVelocity = this.initialVelocity_;
   var minVelocity = this.minVelocity_;
@@ -121,7 +121,7 @@ ol.Kinetic.prototype.createPanFrom = function(source) {
     return initialVelocity * (Math.exp((decay * t) * duration) - 1) /
         (minVelocity - initialVelocity);
   };
-  return ol.animation.createPanFrom({
+  return ol.animation.pan({
     source: source,
     duration: duration,
     easing: easingFunction

--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -298,7 +298,7 @@ ol.View2D.prototype.zoom = function(map, delta, opt_anchor, opt_duration) {
   var currentResolution = this.getResolution();
   if (goog.isDef(currentResolution) && goog.isDef(opt_duration)) {
     map.requestRenderFrame();
-    map.addPreRenderFunction(ol.animation.createZoomFrom({
+    map.addPreRenderFunction(ol.animation.zoom({
       resolution: currentResolution,
       duration: opt_duration
     }));


### PR DESCRIPTION
I think `ol.animation.pan` is more natural sounding than `ol.animation.createPanFrom`.  To me, `createPanFrom` suggests that there might be something like `createPanTo` (which leaves `createPanFrom` with little meaning).

Same goes for the rest.
