### PR TITLE
New map 'idle' event

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -575,6 +575,10 @@ ol.Map.prototype.handlePostRender = function() {
     postRenderFunctions[i](this, this.frameState_);
   }
   postRenderFunctions.length = 0;
+  if (this.isIdle()) {
+    this.dispatchEvent(
+        new ol.MapEvent(ol.MapEventType.IDLE, this, this.frameState_));
+  }
 };
 
 

--- a/src/ol/mapevent.js
+++ b/src/ol/mapevent.js
@@ -9,6 +9,7 @@ goog.require('ol.FrameState');
  * @enum {string}
  */
 ol.MapEventType = {
+  IDLE: 'idle',
   POSTRENDER: 'postrender'
 };
 


### PR DESCRIPTION
Add a new `ol.Map.isIdle()` function and event.
My goal is to create a _screenshot_ control to be able to save a map view into an image (using `canvas.toDataURL()`), the control must wait for all the animation to be finished and all the tiles to be loaded.

This control will be more or less:

``` javascript
ol.Screenshot.prototype.take = function() {
  if (this.map.isIdle()) {
    this.saveImage();
  } else {
    goog.events.listenOnce(this.map, 'idle', this.saveImage, false, this);
  }
};
```

Of course, the control must check if the renderer is canvas; otherwise a synchronized and hidden map could be created.

Is it the right direction? Will it works with a single image layer?
