### PR TITLE
Fix the serve-precommit target.

### DIFF
--- a/build.py
+++ b/build.py
@@ -193,7 +193,7 @@ def serve(t):
 
 @target('serve-precommit', PLOVR_JAR, INTERNAL_SRC)
 def serve_precommit(t):
-    t.run('%(JAVA)s', '-jar', PLOVR_JAR, 'serve', 'build/ol-all.json')
+    t.run('%(JAVA)s', '-jar', PLOVR_JAR, 'serve', 'build/ol-all.json', glob.glob('test/*.json'))
 
 
 virtual('lint', 'build/lint-src-timestamp', 'build/lint-spec-timestamp', 'build/check-requires-timestamp')


### PR DESCRIPTION
When the plovr-jar is being invoked in the serve-precommit target, it needs
the JSON files in `test/` as well to have all requirements for headless testing.

This should also reenable running the testsuite on our continuous integration
server.

Please also see this discussion: https://groups.google.com/forum/#!topic/ol3-dev/JBRoGIiTdvs
