### PR TITLE
fixes for the WMS capabilities parser

### DIFF
--- a/examples/wms-capabilities.html
+++ b/examples/wms-capabilities.html
@@ -13,9 +13,9 @@
         height: 100%;
       }
       #log {
-        height: 500px;
         position: absolute;
         top: 130px;
+        font-size: 12px;
       }
       #text {
           position: absolute;

--- a/examples/wms-capabilities.js
+++ b/examples/wms-capabilities.js
@@ -1,26 +1,19 @@
-goog.require('goog.debug.Console');
-goog.require('goog.debug.DivConsole');
-goog.require('goog.debug.Logger');
-goog.require('goog.debug.Logger.Level');
-goog.require('goog.json.Serializer');
-goog.require('goog.net.XhrIo');
 goog.require('ol.parser.ogc.WMSCapabilities');
-
-
-if (goog.DEBUG) {
-  goog.debug.Console.autoInstall();
-  goog.debug.Logger.getLogger('ol').setLevel(goog.debug.Logger.Level.INFO);
-  var logconsole = new goog.debug.DivConsole(goog.dom.getElement('log'));
-  logconsole.setCapturing(true);
-}
 
 var parser = new ol.parser.ogc.WMSCapabilities(), result;
 var url = '../test/spec/ol/parser/ogc/xml/wmscapabilities_v1_3_0/ogcsample.xml';
-goog.net.XhrIo.send(url, function(e) {
-  var xhr = e.target;
-  result = parser.read(xhr.getResponseXml());
-  if (goog.DEBUG) {
-    var output = new goog.json.Serializer().serialize(result);
-    goog.debug.Logger.getLogger('ol').info(output);
+
+var xhr = new XMLHttpRequest();
+xhr.open('GET', url, true);
+
+
+/**
+ * onload handler for the XHR request.
+ */
+xhr.onload = function() {
+  if (xhr.status == 200) {
+    result = parser.read(xhr.responseXML);
+    document.getElementById('log').innerHTML = window.JSON.stringify(result);
   }
-});
+};
+xhr.send();

--- a/src/ol/parser/ogc/wmscapabilities_v1.js
+++ b/src/ol/parser/ogc/wmscapabilities_v1.js
@@ -19,17 +19,17 @@ ol.parser.ogc.WMSCapabilities_v1 = function() {
         this.readChildNodes(node, obj['service']);
       },
       'Name': function(node, obj) {
-        obj.name = this.getChildValue(node);
+        obj['name'] = this.getChildValue(node);
       },
       'Title': function(node, obj) {
-        obj.title = this.getChildValue(node);
+        obj['title'] = this.getChildValue(node);
       },
       'Abstract': function(node, obj) {
         obj['abstract'] = this.getChildValue(node);
       },
       'BoundingBox': function(node, obj) {
         var bbox = {};
-        bbox.bbox = [
+        bbox['bbox'] = [
           parseFloat(node.getAttribute('minx')),
           parseFloat(node.getAttribute('miny')),
           parseFloat(node.getAttribute('maxx')),
@@ -40,96 +40,96 @@ ol.parser.ogc.WMSCapabilities_v1 = function() {
           y: parseFloat(node.getAttribute('resy'))
         };
         if (! (isNaN(res.x) && isNaN(res.y))) {
-          bbox.res = res;
+          bbox['res'] = res;
         }
         // return the bbox so that descendant classes can set the
         // CRS and SRS and add it to the obj
         return bbox;
       },
       'OnlineResource': function(node, obj) {
-        obj.href = this.getAttributeNS(node, 'http://www.w3.org/1999/xlink',
+        obj['href'] = this.getAttributeNS(node, 'http://www.w3.org/1999/xlink',
             'href');
       },
       'ContactInformation': function(node, obj) {
-        obj.contactInformation = {};
-        this.readChildNodes(node, obj.contactInformation);
+        obj['contactInformation'] = {};
+        this.readChildNodes(node, obj['contactInformation']);
       },
       'ContactPersonPrimary': function(node, obj) {
-        obj.personPrimary = {};
-        this.readChildNodes(node, obj.personPrimary);
+        obj['personPrimary'] = {};
+        this.readChildNodes(node, obj['personPrimary']);
       },
       'ContactPerson': function(node, obj) {
-        obj.person = this.getChildValue(node);
+        obj['person'] = this.getChildValue(node);
       },
       'ContactOrganization': function(node, obj) {
-        obj.organization = this.getChildValue(node);
+        obj['organization'] = this.getChildValue(node);
       },
       'ContactPosition': function(node, obj) {
-        obj.position = this.getChildValue(node);
+        obj['position'] = this.getChildValue(node);
       },
       'ContactAddress': function(node, obj) {
-        obj.contactAddress = {};
-        this.readChildNodes(node, obj.contactAddress);
+        obj['contactAddress'] = {};
+        this.readChildNodes(node, obj['contactAddress']);
       },
       'AddressType': function(node, obj) {
-        obj.type = this.getChildValue(node);
+        obj['type'] = this.getChildValue(node);
       },
       'Address': function(node, obj) {
-        obj.address = this.getChildValue(node);
+        obj['address'] = this.getChildValue(node);
       },
       'City': function(node, obj) {
-        obj.city = this.getChildValue(node);
+        obj['city'] = this.getChildValue(node);
       },
       'StateOrProvince': function(node, obj) {
-        obj.stateOrProvince = this.getChildValue(node);
+        obj['stateOrProvince'] = this.getChildValue(node);
       },
       'PostCode': function(node, obj) {
-        obj.postcode = this.getChildValue(node);
+        obj['postcode'] = this.getChildValue(node);
       },
       'Country': function(node, obj) {
-        obj.country = this.getChildValue(node);
+        obj['country'] = this.getChildValue(node);
       },
       'ContactVoiceTelephone': function(node, obj) {
-        obj.phone = this.getChildValue(node);
+        obj['phone'] = this.getChildValue(node);
       },
       'ContactFacsimileTelephone': function(node, obj) {
-        obj.fax = this.getChildValue(node);
+        obj['fax'] = this.getChildValue(node);
       },
       'ContactElectronicMailAddress': function(node, obj) {
-        obj.email = this.getChildValue(node);
+        obj['email'] = this.getChildValue(node);
       },
       'Fees': function(node, obj) {
         var fees = this.getChildValue(node);
         if (fees && fees.toLowerCase() != 'none') {
-          obj.fees = fees;
+          obj['fees'] = fees;
         }
       },
       'AccessConstraints': function(node, obj) {
         var constraints = this.getChildValue(node);
         if (constraints && constraints.toLowerCase() != 'none') {
-          obj.accessConstraints = constraints;
+          obj['accessConstraints'] = constraints;
         }
       },
       'Capability': function(node, obj) {
-        obj.capability = {
-          nestedLayers: [],
-          layers: []
-        };
-        this.readChildNodes(node, obj.capability);
+        obj['capability'] = {};
+        obj['capability']['nestedLayers'] = [];
+        obj['capability']['layers'] = [];
+        this.readChildNodes(node, obj['capability']);
       },
       'Request': function(node, obj) {
-        obj.request = {};
-        this.readChildNodes(node, obj.request);
+        obj['request'] = {};
+        this.readChildNodes(node, obj['request']);
       },
       'GetCapabilities': function(node, obj) {
-        obj.getcapabilities = {formats: []};
-        this.readChildNodes(node, obj.getcapabilities);
+        obj['getcapabilities'] = {};
+        obj['getcapabilities']['formats'] = [];
+        this.readChildNodes(node, obj['getcapabilities']);
       },
       'Format': function(node, obj) {
-        if (goog.isArray(obj.formats)) {
-          obj.formats.push(this.getChildValue(node));
+        if (goog.isArray(obj['formats'])) {
+          obj['formats'].push(this.getChildValue(node));
         } else {
-          obj.format = this.getChildValue(node);
+          obj['format'] = this.getChildValue(node);
         }
       },
       'DCPType': function(node, obj) {
@@ -139,37 +139,32 @@ ol.parser.ogc.WMSCapabilities_v1 = function() {
         this.readChildNodes(node, obj);
       },
       'Get': function(node, obj) {
-        obj.get = {};
-        this.readChildNodes(node, obj.get);
-        // backwards compatibility
-        if (!obj.href) {
-          obj.href = obj.get.href;
-        }
+        obj['get'] = {};
+        this.readChildNodes(node, obj['get']);
       },
       'Post': function(node, obj) {
-        obj.post = {};
-        this.readChildNodes(node, obj.post);
-        // backwards compatibility
-        if (!obj.href) {
-          obj.href = obj.get.href;
-        }
+        obj['post'] = {};
+        this.readChildNodes(node, obj['post']);
       },
       'GetMap': function(node, obj) {
-        obj.getmap = {formats: []};
-        this.readChildNodes(node, obj.getmap);
+        obj['getmap'] = {};
+        obj['getmap']['formats'] = [];
+        this.readChildNodes(node, obj['getmap']);
       },
       'GetFeatureInfo': function(node, obj) {
-        obj.getfeatureinfo = {formats: []};
-        this.readChildNodes(node, obj.getfeatureinfo);
+        obj['getfeatureinfo'] = {};
+        obj['getfeatureinfo']['formats'] = [];
+        this.readChildNodes(node, obj['getfeatureinfo']);
       },
       'Exception': function(node, obj) {
-        obj.exception = {formats: []};
-        this.readChildNodes(node, obj.exception);
+        obj['exception'] = {};
+        obj['exception']['formats'] = [];
+        this.readChildNodes(node, obj['exception']);
       },
       'Layer': function(node, obj) {
         var parentLayer, capability;
-        if (obj.capability) {
-          capability = obj.capability;
+        if (obj['capability']) {
+          capability = obj['capability'];
           parentLayer = obj;
         } else {
           capability = obj;
@@ -188,113 +183,113 @@ ol.parser.ogc.WMSCapabilities_v1 = function() {
         var fixedHeight = node.getAttribute('fixedHeight');
         var parent = parentLayer || {};
         var layer = {
-          nestedLayers: [],
-          styles: parentLayer ? [].concat(parentLayer.styles) : [],
-          srs: {},
-          metadataURLs: [],
-          bbox: {},
-          llbbox: parent.llbbox,
-          dimensions: {},
-          authorityURLs: {},
-          identifiers: {},
-          keywords: [],
-          queryable: (queryable && queryable !== '') ?
+          'nestedLayers': [],
+          'styles': parentLayer ? [].concat(parentLayer['styles']) : [],
+          'srs': {},
+          'metadataURLs': [],
+          'bbox': {},
+          'llbbox': parent['llbbox'],
+          'dimensions': {},
+          'authorityURLs': {},
+          'identifiers': {},
+          'keywords': [],
+          'queryable': (queryable && queryable !== '') ?
               (queryable === '1' || queryable === 'true') :
-              (parent.queryable || false),
-          cascaded: (cascaded !== null) ? parseInt(cascaded, 10) :
-              (parent.cascaded || 0),
-          opaque: opaque ?
+              (parent['queryable'] || false),
+          'cascaded': (cascaded !== null) ? parseInt(cascaded, 10) :
+              (parent['cascaded'] || 0),
+          'opaque': opaque ?
               (opaque === '1' || opaque === 'true') :
-              (parent.opaque || false),
-          noSubsets: (noSubsets !== null) ?
+              (parent['opaque'] || false),
+          'noSubsets': (noSubsets !== null) ?
               (noSubsets === '1' || noSubsets === 'true') :
-              (parent.noSubsets || false),
-          fixedWidth: (fixedWidth !== null) ?
-              parseInt(fixedWidth, 10) : (parent.fixedWidth || 0),
-          fixedHeight: (fixedHeight !== null) ?
-              parseInt(fixedHeight, 10) : (parent.fixedHeight || 0),
-          minScale: parent.minScale,
-          maxScale: parent.maxScale,
-          attribution: parent.attribution
+              (parent['noSubsets'] || false),
+          'fixedWidth': (fixedWidth !== null) ?
+              parseInt(fixedWidth, 10) : (parent['fixedWidth'] || 0),
+          'fixedHeight': (fixedHeight !== null) ?
+              parseInt(fixedHeight, 10) : (parent['fixedHeight'] || 0),
+          'minScale': parent['minScale'],
+          'maxScale': parent['maxScale'],
+          'attribution': parent['attribution']
         };
         if (parentLayer) {
-          goog.object.extend(layer.srs, parent.srs);
-          goog.object.extend(layer.bbox, parent.bbox);
-          goog.object.extend(layer.dimensions, parent.dimensions);
-          goog.object.extend(layer.authorityURLs, parent.authorityURLs);
+          goog.object.extend(layer['srs'], parent['srs']);
+          goog.object.extend(layer['bbox'], parent['bbox']);
+          goog.object.extend(layer['dimensions'], parent['dimensions']);
+          goog.object.extend(layer['authorityURLs'], parent['authorityURLs']);
         }
-        obj.nestedLayers.push(layer);
-        layer.capability = capability;
+        obj['nestedLayers'].push(layer);
+        layer['capability'] = capability;
         this.readChildNodes(node, layer);
-        delete layer.capability;
-        if (layer.name) {
-          var parts = layer.name.split(':'),
-              request = capability.request,
-              gfi = request.getfeatureinfo;
+        delete layer['capability'];
+        if (layer['name']) {
+          var parts = layer['name'].split(':'),
+              request = capability['request'],
+              gfi = request['getfeatureinfo'];
           if (parts.length > 0) {
-            layer.prefix = parts[0];
+            layer['prefix'] = parts[0];
           }
-          capability.layers.push(layer);
-          if (layer.formats === undefined) {
-            layer.formats = request.getmap.formats;
+          capability['layers'].push(layer);
+          if (layer['formats'] === undefined) {
+            layer['formats'] = request['getmap']['formats'];
           }
-          if (layer.infoFormats === undefined && gfi) {
-            layer.infoFormats = gfi.formats;
+          if (layer['infoFormats'] === undefined && gfi) {
+            layer['infoFormats'] = gfi['formats'];
           }
         }
       },
       'Attribution': function(node, obj) {
-        obj.attribution = {};
-        this.readChildNodes(node, obj.attribution);
+        obj['attribution'] = {};
+        this.readChildNodes(node, obj['attribution']);
       },
       'LogoURL': function(node, obj) {
-        obj.logo = {
-          width: node.getAttribute('width'),
-          height: node.getAttribute('height')
+        obj['logo'] = {
+          'width': node.getAttribute('width'),
+          'height': node.getAttribute('height')
         };
-        this.readChildNodes(node, obj.logo);
+        this.readChildNodes(node, obj['logo']);
       },
       'Style': function(node, obj) {
         var style = {};
-        obj.styles.push(style);
+        obj['styles'].push(style);
         this.readChildNodes(node, style);
       },
       'LegendURL': function(node, obj) {
         var legend = {
-          width: node.getAttribute('width'),
-          height: node.getAttribute('height')
+          'width': node.getAttribute('width'),
+          'height': node.getAttribute('height')
         };
-        obj.legend = legend;
+        obj['legend'] = legend;
         this.readChildNodes(node, legend);
       },
       'MetadataURL': function(node, obj) {
-        var metadataURL = {type: node.getAttribute('type')};
-        obj.metadataURLs.push(metadataURL);
+        var metadataURL = {'type': node.getAttribute('type')};
+        obj['metadataURLs'].push(metadataURL);
         this.readChildNodes(node, metadataURL);
       },
       'DataURL': function(node, obj) {
-        obj.dataURL = {};
-        this.readChildNodes(node, obj.dataURL);
+        obj['dataURL'] = {};
+        this.readChildNodes(node, obj['dataURL']);
       },
       'FeatureListURL': function(node, obj) {
-        obj.featureListURL = {};
-        this.readChildNodes(node, obj.featureListURL);
+        obj['featureListURL'] = {};
+        this.readChildNodes(node, obj['featureListURL']);
       },
       'AuthorityURL': function(node, obj) {
         var name = node.getAttribute('name');
         var authority = {};
         this.readChildNodes(node, authority);
-        obj.authorityURLs[name] = authority.href;
+        obj['authorityURLs'][name] = authority['href'];
       },
       'Identifier': function(node, obj) {
         var authority = node.getAttribute('authority');
-        obj.identifiers[authority] = this.getChildValue(node);
+        obj['identifiers'][authority] = this.getChildValue(node);
       },
       'KeywordList': function(node, obj) {
         this.readChildNodes(node, obj);
       },
       'SRS': function(node, obj) {
-        obj.srs[this.getChildValue(node)] = true;
+        obj['srs'][this.getChildValue(node)] = true;
       }
     }
   };

--- a/src/ol/parser/ogc/wmscapabilities_v1_1.js
+++ b/src/ol/parser/ogc/wmscapabilities_v1_1.js
@@ -15,37 +15,37 @@ ol.parser.ogc.WMSCapabilities_v1_1 = function() {
       this.readChildNodes(node, obj);
     },
     'Keyword': function(node, obj) {
-      if (obj.keywords) {
-        obj.keywords.push({value: this.getChildValue(node)});
+      if (obj['keywords']) {
+        obj['keywords'].push({'value': this.getChildValue(node)});
       }
     },
     'DescribeLayer': function(node, obj) {
-      obj.describelayer = {formats: []};
-      this.readChildNodes(node, obj.describelayer);
+      obj['describelayer'] = {'formats': []};
+      this.readChildNodes(node, obj['describelayer']);
     },
     'GetLegendGraphic': function(node, obj) {
-      obj.getlegendgraphic = {formats: []};
-      this.readChildNodes(node, obj.getlegendgraphic);
+      obj['getlegendgraphic'] = {'formats': []};
+      this.readChildNodes(node, obj['getlegendgraphic']);
     },
     'GetStyles': function(node, obj) {
-      obj.getstyles = {formats: []};
-      this.readChildNodes(node, obj.getstyles);
+      obj['getstyles'] = {'formats': []};
+      this.readChildNodes(node, obj['getstyles']);
     },
     'PutStyles': function(node, obj) {
-      obj.putstyles = {formats: []};
-      this.readChildNodes(node, obj.putstyles);
+      obj['putstyles'] = {'formats': []};
+      this.readChildNodes(node, obj['putstyles']);
     },
     'UserDefinedSymbolization': function(node, obj) {
       var userSymbols = {
-        supportSLD: parseInt(node.getAttribute('SupportSLD'), 10) == 1,
-        userLayer: parseInt(node.getAttribute('UserLayer'), 10) == 1,
-        userStyle: parseInt(node.getAttribute('UserStyle'), 10) == 1,
-        remoteWFS: parseInt(node.getAttribute('RemoteWFS'), 10) == 1
+        'supportSLD': parseInt(node.getAttribute('SupportSLD'), 10) == 1,
+        'userLayer': parseInt(node.getAttribute('UserLayer'), 10) == 1,
+        'userStyle': parseInt(node.getAttribute('UserStyle'), 10) == 1,
+        'remoteWFS': parseInt(node.getAttribute('RemoteWFS'), 10) == 1
       };
-      obj.userSymbols = userSymbols;
+      obj['userSymbols'] = userSymbols;
     },
     'LatLonBoundingBox': function(node, obj) {
-      obj.llbbox = [
+      obj['llbbox'] = [
         parseFloat(node.getAttribute('minx')),
         parseFloat(node.getAttribute('miny')),
         parseFloat(node.getAttribute('maxx')),
@@ -54,8 +54,8 @@ ol.parser.ogc.WMSCapabilities_v1_1 = function() {
     },
     'BoundingBox': function(node, obj) {
       var bbox = bboxreader.apply(this, arguments);
-      bbox.srs = node.getAttribute('SRS');
-      obj.bbox[bbox.srs] = bbox;
+      bbox['srs'] = node.getAttribute('SRS');
+      obj['bbox'][bbox['srs']] = bbox;
     },
     'ScaleHint': function(node, obj) {
       var min = parseFloat(node.getAttribute('min'));
@@ -64,33 +64,33 @@ ol.parser.ogc.WMSCapabilities_v1_1 = function() {
       var dpi = (25.4 / 0.28);
       var ipm = 39.37;
       if (min !== 0) {
-        obj.maxScale = parseFloat((min / rad2) * ipm * dpi);
+        obj['maxScale'] = parseFloat((min / rad2) * ipm * dpi);
       }
       if (max != Number.POSITIVE_INFINITY) {
-        obj.minScale = parseFloat((max / rad2) * ipm * dpi);
+        obj['minScale'] = parseFloat((max / rad2) * ipm * dpi);
       }
     },
     'Dimension': function(node, obj) {
       var name = node.getAttribute('name').toLowerCase();
       var dim = {
-        name: name,
-        units: node.getAttribute('units'),
-        unitsymbol: node.getAttribute('unitSymbol')
+        'name': name,
+        'units': node.getAttribute('units'),
+        'unitsymbol': node.getAttribute('unitSymbol')
       };
-      obj.dimensions[dim.name] = dim;
+      obj['dimensions'][dim.name] = dim;
     },
     'Extent': function(node, obj) {
       var name = node.getAttribute('name').toLowerCase();
       if (name in obj['dimensions']) {
-        var extent = obj.dimensions[name];
-        extent.nearestVal =
+        var extent = obj['dimensions'][name];
+        extent['nearestVal'] =
             node.getAttribute('nearestValue') === '1';
-        extent.multipleVal =
+        extent['multipleVal'] =
             node.getAttribute('multipleValues') === '1';
-        extent.current = node.getAttribute('current') === '1';
+        extent['current'] = node.getAttribute('current') === '1';
         extent['default'] = node.getAttribute('default') || '';
         var values = this.getChildValue(node);
-        extent.values = values.split(',');
+        extent['values'] = values.split(',');
       }
     }
   });

--- a/src/ol/parser/ogc/wmscapabilities_v1_1_0.js
+++ b/src/ol/parser/ogc/wmscapabilities_v1_1_0.js
@@ -15,7 +15,7 @@ ol.parser.ogc.WMSCapabilities_v1_1_0 = function() {
       var srs = this.getChildValue(node);
       var values = srs.split(/ +/);
       for (var i = 0, len = values.length; i < len; i++) {
-        obj.srs[values[i]] = true;
+        obj['srs'][values[i]] = true;
       }
     }
   });

--- a/src/ol/parser/ogc/wmscapabilities_v1_1_1.js
+++ b/src/ol/parser/ogc/wmscapabilities_v1_1_1.js
@@ -12,7 +12,7 @@ ol.parser.ogc.WMSCapabilities_v1_1_1 = function() {
   this.version = '1.1.1';
   goog.object.extend(this.readers['http://www.opengis.net/wms'], {
     'SRS': function(node, obj) {
-      obj.srs[this.getChildValue(node)] = true;
+      obj['srs'][this.getChildValue(node)] = true;
     }
   });
 };

--- a/src/ol/parser/ogc/wmscapabilities_v1_1_1_WMSC.js
+++ b/src/ol/parser/ogc/wmscapabilities_v1_1_1_WMSC.js
@@ -12,11 +12,11 @@ ol.parser.ogc.WMSCapabilities_v1_1_1_WMSC = function() {
   this.profile = 'WMSC';
   goog.object.extend(this.readers['http://www.opengis.net/wms'], {
     'VendorSpecificCapabilities': function(node, obj) {
-      obj.vendorSpecific = {tileSets: []};
-      this.readChildNodes(node, obj.vendorSpecific);
+      obj['vendorSpecific'] = {'tileSets': []};
+      this.readChildNodes(node, obj['vendorSpecific']);
     },
     'TileSet': function(node, vendorSpecific) {
-      var tileset = {srs: {}, bbox: {}, resolutions: []};
+      var tileset = {'srs': {}, 'bbox': {}, 'resolutions': []};
       this.readChildNodes(node, tileset);
       vendorSpecific.tileSets.push(tileset);
     },
@@ -24,21 +24,21 @@ ol.parser.ogc.WMSCapabilities_v1_1_1_WMSC = function() {
       var res = this.getChildValue(node).split(' ');
       for (var i = 0, len = res.length; i < len; i++) {
         if (res[i] !== '') {
-          tileset.resolutions.push(parseFloat(res[i]));
+          tileset['resolutions'].push(parseFloat(res[i]));
         }
       }
     },
     'Width': function(node, tileset) {
-      tileset.width = parseInt(this.getChildValue(node), 10);
+      tileset['width'] = parseInt(this.getChildValue(node), 10);
     },
     'Height': function(node, tileset) {
-      tileset.height = parseInt(this.getChildValue(node), 10);
+      tileset['height'] = parseInt(this.getChildValue(node), 10);
     },
     'Layers': function(node, tileset) {
-      tileset.layers = this.getChildValue(node);
+      tileset['layers'] = this.getChildValue(node);
     },
     'Styles': function(node, tileset) {
-      tileset.styles = this.getChildValue(node);
+      tileset['styles'] = this.getChildValue(node);
     }
   });
 };

--- a/src/ol/parser/ogc/wmscapabilities_v1_3_0.js
+++ b/src/ol/parser/ogc/wmscapabilities_v1_3_0.js
@@ -15,18 +15,18 @@ ol.parser.ogc.WMSCapabilities_v1_3_0 = function() {
       this.readChildNodes(node, obj);
     },
     'LayerLimit': function(node, obj) {
-      obj.layerLimit = parseInt(this.getChildValue(node), 10);
+      obj['layerLimit'] = parseInt(this.getChildValue(node), 10);
     },
     'MaxWidth': function(node, obj) {
-      obj.maxWidth = parseInt(this.getChildValue(node), 10);
+      obj['maxWidth'] = parseInt(this.getChildValue(node), 10);
     },
     'MaxHeight': function(node, obj) {
-      obj.maxHeight = parseInt(this.getChildValue(node), 10);
+      obj['maxHeight'] = parseInt(this.getChildValue(node), 10);
     },
     'BoundingBox': function(node, obj) {
       var bbox = bboxreader.apply(this, arguments);
-      bbox.srs = node.getAttribute('CRS');
-      obj.bbox[bbox.srs] = bbox;
+      bbox['srs'] = node.getAttribute('CRS');
+      obj['bbox'][bbox['srs']] = bbox;
     },
     'CRS': function(node, obj) {
       // CRS is the synonym of SRS
@@ -34,8 +34,8 @@ ol.parser.ogc.WMSCapabilities_v1_3_0 = function() {
     },
     'EX_GeographicBoundingBox': function(node, obj) {
       // replacement of LatLonBoundingBox
-      obj.llbbox = [];
-      this.readChildNodes(node, obj.llbbox);
+      obj['llbbox'] = [];
+      this.readChildNodes(node, obj['llbbox']);
     },
     'westBoundLongitude': function(node, obj) {
       obj[0] = this.getChildValue(node);
@@ -50,10 +50,10 @@ ol.parser.ogc.WMSCapabilities_v1_3_0 = function() {
       obj[3] = this.getChildValue(node);
     },
     'MinScaleDenominator': function(node, obj) {
-      obj.maxScale = parseFloat(this.getChildValue(node)).toPrecision(16);
+      obj['maxScale'] = parseFloat(this.getChildValue(node)).toPrecision(16);
     },
     'MaxScaleDenominator': function(node, obj) {
-      obj.minScale = parseFloat(this.getChildValue(node)).toPrecision(16);
+      obj['minScale'] = parseFloat(this.getChildValue(node)).toPrecision(16);
     },
     'Dimension': function(node, obj) {
       // dimension has extra attributes: default, multipleValues,
@@ -61,27 +61,27 @@ ol.parser.ogc.WMSCapabilities_v1_3_0 = function() {
       // also contains the values.
       var name = node.getAttribute('name').toLowerCase();
       var dim = {
-        name: name,
-        units: node.getAttribute('units'),
-        unitsymbol: node.getAttribute('unitSymbol'),
-        nearestVal: node.getAttribute('nearestValue') === '1',
-        multipleVal: node.getAttribute('multipleValues') === '1',
+        'name': name,
+        'units': node.getAttribute('units'),
+        'unitsymbol': node.getAttribute('unitSymbol'),
+        'nearestVal': node.getAttribute('nearestValue') === '1',
+        'multipleVal': node.getAttribute('multipleValues') === '1',
         'default': node.getAttribute('default') || '',
-        current: node.getAttribute('current') === '1',
-        values: this.getChildValue(node).split(',')
+        'current': node.getAttribute('current') === '1',
+        'values': this.getChildValue(node).split(',')
       };
       // Theoretically there can be more dimensions with the same
       // name, but with a different unit. Until we meet such a case,
       // let's just keep the same structure as the WMS 1.1
       // GetCapabilities parser uses. We will store the last
       // one encountered.
-      obj.dimensions[dim.name] = dim;
+      obj['dimensions'][dim['name']] = dim;
     },
     'Keyword': function(node, obj) {
-      var keyword = {value: this.getChildValue(node),
-        vocabulary: node.getAttribute('vocabulary')};
-      if (obj.keywords) {
-        obj.keywords.push(keyword);
+      var keyword = {'value': this.getChildValue(node),
+        'vocabulary': node.getAttribute('vocabulary')};
+      if (obj['keywords']) {
+        obj['keywords'].push(keyword);
       }
     }
   });
@@ -91,9 +91,9 @@ ol.parser.ogc.WMSCapabilities_v1_3_0 = function() {
       readers.UserDefinedSymbolization.apply(this, arguments);
       // add the two extra attributes
       var value = node.getAttribute('InlineFeature');
-      obj['userSymbols'].inlineFeature = parseInt(value, 10) == 1;
+      obj['userSymbols']['inlineFeature'] = parseInt(value, 10) == 1;
       value = node.getAttribute('RemoteWCS');
-      obj['userSymbols'].remoteWCS = parseInt(value, 10) == 1;
+      obj['userSymbols']['remoteWCS'] = parseInt(value, 10) == 1;
     },
     'DescribeLayer': function(node, obj) {
       var readers = this.readers['http://www.opengis.net/wms'];

--- a/test/spec/ol/parser/ogc/exceptionreport.test.js
+++ b/test/spec/ol/parser/ogc/exceptionreport.test.js
@@ -5,93 +5,88 @@ describe('ol.parser.ogc.exceptionreport', function() {
   var parser = new ol.parser.ogc.ExceptionReport();
 
   describe('test read exception', function() {
-    var result, exceptions;
-    var url = 'spec/ol/parser/ogc/xml/exceptionreport/wms1_3_0.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      result = parser.read(xhr.getResponseXml());
-      exceptions = result.exceptionReport.exceptions;
-    });
     it('OCG WMS 1.3.0 exceptions', function() {
-      expect(exceptions.length).toBe(4);
-      var str = 'Plain text message about an error.';
-      expect(goog.string.trim(exceptions[0].text)).toBe(str);
-      expect(exceptions[1].code).toBe('InvalidUpdateSequence');
-      str = ' Another error message, this one with a service exception ' +
-          'code supplied. ';
-      expect(exceptions[1].text).toBe(str);
-      str = 'Error in module <foo.c>, line 42A message that includes angle ' +
-          'brackets in text must be enclosed in a Character Data Section as ' +
-          'in this example. All XML-like markup is ignored except for this ' +
-          'sequence of three closing characters:';
-      expect(goog.string.trim(exceptions[2].text), str);
-      str = '<Module>foo.c</Module> <Error>An error occurred</Error> ' +
-          '<Explanation>Similarly, actual XML can be enclosed in a CDATA ' +
-          'section. A generic parser will ignore that XML, but ' +
-          'application-specific software may choose to process it.' +
-          '</Explanation>';
-      expect(goog.string.trim(exceptions[3].text), str);
+      var result, exceptions;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/exceptionreport/wms1_3_0.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          result = parser.read(xhr.getResponseXml());
+          exceptions = result.exceptionReport.exceptions;
+        });
+      });
+      waitsFor(function() {
+        return (result !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(exceptions.length).toBe(4);
+        var str = 'Plain text message about an error.';
+        expect(goog.string.trim(exceptions[0].text)).toBe(str);
+        expect(exceptions[1].code).toBe('InvalidUpdateSequence');
+        str = ' Another error message, this one with a service exception ' +
+            'code supplied. ';
+        expect(exceptions[1].text).toBe(str);
+        str = 'Error in module <foo.c>, line 42A message that includes angle ' +
+            'brackets in text must be enclosed in a Character Data Section as' +
+            ' in this example. All XML-like markup is ignored except for this' +
+            ' sequence of three closing characters:';
+        expect(goog.string.trim(exceptions[2].text), str);
+        str = '<Module>foo.c</Module> <Error>An error occurred</Error> ' +
+            '<Explanation>Similarly, actual XML can be enclosed in a CDATA ' +
+            'section. A generic parser will ignore that XML, but ' +
+            'application-specific software may choose to process it.' +
+            '</Explanation>';
+        expect(goog.string.trim(exceptions[3].text), str);
+      });
     });
-  });
-
-  describe('test read exception OWSCommon 1.0.0', function() {
-    var result, report, exception;
-    var url = 'spec/ol/parser/ogc/xml/exceptionreport/ows1_0_0.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      result = parser.read(xhr.getResponseXml());
-      report = result.exceptionReport;
-      exception = report.exceptions[0];
+    it('test read exception OWSCommon 1.0.0', function() {
+      var result, report, exception;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/exceptionreport/ows1_0_0.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          result = parser.read(xhr.getResponseXml());
+          report = result.exceptionReport;
+          exception = report.exceptions[0];
+        });
+      });
+      waitsFor(function() {
+        return (result !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(report.version).toEqual('1.0.0');
+        expect(report.language).toEqual('en');
+        expect(exception.code).toEqual('InvalidParameterValue');
+        expect(exception.locator).toEqual('foo');
+        var msg = 'Update error: Error occured updating features';
+        expect(exception.texts[0]).toEqual(msg);
+        msg = 'Second exception line';
+        expect(exception.texts[1]).toEqual(msg);
+      });
     });
-    it('Version parsed correctly', function() {
-      expect(report.version).toEqual('1.0.0');
-    });
-    it('Language parsed correctly', function() {
-      expect(report.language).toEqual('en');
-    });
-    it('exceptionCode properly parsed', function() {
-      expect(exception.code).toEqual('InvalidParameterValue');
-    });
-    it('locator properly parsed', function() {
-      expect(exception.locator).toEqual('foo');
-    });
-    it('ExceptionText correctly parsed', function() {
-      var msg = 'Update error: Error occured updating features';
-      expect(exception.texts[0]).toEqual(msg);
-    });
-    it('Second ExceptionText correctly parsed', function() {
-      var msg = 'Second exception line';
-      expect(exception.texts[1]).toEqual(msg);
-    });
-  });
-
-  describe('test read exception OWSCommon 1.1.0', function() {
-    var result, report, exception;
-    var url = 'spec/ol/parser/ogc/xml/exceptionreport/ows1_1_0.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      result = parser.read(xhr.getResponseXml());
-      report = result.exceptionReport;
-      exception = report.exceptions[0];
-    });
-    it('Version parsed correctly', function() {
-      expect(report.version).toEqual('1.1.0');
-    });
-    it('Language parsed correctly', function() {
-      expect(report.language).toEqual('en');
-    });
-    it('exceptionCode properly parsed', function() {
-      expect(exception.code).toEqual('InvalidParameterValue');
-    });
-    it('locator properly parsed', function() {
-      expect(exception.locator).toEqual('foo');
-    });
-    it('ExceptionText correctly parsed', function() {
-      var msg = 'Update error: Error occured updating features';
-      expect(exception.texts[0]).toEqual(msg);
-    });
-    it('Second ExceptionText correctly parsed', function() {
-      expect(exception.texts[1]).toEqual('Second exception line');
+    it('test read exception OWSCommon 1.1.0', function() {
+      var result, report, exception;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/exceptionreport/ows1_1_0.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          result = parser.read(xhr.getResponseXml());
+          report = result.exceptionReport;
+          exception = report.exceptions[0];
+        });
+      });
+      waitsFor(function() {
+        return (result !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(report.version).toEqual('1.1.0');
+        expect(report.language).toEqual('en');
+        expect(exception.code).toEqual('InvalidParameterValue');
+        expect(exception.locator).toEqual('foo');
+        var msg = 'Update error: Error occured updating features';
+        expect(exception.texts[0]).toEqual(msg);
+        expect(exception.texts[1]).toEqual('Second exception line');
+      });
     });
   });
 });

--- a/test/spec/ol/parser/ogc/wmscapabilities_v1_1_1.test.js
+++ b/test/spec/ol/parser/ogc/wmscapabilities_v1_1_1.test.js
@@ -5,436 +5,307 @@ describe('ol.parser.ogc.wmscapabilities_v1_1_1', function() {
   var parser = new ol.parser.ogc.WMSCapabilities();
 
   describe('test read exception', function() {
-    var obj, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/exceptionsample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-    });
     it('Error reported correctly', function() {
-      expect(!!obj.error).toBeTruthy();
+      var obj;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/' +
+            'exceptionsample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(!!obj.error).toBeTruthy();
+      });
     });
   });
 
   describe('test read', function() {
-    var obj, capability, getmap, describelayer, getfeatureinfo, layer, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/gssample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      capability = obj.capability;
-      getmap = capability.request.getmap;
-      describelayer = capability.request.describelayer;
-      getfeatureinfo = capability.request.getfeatureinfo;
-      layer = capability.layers[2];
-    });
-    it('object contains capability property', function() {
-      expect(capability).toBeTruthy();
-    });
-    it('getmap formats parsed', function() {
-      expect(getmap.formats.length).toEqual(28);
-    });
-    it('getmap href parsed', function() {
-      var url = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
-      expect(getmap.href).toEqual(url);
-    });
-    it('getmap.get.href parsed', function() {
-      expect(getmap.get.href).toEqual(getmap.href);
-    });
-    it('getmap.post not available', function() {
-      expect(getmap.post).toBeUndefined();
-    });
-    it('describelayer href parsed', function() {
-      var url = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
-      expect(describelayer.href).toEqual(url);
-    });
-    it('describelayer.get.href parsed', function() {
-      expect(describelayer.get.href).toEqual(describelayer.href);
-    });
-    it('describelayer.post not available', function() {
-      expect(describelayer.post).toBeUndefined();
-    });
-    it('getfeatureinfo href parsed', function() {
-      var url = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
-      expect(getfeatureinfo.href).toEqual(url);
-    });
-    it('getmap.get.href parsed', function() {
-      expect(getfeatureinfo.get.href).toEqual(getfeatureinfo.href);
-    });
-    it('getfeatureinfo.post set correctly', function() {
-      var url = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
-      expect(getfeatureinfo.post.href).toEqual(url);
-    });
-    it('layers parsed', function() {
-      expect(capability.layers).toBeTruthy();
-    });
-    it('correct number of layers parsed', function() {
-      expect(capability.layers.length).toEqual(22);
-    });
-    it('infoFormats set on layer', function() {
-      var infoFormats = ['text/plain', 'text/html', 'application/vnd.ogc.gml'];
-      expect(layer.infoFormats).toEqual(infoFormats);
-    });
-    it('[2] correct layer name', function() {
-      expect(layer.name).toEqual('tiger:tiger_roads');
-    });
-    it('[2] correct layer prefix', function() {
-      expect(layer.prefix).toEqual('tiger');
-    });
-    it('[2] correct layer title', function() {
-      expect(layer.title).toEqual('Manhattan (NY) roads');
-    });
-    it('[2] correct layer abstract', function() {
-      var abstr = 'Highly simplified road layout of Manhattan in New York..';
-      expect(layer['abstract']).toEqual(abstr);
-    });
-    it('[2] correct layer bbox', function() {
-      var bbox = [-74.08769307536667, 40.660618924633326,
-          -73.84653192463333, 40.90178007536667];
-      expect(layer.llbbox).toEqual(bbox);
-    });
-    it('[2] correct styles length', function() {
-      expect(layer.styles.length).toEqual(1);
-    });
-    it('[2] correct style name', function() {
-      expect(layer.styles[0].name).toEqual('tiger_roads');
-    });
-    it('[2] correct legend url', function() {
-      var url = 'http://publicus.opengeo.org:80/geoserver/wms/' +
+    it('Test read', function() {
+      var obj, capability, getmap, describelayer, getfeatureinfo, layer;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/gssample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          capability = obj.capability;
+          getmap = capability.request.getmap;
+          describelayer = capability.request.describelayer;
+          getfeatureinfo = capability.request.getfeatureinfo;
+          layer = capability.layers[2];
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(capability).toBeTruthy();
+        expect(getmap.formats.length).toEqual(28);
+        var get = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
+        expect(getmap.get.href).toEqual(get);
+        expect(getmap.post).toBeUndefined();
+        get = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
+        expect(describelayer.get.href).toEqual(get);
+        expect(describelayer.post).toBeUndefined();
+        get = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
+        expect(getfeatureinfo.get.href).toEqual(get);
+        var post = 'http://publicus.opengeo.org:80/geoserver/wms?SERVICE=WMS&';
+        expect(getfeatureinfo.post.href).toEqual(post);
+        expect(capability.layers).toBeTruthy();
+        expect(capability.layers.length).toEqual(22);
+        var infoFormats = ['text/plain', 'text/html',
+            'application/vnd.ogc.gml'];
+        expect(layer.infoFormats).toEqual(infoFormats);
+        expect(layer.name).toEqual('tiger:tiger_roads');
+        expect(layer.prefix).toEqual('tiger');
+        expect(layer.title).toEqual('Manhattan (NY) roads');
+        var abstr = 'Highly simplified road layout of Manhattan in New York..';
+        expect(layer['abstract']).toEqual(abstr);
+        var bbox = [-74.08769307536667, 40.660618924633326,
+            -73.84653192463333, 40.90178007536667];
+        expect(layer.llbbox).toEqual(bbox);
+        expect(layer.styles.length).toEqual(1);
+        expect(layer.styles[0].name).toEqual('tiger_roads');
+        var legend = 'http://publicus.opengeo.org:80/geoserver/wms/' +
           'GetLegendGraphic?VERSION=1.0.0&FORMAT=image/png&WIDTH=20&' +
           'HEIGHT=20&LAYER=tiger:tiger_roads';
-      expect(layer.styles[0].legend.href).toEqual(url);
-    });
-    it('[2] correct legend format', function() {
-      expect(layer.styles[0].legend.format).toEqual('image/png');
-    });
-    it('[2] correct queryable attribute', function() {
-      expect(layer.queryable).toBeTruthy();
+        expect(layer.styles[0].legend.href).toEqual(legend);
+        expect(layer.styles[0].legend.format).toEqual('image/png');
+        expect(layer.queryable).toBeTruthy();
+      });
     });
   });
 
   describe('test layers', function() {
-    var obj, capability, layers = {}, rootlayer, identifiers, authorities;
-    var featurelist, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      capability = obj.capability;
-      for (var i = 0, len = capability.layers.length; i < len; i++) {
-        if ('name' in capability.layers[i]) {
-          layers[capability.layers[i].name] = capability.layers[i];
-        }
-      }
-      rootlayer = capability.layers[capability.layers.length - 1];
-      identifiers = layers['ROADS_RIVERS'].identifiers;
-      authorities = layers['ROADS_RIVERS'].authorityURLs;
-      featurelist = layers['ROADS_RIVERS'].featureListURL;
-    });
-    it('SRS parsed correctly for root layer', function() {
-      expect(rootlayer.srs).toEqual({'EPSG:4326': true});
-    });
-    it('Inheritance of SRS handled correctly when adding SRSes', function() {
-      var srs = {'EPSG:4326': true, 'EPSG:26986': true};
-      expect(layers['ROADS_RIVERS'].srs).toEqual(srs);
-    });
-    var msg = 'Inheritance of SRS handled correctly when redeclaring an ' +
-      'inherited SRS';
-    it(msg, function() {
-      expect(layers['Temperature'].srs).toEqual({'EPSG:4326': true});
-    });
-    it('Correct bbox and res from BoundingBox', function() {
-      var bbox = layers['ROADS_RIVERS'].bbox['EPSG:26986'];
-      expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
-      expect(bbox.res).toEqual({x: 1, y: 1});
-    });
-    it('Correct bbox and res from BoundingBox (override)', function() {
-      bbox = layers['ROADS_RIVERS'].bbox['EPSG:4326'];
-      expect(bbox.bbox).toEqual([-71.63, 41.75, -70.78, 42.90]);
-      expect(bbox.res).toEqual({x: 0.01, y: 0.01});
-    });
-    it('Correctly inherited bbox and resolution', function() {
-      bbox = layers['ROADS_1M'].bbox['EPSG:26986'];
-      expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
-      expect(bbox.res).toEqual({x: 1, y: 1});
-    });
-    it('got identifiers from layer ROADS_RIVERS', function() {
-      expect(identifiers).toBeTruthy();
-    });
-    it('authority attribute from Identifiers parsed correctly', function() {
-      expect('DIF_ID' in identifiers).toBeTruthy();
-    });
-    it('Identifier value parsed correctly', function() {
-      expect(identifiers['DIF_ID']).toEqual('123456');
-    });
-    it('AuthorityURLs parsed and inherited correctly', function() {
-      expect('DIF_ID' in authorities).toBeTruthy();
-    });
-    it('OnlineResource in AuthorityURLs parsed correctly', function() {
-      var url = 'http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html';
-      expect(authorities['DIF_ID']).toEqual(url);
-    });
-    it('layer has FeatureListURL', function() {
-      expect(featurelist).toBeTruthy();
-    });
-    it('FeatureListURL format parsed correctly', function() {
-      expect(featurelist.format).toEqual('application/vnd.ogc.se_xml');
-    });
-    it('FeatureListURL OnlineResource parsed correctly', function() {
-      var url = 'http://www.university.edu/data/roads_rivers.gml';
-      expect(featurelist.href).toEqual(url);
-    });
-    it('queryable property inherited correctly', function() {
-      expect(layers['Pressure'].queryable).toBeTruthy();
-    });
-    it('queryable property has correct default value', function() {
-      expect(layers['ozone_image'].queryable).toBeFalsy();
-    });
-    it('cascaded property parsed correctly', function() {
-      expect(layers['population'].cascaded).toEqual(1);
-    });
-    it('fixedWidth property correctly parsed', function() {
-      expect(layers['ozone_image'].fixedWidth).toEqual(512);
-    });
-    it('fixedHeight property correctly parsed', function() {
-      expect(layers['ozone_image'].fixedHeight).toEqual(256);
-    });
-    it('opaque property parsed correctly', function() {
-      expect(layers['ozone_image'].opaque).toBeTruthy();
-    });
-    it('noSubsets property parsed correctly', function() {
-      expect(layers['ozone_image'].noSubsets).toBeTruthy();
+    it('Test layers', function() {
+      var obj, capability, layers = {}, rootlayer, identifiers, authorities;
+      var featurelist;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          capability = obj.capability;
+          for (var i = 0, len = capability.layers.length; i < len; i++) {
+            if ('name' in capability.layers[i]) {
+              layers[capability.layers[i].name] = capability.layers[i];
+            }
+          }
+          rootlayer = capability.layers[capability.layers.length - 1];
+          identifiers = layers['ROADS_RIVERS'].identifiers;
+          authorities = layers['ROADS_RIVERS'].authorityURLs;
+          featurelist = layers['ROADS_RIVERS'].featureListURL;
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(rootlayer.srs).toEqual({'EPSG:4326': true});
+        var srs = {'EPSG:4326': true, 'EPSG:26986': true};
+        expect(layers['ROADS_RIVERS'].srs).toEqual(srs);
+        expect(layers['Temperature'].srs).toEqual({'EPSG:4326': true});
+        var bbox = layers['ROADS_RIVERS'].bbox['EPSG:26986'];
+        expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
+        expect(bbox.res).toEqual({x: 1, y: 1});
+        bbox = layers['ROADS_RIVERS'].bbox['EPSG:4326'];
+        expect(bbox.bbox).toEqual([-71.63, 41.75, -70.78, 42.90]);
+        expect(bbox.res).toEqual({x: 0.01, y: 0.01});
+        bbox = layers['ROADS_1M'].bbox['EPSG:26986'];
+        expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
+        expect(bbox.res).toEqual({x: 1, y: 1});
+        expect(identifiers).toBeTruthy();
+        expect('DIF_ID' in identifiers).toBeTruthy();
+        expect(identifiers['DIF_ID']).toEqual('123456');
+        expect('DIF_ID' in authorities).toBeTruthy();
+        var url = 'http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html';
+        expect(authorities['DIF_ID']).toEqual(url);
+        expect(featurelist).toBeTruthy();
+        expect(featurelist.format).toEqual('application/vnd.ogc.se_xml');
+        url = 'http://www.university.edu/data/roads_rivers.gml';
+        expect(featurelist.href).toEqual(url);
+        expect(layers['Pressure'].queryable).toBeTruthy();
+        expect(layers['ozone_image'].queryable).toBeFalsy();
+        expect(layers['population'].cascaded).toEqual(1);
+        expect(layers['ozone_image'].fixedWidth).toEqual(512);
+        expect(layers['ozone_image'].fixedHeight).toEqual(256);
+        expect(layers['ozone_image'].opaque).toBeTruthy();
+        expect(layers['ozone_image'].noSubsets).toBeTruthy();
+      });
     });
   });
 
   describe('test dimensions', function() {
-     var obj, capability, layers = {}, time, elevation, url;
-     url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
-     goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      capability = obj.capability;
-      for (var i = 0, len = capability.layers.length; i < len; i++) {
-        if ('name' in capability.layers[i]) {
-          layers[capability.layers[i].name] = capability.layers[i];
-        }
-      }
-      time = layers['Clouds'].dimensions.time;
-      elevation = layers['Pressure'].dimensions.elevation;
-    });
-    it('Default time value parsed correctly', function() {
-      expect(time['default']).toEqual('2000-08-22');
-    });
-    it('Currect number of time extent values/periods', function() {
-      expect(time.values.length).toEqual(1);
-    });
-    it('Time extent values parsed correctly', function() {
-      expect(time.values[0]).toEqual('1999-01-01/2000-08-22/P1D');
-    });
-    it('Dimension units parsed correctly', function() {
-      expect(elevation.units).toEqual('EPSG:5030');
-    });
-    it('Default elevation value parsed correctly', function() {
-      expect(elevation['default']).toEqual('0');
-    });
-    it('NearestValue parsed correctly', function() {
-      expect(elevation.nearestVal).toBeTruthy();
-    });
-    it('Absense of MultipleValues handled correctly', function() {
-      expect(elevation.multipleVal).toBeFalsy();
-    });
-    it('Parsing of comma-separated values done correctly', function() {
-      expect(elevation.values).toEqual(['0', '1000', '3000', '5000', '10000']);
+    it('Test dimensions', function() {
+      var obj, capability, layers = {}, time, elevation;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          capability = obj.capability;
+          for (var i = 0, len = capability.layers.length; i < len; i++) {
+            if ('name' in capability.layers[i]) {
+              layers[capability.layers[i].name] = capability.layers[i];
+            }
+          }
+          time = layers['Clouds'].dimensions.time;
+          elevation = layers['Pressure'].dimensions.elevation;
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(time['default']).toEqual('2000-08-22');
+        expect(time.values.length).toEqual(1);
+        expect(time.values[0]).toEqual('1999-01-01/2000-08-22/P1D');
+        expect(elevation.units).toEqual('EPSG:5030');
+        expect(elevation['default']).toEqual('0');
+        expect(elevation.nearestVal).toBeTruthy();
+        expect(elevation.multipleVal).toBeFalsy();
+        expect(elevation.values).toEqual(['0', '1000', '3000', '5000',
+            '10000']);
+      });
     });
   });
 
   describe('test contact info', function() {
-     var obj, service, contactinfo, personPrimary, addr, url;
-     url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
-     goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      service = obj.service;
-      contactinfo = service.contactInformation;
-      personPrimary = contactinfo.personPrimary;
-      addr = contactinfo.contactAddress;
-    });
-    it('object contains contactInformation property', function() {
-      expect(contactinfo).toBeTruthy();
-    });
-    it('object contains personPrimary property', function() {
-      expect(personPrimary).toBeTruthy();
-    });
-    it('ContactPerson parsed correctly', function() {
-      expect(personPrimary.person).toEqual('Jeff deLaBeaujardiere');
-    });
-    it('ContactOrganization parsed correctly', function() {
-      expect(personPrimary.organization).toEqual('NASA');
-    });
-    it('ContactPosition parsed correctly', function() {
-      expect(contactinfo.position).toEqual('Computer Scientist');
-    });
-    it('object contains contactAddress property', function() {
-      expect(addr).toBeTruthy();
-    });
-    it('AddressType parsed correctly', function() {
-      expect(addr.type).toEqual('postal');
-    });
-    it('Address parsed correctly', function() {
-      var address = 'NASA Goddard Space Flight Center, Code 933';
-      expect(addr.address).toEqual(address);
-    });
-    it('City parsed correctly', function() {
-      expect(addr.city).toEqual('Greenbelt');
-    });
-    it('StateOrProvince parsed correctly', function() {
-      expect(addr.stateOrProvince).toEqual('MD');
-    });
-    it('PostCode parsed correctly', function() {
-      expect(addr.postcode).toEqual('20771');
-    });
-    it('Country parsed correctly', function() {
-      expect(addr.country).toEqual('USA');
-    });
-    it('ContactVoiceTelephone parsed correctly', function() {
-      expect(contactinfo.phone).toEqual('+1 301 286-1569');
-    });
-    it('ContactFacsimileTelephone parsed correctly', function() {
-      expect(contactinfo.fax).toEqual('+1 301 286-1777');
-    });
-    it('ContactElectronicMailAddress parsed correctly', function() {
-      expect(contactinfo.email).toEqual('delabeau@iniki.gsfc.nasa.gov');
+     it('Test contact info', function() {
+       var obj, service, contactinfo, personPrimary, addr;
+       runs(function() {
+         var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/' +
+             'ogcsample.xml';
+         goog.net.XhrIo.send(url, function(e) {
+           var xhr = e.target;
+           obj = parser.read(xhr.getResponseXml());
+           service = obj.service;
+           contactinfo = service.contactInformation;
+           personPrimary = contactinfo.personPrimary;
+           addr = contactinfo.contactAddress;
+         });
+       });
+       waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(contactinfo).toBeTruthy();
+        expect(personPrimary).toBeTruthy();
+        expect(personPrimary.person).toEqual('Jeff deLaBeaujardiere');
+        expect(personPrimary.organization).toEqual('NASA');
+        expect(contactinfo.position).toEqual('Computer Scientist');
+        expect(addr).toBeTruthy();
+        expect(addr.type).toEqual('postal');
+        var address = 'NASA Goddard Space Flight Center, Code 933';
+        expect(addr.address).toEqual(address);
+        expect(addr.city).toEqual('Greenbelt');
+        expect(addr.stateOrProvince).toEqual('MD');
+        expect(addr.postcode).toEqual('20771');
+        expect(addr.country).toEqual('USA');
+        expect(contactinfo.phone).toEqual('+1 301 286-1569');
+        expect(contactinfo.fax).toEqual('+1 301 286-1777');
+        expect(contactinfo.email).toEqual('delabeau@iniki.gsfc.nasa.gov');
+      });
     });
   });
 
   describe('Test fees and constraints', function() {
-    var obj, service, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/gssample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      service = obj.service;
-    });
-    it('Fees=none handled correctly', function() {
-      expect('fees' in service).toBeFalsy();
-    });
-    it('AccessConstraints=none handled correctly', function() {
-      expect('accessConstraints' in service).toBeFalsy();
+    it('Test fees and constraints', function() {
+      var obj, service;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/gssample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          service = obj.service;
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect('fees' in service).toBeFalsy();
+        expect('accessConstraints' in service).toBeFalsy();
+      });
     });
   });
 
   describe('Test requests', function() {
-    var obj, request, exception, userSymbols, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/gssample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      request = obj.capability.request;
-      exception = obj.capability.exception;
-      userSymbols = obj.capability.userSymbols;
-    });
-    it('request property exists', function() {
-      expect(request).toBeTruthy();
-    });
-    it('got GetMap request', function() {
-      expect('getmap' in request).toBeTruthy();
-    });
-    it('got GetFeatureInfo request', function() {
-      expect('getfeatureinfo' in request).toBeTruthy();
-    });
-    it('GetFeatureInfo formats correctly parsed', function() {
-      var formats = ['text/plain', 'text/html', 'application/vnd.ogc.gml'];
-      expect(request.getfeatureinfo.formats).toEqual(formats);
-    });
-    it('got DescribeLayer request', function() {
-      expect('describelayer' in request).toBeTruthy();
-    });
-    it('got GetLegendGraphic request', function() {
-      expect('getlegendgraphic' in request).toBeTruthy();
-    });
-    it('exception property exists', function() {
-      expect(exception).toBeTruthy();
-    });
-    it('Exception Format parsed', function() {
-      expect(exception.formats).toEqual(['application/vnd.ogc.se_xml']);
-    });
-    it('userSymbols property exists', function() {
-      expect(userSymbols).toBeTruthy();
-    });
-    it('supportSLD parsed', function() {
-      expect(userSymbols.supportSLD).toBeTruthy();
-    });
-    it('userLayer parsed', function() {
-      expect(userSymbols.userLayer).toBeTruthy();
-    });
-    it('userStyle parsed', function() {
-      expect(userSymbols.userStyle).toBeTruthy();
-    });
-    it('remoteWFS parsed', function() {
-      expect(userSymbols.remoteWFS).toBeTruthy();
+    it('Test requests', function() {
+      var obj, request, exception, userSymbols;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/gssample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          request = obj.capability.request;
+          exception = obj.capability.exception;
+          userSymbols = obj.capability.userSymbols;
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(request).toBeTruthy();
+        expect('getmap' in request).toBeTruthy();
+        expect('getfeatureinfo' in request).toBeTruthy();
+        var formats = ['text/plain', 'text/html', 'application/vnd.ogc.gml'];
+        expect(request.getfeatureinfo.formats).toEqual(formats);
+        expect('describelayer' in request).toBeTruthy();
+        expect('getlegendgraphic' in request).toBeTruthy();
+        expect(exception).toBeTruthy();
+        expect(exception.formats).toEqual(['application/vnd.ogc.se_xml']);
+        expect(userSymbols).toBeTruthy();
+        expect(userSymbols.supportSLD).toBeTruthy();
+        expect(userSymbols.userLayer).toBeTruthy();
+        expect(userSymbols.userStyle).toBeTruthy();
+        expect(userSymbols.remoteWFS).toBeTruthy();
+      });
     });
   });
 
   describe('test ogc', function() {
-    var obj, capability, attribution, keywords, metadataURLs, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      capability = obj.capability;
-      attribution = capability.layers[2].attribution;
-      keywords = capability.layers[0].keywords;
-      metadataURLs = capability.layers[0].metadataURLs;
-    });
-    it('attribution title parsed correctly.', function() {
-      expect(attribution.title).toEqual('State College University');
-    });
-    it('attribution href parsed correctly.', function() {
-      expect(attribution.href).toEqual('http://www.university.edu/');
-    });
-    it('attribution logo url parsed correctly.', function() {
-      var url = 'http://www.university.edu/icons/logo.gif';
-      expect(attribution.logo.href).toEqual(url);
-    });
-    it('attribution logo format parsed correctly.', function() {
-      expect(attribution.logo.format).toEqual('image/gif');
-    });
-    it('attribution logo width parsed correctly.', function() {
-      expect(attribution.logo.width).toEqual('100');
-    });
-    it('attribution logo height parsed correctly.', function() {
-      expect(attribution.logo.height).toEqual('100');
-    });
-    it('layer has 3 keywords.', function() {
-      expect(keywords.length).toEqual(3);
-    });
-    it('1st keyword parsed correctly.', function() {
-      expect(keywords[0].value).toEqual('road');
-    });
-    it('layer has 2 metadata urls.', function() {
-      expect(metadataURLs.length).toEqual(2);
-    });
-    it('type parsed correctly.', function() {
-      expect(metadataURLs[0].type).toEqual('FGDC');
-    });
-    it('format parsed correctly.', function() {
-      expect(metadataURLs[0].format).toEqual('text/plain');
-    });
-    it('href parsed correctly.', function() {
-      var href = 'http://www.university.edu/metadata/roads.txt';
-      expect(metadataURLs[0].href).toEqual(href);
-    });
-    it('layer.minScale is correct', function() {
-      expect(Math.round(capability.layers[0].minScale)).toEqual(250000);
-    });
-    it('layer.maxScale is correct', function() {
-      expect(Math.round(capability.layers[0].maxScale)).toEqual(1000);
-    });
-    it('layer.minScale for max="Infinity" is correct', function() {
-      expect(capability.layers[1].minScale).toBeUndefined();
-    });
-    it('layer.maxScale for min="0" is correct', function() {
-      expect(capability.layers[1].maxScale).toBeUndefined();
+    it('Test ogc', function() {
+      var obj, capability, attribution, keywords, metadataURLs;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1/ogcsample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          capability = obj.capability;
+          attribution = capability.layers[2].attribution;
+          keywords = capability.layers[0].keywords;
+          metadataURLs = capability.layers[0].metadataURLs;
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(attribution.title).toEqual('State College University');
+        expect(attribution.href).toEqual('http://www.university.edu/');
+        var url = 'http://www.university.edu/icons/logo.gif';
+        expect(attribution.logo.href).toEqual(url);
+        expect(attribution.logo.format).toEqual('image/gif');
+        expect(attribution.logo.width).toEqual('100');
+        expect(attribution.logo.height).toEqual('100');
+        expect(keywords.length).toEqual(3);
+        expect(keywords[0].value).toEqual('road');
+        expect(metadataURLs.length).toEqual(2);
+        expect(metadataURLs[0].type).toEqual('FGDC');
+        expect(metadataURLs[0].format).toEqual('text/plain');
+        var href = 'http://www.university.edu/metadata/roads.txt';
+        expect(metadataURLs[0].href).toEqual(href);
+        expect(Math.round(capability.layers[0].minScale)).toEqual(250000);
+        expect(Math.round(capability.layers[0].maxScale)).toEqual(1000);
+        expect(capability.layers[1].minScale).toBeUndefined();
+        expect(capability.layers[1].maxScale).toBeUndefined();
+      });
     });
   });
 

--- a/test/spec/ol/parser/ogc/wmscapabilities_v1_1_1_WMSC.test.js
+++ b/test/spec/ol/parser/ogc/wmscapabilities_v1_1_1_WMSC.test.js
@@ -8,63 +8,62 @@ describe('ol.parser.ogc.wmscapabilities_v1_1_1_wmsc', function() {
   });
 
   describe('test read', function() {
-    var obj, tilesets, tileset, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1_WMSC/wmsc.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      tilesets = obj.capability.vendorSpecific.tileSets;
-      tileset = tilesets[0];
-    });
-    it('We expect 2 tilesets to be parsed', function() {
-      expect(tilesets.length).toEqual(2);
-    });
-    it('BBOX correctly parsed', function() {
-      var bbox = [-13697515.466796875, 5165920.118906248,
-          -13619243.94984375, 5244191.635859374];
-      expect(tileset.bbox['EPSG:900913'].bbox).toEqual(bbox);
-    });
-    it('Format correctly parsed', function() {
-      expect(tileset.format).toEqual('image/png');
-    });
-    it('Height correctly parsed', function() {
-      expect(tileset.height).toEqual(256);
-    });
-    it('Width correctly parsed', function() {
-      expect(tileset.width).toEqual(256);
-    });
-    it('Layers correctly parsed', function() {
-      expect(tileset.layers).toEqual('medford:hydro');
-    });
-    it('SRS correctly parsed', function() {
-      expect(tileset.srs['EPSG:900913']).toBeTruthy();
-    });
-    it('Resolutions correctly parsed', function() {
-      var resolutions = [156543.03390625, 78271.516953125, 39135.7584765625,
-          19567.87923828125, 9783.939619140625, 4891.9698095703125,
-          2445.9849047851562, 1222.9924523925781, 611.4962261962891,
-          305.74811309814453, 152.87405654907226, 76.43702827453613,
-          38.218514137268066, 19.109257068634033, 9.554628534317017,
-          4.777314267158508, 2.388657133579254, 1.194328566789627,
-          0.5971642833948135, 0.29858214169740677, 0.14929107084870338,
-          0.07464553542435169, 0.037322767712175846, 0.018661383856087923,
-          0.009330691928043961, 0.004665345964021981];
-      expect(tileset.resolutions).toEqual(resolutions);
-    });
-    it('Styles correctly parsed', function() {
-      expect(tileset.styles).toEqual('');
+    it('Test read', function() {
+      var obj, tilesets, tileset;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1_WMSC/wmsc.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          tilesets = obj.capability.vendorSpecific.tileSets;
+          tileset = tilesets[0];
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(tilesets.length).toEqual(2);
+        var bbox = [-13697515.466796875, 5165920.118906248,
+            -13619243.94984375, 5244191.635859374];
+        expect(tileset.bbox['EPSG:900913'].bbox).toEqual(bbox);
+        expect(tileset.format).toEqual('image/png');
+        expect(tileset.height).toEqual(256);
+        expect(tileset.width).toEqual(256);
+        expect(tileset.layers).toEqual('medford:hydro');
+        expect(tileset.srs['EPSG:900913']).toBeTruthy();
+        var resolutions = [156543.03390625, 78271.516953125, 39135.7584765625,
+            19567.87923828125, 9783.939619140625, 4891.9698095703125,
+            2445.9849047851562, 1222.9924523925781, 611.4962261962891,
+            305.74811309814453, 152.87405654907226, 76.43702827453613,
+            38.218514137268066, 19.109257068634033, 9.554628534317017,
+            4.777314267158508, 2.388657133579254, 1.194328566789627,
+            0.5971642833948135, 0.29858214169740677, 0.14929107084870338,
+            0.07464553542435169, 0.037322767712175846, 0.018661383856087923,
+            0.009330691928043961, 0.004665345964021981];
+        expect(tileset.resolutions).toEqual(resolutions);
+        expect(tileset.styles).toEqual('');
+      });
     });
   });
 
   describe('test fallback', function() {
-    var obj, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1_WMSC/fallback.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-    });
-    it('layers parsed with allowFallback true', function() {
-      expect(obj.capability.layers.length).toEqual(2);
+    it('Test fallback', function() {
+      var obj;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_1_1_WMSC/' +
+            'fallback.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(obj.capability.layers.length).toEqual(2);
+      });
     });
   });
 

--- a/test/spec/ol/parser/ogc/wmscapabilities_v1_3_0.test.js
+++ b/test/spec/ol/parser/ogc/wmscapabilities_v1_3_0.test.js
@@ -4,293 +4,152 @@ describe('ol.parser.ogc.wmscapabilities_v1_3_0', function() {
 
   var parser = new ol.parser.ogc.WMSCapabilities();
 
-  var obj, capability, layers = {}, rootlayer, identifiers, authorities;
-  var featurelist, time, elevation, service, contactinfo, personPrimary, addr;
-  var request, exception, attribution, keywords, metadataURLs, url;
-  url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_3_0/ogcsample.xml';
-  goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      obj = parser.read(xhr.getResponseXml());
-      capability = obj.capability;
-      for (var i = 0, len = capability.layers.length; i < len; i++) {
-        if ('name' in capability.layers[i]) {
-          layers[capability.layers[i].name] = capability.layers[i];
-        }
-      }
-      rootlayer = capability.layers[capability.layers.length - 1];
-      identifiers = layers['ROADS_RIVERS'].identifiers;
-      authorities = layers['ROADS_RIVERS'].authorityURLs;
-      featurelist = layers['ROADS_RIVERS'].featureListURL;
-      time = layers['Clouds'].dimensions.time;
-      elevation = layers['Pressure'].dimensions.elevation;
-      service = obj.service;
-      contactinfo = service.contactInformation;
-      personPrimary = contactinfo.personPrimary;
-      addr = contactinfo.contactAddress;
-      request = obj.capability.request;
-      exception = obj.capability.exception;
-      attribution = capability.layers[2].attribution;
-      keywords = capability.layers[0].keywords;
-      metadataURLs = capability.layers[0].metadataURLs;
-  });
-
   describe('test read exception', function() {
-    var result, url;
-    url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_3_0/exceptionsample.xml';
-    goog.net.XhrIo.send(url, function(e) {
-      var xhr = e.target;
-      result = parser.read(xhr.getResponseXml());
-    });
     it('Error reported correctly', function() {
-      expect(!!result.error).toBe(true);
+      var result;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_3_0/' +
+            'exceptionsample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          result = parser.read(xhr.getResponseXml());
+        });
+      });
+      waitsFor(function() {
+        return (result !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(!!result.error).toBe(true);
+      });
     });
   });
 
-  describe('test layers', function() {
-    it('SRS parsed correctly for root layer', function() {
-      expect(rootlayer.srs).toEqual({'CRS:84': true});
-    });
-    it('Inheritance of SRS handled correctly when adding SRSes', function() {
-      var srs = {'CRS:84': true, 'EPSG:26986': true};
-      expect(layers['ROADS_RIVERS'].srs).toEqual(srs);
-    });
-    it('Inheritance of SRS handled correctly when redeclaring an' +
-      ' inherited SRS', function() {
+  describe('test read', function() {
+    it('Test read', function() {
+      var obj, capability, layers = {}, rootlayer, identifiers, authorities;
+      var featurelist, time, elevation, service, contactinfo, personPrimary,
+          addr, request, exception, attribution, keywords, metadataURLs;
+      runs(function() {
+        var url = 'spec/ol/parser/ogc/xml/wmscapabilities_v1_3_0/ogcsample.xml';
+        goog.net.XhrIo.send(url, function(e) {
+          var xhr = e.target;
+          obj = parser.read(xhr.getResponseXml());
+          capability = obj.capability;
+          for (var i = 0, len = capability.layers.length; i < len; i++) {
+            if ('name' in capability.layers[i]) {
+              layers[capability.layers[i].name] = capability.layers[i];
+            }
+          }
+          rootlayer = capability.layers[capability.layers.length - 1];
+          identifiers = layers['ROADS_RIVERS'].identifiers;
+          authorities = layers['ROADS_RIVERS'].authorityURLs;
+          featurelist = layers['ROADS_RIVERS'].featureListURL;
+          time = layers['Clouds'].dimensions.time;
+          elevation = layers['Pressure'].dimensions.elevation;
+          service = obj.service;
+          contactinfo = service.contactInformation;
+          personPrimary = contactinfo.personPrimary;
+          addr = contactinfo.contactAddress;
+          request = obj.capability.request;
+          exception = obj.capability.exception;
+          attribution = capability.layers[2].attribution;
+          keywords = capability.layers[0].keywords;
+          metadataURLs = capability.layers[0].metadataURLs;
+        });
+      });
+      waitsFor(function() {
+        return (obj !== undefined);
+      }, 'XHR timeout', 1000);
+      runs(function() {
+        expect(rootlayer.srs).toEqual({'CRS:84': true});
+        var srs = {'CRS:84': true, 'EPSG:26986': true};
+        expect(layers['ROADS_RIVERS'].srs).toEqual(srs);
         expect(layers['Temperature'].srs).toEqual({'CRS:84': true});
-    });
-    it('infoFormats set correctly on layer', function() {
-      var infoFormats = ['text/xml', 'text/plain', 'text/html'];
-      expect(layers['Temperature'].infoFormats).toEqual(infoFormats);
-    });
-    it('Correct resolution and bbox from BoundingBox', function() {
-      var bbox = layers['ROADS_RIVERS'].bbox['EPSG:26986'];
-      expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
-      expect(bbox.res).toEqual({x: 1, y: 1});
-    });
-    it('Correct resolution and bbox from BoundingBox (override)', function() {
-      var bbox = layers['ROADS_RIVERS'].bbox['CRS:84'];
-      expect(bbox.bbox).toEqual([-71.63, 41.75, -70.78, 42.90]);
-      expect(bbox.res).toEqual({x: 0.01, y: 0.01});
-    });
-    it('Correctly inherited bbox and resolution', function() {
-      var bbox = layers['ROADS_1M'].bbox['EPSG:26986'];
-      expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
-      expect(bbox.res).toEqual({x: 1, y: 1});
-    });
-    it('got identifiers from layer ROADS_RIVERS', function() {
-      expect(identifiers).toBeTruthy();
-    });
-    it('authority attribute from Identifiers parsed correctly', function() {
-      expect('DIF_ID' in identifiers).toBeTruthy();
-    });
-    it('Identifier value parsed correctly', function() {
-      expect(identifiers['DIF_ID']).toEqual('123456');
-    });
-    it('AuthorityURLs parsed and inherited correctly', function() {
-      expect('DIF_ID' in authorities).toBeTruthy();
-    });
-    it('OnlineResource in AuthorityURLs parsed correctly', function() {
-      var url = 'http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html';
-      expect(authorities['DIF_ID']).toEqual(url);
-    });
-    it('layer has FeatureListURL', function() {
-      expect(featurelist).toBeTruthy();
-    });
-    it('FeatureListURL format parsed correctly', function() {
-      expect(featurelist.format).toEqual('XML');
-    });
-    it('FeatureListURL OnlineResource parsed correctly', function() {
-      var url = 'http://www.university.edu/data/roads_rivers.gml';
-      expect(featurelist.href).toEqual(url);
-    });
-    it('queryable property inherited correctly', function() {
-      expect(layers['Pressure'].queryable).toBeTruthy();
-    });
-    it('queryable property has correct default value', function() {
-      expect(layers['ozone_image'].queryable).toBeFalsy();
-    });
-    it('cascaded property parsed correctly', function() {
-      expect(layers['population'].cascaded).toEqual(1);
-    });
-    it('fixedWidth property correctly parsed', function() {
-      expect(layers['ozone_image'].fixedWidth).toEqual(512);
-    });
-    it('fixedHeight property correctly parsed', function() {
-      expect(layers['ozone_image'].fixedHeight).toEqual(256);
-    });
-    it('opaque property parsed correctly', function() {
-      expect(layers['ozone_image'].opaque).toBeTruthy();
-    });
-    it('noSubsets property parsed correctly', function() {
-      expect(layers['ozone_image'].noSubsets).toBeTruthy();
-    });
-  });
-
-  describe('test dimensions', function() {
-    it('Default time value parsed correctly', function() {
-      expect(time['default']).toEqual('2000-08-22');
-    });
-    it('Currect number of time extent values/periods', function() {
-      expect(time.values.length).toEqual(1);
-    });
-    it('Time extent values parsed correctly', function() {
-      expect(time.values[0]).toEqual('1999-01-01/2000-08-22/P1D');
-    });
-    it('Dimension units parsed correctly', function() {
-      expect(elevation.units).toEqual('CRS:88');
-    });
-    it('Default elevation value parsed correctly', function() {
-      expect(elevation['default']).toEqual('0');
-    });
-    it('NearestValue parsed correctly', function() {
-      expect(elevation.nearestVal).toBeTruthy();
-    });
-    it('Absense of MultipleValues handled correctly', function() {
-      expect(elevation.multipleVal).toBeFalsy();
-    });
-    it('Parsing of comma-separated values done correctly', function() {
-      expect(elevation.values).toEqual(['0', '1000', '3000', '5000', '10000']);
+        var infoFormats = ['text/xml', 'text/plain', 'text/html'];
+        expect(layers['Temperature'].infoFormats).toEqual(infoFormats);
+        var bbox = layers['ROADS_RIVERS'].bbox['EPSG:26986'];
+        expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
+        expect(bbox.res).toEqual({x: 1, y: 1});
+        bbox = layers['ROADS_RIVERS'].bbox['CRS:84'];
+        expect(bbox.bbox).toEqual([-71.63, 41.75, -70.78, 42.90]);
+        expect(bbox.res).toEqual({x: 0.01, y: 0.01});
+        bbox = layers['ROADS_1M'].bbox['EPSG:26986'];
+        expect(bbox.bbox).toEqual([189000, 834000, 285000, 962000]);
+        expect(bbox.res).toEqual({x: 1, y: 1});
+        expect(identifiers).toBeTruthy();
+        expect('DIF_ID' in identifiers).toBeTruthy();
+        expect(identifiers['DIF_ID']).toEqual('123456');
+        expect('DIF_ID' in authorities).toBeTruthy();
+        var url = 'http://gcmd.gsfc.nasa.gov/difguide/whatisadif.html';
+        expect(authorities['DIF_ID']).toEqual(url);
+        expect(featurelist).toBeTruthy();
+        expect(featurelist.format).toEqual('XML');
+        url = 'http://www.university.edu/data/roads_rivers.gml';
+        expect(featurelist.href).toEqual(url);
+        expect(layers['Pressure'].queryable).toBeTruthy();
+        expect(layers['ozone_image'].queryable).toBeFalsy();
+        expect(layers['population'].cascaded).toEqual(1);
+        expect(layers['ozone_image'].fixedWidth).toEqual(512);
+        expect(layers['ozone_image'].fixedHeight).toEqual(256);
+        expect(layers['ozone_image'].opaque).toBeTruthy();
+        expect(layers['ozone_image'].noSubsets).toBeTruthy();
+        expect(time['default']).toEqual('2000-08-22');
+        expect(time.values.length).toEqual(1);
+        expect(time.values[0]).toEqual('1999-01-01/2000-08-22/P1D');
+        expect(elevation.units).toEqual('CRS:88');
+        expect(elevation['default']).toEqual('0');
+        expect(elevation.nearestVal).toBeTruthy();
+        expect(elevation.multipleVal).toBeFalsy();
+        expect(elevation.values).toEqual(['0', '1000', '3000', '5000',
+            '10000']);
+        expect(contactinfo).toBeTruthy();
+        expect(personPrimary).toBeTruthy();
+        expect(personPrimary.person).toEqual('Jeff Smith');
+        expect(personPrimary.organization).toEqual('NASA');
+        expect(contactinfo.position).toEqual('Computer Scientist');
+        expect(addr).toBeTruthy();
+        expect(addr.type).toEqual('postal');
+        expect(addr.address).toEqual('NASA Goddard Space Flight Center');
+        expect(addr.city).toEqual('Greenbelt');
+        expect(addr.stateOrProvince).toEqual('MD');
+        expect(addr.postcode).toEqual('20771');
+        expect(addr.country).toEqual('USA');
+        expect(contactinfo.phone).toEqual('+1 301 555-1212');
+        expect(contactinfo.email).toEqual('user@host.com');
+        expect('fees' in service).toBeFalsy();
+        expect('accessConstraints' in service).toBeFalsy();
+        expect(request).toBeTruthy();
+        expect('getmap' in request).toBeTruthy();
+        expect('getfeatureinfo' in request).toBeTruthy();
+        var formats = ['text/xml', 'text/plain', 'text/html'];
+        expect(request.getfeatureinfo.formats).toEqual(formats);
+        expect(exception).toBeTruthy();
+        formats = ['XML', 'INIMAGE', 'BLANK'];
+        expect(exception.formats).toEqual(formats);
+        expect(attribution.title).toEqual('State College University');
+        expect(attribution.href).toEqual('http://www.university.edu/');
+        url = 'http://www.university.edu/icons/logo.gif';
+        expect(attribution.logo.href).toEqual(url);
+        expect(attribution.logo.format).toEqual('image/gif');
+        expect(attribution.logo.width).toEqual('100');
+        expect(attribution.logo.height).toEqual('100');
+        expect(keywords.length).toEqual(3);
+        expect(keywords[0].value).toEqual('road');
+        expect(metadataURLs.length).toEqual(2);
+        expect(metadataURLs[0].type).toEqual('FGDC:1998');
+        expect(metadataURLs[0].format).toEqual('text/plain');
+        url = 'http://www.university.edu/metadata/roads.txt';
+        expect(metadataURLs[0].href).toEqual(url);
+        var minScale = 250000;
+        expect(capability.layers[0].minScale).toEqual(minScale.toPrecision(16));
+        var maxScale = 1000;
+        expect(capability.layers[0].maxScale).toEqual(maxScale.toPrecision(16));
+        expect(obj.service.layerLimit).toEqual(16);
+        expect(obj.service.maxHeight).toEqual(2048);
+        expect(obj.service.maxWidth).toEqual(2048);
+      });
     });
   });
-
-  describe('test contact info', function() {
-    it('object contains contactInformation property', function() {
-      expect(contactinfo).toBeTruthy();
-    });
-    it('object contains personPrimary property', function() {
-      expect(personPrimary).toBeTruthy();
-    });
-    it('ContactPerson parsed correctly', function() {
-      expect(personPrimary.person).toEqual('Jeff Smith');
-    });
-    it('ContactOrganization parsed correctly', function() {
-      expect(personPrimary.organization).toEqual('NASA');
-    });
-    it('ContactPosition parsed correctly', function() {
-      expect(contactinfo.position).toEqual('Computer Scientist');
-    });
-    it('object contains contactAddress property', function() {
-      expect(addr).toBeTruthy();
-    });
-    it('AddressType parsed correctly', function() {
-      expect(addr.type).toEqual('postal');
-    });
-    it('Address parsed correctly', function() {
-      expect(addr.address).toEqual('NASA Goddard Space Flight Center');
-    });
-    it('City parsed correctly', function() {
-      expect(addr.city).toEqual('Greenbelt');
-    });
-    it('StateOrProvince parsed correctly', function() {
-      expect(addr.stateOrProvince).toEqual('MD');
-    });
-    it('PostCode parsed correctly', function() {
-      expect(addr.postcode).toEqual('20771');
-    });
-    it('Country parsed correctly', function() {
-      expect(addr.country).toEqual('USA');
-    });
-    it('ContactVoiceTelephone parsed correctly', function() {
-      expect(contactinfo.phone).toEqual('+1 301 555-1212');
-    });
-    it('ContactElectronicMailAddress parsed correctly', function() {
-      expect(contactinfo.email).toEqual('user@host.com');
-    });
-  });
-
-  describe('test fees and constraints', function() {
-    it('Fees=none handled correctly', function() {
-      expect('fees' in service).toBeFalsy();
-    });
-    it('AccessConstraints=none handled correctly', function() {
-      expect('accessConstraints' in service).toBeFalsy();
-    });
-  });
-
-  describe('test requests', function() {
-    it('request property exists', function() {
-      expect(request).toBeTruthy();
-    });
-    it('got GetMap request', function() {
-      expect('getmap' in request).toBeTruthy();
-    });
-    it('got GetFeatureInfo request', function() {
-      expect('getfeatureinfo' in request).toBeTruthy();
-    });
-    it('GetFeatureInfo formats correctly parsed', function() {
-      var formats = ['text/xml', 'text/plain', 'text/html'];
-      expect(request.getfeatureinfo.formats).toEqual(formats);
-    });
-    it('exception property exists', function() {
-      expect(exception).toBeTruthy();
-    });
-    it('Exception Format parsed', function() {
-      var formats = ['XML', 'INIMAGE', 'BLANK'];
-      expect(exception.formats).toEqual(formats);
-    });
-  });
-
-  describe('test ogc', function() {
-    it('attribution title parsed correctly.', function() {
-      expect(attribution.title).toEqual('State College University');
-    });
-    it('attribution href parsed correctly.', function() {
-      expect(attribution.href).toEqual('http://www.university.edu/');
-    });
-    it('attribution logo url parsed correctly.', function() {
-      var url = 'http://www.university.edu/icons/logo.gif';
-      expect(attribution.logo.href).toEqual(url);
-    });
-    it('attribution logo format parsed correctly.', function() {
-      expect(attribution.logo.format).toEqual('image/gif');
-    });
-    it('attribution logo width parsed correctly.', function() {
-      expect(attribution.logo.width).toEqual('100');
-    });
-    it('attribution logo height parsed correctly.', function() {
-      expect(attribution.logo.height).toEqual('100');
-    });
-    it('layer has 3 keywords.', function() {
-      expect(keywords.length).toEqual(3);
-    });
-    it('1st keyword parsed correctly.', function() {
-      expect(keywords[0].value).toEqual('road');
-    });
-    it('layer has 2 metadata urls.', function() {
-      expect(metadataURLs.length).toEqual(2);
-    });
-    it('type parsed correctly.', function() {
-      expect(metadataURLs[0].type).toEqual('FGDC:1998');
-    });
-    it('format parsed correctly.', function() {
-      expect(metadataURLs[0].format).toEqual('text/plain');
-    });
-    it('href parsed correctly.', function() {
-      var url = 'http://www.university.edu/metadata/roads.txt';
-      expect(metadataURLs[0].href).toEqual(url);
-    });
-    it('layer.minScale is correct', function() {
-      var minScale = 250000;
-      expect(capability.layers[0].minScale).toEqual(minScale.toPrecision(16));
-    });
-    it('layer.maxScale is correct', function() {
-      var maxScale = 1000;
-      expect(capability.layers[0].maxScale).toEqual(maxScale.toPrecision(16));
-    });
-  });
-
-  describe('test WMS 1.3 specials', function() {
-    it('LayerLimit parsed correctly', function() {
-      expect(obj.service.layerLimit).toEqual(16);
-    });
-    it('MaxHeight parsed correctly', function() {
-      expect(obj.service.maxHeight).toEqual(2048);
-    });
-    it('MaxWidth parsed correctly', function() {
-      expect(obj.service.maxWidth).toEqual(2048);
-    });
-  });
-
 });
 
 goog.require('goog.net.XhrIo');


### PR DESCRIPTION
This PR fixes several issues with the WMS capabilities parser:
- make sure the output objects from the read method have a consistent structure
- make sure the example works when deployed and also outputs something when debug is not true
- git rid of some code which was used for backwards compatibility
