### PR TITLE
Share common code to find loaded tiles

### DIFF
--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -129,8 +129,11 @@ ol.renderer.canvas.TileLayer.prototype.renderFrame =
   var tilesToDrawByZ = {};
   tilesToDrawByZ[z] = {};
 
+  function isLoaded(tile) {
+    return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED;
+  }
   var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
-      tilesToDrawByZ);
+      tilesToDrawByZ, isLoaded);
 
   var allTilesLoaded = true;
   var tile, tileCenter, tileCoord, tileState, x, y;

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -93,8 +93,11 @@ ol.renderer.dom.TileLayer.prototype.renderFrame =
   var tilesToDrawByZ = {};
   tilesToDrawByZ[z] = {};
 
+  function isLoaded(tile) {
+    return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED;
+  }
   var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
-      tilesToDrawByZ);
+      tilesToDrawByZ, isLoaded);
 
   var allTilesLoaded = true;
   var tile, tileCenter, tileCoord, tileState, x, y;

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -365,8 +365,12 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame =
     var tilesToDrawByZ = {};
     tilesToDrawByZ[z] = {};
 
+    function isLoaded(tile) {
+      return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED &&
+          mapRenderer.isTileTextureLoaded(tile);
+    }
     var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
-        tilesToDrawByZ);
+        tilesToDrawByZ, isLoaded);
 
     var tilesToLoad = new goog.structs.PriorityQueue();
 

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -8,7 +8,6 @@ goog.require('ol.Projection');
 goog.require('ol.Tile');
 goog.require('ol.TileCoord');
 goog.require('ol.TileRange');
-goog.require('ol.TileState');
 goog.require('ol.source.Source');
 goog.require('ol.tilegrid.TileGrid');
 
@@ -66,16 +65,17 @@ ol.source.TileSource.prototype.expireCache = goog.abstractMethod;
  *
  * @param {Object.<number, Object.<string, ol.Tile>>} loadedTilesByZ A lookup of
  *     loaded tiles by zoom level.
+ * @param {function(ol.Tile): boolean} isLoaded A function to determine if a
+ *     tile is fully loaded.
  * @param {number} z Zoom level.
  * @param {ol.TileRange} tileRange Tile range.
  * @return {boolean} The tile range is fully covered with loaded tiles.
  */
-ol.source.TileSource.prototype.findLoadedTiles = function(loadedTilesByZ, z,
-    tileRange) {
+ol.source.TileSource.prototype.findLoadedTiles = function(loadedTilesByZ,
+    isLoaded, z, tileRange) {
   // FIXME this could be more efficient about filling partial holes
   var fullyCovered = true;
   var tile, tileCoord, tileCoordKey, x, y;
-  // TODO: tile range is misunderstood (inclusive or not?)
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
       tileCoord = new ol.TileCoord(z, x, y);
@@ -84,7 +84,7 @@ ol.source.TileSource.prototype.findLoadedTiles = function(loadedTilesByZ, z,
         continue;
       }
       tile = this.getTile(tileCoord);
-      if (!goog.isNull(tile) && tile.getState() == ol.TileState.LOADED) {
+      if (isLoaded(tile)) {
         if (!loadedTilesByZ[z]) {
           loadedTilesByZ[z] = {};
         }

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -14,6 +14,10 @@ describe('ol.source.TileSource', function() {
 
   describe('#findLoadedTiles()', function() {
 
+    function isLoaded(tile) {
+      return !goog.isNull(tile) && tile.getState() === ol.TileState.LOADED;
+    }
+
     it('adds no tiles if none are already loaded', function() {
       // a source with no loaded tiles
       var source = new ol.test.source.MockTileSource({});
@@ -21,7 +25,7 @@ describe('ol.source.TileSource', function() {
       var loadedTilesByZ = {};
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 3);
-      source.findLoadedTiles(loadedTilesByZ, 3, range);
+      source.findLoadedTiles(loadedTilesByZ, isLoaded, 3, range);
 
       var keys = goog.object.getKeys(loadedTilesByZ);
       expect(keys.length).toBe(0);
@@ -37,7 +41,7 @@ describe('ol.source.TileSource', function() {
       var loadedTilesByZ = {};
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 0);
-      source.findLoadedTiles(loadedTilesByZ, 0, range);
+      source.findLoadedTiles(loadedTilesByZ, isLoaded, 0, range);
       var keys = goog.object.getKeys(loadedTilesByZ);
       expect(keys.length).toBe(1);
       var tile = loadedTilesByZ['0']['0/0/0'];
@@ -55,7 +59,7 @@ describe('ol.source.TileSource', function() {
       var loadedTilesByZ = {};
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 1);
-      source.findLoadedTiles(loadedTilesByZ, 1, range);
+      source.findLoadedTiles(loadedTilesByZ, isLoaded, 1, range);
       var keys = goog.object.getKeys(loadedTilesByZ);
       expect(keys.length).toBe(1);
       var tile = loadedTilesByZ['1']['1/0/0'];
@@ -75,8 +79,8 @@ describe('ol.source.TileSource', function() {
       var loadedTilesByZ = {};
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 1);
-      var allLoaded = source.findLoadedTiles(loadedTilesByZ, 1, range);
-      expect(allLoaded).toBe(true);
+      var loaded = source.findLoadedTiles(loadedTilesByZ, isLoaded, 1, range);
+      expect(loaded).toBe(true);
     });
 
     it('returns true when all tiles are already loaded (part 2)', function() {
@@ -94,8 +98,8 @@ describe('ol.source.TileSource', function() {
       };
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 1);
-      var allLoaded = source.findLoadedTiles(loadedTilesByZ, 1, range);
-      expect(allLoaded).toBe(true);
+      var loaded = source.findLoadedTiles(loadedTilesByZ, isLoaded, 1, range);
+      expect(loaded).toBe(true);
     });
 
     it('returns false when all tiles are already loaded', function() {
@@ -110,8 +114,8 @@ describe('ol.source.TileSource', function() {
       var loadedTilesByZ = {};
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 1);
-      var allLoaded = source.findLoadedTiles(loadedTilesByZ, 1, range);
-      expect(allLoaded).toBe(false);
+      var loaded = source.findLoadedTiles(loadedTilesByZ, isLoaded, 1, range);
+      expect(loaded).toBe(false);
     });
 
     it('returns false when all tiles are already loaded (part 2)', function() {
@@ -128,8 +132,8 @@ describe('ol.source.TileSource', function() {
       };
       var grid = source.getTileGrid();
       var range = grid.getTileRangeForExtentAndZ(source.getExtent(), 1);
-      var allLoaded = source.findLoadedTiles(loadedTilesByZ, 1, range);
-      expect(allLoaded).toBe(false);
+      var loaded = source.findLoadedTiles(loadedTilesByZ, isLoaded, 1, range);
+      expect(loaded).toBe(false);
     });
 
   });


### PR DESCRIPTION
All renderers have a copy of the `findInterimTiles` function.  This can be shared on the tile source, and is better named `findLoadedTiles`.

The function is supposed to iterate through all coords in a range, add already loaded tiles to a lookup, and return whether the requested range is covered with loaded tiles.

Previously, the function was returning `undefined` if the min x/y tile in the range was already included in the lookup.  6aa4e99fe536e50c4c2f3ed47cf930f4233bc3dd addresses this.

The previous function treats the provided tile range as having inclusive max x/y values.  The `getTileRangeForExtentAndZ` method is not consistent in terms of returning inclusive or exclusive ranges.
