### PR TITLE
Fewer bitwise operators

### DIFF
--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -333,8 +333,9 @@ ol.tilegrid.createForProjection =
       opt_tileSize : new ol.Size(ol.DEFAULT_TILE_SIZE, ol.DEFAULT_TILE_SIZE);
   var resolutions = new Array(maxZoom + 1);
   goog.asserts.assert(tileSize.width == tileSize.height);
+  size = size / tileSize.width;
   for (var z = 0, zz = resolutions.length; z < zz; ++z) {
-    resolutions[z] = size / (tileSize.width << z);
+    resolutions[z] = size / Math.pow(2, z);
   }
   return new ol.tilegrid.TileGrid({
     origin: projectionExtent.getTopLeft(),

--- a/src/ol/tilegrid/xyztilegrid.js
+++ b/src/ol/tilegrid/xyztilegrid.js
@@ -17,9 +17,9 @@ ol.tilegrid.XYZ = function(xyzOptions) {
 
   var resolutions = new Array(xyzOptions.maxZoom + 1);
   var z;
+  var size = 2 * ol.Projection.EPSG_3857_HALF_SIZE / ol.DEFAULT_TILE_SIZE;
   for (z = 0; z <= xyzOptions.maxZoom; ++z) {
-    resolutions[z] =
-        2 * ol.Projection.EPSG_3857_HALF_SIZE / (ol.DEFAULT_TILE_SIZE << z);
+    resolutions[z] = size / Math.pow(2, z);
   }
 
   goog.base(this, {

--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -56,7 +56,7 @@ ol.View2D = function(opt_view2DOptions) {
         projectionExtent.maxX - projectionExtent.minX,
         projectionExtent.maxY - projectionExtent.minY);
     values[ol.View2DProperty.RESOLUTION] =
-        size / (ol.DEFAULT_TILE_SIZE << view2DOptions.zoom);
+        size / (ol.DEFAULT_TILE_SIZE * Math.pow(2, view2DOptions.zoom));
   }
   values[ol.View2DProperty.ROTATION] = view2DOptions.rotation;
   this.setValues(values);

--- a/test/spec/ol/tilegrid.test.js
+++ b/test/spec/ol/tilegrid.test.js
@@ -94,6 +94,37 @@ describe('ol.tilegrid.TileGrid', function() {
     });
   });
 
+  describe('createForProjection', function() {
+
+    it('allows easier creation of a tile grid', function() {
+      var projection = ol.Projection.getFromCode('EPSG:3857');
+      var grid = ol.tilegrid.createForProjection(projection);
+      expect(grid).toBeA(ol.tilegrid.TileGrid);
+
+      var resolutions = grid.getResolutions();
+      expect(resolutions.length).toBe(19);
+    });
+
+    it('accepts a number of zoom levels', function() {
+      var projection = ol.Projection.getFromCode('EPSG:3857');
+      var grid = ol.tilegrid.createForProjection(projection, 22);
+      expect(grid).toBeA(ol.tilegrid.TileGrid);
+
+      var resolutions = grid.getResolutions();
+      expect(resolutions.length).toBe(23);
+    });
+
+    it('accepts a big number of zoom levels', function() {
+      var projection = ol.Projection.getFromCode('EPSG:3857');
+      var grid = ol.tilegrid.createForProjection(projection, 23);
+      expect(grid).toBeA(ol.tilegrid.TileGrid);
+
+      var resolutions = grid.getResolutions();
+      expect(resolutions.length).toBe(24);
+    });
+
+  });
+
   describe('getTileCoordFromCoordAndZ', function() {
 
     describe('Y North, X East', function() {


### PR DESCRIPTION
The way left shift [is used](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/tilecoord.js#L45) [in](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/source/tilejsonsource.js#L115) [some](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/source/bingmapssource.js#L100) [places](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/source/xyzsource.js#L67), we'll get good behavior with ~31 zoom levels.  This may be acceptable for popular xyz layers.  The way left shift [is used](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/tilegrid/tilegrid.js#L337) to [calculate](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/view2d.js#L59) [resolutions](https://github.com/openlayers/ol3/blob/4c2463dd91bc9c112a2a404cf7ddbb66a15543b2/src/ol/tilegrid/xyztilegrid.js#L22), we only get 23 levels with the default tile size.  This is an unnecessary restriction.
