### PR TITLE
Remove extent property from ol.tilegrid.TileGridOptions

### DIFF
--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -130,7 +130,6 @@
 @exportObjectLiteralProperty ol.source.TiledWMSOptions.urls Array.<string>|undefined
 
 @exportObjectLiteral ol.tilegrid.TileGridOptions
-@exportObjectLiteralProperty ol.tilegrid.TileGridOptions.extent ol.Extent|undefined
 @exportObjectLiteralProperty ol.tilegrid.TileGridOptions.origin ol.Coordinate|undefined
 @exportObjectLiteralProperty ol.tilegrid.TileGridOptions.origins Array.<ol.Coordinate>|undefined
 @exportObjectLiteralProperty ol.tilegrid.TileGridOptions.resolutions !Array.<number>

--- a/src/ol/tilegrid/xyztilegrid.js
+++ b/src/ol/tilegrid/xyztilegrid.js
@@ -23,7 +23,6 @@ ol.tilegrid.XYZ = function(xyzOptions) {
   }
 
   goog.base(this, {
-    extent: ol.Projection.EPSG_3857_EXTENT,
     origin: new ol.Coordinate(-ol.Projection.EPSG_3857_HALF_SIZE,
                               ol.Projection.EPSG_3857_HALF_SIZE),
     resolutions: resolutions,


### PR DESCRIPTION
This follows tilegrid extent_ property removal from #216.
