### PR TITLE
SIMPLE and WHITESPACE builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -98,7 +98,7 @@ virtual('all', 'build-all', 'build', 'examples', 'precommit')
 virtual('precommit', 'lint', 'build-all', 'test', 'build', 'build-examples', 'doc')
 
 
-virtual('build', 'build/ol.css', 'build/ol.js')
+virtual('build', 'build/ol.css', 'build/ol.js', 'build/ol-simple.js', 'build/ol-whitespace.js')
 
 
 virtual('todo', 'fixme')
@@ -112,6 +112,18 @@ def build_ol_css(t):
 @target('build/ol.js', PLOVR_JAR, SRC, EXTERNAL_SRC, 'base.json', 'build/ol.json')
 def build_ol_js(t):
     t.output('%(JAVA)s', '-jar', PLOVR_JAR, 'build', 'build/ol.json')
+    report_sizes(t)
+
+
+@target('build/ol-simple.js', PLOVR_JAR, SRC, EXTERNAL_SRC, 'base.json', 'build/ol.json', 'build/ol-simple.json')
+def build_ol_js(t):
+    t.output('%(JAVA)s', '-jar', PLOVR_JAR, 'build', 'build/ol-simple.json')
+    report_sizes(t)
+
+
+@target('build/ol-whitespace.js', PLOVR_JAR, SRC, EXTERNAL_SRC, 'base.json', 'build/ol.json', 'build/ol-whitespace.json')
+def build_ol_js(t):
+    t.output('%(JAVA)s', '-jar', PLOVR_JAR, 'build', 'build/ol-whitespace.json')
     report_sizes(t)
 
 
@@ -337,7 +349,7 @@ def hostexamples(t):
     t.makedirs('build/gh-pages/%(BRANCH)s/build')
     t.cp(EXAMPLES, (path.replace('.html', '.js') for path in EXAMPLES), 'examples/style.css', 'build/gh-pages/%(BRANCH)s/examples/')
     t.cp('build/loader_hosted_examples.js', 'build/gh-pages/%(BRANCH)s/examples/loader.js')
-    t.cp('build/ol.js', 'build/ol.css', 'build/gh-pages/%(BRANCH)s/build/')
+    t.cp('build/ol.js', 'build/ol-simple.js', 'build/ol-whitespace.js', 'build/ol.css', 'build/gh-pages/%(BRANCH)s/build/')
     t.cp('examples/example-list.html', 'build/gh-pages/%(BRANCH)s/examples/index.html')
     t.cp('examples/example-list.js', 'examples/example-list.xml', 'examples/Jugl.js', 'build/gh-pages/%(BRANCH)s/examples/')
 

--- a/build/loader_hosted_examples.js
+++ b/build/loader_hosted_examples.js
@@ -6,9 +6,9 @@
  * This loader is used for the hosted examples. It is used in place of the
  * development loader (examples/loader.js).
  *
- * ol.css and ol.js are built with Plovr/Closure, based on build/ol.json.
- * (`build.py build` builds them). They are located in the ../build/
- * directory, relatively to this script.
+ * ol.css, ol.js, ol-simple.js, and ol-whitespace.js are built with
+ * Plovr/Closure.  `build.py build` builds them. They are located in the
+ * ../build/ directory, relatively to this script.
  *
  * The script should be named loader.js. So it needs to be renamed to
  * loader.js from loader_hosted_examples.js.
@@ -19,9 +19,27 @@
  */
 
 (function() {
-  var scripts = document.getElementsByTagName('script');
 
-  var i, src, index, search, chunks, pair, params = {};
+  var i, pair;
+
+  var href = window.location.href, start, end, paramsString, pairs,
+      pageParams = {};
+  if (href.indexOf('?') > 0) {
+    start = href.indexOf('?') + 1;
+    end = href.indexOf('#') > 0 ? href.indexOf('#') : href.length;
+    paramsString = href.substring(start, end);
+    pairs = paramsString.split(/[&;]/);
+    for (i = 0; i < pairs.length; ++i) {
+      pair = pairs[i].split('=');
+      if (pair[0]) {
+          pageParams[decodeURIComponent(pair[0])] =
+              decodeURIComponent(pair[1]);
+      }
+    }
+  }
+
+  var scripts = document.getElementsByTagName('script');
+  var src, index, search, chunks, scriptParams = {};
   for (i = scripts.length - 1; i >= 0; --i) {
     src = scripts[i].getAttribute('src');
     if (~(index = src.indexOf('loader.js?'))) {
@@ -29,18 +47,29 @@
       chunks = search ? search.split('&') : [];
       for (i = chunks.length - 1; i >= 0; --i) {
         pair = chunks[i].split('=');
-        params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+        if (pair[0]) {
+          scriptParams[decodeURIComponent(pair[0])] =
+              decodeURIComponent(pair[1]);
+        }
       }
       break;
+    }
+  }
+
+  var oljs = 'ol.js', mode;
+  if ('mode' in pageParams) {
+    mode = pageParams.mode.toLowerCase();
+    if (mode != 'advanced') {
+      oljs = 'ol-' + mode + '.js';
     }
   }
 
   document.write('<link rel="stylesheet" href="../build/ol.css" '+
                  'type="text/css">');
   document.write('<scr' + 'ipt type="text/javascript" ' +
-                 'src="../build/ol.js">' +
+                 'src="../build/' + oljs + '">' +
                  '</scr' + 'ipt>');
   document.write('<scr' + 'ipt type="text/javascript" ' +
-                 'src="' + encodeURIComponent(params.id) + '.js">' +
+                 'src="' + encodeURIComponent(scriptParams.id) + '.js">' +
                  '</scr' + 'ipt>');
 }());

--- a/build/ol-simple.json
+++ b/build/ol-simple.json
@@ -1,0 +1,24 @@
+{
+
+  "id": "ol-simple",
+
+  "externs": [
+    "externs/bingmaps.js",
+    "externs/proj4js.js",
+    "externs/tilejson.js"
+  ],
+
+  "inherits": "ol.json",
+
+  "inputs": [
+    "build/src/internal/src/requireall.js",
+    "build/src/internal/src/types.js"
+  ],
+
+  "mode": "SIMPLE",
+
+  // Note: we can't have a (function(){%output%})() output wrapper with
+  // WHITESPACE and SIMPLE modes. See this link for explanations:
+  // https://groups.google.com/forum/#!topic/plovr/gQyZEa2NpsU
+  "output-wrapper": "%output%"
+}

--- a/build/ol-whitespace.json
+++ b/build/ol-whitespace.json
@@ -1,0 +1,24 @@
+{
+
+  "id": "ol-whitespace",
+
+  "externs": [
+    "externs/bingmaps.js",
+    "externs/proj4js.js",
+    "externs/tilejson.js"
+  ],
+
+  "inherits": "ol.json",
+
+  "inputs": [
+    "build/src/internal/src/requireall.js",
+    "build/src/internal/src/types.js"
+  ],
+
+  "mode": "WHITESPACE",
+
+  // Note: we can't have a (function(){%output%})() output wrapper with
+  // WHITESPACE and SIMPLE modes. See this link for explanations:
+  // https://groups.google.com/forum/#!topic/plovr/gQyZEa2NpsU
+  "output-wrapper": "%output%"
+}


### PR DESCRIPTION
This PR enables running the examples hosted on http://openlayers.github.com against the `ol.js` build (ADVANCED compilation), as well as against `ol-simple.js` (SIMPLE compilation) and `ol-whitespace.js` (WHITESPACE compilation) builds. I think can be useful for debugging, and playing around with the examples.

Selecting the mode is done similarly as when using Plovr, for example: `full-screen.html?mode=whitespace`.

(Note that I still think we need more simplicity, see #241.)
