### PR TITLE
Invalid ol.BingMapsStyle

### DIFF
--- a/examples/two-layers.js
+++ b/examples/two-layers.js
@@ -1,4 +1,3 @@
-goog.require('ol.BingMapsStyle');
 goog.require('ol.Collection');
 goog.require('ol.Coordinate');
 goog.require('ol.Map');
@@ -14,7 +13,7 @@ var layers = new ol.Collection([
   new ol.layer.TileLayer({
     source: new ol.source.BingMaps({
       key: 'AgtFlPYDnymLEe9zJ5PCkghbNiFZE9aAtTy3mPaEnEBXqLHtFuTcKoZ-miMC3w7R',
-      style: ol.BingMapsStyle.AERIAL
+      style: 'Aerial'
     })
   }),
   new ol.layer.TileLayer({

--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -96,7 +96,7 @@
 @exportObjectLiteral ol.source.BingMapsOptions
 @exportObjectLiteralProperty ol.source.BingMapsOptions.culture string|undefined
 @exportObjectLiteralProperty ol.source.BingMapsOptions.key string
-@exportObjectLiteralProperty ol.source.BingMapsOptions.style ol.BingMapsStyle
+@exportObjectLiteralProperty ol.source.BingMapsOptions.style string
 
 @exportObjectLiteral ol.source.DebugTileSourceOptions
 @exportObjectLiteralProperty ol.source.DebugTileSourceOptions.extent ol.Extent|undefined

--- a/src/ol/source/bingmaps.exports
+++ b/src/ol/source/bingmaps.exports
@@ -1,7 +1,1 @@
 @exportSymbol ol.source.BingMaps
-@exportSymbol ol.BingMapsStyle
-@exportProperty ol.BingMapsStyle.AERIAL
-@exportProperty ol.BingMapsStyle.AERIAL_WITH_LABELS
-@exportProperty ol.BingMapsStyle.ROAD
-@exportProperty ol.BingMapsStyle.ORDNANCE_SURVEY
-@exportProperty ol.BingMapsStyle.COLLINS_BART

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -1,4 +1,3 @@
-goog.provide('ol.BingMapsStyle');
 goog.provide('ol.source.BingMaps');
 
 goog.require('goog.Uri');
@@ -13,18 +12,6 @@ goog.require('ol.TileUrlFunction');
 goog.require('ol.projection');
 goog.require('ol.source.ImageTileSource');
 goog.require('ol.tilegrid.XYZ');
-
-
-/**
- * @enum {string}
- */
-ol.BingMapsStyle = {
-  AERIAL: 'Aerial',
-  AERIAL_WITH_LABELS: 'AerialWithLabels',
-  ROAD: 'Road',
-  ORDNANCE_SURVEY: 'OrdnanceSurvey',
-  COLLINS_BART: 'CollinsBart'
-};
 
 
 


### PR DESCRIPTION
According to the doc (http://msdn.microsoft.com/en-us/library/ff701716.aspx), the valid imagerySet values are:
- Aerial - Aerial imagery.
- AerialWithLabels - Aerial imagery with a road overlay.
- Birdseye - Bird’s eye (oblique-angle) imagery
- BirdseyeWithLabels - Bird’s eye imagery with a road overlay.
- Road - Roads without additional imagery.

And not OrdnanceSurvey or CollinsBart.

BTW, this list should problably moved to externs/bingmaps.js
