### PR TITLE
Fixing extent check for undefined extents.

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -27,6 +27,7 @@ var layers = new ol.Collection([
     source: new ol.source.TiledWMS({
       url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
       crossOrigin: null,
+      version: '1.1.1',
       params: {
         'LAYERS': 'basic',
         'FORMAT': 'image/jpeg'

--- a/src/ol/source/tiledwmssource.js
+++ b/src/ol/source/tiledwmssource.js
@@ -49,9 +49,11 @@ ol.source.TiledWMS = function(tiledWMSOptions) {
     var x = tileCoord.x;
     var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
     var projectionExtent = projection.getExtent();
+    var extent = goog.isDef(tiledWMSOptions.extent) ?
+        tiledWMSOptions.extent : projectionExtent;
     // FIXME do we want a wrapDateLine param? The code below will break maps
     // with projections that do not span the whole world width.
-    if (extent && extent.minX === projectionExtent.minX &&
+    if (extent.minX === projectionExtent.minX &&
         extent.maxX === projectionExtent.maxX) {
       var numCols = Math.ceil(
           (extent.maxX - extent.minX) / (tileExtent.maxX - tileExtent.minX));


### PR DESCRIPTION
Thanks @marcjansen for spotting this. To make the epsg-4326
example work, I also had to change the WMS version to 1.1.1.
