### PR TITLE
Check the examples against whitespace build first

### DIFF
--- a/build.py
+++ b/build.py
@@ -384,9 +384,9 @@ def hostexamples(t):
 def check_examples(t):
     directory = 'build/gh-pages/%(BRANCH)s/'
     examples = ['build/gh-pages/%(BRANCH)s/' + e for e in EXAMPLES]
-    all_examples = examples + \
+    all_examples = [e + '?mode=whitespace' for e in examples] + \
         [e + '?mode=simple' for e in examples] + \
-        [e + '?mode=whitespace' for e in examples]
+        examples
     for example in all_examples:
         t.run('%(PHANTOMJS)s', 'bin/check-example.js', example)
 


### PR DESCRIPTION
This is to produce stack traces that are easier to understand when an example fails to load.
