### PR TITLE
Nicer test output for headless tests

### DIFF
--- a/test/phantom-jasmine/console-runner.js
+++ b/test/phantom-jasmine/console-runner.js
@@ -13,16 +13,16 @@
     throw "jasmine library isn't loaded!";
   }
 
-  var ANSI = {}
+  var ANSI = {};
   ANSI.color_map = {
       "green" : 32,
       "red"   : 31
-  }
+  };
 
   ANSI.colorize_text = function(text, color) {
     var color_code = this.color_map[color];
     return "\033[" + color_code + "m" + text + "\033[0m";
-  }
+  };
 
   var ConsoleReporter = function() {
     if (!console || !console.log) { throw "console isn't present!"; }
@@ -79,7 +79,7 @@
     var resultText = spec.suite.description + " : " + spec.description;
     this.log(resultText, "red");
 
-    var items = spec.results().getItems()
+    var items = spec.results().getItems();
     for (var i = 0; i < items.length; i++) {
       var trace = items[i].trace.stack || items[i].trace;
       this.log(trace, "red");
@@ -95,8 +95,8 @@
    * Pads given string up to a target length with a given character on either
    * the left or right side.
    */
-  proto.pad = function(str, len, char, side){
-    var str = str + "",
+  proto.pad = function(string, len, char, side){
+    var str = string + "",
         whichSide = side || 'left',
         buff = "",
         padChar = char || " ",
@@ -113,7 +113,7 @@
     }
     // we still need a substring when we are called with e.g. " . " as char.
     return padded.substring(0, len);
-  }
+  };
 
   /**
    * Pads given string up to a target length with a given character on the right
@@ -121,7 +121,7 @@
    */
   proto.padRight = function(str, len, char){
     return this.pad(str, len, char, 'right');
-  }
+  };
 
   /**
    * Pads given string up to a target length with a given character on the right
@@ -129,7 +129,7 @@
    */
   proto.padLeft = function(str, len, char){
     return this.pad(str, len, char, 'left');
-  }
+  };
 
   proto.reportSuiteResults = function(suite) {
     if (!suite.parentSuite) { return; }
@@ -152,8 +152,8 @@
   };
 
   proto.log = function(str, color) {
-    var text = (color != undefined)? ANSI.colorize_text(str, color) : str;
-    console.log(text)
+    var text = (color)? ANSI.colorize_text(str, color) : str;
+    console.log(text);
   };
 
   jasmine.ConsoleReporter = ConsoleReporter;


### PR DESCRIPTION
This pull request suggests changing the output of the headless test suite from 

```
2013-03-05 15:39:30,594 test: phantomjs test/phantom-jasmine/run_jasmine_test.coffee test/ol.html
Starting...
create an empty collection: 3 of 3 passed.
create a collection from an array: 3 of 3 passed.
push to a collection: 3 of 3 passed.
pop from a collection: 3 of 3 passed.
insertAt: 3 of 3 passed.
setAt: 3 of 3 passed.
removeAt: 2 of 2 passed.
on an empty collection: 1 of 1 passed.
on a non-empty collection: 1 of 1 passed.
scope: 1 of 1 passed.
forEach: 3 of 3 passed.
```

... to ...

```
2013-03-05 15:41:31,612 test: phantomjs test/phantom-jasmine/run_jasmine_test.coffee test/ol.html
Starting...

ol.collection 
 create an empty collection .................................   3/3    ok
 create a collection from an array ..........................   3/3    ok
 push to a collection .......................................   3/3    ok
 pop from a collection ......................................   3/3    ok
 insertAt ...................................................   3/3    ok
 setAt ......................................................   3/3    ok
 removeAt ...................................................   2/2    ok

ol.collection forEach 
 on an empty collection .....................................   1/1    ok
 on a non-empty collection ..................................   1/1    ok
 scope ......................................................   1/1    ok
```

... which is easier to read.

Please review.
