### PR TITLE
Collection improvements

### DIFF
--- a/src/ol/collection.exports
+++ b/src/ol/collection.exports
@@ -6,5 +6,6 @@
 @exportProperty ol.Collection.prototype.insertAt
 @exportProperty ol.Collection.prototype.pop
 @exportProperty ol.Collection.prototype.push
+@exportProperty ol.Collection.prototype.remove
 @exportProperty ol.Collection.prototype.removeAt
 @exportProperty ol.Collection.prototype.setAt

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -160,6 +160,22 @@ ol.Collection.prototype.push = function(elem) {
 
 
 /**
+ * Removes the first occurence of elem from the collection.
+ * @param {*} elem Element.
+ * @return {*} The removed element or undefined if elem was not found.
+ */
+ol.Collection.prototype.remove = function(elem) {
+  var i;
+  for (i = 0; i < this.array_.length; ++i) {
+    if (this.array_[i] === elem) {
+      return this.removeAt(i);
+    }
+  }
+  return undefined;
+};
+
+
+/**
  * @param {number} index Index.
  * @return {*} Value.
  */

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -104,6 +104,35 @@ describe('ol.collection', function() {
     });
   });
 
+  describe('remove', function() {
+    it('removes the first matching element', function() {
+      var collection = new ol.Collection([0, 1, 2]);
+      expect(collection.remove(1)).toEqual(1);
+      expect(collection.getArray()).toEqual([0, 2]);
+      expect(collection.getLength()).toEqual(2);
+    });
+    it('fires a remove event', function() {
+      var collection = new ol.Collection([0, 1, 2]);
+      var cb = jasmine.createSpy();
+      goog.events.listen(collection, ol.CollectionEventType.REMOVE, cb);
+      expect(collection.remove(1)).toEqual(1);
+      expect(cb).toHaveBeenCalled();
+      expect(cb.mostRecentCall.args[0].elem).toEqual(1);
+    });
+    it('does not remove more than one matching element', function() {
+      var collection = new ol.Collection([0, 1, 1, 2]);
+      expect(collection.remove(1)).toEqual(1);
+      expect(collection.getArray()).toEqual([0, 1, 2]);
+      expect(collection.getLength()).toEqual(3);
+    });
+    it('returns undefined if the element is not found', function() {
+      var collection = new ol.Collection([0, 1, 2]);
+      expect(collection.remove(3)).toBeUndefined();
+      expect(collection.getArray()).toEqual([0, 1, 2]);
+      expect(collection.getLength()).toEqual(3);
+    });
+  });
+
   describe('setAt and event', function() {
     it('does dispatch events', function() {
       var collection = new ol.Collection(['a', 'b']);


### PR DESCRIPTION
This PR implements the modifications to `ol.Collection`, as discussed:
- remove unused (and problematic) `insert_at`, `remove_at`, and `set_at` events
- don't export dangerous `ol.Collection.prototype.getArray` function by default
- add `remove` method
