### PR TITLE
Build error

### DIFF
--- a/build.py
+++ b/build.py
@@ -115,13 +115,13 @@ def build_ol_js(t):
     report_sizes(t)
 
 
-@target('build/ol-simple.js', PLOVR_JAR, SRC, EXTERNAL_SRC, 'base.json', 'build/ol.json', 'build/ol-simple.json')
+@target('build/ol-simple.js', PLOVR_JAR, SRC, INTERNAL_SRC, 'base.json', 'build/ol.json', 'build/ol-simple.json')
 def build_ol_js(t):
     t.output('%(JAVA)s', '-jar', PLOVR_JAR, 'build', 'build/ol-simple.json')
     report_sizes(t)
 
 
-@target('build/ol-whitespace.js', PLOVR_JAR, SRC, EXTERNAL_SRC, 'base.json', 'build/ol.json', 'build/ol-whitespace.json')
+@target('build/ol-whitespace.js', PLOVR_JAR, SRC, INTERNAL_SRC, 'base.json', 'build/ol.json', 'build/ol-whitespace.json')
 def build_ol_js(t):
     t.output('%(JAVA)s', '-jar', PLOVR_JAR, 'build', 'build/ol-whitespace.json')
     report_sizes(t)


### PR DESCRIPTION
With a fresh clone of ol3 I get the following error when running `build.py build`:

```
2013-03-06 15:14:56,415 build/ol-simple.js: java -jar bin/plovr-eba786b34df9.jar build build/ol-simple.json
Exception in thread "main" java.lang.RuntimeException: java.io.FileNotFoundException: /home/elemoine/public_html/openlayers/ol3_sample_app/ol3/build/../build/src/internal/src/requireall.js (No such file or directory)
```

A target dependency is probably missing.
