### PR TITLE
Add a setExtent method to ol.Projection

### DIFF
--- a/src/ol/projection.js
+++ b/src/ol/projection.js
@@ -104,6 +104,14 @@ ol.Projection.prototype.getExtent = function() {
 
 
 /**
+ * @param {ol.Extent} extent Extent.
+ */
+ol.Projection.prototype.setExtent = function(extent) {
+  this.extent_ = extent;
+};
+
+
+/**
  * @param {number} resolution Resolution.
  * @param {ol.Coordinate} point Point.
  * @return {number} Point resolution.


### PR DESCRIPTION
so that we can set an extent to a projection that have been retrieved using getFromCode function.
