### PR TITLE
NumberFormatException with GeoServer WMS

### DIFF
--- a/src/ol/source/wms.js
+++ b/src/ol/source/wms.js
@@ -17,8 +17,8 @@ ol.source.wms.getUrl =
     'REQUEST': 'GetMap',
     'FORMAT': 'image/png',
     'TRANSPARENT': true,
-    'WIDTH': size.width,
-    'HEIGHT': size.height
+    'WIDTH': Math.round(size.width),
+    'HEIGHT': Math.round(size.height)
   };
   goog.object.extend(baseParams, params);
 


### PR DESCRIPTION
The new wms-single-image example is based on http://demo.opengeo.org/geoserver/wms. The example is currently broken because we send non-integer height and width values to GeoServer.

See https://gist.github.com/elemoine/5107729.

Fix to follow.
