### PR TITLE
precommit target is too slow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 
 before_script:
   - "./build.py plovr"
-  - "./build.py serve-precommit &"
+  - "./build.py serve-integration-test &"
   - "sleep 3"
 
-script: "./build.py JSDOC=jsdoc/jsdoc precommit"
+script: "./build.py JSDOC=jsdoc/jsdoc integration-test"

--- a/README.md
+++ b/README.md
@@ -77,13 +77,33 @@ Then:
 
     $ ./build.py lint
 
-## Run the precommit hook before pushing a commit:
+## Run the check hook before pushing a commit
 
-First, install the latest version of [JSDoc3](https://github.com/jsdoc3/jsdoc). Then:
+    $ ./build.py check
 
-    $ ./build.py precommit
+The check hook does a few quick tests to make sure that the basics still work.  This includes:
 
-This makes sure that your commit won't break the build. It also runs JSDoc3 to make sure that there are no invalid API doc directives. 
+ * Running the linter
+ * Building the library
+ * Running the tests
+
+
+## Continuous integration tests
+
+When you submit a pull request the [Travis continuous integration
+server](https://travis-ci.org/) will run a full suite of tests, including
+building all versions of the library and checking that all of the examples
+work.  You will receive an email with the results, and the status will be
+displayed in the pull request.  If you want to run the integration tests
+locally, then you'll need to make sure that Plovr is running if it isn't
+already, and then start the tests:
+
+    $ ./build.py integration-test
+
+Running the full suite of integration tests currently takes 5-10 minutes.
+
+This makes sure that your commit won't break the build. It also runs JSDoc3 to
+make sure that there are no invalid API doc directives.
 
 ## Add examples
 

--- a/build.py
+++ b/build.py
@@ -96,13 +96,16 @@ def report_sizes(t):
     t.info('  compressed: %d bytes', len(stringio.getvalue()))
 
 
-virtual('all', 'build-all', 'build', 'examples', 'precommit')
+virtual('default', 'build')
 
 
-virtual('precommit', 'lint', 'build-all', 'test', 'build', 'build-examples', 'check-examples', 'doc')
+virtual('integration-test', 'lint', 'build', 'build-all', 'test', 'build-examples', 'check-examples', 'doc')
 
 
 virtual('build', 'build/ol.css', 'build/ol.js', 'build/ol-simple.js', 'build/ol-whitespace.js')
+
+
+virtual('check', 'lint', 'build/ol.css', 'build/ol.js', 'test')
 
 
 virtual('todo', 'fixme')
@@ -236,7 +239,7 @@ def serve(t):
     t.run('%(JAVA)s', '-jar', PLOVR_JAR, 'serve', 'build/ol.json', 'build/ol-all.json', EXAMPLES_JSON, 'test/test.json')
 
 
-@target('serve-precommit', PLOVR_JAR, INTERNAL_SRC)
+@target('serve-integration-test', PLOVR_JAR, INTERNAL_SRC)
 def serve_precommit(t):
     t.run('%(JAVA)s', '-jar', PLOVR_JAR, 'serve', 'build/ol-all.json', 'test/test.json')
 


### PR DESCRIPTION
Following #295, there are many, many examples. The `precommit` target builds and tests all of them, which takes a long time.

Suggestion:
- Modify `precommit` to do less work
- Add a `travis` target (or similar) so that the Travis CI server still builds and tests all the examples
