### PR TITLE
Prioritize tile loading around mouse position

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -244,6 +244,12 @@ ol.Map = function(mapOptions) {
 
   /**
    * @private
+   * @type {ol.Coordinate}
+   */
+  this.focus_ = null;
+
+  /**
+   * @private
    * @type {Array.<ol.PreRenderFunction>}
    */
   this.preRenderFunctions_ = [];
@@ -487,9 +493,10 @@ ol.Map.prototype.getTilePriority = function(tile, tileSourceKey, tileCenter) {
   if (!frameState.wantedTiles[tileSourceKey][coordKey]) {
     return ol.TileQueue.DROP;
   }
-  var center = frameState.view2DState.center;
-  var deltaX = tileCenter.x - center.x;
-  var deltaY = tileCenter.y - center.y;
+  var focus = goog.isNull(this.focus_) ?
+      frameState.view2DState.center : this.focus_;
+  var deltaX = tileCenter.x - focus.x;
+  var deltaY = tileCenter.y - focus.y;
   return deltaX * deltaX + deltaY * deltaY;
 };
 
@@ -502,6 +509,11 @@ ol.Map.prototype.handleBrowserEvent = function(browserEvent, opt_type) {
   var type = opt_type || browserEvent.type;
   var mapBrowserEvent = new ol.MapBrowserEvent(type, this, browserEvent);
   this.handleMapBrowserEvent(mapBrowserEvent);
+  if (type == goog.events.EventType.MOUSEOUT) {
+    this.focus_ = null;
+  } else {
+    this.focus_ = mapBrowserEvent.getCoordinate();
+  }
 };
 
 


### PR DESCRIPTION
This PR is small but awesome.

The goal is to prioritize loading tiles at the user's focus of attention. We use the mouse position as a proxy for this. If the user is mouse wheel zooming somewhere, or if he/she is hover the mouse somewhere, we prioritize tile loads at this point. When the mouse leaves the map we switch back to the default strategy of prioritizing tiles near the center of the map.

The net result is that tiles are loaded first where the user is looking, and as a result the map feels even snappier.
