### PR TITLE
Canvas renderer is not properly cleared

### DIFF
--- a/src/ol/imagetile.js
+++ b/src/ol/imagetile.js
@@ -13,12 +13,13 @@ goog.require('ol.TileState');
  * @constructor
  * @extends {ol.Tile}
  * @param {ol.TileCoord} tileCoord Tile coordinate.
+ * @param {ol.TileState} state State.
  * @param {string} src Image source URI.
  * @param {?string} crossOrigin Cross origin.
  */
-ol.ImageTile = function(tileCoord, src, crossOrigin) {
+ol.ImageTile = function(tileCoord, state, src, crossOrigin) {
 
-  goog.base(this, tileCoord);
+  goog.base(this, tileCoord, state);
 
   /**
    * Image URI

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -110,10 +110,6 @@ ol.renderer.dom.TileLayer.prototype.renderFrame =
 
       tileCoord = new ol.TileCoord(z, x, y);
       tile = tileSource.getTile(tileCoord, tileGrid, projection);
-      if (goog.isNull(tile)) {
-        continue;
-      }
-
       tileState = tile.getState();
       if (tileState == ol.TileState.IDLE) {
         this.updateWantedTiles(frameState.wantedTiles, tileSource, tileCoord);
@@ -124,7 +120,8 @@ ol.renderer.dom.TileLayer.prototype.renderFrame =
       } else if (tileState == ol.TileState.LOADED) {
         tilesToDrawByZ[z][tileCoord.toString()] = tile;
         continue;
-      } else if (tileState == ol.TileState.ERROR) {
+      } else if (tileState == ol.TileState.ERROR ||
+                 tileState == ol.TileState.EMPTY) {
         continue;
       }
 

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -385,10 +385,6 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame =
 
         tileCoord = new ol.TileCoord(z, x, y);
         tile = tileSource.getTile(tileCoord, tileGrid, projection);
-        if (goog.isNull(tile)) {
-          continue;
-        }
-
         tileState = tile.getState();
         if (tileState == ol.TileState.IDLE) {
           this.updateWantedTiles(frameState.wantedTiles, tileSource, tileCoord);
@@ -407,7 +403,8 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame =
             priority = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
             tilesToLoad.enqueue(priority, tile);
           }
-        } else if (tileState == ol.TileState.ERROR) {
+        } else if (tileState == ol.TileState.ERROR ||
+                   tileState == ol.TileState.EMPTY) {
           continue;
         }
 

--- a/src/ol/source/debugtilesource.js
+++ b/src/ol/source/debugtilesource.js
@@ -19,9 +19,7 @@ goog.require('ol.tilegrid.TileGrid');
  */
 ol.DebugTile_ = function(tileCoord, tileGrid) {
 
-  goog.base(this, tileCoord);
-
-  this.state = ol.TileState.LOADED;
+  goog.base(this, tileCoord, ol.TileState.LOADED);
 
   /**
    * @private
@@ -127,7 +125,7 @@ ol.source.DebugTileSource.prototype.expireCache = function(usedTiles) {
 ol.source.DebugTileSource.prototype.getTile = function(tileCoord) {
   var key = tileCoord.toString();
   if (this.tileCache_.containsKey(key)) {
-    return /** @type {ol.DebugTile_} */ (this.tileCache_.get(key));
+    return /** @type {!ol.DebugTile_} */ (this.tileCache_.get(key));
   } else {
     var tile = new ol.DebugTile_(tileCoord, this.tileGrid);
     this.tileCache_.set(key, tile);

--- a/src/ol/source/imagetilesource.js
+++ b/src/ol/source/imagetilesource.js
@@ -7,6 +7,7 @@ goog.require('ol.ImageTile');
 goog.require('ol.Projection');
 goog.require('ol.Tile');
 goog.require('ol.TileCache');
+goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.TileUrlFunctionType');
 goog.require('ol.source.TileSource');
@@ -89,18 +90,17 @@ ol.source.ImageTileSource.prototype.getTile =
     function(tileCoord, tileGrid, projection) {
   var key = tileCoord.toString();
   if (this.tileCache_.containsKey(key)) {
-    return /** @type {ol.Tile} */ (this.tileCache_.get(key));
+    return /** @type {!ol.Tile} */ (this.tileCache_.get(key));
   } else {
     goog.asserts.assert(tileGrid);
     goog.asserts.assert(projection);
     var tileUrl = this.tileUrlFunction(tileCoord, tileGrid, projection);
-    var tile;
-    if (goog.isDef(tileUrl)) {
-      tile = new ol.ImageTile(tileCoord, tileUrl, this.crossOrigin_);
-      this.tileCache_.set(key, tile);
-    } else {
-      tile = null;
-    }
+    var tile = new ol.ImageTile(
+        tileCoord,
+        goog.isDef(tileUrl) ? ol.TileState.IDLE : ol.TileState.EMPTY,
+        goog.isDef(tileUrl) ? tileUrl : '',
+        this.crossOrigin_);
+    this.tileCache_.set(key, tile);
     return tile;
   }
 };

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -125,7 +125,7 @@ ol.source.TileSource.prototype.getResolutions = function() {
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {ol.tilegrid.TileGrid=} opt_tileGrid Tile grid.
  * @param {ol.Projection=} opt_projection Projection.
- * @return {ol.Tile} Tile.
+ * @return {!ol.Tile} Tile.
  */
 ol.source.TileSource.prototype.getTile = goog.abstractMethod;
 

--- a/src/ol/tile.js
+++ b/src/ol/tile.js
@@ -16,7 +16,8 @@ ol.TileState = {
   IDLE: 0,
   LOADING: 1,
   LOADED: 2,
-  ERROR: 3
+  ERROR: 3,
+  EMPTY: 4
 };
 
 
@@ -25,8 +26,9 @@ ol.TileState = {
  * @constructor
  * @extends {goog.events.EventTarget}
  * @param {ol.TileCoord} tileCoord Tile coordinate.
+ * @param {ol.TileState} state State.
  */
-ol.Tile = function(tileCoord) {
+ol.Tile = function(tileCoord, state) {
 
   goog.base(this);
 
@@ -39,7 +41,7 @@ ol.Tile = function(tileCoord) {
    * @protected
    * @type {ol.TileState}
    */
-  this.state = ol.TileState.IDLE;
+  this.state = state;
 
 };
 goog.inherits(ol.Tile, goog.events.EventTarget);

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -220,12 +220,9 @@ goog.inherits(ol.test.source.MockTileSource, ol.source.TileSource);
  * @inheritDoc
  */
 ol.test.source.MockTileSource.prototype.getTile = function(tileCoord) {
-  var tile = new ol.Tile(tileCoord);
   var key = tileCoord.toString();
-  if (this.loaded_[key]) {
-    tile.state = ol.TileState.LOADED;
-  }
-  return tile;
+  var tileState = this.loaded_[key] ? ol.TileState.LOADED : ol.TileState.IDLE;
+  return new ol.Tile(tileCoord, tileState);
 };
 
 


### PR DESCRIPTION
With the changes in #263, we are left with rendering artifacts like this:
![canvas-issue](https://f.cloud.github.com/assets/41094/235662/914cba44-87b7-11e2-907b-863b0f798d12.png)

(append `?renderer=canvas` to the full screen example and zoom in/out to reproduce)
