### PR TITLE
Use constant for CSS class 'ol-unselectable'.

### DIFF
--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -8,6 +8,7 @@ goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.object');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.FrameState');
 goog.require('ol.MapEvent');
@@ -30,7 +31,7 @@ ol.control.Attribution = function(opt_options) {
   this.ulElement_ = goog.dom.createElement(goog.dom.TagName.UL);
 
   var element = goog.dom.createDom(goog.dom.TagName.DIV, {
-    'class': 'ol-attribution ol-unselectable'
+    'class': 'ol-attribution ' + ol.CSS_CLASS_UNSELECTABLE
   }, this.ulElement_);
 
   goog.base(this, {

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -3,6 +3,7 @@ goog.provide('ol.control.ScaleLineUnits');
 
 goog.require('goog.dom');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.FrameState');
 goog.require('ol.MapEvent');
 goog.require('ol.MapEventType');
@@ -48,7 +49,7 @@ ol.control.ScaleLine = function(opt_options) {
    * @type {Element}
    */
   this.element_ = goog.dom.createDom(goog.dom.TagName.DIV, {
-    'class': 'ol-scale-line ol-unselectable'
+    'class': 'ol-scale-line ' + ol.CSS_CLASS_UNSELECTABLE
   }, this.innerElement_);
 
   /**

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -6,6 +6,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('ol');
 goog.require('ol.control.Control');
 
 
@@ -43,8 +44,9 @@ ol.control.Zoom = function(opt_options) {
     goog.events.EventType.CLICK
   ], this.handleOut_, false, this);
 
-  var element = goog.dom.createDom(
-      goog.dom.TagName.DIV, 'ol-zoom ol-unselectable', inElement, outElement);
+  var cssClasses = 'ol-zoom ' + ol.CSS_CLASS_UNSELECTABLE;
+  var element = goog.dom.createDom(goog.dom.TagName.DIV, cssClasses, inElement,
+      outElement);
 
   goog.base(this, {
     element: element,

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -7,3 +7,11 @@ if (goog.DEBUG) {
   var logger = goog.debug.Logger.getLogger('ol');
   logger.setLevel(goog.debug.Logger.Level.FINEST);
 }
+
+
+/**
+ * The CSS class that we'll give the DOM elements to have them unselectable.
+ *
+ * @const {string}
+ */
+ol.CSS_CLASS_UNSELECTABLE = 'ol-unselectable';

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -6,6 +6,7 @@ goog.require('goog.array');
 goog.require('goog.dom');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
+goog.require('ol');
 goog.require('ol.Size');
 goog.require('ol.layer.ImageLayer');
 goog.require('ol.layer.TileLayer');
@@ -38,7 +39,7 @@ ol.renderer.canvas.Map = function(container, map) {
   this.canvas_ = goog.dom.createElement(goog.dom.TagName.CANVAS);
   this.canvas_.height = this.canvasSize_.height;
   this.canvas_.width = this.canvasSize_.width;
-  this.canvas_.className = 'ol-unselectable';
+  this.canvas_.className = ol.CSS_CLASS_UNSELECTABLE;
   goog.dom.insertChildAt(container, this.canvas_, 0);
 
   /**

--- a/src/ol/renderer/dom/dommaprenderer.js
+++ b/src/ol/renderer/dom/dommaprenderer.js
@@ -5,6 +5,7 @@ goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.layer.ImageLayer');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.renderer.Map');
@@ -28,7 +29,7 @@ ol.renderer.dom.Map = function(container, map) {
    * @private
    */
   this.layersPane_ = goog.dom.createElement(goog.dom.TagName.DIV);
-  this.layersPane_.className = 'ol-layers ol-unselectable';
+  this.layersPane_.className = 'ol-layers ' + ol.CSS_CLASS_UNSELECTABLE;
   var style = this.layersPane_.style;
   style.position = 'absolute';
   style.width = '100%';

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -11,6 +11,7 @@ goog.require('goog.events');
 goog.require('goog.events.Event');
 goog.require('goog.style');
 goog.require('goog.webgl');
+goog.require('ol');
 goog.require('ol.FrameState');
 goog.require('ol.Size');
 goog.require('ol.Tile');
@@ -122,7 +123,7 @@ ol.renderer.webgl.Map = function(container, map) {
   this.canvas_ = goog.dom.createElement(goog.dom.TagName.CANVAS);
   this.canvas_.height = container.clientHeight;
   this.canvas_.width = container.clientWidth;
-  this.canvas_.className = 'ol-unselectable';
+  this.canvas_.className = ol.CSS_CLASS_UNSELECTABLE;
   goog.dom.insertChildAt(container, this.canvas_, 0);
 
   /**


### PR DESCRIPTION
This pull request suggests replacing the various occurencies of the string `'ol-unselectable'` (a CSS class we add to DOM elements) with a constant defined in `ol.js`.

Note: Currently the integration tests (which are also running on travis) run into a timeout as an external WMS server seems to be down. See #353.
