### PR TITLE
Abort check-examples target if phantomjs takes too long to run examples.

### DIFF
--- a/build.py
+++ b/build.py
@@ -439,10 +439,16 @@ def hostexamples(t):
         '--output_file', 'build/gh-pages/%(BRANCH)s/build/ol-deps.js')
 
 
+def _uses_opengeo_org(example):
+    # opengeo.org servers are unreliable, don't use them integration tests
+    with open(example.replace('.html', '.js')) as f:
+        return f.read().find('opengeo.org') != -1
+
+
 @target('check-examples', 'hostexamples', phony=True)
 def check_examples(t):
     directory = 'build/gh-pages/%(BRANCH)s/'
-    examples = ['build/gh-pages/%(BRANCH)s/' + e for e in EXAMPLES]
+    examples = ['build/gh-pages/%(BRANCH)s/' + e for e in EXAMPLES if not _uses_opengeo_org(e)]
     all_examples = \
         [e + '?mode=raw' for e in examples] + \
         [e + '?mode=whitespace' for e in examples] + \


### PR DESCRIPTION
Currently a WMS server (http://demo.opengeo.org/geoserver) seems to be down, which results in a neverending `integration-test` target:

```
2013-03-12 09:13:12,232 check-examples: phantomjs bin/check-example.js build/gh-pages/unselectable-css-const/examples/wms-single-image.html?mode=raw
```

We should probably abort `phantomjs` after a certain amount of time has passed.
