### PR TITLE
Remove unused imports.

### DIFF
--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -10,7 +10,6 @@ goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.fx.Dragger');
 goog.require('goog.style');
-goog.require('ol.FrameState');
 goog.require('ol.MapEventType');
 goog.require('ol.control.Control');
 

--- a/test/spec/ol/control/zoomslider.test.js
+++ b/test/spec/ol/control/zoomslider.test.js
@@ -100,6 +100,5 @@ goog.require('goog.dom');
 goog.require('goog.dom.classes');
 goog.require('goog.fx.Dragger');
 goog.require('goog.math.Rect');
-goog.require('goog.style');
 goog.require('ol.Map');
 goog.require('ol.control.ZoomSlider');


### PR DESCRIPTION
Since 9b1c389c80e49ca0f76a6d45a8fd7bc21aa64ab7 the detection of unused imports works again and detects two unused imports in the zoomslider files.

Please review.
