### PR TITLE
Use correct singular/plural of noun.

### DIFF
--- a/build.py
+++ b/build.py
@@ -506,7 +506,9 @@ def find_fixme(t):
         f.close()
 
     for filename in matches:
-        print '  %s has %d matches:' % (filename, len(matches[filename]))
+        num_matches = len(matches[filename])
+        noun = 'matches' if num_matches > 1 else 'match'
+        print '  %s has %d %s:' % (filename, num_matches, noun)
         for match in matches[filename]:
             print '    %s' % (match,)
         print


### PR DESCRIPTION
Tiny correction of the output of the `todo` build-target.

Before: 

```
src/ol/renderer/webgl/webglmaprenderer.js has 1 matches:
```

After:

```
src/ol/renderer/webgl/webglmaprenderer.js has 1 match:
```
