### PR TITLE
Use CSS class constant in zoomslider.

### DIFF
--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -10,6 +10,7 @@ goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.fx.Dragger');
 goog.require('goog.style');
+goog.require('ol');
 goog.require('ol.MapEventType');
 goog.require('ol.control.Control');
 
@@ -361,10 +362,10 @@ ol.control.ZoomSlider.prototype.createDraggable_ = function(elem) {
  */
 ol.control.ZoomSlider.prototype.createDom_ = function(opt_elem) {
   var elem,
-      sliderCssCls = ol.control.ZoomSlider.CSS_CLASS_CONTAINER +
-          ' ol-unselectable',
-      thumbCssCls = ol.control.ZoomSlider.CSS_CLASS_THUMB +
-          ' ol-unselectable';
+      sliderCssCls = ol.control.ZoomSlider.CSS_CLASS_CONTAINER + ' ' +
+          ol.CSS_CLASS_UNSELECTABLE,
+      thumbCssCls = ol.control.ZoomSlider.CSS_CLASS_THUMB + ' ' +
+          ol.CSS_CLASS_UNSELECTABLE;
 
   elem = goog.dom.createDom(goog.dom.TagName.DIV, sliderCssCls,
       goog.dom.createDom(goog.dom.TagName.DIV, thumbCssCls));


### PR DESCRIPTION
Commit 5e5e4d110a74218aec85bba68bc54135a9859a77 introduced the constant `ol.CSS_CLASS_UNSELECTABLE`, which wasn't used inside of the zoomslider control.

This pull request fixes this.
