### PR TITLE
Add fallback host when examples are accessed through file:-protocol.

### DIFF
--- a/examples/loader.js
+++ b/examples/loader.js
@@ -23,6 +23,9 @@
     mode: 'ADVANCED',
     id: 'ol'
   };
+  if (window.location.protocol === 'file:' && !params.hostname) {
+    params.hostname = 'localhost';
+  }
   var chunks, search, pair;
 
   var src, index, id, i;


### PR DESCRIPTION
When opening an example through the `file:`-protocol, e.g.
`file:///ol3/examples/full-screen.html` our `loader.js` would inject
a `<script>` tag with a `src` pointing to an illegal URL
`http://:9810/compile?mode=ADVANCED&id=full-screen`.

This changes the respective logic, so that in the case that we are accessed
through the `file:`-protocol, we fallback to using `localhost` as hostname
for the plovr-compiler.

The examples that do not use XHR (like e.g. `wms-capabilities.html`) now
work as expected when accessed through `file:`-protocol.
