### PR TITLE
Rule-based styling does not work in hosted style-rules example

### DIFF
--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -100,6 +100,12 @@
 @exportObjectLiteralProperty ol.layer.LayerOptions.source ol.source.Source
 @exportObjectLiteralProperty ol.layer.LayerOptions.visible boolean|undefined
 
+@exportObjectLiteral ol.layer.VectorLayerOptions
+@exportObjectLiteralProperty ol.layer.VectorLayerOptions.opacity number|undefined
+@exportObjectLiteralProperty ol.layer.VectorLayerOptions.source ol.source.Source
+@exportObjectLiteralProperty ol.layer.VectorLayerOptions.style ol.style.Style|undefined
+@exportObjectLiteralProperty ol.layer.VectorLayerOptions.visible boolean|undefined
+
 @exportObjectLiteral ol.AnchoredElementOptions
 @exportObjectLiteralProperty ol.AnchoredElementOptions.element Element|undefined
 @exportObjectLiteralProperty ol.AnchoredElementOptions.map ol.Map|undefined

--- a/src/ol/layer/vectorlayer.exports
+++ b/src/ol/layer/vectorlayer.exports
@@ -1,3 +1,3 @@
-@exportClass ol.layer.Vector ol.layer.LayerOptions
+@exportClass ol.layer.Vector ol.layer.VectorLayerOptions
 
 @exportProperty ol.layer.Vector.prototype.parseFeatures

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -153,10 +153,15 @@ ol.layer.FeatureCache.prototype.getFeaturesByIds_ = function(ids) {
 /**
  * @constructor
  * @extends {ol.layer.Layer}
- * @param {ol.layer.LayerOptions} layerOptions Layer options.
+ * @param {ol.layer.VectorLayerOptions} layerOptions Layer options.
  */
 ol.layer.Vector = function(layerOptions) {
-  goog.base(this, layerOptions);
+
+  goog.base(this, {
+    opacity: layerOptions.opacity,
+    source: layerOptions.source,
+    visible: layerOptions.visible
+  });
 
   /**
    * @private


### PR DESCRIPTION
Instead of nice rule based styling with multiple symbolizers, the style-rules example on http://openlayers.github.com/ol3/master/examples/style-rules.html only shows 1-pixel black lines. As of now, I have no clue why, and hence no idea how to fix it.
