### PR TITLE
Do not recenter map and zoom on repeated clicks on +/-

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -197,6 +197,7 @@ ol.Map = function(mapOptions) {
       'ol-overlaycontainer');
   goog.events.listen(this.overlayContainer_, [
     goog.events.EventType.CLICK,
+    goog.events.EventType.DBLCLICK,
     ol.BrowserFeature.HAS_TOUCH ?
         goog.events.EventType.TOUCHSTART : goog.events.EventType.MOUSEDOWN
   ], goog.events.Event.stopPropagation);


### PR DESCRIPTION
Multiple fast clicks get interpreted as DBLCLICK by the browser,
so it makes sense to stop propagation of DBLCLICK events when
they happen on elements on the overlay container. This is also
a good change because DBLCLICK might have a meaning on other map
overlays as well.
