### PR TITLE
Make social links more social

### DIFF
--- a/examples/anchored-elements.html
+++ b/examples/anchored-elements.html
@@ -71,8 +71,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -109,6 +111,7 @@
     </div>
 
     <script src="loader.js?id=anchored-elements" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/animation.html
+++ b/examples/animation.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -55,6 +57,7 @@
     </div>
 
     <script src="loader.js?id=animation" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/bind-input.html
+++ b/examples/bind-input.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -79,6 +81,7 @@
     </div>
 
     <script src="loader.js?id=bind-input" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -54,6 +56,7 @@
 
     <script src="jquery.min.js" type="text/javascript"></script>
     <script src="loader.js?id=bing-maps" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/brightness-contrast.html
+++ b/examples/brightness-contrast.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -57,6 +59,7 @@
     </div>
 
     <script src="loader.js?id=brightness-contrast" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/canvas-tiles.html
+++ b/examples/canvas-tiles.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=canvas-tiles" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/epsg-4326.html
+++ b/examples/epsg-4326.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=epsg-4326" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/example-list.html
+++ b/examples/example-list.html
@@ -180,8 +180,10 @@
             <span id="count"></span>
           </form>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -206,6 +208,8 @@
       </div>
 
     </div>
+
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/examples.css
+++ b/examples/examples.css
@@ -13,3 +13,8 @@ body {
 #tags {
   display: none;
 }
+
+/* padding for social links to match bootstrap nav links */
+.nav>li>.twitter-share-button, .nav>li>.g-plusone-wrapper, .nav>li>.github-watch-button {
+  padding: 10px 10px 0px;
+}

--- a/examples/export-jpeg.html
+++ b/examples/export-jpeg.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -48,6 +50,7 @@
     </div>
 
     <script src="loader.js?id=export-jpeg" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/geolocation.html
+++ b/examples/geolocation.html
@@ -22,8 +22,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -56,6 +58,7 @@
     <script src="jquery.min.js" type="text/javascript"></script>
     <script src="bootstrap/js/bootstrap.min.js" type="text/javascript"></script>
     <script src="loader.js?id=geolocation" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/hue-saturation.html
+++ b/examples/hue-saturation.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -57,6 +59,7 @@
     </div>
 
     <script src="loader.js?id=hue-saturation" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/mapquest.html
+++ b/examples/mapquest.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=mapquest" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/mouse-position.html
+++ b/examples/mouse-position.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -48,6 +50,7 @@
     </div>
 
     <script src="loader.js?id=mouse-position" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/rotation.html
+++ b/examples/rotation.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=rotation" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/scale-line.html
+++ b/examples/scale-line.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=scale-line" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/semi-transparent-layer.html
+++ b/examples/semi-transparent-layer.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=semi-transparent-layer" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/side-by-side.html
+++ b/examples/side-by-side.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -72,6 +74,7 @@
     </div>
 
     <script src="loader.js?id=side-by-side" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=simple" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/social-links.js
+++ b/examples/social-links.js
@@ -1,0 +1,22 @@
+
+
+// add tweet buttons (adapated from https://twitter.com/about/resources/buttons)
+(function() {
+  var self = document.getElementsByTagName('script')[0];
+  var script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.async = true;
+  script.src = '//platform.twitter.com/widgets.js';
+  self.parentNode.insertBefore(script, self);
+})();
+
+
+// add g+1 buttons (adapted from https://developers.google.com/+/web/+1button)
+(function() {
+  var self = document.getElementsByTagName('script')[0];
+  var script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.async = true;
+  script.src = 'https://apis.google.com/js/plusone.js';
+  self.parentNode.insertBefore(script, self);
+})();

--- a/examples/stamen.html
+++ b/examples/stamen.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=stamen" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/style-rules.html
+++ b/examples/style-rules.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=style-rules" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/tilejson.html
+++ b/examples/tilejson.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=tilejson" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/vector-layer.html
+++ b/examples/vector-layer.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=vector-layer" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wms-capabilities.html
+++ b/examples/wms-capabilities.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -45,6 +47,7 @@
     </div>
 
     <script src="loader.js?id=wms-capabilities" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wms-custom-proj.html
+++ b/examples/wms-custom-proj.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -49,6 +51,7 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/proj4js-compressed.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/defs/EPSG21781.js" type="text/javascript"></script>
     <script src="loader.js?id=wms-custom-proj" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wms-single-image-custom-proj.html
+++ b/examples/wms-single-image-custom-proj.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -49,6 +51,7 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/proj4js-compressed.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/defs/EPSG21781.js" type="text/javascript"></script>
     <script src="loader.js?id=wms-single-image-custom-proj" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wms-single-image.html
+++ b/examples/wms-single-image.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=wms-single-image" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wms-tiled.html
+++ b/examples/wms-tiled.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=wms-tiled" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wmts-from-capabilities.html
+++ b/examples/wmts-from-capabilities.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -49,6 +51,7 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/proj4js-compressed.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/defs/EPSG21781.js" type="text/javascript"></script>
     <script src="loader.js?id=wmts-from-capabilities" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/wmts.html
+++ b/examples/wmts.html
@@ -16,8 +16,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -47,6 +49,7 @@
     </div>
 
     <script src="loader.js?id=wmts" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
 
   </body>
 </html>

--- a/examples/zoomslider.html
+++ b/examples/zoomslider.html
@@ -68,8 +68,10 @@
         <div class="container">
           <a class="brand" href="example-list.html">OpenLayers 3 Examples</a>
           <ul class="nav pull-right">
-            <li><a href="https://github.com/openlayers/ol3"><i class="icon-github"></i></a></li>
-            <li><a href="https://twitter.com/openlayers"><i class="icon-twitter"></i></a></li>
+            <li><iframe class="github-watch-button" src="http://ghbtns.com/github-btn.html?user=openlayers&repo=ol3&type=watch&count=true"
+  allowtransparency="true" frameborder="0" scrolling="0" height="20" width="90"></iframe></li>
+            <li><a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="openlayers">&nbsp;</a></li>
+            <li><div class="g-plusone-wrapper"><div class="g-plusone" data-size="medium" data-annotation="none"></div></div></li>
           </ul>
         </div>
       </div>
@@ -111,5 +113,8 @@
     </div>
 
     <script src="loader.js?id=zoomslider" type="text/javascript"></script>
+    <script src="social-links.js" type="text/javascript"></script>
+
   </body>
+
 </html>


### PR DESCRIPTION
Instead of just a link to our GitHub repo, we can have a button that encourages people to star.  Instead of a link to our twitter feed, we can encourage people to tweet.  For people that g+, we have a link that encourages them to g+1.

Without these changes:
![before](https://f.cloud.github.com/assets/41094/272433/78f6f096-9003-11e2-83cd-ee81829f0ec1.png)

With these changes:
![after](https://f.cloud.github.com/assets/41094/272435/7fdfdc6a-9003-11e2-8798-6225210b55e5.png)
