### PR TITLE
Optionally extend ol.Coordinate to the third dimension

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -28,7 +28,7 @@ ol.Coordinate = function(x, y, opt_z) {
   /**
    * @type {number}
    */
-  this.z = opt_z || 0;
+  this.z = goog.isDef(opt_z) ? opt_z : NaN;
 
 };
 goog.inherits(ol.Coordinate, goog.math.Vec2);


### PR DESCRIPTION
This PR makes `ol.Coordinate` optionally three dimensional.

Surprisingly, this is all that is required. With this, everything else continues to function (well, at least all the tests pass).

This is so that @mrmattf can continue his awesome work on Cesium / ol3 integration.
