### PR TITLE
crossOrigin defaults to null

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -13,7 +13,6 @@ var layers = [
   new ol.layer.TileLayer({
     source: new ol.source.TiledWMS({
       url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
-      crossOrigin: null,
       params: {
         'VERSION': '1.1.1',
         'LAYERS': 'basic',

--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -15,7 +15,8 @@ var map = new ol.Map({
     }),
     new ol.layer.TileLayer({
       source: new ol.source.TileJSON({
-        uri: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.jsonp'
+        uri: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.jsonp',
+        crossOrigin: 'anonymous'
       })
     })
   ],

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -10,7 +10,8 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       source: new ol.source.TileJSON({
-        uri: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp'
+        uri: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp',
+        crossOrigin: 'anonymous'
       })
     })
   ],

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -22,6 +22,7 @@ var layers = [
   new ol.layer.TileLayer({
     source: new ol.source.TiledWMS({
       url: 'http://wms.geo.admin.ch/',
+      crossOrigin: 'anonymous',
       attributions: [new ol.Attribution(
           '&copy; ' +
           '<a href="http://www.geo.admin.ch/internet/geoportal/en/home.html">' +
@@ -36,6 +37,7 @@ var layers = [
   new ol.layer.TileLayer({
     source: new ol.source.TiledWMS({
       url: 'http://wms.geo.admin.ch/',
+      crossOrigin: 'anonymous',
       attributions: [new ol.Attribution(
           '&copy; ' +
           '<a href="http://www.geo.admin.ch/internet/geoportal/en/home.html">' +

--- a/examples/wms-single-image-custom-proj.js
+++ b/examples/wms-single-image-custom-proj.js
@@ -19,6 +19,7 @@ var layers = [
   new ol.layer.ImageLayer({
     source: new ol.source.SingleImageWMS({
       url: 'http://wms.geo.admin.ch/',
+      crossOrigin: 'anonymous',
       attributions: [new ol.Attribution(
           '&copy; ' +
           '<a href="http://www.geo.admin.ch/internet/geoportal/en/home.html">' +
@@ -33,6 +34,7 @@ var layers = [
   new ol.layer.ImageLayer({
     source: new ol.source.SingleImageWMS({
       url: 'http://wms.geo.admin.ch/',
+      crossOrigin: 'anonymous',
       attributions: [new ol.Attribution(
           '&copy; ' +
           '<a href="http://www.geo.admin.ch/internet/geoportal/en/home.html">' +

--- a/examples/wms-single-image.js
+++ b/examples/wms-single-image.js
@@ -16,7 +16,6 @@ var layers = [
   new ol.layer.ImageLayer({
     source: new ol.source.SingleImageWMS({
       url: 'http://demo.opengeo.org/geoserver/wms',
-      crossOrigin: null,
       params: {'LAYERS': 'topp:states'},
       extent: new ol.Extent(-13884991, 2870341, -7455066, 6338219)
     })

--- a/examples/wms-tiled.js
+++ b/examples/wms-tiled.js
@@ -15,7 +15,6 @@ var layers = [
   new ol.layer.TileLayer({
     source: new ol.source.TiledWMS({
       url: 'http://demo.opengeo.org/geoserver/wms',
-      crossOrigin: null,
       params: {'LAYERS': 'topp:states', 'TILED': true},
       extent: new ol.Extent(-13884991, 2870341, -7455066, 6338219)
     })

--- a/examples/wmts-from-capabilities.js
+++ b/examples/wmts-from-capabilities.js
@@ -28,6 +28,7 @@ xhr.onload = function() {
     capabilities = parser.read(xhr.responseXML);
     var wmtsOptions = ol.source.WMTS.optionsFromCapabilities(
         capabilities, 'ch.swisstopo.pixelkarte-farbe');
+    wmtsOptions.crossOrigin = 'anonymous';
     map = new ol.Map({
       layers: [
         new ol.layer.TileLayer({

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -40,7 +40,6 @@ var map = new ol.Map({
           matrixIds: matrixIds
         }),
         style: '_null',
-        crossOrigin: null, // FIXME: this should be the default
         extent: new ol.Extent(-13682835, 5204068, -13667473, 5221690)
       })
     })

--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -154,6 +154,7 @@
 @exportObjectLiteralProperty ol.source.StaticImageOptions.url string|undefined
 
 @exportObjectLiteral ol.source.TileJSONOptions
+@exportObjectLiteralProperty ol.source.TileJSONOptions.crossOrigin null|string|undefined
 @exportObjectLiteralProperty ol.source.TileJSONOptions.uri string
 
 @exportObjectLiteral ol.source.TiledWMSOptions

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -23,6 +23,7 @@ goog.require('ol.tilegrid.XYZ');
 ol.source.BingMaps = function(bingMapsOptions) {
 
   goog.base(this, {
+    crossOrigin: 'anonymous',
     opaque: true,
     projection: ol.projection.get('EPSG:3857')
   });

--- a/src/ol/source/imagesource.js
+++ b/src/ol/source/imagesource.js
@@ -53,7 +53,7 @@ ol.source.ImageSource = function(options) {
    * @type {?string}
    */
   this.crossOrigin_ =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : 'anonymous';
+      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
 
   /**
    * @private

--- a/src/ol/source/imagetilesource.js
+++ b/src/ol/source/imagetilesource.js
@@ -55,7 +55,7 @@ ol.source.ImageTileSource = function(options) {
    * @type {?string}
    */
   this.crossOrigin_ =
-      goog.isDef(options.crossOrigin) ? options.crossOrigin : 'anonymous';
+      goog.isDef(options.crossOrigin) ? options.crossOrigin : null;
 
   /**
    * @private

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -26,6 +26,7 @@ ol.source.MapQuestOSM = function() {
 
   goog.base(this, {
     attributions: attributions,
+    crossOrigin: 'anonymous',
     opaque: true,
     maxZoom: 28,
     url: 'http://otile{1-4}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg'
@@ -54,6 +55,7 @@ ol.source.MapQuestOpenAerial = function() {
 
   goog.base(this, {
     attributions: attributions,
+    crossOrigin: 'anonymous',
     maxZoom: 18,
     opaque: true,
     url: 'http://oatile{1-4}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg'

--- a/src/ol/source/openstreetmapsource.js
+++ b/src/ol/source/openstreetmapsource.js
@@ -18,6 +18,7 @@ ol.source.OpenStreetMap = function() {
 
   goog.base(this, {
     attributions: [attribution],
+    crossOrigin: 'anonymous',
     opaque: true,
     maxZoom: 18,
     url: 'http://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -106,6 +106,7 @@ ol.source.Stamen = function(options) {
 
   goog.base(this, {
     attributions: ol.source.STAMEN_ATTRIBUTIONS,
+    crossOrigin: 'anonymous',
     maxZoom: providerConfig.maxZoom,
     // FIXME uncomment the following when tilegrid supports minZoom
     //minZoom: providerConfig.minZoom,

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -46,6 +46,7 @@ goog.exportSymbol('grid', grid);
 ol.source.TileJSON = function(tileJsonOptions) {
 
   goog.base(this, {
+    crossOrigin: tileJsonOptions.crossOrigin,
     projection: ol.projection.get('EPSG:3857')
   });
 


### PR DESCRIPTION
With this PR `crossOrigin` is `null` by default in the base `ImageSource` and `ImageTileSource` classes.
