### PR TITLE
Use jsdoc v3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
   - "sudo pip install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
-  - "git clone https://github.com/jsdoc3/jsdoc"
+  - "git clone https://github.com/jsdoc3/jsdoc && (cd jsdoc && git checkout v3.1.1)"
 
 before_script:
   - "./build.py plovr"


### PR DESCRIPTION
We're having issues with the latest jsdoc (master). Refs #405. With jsdoc v3.1.1 the build passes again: https://travis-ci.org/elemoine/ol3/builds/5670880.
