### PR TITLE
Tile renderers needn't listen for tile change

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -271,7 +271,8 @@ ol.Map = function(mapOptions) {
    * @private
    * @type {ol.TileQueue}
    */
-  this.tileQueue_ = new ol.TileQueue(goog.bind(this.getTilePriority, this));
+  this.tileQueue_ = new ol.TileQueue(goog.bind(this.getTilePriority, this),
+      goog.bind(this.handleTileChange_, this));
 
   goog.events.listen(this, ol.Object.getChangedEventType(ol.MapProperty.VIEW),
       this.handleViewChanged_, false, this);
@@ -543,13 +544,7 @@ ol.Map.prototype.handleMapBrowserEvent = function(mapBrowserEvent) {
  */
 ol.Map.prototype.handlePostRender = function() {
   this.tileQueue_.reprioritize(); // FIXME only call if needed
-  var moreLoadingTiles = this.tileQueue_.loadMoreTiles();
-  if (moreLoadingTiles) {
-    // The tile layer renderers need to know when tiles change
-    // to the LOADING state (to register the change listener
-    // on the tile).
-    this.requestRenderFrame();
-  }
+  this.tileQueue_.loadMoreTiles();
 
   var postRenderFunctions = this.postRenderFunctions_;
   var i;
@@ -582,6 +577,14 @@ ol.Map.prototype.handleBrowserWindowResize = function() {
  */
 ol.Map.prototype.handleSizeChanged_ = function() {
   this.render();
+};
+
+
+/**
+ * @private
+ */
+ol.Map.prototype.handleTileChange_ = function() {
+  this.requestRenderFrame();
 };
 
 

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -167,8 +167,6 @@ ol.renderer.canvas.TileLayer.prototype.renderFrame =
         this.updateWantedTiles(frameState.wantedTiles, tileSource, tileCoord);
         tileCenter = tileGrid.getTileCoordCenter(tileCoord);
         frameState.tileQueue.enqueue(tile, tileSourceKey, tileCenter);
-      } else if (tileState == ol.TileState.LOADING) {
-        this.listenToTileChange(tile);
       } else if (tileState == ol.TileState.LOADED ||
                  tileState == ol.TileState.EMPTY) {
         tilesToDrawByZ[z][tileCoord.toString()] = tile;

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -124,8 +124,6 @@ ol.renderer.dom.TileLayer.prototype.renderFrame =
         this.updateWantedTiles(frameState.wantedTiles, tileSource, tileCoord);
         tileCenter = tileGrid.getTileCoordCenter(tileCoord);
         frameState.tileQueue.enqueue(tile, tileSourceKey, tileCenter);
-      } else if (tileState == ol.TileState.LOADING) {
-        this.listenToTileChange(tile);
       } else if (tileState == ol.TileState.LOADED) {
         tilesToDrawByZ[z][tileCoord.toString()] = tile;
         continue;

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -41,12 +41,6 @@ ol.renderer.Layer = function(mapRenderer, layer) {
    */
   this.layer_ = layer;
 
-  /**
-   * @protected
-   * @type {Object.<string, boolean>}
-   */
-  this.observedTileKeys = {};
-
   goog.events.listen(this.layer_,
       ol.Object.getChangedEventType(ol.layer.LayerProperty.BRIGHTNESS),
       this.handleLayerBrightnessChange, false, this);
@@ -180,22 +174,6 @@ ol.renderer.Layer.prototype.handleTileChange_ = function(event) {
   var tile = /** @type {ol.Tile} */ (event.target);
   if (tile.getState() === ol.TileState.LOADED) {
     this.getMap().requestRenderFrame();
-  }
-  delete this.observedTileKeys[tile.getKey()];
-};
-
-
-/**
- * Listen once to tileKey, le change event.
- * @param {ol.Tile} tile Tile.
- * @protected
- */
-ol.renderer.Layer.prototype.listenToTileChange = function(tile) {
-  var tileKey = tile.getKey();
-  if (!(tileKey in this.observedTileKeys)) {
-    this.observedTileKeys[tileKey] = true;
-    goog.events.listenOnce(tile, goog.events.EventType.CHANGE,
-        this.handleTileChange_, false, this);
   }
 };
 

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -398,8 +398,6 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame =
           this.updateWantedTiles(frameState.wantedTiles, tileSource, tileCoord);
           tileCenter = tileGrid.getTileCoordCenter(tileCoord);
           frameState.tileQueue.enqueue(tile, tileSourceKey, tileCenter);
-        } else if (tileState == ol.TileState.LOADING) {
-          this.listenToTileChange(tile);
         } else if (tileState == ol.TileState.LOADED) {
           if (mapRenderer.isTileTextureLoaded(tile)) {
             tilesToDrawByZ[z][tileCoord.toString()] = tile;

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -30,14 +30,22 @@ ol.TilePriorityFunction;
  * @constructor
  * @param {ol.TilePriorityFunction} tilePriorityFunction
  *     Tile priority function.
+ * @param {Function} tileChangeCallback
+ *     Function called on each tile change event.
  */
-ol.TileQueue = function(tilePriorityFunction) {
+ol.TileQueue = function(tilePriorityFunction, tileChangeCallback) {
 
   /**
    * @private
    * @type {ol.TilePriorityFunction}
    */
   this.tilePriorityFunction_ = tilePriorityFunction;
+
+  /**
+   * @private
+   * @type {Function}
+   */
+  this.tileChangeCallback_ = tileChangeCallback;
 
   /**
    * @private
@@ -120,6 +128,7 @@ ol.TileQueue.prototype.enqueue = function(tile, tileSourceKey, tileCenter) {
  */
 ol.TileQueue.prototype.handleTileChange = function() {
   --this.tilesLoading_;
+  this.tileChangeCallback_();
 };
 
 
@@ -168,7 +177,7 @@ ol.TileQueue.prototype.heapify_ = function() {
 
 
 /**
- * @return {boolean} New loading tiles?
+ *  FIXME empty description for jsdoc
  */
 ol.TileQueue.prototype.loadMoreTiles = function() {
   var tile;
@@ -179,7 +188,6 @@ ol.TileQueue.prototype.loadMoreTiles = function() {
     tile.load();
     ++this.tilesLoading_;
   }
-  return goog.isDef(tile);
 };
 
 


### PR DESCRIPTION
With this change the tile layer renderers no longer listen to tile changes. They just give tiles to load to the tile queue and wait for the tile queue/map to wake them up (`renderFrame_` calls) when new tiles have come in. This simplifies the code ("20 additions and 30 deletions"), and fixes a [bug](https://github.com/openlayers/ol3/pull/357#issuecomment-14900406) where the tile queue may have tiles to load but no one to trigger the load action.
