### PR TITLE
Keep the search-filter on submit in example index.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -176,7 +176,7 @@
         <div class="container">
           <a class="brand" href="./">OpenLayers 3 Examples</a>
           <form class="navbar-search pull-left">
-            <input type="text" id="keywords" class="search-query" placeholder="Search">
+            <input name="q" type="text" id="keywords" class="search-query" placeholder="Search">
             <span id="count"></span>
           </form>
           <ul class="nav pull-right">


### PR DESCRIPTION
When one would hit `ENTER` after filtering the list of examples, the form would
be submitted and the filter would be gone after the page reload. By giving the
main search field the appropriate `name`-attribute, this is being solved.
