### PR TITLE
Remove descriptions from JSDoc/Closure Compiler type tags

### DIFF
--- a/src/ol/browserfeature.js
+++ b/src/ol/browserfeature.js
@@ -12,7 +12,8 @@ ol.ASSUME_TOUCH = false;
  */
 ol.BrowserFeature = {
   /**
-   * @type {boolean} True if browser supports touch events
+   * True if browser supports touch events.
+   * @type {boolean}
    */
   HAS_TOUCH: ol.ASSUME_TOUCH ||
       (document && 'ontouchstart' in document.documentElement) ||

--- a/src/ol/canvas/canvas.js
+++ b/src/ol/canvas/canvas.js
@@ -5,8 +5,9 @@ goog.require('goog.dom.TagName');
 
 
 /**
+ * Is supported.
  * @const
- * @type {boolean} Is supported.
+ * @type {boolean}
  */
 ol.canvas.SUPPORTED = (function() {
   if (!('HTMLCanvasElement' in goog.global)) {

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -109,8 +109,9 @@ ol.Geolocation.prototype.handleTrackingChanged_ = function() {
 
 
 /**
+ * Is supported.
  * @const
- * @type {boolean} Is supported.
+ * @type {boolean}
  */
 ol.Geolocation.SUPPORTED = 'geolocation' in navigator;
 

--- a/src/ol/projection/projection.js
+++ b/src/ol/projection/projection.js
@@ -19,7 +19,8 @@ ol.ENABLE_PROJ4JS = true;
 
 
 /**
- * @const {boolean} Have Proj4js.
+ * Have Proj4js.
+ * @const {boolean}
  */
 ol.HAVE_PROJ4JS = ol.ENABLE_PROJ4JS && typeof Proj4js == 'object';
 

--- a/src/ol/renderer/canvas/canvasrenderer.js
+++ b/src/ol/renderer/canvas/canvasrenderer.js
@@ -4,7 +4,8 @@ goog.require('ol.canvas');
 
 
 /**
+ * Is supported.
  * @const
- * @type {boolean} Is supported.
+ * @type {boolean}
  */
 ol.renderer.canvas.SUPPORTED = ol.canvas.SUPPORTED;

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -81,9 +81,9 @@ ol.renderer.canvas.VectorLayer = function(mapRenderer, layer) {
 
   /**
    * Geometry filters in rendering order.
+   * TODO: these will go away shortly (in favor of one call per symbolizer type)
    * @private
    * @type {Array.<ol.filter.Geometry>}
-   * TODO: these will go away shortly (in favor of one call per symbolizer type)
    */
   this.geometryFilters_ = [
     new ol.filter.Geometry(ol.geom.GeometryType.POINT),

--- a/src/ol/renderer/dom/domrenderer.js
+++ b/src/ol/renderer/dom/domrenderer.js
@@ -2,7 +2,8 @@ goog.provide('ol.renderer.dom.SUPPORTED');
 
 
 /**
+ * Is supported.
  * @const
- * @type {boolean} Is supported.
+ * @type {boolean}
  */
 ol.renderer.dom.SUPPORTED = true;

--- a/src/ol/renderer/webgl/webglrenderer.js
+++ b/src/ol/renderer/webgl/webglrenderer.js
@@ -4,7 +4,8 @@ goog.require('ol.webgl');
 
 
 /**
+ * Is supported.
  * @const
- * @type {boolean} Is supported.
+ * @type {boolean}
  */
 ol.renderer.webgl.SUPPORTED = ol.webgl.SUPPORTED;

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -28,7 +28,8 @@ ol.TileCoord = function(z, x, y) {
   goog.base(this, x, y);
 
   /**
-   * @type {number} Zoom level
+   * Zoom level.
+   * @type {number}
    */
   this.z = z;
 

--- a/src/ol/webgl/webgl.js
+++ b/src/ol/webgl/webgl.js
@@ -45,8 +45,9 @@ ol.webgl.getContext = function(canvas, opt_attributes) {
 
 
 /**
+ * Is supported.
  * @const
- * @type {boolean} Is supported.
+ * @type {boolean}
  */
 ol.webgl.SUPPORTED = (function() {
   if (!('WebGLRenderingContext' in goog.global)) {


### PR DESCRIPTION
This pull request corrects the syntax of `@type` tags in block comments. With this pull request, you should not see any errors when using the current development version of [JSDoc](https://github.com/jsdoc3/jsdoc).

I've submitted a CLA and verified that these changes do not break Closure Lint or Closure Compiler.
