### PR TITLE
Use JSDoc master again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
   - "sudo pip install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
-  - "git clone https://github.com/jsdoc3/jsdoc && (cd jsdoc && git checkout v3.1.1)"
+  - "git clone https://github.com/jsdoc3/jsdoc && (cd jsdoc && git checkout master)"
 
 before_script:
   - "./build.py plovr"


### PR DESCRIPTION
... so we're able to always give the JSDoc project instant
feedback on how it works with code that uses the Closure
library.
