### PR TITLE
Don't create tile if rendering needs to be deferred

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -341,6 +341,7 @@ ol.renderer.canvas.VectorLayer.prototype.renderFrame =
     }
   }
 
+  renderByGeometryType:
   for (type in featuresToRender) {
     groups = layer.groupFeaturesBySymbolizerLiteral(featuresToRender[type]);
     numGroups = groups.length;
@@ -350,12 +351,13 @@ ol.renderer.canvas.VectorLayer.prototype.renderFrame =
           /** @type {ol.geom.GeometryType} */ (type),
           group[0], group[1]);
       if (deferred) {
-        break;
+        break renderByGeometryType;
       }
     }
-    if (!deferred) {
-      goog.object.extend(tilesToRender, tilesOnSketchCanvas);
-    }
+  }
+
+  if (!deferred) {
+    goog.object.extend(tilesToRender, tilesOnSketchCanvas);
   }
 
   for (key in tilesToRender) {

--- a/src/ol/renderer/canvas/canvasvectorrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorrenderer.js
@@ -379,7 +379,6 @@ ol.renderer.canvas.VectorRenderer.renderIcon = function(icon, opt_callback) {
             opt_callback),
         false, ol.renderer.canvas.VectorRenderer.renderIcon);
     image.setAttribute('src', url);
-    ol.renderer.canvas.VectorRenderer.icons_[url] = image;
   } else if (!goog.isNull(image)) {
     var width = icon.width,
         height = icon.height;


### PR DESCRIPTION
Rendering vector tiles with mixed geometry types does not work
as expected, because the tile is created without the geometries
that need another rendering pass because of missing icons. This
was discovered by @bartvde when working on the KML parser, where
mixed geometry types are common.

This change fixes the issue by breaking out from rendering
entirely when renderFeaturesByGeometryType returns a deferred
state. In addition, there was a related bug because icons are
added to the cache regardless of its loaded state. This is also
fixed now.
