### PR TITLE
Fix use of this in ol.source.BingMaps

### DIFF
--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -81,6 +81,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
   });
   this.tileGrid = tileGrid;
 
+  var culture = this.culture_;
   this.tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
       function(tileCoord) {
         if (tileCoord.z < zoomMin || zoomMax < tileCoord.z) {
@@ -101,7 +102,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
               function(subdomain) {
                 var imageUrl = resource.imageUrl
                     .replace('{subdomain}', subdomain)
-                    .replace('{culture}', this.culture_);
+                    .replace('{culture}', culture);
                 return function(tileCoord) {
                   if (goog.isNull(tileCoord)) {
                     return undefined;


### PR DESCRIPTION
This fixes an incorrect use of `this` in `ol.source.BingMapsSource`, which prevented the Bing Maps example from working in advanced mode.
