### PR TITLE
Rename TileJSONOptions.uri to TileJSONOptions.url

### DIFF
--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -15,7 +15,7 @@ var map = new ol.Map({
     }),
     new ol.layer.TileLayer({
       source: new ol.source.TileJSON({
-        uri: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.jsonp',
+        url: 'http://api.tiles.mapbox.com/v3/mapbox.va-quake-aug.jsonp',
         crossOrigin: 'anonymous'
       })
     })

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -10,7 +10,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       source: new ol.source.TileJSON({
-        uri: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp',
+        url: 'http://api.tiles.mapbox.com/v3/mapbox.geography-class.jsonp',
         crossOrigin: 'anonymous'
       })
     })

--- a/src/objectliterals.exports
+++ b/src/objectliterals.exports
@@ -155,7 +155,7 @@
 
 @exportObjectLiteral ol.source.TileJSONOptions
 @exportObjectLiteralProperty ol.source.TileJSONOptions.crossOrigin null|string|undefined
-@exportObjectLiteralProperty ol.source.TileJSONOptions.uri string
+@exportObjectLiteralProperty ol.source.TileJSONOptions.url string
 
 @exportObjectLiteral ol.source.TiledWMSOptions
 @exportObjectLiteralProperty ol.source.TiledWMSOptions.attributions Array.<ol.Attribution>|undefined

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -61,7 +61,7 @@ ol.source.TileJSON = function(tileJsonOptions) {
    * @type {!goog.async.Deferred}
    */
   this.deferred_ =
-      goog.net.jsloader.load(tileJsonOptions.uri, {cleanupWhenDone: true});
+      goog.net.jsloader.load(tileJsonOptions.url, {cleanupWhenDone: true});
   this.deferred_.addCallback(this.handleTileJSONResponse, this);
 
 };


### PR DESCRIPTION
`url` (or `urls`) is used everywhere except in `TileJSONOptions`.
