### PR TITLE
Move ol.tilegrid.XYZ tests to their proper place

### DIFF
--- a/test/spec/ol/source/xyzsource.test.js
+++ b/test/spec/ol/source/xyzsource.test.js
@@ -1,5 +1,6 @@
 goog.provide('ol.test.source.XYZ');
 
+
 describe('ol.source.XYZ', function() {
 
   describe('tileUrlFunction', function() {
@@ -15,6 +16,7 @@ describe('ol.source.XYZ', function() {
     });
 
     it('return the expected URL', function() {
+
       var coordinate = new ol.Coordinate(829330.2064098881, 5933916.615134273);
       var tileUrl;
 
@@ -45,9 +47,11 @@ describe('ol.source.XYZ', function() {
       tileUrl = xyzTileSource.tileUrlFunction(
           tileGrid.getTileCoordForCoordAndZ(coordinate, 6));
       expect(tileUrl).to.eql('6/33/22');
+
     });
 
     describe('wrap x', function() {
+
       it('returns the expected URL', function() {
         var tileUrl = xyzTileSource.tileUrlFunction(
             new ol.TileCoord(6, -31, -23));
@@ -59,9 +63,11 @@ describe('ol.source.XYZ', function() {
         tileUrl = xyzTileSource.tileUrlFunction(new ol.TileCoord(6, 97, -23));
         expect(tileUrl).to.eql('6/33/22');
       });
+
     });
 
     describe('crop y', function() {
+
       it('returns the expected URL', function() {
         var tileUrl = xyzTileSource.tileUrlFunction(
             new ol.TileCoord(6, 33, -87));
@@ -73,64 +79,13 @@ describe('ol.source.XYZ', function() {
         tileUrl = xyzTileSource.tileUrlFunction(new ol.TileCoord(6, 33, 41));
         expect(tileUrl).to.be(undefined);
       });
+
     });
-  });
 
-  describe('forEachTileCoordParentTileRange', function() {
-    it('iterates as expected', function() {
-      var xyzTileGrid = new ol.tilegrid.XYZ({maxZoom: 6});
-
-      var tileCoord = new ol.TileCoord(5, 11, 21);
-      var zs = [], tileRanges = [];
-      xyzTileGrid.forEachTileCoordParentTileRange(
-          tileCoord,
-          function(z, tileRange) {
-            zs.push(z);
-            tileRanges.push(new ol.TileRange(
-                tileRange.minX, tileRange.minY,
-                tileRange.maxX, tileRange.maxY));
-            return false;
-          });
-
-      expect(zs.length).to.eql(5);
-      expect(tileRanges.length).to.eql(5);
-
-      expect(zs[0]).to.eql(4);
-      expect(tileRanges[0].minX).to.eql(5);
-      expect(tileRanges[0].minY).to.eql(10);
-      expect(tileRanges[0].maxX).to.eql(5);
-      expect(tileRanges[0].maxY).to.eql(10);
-
-      expect(zs[1]).to.eql(3);
-      expect(tileRanges[1].minX).to.eql(2);
-      expect(tileRanges[1].minY).to.eql(5);
-      expect(tileRanges[1].maxX).to.eql(2);
-      expect(tileRanges[1].maxY).to.eql(5);
-
-      expect(zs[2]).to.eql(2);
-      expect(tileRanges[2].minX).to.eql(1);
-      expect(tileRanges[2].minY).to.eql(2);
-      expect(tileRanges[2].maxX).to.eql(1);
-      expect(tileRanges[2].maxY).to.eql(2);
-
-      expect(zs[3]).to.eql(1);
-      expect(tileRanges[3].minX).to.eql(0);
-      expect(tileRanges[3].minY).to.eql(1);
-      expect(tileRanges[3].maxX).to.eql(0);
-      expect(tileRanges[3].maxY).to.eql(1);
-
-      expect(zs[4]).to.eql(0);
-      expect(tileRanges[4].minX).to.eql(0);
-      expect(tileRanges[4].minY).to.eql(0);
-      expect(tileRanges[4].maxX).to.eql(0);
-      expect(tileRanges[4].maxY).to.eql(0);
-    });
   });
 
 });
 
 goog.require('ol.Coordinate');
 goog.require('ol.TileCoord');
-goog.require('ol.TileRange');
-goog.require('ol.tilegrid.XYZ');
 goog.require('ol.source.XYZ');

--- a/test/spec/ol/tilegrid/xyztilegrid.test.js
+++ b/test/spec/ol/tilegrid/xyztilegrid.test.js
@@ -3,13 +3,70 @@ goog.provide('ol.test.tilegrid.XYZ');
 
 describe('ol.tilegrid.XYZ', function() {
 
+  var xyzTileGrid;
+  beforeEach(function() {
+    xyzTileGrid = new ol.tilegrid.XYZ({
+      maxZoom: 22
+    });
+  });
+
+  describe('forEachTileCoordParentTileRange', function() {
+
+    it('iterates as expected', function() {
+
+      var tileCoord = new ol.TileCoord(5, 11, 21);
+      var zs = [], tileRanges = [];
+      xyzTileGrid.forEachTileCoordParentTileRange(
+          tileCoord,
+          function(z, tileRange) {
+            zs.push(z);
+            tileRanges.push(new ol.TileRange(
+                tileRange.minX, tileRange.minY,
+                tileRange.maxX, tileRange.maxY));
+            return false;
+          });
+
+      expect(zs.length).to.eql(5);
+      expect(tileRanges.length).to.eql(5);
+
+      expect(zs[0]).to.eql(4);
+      expect(tileRanges[0].minX).to.eql(5);
+      expect(tileRanges[0].minY).to.eql(10);
+      expect(tileRanges[0].maxX).to.eql(5);
+      expect(tileRanges[0].maxY).to.eql(10);
+
+      expect(zs[1]).to.eql(3);
+      expect(tileRanges[1].minX).to.eql(2);
+      expect(tileRanges[1].minY).to.eql(5);
+      expect(tileRanges[1].maxX).to.eql(2);
+      expect(tileRanges[1].maxY).to.eql(5);
+
+      expect(zs[2]).to.eql(2);
+      expect(tileRanges[2].minX).to.eql(1);
+      expect(tileRanges[2].minY).to.eql(2);
+      expect(tileRanges[2].maxX).to.eql(1);
+      expect(tileRanges[2].maxY).to.eql(2);
+
+      expect(zs[3]).to.eql(1);
+      expect(tileRanges[3].minX).to.eql(0);
+      expect(tileRanges[3].minY).to.eql(1);
+      expect(tileRanges[3].maxX).to.eql(0);
+      expect(tileRanges[3].maxY).to.eql(1);
+
+      expect(zs[4]).to.eql(0);
+      expect(tileRanges[4].minX).to.eql(0);
+      expect(tileRanges[4].minY).to.eql(0);
+      expect(tileRanges[4].maxX).to.eql(0);
+      expect(tileRanges[4].maxY).to.eql(0);
+
+    });
+
+  });
+
   describe('getResolution', function() {
 
     it('returns the correct resolution at the equator', function() {
       // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
-      var xyzTileGrid = new ol.tilegrid.XYZ({
-        maxZoom: 22
-      });
       expect(xyzTileGrid.getResolution(0)).to.roughlyEqual(156543.04, 1e-2);
       expect(xyzTileGrid.getResolution(1)).to.roughlyEqual(78271.52, 1e-2);
       expect(xyzTileGrid.getResolution(2)).to.roughlyEqual(39135.76, 1e-2);
@@ -37,4 +94,6 @@ describe('ol.tilegrid.XYZ', function() {
 });
 
 
+goog.require('ol.TileCoord');
+goog.require('ol.TileRange');
 goog.require('ol.tilegrid.XYZ');


### PR DESCRIPTION
Some `ol.tilegrid.XYZ` tests were mixed up with the `ol.source.XYZ` tests. This PR puts them back in their proper place.
