### PR TITLE
Use @expose for Coordinate.z

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -26,6 +26,7 @@ ol.Coordinate = function(x, y, opt_z) {
   goog.base(this, x, y);
 
   /**
+   * @expose
    * @type {number}
    */
   this.z = goog.isDef(opt_z) ? opt_z : NaN;


### PR DESCRIPTION
By annotating the z property with `@expose` the compiler does not try to optimize that property in any way. See
https://developers.google.com/closure/compiler/docs/js-for-compiler. The doc says that `@expose` should never be used in library code, but that's the only way I found for our case.
