### PR TITLE
Fix build/src/external/src/types.js dependency

### DIFF
--- a/build.py
+++ b/build.py
@@ -178,7 +178,7 @@ def build_src_external_src_exports_js(t):
              '--exports', 'src/objectliterals.exports', EXPORTS)
 
 
-@target('build/src/external/src/types.js', 'bin/generate-exports',
+@target('build/src/external/src/types.js', 'bin/generate-exports.py',
         'src/objectliterals.exports')
 def build_src_external_src_types_js(t):
     t.output('%(PYTHON)s', 'bin/generate-exports.py',


### PR DESCRIPTION
The dependencies for `build/src/external/src/types.js` were wrong, which meant that `build/src/external/src/types.js` would always be rebuilt, which meant that almost everything else would be rebuilt too.
