### PR TITLE
Add on and un methods to ol.Object

### DIFF
--- a/src/ol/object.exports
+++ b/src/ol/object.exports
@@ -3,8 +3,10 @@
 @exportProperty ol.Object.prototype.changed
 @exportProperty ol.Object.prototype.get
 @exportProperty ol.Object.prototype.notify
+@exportProperty ol.Object.prototype.on
 @exportProperty ol.Object.prototype.set
 @exportProperty ol.Object.prototype.setOptions
 @exportProperty ol.Object.prototype.setValues
+@exportProperty ol.Object.prototype.un
 @exportProperty ol.Object.prototype.unbind
 @exportProperty ol.Object.prototype.unbindAll

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -230,6 +230,17 @@ ol.Object.prototype.notifyInternal_ = function(key) {
 
 
 /**
+ * @param {string} type The event type.
+ * @param {Function} listener The listener function.
+ * @param {Object=} opt_scope Object is whose scope to call
+ *     the listener.
+ */
+ol.Object.prototype.on = function(type, listener, opt_scope) {
+  goog.events.listen(this, type, listener, false, opt_scope);
+};
+
+
+/**
  * @param {string} key Key.
  * @param {*} value Value.
  */
@@ -289,6 +300,17 @@ ol.Object.prototype.unbind = function(key) {
     delete accessors[key];
     this.values_[key] = value;
   }
+};
+
+
+/**
+ * @param {string} type The event type.
+ * @param {Function} listener The listener function.
+ * @param {Object=} opt_scope Object is whose scope to call
+ *     the listener.
+ */
+ol.Object.prototype.un = function(type, listener, opt_scope) {
+  goog.events.unlisten(this, type, listener, false, opt_scope);
 };
 
 


### PR DESCRIPTION
With this one can register and unregister event listeners using `on` and `un` on any `ol.Object` object. For example:

```
map.on('dragstart', function() { window.console.log('dragstart'); });
```
