### PR TITLE
Do not pass tile grid to getTile and tileUrlFunc

### DIFF
--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -195,7 +195,7 @@ ol.renderer.canvas.TileLayer.prototype.renderFrame =
 
   var getTileIfLoaded = this.createGetTileIfLoadedFunction(function(tile) {
     return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED;
-  }, tileSource, tileGrid, projection);
+  }, tileSource, projection);
   var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
       tilesToDrawByZ, getTileIfLoaded);
 
@@ -204,7 +204,7 @@ ol.renderer.canvas.TileLayer.prototype.renderFrame =
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
 
-      tile = tileSource.getTile(z, x, y, tileGrid, projection);
+      tile = tileSource.getTile(z, x, y, projection);
       tileState = tile.getState();
       if (tileState == ol.TileState.LOADED || tileState == ol.TileState.EMPTY) {
         tilesToDrawByZ[z][tile.tileCoord.toString()] = tile;

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -107,7 +107,7 @@ ol.renderer.dom.TileLayer.prototype.renderFrame =
 
   var getTileIfLoaded = this.createGetTileIfLoadedFunction(function(tile) {
     return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED;
-  }, tileSource, tileGrid, projection);
+  }, tileSource, projection);
   var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
       tilesToDrawByZ, getTileIfLoaded);
 
@@ -116,7 +116,7 @@ ol.renderer.dom.TileLayer.prototype.renderFrame =
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
 
-      tile = tileSource.getTile(z, x, y, tileGrid, projection);
+      tile = tileSource.getTile(z, x, y, projection);
       tileState = tile.getState();
       if (tileState == ol.TileState.LOADED) {
         tilesToDrawByZ[z][tile.tileCoord.toString()] = tile;

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -249,15 +249,14 @@ ol.renderer.Layer.prototype.updateUsedTiles =
  * @param {function(ol.Tile): boolean} isLoadedFunction Function to
  *     determine if the tile is loaded.
  * @param {ol.source.TileSource} tileSource Tile source.
- * @param {ol.tilegrid.TileGrid} tileGrid Tile grid.
  * @param {ol.Projection} projection Projection.
  * @return {function(number, number, number): ol.Tile} Returns a tile if it is
  *     loaded.
  */
 ol.renderer.Layer.prototype.createGetTileIfLoadedFunction =
-    function(isLoadedFunction, tileSource, tileGrid, projection) {
+    function(isLoadedFunction, tileSource, projection) {
   return function(z, x, y) {
-    var tile = tileSource.getTile(z, x, y, tileGrid, projection);
+    var tile = tileSource.getTile(z, x, y, projection);
     return isLoadedFunction(tile) ? tile : null;
   };
 };
@@ -314,7 +313,7 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
     for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
       for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
         if (currentZ - z <= preload) {
-          tile = tileSource.getTile(z, x, y, tileGrid, projection);
+          tile = tileSource.getTile(z, x, y, projection);
           if (tile.getState() == ol.TileState.IDLE) {
             wantedTiles[tile.tileCoord.toString()] = true;
             if (!tileQueue.isKeyQueued(tile.getKey())) {

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -205,7 +205,7 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame =
     var getTileIfLoaded = this.createGetTileIfLoadedFunction(function(tile) {
       return !goog.isNull(tile) && tile.getState() == ol.TileState.LOADED &&
           mapRenderer.isTileTextureLoaded(tile);
-    }, tileSource, tileGrid, projection);
+    }, tileSource, projection);
     var findLoadedTiles = goog.bind(tileSource.findLoadedTiles, tileSource,
         tilesToDrawByZ, getTileIfLoaded);
 
@@ -214,7 +214,7 @@ ol.renderer.webgl.TileLayer.prototype.renderFrame =
     for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
       for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
 
-        tile = tileSource.getTile(z, x, y, tileGrid, projection);
+        tile = tileSource.getTile(z, x, y, projection);
         tileState = tile.getState();
         if (tileState == ol.TileState.LOADED) {
           if (mapRenderer.isTileTextureLoaded(tile)) {

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -103,7 +103,9 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
                 var imageUrl = resource.imageUrl
                     .replace('{subdomain}', subdomain)
                     .replace('{culture}', culture);
-                return function(tileCoord) {
+                return function(tileCoord, projection) {
+                  goog.asserts.assert(ol.projection.equivalent(
+                      projection, this.getProjection()));
                   if (goog.isNull(tileCoord)) {
                     return undefined;
                   } else {

--- a/src/ol/source/imagetilesource.js
+++ b/src/ol/source/imagetilesource.js
@@ -87,16 +87,14 @@ ol.source.ImageTileSource.prototype.expireCache = function(usedTiles) {
 /**
  * @inheritDoc
  */
-ol.source.ImageTileSource.prototype.getTile =
-    function(z, x, y, tileGrid, projection) {
+ol.source.ImageTileSource.prototype.getTile = function(z, x, y, projection) {
   var tileCoordKey = ol.TileCoord.getKeyZXY(z, x, y);
   if (this.tileCache_.containsKey(tileCoordKey)) {
     return /** @type {!ol.Tile} */ (this.tileCache_.get(tileCoordKey));
   } else {
-    goog.asserts.assert(tileGrid);
     goog.asserts.assert(projection);
     var tileCoord = new ol.TileCoord(z, x, y);
-    var tileUrl = this.tileUrlFunction(tileCoord, tileGrid, projection);
+    var tileUrl = this.tileUrlFunction(tileCoord, projection);
     var tile = new ol.ImageTile(
         tileCoord,
         goog.isDef(tileUrl) ? ol.TileState.IDLE : ol.TileState.EMPTY,

--- a/src/ol/source/tiledwmssource.js
+++ b/src/ol/source/tiledwmssource.js
@@ -42,7 +42,11 @@ ol.source.TiledWMS = function(tiledWMSOptions) {
       tiledWMSOptions.params['TRANSPARENT'] : true;
   var extent = tiledWMSOptions.extent;
 
-  var tileCoordTransform = function(tileCoord, tileGrid, projection) {
+  var tileCoordTransform = function(tileCoord, projection) {
+    var tileGrid = this.getTileGrid();
+    if (goog.isNull(tileGrid)) {
+      tileGrid = ol.tilegrid.getForProjection(projection);
+    }
     if (tileGrid.getResolutions().length <= tileCoord.z) {
       return null;
     }

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -124,7 +124,6 @@ ol.source.TileSource.prototype.getResolutions = function() {
  * @param {number} z Tile coordinate z.
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
- * @param {ol.tilegrid.TileGrid=} opt_tileGrid Tile grid.
  * @param {ol.Projection=} opt_projection Projection.
  * @return {!ol.Tile} Tile.
  */

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -112,7 +112,9 @@ ol.source.WMTS = function(wmtsOptions) {
   }
 
   tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
-      function(tileCoord, tileGrid, projection) {
+      function(tileCoord, projection) {
+        var tileGrid = this.getTileGrid();
+        goog.asserts.assert(!goog.isNull(tileGrid));
         if (tileGrid.getResolutions().length <= tileCoord.z) {
           return null;
         }

--- a/test/spec/ol/source/wms.test.js
+++ b/test/spec/ol/source/wms.test.js
@@ -5,35 +5,32 @@ describe('ol.source.wms', function() {
   describe('ol.source.wms.getUrl', function() {
     it('creates expected URL', function() {
       var epsg3857 = ol.projection.get('EPSG:3857');
-      var tileGrid = ol.tilegrid.getForProjection(epsg3857);
-      var tileUrlFunction = ol.TileUrlFunction.createFromParamsFunction(
-          'http://wms', {'foo': 'bar'}, ol.source.wms.getUrl);
-      var tileCoord = new ol.TileCoord(1, 0, 0);
-      var tileUrl = tileUrlFunction(tileCoord, tileGrid, epsg3857);
+      var extent = new ol.Extent(
+          -20037508.342789244, -20037508.342789244, 0, 0);
       var expected = 'http://wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=' +
           'GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&WIDTH=256&HEIGHT=256&' +
           'foo=bar&STYLES=&CRS=EPSG%3A3857&BBOX=' +
           '-20037508.342789244%2C-20037508.342789244%2C0%2C0';
-      expect(tileUrl).to.eql(expected);
+      var url = ol.source.wms.getUrl('http://wms', {'foo': 'bar'},
+          extent, new ol.Size(256, 256), epsg3857);
+      expect(url).to.eql(expected);
     });
     it('creates expected URL respecting axis orientation', function() {
       var epsg4326 = ol.projection.get('EPSG:4326');
-      var tileGrid = ol.tilegrid.getForProjection(epsg4326);
-      var tileUrlFunction = ol.TileUrlFunction.createFromParamsFunction(
-          'http://wms', {'foo': 'bar'}, ol.source.wms.getUrl);
-      var tileCoord = new ol.TileCoord(1, 0, 0);
-      var tileUrl = tileUrlFunction(tileCoord, tileGrid, epsg4326);
+      var extent = new ol.Extent(-180, -90, 0, 90);
       var expected = 'http://wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=' +
           'GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&WIDTH=256&HEIGHT=256&' +
           'foo=bar&STYLES=&CRS=EPSG%3A4326&BBOX=-90%2C-180%2C90%2C0';
-      expect(tileUrl).to.eql(expected);
+      var url = ol.source.wms.getUrl('http://wms', {'foo': 'bar'},
+          extent, new ol.Size(256, 256), epsg4326);
+      expect(url).to.eql(expected);
     });
   });
 
 });
 
 
-goog.require('ol.TileCoord');
-goog.require('ol.TileUrlFunction');
+goog.require('ol.Extent');
+goog.require('ol.Size');
 goog.require('ol.projection');
 goog.require('ol.source.wms');

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -81,12 +81,13 @@ describe('ol.TileUrlFunction', function() {
   describe('createFromParamsFunction', function() {
     var paramsFunction = function(url, params) { return arguments; };
     var projection = ol.projection.get('EPSG:3857');
+    var fakeTileSource = {getTileGrid: function() {return null;}};
     var params = {foo: 'bar'};
     var tileUrlFunction = ol.TileUrlFunction.createFromParamsFunction(
         'url', params, paramsFunction);
     it('calls the passed function with the correct arguments', function() {
-      var args = tileUrlFunction(new ol.TileCoord(0, 0, 0),
-          ol.tilegrid.getForProjection(projection), projection);
+      var args = tileUrlFunction.call(fakeTileSource,
+          new ol.TileCoord(0, 0, 0), projection);
       expect(args[0]).to.eql('url');
       expect(args[1]).to.be(params);
       expect(args[2]).to.eql(projection.getExtent());


### PR DESCRIPTION
getTile and the tileUrlFunc are functions of the source, so they do need to be passed the tile grid. The tile source knows its tile grid, and can get the projection's tile grid if it itself doesn't have a tile grid.
