### PR TITLE
Uncaught AssertionError: Assertion failed: Event target is not initialized. Did you call superclass (goog.events.EventTarget) constructor?

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -155,7 +155,11 @@ ol.MapBrowserEventHandler = function(map) {
    * @private
    */
   this.touchListenerKeys_ = null;
-
+    /**
+     * @type {Array.<number>}
+     * @private
+     */
+    this.eventTargetListeners_ = [];
   /**
    * @type {goog.events.BrowserEvent}
    * @private


### PR DESCRIPTION
Fix the error:
Uncaught AssertionError: Assertion failed: Event target is not initialized. Did you call superclass (goog.events.EventTarget) constructor? 

Occurs when debugging not compiled code. 

MapBrowserEventHandler should have the  eventTargetListeners_ implemented because it  is neseccary to pass the assert in goog.events.EventTarget.prototype.assertInitialized
