### PR TITLE
add goog.base(this) to the MapBrowserEventHandler's constructor

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -105,6 +105,8 @@ ol.MapBrowserEvent.prototype.isMouseActionButton = function() {
  */
 ol.MapBrowserEventHandler = function(map) {
 
+  goog.base(this);
+
   /**
    * This is the element that we will listen to the real events on.
    * @type {ol.Map}
@@ -155,11 +157,7 @@ ol.MapBrowserEventHandler = function(map) {
    * @private
    */
   this.touchListenerKeys_ = null;
-    /**
-     * @type {Array.<number>}
-     * @private
-     */
-    this.eventTargetListeners_ = [];
+
   /**
    * @type {goog.events.BrowserEvent}
    * @private


### PR DESCRIPTION
fixes the Uncaught AssertionError: Assertion failed: Event target is not initialized. Did you call superclass (goog.events.EventTarget) constructor?

the error occurs when running the not compiled code
