### PR TITLE
Throttle image requests

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -78,6 +78,12 @@ ol.ENABLE_WEBGL = true;
 
 
 /**
+ * @define {number} Maximum number of simultaneously loading tiles.
+ */
+ol.MAXIMUM_TILES_LOADING = 8;
+
+
+/**
  * @define {number} Maximum new tile loads per frame.
  */
 ol.MAXIMUM_NEW_TILE_LOADS_PER_FRAME = 2;
@@ -279,7 +285,9 @@ ol.Map = function(mapOptions) {
    * @private
    * @type {ol.TileQueue}
    */
-  this.tileQueue_ = new ol.TileQueue(goog.bind(this.getTilePriority, this),
+  this.tileQueue_ = new ol.TileQueue(
+      ol.MAXIMUM_TILES_LOADING,
+      goog.bind(this.getTilePriority, this),
       goog.bind(this.handleTileChange_, this));
 
   goog.events.listen(this, ol.Object.getChangedEventType(ol.MapProperty.VIEW),

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -18,12 +18,15 @@ ol.TilePriorityFunction;
 /**
  * @constructor
  * @extends {ol.structs.PriorityQueue}
+ * @param {number} maxTilesLoading Maximum number of simultaneously loading
+ *     tiles.
  * @param {ol.TilePriorityFunction} tilePriorityFunction
  *     Tile priority function.
  * @param {Function} tileChangeCallback
  *     Function called on each tile change event.
  */
-ol.TileQueue = function(tilePriorityFunction, tileChangeCallback) {
+ol.TileQueue =
+    function(maxTilesLoading, tilePriorityFunction, tileChangeCallback) {
 
   goog.base(
       this,
@@ -52,7 +55,7 @@ ol.TileQueue = function(tilePriorityFunction, tileChangeCallback) {
    * @private
    * @type {number}
    */
-  this.maxTilesLoading_ = 8;
+  this.maxTilesLoading_ = maxTilesLoading;
 
   /**
    * @private


### PR DESCRIPTION
Currently no more that 8 simultaneous image requests are simultaneously "in flight":
  https://github.com/openlayers/ol3/blob/master/src/ol/tilequeue.js#L54

However, setting 'image.src = url' is very expensive and can currently cause us to overrun our 16 millisecond frame budget. The current implementation means that 8 images can be requested in the same frame, which is bad.

It would be better to slow down the image requests. Empirically, this means limiting the rate to 1-2 new requests per frame.

Empirically I've observed that ol3 is currently smoother on poor internet connections than on good internet connections. I currently attribute this to the fact that image requests naturally become more spaced out (i.e. more evenly distributed) on slow connections.
