### PR TITLE
Add goog.base(this) to the MapBrowserEventHandler's constructor

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -105,6 +105,8 @@ ol.MapBrowserEvent.prototype.isMouseActionButton = function() {
  */
 ol.MapBrowserEventHandler = function(map) {
 
+  goog.base(this);
+
   /**
    * This is the element that we will listen to the real events on.
    * @type {ol.Map}


### PR DESCRIPTION
Fixes the:
"Uncaught AssertionError: Assertion failed: Event target is not initialized. Did you call superclass (goog.events.EventTarget) constructor?"

The error occurs when running the not compiled code while asserting in the property eventTargetListeners_ in goog.events.EventTarget.prototype.assertInitialized.
