### PR TITLE
Remove social widgets when debugging

### DIFF
--- a/resources/social-links.js
+++ b/resources/social-links.js
@@ -1,22 +1,26 @@
+if (window.location.search == '') {
+
+  // add tweet buttons
+  // (adapated from https://twitter.com/about/resources/buttons)
+  (function() {
+    var self = document.getElementsByTagName('script')[0];
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = '//platform.twitter.com/widgets.js';
+    self.parentNode.insertBefore(script, self);
+  })();
 
 
-// add tweet buttons (adapated from https://twitter.com/about/resources/buttons)
-(function() {
-  var self = document.getElementsByTagName('script')[0];
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.async = true;
-  script.src = '//platform.twitter.com/widgets.js';
-  self.parentNode.insertBefore(script, self);
-})();
+  // add g+1 buttons
+  // (adapted from https://developers.google.com/+/web/+1button)
+  (function() {
+    var self = document.getElementsByTagName('script')[0];
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    script.src = 'https://apis.google.com/js/plusone.js';
+    self.parentNode.insertBefore(script, self);
+  })();
 
-
-// add g+1 buttons (adapted from https://developers.google.com/+/web/+1button)
-(function() {
-  var self = document.getElementsByTagName('script')[0];
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.async = true;
-  script.src = 'https://apis.google.com/js/plusone.js';
-  self.parentNode.insertBefore(script, self);
-})();
+}


### PR DESCRIPTION
Social widgets increase load times, add uncontrolled JavaScript code,
and open potential security holes.  None of these are desirable,
especially when debugging.  This commit removes the Twatter and Google
Minus widgets, at least when the window location has a query string
(e.g. "?mode=RAW").
