### PR TITLE
Tile loading is slow to start

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -43,6 +43,7 @@ goog.require('ol.Tile');
 goog.require('ol.TileQueue');
 goog.require('ol.View');
 goog.require('ol.View2D');
+goog.require('ol.ViewHint');
 goog.require('ol.control.defaults');
 goog.require('ol.interaction.defaults');
 goog.require('ol.layer.Layer');
@@ -588,8 +589,19 @@ ol.Map.prototype.handleMapBrowserEvent = function(mapBrowserEvent) {
  * @protected
  */
 ol.Map.prototype.handlePostRender = function() {
+
+  // Limit the number of tile loads if animating or interacting.
+  var limit = (1 << 30) - 1; // a large enough integer
+  var frameState = this.frameState_;
+  if (!goog.isNull(frameState)) {
+    var hints = frameState.viewHints;
+    if (hints[ol.ViewHint.ANIMATING] || hints[ol.ViewHint.INTERACTING]) {
+      limit = ol.MAXIMUM_NEW_TILE_LOADS_PER_FRAME;
+    }
+  }
+
   this.tileQueue_.reprioritize(); // FIXME only call if needed
-  this.tileQueue_.loadMoreTiles(ol.MAXIMUM_NEW_TILE_LOADS_PER_FRAME);
+  this.tileQueue_.loadMoreTiles(limit);
 
   var postRenderFunctions = this.postRenderFunctions_;
   var i;


### PR DESCRIPTION
Since #437, a maximum of two new tiles are loaded per frame. This delays loading when a large number of new tiles must be loaded:
- When the map is initially rendered
- If the user radically changes the view (e.g. by changing center or resolution)

For more information, see [@elemoine's comment](https://github.com/openlayers/ol3/pull/437#issuecomment-15957286).
