### PR TITLE
OpenStreetMap licenses are inconsistent

### DIFF
--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -10,12 +10,12 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       source: new ol.source.OpenStreetMap({
-        attribution: new ol.Attribution(
-            'All maps &copy; ' +
-            '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>, ' +
-            'map data &copy; ' +
-            '<a href="http://www.openstreetmap.org/">OpenStreetMap</a> ' +
-            '(<a href="http://www.openstreetmap.org/copyright">ODbL</a>)'),
+        attributions: [
+          new ol.Attribution(
+              'All maps &copy; ' +
+              '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'),
+          ol.source.OpenStreetMap.DATA_ATTRIBUTION
+        ],
         url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
       })
     })

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -2,6 +2,7 @@ goog.provide('ol.source.MapQuestOSM');
 goog.provide('ol.source.MapQuestOpenAerial');
 
 goog.require('ol.Attribution');
+goog.require('ol.source.OpenStreetMap');
 goog.require('ol.source.XYZ');
 
 
@@ -16,11 +17,7 @@ ol.source.MapQuestOSM = function() {
     new ol.Attribution(
         'Tiles Courtesy of ' +
         '<a href="http://www.mapquest.com/" target="_blank">MapQuest</a>'),
-    new ol.Attribution(
-        'Data &copy; ' +
-        '<a href="http://www.openstreetmap.org">OpenStreetMap</a> ' +
-        'contributors, ' +
-        '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA</a>')
+    ol.source.OpenStreetMap.DATA_ATTRIBUTION
   ];
 
   goog.base(this, {

--- a/src/ol/source/openstreetmapsource.exports
+++ b/src/ol/source/openstreetmapsource.exports
@@ -1,2 +1,4 @@
 @exportSymbol ol.source.OpenStreetMap
+@exportProperty ol.source.OpenStreetMap.DATA_ATTRIBUTION
+@exportProperty ol.source.OpenStreetMap.TILE_ATTRIBUTION
 

--- a/src/ol/source/openstreetmapsource.js
+++ b/src/ol/source/openstreetmapsource.js
@@ -4,16 +4,6 @@ goog.require('ol.Attribution');
 goog.require('ol.source.XYZ');
 
 
-/**
- * @const
- * @type {Array.<ol.Attribution>}
- */
-ol.source.OPENSTREETMAP_ATTRIBUTIONS = [new ol.Attribution(
-    '&copy; <a href="http://www.openstreetmap.org">OpenStreetMap</a> ' +
-    'contributors, ' +
-    '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA</a>')];
-
-
 
 /**
  * @constructor
@@ -30,7 +20,7 @@ ol.source.OpenStreetMap = function(opt_options) {
   } else if (goog.isDef(options.attribution)) {
     attributions = [options.attribution];
   } else {
-    attributions = ol.source.OPENSTREETMAP_ATTRIBUTIONS;
+    attributions = ol.source.OpenStreetMap.ATTRIBUTIONS;
   }
 
   var maxZoom = goog.isDef(options.maxZoom) ? options.maxZoom : 18;
@@ -48,3 +38,34 @@ ol.source.OpenStreetMap = function(opt_options) {
 
 };
 goog.inherits(ol.source.OpenStreetMap, ol.source.XYZ);
+
+
+/**
+ * @const
+ * @type {ol.Attribution}
+ */
+ol.source.OpenStreetMap.DATA_ATTRIBUTION = new ol.Attribution(
+    'Data &copy; <a href="http://www.openstreetmap.org/">OpenStreetMap</a> ' +
+    'contributors, ' +
+    '<a href="http://www.openstreetmap.org/copyright">ODbL</a>');
+
+
+/**
+ * @const
+ * @type {ol.Attribution}
+ */
+ol.source.OpenStreetMap.TILE_ATTRIBUTION = new ol.Attribution(
+    'Tiles &copy; ' +
+    '<a href="http://www.openstreetmap.org/">OpenStreetMap</a> ' +
+    'contributors, ' +
+    '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC BY-SA</a>');
+
+
+/**
+ * @const
+ * @type {Array.<ol.Attribution>}
+ */
+ol.source.OpenStreetMap.ATTRIBUTIONS = [
+  ol.source.OpenStreetMap.TILE_ATTRIBUTION,
+  ol.source.OpenStreetMap.DATA_ATTRIBUTION
+];

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -2,6 +2,7 @@ goog.provide('ol.source.Stamen');
 
 goog.require('goog.asserts');
 goog.require('ol.Attribution');
+goog.require('ol.source.OpenStreetMap');
 goog.require('ol.source.XYZ');
 
 
@@ -78,11 +79,12 @@ ol.source.StamenProviderConfig = {
 /**
  * @const {Array.<ol.Attribution>}
  */
-ol.source.STAMEN_ATTRIBUTIONS = [new ol.Attribution(
-    'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under ' +
-    '<a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. ' +
-    'Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under ' +
-    '<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.')];
+ol.source.STAMEN_ATTRIBUTIONS = [
+  new ol.Attribution(
+      'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, under ' +
+      '<a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.'),
+  ol.source.OpenStreetMap.DATA_ATTRIBUTION
+];
 
 
 


### PR DESCRIPTION
Right now, there are three different licenses for OpenStreetMap data:
- Our own source claims that it's [CC-SA-2.0](https://github.com/openlayers/ol3/blob/master/src/ol/source/openstreetmapsource.js#L14)
- Stamen thinks that it's [CC-SA-3.0](http://maps.stamen.com/#watercolor/12/37.7706/-122.3782) (scroll down to "How to Use These Tiles Elsewhere / COPY HTML)
- OpenCycleMap thinks that it's [ODbL](http://opencyclemap.org/) (see attribution and link in bottom left corner)

At least two of these three are wrong. Who's correct? The [OpenStreetMap copyright page](http://www.openstreetmap.org/copyright) would suggest that it's OpenCycleMap.

Does anybody actually know?
