### PR TITLE
Only rotate coordinate when it's needed

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -62,12 +62,14 @@ ol.coordinate.degreesToStringHDMS_ = function(degrees, hemispheres) {
  * @return {ol.Coordinate} Coordinate.
  */
 ol.coordinate.rotate = function(coordinate, angle) {
-  var cosAngle = Math.cos(angle);
-  var sinAngle = Math.sin(angle);
-  var x = coordinate[0] * cosAngle - coordinate[1] * sinAngle;
-  var y = coordinate[1] * cosAngle + coordinate[0] * sinAngle;
-  coordinate[0] = x;
-  coordinate[1] = y;
+  if (angle != 0) {
+    var cosAngle = Math.cos(angle);
+    var sinAngle = Math.sin(angle);
+    var x = coordinate[0] * cosAngle - coordinate[1] * sinAngle;
+    var y = coordinate[1] * cosAngle + coordinate[0] * sinAngle;
+    coordinate[0] = x;
+    coordinate[1] = y;
+  }
   return coordinate;
 };
 


### PR DESCRIPTION
Most of the time, the rotation angle is equal to zero and no transformation needs to be done.

Question:
- test with `angle % (2 * Math.PI)` instead?
- Premature optimization is the root of all evil?
