### PR TITLE
Copying data folder to hosted examples directory

### DIFF
--- a/build.py
+++ b/build.py
@@ -626,10 +626,10 @@ def host_examples(t):
     t.makedirs(examples_dir)
     t.rm_rf(build_dir)
     t.makedirs(build_dir)
-    t.rm_rf(examples_dir)
-    t.cp_r('examples', examples_dir)
+    t.cp(EXAMPLES, examples_dir)
     for example in [path.replace('.html', '.js') for path in EXAMPLES]:
         split_example_file(example, examples_dir % vars(variables))
+    t.cp_r('examples/data', examples_dir + '/data')
     t.cp('bin/loader_hosted_examples.js', examples_dir + '/loader.js')
     t.cp('build/ol.js', 'build/ol-simple.js', 'build/ol-whitespace.js',
          'build/ol.css', build_dir)


### PR DESCRIPTION
We need to copy all of the examples directory, because we need
the data subdirectory.
