### PR TITLE
Export the pixel location of the MapBrowserEvent

### DIFF
--- a/src/ol/mapbrowserevent.exports
+++ b/src/ol/mapbrowserevent.exports
@@ -1,1 +1,2 @@
 @exportProperty ol.MapBrowserEvent.prototype.getCoordinate
+@exportProperty ol.MapBrowserEvent.prototype.getPixel


### PR DESCRIPTION
This is useful for getting the pixel coordinate relative to the
map viewport, which is used e.g. for WMS GetFeatureInfo.
