### PR TITLE
Tile limits are too low

### DIFF
--- a/src/ol/tilecache.js
+++ b/src/ol/tilecache.js
@@ -8,7 +8,7 @@ goog.require('ol.structs.LRUCache');
 /**
  * @define {number} Default high water mark.
  */
-ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK = 512;
+ol.DEFAULT_TILE_CACHE_HIGH_WATER_MARK = 2048;
 
 
 


### PR DESCRIPTION
Currently:
- [Each tile source caches about 512 tiles](https://github.com/openlayers/ol3/blob/master/src/ol/tilecache.js#L11)
- [Only 1024 WebGL textures are preserved](https://github.com/openlayers/ol3/blob/master/src/ol/renderer/webgl/webglmaprenderer.js#L34)

These limits are _way_ too low, and normal interaction with the map quickly results in tiles/textures being reloaded. We should set more appropriate limits.

Notes:
- one 256x256 pixel tile in 32-bit color is 256Kb uncompressed
- the browser already does a lot of caching (to both RAM and disk), we can push up the number of tiles and the browser will do a good job, even when we push too hard
