### PR TITLE
OpenStreetMap to OSM renaming

### DIFF
--- a/examples/animation.js
+++ b/examples/animation.js
@@ -5,7 +5,7 @@ goog.require('ol.animation');
 goog.require('ol.easing');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.projection');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var london = ol.projection.transform(
@@ -29,7 +29,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       preload: 4,
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderers: ol.RendererHints.createFromQueryData(),

--- a/examples/bind-input.js
+++ b/examples/bind-input.js
@@ -3,10 +3,10 @@ goog.require('ol.RendererHints');
 goog.require('ol.View2D');
 goog.require('ol.dom.Input');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 var layer = new ol.layer.TileLayer({
-  source: new ol.source.OpenStreetMap()
+  source: new ol.source.OSM()
 });
 var map = new ol.Map({
   layers: [layer],

--- a/examples/canvas-tiles.js
+++ b/examples/canvas-tiles.js
@@ -4,14 +4,14 @@ goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.projection');
 goog.require('ol.source.DebugTileSource');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 goog.require('ol.tilegrid.XYZ');
 
 
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     }),
     new ol.layer.TileLayer({
       source: new ol.source.DebugTileSource({

--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -2,13 +2,13 @@ goog.require('ol.Map');
 goog.require('ol.RendererHint');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderer: ol.RendererHint.CANVAS,

--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -4,13 +4,13 @@ goog.require('ol.Overlay');
 goog.require('ol.RendererHints');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderers: ol.RendererHints.createFromQueryData(),

--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -3,18 +3,18 @@ goog.require('ol.Map');
 goog.require('ol.RendererHints');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap({
+      source: new ol.source.OSM({
         attributions: [
           new ol.Attribution(
               'All maps &copy; ' +
               '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'),
-          ol.source.OpenStreetMap.DATA_ATTRIBUTION
+          ol.source.OSM.DATA_ATTRIBUTION
         ],
         url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
       })

--- a/examples/mouse-position.js
+++ b/examples/mouse-position.js
@@ -5,7 +5,7 @@ goog.require('ol.control.MousePosition');
 goog.require('ol.control.defaults');
 goog.require('ol.coordinate');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
@@ -19,7 +19,7 @@ var map = new ol.Map({
   ]),
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderers: ol.RendererHints.createFromQueryData(),

--- a/examples/rotation.js
+++ b/examples/rotation.js
@@ -2,13 +2,13 @@ goog.require('ol.Map');
 goog.require('ol.RendererHints');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderers: ol.RendererHints.createFromQueryData(),

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -5,7 +5,7 @@ goog.require('ol.control.ScaleLine');
 goog.require('ol.control.ScaleLineUnits');
 goog.require('ol.control.defaults');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
@@ -16,7 +16,7 @@ var map = new ol.Map({
   ]),
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderers: ol.RendererHints.createFromQueryData(),

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -2,13 +2,13 @@ goog.require('ol.Map');
 goog.require('ol.RendererHints');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 
 
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap()
+      source: new ol.source.OSM()
     })
   ],
   renderers: ol.RendererHints.createFromQueryData(),

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -4,7 +4,7 @@ goog.require('ol.RendererHint');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.projection');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
 
@@ -23,7 +23,7 @@ for (var z = 0; z < 26; ++z) {
 var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
-      source: new ol.source.OpenStreetMap(),
+      source: new ol.source.OSM(),
       opacity: 0.7
     }),
     new ol.layer.TileLayer({

--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -224,7 +224,7 @@
  */
 
 /**
- * @typedef {Object} ol.source.OpenStreetMapOptions
+ * @typedef {Object} ol.source.OSMOptions
  * @property {ol.Attribution|undefined} attribution Attribution.
  * @property {Array.<ol.Attribution>|undefined} attributions Attributions.
  * @property {number|undefined} maxZoom Max zoom.

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -2,7 +2,7 @@ goog.provide('ol.source.MapQuestOSM');
 goog.provide('ol.source.MapQuestOpenAerial');
 
 goog.require('ol.Attribution');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 goog.require('ol.source.XYZ');
 
 
@@ -17,7 +17,7 @@ ol.source.MapQuestOSM = function() {
     new ol.Attribution(
         'Tiles Courtesy of ' +
         '<a href="http://www.mapquest.com/" target="_blank">MapQuest</a>'),
-    ol.source.OpenStreetMap.DATA_ATTRIBUTION
+    ol.source.OSM.DATA_ATTRIBUTION
   ];
 
   goog.base(this, {

--- a/src/ol/source/openstreetmapsource.exports
+++ b/src/ol/source/openstreetmapsource.exports
@@ -1,3 +1,0 @@
-@exportSymbol ol.source.OpenStreetMap
-@exportProperty ol.source.OpenStreetMap.DATA_ATTRIBUTION
-@exportProperty ol.source.OpenStreetMap.TILE_ATTRIBUTION

--- a/src/ol/source/osmsource.exports
+++ b/src/ol/source/osmsource.exports
@@ -1,0 +1,3 @@
+@exportSymbol ol.source.OSM
+@exportProperty ol.source.OSM.DATA_ATTRIBUTION
+@exportProperty ol.source.OSM.TILE_ATTRIBUTION

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -1,4 +1,4 @@
-goog.provide('ol.source.OpenStreetMap');
+goog.provide('ol.source.OSM');
 
 goog.require('ol.Attribution');
 goog.require('ol.source.XYZ');
@@ -8,9 +8,9 @@ goog.require('ol.source.XYZ');
 /**
  * @constructor
  * @extends {ol.source.XYZ}
- * @param {ol.source.OpenStreetMapOptions=} opt_options Open Street Map options.
+ * @param {ol.source.OSMOptions=} opt_options Open Street Map options.
  */
-ol.source.OpenStreetMap = function(opt_options) {
+ol.source.OSM = function(opt_options) {
 
   var options = goog.isDef(opt_options) ? opt_options : {};
 
@@ -20,7 +20,7 @@ ol.source.OpenStreetMap = function(opt_options) {
   } else if (goog.isDef(options.attribution)) {
     attributions = [options.attribution];
   } else {
-    attributions = ol.source.OpenStreetMap.ATTRIBUTIONS;
+    attributions = ol.source.OSM.ATTRIBUTIONS;
   }
 
   var maxZoom = goog.isDef(options.maxZoom) ? options.maxZoom : 18;
@@ -37,14 +37,14 @@ ol.source.OpenStreetMap = function(opt_options) {
   });
 
 };
-goog.inherits(ol.source.OpenStreetMap, ol.source.XYZ);
+goog.inherits(ol.source.OSM, ol.source.XYZ);
 
 
 /**
  * @const
  * @type {ol.Attribution}
  */
-ol.source.OpenStreetMap.DATA_ATTRIBUTION = new ol.Attribution(
+ol.source.OSM.DATA_ATTRIBUTION = new ol.Attribution(
     'Data &copy; <a href="http://www.openstreetmap.org/">OpenStreetMap</a> ' +
     'contributors, ' +
     '<a href="http://www.openstreetmap.org/copyright">ODbL</a>');
@@ -54,7 +54,7 @@ ol.source.OpenStreetMap.DATA_ATTRIBUTION = new ol.Attribution(
  * @const
  * @type {ol.Attribution}
  */
-ol.source.OpenStreetMap.TILE_ATTRIBUTION = new ol.Attribution(
+ol.source.OSM.TILE_ATTRIBUTION = new ol.Attribution(
     'Tiles &copy; ' +
     '<a href="http://www.openstreetmap.org/">OpenStreetMap</a> ' +
     'contributors, ' +
@@ -65,7 +65,7 @@ ol.source.OpenStreetMap.TILE_ATTRIBUTION = new ol.Attribution(
  * @const
  * @type {Array.<ol.Attribution>}
  */
-ol.source.OpenStreetMap.ATTRIBUTIONS = [
-  ol.source.OpenStreetMap.TILE_ATTRIBUTION,
-  ol.source.OpenStreetMap.DATA_ATTRIBUTION
+ol.source.OSM.ATTRIBUTIONS = [
+  ol.source.OSM.TILE_ATTRIBUTION,
+  ol.source.OSM.DATA_ATTRIBUTION
 ];

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -2,7 +2,7 @@ goog.provide('ol.source.Stamen');
 
 goog.require('goog.asserts');
 goog.require('ol.Attribution');
-goog.require('ol.source.OpenStreetMap');
+goog.require('ol.source.OSM');
 goog.require('ol.source.XYZ');
 
 
@@ -83,7 +83,7 @@ ol.source.STAMEN_ATTRIBUTIONS = [
   new ol.Attribution(
       'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, under ' +
       '<a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.'),
-  ol.source.OpenStreetMap.DATA_ATTRIBUTION
+  ol.source.OSM.DATA_ATTRIBUTION
 ];
 
 


### PR DESCRIPTION
OSM is a well-known name, and is shorter than OpenStreetMap.
