### PR TITLE
Bigger + and - zoom buttons on touch devices

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -140,6 +140,12 @@ a.ol-full-screen-true:after {
   line-height: 19px;
   background: rgba(0,60,136,0.5);
 }
+.ol-touch .ol-zoom a {
+  font-size: 20px;
+  height: 30px;
+  width: 30px;
+  line-height: 26px;
+}
 .ol-zoom a:hover {
   background: rgba(0,60,136,0.7);
 }

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -207,6 +207,9 @@ ol.Map = function(options) {
   this.viewport_.style.height = '100%';
   // prevent page zoom on IE >= 10 browsers
   this.viewport_.style.msTouchAction = 'none';
+  if (ol.BrowserFeature.HAS_TOUCH) {
+    this.viewport_.className = 'ol-touch';
+  }
   goog.dom.appendChild(this.target_, this.viewport_);
 
   /**


### PR DESCRIPTION
I find the + and - zoom buttons too small on my iPhone. This PR makes the buttons bigger on touch devices.

Example: http://erilem.net/ol3/zoom-css/examples/stamen.html.
