### PR TITLE
Add a condition param to the KeyboardPan and KeyboardZoom interactions.

### DIFF
--- a/src/ol/interaction/defaults.js
+++ b/src/ol/interaction/defaults.js
@@ -73,8 +73,10 @@ ol.interaction.defaults = function(opt_options, opt_interactions) {
   var keyboard = goog.isDef(options.keyboard) ?
       options.keyboard : true;
   if (keyboard) {
-    interactions.push(new ol.interaction.KeyboardPan());
-    interactions.push(new ol.interaction.KeyboardZoom());
+    interactions.push(new ol.interaction.KeyboardPan(
+        ol.interaction.condition.noModifierKeys));
+    interactions.push(new ol.interaction.KeyboardZoom(
+        ol.interaction.condition.noModifierKeys));
   }
 
   var mouseWheelZoom = goog.isDef(options.mouseWheelZoom) ?

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -7,6 +7,7 @@ goog.require('goog.events.KeyCodes');
 goog.require('goog.events.KeyHandler.EventType');
 goog.require('ol.View2D');
 goog.require('ol.coordinate');
+goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Interaction');
 
 
@@ -20,13 +21,20 @@ ol.interaction.KEYBOARD_PAN_DURATION = 100;
 /**
  * @constructor
  * @extends {ol.interaction.Interaction}
+ * @param {ol.interaction.ConditionType} condition Condition.
  * @param {ol.interaction.KeyboardPanOptions=} opt_options Options.
  */
-ol.interaction.KeyboardPan = function(opt_options) {
+ol.interaction.KeyboardPan = function(condition, opt_options) {
 
   goog.base(this);
 
   var options = goog.isDef(opt_options) ? opt_options : {};
+
+  /**
+   * @private
+   * @type {ol.interaction.ConditionType}
+   */
+  this.condition_ = condition;
 
   /**
    * @private
@@ -47,10 +55,10 @@ ol.interaction.KeyboardPan.prototype.handleMapBrowserEvent =
     var keyEvent = /** @type {goog.events.KeyEvent} */
         (mapBrowserEvent.browserEvent);
     var keyCode = keyEvent.keyCode;
-    if (keyCode == goog.events.KeyCodes.DOWN ||
+    if (this.condition_(keyEvent) && (keyCode == goog.events.KeyCodes.DOWN ||
         keyCode == goog.events.KeyCodes.LEFT ||
         keyCode == goog.events.KeyCodes.RIGHT ||
-        keyCode == goog.events.KeyCodes.UP) {
+        keyCode == goog.events.KeyCodes.UP)) {
       var map = mapBrowserEvent.map;
       // FIXME works for View2D only
       var view = map.getView();

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -4,6 +4,7 @@ goog.provide('ol.interaction.KeyboardZoom');
 
 goog.require('goog.asserts');
 goog.require('goog.events.KeyHandler.EventType');
+goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Interaction');
 
 
@@ -16,14 +17,21 @@ ol.interaction.KEYBOARD_ZOOM_DURATION = 100;
 
 /**
  * @constructor
+ * @param {ol.interaction.ConditionType} condition Condition.
  * @param {ol.interaction.KeyboardZoomOptions=} opt_options Options.
  * @extends {ol.interaction.Interaction}
  */
-ol.interaction.KeyboardZoom = function(opt_options) {
+ol.interaction.KeyboardZoom = function(condition, opt_options) {
 
   goog.base(this);
 
   var options = goog.isDef(opt_options) ? opt_options : {};
+
+  /**
+   * @private
+   * @type {ol.interaction.ConditionType}
+   */
+  this.condition_ = condition;
 
   /**
    * @private
@@ -44,7 +52,8 @@ ol.interaction.KeyboardZoom.prototype.handleMapBrowserEvent =
     var keyEvent = /** @type {goog.events.KeyEvent} */
         (mapBrowserEvent.browserEvent);
     var charCode = keyEvent.charCode;
-    if (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0)) {
+    if (this.condition_(keyEvent) &&
+        (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0))) {
       var map = mapBrowserEvent.map;
       var delta = (charCode == '+'.charCodeAt(0)) ? this.delta_ : -this.delta_;
       map.requestRenderFrame();


### PR DESCRIPTION
By default, the action is ignored if a modifier key is pressed.
