### PR TITLE
Fix DOM layer visibility

### DIFF
--- a/src/ol/renderer/dom/domlayerrenderer.js
+++ b/src/ol/renderer/dom/domlayerrenderer.js
@@ -28,15 +28,6 @@ goog.inherits(ol.renderer.dom.Layer, ol.renderer.Layer);
 
 
 /**
- * @inheritDoc
- */
-ol.renderer.dom.Layer.prototype.disposeInternal = function() {
-  goog.dom.removeNode(this.target);
-  goog.base(this, 'disposeInternal');
-};
-
-
-/**
  * @protected
  * @return {!Element} Target.
  */

--- a/src/ol/renderer/dom/dommaprenderer.js
+++ b/src/ol/renderer/dom/dommaprenderer.js
@@ -4,6 +4,7 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
+goog.require('goog.object');
 goog.require('goog.style');
 goog.require('ol.css');
 goog.require('ol.layer.ImageLayer');
@@ -85,6 +86,14 @@ ol.renderer.dom.Map.prototype.renderFrame = function(frameState) {
       layerRenderer.renderFrame(frameState, layerState);
     }
   }, this);
+
+  goog.object.forEach(
+      this.getLayerRenderers(),
+      function(layerRenderer, layerKey) {
+        if (!(layerKey in frameState.layerStates)) {
+          goog.dom.removeNode(layerRenderer.getTarget());
+        }
+      });
 
   if (!this.renderedVisible_) {
     goog.style.showElement(this.layersPane_, true);


### PR DESCRIPTION
This fixes a a couple of bugs in the DOM renderer:
- Layers where not hidden when `layer.setVisible(false)` was called
- Layers were removed from the DOM in post render functions, not immediately
