### PR TITLE
Add AsyncStringFeatureParser and use plain

### DIFF
--- a/examples/kml.html
+++ b/examples/kml.html
@@ -48,7 +48,6 @@
 
     </div>
 
-    <script src="jquery.min.js" type="text/javascript"></script>
     <script src="loader.js?id=kml" type="text/javascript"></script>
     <script src="../resources/social-links.js" type="text/javascript"></script>
 

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -43,8 +43,19 @@ var map = new ol.Map({
 var kml = new ol.parser.KML({
   maxDepth: 1, dimension: 2, extractStyles: true, extractAttributes: true});
 
-$.ajax({
-  url: 'data/kml/lines.kml'
-}).done(function(data) {
-  vector.parseFeatures(data, kml, epsg4326);
-});
+var url = 'data/kml/lines.kml';
+var xhr = new XMLHttpRequest();
+xhr.open('GET', url, true);
+
+
+/**
+ * onload handler for the XHR request.
+ */
+xhr.onload = function() {
+  if (xhr.status == 200) {
+    // this is silly to have to tell the layer the destination projection
+    var projection = map.getView().getProjection();
+    vector.parseFeatures(xhr.responseText, kml, epsg4326);
+  }
+};
+xhr.send();

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -350,10 +350,15 @@ ol.layer.Vector.prototype.parseFeatures = function(data, parser, projection) {
   };
 
   if (goog.isString(data)) {
-    goog.asserts.assert(goog.isFunction(parser.readFeaturesFromString),
-        'Expected a parser with readFeaturesFromString method.');
-    features = parser.readFeaturesFromString(data, {callback: callback});
-    addFeatures.call(this, features);
+    if (goog.isFunction(parser.readFeaturesFromStringAsync)) {
+      parser.readFeaturesFromStringAsync(data, goog.bind(addFeatures, this),
+          {callback: callback});
+    } else {
+      goog.asserts.assert(goog.isFunction(parser.readFeaturesFromString),
+          'Expected a parser with readFeaturesFromString method.');
+      features = parser.readFeaturesFromString(data, {callback: callback});
+      addFeatures.call(this, features);
+    }
   } else if (goog.isObject(data)) {
     if (goog.isFunction(parser.readFeaturesFromObjectAsync)) {
       parser.readFeaturesFromObjectAsync(data, goog.bind(addFeatures, this),

--- a/src/ol/parser/featureparser.js
+++ b/src/ol/parser/featureparser.js
@@ -1,4 +1,5 @@
 goog.provide('ol.parser.AsyncObjectFeatureParser');
+goog.provide('ol.parser.AsyncStringFeatureParser');
 goog.provide('ol.parser.DomFeatureParser');
 goog.provide('ol.parser.ObjectFeatureParser');
 goog.provide('ol.parser.ReadFeaturesOptions');
@@ -52,6 +53,23 @@ ol.parser.StringFeatureParser = function() {};
  * @return {Array.<ol.Feature>} Array of features.
  */
 ol.parser.StringFeatureParser.prototype.readFeaturesFromString =
+    goog.abstractMethod;
+
+
+
+/**
+ * @interface
+ */
+ol.parser.AsyncStringFeatureParser = function() {};
+
+
+/**
+ * @param {string} data String data.
+ * @param {function(Array.<ol.Feature>)} callback Callback which is called
+ * after parsing.
+ * @param {ol.parser.ReadFeaturesOptions=} opt_options Feature reading options.
+ */
+ol.parser.AsyncStringFeatureParser.prototype.readFeaturesFromStringAsync =
     goog.abstractMethod;
 
 

--- a/src/ol/parser/kml.js
+++ b/src/ol/parser/kml.js
@@ -21,6 +21,7 @@ goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
 goog.require('ol.geom.SharedVertices');
 goog.require('ol.parser.AsyncObjectFeatureParser');
+goog.require('ol.parser.AsyncStringFeatureParser');
 goog.require('ol.parser.DomFeatureParser');
 goog.require('ol.parser.ReadFeaturesOptions');
 goog.require('ol.parser.StringFeatureParser');
@@ -47,6 +48,7 @@ ol.parser.KMLOptions;
  * @implements {ol.parser.DomFeatureParser}
  * @implements {ol.parser.StringFeatureParser}
  * @implements {ol.parser.AsyncObjectFeatureParser}
+ * @implements {ol.parser.AsyncStringFeatureParser}
  * @param {ol.parser.KMLOptions=} opt_options Optional configuration object.
  * @extends {ol.parser.XML}
  */
@@ -815,6 +817,19 @@ ol.parser.KML.prototype.readFeaturesFromObjectAsync =
     function(obj, callback, opt_options) {
   this.readFeaturesOptions_ = opt_options;
   this.read(obj, callback);
+};
+
+
+/**
+ * @param {string} str KML document.
+ * @param {function(Array.<ol.Feature>)} callback Callback which is called
+ * after parsing.
+ * @param {ol.parser.ReadFeaturesOptions=} opt_options Feature reading options.
+ */
+ol.parser.KML.prototype.readFeaturesFromStringAsync =
+    function(str, callback, opt_options) {
+  this.readFeaturesOptions_ = opt_options;
+  this.read(str, callback);
 };
 
 


### PR DESCRIPTION
XMLHttpRequest in the KML example

Since the content-type on github.io is application/octet-stream we need
to implement an Async string based parser interface in the KML parser.
Also use plain XmlHttpRequest in the example instead of jQuery Ajax since
the vector-features example also uses that.
