### PR TITLE
Remove unused ol.Object.prototype.changed

### DIFF
--- a/src/ol/object.exports
+++ b/src/ol/object.exports
@@ -1,6 +1,5 @@
 @exportSymbol ol.Object
 @exportProperty ol.Object.prototype.bindTo
-@exportProperty ol.Object.prototype.changed
 @exportProperty ol.Object.prototype.get
 @exportProperty ol.Object.prototype.notify
 @exportProperty ol.Object.prototype.on

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -162,12 +162,6 @@ ol.Object.prototype.bindTo =
 
 /**
  * @param {string} key Key.
- */
-ol.Object.prototype.changed = goog.nullFunction;
-
-
-/**
- * @param {string} key Key.
  * @return {*} Value.
  */
 ol.Object.prototype.get = function(key) {


### PR DESCRIPTION
The function doesn't seem to be used, do we want to keep it?
