### PR TITLE
Use negative frame index as frame marker

### DIFF
--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -521,7 +521,7 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
 
   this.focus_ = frameState.focus;
 
-  this.textureCache_.set(frameState.index.toString(), null);
+  this.textureCache_.set((-frameState.index).toString(), null);
   ++this.textureCacheFrameMarkerCount_;
 
   var layerStates = frameState.layerStates;


### PR DESCRIPTION
This PR fixes the canvas tile example (see #639).

The problem was that `ol.DebugTile_#getKey()` falls back to the default `ol.Tile#getKey()` implementation, which uses `goog.getUid(this)` as the key. `goog.getUid` returns numbers that were conflicting with the use of frame indexes as frame markers in the WebGL renderer's LRU texture cache (see #564).

The PR fixes the problem by negating the frame index used a frame marker, thus avoiding the conflict with `goog.getUid`.
