### PR TITLE
Bing Maps example is broken

### DIFF
--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -561,7 +561,7 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
     layer = layersArray[i];
     layerState = frameState.layerStates[goog.getUid(layer)];
     if (!layerState.visible || !layerState.ready) {
-      return;
+      continue;
     }
     var useColor =
         layerState.brightness ||


### PR DESCRIPTION
No map is displayed.

This is probably due to the changes introduced in #542, #560 and #562.
