### PR TITLE
Scale tile queue according to number of sources

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -656,6 +656,9 @@ ol.Map.prototype.handlePostRender = function() {
         maxNewLoads = 2;
       }
     }
+    var tileSourceCount = goog.object.getCount(frameState.wantedTiles);
+    maxTotalLoading *= tileSourceCount;
+    maxNewLoads *= tileSourceCount;
     if (tileQueue.getTilesLoading() < maxTotalLoading) {
       tileQueue.reprioritize(); // FIXME only call if view has changed
       tileQueue.loadMoreTiles(maxTotalLoading, maxNewLoads);


### PR DESCRIPTION
@gjn [reports](https://groups.google.com/d/msg/ol3-dev/dZCj_kwaZS8/GLaoR6a8YuEJ) that this significantly improves performance when there are a large number of layers.
