### PR TITLE
Prevent Bootstrap's setting of max-width from infecting map

### DIFF
--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -104,6 +104,10 @@ ol.renderer.dom.ImageLayer.prototype.renderFrame =
         0);
     if (image != this.image_) {
       var imageElement = image.getImageElement(this);
+      // Bootstrap sets the style max-width: 100% for all images, which breaks
+      // prevents the image from being displayed in FireFox.  Workaround by
+      // overriding the max-width style.
+      imageElement.style.maxWidth = 'none';
       imageElement.style.position = 'absolute';
       goog.dom.removeChildren(this.target);
       goog.dom.appendChild(this.target, imageElement);

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -315,6 +315,10 @@ ol.renderer.dom.TileLayerZ_.prototype.addTile = function(tile) {
   var tileSize = this.tileGrid_.getTileSize(tileCoord.z);
   var image = tile.getImage(this);
   var style = image.style;
+  // Bootstrap sets the style max-width: 100% for all images, which breaks
+  // prevents the tile from being displayed in FireFox.  Workaround by
+  // overriding the max-width style.
+  style.maxWidth = 'none';
   style.position = 'absolute';
   style.left =
       ((tileCoord.x - this.tileCoordOrigin_.x) * tileSize.width) + 'px';


### PR DESCRIPTION
Thanks to @ThomasG77.

This is a possible way of fixing #664. I've verified that the fix works on Firefox 20.0 on Mac OS X.
