### PR TITLE
Always set CLOSURE_NO_DEPS to true

### DIFF
--- a/bin/loader_hosted_examples.js
+++ b/bin/loader_hosted_examples.js
@@ -65,12 +65,19 @@
     }
   }
 
+  // CLOSURE_NO_DEPS has an effect in "raw" and "whitespace" modes only (i.e.
+  // when COMPILED is false). In "raw" mode we use our own deps file
+  // (ol-deps.js), so we set CLOSURE_NO_DEPS to true to prevent Google
+  // Library's base.js script to load deps.js. In "whitespace" mode
+  // no deps file is needed at all, yet base.js will attempt to load deps.js
+  // if CLOSURE_NO_DEPS is not set to true.
+  window.CLOSURE_NO_DEPS = true;
+
   var scriptId = encodeURIComponent(scriptParams.id);
   document.write('<link rel="stylesheet" href="../build/ol.css" type="text/css">');
   if (mode != 'raw') {
     document.write('<scr' + 'ipt type="text/javascript" src="../build/' + oljs + '"></scr' + 'ipt>');
   } else {
-    window.CLOSURE_NO_DEPS = true; // we've got our own deps file
     document.write('<scr' + 'ipt type="text/javascript" src="../closure-library/closure/goog/base.js"></scr' + 'ipt>');
     document.write('<scr' + 'ipt type="text/javascript" src="../build/ol-deps.js"></scr' + 'ipt>');
     document.write('<scr' + 'ipt type="text/javascript" src="' + scriptId + '-require.js"></scr' + 'ipt>');


### PR DESCRIPTION
Because we generate our own deps file (`ol-deps.js`), we already set `CLOSURE_NO_DEPS` to `true` for the hosted examples in `raw` mode.

In `whitespace` mode the Closure Library also attempts to load `deps.js`. This is not needed, and not desired because it causes a 404. The issue was reported by @ThomasG77 in #667.

This PR fixes it by setting `CLOSURE_NO_DEPS` to `true` for any mode - it has no effect at all for the `simple` and `advanced` modes.
