### PR TITLE
Improvements for xmleql

### DIFF
--- a/test/spec/ol/expect.test.js
+++ b/test/spec/ol/expect.test.js
@@ -91,14 +91,47 @@ describe('expect.js', function() {
 
   describe('Test equality of XML documents - xmleql', function() {
 
-    it('Test XML docs', function() {
-      var url = 'spec/ol/parser/kml/point.kml';
-      afterLoadXml(url, function(xml) {
-        var parser = new ol.parser.KML();
-        var obj = parser.read(xml);
-        var output = parser.write(obj);
-        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
-      });
+    it('Test XML document with single root, different prefix', function() {
+      var doc1 = '<bar:foo xmlns:bar="http://foo"></bar:foo>';
+      var doc2 = '<foo xmlns="http://foo"></foo>';
+      expect(goog.dom.xml.loadXml(doc1)).to.xmleql(
+          goog.dom.xml.loadXml(doc2));
+    });
+
+    it('Test XML document with single root, different prefix, prefix true',
+        function() {
+          var doc1 = '<bar:foo xmlns:bar="http://foo"></bar:foo>';
+          var doc2 = '<foo xmlns="http://foo"></foo>';
+          expect(goog.dom.xml.loadXml(doc1)).to.not.xmleql(
+              goog.dom.xml.loadXml(doc2), {prefix: true});
+        });
+
+    it('Test XML document with different root', function() {
+      var doc1 = '<foo></foo>';
+      var doc2 = '<bar></bar>';
+      expect(goog.dom.xml.loadXml(doc1)).to.not.xmleql(
+          goog.dom.xml.loadXml(doc2));
+    });
+
+    it('Test different number of attributes', function() {
+      var doc1 = '<foo attr="bla"></foo>';
+      var doc2 = '<foo></foo>';
+      expect(goog.dom.xml.loadXml(doc1)).to.not.xmleql(
+          goog.dom.xml.loadXml(doc2));
+    });
+
+    it('Test different attribute value', function() {
+      var doc1 = '<foo attr="bla"></foo>';
+      var doc2 = '<foo attr="foo"></foo>';
+      expect(goog.dom.xml.loadXml(doc1)).to.not.xmleql(
+          goog.dom.xml.loadXml(doc2));
+    });
+
+    it('Test different number of children', function() {
+      var doc1 = '<foo><mynode></mynode></foo>';
+      var doc2 = '<foo></foo>';
+      expect(goog.dom.xml.loadXml(doc1)).to.not.xmleql(
+          goog.dom.xml.loadXml(doc2));
     });
 
   });
@@ -106,4 +139,3 @@ describe('expect.js', function() {
 });
 
 goog.require('goog.dom.xml');
-goog.require('ol.parser.KML');


### PR DESCRIPTION
This adds some improvements for the xmleql test assertion. When passed in a
document, use the documentElement. Also improve error reporting as suggested
by @tschaub.
