### PR TITLE
Add default CSS for mouse position control

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -81,6 +81,13 @@ a.ol-full-screen-true:after {
   display: inline;
   list-style: none;
 }
+
+.ol-mouseposition {
+  top: 8px;
+  right: 8px;
+  position: absolute;  
+}
+
 .ol-scale-line {
   background: rgba(0,60,136,0.3);
   border-radius: 4px;

--- a/examples/mouse-position.html
+++ b/examples/mouse-position.html
@@ -8,6 +8,12 @@
     <link rel="stylesheet" href="../resources/layout.css" type="text/css">
     <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
     <title>Mouse position example</title>
+    <style type="text/css">
+      /* Nullify the default .ol-mouseposition rule */
+      #mouse-position .ol-mouseposition {
+        position: static;
+      }
+    </style>
   </head>
   <body>
 

--- a/examples/mouse-position.js
+++ b/examples/mouse-position.js
@@ -13,6 +13,8 @@ var map = new ol.Map({
     new ol.control.MousePosition({
       coordinateFormat: ol.coordinate.toStringHDMS,
       projection: 'EPSG:4326',
+      // comment the following line to have the mouse position
+      // be placed within the map.
       target: document.getElementById('mouse-position'),
       undefinedHTML: '&nbsp;'
     })

--- a/src/ol/control/mousepositioncontrol.js
+++ b/src/ol/control/mousepositioncontrol.js
@@ -28,7 +28,7 @@ ol.control.MousePosition = function(opt_options) {
   var options = goog.isDef(opt_options) ? opt_options : {};
 
   var element = goog.dom.createDom(goog.dom.TagName.DIV, {
-    'class': 'ol-mouse-position'
+    'class': 'ol-mouseposition'
   });
 
   goog.base(this, {


### PR DESCRIPTION
This PR adds default CSS for placing the mouse position control within the map container when the control has no specific target.

Supersedes #685, and fixes #680.

Thanks @ThomasG77 for the work on that.
