### PR TITLE
Change ol.Object event name syntax

### DIFF
--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -31,7 +31,7 @@ var marker = new ol.Overlay({
 // bind the marker position to the device location.
 marker.bindTo('position', geolocation);
 
-geolocation.addEventListener('accuracy_changed', function() {
+geolocation.on('change:accuracy', function() {
   $(marker.getElement()).tooltip({
     title: this.getAccuracy() + 'm from this point'
   });

--- a/examples/mobile-full-screen.js
+++ b/examples/mobile-full-screen.js
@@ -29,7 +29,7 @@ var geolocation = new ol.Geolocation({
   tracking: true
 });
 geolocation.bindTo('projection', view);
-geolocation.once('position_changed', function() {
+geolocation.once('change:position', function() {
   view.setCenter(geolocation.getPosition());
   view.setResolution(2.388657133911758);
 });

--- a/src/ol/dom/input.js
+++ b/src/ol/dom/input.js
@@ -34,10 +34,10 @@ ol.dom.Input = function(target) {
       this.handleInputChanged_, false, this);
 
   goog.events.listen(this,
-      ol.Object.getChangedEventType(ol.dom.InputProperty.VALUE),
+      ol.Object.getChangeEventType(ol.dom.InputProperty.VALUE),
       this.handleValueChanged_, false, this);
   goog.events.listen(this,
-      ol.Object.getChangedEventType(ol.dom.InputProperty.CHECKED),
+      ol.Object.getChangeEventType(ol.dom.InputProperty.CHECKED),
       this.handleCheckedChanged_, false, this);
 };
 goog.inherits(ol.dom.Input, ol.Object);

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -60,10 +60,10 @@ ol.Geolocation = function(opt_options) {
   this.watchId_ = undefined;
 
   goog.events.listen(
-      this, ol.Object.getChangedEventType(ol.GeolocationProperty.PROJECTION),
+      this, ol.Object.getChangeEventType(ol.GeolocationProperty.PROJECTION),
       this.handleProjectionChanged_, false, this);
   goog.events.listen(
-      this, ol.Object.getChangedEventType(ol.GeolocationProperty.TRACKING),
+      this, ol.Object.getChangeEventType(ol.GeolocationProperty.TRACKING),
       this.handleTrackingChanged_, false, this);
 
   if (goog.isDef(options.projection)) {

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -307,13 +307,13 @@ ol.Map = function(options) {
    */
   this.layersListenerKeys_ = null;
 
-  goog.events.listen(this, ol.Object.getChangedEventType(ol.MapProperty.LAYERS),
+  goog.events.listen(this, ol.Object.getChangeEventType(ol.MapProperty.LAYERS),
       this.handleLayersChanged_, false, this);
-  goog.events.listen(this, ol.Object.getChangedEventType(ol.MapProperty.VIEW),
+  goog.events.listen(this, ol.Object.getChangeEventType(ol.MapProperty.VIEW),
       this.handleViewChanged_, false, this);
-  goog.events.listen(this, ol.Object.getChangedEventType(ol.MapProperty.SIZE),
+  goog.events.listen(this, ol.Object.getChangeEventType(ol.MapProperty.SIZE),
       this.handleSizeChanged_, false, this);
-  goog.events.listen(this, ol.Object.getChangedEventType(ol.MapProperty.TARGET),
+  goog.events.listen(this, ol.Object.getChangeEventType(ol.MapProperty.TARGET),
       this.handleTargetChanged_, false, this);
 
   // setValues will trigger the rendering of the map if the map
@@ -727,7 +727,7 @@ ol.Map.prototype.handleViewChanged_ = function() {
   var view = this.getView();
   if (goog.isDefAndNotNull(view)) {
     this.viewPropertyListenerKey_ = goog.events.listen(
-        view, ol.ObjectEventType.CHANGED,
+        view, ol.ObjectEventType.CHANGE,
         this.handleViewPropertyChanged_, false, this);
   }
   this.render();

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -18,7 +18,7 @@ goog.require('goog.object');
  * @enum {string}
  */
 ol.ObjectEventType = {
-  CHANGED: 'changed'
+  CHANGE: 'change'
 };
 
 
@@ -57,7 +57,7 @@ goog.inherits(ol.Object, goog.events.EventTarget);
  * @private
  * @type {Object.<string, string>}
  */
-ol.Object.changedEventTypeCache_ = {};
+ol.Object.changeEventTypeCache_ = {};
 
 
 /**
@@ -95,12 +95,12 @@ ol.Object.getAccessors = function(obj) {
 
 /**
  * @param {string} key Key.
- * @return {string} Changed name.
+ * @return {string} Change name.
  */
-ol.Object.getChangedEventType = function(key) {
-  return ol.Object.changedEventTypeCache_.hasOwnProperty(key) ?
-      ol.Object.changedEventTypeCache_[key] :
-      (ol.Object.changedEventTypeCache_[key] = key.toLowerCase() + '_changed');
+ol.Object.getChangeEventType = function(key) {
+  return ol.Object.changeEventTypeCache_.hasOwnProperty(key) ?
+      ol.Object.changeEventTypeCache_[key] :
+      (ol.Object.changeEventTypeCache_[key] = 'change:' + key.toLowerCase());
 };
 
 
@@ -146,7 +146,7 @@ ol.Object.prototype.bindTo =
     function(key, target, opt_targetKey, opt_noNotify) {
   var targetKey = opt_targetKey || key;
   this.unbind(key);
-  var eventType = ol.Object.getChangedEventType(targetKey);
+  var eventType = ol.Object.getChangeEventType(targetKey);
   var listeners = ol.Object.getListeners(this);
   listeners[key] = goog.events.listen(target, eventType, function() {
     this.notifyInternal_(key);
@@ -217,9 +217,9 @@ ol.Object.prototype.notify = function(key) {
  * @private
  */
 ol.Object.prototype.notifyInternal_ = function(key) {
-  var eventType = ol.Object.getChangedEventType(key);
+  var eventType = ol.Object.getChangeEventType(key);
   this.dispatchEvent(eventType);
-  this.dispatchEvent(ol.ObjectEventType.CHANGED);
+  this.dispatchEvent(ol.ObjectEventType.CHANGE);
 };
 
 

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -69,20 +69,20 @@ ol.Overlay = function(options) {
   };
 
   goog.events.listen(
-      this, ol.Object.getChangedEventType(ol.OverlayProperty.ELEMENT),
+      this, ol.Object.getChangeEventType(ol.OverlayProperty.ELEMENT),
       this.handleElementChanged, false, this);
 
   goog.events.listen(
-      this, ol.Object.getChangedEventType(ol.OverlayProperty.MAP),
+      this, ol.Object.getChangeEventType(ol.OverlayProperty.MAP),
       this.handleMapChanged, false, this);
 
   goog.events.listen(
-      this, ol.Object.getChangedEventType(ol.OverlayProperty.POSITION),
+      this, ol.Object.getChangeEventType(ol.OverlayProperty.POSITION),
       this.handlePositionChanged, false, this);
 
   goog.events.listen(
       this,
-      ol.Object.getChangedEventType(ol.OverlayProperty.POSITIONING),
+      ol.Object.getChangeEventType(ol.OverlayProperty.POSITIONING),
       this.handlePositioningChanged, false, this);
 
   if (goog.isDef(options.element)) {

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -43,30 +43,30 @@ ol.renderer.Layer = function(mapRenderer, layer) {
   this.layer_ = layer;
 
   goog.events.listen(this.layer_,
-      ol.Object.getChangedEventType(ol.layer.LayerProperty.BRIGHTNESS),
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.BRIGHTNESS),
       this.handleLayerBrightnessChange, false, this);
 
   goog.events.listen(this.layer_,
-      ol.Object.getChangedEventType(ol.layer.LayerProperty.CONTRAST),
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.CONTRAST),
       this.handleLayerContrastChange, false, this);
 
   goog.events.listen(this.layer_,
-      ol.Object.getChangedEventType(ol.layer.LayerProperty.HUE),
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.HUE),
       this.handleLayerHueChange, false, this);
 
   goog.events.listen(this.layer_, goog.events.EventType.LOAD,
       this.handleLayerLoad, false, this);
 
   goog.events.listen(this.layer_,
-      ol.Object.getChangedEventType(ol.layer.LayerProperty.OPACITY),
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.OPACITY),
       this.handleLayerOpacityChange, false, this);
 
   goog.events.listen(this.layer_,
-      ol.Object.getChangedEventType(ol.layer.LayerProperty.SATURATION),
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.SATURATION),
       this.handleLayerSaturationChange, false, this);
 
   goog.events.listen(this.layer_,
-      ol.Object.getChangedEventType(ol.layer.LayerProperty.VISIBLE),
+      ol.Object.getChangeEventType(ol.layer.LayerProperty.VISIBLE),
       this.handleLayerVisibleChange, false, this);
 
 };

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -195,30 +195,30 @@ describe('ol.collection', function() {
     });
   });
 
-  describe('length_changed event', function() {
+  describe('change:length event', function() {
     var collection, cb;
     beforeEach(function() {
       collection = new ol.Collection([0, 1, 2]);
       cb = sinon.spy();
-      goog.events.listen(collection, 'length_changed', cb);
+      goog.events.listen(collection, 'change:length', cb);
     });
 
     describe('insertAt', function() {
-      it('triggers length_changed event', function() {
+      it('triggers change:length event', function() {
         collection.insertAt(2, 3);
         expect(cb).to.be.called();
       });
     });
 
     describe('removeAt', function() {
-      it('triggers length_changed event', function() {
+      it('triggers change:length event', function() {
         collection.removeAt(0);
         expect(cb).to.be.called();
       });
     });
 
     describe('setAt', function() {
-      it('does not trigger length_changed event', function() {
+      it('does not trigger change:length event', function() {
         collection.setAt(1, 1);
         expect(cb).to.not.be.called();
       });

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -103,15 +103,15 @@ describe('ol.Object', function() {
 
     beforeEach(function() {
       listener1 = sinon.spy();
-      goog.events.listen(o, 'k_changed', listener1);
+      goog.events.listen(o, 'change:k', listener1);
 
       listener2 = sinon.spy();
-      goog.events.listen(o, 'changed', listener2);
+      goog.events.listen(o, 'change', listener2);
 
       var o2 = new ol.Object();
       o2.bindTo('k', o);
       listener3 = sinon.spy();
-      goog.events.listen(o2, 'k_changed', listener3);
+      goog.events.listen(o2, 'change:k', listener3);
     });
 
     it('dispatches events', function() {
@@ -136,15 +136,15 @@ describe('ol.Object', function() {
 
     beforeEach(function() {
       listener1 = sinon.spy();
-      goog.events.listen(o, 'k_changed', listener1);
+      goog.events.listen(o, 'change:k', listener1);
 
       listener2 = sinon.spy();
-      goog.events.listen(o, 'changed', listener2);
+      goog.events.listen(o, 'change', listener2);
 
       o2 = new ol.Object();
       o2.bindTo('k', o);
       listener3 = sinon.spy();
-      goog.events.listen(o2, 'k_changed', listener3);
+      goog.events.listen(o2, 'change:k', listener3);
     });
 
     it('dispatches events to object', function() {
@@ -288,10 +288,10 @@ describe('ol.Object', function() {
       o2.bindTo('k2', o, 'k1');
 
       listener1 = sinon.spy();
-      goog.events.listen(o, 'k1_changed', listener1);
+      goog.events.listen(o, 'change:k1', listener1);
 
       listener2 = sinon.spy();
-      goog.events.listen(o2, 'k2_changed', listener2);
+      goog.events.listen(o2, 'change:k2', listener2);
     });
 
     it('sets the expected properties', function() {
@@ -460,9 +460,9 @@ describe('ol.Object', function() {
 
     beforeEach(function() {
       listener1 = sinon.spy();
-      goog.events.listen(o, 'k_changed', listener1);
+      goog.events.listen(o, 'change:k', listener1);
       listener2 = sinon.spy();
-      goog.events.listen(o, 'K_changed', listener2);
+      goog.events.listen(o, 'change:K', listener2);
     });
 
     it('dispatches the expected event', function() {


### PR DESCRIPTION
`changed` to `change` and `<attribute>_changed` to `change:<attribute>`.
Syntax borrowed from backbone.js.

I personally prefer this syntax ... comments welcome !
