### PR TITLE
Add and export View2D.calculateExtent

### DIFF
--- a/src/ol/view2d.exports
+++ b/src/ol/view2d.exports
@@ -1,3 +1,4 @@
 @exportClass ol.View2D ol.View2DOptions
 @exportProperty ol.View2D.prototype.fitExtent
+@exportProperty ol.View2D.prototype.calculateExtent
 @exportProperty ol.View2D.prototype.getView2D

--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -1,5 +1,4 @@
 // FIXME getView3D has not return type
-// FIXME remove getExtent?
 
 goog.provide('ol.View2D');
 goog.provide('ol.View2DProperty');
@@ -167,10 +166,12 @@ goog.exportProperty(
 
 
 /**
+ * Calculate the extent for the given size in pixels, the current
+ * resolution and the current center.
  * @param {ol.Size} size Box pixel size.
  * @return {ol.Extent} Extent.
  */
-ol.View2D.prototype.getExtent = function(size) {
+ol.View2D.prototype.calculateExtent = function(size) {
   goog.asserts.assert(this.isDef());
   var center = this.getCenter();
   var resolution = this.getResolution();


### PR DESCRIPTION
This PR suggests to rename View2D:getExtent to View2D:calculateExtent, as discussed in this ol3-dev thread: https://groups.google.com/d/msg/ol3-dev/kJntPZCcsQ0/QlZFafa-GHEJ. It also exports calculateExtent for external use, which was @adube's initial request.
