### PR TITLE
Remove google.exports

### DIFF
--- a/src/goog.exports
+++ b/src/goog.exports
@@ -1,1 +1,0 @@
-@exportSymbol goog.require goog.nullFunction


### PR DESCRIPTION
This .exports file made goog.require be exported as a null function. This was needed to be able to run the ol3 examples uncompiled against the ol.js build. Now that host-examples target removes the goog.require statements from the examples' js files (74b8fea6) we don't need to export goog.require anymore.

Once merged the corresponding note should be removed from https://github.com/openlayers/ol3/wiki/Exports-Files.
