### PR TITLE
Use closure_linter-2.3.9.tar.gz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - "sudo pip install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
+  - "sudo pip install http://closure-linter.googlecode.com/files/closure_linter-2.3.9.tar.gz"
   - "git clone --depth=50 https://github.com/jsdoc3/jsdoc build/jsdoc"
   - "git clone https://code.google.com/p/glsl-unit/ build/glsl-unit"
 


### PR DESCRIPTION
closure_linter-latest.tar.gz is no longer available in http://closure-linter.googlecode.com/files/, so use closure_linter-2.3.9.tar.gz. At least for now.
