### PR TITLE
The compilation of ol.js produces a warning

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -17,6 +17,7 @@ oli.control.Control = function() {};
 
 /**
  * @param {ol.MapEvent} mapEvent Map event.
+ * @return {undefined} Undefined.
  */
 oli.control.Control.prototype.handleMapPostrender = function(mapEvent) {};
 


### PR DESCRIPTION
```
$ ./build.py build/ol.js
2013-05-10 13:57:03,620 build/ol.js: java -jar build/plovr-eba786b34df9.jar build buildcfg/ol.json
JSC_EXPORTED_FUNCTION_UNKNOWN_RETURN_TYPE. Unable to determine return type for exported function ol.control.Control.prototype.handleMapPostrender at ../src/ol/control/control.js line 79 : 51

ATTENTION: 0 error(s), 1 warning(s), 96.16% typed
2013-05-10 13:57:23,638 build/ol.js: uncompressed: 201864 bytes
2013-05-10 13:57:23,661 build/ol.js:   compressed: 67486 bytes
```

Caused by 88352092ee14e249c91dcd5cf12fcf6d5acc0a12 and 3a4fc2a99a5eda0df297dec4f8b5939b8aab09e6.
