### PR TITLE
Properly reset the dirty flag

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -393,6 +393,7 @@ ol.renderer.canvas.VectorLayer.prototype.renderFrame =
   var filters = this.geometryFilters_,
       numFilters = filters.length,
       deferred = false,
+      dirty = false,
       i, geomFilter, tileExtent, extentFilter, type,
       groups, group, j, numGroups;
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
@@ -420,10 +421,11 @@ ol.renderer.canvas.VectorLayer.prototype.renderFrame =
         }
         tilesOnSketchCanvas[key] = tileCoord;
       } else {
-        this.dirty_ = true;
+        dirty = true;
       }
     }
   }
+  this.dirty_ = dirty;
 
   renderByGeometryType:
   for (type in featuresToRender) {


### PR DESCRIPTION
Currently, the dirty flag is never reset (to false).  This is a bug.

Because `renderFrame` is called very often (every layer render gets called when every other layer needs to re-render), it is criticial to know when we can bail out early.  The dirty flag is currently the way that the vector layer renderer knows that it needs to do more work.  On an empty cache, the `renderFrame` method of the vector layer renderer is called ~30 times for a single zoom in the vector layer example (due to tiles loading on other layers).  Without this change, we miss the fast path out and clear/re-render the canvas all 30 times.  With this change, we are only clear the canvas and redraw 6 times in a typical zoom animation.

I'd like to talk separately about improving the situation with `renderFrame` (I think some of our performance issues with multiple layers could be related to the fact that every layer renderer has to do work when a tile needs to be rendered on any other layer).
