### PR TITLE
Small fixes for KML write.

### DIFF
--- a/src/ol/parser/kml.js
+++ b/src/ol/parser/kml.js
@@ -51,6 +51,8 @@ ol.parser.KML = function(opt_options) {
       options.extractAttributes : true;
   this.extractStyles = goog.isDef(options.extractStyles) ?
       options.extractStyles : false;
+  this.schemaLocation = 'http://www.opengis.net/kml/2.2 ' +
+      'http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd';
   // TODO re-evaluate once shared structures support 3D
   this.dimension = goog.isDef(options.dimension) ? options.dimension : 3;
   this.maxDepth = goog.isDef(options.maxDepth) ? options.maxDepth : 0;
@@ -557,7 +559,6 @@ ol.parser.KML = function(opt_options) {
     'http://www.opengis.net/kml/2.2': {
       'kml': function(options) {
         var node = this.createElementNS('kml');
-        node.setAttribute('xmlns', this.defaultNamespaceURI);
         this.writeNode('Document', options, null, node);
         return node;
       },
@@ -1046,5 +1047,8 @@ ol.parser.KML.prototype.createGeometry_ = function(container,
  */
 ol.parser.KML.prototype.write = function(obj) {
   var root = this.writeNode('kml', obj);
-  return goog.dom.xml.serialize(root);
+  this.setAttributeNS(
+      root, 'http://www.w3.org/2001/XMLSchema-instance',
+      'xsi:schemaLocation', this.schemaLocation);
+  return this.serialize(root);
 };

--- a/test/spec/ol/parser/kml.test.js
+++ b/test/spec/ol/parser/kml.test.js
@@ -156,7 +156,10 @@ describe('ol.parser.kml', function() {
       expect(obj.features[0].get('name')).to.eql('Pezinok');
     });
     it('Test line style', function() {
-      var test_style = '<kml xmlns="http://www.opengis.net/kml/2.2"> ' +
+      var test_style = '<kml xmlns="http://www.opengis.net/kml/2.2" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.opengis.net/kml/2.2 ' +
+          'http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd"> ' +
           '<Document><Placemark><Style><LineStyle> <color>870000ff</color> ' +
           '<width>10</width> </LineStyle> </Style>  <LineString> ' +
           '<coordinates> -112,36 -113,37 </coordinates> </LineString>' +
@@ -173,7 +176,7 @@ describe('ol.parser.kml', function() {
       expect(symbolizer.strokeWidth).to.eql(10);
     });
     it('Test style fill', function() {
-      var test_style_fill = '<kml xmlns="http://www.opengis.net/kml/2.2"> ' +
+      var test_style_fill = '<kml xmlns="http://www.opengis.net/kml/2.2">' +
           '<Document><Placemark>    <Style> <PolyStyle> <fill>1</fill> ' +
           '<color>870000ff</color> <width>10</width> </PolyStyle> </Style>' +
           '<Polygon><outerBoundaryIs><LinearRing><coordinates>' +
@@ -188,7 +191,10 @@ describe('ol.parser.kml', function() {
           '49.630662409673505 8.397385910100951,48.45172350357396 ' +
           '5.001370157823406,49.26855713824488</coordinates></LinearRing>' +
           '</outerBoundaryIs></Polygon></Placemark></Document></kml>';
-      var style_fill_write = '<kml xmlns="http://www.opengis.net/kml/2.2"> ' +
+      var style_fill_write = '<kml xmlns="http://www.opengis.net/kml/2.2" ' +
+          'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+          'xsi:schemaLocation="http://www.opengis.net/kml/2.2 ' +
+          'http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd"> ' +
           '<Document><Placemark>    <Style> <PolyStyle> <fill>1</fill> ' +
           '<color>870000ff</color> <width>10</width> </PolyStyle> </Style>' +
           '<Polygon><outerBoundaryIs><LinearRing><coordinates>' +

--- a/test/spec/ol/parser/kml/depth.kml
+++ b/test/spec/ol/parser/kml/depth.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
     <Document>
     <NetworkLink><Link><href>spec/ol/parser/kml/polygon.kml</href></Link></NetworkLink>
     </Document>

--- a/test/spec/ol/parser/kml/extended_data.kml
+++ b/test/spec/ol/parser/kml/extended_data.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
   <Placemark>
     <name>Extended data placemark</name>
     <description>Attached to the ground. Intelligently places itself 

--- a/test/spec/ol/parser/kml/extended_data2.kml
+++ b/test/spec/ol/parser/kml/extended_data2.kml
@@ -1,4 +1,5 @@
-<kml xmlns="http://earth.google.com/kml/2.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://earth.google.com/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
 <Document>
 <Placemark>
   <name>Easy trail</name>

--- a/test/spec/ol/parser/kml/iconstyle.kml
+++ b/test/spec/ol/parser/kml/iconstyle.kml
@@ -1,4 +1,5 @@
-<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
   <Document>
     <Style id="pushpin">
       <IconStyle id="mystyle">

--- a/test/spec/ol/parser/kml/linestring.kml
+++ b/test/spec/ol/parser/kml/linestring.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
 <Document>
   <name>LineString.kml</name>
   <open>1</open>

--- a/test/spec/ol/parser/kml/macnoise.kml
+++ b/test/spec/ol/parser/kml/macnoise.kml
@@ -1,4 +1,5 @@
-<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
 <Document>
 <Camera>
   <gx:TimeStamp>

--- a/test/spec/ol/parser/kml/multigeometry.kml
+++ b/test/spec/ol/parser/kml/multigeometry.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
 <Document>
   <name>Polygon.kml</name>
   <open>0</open>

--- a/test/spec/ol/parser/kml/multigeometry_discrete.kml
+++ b/test/spec/ol/parser/kml/multigeometry_discrete.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
 <Document>
   <name>Polygon.kml</name>
   <open>0</open>

--- a/test/spec/ol/parser/kml/networklink.kml
+++ b/test/spec/ol/parser/kml/networklink.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
     <Document>
     <Placemark>
         <name>Simple placemark</name>

--- a/test/spec/ol/parser/kml/networklink_depth.kml
+++ b/test/spec/ol/parser/kml/networklink_depth.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
     <Document>
     <Placemark>
         <name>Simple placemark</name>

--- a/test/spec/ol/parser/kml/point.kml
+++ b/test/spec/ol/parser/kml/point.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
   <Document>
     <Placemark>
       <name>Simple placemark</name>

--- a/test/spec/ol/parser/kml/polygon.kml
+++ b/test/spec/ol/parser/kml/polygon.kml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
 <Document>
   <name>Polygon.kml</name>
   <open>0</open>


### PR DESCRIPTION
Be a good XML citizen and always write out schemaLocation.
Use serialize on ol.parser.XML so that we don't have to set xmlns manually.
