### PR TITLE
Add parser.jsdoc file for docs on parser options.

### DIFF
--- a/src/ol/parser.jsdoc
+++ b/src/ol/parser.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace ol.parser
+ */


### PR DESCRIPTION
Pointer by @ahocevar in #735

I've verified locally with ./build.py doc that this solves the issue.
