### PR TITLE
Allow user to stop map at the end of a drag

### DIFF
--- a/src/ol/kinetic.js
+++ b/src/ol/kinetic.js
@@ -79,6 +79,10 @@ ol.Kinetic.prototype.update = function(x, y) {
 ol.Kinetic.prototype.end = function() {
   var delay = goog.now() - this.delay_;
   var lastIndex = this.points_.length - 3;
+  if (this.points_[lastIndex + 2] < delay) {
+    // the user stopped panning before releasing the map
+    return false;
+  }
   var firstIndex = lastIndex - 3;
   while (firstIndex >= 0 && this.points_[firstIndex + 2] > delay) {
     firstIndex -= 3;


### PR DESCRIPTION
If the time between the last move and now is longer than the configured delay, this means that the user stopped panning before releasing the map.

Currently, if the user pans, stops, waits, and then releases the map, it can start panning again.  Easiest to reproduce while dragging with a touch pad:
- open [an example](http://ol3js.org/en/master/examples/simple.html)
- click and hold down on the touch pad with your thumb
- flick your finger to pan (keeping your thumb down, finger comes up at the end of the pan)
- wait
- release your thumb

In this sequence, you should expect the map to stay at rest after you release, instead it slips away.
