### PR TITLE
Style for attribution control

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -6,14 +6,14 @@
   right: 0;
   background: rgba(0,60,136,0.3);
   font-family: 'Lucida Grande',Verdana,Geneva,Lucida,Arial,Helvetica,sans-serif;
-  padding: 2px 4px;
+  padding: 6px;
 }
 .ol-attribution a {
   color: white;
   text-decoration: none;
 }
 .ol-attribution ul {
-  margin: 3px 0;
+  margin: 0;
   padding: 0;
   font-size: 10px;
   line-height: 12px;


### PR DESCRIPTION
Bootstrap sets a 20px line height on the body and `li` elements.  This overrides that for our attribution control.
