### PR TITLE
Exposing ol.geom.GeometryType

### DIFF
--- a/src/ol/geom.exports
+++ b/src/ol/geom.exports
@@ -1,3 +1,4 @@
+@exportSymbol ol.geom.GeometryType
 @exportSymbol ol.geom.Point
 @exportSymbol ol.geom.LineString
 @exportSymbol ol.geom.Polygon

--- a/src/ol/geom.jsdoc
+++ b/src/ol/geom.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace ol.geom
+ */

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -57,6 +57,8 @@ ol.geom.Geometry.prototype.getType = goog.abstractMethod;
 
 
 /**
+ * Geometry types.
+ *
  * @enum {string}
  */
 ol.geom.GeometryType = {


### PR DESCRIPTION
This is necessary for using ol.filter.Geometry.
