### PR TITLE
Cleanup attribution control

### DIFF
--- a/src/ol/control/attributioncontrol.js
+++ b/src/ol/control/attributioncontrol.js
@@ -65,36 +65,44 @@ goog.inherits(ol.control.Attribution, ol.control.Control);
 
 /**
  * @param {?ol.FrameState} frameState Frame state.
- * @return {Object.<string, ol.Attribution>} Attributions.
+ * @return {Array.<Object.<string, ol.Attribution>>} Attributions.
  */
-ol.control.Attribution.prototype.getTileSourceAttributions =
+ol.control.Attribution.prototype.getSourceAttributions =
     function(frameState) {
-  /** @type {Object.<string, ol.Attribution>} */
-  var attributions = {};
-  var i, ii, j, jj, tileRanges, tileSource, tileSourceAttribution,
-      tileSourceAttributionKey, tileSourceAttributions, tileSourceKey;
+  var i, ii, j, jj, tileRanges, source, sourceAttribution,
+      sourceAttributionKey, sourceAttributions, sourceKey;
   var layers = frameState.layersArray;
+  /** @type {Object.<string, ol.Attribution>} */
+  var attributions = goog.object.clone(frameState.attributions);
+  /** @type {Object.<string, ol.Attribution>} */
+  var hiddenAttributions = {};
   for (i = 0, ii = layers.length; i < ii; i++) {
-    tileSource = layers[i].getSource();
-    tileSourceKey = goog.getUid(tileSource).toString();
-    if (tileSourceKey in frameState.usedTiles) {
-      tileSourceAttributions = tileSource.getAttributions();
-      if (goog.isNull(tileSourceAttributions)) {
+    source = layers[i].getSource();
+    sourceKey = goog.getUid(source).toString();
+    sourceAttributions = source.getAttributions();
+    if (goog.isNull(sourceAttributions)) {
+      continue;
+    }
+    for (j = 0, jj = sourceAttributions.length; j < jj; j++) {
+      sourceAttribution = sourceAttributions[j];
+      sourceAttributionKey = goog.getUid(sourceAttribution).toString();
+      if (sourceAttributionKey in attributions) {
         continue;
       }
-      tileRanges = frameState.usedTiles[tileSourceKey];
-      for (j = 0, jj = tileSourceAttributions.length; j < jj; j++) {
-        tileSourceAttribution = tileSourceAttributions[j];
-        tileSourceAttributionKey =
-            goog.getUid(tileSourceAttribution).toString();
-        if (!(tileSourceAttributionKey in attributions) &&
-            tileSourceAttribution.intersectsAnyTileRange(tileRanges)) {
-          attributions[tileSourceAttributionKey] = tileSourceAttribution;
+      tileRanges = frameState.usedTiles[sourceKey];
+      if (goog.isDef(tileRanges) &&
+          sourceAttribution.intersectsAnyTileRange(tileRanges)) {
+        if (sourceAttributionKey in hiddenAttributions) {
+          delete hiddenAttributions[sourceAttributionKey];
         }
+        attributions[sourceAttributionKey] = sourceAttribution;
+      }
+      else {
+        hiddenAttributions[sourceAttributionKey] = sourceAttribution;
       }
     }
   }
-  return attributions;
+  return [attributions, hiddenAttributions];
 };
 
 
@@ -120,18 +128,28 @@ ol.control.Attribution.prototype.updateElement_ = function(frameState) {
     return;
   }
 
+  var attributions = this.getSourceAttributions(frameState);
   /** @type {Object.<string, ol.Attribution>} */
-  var attributions = goog.object.clone(frameState.attributions);
-  goog.object.extend(attributions, this.getTileSourceAttributions(frameState));
+  var visibleAttributions = attributions[0];
+  /** @type {Object.<string, ol.Attribution>} */
+  var hiddenAttributions = attributions[1];
 
   var attributionElement, attributionKey;
   for (attributionKey in this.attributionElements_) {
-    if (attributionKey in attributions) {
+    if (attributionKey in visibleAttributions) {
       if (!this.attributionElementRenderedVisible_[attributionKey]) {
         goog.style.showElement(this.attributionElements_[attributionKey], true);
         this.attributionElementRenderedVisible_[attributionKey] = true;
       }
-      delete attributions[attributionKey];
+      delete visibleAttributions[attributionKey];
+    }
+    else if (attributionKey in hiddenAttributions) {
+      if (this.attributionElementRenderedVisible_[attributionKey]) {
+        goog.style.showElement(
+            this.attributionElements_[attributionKey], false);
+        delete this.attributionElementRenderedVisible_[attributionKey];
+      }
+      delete hiddenAttributions[attributionKey];
     }
     else {
       goog.dom.removeNode(this.attributionElements_[attributionKey]);
@@ -139,15 +157,25 @@ ol.control.Attribution.prototype.updateElement_ = function(frameState) {
       delete this.attributionElementRenderedVisible_[attributionKey];
     }
   }
-  for (attributionKey in attributions) {
+  for (attributionKey in visibleAttributions) {
     attributionElement = goog.dom.createElement(goog.dom.TagName.LI);
-    attributionElement.innerHTML = attributions[attributionKey].getHTML();
+    attributionElement.innerHTML =
+        visibleAttributions[attributionKey].getHTML();
     goog.dom.appendChild(this.ulElement_, attributionElement);
     this.attributionElements_[attributionKey] = attributionElement;
     this.attributionElementRenderedVisible_[attributionKey] = true;
   }
+  for (attributionKey in hiddenAttributions) {
+    attributionElement = goog.dom.createElement(goog.dom.TagName.LI);
+    attributionElement.innerHTML =
+        hiddenAttributions[attributionKey].getHTML();
+    goog.style.showElement(attributionElement, false);
+    goog.dom.appendChild(this.ulElement_, attributionElement);
+    this.attributionElements_[attributionKey] = attributionElement;
+  }
 
-  var renderVisible = !goog.object.isEmpty(this.attributionElements_);
+  var renderVisible =
+      !goog.object.isEmpty(this.attributionElementRenderedVisible_);
   if (this.renderedVisible_ != renderVisible) {
     goog.style.showElement(this.element, renderVisible);
     this.renderedVisible_ = renderVisible;


### PR DESCRIPTION
In this PR, the attribution control will now use the layers from `frameState.layersArray` rather than from `map.getLayers()` and will remove the `attributionElementRenderedVisible_` property which was not used.
So the attribution now works in a similar way as the logo control.
