### PR TITLE
Add parser for OGC Filter version 1.0 and 1.1

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -520,6 +520,34 @@
  */
 
 /**
+ * @typedef {Object} ol.filter.ComparisonOptions
+ * @property {ol.filter.ComparisonType} type The type of comparison filter.
+ * @property {string} property The property associated with the filter.
+ * @property {string|undefined} value The value associated with the filter.
+ * @property {string|undefined} lowerBoundary The lower boundary of a between
+ *     filter.
+ * @property {string|undefined} upperBoundary The upper boundary of a between
+ *     filter.
+ */
+
+/**
+ * @typedef {Object} ol.filter.SpatialOptions
+ * @property {ol.filter.SpatialType} type The type of spatial filter.
+ * @property {string|undefined} property The property associated with the filter.
+ * @property {ol.geom.Geometry} value The value associated with the filter.
+ * @property {number|undefined} distance The distance of the DWITHIN filter.
+ * @property {string|undefined} distanceUnits The distance units of the
+ *     DWITHIN filter.
+ */
+
+/**
+ * @typedef {Object} ol.filter.FunctionOptions
+ * @property {string} name The name of the function to use.
+ * @property {Array.<ol.filter.Function|string|number>} params The parameters
+ *     to use.
+ */
+
+/**
  * @typedef {Object} ol.style.ShapeOptions
  * @property {ol.style.ShapeType|undefined} type Type.
  * @property {number|ol.Expression|undefined} size Size in pixels.

--- a/src/ol/filter.exports
+++ b/src/ol/filter.exports
@@ -1,7 +1,28 @@
 @exportSymbol ol.filter.Filter
 @exportSymbol ol.filter.Geometry
 @exportSymbol ol.filter.Logical
+@exportSymbol ol.filter.Comparison
+@exportSymbol ol.filter.FeatureId
+@exportSymbol ol.filter.Spatial
 
 @exportSymbol ol.filter.LogicalOperator
 @exportProperty ol.filter.LogicalOperator.AND
 @exportProperty ol.filter.LogicalOperator.OR
+
+@exportSymbol ol.filter.ComparisonType
+@exportProperty ol.filter.ComparisonType.EQUAL_TO
+@exportProperty ol.filter.ComparisonType.NOT_EQUAL_TO
+@exportProperty ol.filter.ComparisonType.LESS_THAN
+@exportProperty ol.filter.ComparisonType.GREATER_THAN
+@exportProperty ol.filter.ComparisonType.LESS_THAN_OR_EQUAL_TO
+@exportProperty ol.filter.ComparisonType.GREATER_THAN_OR_EQUAL_TO
+@exportProperty ol.filter.ComparisonType.BETWEEN
+@exportProperty ol.filter.ComparisonType.LIKE
+@exportProperty ol.filter.ComparisonType.IS_NULL
+
+@exportSymbol ol.filter.SpatialType
+@exportProperty ol.filter.SpatialType.BBOX
+@exportProperty ol.filter.SpatialType.INTERSECTS
+@exportProperty ol.filter.SpatialType.DWITHIN
+@exportProperty ol.filter.SpatialType.WITHIN
+@exportProperty ol.filter.SpatialType.CONTAINS

--- a/src/ol/filter/comparisonfilter.js
+++ b/src/ol/filter/comparisonfilter.js
@@ -1,0 +1,207 @@
+goog.provide('ol.filter.Comparison');
+goog.provide('ol.filter.ComparisonType');
+
+goog.require('ol.Expression');
+goog.require('ol.filter.Filter');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.filter.Filter}
+ * @param {ol.filter.ComparisonOptions} options Options.
+ */
+ol.filter.Comparison = function(options) {
+  goog.base(this);
+
+  /**
+   * @type {ol.filter.ComparisonType}
+   * @private
+   */
+  this.type_ = options.type;
+
+  this.property_ = options.property;
+
+  this.value_ = options.value;
+
+  this.lowerBoundary_ = options.lowerBoundary;
+
+  this.upperBoundary_ = options.upperBoundary;
+
+  this.matchCase_ = options.matchCase;
+
+  var expr;
+  var quote = '';
+  if (goog.isString(this.value_)) {
+    quote = '"';
+  }
+  switch (this.type_) {
+    case ol.filter.ComparisonType.EQUAL_TO:
+      expr = this.property_ + '==' + quote + this.value_ + quote;
+      break;
+    case ol.filter.ComparisonType.NOT_EQUAL_TO:
+      expr = this.property_ + '!=' + quote + this.value_ + quote;
+      break;
+    case ol.filter.ComparisonType.LESS_THAN:
+      expr = this.property_ + '<' + this.value_;
+      break;
+    case ol.filter.ComparisonType.GREATER_THAN:
+      expr = this.property_ + '>' + this.value_;
+      break;
+    case ol.filter.ComparisonType.LESS_THAN_OR_EQUAL_TO:
+      expr = this.property_ + '<=' + this.value_;
+      break;
+    case ol.filter.ComparisonType.GREATER_THAN_OR_EQUAL_TO:
+      expr = this.property_ + '>=' + this.value_;
+      break;
+    case ol.filter.ComparisonType.BETWEEN:
+      expr = this.property_ + '>=' + this.lowerBoundary_ + '&&' +
+          this.property_ + '<=' + this.upperBoundary_;
+      break;
+    case ol.filter.ComparisonType.LIKE:
+      this.applies = function(feature) {
+        var attr = feature.getAttributes();
+        return new RegExp(this.value_, 'gi').test(attr[this.property_]);
+      };
+      break;
+    case ol.filter.ComparisonType.IS_NULL:
+      expr = this.property_ + '=== null';
+      break;
+    default:
+      throw new Error('Unknown filter comparison type: ' + this.type_);
+      break;
+  }
+  if (goog.isDef(expr)) {
+    this.expression_ = new ol.Expression(expr);
+  }
+};
+goog.inherits(ol.filter.Comparison, ol.filter.Filter);
+
+
+/**
+ * @return {ol.filter.ComparisonType} The type of comparison filter.
+ */
+ol.filter.Comparison.prototype.getType = function() {
+  return this.type_;
+};
+
+
+/**
+ * @return {string} The name of the property associated with the filter.
+ */
+ol.filter.Comparison.prototype.getProperty = function() {
+  return this.property_;
+};
+
+
+/**
+ * @return {string|number|undefined} The value to filter on.
+ */
+ol.filter.Comparison.prototype.getValue = function() {
+  return this.value_;
+};
+
+
+/**
+ * @return {string|number|undefined} The lower boundary of the between filter.
+ */
+ol.filter.Comparison.prototype.getLowerBoundary = function() {
+  return this.lowerBoundary_;
+};
+
+
+/**
+ * @return {string|number|undefined} The upper boundary of the between filter.
+ */
+ol.filter.Comparison.prototype.getUpperBoundary = function() {
+  return this.upperBoundary_;
+};
+
+
+/**
+ * @return {boolean} Force case sensitive searches or not.
+ */
+ol.filter.Comparison.prototype.getMatchCase = function() {
+  return this.matchCase_;
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.filter.Comparison.prototype.applies = function(feature) {
+  var attr = feature.getAttributes();
+  return /** @type {boolean} */(this.expression_.evaluate(feature, attr));
+};
+
+
+/**
+ * @param {string} wildCard wildcard character in the value, default is '*'.
+ * @param {string} singleChar single-character in the value, default is '.'.
+ * @param {string} escapeChar escape character in the value, default is '!'.
+ * @return {string} regular expression string.
+ */
+ol.filter.Comparison.prototype.value2regex = function(wildCard, singleChar,
+    escapeChar) {
+  if (wildCard == '.') {
+    throw new Error('"." is an unsupported wildCard character for ' +
+        'ol.filter.Comparison');
+  }
+  // set UMN MapServer defaults for unspecified parameters
+  wildCard = goog.isDef(wildCard) ? wildCard : '*';
+  singleChar = goog.isDef(singleChar) ? singleChar : '.';
+  escapeChar = goog.isDef(escapeChar) ? escapeChar : '!';
+  this.value_ = this.value_.replace(
+      new RegExp('\\' + escapeChar + '(.|$)', 'g'), '\\$1');
+  this.value_ = this.value_.replace(
+      new RegExp('\\' + singleChar, 'g'), '.');
+  this.value_ = this.value_.replace(
+      new RegExp('\\' + wildCard, 'g'), '.*');
+  this.value_ = this.value_.replace(
+      new RegExp('\\\\.\\*', 'g'), '\\' + wildCard);
+  this.value_ = this.value_.replace(
+      new RegExp('\\\\\\.', 'g'), '\\' + singleChar);
+  return this.value_;
+};
+
+
+/**
+ * Convert the value of this rule from a regular expression string into an
+ *     ogc literal string using a wildCard of *, a singleChar of ., and an
+ *     escape of !.
+ * @return {string} A string value.
+ */
+ol.filter.Comparison.prototype.regex2value = function() {
+  var value = this.value_;
+  // replace ! with !!
+  value = value.replace(/!/g, '!!');
+  // replace \. with !. (watching out for \\.)
+  value = value.replace(/(\\)?\\\./g, function($0, $1) {
+    return $1 ? $0 : '!.';
+  });
+  // replace \* with #* (watching out for \\*)
+  value = value.replace(/(\\)?\\\*/g, function($0, $1) {
+    return $1 ? $0 : '!*';
+  });
+  // replace \\ with \
+  value = value.replace(/\\\\/g, '\\');
+  // convert .* to * (the sequence #.* is not allowed)
+  value = value.replace(/\.\*/g, '*');
+  return value;
+};
+
+
+/**
+ * @enum {string}
+ */
+ol.filter.ComparisonType = {
+  EQUAL_TO: '==',
+  NOT_EQUAL_TO: '!=',
+  LESS_THAN: '<',
+  GREATER_THAN: '>',
+  LESS_THAN_OR_EQUAL_TO: '<=',
+  GREATER_THAN_OR_EQUAL_TO: '>=',
+  BETWEEN: '..',
+  LIKE: '~',
+  IS_NULL: 'NULL'
+};

--- a/src/ol/filter/featureidfilter.js
+++ b/src/ol/filter/featureidfilter.js
@@ -1,0 +1,40 @@
+goog.provide('ol.filter.FeatureId');
+
+goog.require('goog.object');
+goog.require('ol.filter.Filter');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.filter.Filter}
+ * @param {Object.<string>} fids The feature ids to use.
+ */
+ol.filter.FeatureId = function(fids) {
+  goog.base(this);
+
+  /**
+   * @type {Object.<string>}
+   * @private
+   */
+  this.fids_ = fids;
+
+};
+goog.inherits(ol.filter.FeatureId, ol.filter.Filter);
+
+
+/**
+ * @return {Object.<string>} The feature ids that are part of this filter.
+ */
+ol.filter.FeatureId.prototype.getFids = function() {
+  return this.fids_;
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.filter.FeatureId.prototype.applies = function(feature) {
+  var fid = feature.getFeatureId();
+  return goog.isDef(fid) && (goog.object.containsKey(this.fids_, fid));
+};

--- a/src/ol/filter/functionfilter.js
+++ b/src/ol/filter/functionfilter.js
@@ -1,0 +1,46 @@
+goog.provide('ol.filter.Function');
+
+goog.require('ol.filter.Filter');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.filter.Filter}
+ * @param {ol.filter.FunctionOptions} options The options to set on this
+ *     instance.
+ */
+ol.filter.Function = function(options) {
+  goog.base(this);
+
+  /**
+   * @type {string}
+   * @private
+   */
+  this.name_ = options.name;
+
+  /**
+   * @type {Array.<ol.filter.Function|string|number>}
+   * @private
+   */
+  this.params_ = options.params;
+
+};
+goog.inherits(ol.filter.Function, ol.filter.Filter);
+
+
+/**
+ * @return {Array.<ol.filter.Function|string|number>} The parameters
+ *     of this filter function.
+ */
+ol.filter.Function.prototype.getParams = function() {
+  return this.params_;
+};
+
+
+/**
+ * @return {string} The name of the function.
+ */
+ol.filter.Function.prototype.getName = function() {
+  return this.name_;
+};

--- a/src/ol/filter/spatialfilter.js
+++ b/src/ol/filter/spatialfilter.js
@@ -1,0 +1,114 @@
+goog.provide('ol.filter.Spatial');
+goog.provide('ol.filter.SpatialType');
+
+goog.require('ol.filter.Filter');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.filter.Filter}
+ * @param {ol.filter.SpatialOptions} options Options.
+ */
+ol.filter.Spatial = function(options) {
+  goog.base(this);
+
+  /**
+   * @type {ol.filter.SpatialType}
+   * @private
+   */
+  this.type_ = options.type;
+
+  this.property_ = options.property;
+
+  this.value_ = options.value;
+
+  this.distance_ = options.distance;
+
+  this.distanceUnits_ = options.distanceUnits;
+
+  this.projection_ = options.projection;
+};
+goog.inherits(ol.filter.Spatial, ol.filter.Filter);
+
+
+/**
+ * @return {ol.filter.SpatialType} The type of spatial filter.
+ */
+ol.filter.Spatial.prototype.getType = function() {
+  return this.type_;
+};
+
+
+/**
+ * @return {string} The projection of the spatial filter.
+ */
+ol.filter.Spatial.prototype.getProjection = function() {
+  return this.projection_;
+};
+
+
+/**
+ * @return {string|undefined} The property to filter on.
+ */
+ol.filter.Spatial.prototype.getProperty = function() {
+  return this.property_;
+};
+
+
+/**
+ * @return {ol.geom.Geometry} The value of the spatial filter.
+ */
+ol.filter.Spatial.prototype.getValue = function() {
+  return this.value_;
+};
+
+
+/**
+ * @return {number|undefined} The distance for a DWITHIN filter.
+ */
+ol.filter.Spatial.prototype.getDistance = function() {
+  return this.distance_;
+};
+
+
+/**
+ * @return {string|undefined} The distance units in the case of DWITHIN.
+ */
+ol.filter.Spatial.prototype.getDistanceUnits = function() {
+  return this.distanceUnits_;
+};
+
+
+/**
+ * @inheritDoc
+ */
+ol.filter.Spatial.prototype.applies = function(feature) {
+  var geometry = feature.getGeometry();
+  var intersect = false;
+  if (!goog.isNull(geometry)) {
+    switch (this.type_) {
+      case ol.filter.SpatialType.BBOX:
+      case ol.filter.SpatialType.INTERSECTS:
+        // TODO compare this.value_ with geometry and set intersect
+        break;
+      default:
+        throw new Error('Applies is not implemented for this spatial' +
+            'filter type: ' + this.type_);
+        break;
+    }
+  }
+  return intersect;
+};
+
+
+/**
+ * @enum {string}
+ */
+ol.filter.SpatialType = {
+  BBOX: 'BBOX',
+  INTERSECTS: 'INTERSECTS',
+  DWITHIN: 'DWITHIN',
+  WITHIN: 'WITHIN',
+  CONTAINS: 'CONTAINS'
+};

--- a/src/ol/parser/ogc/filter.js
+++ b/src/ol/parser/ogc/filter.js
@@ -1,0 +1,37 @@
+goog.provide('ol.parser.ogc.Filter');
+goog.require('ol.parser.ogc.Filter_v1_0_0');
+goog.require('ol.parser.ogc.Filter_v1_1_0');
+goog.require('ol.parser.ogc.Versioned');
+
+
+/**
+ * @define {boolean} Whether to enable OGC Filter version 1.0.0.
+ */
+ol.ENABLE_OGCFILTER_1_0_0 = true;
+
+
+/**
+ * @define {boolean} Whether to enable OGC Filter version 1.1.0.
+ */
+ol.ENABLE_OGCFILTER_1_1_0 = true;
+
+
+
+/**
+ * @constructor
+ * @param {Object=} opt_options Options which will be set on this object.
+ * @extends {ol.parser.ogc.Versioned}
+ */
+ol.parser.ogc.Filter = function(opt_options) {
+  opt_options = opt_options || {};
+  opt_options['defaultVersion'] = '1.0.0';
+  this.parsers = {};
+  if (ol.ENABLE_OGCFILTER_1_0_0) {
+    this.parsers['v1_0_0'] = ol.parser.ogc.Filter_v1_0_0;
+  }
+  if (ol.ENABLE_OGCFILTER_1_1_0) {
+    this.parsers['v1_1_0'] = ol.parser.ogc.Filter_v1_1_0;
+  }
+  goog.base(this, opt_options);
+};
+goog.inherits(ol.parser.ogc.Filter, ol.parser.ogc.Versioned);

--- a/src/ol/parser/ogc/filter_v1.js
+++ b/src/ol/parser/ogc/filter_v1.js
@@ -1,0 +1,457 @@
+goog.provide('ol.parser.ogc.Filter_v1');
+goog.require('goog.dom.xml');
+goog.require('goog.string');
+goog.require('ol.filter.Comparison');
+goog.require('ol.filter.ComparisonType');
+goog.require('ol.filter.FeatureId');
+goog.require('ol.filter.Function');
+goog.require('ol.filter.Logical');
+goog.require('ol.filter.LogicalOperator');
+goog.require('ol.filter.Spatial');
+goog.require('ol.filter.SpatialType');
+goog.require('ol.parser.XML');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.parser.XML}
+ */
+ol.parser.ogc.Filter_v1 = function() {
+  this.defaultNamespaceURI = 'http://www.opengis.net/ogc';
+  this.errorProperty = 'filter';
+  this.readers = {
+    'http://www.opengis.net/ogc': {
+      '_expression': function(node) {
+        // only the simplest of ogc:expression handled
+        // "some text and an <PropertyName>attribute</PropertyName>"
+        var obj, value = '';
+        for (var child = node.firstChild; child; child = child.nextSibling) {
+          switch (child.nodeType) {
+            case 1:
+              obj = this.readNode(child);
+              if (obj['property']) {
+                value += obj['property'];
+              } else if (goog.isDef(obj['value'])) {
+                value += obj['value'];
+              }
+              break;
+            case 3: // text node
+            case 4: // cdata section
+              value += child.nodeValue;
+              break;
+            default:
+              break;
+          }
+        }
+        return value;
+      },
+      'Filter': function(node, obj) {
+        var container = {
+          'filters': []
+        };
+        this.readChildNodes(node, container);
+        if (goog.isDef(container['fids'])) {
+          obj['filter'] = new ol.filter.FeatureId(container['fids']);
+        } else if (container['filters'].length > 0) {
+          obj['filter'] = container['filters'][0];
+        }
+      },
+      'FeatureId': function(node, obj) {
+        var fid = node.getAttribute('fid');
+        if (fid) {
+          if (!goog.isDef(obj['fids'])) {
+            obj['fids'] = {};
+          }
+          obj['fids'][fid] = true;
+        }
+      },
+      'And': function(node, obj) {
+        var container = {'filters': []};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Logical(container['filters'],
+            ol.filter.LogicalOperator.AND));
+      },
+      'Or': function(node, obj) {
+        var container = {'filters': []};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Logical(container['filters'],
+            ol.filter.LogicalOperator.OR));
+      },
+      'Not': function(node, obj) {
+        var container = {'filters': []};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Logical(container['filters'],
+            ol.filter.LogicalOperator.NOT));
+      },
+      'PropertyIsNull': function(node, obj) {
+        var container = {};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.IS_NULL,
+          property: container['property']
+        }));
+      },
+      'PropertyIsLessThan': function(node, obj) {
+        var container = {};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.LESS_THAN,
+          property: container['property'],
+          value: container['value']
+        }));
+      },
+      'PropertyIsGreaterThan': function(node, obj) {
+        var container = {};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.GREATER_THAN,
+          property: container['property'],
+          value: container['value']
+        }));
+      },
+      'PropertyIsLessThanOrEqualTo': function(node, obj) {
+        var container = {};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.LESS_THAN_OR_EQUAL_TO,
+          property: container['property'],
+          value: container['value']
+        }));
+      },
+      'PropertyIsGreaterThanOrEqualTo': function(node, obj) {
+        var container = {};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.GREATER_THAN_OR_EQUAL_TO,
+          property: container['property'],
+          value: container['value']
+        }));
+      },
+      'PropertyIsBetween': function(node, obj) {
+        var container = {};
+        this.readChildNodes(node, container);
+        obj['filters'].push(new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.BETWEEN,
+          property: container['property'],
+          lowerBoundary: container['lowerBoundary'],
+          upperBoundary: container['upperBoundary']
+        }));
+      },
+      'Literal': function(node, obj) {
+        var nodeValue = this.getChildValue(node);
+        var value = goog.string.toNumber(nodeValue);
+        obj['value'] = isNaN(value) ? nodeValue : value;
+      },
+      'PropertyName': function(node, obj) {
+        obj['property'] = this.getChildValue(node);
+      },
+      'LowerBoundary': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        obj['lowerBoundary'] = goog.string.toNumber(
+            readers['_expression'].call(this, node));
+      },
+      'UpperBoundary': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        obj['upperBoundary'] = goog.string.toNumber(
+            readers['_expression'].call(this, node));
+      },
+      '_spatial': function(node, obj, type) {
+        var container = {};
+        this.readChildNodes(node, container);
+        var geom = goog.isDef(container.geometry) ?
+            this.gml_.createGeometry(container) : container.bounds;
+        container.value = geom;
+        container.type = type;
+        delete container.geometry;
+        obj['filters'].push(new ol.filter.Spatial(
+            /** {ol.filter.SpatialOptions} */(container)));
+      },
+      'BBOX': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        readers['_spatial'].call(this, node, obj,
+            ol.filter.SpatialType.BBOX);
+      },
+      'Intersects': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        readers['_spatial'].call(this, node, obj,
+            ol.filter.SpatialType.INTERSECTS);
+      },
+      'Within': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        readers['_spatial'].call(this, node, obj,
+            ol.filter.SpatialType.WITHIN);
+      },
+      'Contains': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        readers['_spatial'].call(this, node, obj,
+            ol.filter.SpatialType.CONTAINS);
+      },
+      'DWithin': function(node, obj) {
+        var readers = this.readers[this.defaultNamespaceURI];
+        readers['_spatial'].call(this, node, obj,
+            ol.filter.SpatialType.DWITHIN);
+      },
+      'Distance': function(node, obj) {
+        obj['distance'] = parseInt(this.getChildValue(node), 10);
+        obj['distanceUnits'] = node.getAttribute('units');
+      }
+    }
+  };
+  this.writers = {
+    'http://www.opengis.net/ogc': {
+      'Filter': function(filter) {
+        var node = this.createElementNS('ogc:Filter');
+        this.writeNode(this.getFilterType_(filter), filter, null, node);
+        return node;
+      },
+      '_featureIds': function(filter) {
+        var node = this.createDocumentFragment();
+        var fids = filter.getFids();
+        for (var key in fids) {
+          this.writeNode('FeatureId', key, null, node);
+        }
+        return node;
+      },
+      'FeatureId': function(fid) {
+        var node = this.createElementNS('ogc:FeatureId');
+        node.setAttribute('fid', fid);
+        return node;
+      },
+      'And': function(filter) {
+        var node = this.createElementNS('ogc:And');
+        var childFilter;
+        for (var i = 0, ii = filter.getFilters().length; i < ii; ++i) {
+          childFilter = filter.getFilters()[i];
+          this.writeNode(this.getFilterType_(childFilter), childFilter, null,
+              node);
+        }
+        return node;
+      },
+      'Or': function(filter) {
+        var node = this.createElementNS('ogc:Or');
+        var childFilter;
+        for (var i = 0, ii = filter.getFilters().length; i < ii; ++i) {
+          childFilter = filter.getFilters()[i];
+          this.writeNode(this.getFilterType_(childFilter), childFilter, null,
+              node);
+        }
+        return node;
+      },
+      'Not': function(filter) {
+        var node = this.createElementNS('ogc:Not');
+        var childFilter = filter.getFilters()[0];
+        this.writeNode(this.getFilterType_(childFilter), childFilter, null,
+            node);
+        return node;
+      },
+      'PropertyIsLessThan': function(filter) {
+        var node = this.createElementNS('ogc:PropertyIsLessThan');
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+        this.writeOgcExpression(filter.getValue(), node);
+        return node;
+      },
+      'PropertyIsGreaterThan': function(filter) {
+        var node = this.createElementNS('ogc:PropertyIsGreaterThan');
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+        this.writeOgcExpression(filter.getValue(), node);
+        return node;
+      },
+      'PropertyIsLessThanOrEqualTo': function(filter) {
+        var node = this.createElementNS('ogc:PropertyIsLessThanOrEqualTo');
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+        this.writeOgcExpression(filter.getValue(), node);
+        return node;
+      },
+      'PropertyIsGreaterThanOrEqualTo': function(filter) {
+        var node = this.createElementNS('ogc:PropertyIsGreaterThanOrEqualTo');
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+        this.writeOgcExpression(filter.getValue(), node);
+        return node;
+      },
+      'PropertyIsBetween': function(filter) {
+        var node = this.createElementNS('ogc:PropertyIsBetween');
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+        this.writeNode('LowerBoundary', filter, null, node);
+        this.writeNode('UpperBoundary', filter, null, node);
+        return node;
+      },
+      'PropertyName': function(name) {
+        var node = this.createElementNS('ogc:PropertyName');
+        node.appendChild(this.createTextNode(name));
+        return node;
+      },
+      'Literal': function(value) {
+        if (value instanceof Date) {
+          value = value.toISOString();
+        }
+        var node = this.createElementNS('ogc:Literal');
+        node.appendChild(this.createTextNode(value));
+        return node;
+      },
+      'LowerBoundary': function(filter) {
+        var node = this.createElementNS('ogc:LowerBoundary');
+        this.writeOgcExpression(filter.getLowerBoundary(), node);
+        return node;
+      },
+      'UpperBoundary': function(filter) {
+        var node = this.createElementNS('ogc:UpperBoundary');
+        this.writeOgcExpression(filter.getUpperBoundary(), node);
+        return node;
+      },
+      'INTERSECTS': function(filter) {
+        return this.writeSpatial_(filter, 'Intersects');
+      },
+      'WITHIN': function(filter) {
+        return this.writeSpatial_(filter, 'Within');
+      },
+      'CONTAINS': function(filter) {
+        return this.writeSpatial_(filter, 'Contains');
+      },
+      'DWITHIN': function(filter) {
+        var node = this.writeSpatial_(filter, 'DWithin');
+        this.writeNode('Distance', filter, null, node);
+        return node;
+      },
+      'Distance': function(filter) {
+        var node = this.createElementNS('ogc:Distance');
+        node.setAttribute('units', filter.getDistanceUnits());
+        node.appendChild(this.createTextNode(filter.getDistance()));
+        return node;
+      },
+      'Function': function(filter) {
+        var node = this.createElementNS('ogc:Function');
+        node.setAttribute('name', filter.getName());
+        var params = filter.getParams();
+        for (var i = 0, len = params.length; i < len; i++) {
+          this.writeOgcExpression(params[i], node);
+        }
+        return node;
+      },
+      'PropertyIsNull': function(filter) {
+        var node = this.createElementNS('ogc:PropertyIsNull');
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+        return node;
+      }
+    }
+  };
+  this.filterMap_ = {
+    '&&': 'And',
+    '||': 'Or',
+    '!': 'Not',
+    '==': 'PropertyIsEqualTo',
+    '!=': 'PropertyIsNotEqualTo',
+    '<': 'PropertyIsLessThan',
+    '>': 'PropertyIsGreaterThan',
+    '<=': 'PropertyIsLessThanOrEqualTo',
+    '>=': 'PropertyIsGreaterThanOrEqualTo',
+    '..': 'PropertyIsBetween',
+    '~': 'PropertyIsLike',
+    'NULL': 'PropertyIsNull',
+    'BBOX': 'BBOX',
+    'DWITHIN': 'DWITHIN',
+    'WITHIN': 'WITHIN',
+    'CONTAINS': 'CONTAINS',
+    'INTERSECTS': 'INTERSECTS',
+    'FID': '_featureIds'
+  };
+  goog.base(this);
+};
+goog.inherits(ol.parser.ogc.Filter_v1, ol.parser.XML);
+
+
+/**
+ * @param {ol.filter.Filter} filter The filter to determine the type of.
+ * @return {string} The type of filter.
+ * @private
+ */
+ol.parser.ogc.Filter_v1.prototype.getFilterType_ = function(filter) {
+  var type;
+  if (filter instanceof ol.filter.Logical) {
+    type = filter.operator;
+  } else if (filter instanceof ol.filter.FeatureId) {
+    type = 'FID';
+  } else if (filter instanceof ol.filter.Spatial ||
+      filter instanceof ol.filter.Comparison) {
+    type = filter.getType();
+  }
+  var filterType = this.filterMap_[type];
+  if (!filterType) {
+    throw new Error('Filter writing not supported for rule type: ' + type);
+  }
+  return filterType;
+};
+
+
+/**
+ * @param {string|Document|Element} data Data to read.
+ * @return {Object} An object representing the document.
+ */
+ol.parser.ogc.Filter_v1.prototype.read = function(data) {
+  if (goog.isString(data)) {
+    data = goog.dom.xml.loadXml(data);
+  }
+  if (data && data.nodeType == 9) {
+    data = data.documentElement;
+  }
+  var obj = {};
+  this.readNode(data, obj);
+  return obj['filter'];
+};
+
+
+/**
+ * @param {ol.filter.Filter} filter The filter to write out.
+ * @return {string} The serialized filter.
+ */
+ol.parser.ogc.Filter_v1.prototype.write = function(filter) {
+  var root = this.writeNode('Filter', filter);
+  this.setAttributeNS(
+      root, 'http://www.w3.org/2001/XMLSchema-instance',
+      'xsi:schemaLocation', this.schemaLocation);
+  return this.serialize(root);
+};
+
+
+/**
+ * @param {ol.filter.Function|string|number} value The value write out.
+ * @param {Element} node The node to append to.
+ * @return {Element} The node to which was appended.
+ * @protected
+ */
+ol.parser.ogc.Filter_v1.prototype.writeOgcExpression = function(value, node) {
+  if (value instanceof ol.filter.Function) {
+    this.writeNode('Function', value, null, node);
+  } else {
+    this.writeNode('Literal', value, null, node);
+  }
+  return node;
+};
+
+
+/**
+ * @param {ol.parser.ogc.GML_v2|ol.parser.ogc.GML_v3} gml The GML parser to
+ *     use.
+ * @protected
+ */
+ol.parser.ogc.Filter_v1.prototype.setGmlParser = function(gml) {
+  this.gml_ = gml;
+  for (var uri in this.gml_.readers) {
+    for (var key in this.gml_.readers[uri]) {
+      if (!goog.isDef(this.readers[uri])) {
+        this.readers[uri] = {};
+      }
+      this.readers[uri][key] = goog.bind(this.gml_.readers[uri][key],
+          this.gml_);
+    }
+  }
+  for (uri in this.gml_.writers) {
+    for (key in this.gml_.writers[uri]) {
+      if (!goog.isDef(this.writers[uri])) {
+        this.writers[uri] = {};
+      }
+      this.writers[uri][key] = goog.bind(this.gml_.writers[uri][key],
+          this.gml_);
+    }
+  }
+};

--- a/src/ol/parser/ogc/filter_v1_0_0.js
+++ b/src/ol/parser/ogc/filter_v1_0_0.js
@@ -1,0 +1,139 @@
+goog.provide('ol.parser.ogc.Filter_v1_0_0');
+
+goog.require('goog.object');
+goog.require('ol.filter.Comparison');
+goog.require('ol.filter.ComparisonType');
+goog.require('ol.filter.Function');
+goog.require('ol.geom.Geometry');
+goog.require('ol.parser.ogc.Filter_v1');
+goog.require('ol.parser.ogc.GML_v2');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.parser.ogc.Filter_v1}
+ */
+ol.parser.ogc.Filter_v1_0_0 = function() {
+  goog.base(this);
+  this.version = '1.0.0';
+  this.schemaLocation = 'http://www.opengis.net/ogc ' +
+      'http://schemas.opengis.net/filter/1.0.0/filter.xsd';
+  goog.object.extend(this.readers['http://www.opengis.net/ogc'], {
+    'PropertyIsEqualTo': function(node, obj) {
+      var container = {};
+      this.readChildNodes(node, container);
+      obj['filters'].push(new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.EQUAL_TO,
+        property: container['property'],
+        value: container['value']
+      }));
+    },
+    'PropertyIsNotEqualTo': function(node, obj) {
+      var container = {};
+      this.readChildNodes(node, container);
+      obj['filters'].push(new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.NOT_EQUAL_TO,
+        property: container['property'],
+        value: container['value']
+      }));
+    },
+    'PropertyIsLike': function(node, obj) {
+      var container = {};
+      this.readChildNodes(node, container);
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.LIKE,
+        property: container['property'],
+        value: container['value']
+      });
+      var wildCard = node.getAttribute('wildCard');
+      var singleChar = node.getAttribute('singleChar');
+      var esc = node.getAttribute('escape');
+      filter.value2regex(wildCard, singleChar, esc);
+      obj['filters'].push(filter);
+    }
+  });
+  goog.object.extend(this.writers['http://www.opengis.net/ogc'], {
+    'PropertyIsEqualTo': function(filter) {
+      var node = this.createElementNS('ogc:PropertyIsEqualTo');
+      var property = filter.getProperty();
+      if (goog.isDef(property)) {
+        this.writeNode('PropertyName', property, null, node);
+      }
+      this.writeOgcExpression(filter.getValue(), node);
+      return node;
+    },
+    'PropertyIsNotEqualTo': function(filter) {
+      var node = this.createElementNS('ogc:PropertyIsNotEqualTo');
+      var property = filter.getProperty();
+      if (goog.isDef(property)) {
+        this.writeNode('PropertyName', property, null, node);
+      }
+      this.writeOgcExpression(filter.getValue(), node);
+      return node;
+    },
+    'PropertyIsLike': function(filter) {
+      var node = this.createElementNS('ogc:PropertyIsLike');
+      node.setAttribute('wildCard', '*');
+      node.setAttribute('singleChar', '.');
+      node.setAttribute('escape', '!');
+      var property = filter.getProperty();
+      if (goog.isDef(property)) {
+        this.writeNode('PropertyName', property, null, node);
+      }
+      // convert regex string to ogc string
+      this.writeNode('Literal', filter.regex2value(), null, node);
+      return node;
+    },
+    'BBOX': function(filter) {
+      var node = this.createElementNS('ogc:BBOX');
+      // PropertyName is mandatory in 1.0.0, but e.g. GeoServer also
+      // accepts filters without it.
+      var property = filter.getProperty();
+      if (goog.isDef(property)) {
+        this.writeNode('PropertyName', property, null, node);
+      }
+      var box = this.writeNode('Box', filter.getValue(),
+          'http://www.opengis.net/gml', node);
+      var projection = filter.getProjection();
+      if (goog.isDef(projection)) {
+        box.setAttribute('srsName', projection);
+      }
+      return node;
+    }
+  });
+  this.setGmlParser(new ol.parser.ogc.GML_v2({featureNS: 'http://foo'}));
+};
+goog.inherits(ol.parser.ogc.Filter_v1_0_0,
+    ol.parser.ogc.Filter_v1);
+
+
+/**
+ * @param {ol.filter.Spatial} filter The filter to write out.
+ * @param {string} name The name of the spatial operator.
+ * @return {Element} The node created.
+ * @private
+ */
+ol.parser.ogc.Filter_v1_0_0.prototype.writeSpatial_ = function(filter, name) {
+  var node = this.createElementNS('ogc:' + name);
+  var property = filter.getProperty();
+  if (goog.isDef(property)) {
+    this.writeNode('PropertyName', property, null, node);
+  }
+  var value = filter.getValue();
+  if (value instanceof ol.filter.Function) {
+    this.writeNode('Function', value, null, node);
+  } else {
+    var child;
+    if (filter.getValue() instanceof ol.geom.Geometry) {
+      child = this.writeNode('_geometry', filter.getValue(),
+          this.gml_.featureNS).firstChild;
+    } else {
+      child = this.writeNode('Box', filter.getValue(),
+          'http://www.opengis.net/gml');
+    }
+    // TODO handle projection / srsName
+    node.appendChild(child);
+  }
+  return node;
+};

--- a/src/ol/parser/ogc/filter_v1_1_0.js
+++ b/src/ol/parser/ogc/filter_v1_1_0.js
@@ -1,0 +1,164 @@
+goog.provide('ol.parser.ogc.Filter_v1_1_0');
+
+goog.require('goog.object');
+goog.require('ol.filter.Comparison');
+goog.require('ol.filter.ComparisonType');
+goog.require('ol.filter.Function');
+goog.require('ol.geom.Geometry');
+goog.require('ol.parser.ogc.Filter_v1');
+goog.require('ol.parser.ogc.GML_v3');
+
+
+
+/**
+ * @constructor
+ * @extends {ol.parser.ogc.Filter_v1}
+ */
+ol.parser.ogc.Filter_v1_1_0 = function() {
+  goog.base(this);
+  this.version = '1.1.0';
+  this.schemaLocation = 'http://www.opengis.net/ogc ' +
+      'http://schemas.opengis.net/filter/1.1.0/filter.xsd';
+  goog.object.extend(this.readers['http://www.opengis.net/ogc'], {
+    'PropertyIsEqualTo': function(node, obj) {
+      var matchCase = node.getAttribute('matchCase');
+      var container = {};
+      this.readChildNodes(node, container);
+      obj['filters'].push(new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.EQUAL_TO,
+        matchCase: !(matchCase === 'false' || matchCase === '0'),
+        property: container['property'],
+        value: container['value']
+      }));
+    },
+    'PropertyIsNotEqualTo': function(node, obj) {
+      var matchCase = node.getAttribute('matchCase');
+      var container = {};
+      this.readChildNodes(node, container);
+      obj['filters'].push(new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.NOT_EQUAL_TO,
+        matchCase: !(matchCase === 'false' || matchCase === '0'),
+        property: container['property'],
+        value: container['value']
+      }));
+    },
+    'PropertyIsLike': function(node, obj) {
+      var container = {};
+      this.readChildNodes(node, container);
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.LIKE,
+        property: container['property'],
+        value: container['value']
+      });
+      var wildCard = node.getAttribute('wildCard');
+      var singleChar = node.getAttribute('singleChar');
+      var esc = node.getAttribute('escapeChar');
+      filter.value2regex(wildCard, singleChar, esc);
+      obj['filters'].push(filter);
+    }
+  });
+  goog.object.extend(this.writers['http://www.opengis.net/ogc'], {
+    'PropertyIsEqualTo': function(filter) {
+      var node = this.createElementNS('ogc:PropertyIsEqualTo');
+      var matchCase = filter.getMatchCase();
+      if (goog.isDef(matchCase)) {
+        node.setAttribute('matchCase', matchCase);
+      }
+      this.writeNode('PropertyName', filter.getProperty(), null, node);
+      this.writeOgcExpression(filter.getValue(), node);
+      return node;
+    },
+    'PropertyIsNotEqualTo': function(filter) {
+      var node = this.createElementNS('ogc:PropertyIsNotEqualTo');
+      var matchCase = filter.getMatchCase();
+      if (goog.isDef(matchCase)) {
+        node.setAttribute('matchCase', matchCase);
+      }
+      this.writeNode('PropertyName', filter.getProperty(), null, node);
+      this.writeOgcExpression(filter.getValue(), node);
+      return node;
+    },
+    'PropertyIsLike': function(filter) {
+      var node = this.createElementNS('ogc:PropertyIsLike');
+      var matchCase = filter.getMatchCase();
+      if (goog.isDef(matchCase)) {
+        node.setAttribute('matchCase', matchCase);
+      }
+      node.setAttribute('wildCard', '*');
+      node.setAttribute('singleChar', '.');
+      node.setAttribute('escapeChar', '!');
+      this.writeNode('PropertyName', filter.getProperty(), null, node);
+      // convert regex string to ogc string
+      this.writeNode('Literal', filter.regex2value(), null, node);
+      return node;
+    },
+    'BBOX': function(filter) {
+      var node = this.createElementNS('ogc:BBOX');
+      // PropertyName is optional in 1.1.0
+      if (goog.isDef(filter.getProperty())) {
+        this.writeNode('PropertyName', filter.getProperty(), null, node);
+      }
+      var box = this.writeNode('Envelope', filter.getValue(),
+          'http://www.opengis.net/gml');
+      var projection = filter.getProjection();
+      if (goog.isDef(projection)) {
+        box.setAttribute('srsName', projection);
+      }
+      node.appendChild(box);
+      return node;
+    },
+    'SortBy': function(sortProperties) {
+      var node = this.createElementNS('ogc:SortBy');
+      for (var i = 0, l = sortProperties.length; i < l; i++) {
+        this.writeNode('SortProperty', sortProperties[i], null, node);
+      }
+      return node;
+    },
+    'SortProperty': function(sortProperty) {
+      var node = this.createElementNS('ogc:SortProperty');
+      this.writeNode('PropertyName', sortProperty['property'], null, node);
+      this.writeNode('SortOrder',
+          (sortProperty['order'] == 'DESC') ? 'DESC' : 'ASC', null, node);
+      return node;
+    },
+    'SortOrder': function(value) {
+      var node = this.createElementNS('ogc:SortOrder');
+      node.appendChild(this.createTextNode(value));
+      return node;
+    }
+  });
+  this.setGmlParser(new ol.parser.ogc.GML_v3());
+};
+goog.inherits(ol.parser.ogc.Filter_v1_1_0,
+    ol.parser.ogc.Filter_v1);
+
+
+/**
+ * @param {ol.filter.Spatial} filter The filter to write out.
+ * @param {string} name The name of the spatial operator.
+ * @return {Element} The node created.
+ * @private
+ */
+ol.parser.ogc.Filter_v1_1_0.prototype.writeSpatial_ = function(filter, name) {
+  var node = this.createElementNS('ogc:' + name);
+  var property = filter.getProperty();
+  if (goog.isDef(property)) {
+    this.writeNode('PropertyName', property, null, node);
+  }
+  var value = filter.getValue();
+  if (value instanceof ol.filter.Function) {
+    this.writeNode('Function', value, null, node);
+  } else {
+    var child;
+    if (filter.getValue() instanceof ol.geom.Geometry) {
+      child = this.writeNode('_geometry', filter.getValue(),
+          this.gml_.featureNS).firstChild;
+    } else {
+      child = this.writeNode('Envelope', filter.getValue(),
+          'http://www.opengis.net/gml');
+    }
+    // TODO handle projection / srsName
+    node.appendChild(child);
+  }
+  return node;
+};

--- a/src/ol/parser/ogc/gml.js
+++ b/src/ol/parser/ogc/gml.js
@@ -40,7 +40,7 @@ ol.parser.ogc.GML = function(opt_options) {
   this.multiSurface = goog.isDef(options.multiSurface) ?
       options.multiSurface : true;
   this.srsName = goog.isDef(options.srsName) ?
-      options.srsName : null;
+      options.srsName : undefined;
   if (goog.isDef(options.schemaLocation)) {
     this.schemaLocation = options.schemaLocation;
   }
@@ -284,7 +284,7 @@ ol.parser.ogc.GML = function(opt_options) {
             sharedVertices = callback(feature, geom.type);
           }
         }
-        var geometry = this.createGeometry_({geometry: geom},
+        var geometry = this.createGeometry({geometry: geom},
             sharedVertices);
         if (goog.isDef(geometry)) {
           feature.setGeometry(geometry);
@@ -503,13 +503,12 @@ ol.parser.ogc.GML.prototype.readNode = function(node, obj, opt_first) {
 
 
 /**
- * @private
  * @param {Object} container Geometry container.
  * @param {ol.geom.SharedVertices=} opt_vertices Shared vertices.
  * @return {ol.geom.Geometry} The geometry created.
  */
 // TODO use a mixin since this is also used in the KML parser
-ol.parser.ogc.GML.prototype.createGeometry_ = function(container,
+ol.parser.ogc.GML.prototype.createGeometry = function(container,
     opt_vertices) {
   var geometry = null, coordinates, i, ii;
   switch (container.geometry.type) {
@@ -553,7 +552,7 @@ ol.parser.ogc.GML.prototype.createGeometry_ = function(container,
     case ol.geom.GeometryType.GEOMETRYCOLLECTION:
       var geometries = [];
       for (i = 0, ii = container.geometry.parts.length; i < ii; i++) {
-        geometries.push(this.createGeometry_({
+        geometries.push(this.createGeometry({
           geometry: container.geometry.parts[i]
         }, opt_vertices));
       }

--- a/src/ol/parser/ogc/gml_v2.js
+++ b/src/ol/parser/ogc/gml_v2.js
@@ -90,8 +90,8 @@ ol.parser.ogc.GML_v2 = function(opt_options) {
     },
     'Box': function(extent) {
       var node = this.createElementNS('gml:Box');
-      this.writeNode('coordinates', [[extent.minX, extent.minY],
-            [extent.maxX, extent.maxY]], null, node);
+      this.writeNode('coordinates', [[extent[0], extent[1]],
+            [extent[2], extent[3]]], null, node);
       // srsName attribute is optional for gml:Box
       if (goog.isDef(this.srsName)) {
         node.setAttribute('srsName', this.srsName);

--- a/src/ol/parser/ogc/gml_v3.js
+++ b/src/ol/parser/ogc/gml_v3.js
@@ -374,9 +374,9 @@ ol.parser.ogc.GML_v3 = function(opt_options) {
       // only 2d for simple features profile
       var pos;
       if (this.axisOrientation.substr(0, 2) === 'en') {
-        pos = (bounds.left + ' ' + bounds.bottom);
+        pos = (bounds[0] + ' ' + bounds[2]);
       } else {
-        pos = (bounds.bottom + ' ' + bounds.left);
+        pos = (bounds[2] + ' ' + bounds[0]);
       }
       var node = this.createElementNS('gml:lowerCorner');
       node.appendChild(this.createTextNode(pos));
@@ -386,9 +386,9 @@ ol.parser.ogc.GML_v3 = function(opt_options) {
       // only 2d for simple features profile
       var pos;
       if (this.axisOrientation.substr(0, 2) === 'en') {
-        pos = (bounds.right + ' ' + bounds.top);
+        pos = (bounds[1] + ' ' + bounds[3]);
       } else {
-        pos = (bounds.top + ' ' + bounds.right);
+        pos = (bounds[3] + ' ' + bounds[1]);
       }
       var node = this.createElementNS('gml:upperCorner');
       node.appendChild(this.createTextNode(pos));

--- a/src/ol/parser/xml.js
+++ b/src/ol/parser/xml.js
@@ -182,8 +182,9 @@ ol.parser.XML.prototype.createElementNS = function(name, opt_uri) {
  * results to a node.
  *
  * @param {string} name The name of a node to generate. Only use a local name.
- * @param {Object} obj Structure containing data for the writer.
- * @param {string=} opt_uri The name space uri to which the node belongs.
+ * @param {Object|string|number} obj Structure containing data for the writer.
+ * @param {?string=} opt_uri The name space uri to which the node
+ *     belongs.
  * @param {Element=} opt_parent Result will be appended to this node. If no
  * parent is supplied, the node will not be appended to anything.
  * @return {?Element} The child node.
@@ -272,4 +273,23 @@ ol.parser.XML.prototype.serialize = function(node) {
   } else {
     return goog.dom.xml.serialize(node);
   }
+};
+
+
+/**
+ * Create a document fragment node that can be appended to another node
+ *     created by createElementNS. This will call
+ *     document.createDocumentFragment outside of IE. In IE, the ActiveX
+ *     object's createDocumentFragment method is used.
+ *
+ * @return {Element} A document fragment.
+ */
+ol.parser.XML.prototype.createDocumentFragment = function() {
+  var element;
+  if (this.xmldom) {
+    element = this.xmldom.createDocumentFragment();
+  } else {
+    element = document.createDocumentFragment();
+  }
+  return element;
 };

--- a/test/spec/ol/filter/comparisonfilter.test.js
+++ b/test/spec/ol/filter/comparisonfilter.test.js
@@ -1,0 +1,169 @@
+goog.provide('ol.test.filter.Comparison');
+
+
+describe('ol.filter.Comparison', function() {
+
+  describe('#equal', function() {
+    it('equal to works as expected', function() {
+      var feature = new ol.Feature({'foo': 'bar'});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.EQUAL_TO,
+        property: 'foo',
+        value: 'bar'
+      });
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 'baz'});
+      expect(filter.applies(feature)).to.be(false);
+      filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.EQUAL_TO,
+        property: 'foo',
+        value: 15
+      });
+      feature = new ol.Feature({'foo': 15});
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 25});
+      expect(filter.applies(feature)).to.be(false);
+    });
+  });
+
+  describe('#notequal', function() {
+    it('not equal to works as expected', function() {
+      var feature = new ol.Feature({'foo': 'bar'});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.NOT_EQUAL_TO,
+        property: 'foo',
+        value: 'bar'
+      });
+      expect(filter.applies(feature)).to.be(false);
+      feature = new ol.Feature({'foo': 'baz'});
+      expect(filter.applies(feature)).to.be(true);
+      filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.NOT_EQUAL_TO,
+        property: 'foo',
+        value: 15
+      });
+      feature = new ol.Feature({'foo': 15});
+      expect(filter.applies(feature)).to.be(false);
+      feature = new ol.Feature({'foo': 25});
+      expect(filter.applies(feature)).to.be(true);
+    });
+  });
+
+  describe('#greater than', function() {
+    it('greater than works as expected', function() {
+      var feature = new ol.Feature({'foo': 15});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.GREATER_THAN,
+        property: 'foo',
+        value: 10
+      });
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 5});
+      expect(filter.applies(feature)).to.be(false);
+      feature = new ol.Feature({'foo': 10});
+      expect(filter.applies(feature)).to.be(false);
+    });
+  });
+
+  describe('#greater than or equal to', function() {
+    it('greater than or equal to works as expected', function() {
+      var feature = new ol.Feature({'foo': 10});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.GREATER_THAN_OR_EQUAL_TO,
+        property: 'foo',
+        value: 10
+      });
+      expect(filter.applies(feature)).to.be(true);
+    });
+  });
+
+  describe('#less than', function() {
+    it('less than works as expected', function() {
+      var feature = new ol.Feature({'foo': 15});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.LESS_THAN,
+        property: 'foo',
+        value: 10
+      });
+      expect(filter.applies(feature)).to.be(false);
+      feature = new ol.Feature({'foo': 5});
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 10});
+      expect(filter.applies(feature)).to.be(false);
+    });
+  });
+
+  describe('#less than or equal to', function() {
+    it('less than or equal to works as expected', function() {
+      var feature = new ol.Feature({'foo': 10});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.LESS_THAN_OR_EQUAL_TO,
+        property: 'foo',
+        value: 10
+      });
+      expect(filter.applies(feature)).to.be(true);
+    });
+  });
+
+  describe('#between', function() {
+    it('between filtering works as expected', function() {
+      var feature = new ol.Feature({'foo': 10});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.BETWEEN,
+        property: 'foo',
+        lowerBoundary: 5,
+        upperBoundary: 15
+      });
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 5});
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 15});
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': 20});
+      expect(filter.applies(feature)).to.be(false);
+      feature = new ol.Feature({'foo': 4});
+      expect(filter.applies(feature)).to.be(false);
+    });
+  });
+
+  describe('#value2regex', function() {
+    it('value2regex works as expected', function() {
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.LIKE,
+        property: 'foo',
+        value: '*b?r\\*\\?*'
+      });
+      filter.value2regex('*', '?', '\\');
+      expect(filter.value_).to.eql('.*b.r\\*\\?.*');
+      filter.value_ = '%b.r!%!.%';
+      filter.value2regex('%', '.', '!');
+      expect(filter.value_).to.eql('.*b.r\\%\\..*');
+      filter.value_ = '!!';
+      filter.value2regex();
+      expect(filter.value_).to.eql('\\!');
+      filter.value_ = '!!c!!!d!e';
+      filter.value2regex();
+      expect(filter.value_).to.eql('\\!c\\!\\d\\e');
+    });
+  });
+
+  describe('#isnull', function() {
+    it('is null filtering works as expected', function() {
+      var feature = new ol.Feature({'foo': null});
+      var filter = new ol.filter.Comparison({
+        type: ol.filter.ComparisonType.IS_NULL,
+        property: 'foo'
+      });
+      expect(filter.applies(feature)).to.be(true);
+      feature = new ol.Feature({'foo': undefined});
+      expect(filter.applies(feature)).to.be(false);
+      feature = new ol.Feature({'foo': 'bar'});
+      expect(filter.applies(feature)).to.be(false);
+    });
+  });
+
+});
+
+goog.require('ol.Feature');
+goog.require('ol.filter.Comparison');
+goog.require('ol.filter.ComparisonType');

--- a/test/spec/ol/parser/ogc/filter_v1_0_0.js
+++ b/test/spec/ol/parser/ogc/filter_v1_0_0.js
@@ -1,0 +1,219 @@
+goog.provide('ol.test.parser.ogc.Filter_v1_0_0');
+
+describe('ol.parser.ogc.Filter_v1_0_0', function() {
+
+  var parser = new ol.parser.ogc.Filter_v1_0_0();
+
+  describe('#readwrite', function() {
+
+    it('intersects filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/intersects.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Spatial).to.be(true);
+        expect(filter.getType()).to.eql(ol.filter.SpatialType.INTERSECTS);
+        var geom = filter.getValue();
+        expect(geom instanceof ol.geom.Polygon).to.be(true);
+        expect(filter.getProperty()).to.eql('Geometry');
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('within filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/within.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Spatial).to.be(true);
+        expect(filter.getType()).to.eql(ol.filter.SpatialType.WITHIN);
+        var geom = filter.getValue();
+        expect(geom instanceof ol.geom.Polygon).to.be(true);
+        expect(filter.getProperty()).to.eql('Geometry');
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('contains filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/contains.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Spatial).to.be(true);
+        expect(filter.getType()).to.eql(ol.filter.SpatialType.CONTAINS);
+        var geom = filter.getValue();
+        expect(geom instanceof ol.geom.Polygon).to.be(true);
+        expect(filter.getProperty()).to.eql('Geometry');
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('between filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/between.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Comparison).to.be.ok();
+        expect(filter.getType()).to.eql(ol.filter.ComparisonType.BETWEEN);
+        expect(filter.getProperty()).to.eql('number');
+        expect(filter.getLowerBoundary()).to.eql(0);
+        expect(filter.getUpperBoundary()).to.eql(100);
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('between filter read correctly without literals', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/between2.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Comparison).to.be.ok();
+        expect(filter.getType()).to.eql(ol.filter.ComparisonType.BETWEEN);
+        expect(filter.getProperty()).to.eql('number');
+        expect(filter.getLowerBoundary()).to.eql(0);
+        expect(filter.getUpperBoundary()).to.eql(100);
+      });
+    });
+
+    it('null filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/null.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Comparison).to.be.ok();
+        expect(filter.getType()).to.eql(ol.filter.ComparisonType.IS_NULL);
+        expect(filter.getProperty()).to.eql('prop');
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('BBOX written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/bbox.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Spatial({
+          type: ol.filter.SpatialType.BBOX,
+          property: 'the_geom',
+          value: [-180, -90, 180, 90],
+          projection: 'EPSG:4326'
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('BBOX without geometry name written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/bbox_nogeom.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Spatial({
+          type: ol.filter.SpatialType.BBOX,
+          value: [-180, -90, 180, 90],
+          projection: 'EPSG:4326'
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('DWithin written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/dwithin.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Spatial({
+          type: ol.filter.SpatialType.DWITHIN,
+          property: 'Geometry',
+          value: new ol.geom.Point([2488789, 289552]),
+          distance: 1000,
+          distanceUnits: 'm'
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+        filter = parser.read(xml);
+        output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+  });
+
+  // the Filter Encoding spec doesn't allow for FID filters inside logical
+  // filters however, to be liberal, we will write them without complaining
+  describe('#logicalfid', function() {
+
+    it('logical filter [OR] with fid filter written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureid.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Logical([
+          new ol.filter.Comparison({
+            type: ol.filter.ComparisonType.LIKE,
+            property: 'person',
+            value: 'me'
+          }),
+          new ol.filter.FeatureId({'foo.1': true, 'foo.2': true})
+        ], ol.filter.LogicalOperator.OR);
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('logical filter [AND] with fid filter written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureidand.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Logical([
+          new ol.filter.Comparison({
+            type: ol.filter.ComparisonType.LIKE,
+            property: 'person',
+            value: 'me'
+          }),
+          new ol.filter.FeatureId({'foo.1': true, 'foo.2': true})
+        ], ol.filter.LogicalOperator.AND);
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('logical filter [NOT] with fid filter written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureidnot.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Logical([
+          new ol.filter.FeatureId({'foo.2': true})
+        ], ol.filter.LogicalOperator.NOT);
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+  });
+
+  describe('#date', function() {
+
+    it('date writing works as expected', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_0_0/betweendates.xml';
+      afterLoadXml(url, function(xml) {
+        // ISO 8601: 2010-11-27T18:19:15.123Z
+        var start = new Date(Date.UTC(2010, 10, 27, 18, 19, 15, 123));
+        // ISO 8601: 2011-12-27T18:19:15.123Z
+        var end = new Date(Date.UTC(2011, 11, 27, 18, 19, 15, 123));
+        var filter = new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.BETWEEN,
+          property: 'when',
+          lowerBoundary: start,
+          upperBoundary: end
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+  });
+
+});
+
+goog.require('goog.dom.xml');
+goog.require('ol.filter.Comparison');
+goog.require('ol.filter.ComparisonType');
+goog.require('ol.filter.FeatureId');
+goog.require('ol.filter.Logical');
+goog.require('ol.filter.LogicalOperator');
+goog.require('ol.filter.Spatial');
+goog.require('ol.filter.SpatialType');
+goog.require('ol.geom.Point');
+goog.require('ol.geom.Polygon');
+goog.require('ol.parser.ogc.Filter_v1_0_0');

--- a/test/spec/ol/parser/ogc/filter_v1_1_0.js
+++ b/test/spec/ol/parser/ogc/filter_v1_1_0.js
@@ -1,0 +1,224 @@
+goog.provide('ol.test.parser.ogc.Filter_v1_1_0');
+
+describe('ol.parser.ogc.Filter_v1_1_0', function() {
+
+  var parser = new ol.parser.ogc.Filter_v1_1_0();
+
+  describe('#readwrite', function() {
+
+    it('filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/test.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        expect(filter instanceof ol.filter.Logical).to.be(true);
+        expect(filter.operator).to.eql(ol.filter.LogicalOperator.OR);
+        expect(filter.getFilters().length).to.eql(5);
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('matchCase read correctly', function() {
+      var cases = [{
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsEqualTo>' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsEqualTo>' +
+            '</ogc:Filter>',
+        exp: true
+      }, {
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsEqualTo matchCase="1">' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsEqualTo>' +
+            '</ogc:Filter>',
+        exp: true
+      }, {
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsEqualTo matchCase="true">' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsEqualTo>' +
+            '</ogc:Filter>',
+        exp: true
+      }, {
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsEqualTo matchCase="0">' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsEqualTo>' +
+            '</ogc:Filter>',
+        exp: false
+      }, {
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsEqualTo matchCase="0">' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsEqualTo>' +
+            '</ogc:Filter>',
+        exp: false
+      }, {
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsNotEqualTo matchCase="true">' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsNotEqualTo>' +
+            '</ogc:Filter>',
+        exp: true
+      }, {
+        str:
+            '<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+                '<ogc:PropertyIsNotEqualTo matchCase="false">' +
+                    '<ogc:PropertyName>cat</ogc:PropertyName>' +
+                    '<ogc:Literal>dog</ogc:Literal>' +
+                '</ogc:PropertyIsNotEqualTo>' +
+            '</ogc:Filter>',
+        exp: false
+      }];
+      var filter, c;
+      for (var i = 0; i < cases.length; ++i) {
+        c = cases[i];
+        filter = parser.read(c.str);
+        expect(filter.getMatchCase()).to.eql(c.exp);
+      }
+    });
+
+    it('BBOX filter written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/bbox.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        var output = parser.write(filter);
+        // TODO srsName in gml:Envelope
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('BBOX filter without property name written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/bbox_nogeomname.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        var output = parser.write(filter);
+        // TODO srsName in gml:Envelope
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('Intersects filter read / written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/intersects.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = parser.read(xml);
+        var output = parser.write(filter);
+        // TODO srsName in gml:Envelope
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('Filter functions written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/function.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Spatial({
+          property: 'the_geom',
+          type: ol.filter.SpatialType.INTERSECTS,
+          value: new ol.filter.Function({
+            name: 'querySingle',
+            params: ['sf:restricted', 'the_geom', 'cat=3']
+          })
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('Custom filter functions written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/customfunction.xml';
+      afterLoadXml(url, function(xml) {
+        var filters = [
+          new ol.filter.Comparison({type: ol.filter.ComparisonType.NOT_EQUAL_TO,
+            matchCase: false,
+            property: 'FOO',
+            value: new ol.filter.Function({
+              name: 'customFunction',
+              params: ['param1', 'param2']
+            })
+          })
+        ];
+        var filter = new ol.filter.Logical(filters,
+            ol.filter.LogicalOperator.AND);
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('Nested filter functions written correctly', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/nestedfunction.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Spatial({
+          property: 'the_geom',
+          type: ol.filter.SpatialType.DWITHIN,
+          value: new ol.filter.Function({
+            name: 'collectGeometries',
+            params: [
+              new ol.filter.Function({
+                name: 'queryCollection',
+                params: ['sf:roads', 'the_geom', 'INCLUDE']
+              })
+            ]
+          }),
+          distanceUnits: 'meters',
+          distance: 200
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('matchCase written correctly on Like filter', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/likematchcase.xml';
+      afterLoadXml(url, function(xml) {
+        var filter = new ol.filter.Comparison({
+          type: ol.filter.ComparisonType.LIKE,
+          property: 'person',
+          value: '*me*',
+          matchCase: false
+        });
+        var output = parser.write(filter);
+        expect(goog.dom.xml.loadXml(output)).to.xmleql(xml);
+      });
+    });
+
+    it('sortBy written correctly on Like filter', function() {
+      var url = 'spec/ol/parser/ogc/xml/filter_v1_1_0/sortby.xml';
+      afterLoadXml(url, function(xml) {
+        var writer = parser.writers['http://www.opengis.net/ogc']['SortBy'];
+        var output = writer.call(parser, [{
+          'property': 'Title',
+          'order': 'ASC'
+        },{
+          'property': 'Relevance',
+          'order': 'DESC'
+        }]);
+        expect(output).to.xmleql(xml);
+      });
+    });
+
+  });
+
+});
+
+goog.require('goog.dom.xml');
+goog.require('ol.filter.Comparison');
+goog.require('ol.filter.ComparisonType');
+goog.require('ol.filter.Function');
+goog.require('ol.filter.Logical');
+goog.require('ol.filter.LogicalOperator');
+goog.require('ol.filter.Spatial');
+goog.require('ol.filter.SpatialType');
+goog.require('ol.parser.ogc.Filter_v1_1_0');

--- a/test/spec/ol/parser/ogc/gml_v2.test.js
+++ b/test/spec/ol/parser/ogc/gml_v2.test.js
@@ -18,7 +18,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -44,7 +44,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -71,7 +71,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -97,7 +97,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -129,7 +129,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -159,7 +159,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -176,7 +176,7 @@ describe('ol.parser.gml_v2', function() {
         var p = new ol.parser.ogc.GML_v2({srsName: 'foo',
           featureNS: 'http://foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);
@@ -215,7 +215,7 @@ describe('ol.parser.gml_v2', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);

--- a/test/spec/ol/parser/ogc/gml_v3.test.js
+++ b/test/spec/ol/parser/ogc/gml_v3.test.js
@@ -16,7 +16,7 @@ describe('ol.parser.gml_v3', function() {
       var url = 'spec/ol/parser/ogc/xml/gml_v3/linearring.xml';
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         parser.srsName = 'foo';
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
@@ -31,7 +31,7 @@ describe('ol.parser.gml_v3', function() {
       var url = 'spec/ol/parser/ogc/xml/gml_v3/linestring.xml';
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         parser.srsName = 'foo';
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
@@ -55,7 +55,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var p = new ol.parser.ogc.GML_v3({curve: true, srsName: 'foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);
@@ -78,7 +78,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var p = new ol.parser.ogc.GML_v3({multiCurve: false, srsName: 'foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);
@@ -92,7 +92,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -108,7 +108,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var p = new ol.parser.ogc.GML_v3({curve: true, srsName: 'foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);
@@ -133,7 +133,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -158,7 +158,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var p = new ol.parser.ogc.GML_v3({multiSurface: false, srsName: 'foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);
@@ -181,7 +181,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
         parser.srsName = 'foo';
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(parser.serialize(node))).to.xmleql(xml);
@@ -196,7 +196,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var p = new ol.parser.ogc.GML_v3({surface: true, srsName: 'foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);
@@ -209,7 +209,7 @@ describe('ol.parser.gml_v3', function() {
       var url = 'spec/ol/parser/ogc/xml/gml_v3/point.xml';
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         parser.srsName = 'foo';
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
@@ -223,7 +223,7 @@ describe('ol.parser.gml_v3', function() {
       var url = 'spec/ol/parser/ogc/xml/gml_v3/polygon.xml';
       afterLoadXml(url, function(xml) {
         var obj = parser.read(xml);
-        var geom = parser.createGeometry_({geometry: obj.geometry});
+        var geom = parser.createGeometry({geometry: obj.geometry});
         parser.srsName = 'foo';
         var node = parser.featureNSWiters_['_geometry'].apply(parser,
             [geom]).firstChild;
@@ -245,7 +245,7 @@ describe('ol.parser.gml_v3', function() {
       afterLoadXml(url, function(xml) {
         var p = new ol.parser.ogc.GML_v3({surface: true, srsName: 'foo'});
         var obj = p.read(xml);
-        var geom = p.createGeometry_({geometry: obj.geometry});
+        var geom = p.createGeometry({geometry: obj.geometry});
         var node = p.featureNSWiters_['_geometry'].apply(p,
             [geom]).firstChild;
         expect(goog.dom.xml.loadXml(p.serialize(node))).to.xmleql(xml);

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0.xml
@@ -1,0 +1,23 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+  <ogc:Or>
+    <ogc:PropertyIsBetween>
+      <ogc:PropertyName>number</ogc:PropertyName>
+      <ogc:LowerBoundary>
+        <ogc:Literal>1064866676</ogc:Literal>
+      </ogc:LowerBoundary>
+      <ogc:UpperBoundary>
+        <ogc:Literal>1065512599</ogc:Literal>
+      </ogc:UpperBoundary>
+    </ogc:PropertyIsBetween>
+    <ogc:PropertyIsLike wildCard="*" singleChar="." escape="!">
+      <ogc:PropertyName>cat</ogc:PropertyName>
+      <ogc:Literal>*dog.food!*good</ogc:Literal>
+    </ogc:PropertyIsLike>
+    <ogc:Not>
+      <ogc:PropertyIsLessThanOrEqualTo>
+        <ogc:PropertyName>FOO</ogc:PropertyName>
+        <ogc:Literal>5000</ogc:Literal>
+      </ogc:PropertyIsLessThanOrEqualTo>
+    </ogc:Not>
+  </ogc:Or>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/bbox.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/bbox.xml
@@ -1,0 +1,8 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+  <ogc:BBOX>
+    <ogc:PropertyName>the_geom</ogc:PropertyName>
+    <gml:Box xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:4326">
+      <gml:coordinates decimal="." cs="," ts=" ">-180,-90 180,90</gml:coordinates>
+    </gml:Box>
+  </ogc:BBOX>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/bbox_nogeom.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/bbox_nogeom.xml
@@ -1,0 +1,7 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+  <ogc:BBOX>
+    <gml:Box xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:4326">
+      <gml:coordinates decimal="." cs="," ts=" ">-180,-90 180,90</gml:coordinates>
+    </gml:Box>
+  </ogc:BBOX>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/between.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/between.xml
@@ -1,0 +1,11 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+  <ogc:PropertyIsBetween>
+    <ogc:PropertyName>number</ogc:PropertyName>
+    <ogc:LowerBoundary>
+      <ogc:Literal>0</ogc:Literal>
+    </ogc:LowerBoundary>
+    <ogc:UpperBoundary>
+      <ogc:Literal>100</ogc:Literal>
+    </ogc:UpperBoundary>
+  </ogc:PropertyIsBetween>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/between2.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/between2.xml
@@ -1,0 +1,7 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+  <ogc:PropertyIsBetween>
+    <ogc:PropertyName>number</ogc:PropertyName>
+    <ogc:LowerBoundary>0</ogc:LowerBoundary>
+    <ogc:UpperBoundary>100</ogc:UpperBoundary>
+  </ogc:PropertyIsBetween>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/betweendates.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/betweendates.xml
@@ -1,0 +1,11 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+    <ogc:PropertyIsBetween>
+        <ogc:PropertyName>when</ogc:PropertyName>
+        <ogc:LowerBoundary>
+            <ogc:Literal>2010-11-27T18:19:15.123Z</ogc:Literal>
+        </ogc:LowerBoundary>
+        <ogc:UpperBoundary>
+            <ogc:Literal>2011-12-27T18:19:15.123Z</ogc:Literal>
+        </ogc:UpperBoundary>
+    </ogc:PropertyIsBetween>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/contains.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/contains.xml
@@ -1,0 +1,12 @@
+<Filter xmlns="http://www.opengis.net/ogc" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Contains>
+    <PropertyName>Geometry</PropertyName>
+    <gml:Polygon xmlns:gml="http://www.opengis.net/gml">
+      <gml:outerBoundaryIs>
+        <gml:LinearRing>
+          <gml:coordinates decimal="." cs="," ts=" ">2488789,289552 2588789,289552 2588789,389552 2488789,389552 2488789,289552</gml:coordinates>
+        </gml:LinearRing>
+      </gml:outerBoundaryIs>
+    </gml:Polygon>
+  </Contains>
+</Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/custombetweendates.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/custombetweendates.xml
@@ -1,0 +1,11 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+    <ogc:PropertyIsBetween>
+        <ogc:PropertyName>when</ogc:PropertyName>
+        <ogc:LowerBoundary>
+            <ogc:Literal>2010-11-27</ogc:Literal>
+        </ogc:LowerBoundary>
+        <ogc:UpperBoundary>
+            <ogc:Literal>2011-12-27</ogc:Literal>
+        </ogc:UpperBoundary>
+    </ogc:PropertyIsBetween>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/dwithin.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/dwithin.xml
@@ -1,0 +1,9 @@
+<Filter xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+  <DWithin>
+    <PropertyName>Geometry</PropertyName>
+    <gml:Point xmlns:gml="http://www.opengis.net/gml">
+      <gml:coordinates decimal="." cs="," ts=" ">2488789,289552</gml:coordinates>
+    </gml:Point>
+    <Distance units="m">1000</Distance>
+  </DWithin>
+</Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/intersects.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/intersects.xml
@@ -1,0 +1,12 @@
+<Filter xmlns="http://www.opengis.net/ogc" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Intersects>
+    <PropertyName>Geometry</PropertyName>
+    <gml:Polygon xmlns:gml="http://www.opengis.net/gml">
+      <gml:outerBoundaryIs>
+        <gml:LinearRing>
+          <gml:coordinates decimal="." cs="," ts=" ">2488789,289552 2588789,289552 2588789,389552 2488789,389552 2488789,289552</gml:coordinates>
+        </gml:LinearRing>
+      </gml:outerBoundaryIs>
+    </gml:Polygon>
+  </Intersects>
+</Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureid.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureid.xml
@@ -1,0 +1,10 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+    <ogc:Or>
+        <ogc:PropertyIsLike wildCard="*" singleChar="." escape="!">
+            <ogc:PropertyName>person</ogc:PropertyName>
+            <ogc:Literal>me</ogc:Literal>
+        </ogc:PropertyIsLike>
+        <ogc:FeatureId fid="foo.1"/>
+        <ogc:FeatureId fid="foo.2"/>
+    </ogc:Or>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureidand.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureidand.xml
@@ -1,0 +1,10 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+    <ogc:And>
+        <ogc:PropertyIsLike wildCard="*" singleChar="." escape="!">
+            <ogc:PropertyName>person</ogc:PropertyName>
+            <ogc:Literal>me</ogc:Literal>
+        </ogc:PropertyIsLike>
+        <ogc:FeatureId fid="foo.1"/>
+        <ogc:FeatureId fid="foo.2"/>
+    </ogc:And>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureidnot.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/logicalfeatureidnot.xml
@@ -1,0 +1,5 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+    <ogc:Not>
+        <ogc:FeatureId fid="foo.2"/>
+    </ogc:Not>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/null.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/null.xml
@@ -1,0 +1,5 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd">
+  <ogc:PropertyIsNull>
+    <ogc:PropertyName>prop</ogc:PropertyName>
+  </ogc:PropertyIsNull>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_0_0/within.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_0_0/within.xml
@@ -1,0 +1,12 @@
+<Filter xmlns="http://www.opengis.net/ogc" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.0.0/filter.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Within>
+    <PropertyName>Geometry</PropertyName>
+    <gml:Polygon xmlns:gml="http://www.opengis.net/gml">
+      <gml:outerBoundaryIs>
+        <gml:LinearRing>
+          <gml:coordinates decimal="." cs="," ts=" ">2488789,289552 2588789,289552 2588789,389552 2488789,389552 2488789,289552</gml:coordinates>
+        </gml:LinearRing>
+      </gml:outerBoundaryIs>
+    </gml:Polygon>
+  </Within>
+</Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/bbox.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/bbox.xml
@@ -1,0 +1,9 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <ogc:BBOX>
+    <ogc:PropertyName>the_geom</ogc:PropertyName>
+    <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
+      <gml:lowerCorner>-180 -90</gml:lowerCorner>
+      <gml:upperCorner>180 90</gml:upperCorner>
+    </gml:Envelope>
+  </ogc:BBOX>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/bbox_nogeomname.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/bbox_nogeomname.xml
@@ -1,0 +1,8 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <ogc:BBOX>
+    <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
+      <gml:lowerCorner>-180 -90</gml:lowerCorner>
+      <gml:upperCorner>180 90</gml:upperCorner>
+    </gml:Envelope>
+  </ogc:BBOX>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/customfunction.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/customfunction.xml
@@ -1,0 +1,11 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <ogc:And>
+    <ogc:PropertyIsNotEqualTo matchCase="false">
+      <ogc:PropertyName>FOO</ogc:PropertyName>
+      <ogc:Function name="customFunction">
+        <ogc:Literal>param1</ogc:Literal>
+        <ogc:Literal>param2</ogc:Literal>
+      </ogc:Function>
+    </ogc:PropertyIsNotEqualTo>
+  </ogc:And>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/function.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/function.xml
@@ -1,0 +1,10 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <ogc:Intersects>
+    <ogc:PropertyName>the_geom</ogc:PropertyName>
+    <ogc:Function name="querySingle">
+      <ogc:Literal>sf:restricted</ogc:Literal>
+      <ogc:Literal>the_geom</ogc:Literal>
+      <ogc:Literal>cat=3</ogc:Literal>
+    </ogc:Function>
+  </ogc:Intersects>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/intersects.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/intersects.xml
@@ -1,0 +1,9 @@
+<Filter xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <Intersects>
+    <PropertyName>Geometry</PropertyName>
+    <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
+      <gml:lowerCorner>-180 -90</gml:lowerCorner>
+      <gml:upperCorner>180 90</gml:upperCorner>
+    </gml:Envelope>
+  </Intersects>
+</Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/likematchcase.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/likematchcase.xml
@@ -1,0 +1,6 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+    <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!" matchCase="false">
+        <ogc:PropertyName>person</ogc:PropertyName>
+        <ogc:Literal>*me*</ogc:Literal>
+    </ogc:PropertyIsLike>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/nestedfunction.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/nestedfunction.xml
@@ -1,0 +1,13 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <ogc:DWithin>
+    <ogc:PropertyName>the_geom</ogc:PropertyName>
+      <ogc:Function name="collectGeometries">
+        <ogc:Function name="queryCollection">
+          <ogc:Literal>sf:roads</ogc:Literal>
+          <ogc:Literal>the_geom</ogc:Literal>
+          <ogc:Literal>INCLUDE</ogc:Literal>
+        </ogc:Function>
+      </ogc:Function>
+    <ogc:Distance units="meters">200</ogc:Distance>
+  </ogc:DWithin>
+</ogc:Filter>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/sortby.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/sortby.xml
@@ -1,0 +1,10 @@
+<ogc:SortBy xmlns:ogc="http://www.opengis.net/ogc">
+  <ogc:SortProperty>
+    <ogc:PropertyName>Title</ogc:PropertyName>
+    <ogc:SortOrder>ASC</ogc:SortOrder>
+  </ogc:SortProperty>
+  <ogc:SortProperty>
+    <ogc:PropertyName>Relevance</ogc:PropertyName>
+    <ogc:SortOrder>DESC</ogc:SortOrder>
+  </ogc:SortProperty>
+</ogc:SortBy>

--- a/test/spec/ol/parser/ogc/xml/filter_v1_1_0/test.xml
+++ b/test/spec/ol/parser/ogc/xml/filter_v1_1_0/test.xml
@@ -1,0 +1,31 @@
+<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/filter/1.1.0/filter.xsd">
+  <ogc:Or>
+    <ogc:PropertyIsBetween>
+      <ogc:PropertyName>number</ogc:PropertyName>
+        <ogc:LowerBoundary>
+          <ogc:Literal>1064866676</ogc:Literal>
+        </ogc:LowerBoundary>
+      <ogc:UpperBoundary>
+        <ogc:Literal>1065512599</ogc:Literal>
+      </ogc:UpperBoundary>
+    </ogc:PropertyIsBetween>
+    <ogc:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">
+      <ogc:PropertyName>cat</ogc:PropertyName>
+      <ogc:Literal>*dog.food!*good</ogc:Literal>
+    </ogc:PropertyIsLike>
+    <ogc:Not>
+      <ogc:PropertyIsLessThanOrEqualTo>
+        <ogc:PropertyName>FOO</ogc:PropertyName>
+        <ogc:Literal>5000</ogc:Literal>
+      </ogc:PropertyIsLessThanOrEqualTo>
+    </ogc:Not>
+    <ogc:PropertyIsEqualTo matchCase="true">
+      <ogc:PropertyName>cat</ogc:PropertyName>
+      <ogc:Literal>dog</ogc:Literal>
+    </ogc:PropertyIsEqualTo>
+    <ogc:PropertyIsEqualTo matchCase="false">
+      <ogc:PropertyName>cat</ogc:PropertyName>
+      <ogc:Literal>dog</ogc:Literal>
+    </ogc:PropertyIsEqualTo>
+  </ogc:Or>
+</ogc:Filter>


### PR DESCRIPTION
Adds a parser for OGC Filter Encoding version 1.0.0 and 1.1.0. The parser
supports read and write.

This is not yet ready for review since it depends on the javascript filter language that @tschaub is working on, this will need to be integrated later, but I thought I'd put this out here already.
