### PR TITLE
More useful detail in log messages

### DIFF
--- a/build.py
+++ b/build.py
@@ -511,7 +511,7 @@ def build_check_requires_timestamp(t):
         missing_requires = uses - requires - provides
         if missing_requires:
             for missing_require in sorted(missing_requires):
-                t.info("%s:%d missing goog.requires('%s')" %
+                t.info("%s:%d missing goog.require('%s')" %
                        (filename, uses_linenos[missing_require], missing_require))
                 missing_count += 1
     if unused_count or missing_count:


### PR DESCRIPTION
This adds more detail to the output of the `build/check-requires-timestamp` task.

Before:

``` bash
$ ./build.py build/check-requires-timestamp
2013-06-11 16:51:28,992 build/check-requires-timestamp: src/ol/source/bingmapssource.js: missing goog.requires: goog.asserts, goog.net.Jsonp, ol.Attribution
2013-06-11 16:51:29,401 pake: build/check-requires-timestamp: 0 unused goog.requires, 3 missing goog.requires
```

After:

``` bash
$ ./build.py build/check-requires-timestamp
2013-06-11 16:50:34,046 build/check-requires-timestamp: src/ol/source/bingmapssource.js:92 missing goog.require('goog.asserts')
2013-06-11 16:50:34,046 build/check-requires-timestamp: src/ol/source/bingmapssource.js:40 missing goog.require('goog.net.Jsonp')
2013-06-11 16:50:34,046 build/check-requires-timestamp: src/ol/source/bingmapssource.js:130 missing goog.require('ol.Attribution')
2013-06-11 16:50:34,458 pake: build/check-requires-timestamp: 0 unused goog.requires, 3 missing goog.requires
```
