### PR TITLE
Simplifying ranges structure by adding compiler hints

### DIFF
--- a/test/spec/ol/geom2/linecollection.test.js
+++ b/test/spec/ol/geom2/linecollection.test.js
@@ -41,8 +41,8 @@ describe('ol.geom2.LineStringCollection', function() {
           [[[0, 1], [2, 3], [4, 5]], [[6, 7], [8, 9]]]);
       expect(lsc.buf.getArray()).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
       expect(lsc.getCount()).to.be(2);
-      expect(lsc.ranges[0]).to.eql([0, 6]);
-      expect(lsc.ranges[6]).to.eql([6, 10]);
+      expect(lsc.ranges[0]).to.be(6);
+      expect(lsc.ranges[6]).to.be(10);
       expect(lsc.dim).to.be(2);
     });
 
@@ -51,8 +51,8 @@ describe('ol.geom2.LineStringCollection', function() {
           [[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]]);
       expect(lsc.buf.getArray()).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
       expect(lsc.getCount()).to.be(2);
-      expect(lsc.ranges[0]).to.eql([0, 6]);
-      expect(lsc.ranges[6]).to.eql([6, 12]);
+      expect(lsc.ranges[0]).to.be(6);
+      expect(lsc.ranges[6]).to.be(12);
       expect(lsc.dim).to.be(3);
     });
 
@@ -63,8 +63,8 @@ describe('ol.geom2.LineStringCollection', function() {
           [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
       expect(lsc.buf.getArray()).to.have.length(32);
       expect(lsc.getCount()).to.be(2);
-      expect(lsc.ranges[0]).to.eql([0, 6]);
-      expect(lsc.ranges[6]).to.eql([6, 10]);
+      expect(lsc.ranges[0]).to.be(6);
+      expect(lsc.ranges[6]).to.be(10);
       expect(lsc.dim).to.be(2);
     });
 
@@ -106,7 +106,7 @@ describe('ol.geom2.LineStringCollection', function() {
         var offset = lsc.add([[0, 1], [2, 3]]);
         expect(offset).to.be(0);
         expect(lsc.getCount()).to.be(1);
-        expect(lsc.ranges[0]).to.eql([0, 4]);
+        expect(lsc.ranges[0]).to.be(4);
         expect(lsc.dim).to.be(2);
       });
 
@@ -163,8 +163,8 @@ describe('ol.geom2.LineStringCollection', function() {
         var offset2 = lsc.add([[4, 5], [6, 7]]);
         expect(offset2).to.be(4);
         expect(lsc.getCount()).to.be(2);
-        expect(lsc.ranges[0]).to.eql([0, 4]);
-        expect(lsc.ranges[4]).to.eql([4, 8]);
+        expect(lsc.ranges[0]).to.be(4);
+        expect(lsc.ranges[4]).to.be(8);
         expect(lsc.dim).to.be(2);
       });
 


### PR DESCRIPTION
In JavaScript, keys of object literals are always strings, and
internal type conversions are performed. Now if we tell the
compiler that keys are numbers, we get inconsistent types when
iterating through keys. So instead we set the key type to string
and do a type cast to make the compiler happy. Note that we
could also do toString() instead of a type cast, but it would
add a performance penalty (see
http://jsperf.com/internal-type-conversion-vs-tostring-for-object-keys).
