### PR TITLE
Click handler called with empty event object on Android

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -373,7 +373,9 @@ ol.MapBrowserEventHandler.prototype.handleTouchEnd_ = function(browserEvent) {
     } else {
       this.timestamp_ = 0;
     }
-    this.click_(this.down_);
+    if (!goog.isNull(this.down_)) {
+      this.click_(this.down_);
+    }
   }
   this.down_ = null;
 };


### PR DESCRIPTION
On Android (both native browser and Chrome), the handleTouchEnd_
method is sometimes reached in a state where this.down_ is null.
This check protects against this.click_ being called without
an event object. To see this issue, open any example in Android,
and tap the zoom + or - button.
