### PR TITLE
Use ol.Projection#getMetersPerUnit()

### DIFF
--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -413,7 +413,7 @@ ol.tilegrid.createForProjection =
   var projectionExtent = projection.getExtent();
   var size = goog.isNull(projectionExtent) ?
       360 * ol.METERS_PER_UNIT[ol.ProjectionUnits.DEGREES] /
-          ol.METERS_PER_UNIT[projection.getUnits()] :
+          projection.getMetersPerUnit() :
       Math.max(projectionExtent[1] - projectionExtent[0],
           projectionExtent[3] - projectionExtent[2]);
   var maxZoom = goog.isDef(opt_maxZoom) ?
@@ -421,9 +421,9 @@ ol.tilegrid.createForProjection =
   var tileSize = goog.isDef(opt_tileSize) ?
       opt_tileSize : [ol.DEFAULT_TILE_SIZE, ol.DEFAULT_TILE_SIZE];
   var resolutions = new Array(maxZoom + 1);
-  size = size / Math.max(tileSize[0], tileSize[1]);
+  var maxResolution = size / Math.max(tileSize[0], tileSize[1]);
   for (var z = 0, zz = resolutions.length; z < zz; ++z) {
-    resolutions[z] = size / Math.pow(2, z);
+    resolutions[z] = maxResolution / Math.pow(2, z);
   }
   return new ol.tilegrid.TileGrid({
     origin: goog.isNull(projectionExtent) ? [0, 0] :

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -190,6 +190,16 @@ describe('ol.tilegrid.TileGrid', function() {
       expect(resolutions.length).to.be(24);
     });
 
+    it('works for projections unknown to the client', function() {
+      var projection = new ol.Projection(
+          {code: 'EPSG:31287', units: 'm'});
+      var grid = ol.tilegrid.createForProjection(projection);
+      var resolutions = grid.getResolutions();
+      expect(resolutions[5]).to.be(
+          360 * ol.METERS_PER_UNIT[ol.ProjectionUnits.DEGREES] /
+          ol.DEFAULT_TILE_SIZE / Math.pow(2, 5));
+    });
+
   });
 
   describe('getForProjection', function() {
@@ -633,6 +643,8 @@ describe('ol.tilegrid.TileGrid', function() {
 });
 
 goog.require('ol.Coordinate');
+goog.require('ol.Projection');
+goog.require('ol.ProjectionUnits');
 goog.require('ol.TileCoord');
 goog.require('ol.proj');
 goog.require('ol.tilegrid.TileGrid');


### PR DESCRIPTION
As a follow-up to #815, this change makes
ol.tilegrid.createForProjection work in cases where a Proj4
projection does not have units set. For better code readability,
a new variable is used when calculating the resolution.
