### PR TITLE
Drag rotate and zoom example is broken

### DIFF
--- a/src/ol/interaction/draginteraction.js
+++ b/src/ol/interaction/draginteraction.js
@@ -128,6 +128,7 @@ ol.interaction.Drag.prototype.handleMapBrowserEvent =
     if (handled) {
       this.dragging_ = true;
       mapBrowserEvent.preventDefault();
+      mapBrowserEvent.stopOtherInteractions();
     }
   }
 };


### PR DESCRIPTION
According to `git bisect`, bed44dd82cea6b5355c0363b66799196574e0018 broke the interaction stack, at least in the drag-rotate-and-zoom example. Both the drag-rotate-and-zoom and drag-zoom interactions capture and respond to map events, leading to weird behaviour.
