### PR TITLE
Tile has a child if z < maxZoom

### DIFF
--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -193,7 +193,7 @@ ol.tilegrid.TileGrid.prototype.getResolutions = function() {
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordChildTileRange =
     function(tileCoord, opt_tileRange, opt_extent) {
-  if (tileCoord.z < this.resolutions_.length) {
+  if (tileCoord.z < this.maxZoom) {
     var tileCoordExtent = this.getTileCoordExtent(tileCoord, opt_extent);
     return this.getTileRangeForExtentAndZ(
         tileCoordExtent, tileCoord.z + 1, opt_tileRange);


### PR DESCRIPTION
This fixes a bug where the tile grid attemps to get the child tile range of a tile whereas the tile has no child. Note that ol.tilegrid.XYZ#getTileCoordChildTileRange has this right. The bug is in ol.tilegrid.TileGrid only.

Please review.

```
AssertionError: Assertion failed
    at new goog.asserts.AssertionError (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:2151:20)
    at Object.goog.asserts.doAssertFailure_ (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:2168:9)
    at Object.goog.asserts.assert (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:2172:18)
    at ol.tilegrid.TileGrid.getResolution (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:14926:16)
    at ol.tilegrid.TileGrid.getTileRangeForExtentAndZ (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:14959:25)
    at ol.tilegrid.TileGrid.getTileCoordChildTileRange (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:14935:17)
    at ol.renderer.canvas.TileLayer.renderFrame (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:16395:35)
    at ol.renderer.canvas.Map.renderFrame (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:17879:19)
    at ol.Map.renderFrame_ (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:20741:18)
    at goog.async.AnimationDelay.doAction_ (http://mf-geoadmin30t.bgdi.admin.ch/elemoine/app/lib/ol-whitespace.js:9718:18) 
```
