### PR TITLE
Fix wmts-ign example when hosted

### DIFF
--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -66,8 +66,8 @@ xhr.onload = function() {
           capabilities, layerIdentifiers[i]);
       // we need to set the URL because it must include the key.
       sourceOptions.urls = [wmtsUrl];
+      sourceOptions.attributions = [attribution];
       source = new ol.source.WMTS(sourceOptions);
-      source.setAttributions([attribution]);
       source.setLogo(layerLogos[i]);
       layer = new ol.layer.TileLayer({source: source});
       map.addLayer(layer);


### PR DESCRIPTION
ol.source.Source#setAttributions is not exported. We can use the "attributions" constructor option in that case.
