### PR TITLE
tilejson example error

### DIFF
--- a/src/ol/tilegrid/xyztilegrid.js
+++ b/src/ol/tilegrid/xyztilegrid.js
@@ -48,7 +48,7 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
   if (goog.isDef(options.extent)) {
     tileRangeByZ = new Array(maxZ + 1);
     var z;
-    for (z = 0; z < maxZ; ++z) {
+    for (z = 0; z <= maxZ; ++z) {
       if (z < minZ) {
         tileRangeByZ[z] = null;
       } else {


### PR DESCRIPTION
http://ol3js.org/en/r3.0.0-alpha.3/examples/tilejson.html
Zooming beyond zoom level 7 produce an error:

```
Uncaught TypeError: Cannot call method 'contains' of undefined 
```
