### PR TITLE
Update key in bing-maps example

### DIFF
--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -13,7 +13,7 @@ for (var i = 0; i < styles.length; ++i) {
     visible: false,
     preload: Infinity,
     source: new ol.source.BingMaps({
-      key: 'AlQLZ0-5yk301_ESrmNLma3LYxEKNSg7w-e_knuRfyYFtld-UFvXVs38NOulku3Q',
+      key: 'Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt',
       style: styles[i]
     })
   }));

--- a/examples/full-screen-drag-rotate-and-zoom.js
+++ b/examples/full-screen-drag-rotate-and-zoom.js
@@ -19,7 +19,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       source: new ol.source.BingMaps({
-        key: 'AlQLZ0-5yk301_ESrmNLma3LYxEKNSg7w-e_knuRfyYFtld-UFvXVs38NOulku3Q',
+        key: 'Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt',
         style: 'Aerial'
       })
     })

--- a/examples/full-screen.js
+++ b/examples/full-screen.js
@@ -19,7 +19,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       source: new ol.source.BingMaps({
-        key: 'AlQLZ0-5yk301_ESrmNLma3LYxEKNSg7w-e_knuRfyYFtld-UFvXVs38NOulku3Q',
+        key: 'Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt',
         style: 'Aerial'
       })
     })

--- a/examples/hue-saturation.js
+++ b/examples/hue-saturation.js
@@ -8,7 +8,7 @@ goog.require('ol.source.BingMaps');
 
 var layer = new ol.layer.TileLayer({
   source: new ol.source.BingMaps({
-    key: 'AlQLZ0-5yk301_ESrmNLma3LYxEKNSg7w-e_knuRfyYFtld-UFvXVs38NOulku3Q',
+    key: 'Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt',
     style: 'Aerial'
   })
 });

--- a/examples/mobile-full-screen.js
+++ b/examples/mobile-full-screen.js
@@ -15,7 +15,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.TileLayer({
       source: new ol.source.BingMaps({
-        key: 'AlQLZ0-5yk301_ESrmNLma3LYxEKNSg7w-e_knuRfyYFtld-UFvXVs38NOulku3Q',
+        key: 'Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt',
         style: 'Road'
       })
     })

--- a/examples/preload.js
+++ b/examples/preload.js
@@ -10,7 +10,7 @@ var map1 = new ol.Map({
     new ol.layer.TileLayer({
       preload: Infinity,
       source: new ol.source.BingMaps({
-        key: 'AlQLZ0-5yk301_ESrmNLma3LYxEKNSg7w-e_knuRfyYFtld-UFvXVs38NOulku3Q',
+        key: 'Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt',
         style: 'Aerial'
       })
     })


### PR DESCRIPTION
Key information:

```
OpenLayers Trial/Windows Store
Ar33pRUvQOdESG8m_T15MUmNz__E1twPo42bFx9jvdDePhX0PNgAcEm44OVTS7tt
Update Trial / Windows Store app
Created Date: 07/17/2013      Expiration Date: 10/15/2013
```

I had to create an "Update Trial / Windows Store app" key - the bing maps site refused that I create another "Trial / Public website" key for my account. Though the key seems to work, I'm not sure it's appropriate.

Also, my bing maps account has this message:

```
You have created the maximum of 3 keys for this account. Once a key is created, you cannot delete
the key or change the key type or application type. If you require additional keys, you may need a
licensed account. For information on licensing, please contact us.
```

So I'm not sure I'll be able to renew the key the next time it's expiring.
