### PR TITLE
Rename {Function} to {function} in JSDoc tags

### DIFF
--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -97,9 +97,9 @@ ol.Collection.prototype.extend = function(arr) {
 
 /**
  * Iterate over each element, calling the provided callback.
- * @param {Function} f The function to call for every element. This function
- *     takes 3 arguments (the element, the index and the array). The return
- *     value is ignored.
+ * @param {function(?, number, Array)} f The function to call for every element.
+ *     This function takes 3 arguments (the element, the index and the array).
+ *     The return value is ignored.
  * @param {Object=} opt_obj The object to be used as the value of 'this'
  *     within f.
  */

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -232,7 +232,7 @@ ol.Object.prototype.notifyInternal_ = function(key) {
 /**
  * Listen for a certain type of event.
  * @param {string|Array.<string>} type The event type or array of event types.
- * @param {Function} listener The listener function.
+ * @param {function()} listener The listener function.
  * @param {Object=} opt_scope Object is whose scope to call
  *     the listener.
  * @return {?number} Unique key for the listener.
@@ -245,7 +245,7 @@ ol.Object.prototype.on = function(type, listener, opt_scope) {
 /**
  * Listen once for a certain type of event.
  * @param {string|Array.<string>} type The event type or array of event types.
- * @param {Function} listener The listener function.
+ * @param {function()} listener The listener function.
  * @param {Object=} opt_scope Object is whose scope to call
  *     the listener.
  * @return {?number} Unique key for the listener.
@@ -326,7 +326,7 @@ ol.Object.prototype.unbind = function(key) {
 /**
  * Unlisten for a certain type of event.
  * @param {string|Array.<string>} type The event type or array of event types.
- * @param {Function} listener The listener function.
+ * @param {function()} listener The listener function.
  * @param {Object=} opt_scope Object is whose scope to call
  *     the listener.
  */

--- a/src/ol/parser/kml.js
+++ b/src/ol/parser/kml.js
@@ -886,7 +886,7 @@ ol.parser.KML.prototype.readFeaturesFromObject =
 /**
  * @param {Array} deferreds List of deferred instances.
  * @param {Object} obj The returned object from the parser.
- * @param {Function} done A callback for when all links have been retrieved.
+ * @param {function()} done A callback for when all links have been retrieved.
  */
 ol.parser.KML.prototype.parseLinks = function(deferreds, obj, done) {
   var unvisited;
@@ -930,8 +930,8 @@ ol.parser.KML.prototype.parseLinks = function(deferreds, obj, done) {
 
 /**
  * @param {string|Document|Element|Object} data Data to read.
- * @param {Function=} opt_callback Optional callback to call when reading
- * is done.
+ * @param {function(Array.<ol.Feature>)=} opt_callback Optional callback
+ *     to call when reading is done.
  * @return {Object} An object representing the document.
  */
 ol.parser.KML.prototype.read = function(data, opt_callback) {

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -96,7 +96,7 @@ ol.structs.LRUCache.prototype.containsKey = function(key) {
 
 
 /**
- * @param {Function} f Function.
+ * @param {function(*, string, ol.structs.LRUCache)} f Function.
  * @param {Object=} opt_obj Object.
  */
 ol.structs.LRUCache.prototype.forEach = function(f, opt_obj) {

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -20,7 +20,7 @@ ol.TilePriorityFunction;
  * @extends {ol.structs.PriorityQueue}
  * @param {ol.TilePriorityFunction} tilePriorityFunction
  *     Tile priority function.
- * @param {Function} tileChangeCallback
+ * @param {function()} tileChangeCallback
  *     Function called on each tile change event.
  */
 ol.TileQueue = function(tilePriorityFunction, tileChangeCallback) {
@@ -44,7 +44,7 @@ ol.TileQueue = function(tilePriorityFunction, tileChangeCallback) {
 
   /**
    * @private
-   * @type {Function}
+   * @type {function()}
    */
   this.tileChangeCallback_ = tileChangeCallback;
 


### PR DESCRIPTION
I'm not 100% confident with the `{function}` arguments and return type ...
