### PR TITLE
Api docs does not list Object#setValues

### DIFF
--- a/src/ol/object.exports
+++ b/src/ol/object.exports
@@ -5,7 +5,6 @@
 @exportProperty ol.Object.prototype.on
 @exportProperty ol.Object.prototype.once
 @exportProperty ol.Object.prototype.set
-@exportProperty ol.Object.prototype.setOptions
 @exportProperty ol.Object.prototype.setValues
 @exportProperty ol.Object.prototype.un
 @exportProperty ol.Object.prototype.unByKey

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -281,12 +281,12 @@ ol.Object.prototype.set = function(key, value) {
 
 /**
  * Sets a collection of key-value pairs.
- * @param {Object.<string, *>} options Options.
+ * @param {Object.<string, *>} values Values.
  */
-ol.Object.prototype.setOptions = function(options) {
+ol.Object.prototype.setValues = function(values) {
   var key, value, setterName;
-  for (key in options) {
-    value = options[key];
+  for (key in values) {
+    value = values[key];
     setterName = ol.Object.getSetterName(key);
     if (this[setterName]) {
       this[setterName](value);
@@ -295,13 +295,6 @@ ol.Object.prototype.setOptions = function(options) {
     }
   }
 };
-
-
-/**
- * Sets a collection of key-value pairs.
- * @param {Object.<string, *>} values Values.
- */
-ol.Object.prototype.setValues = ol.Object.prototype.setOptions;
 
 
 /**


### PR DESCRIPTION
I've noticed a small issue with the api docs. If you look at any of the objects that inherit from ol.Object, they list setValues() with a link to ol.Object#setValues. However, if you click on this, you find that that function isn't listed, which is a bit confusing. I assume this is because ol.Object#setValues isn't a proper function but just an alias for setOptions. Any solution?
