### PR TITLE
Better label placement for polygons

### DIFF
--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -136,10 +136,11 @@ ol.geom.Polygon.prototype.containsCoordinate = function(coordinate) {
 
 
 /**
- * Calculates a label point that is guaranteed to be inside the polygon.
- * @return {ol.Coordinate} The label point.
+ * Calculates a point that is guaranteed to lie in the interior of the polygon.
+ * Inspired by JTS's com.vividsolutions.jts.geom.Geometry#getInteriorPoint.
+ * @return {ol.Coordinate} A point which is in the interior of the polygon.
  */
-ol.geom.Polygon.prototype.getLabelPoint = function() {
+ol.geom.Polygon.prototype.getInteriorPoint = function() {
   if (goog.isNull(this.labelPoint_)) {
     var center = ol.extent.getCenter(this.getBounds()),
         resultY = center[1],

--- a/src/ol/renderer/canvas/canvasvectorrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorrenderer.js
@@ -445,7 +445,7 @@ ol.renderer.canvas.VectorRenderer.getLabelVectors = function(geometry) {
     return [[geometry.get(0), geometry.get(1), 0]];
   }
   if (type == ol.geom.GeometryType.POLYGON) {
-    var coordinates = geometry.getLabelPoint();
+    var coordinates = geometry.getInteriorPoint();
     return [[coordinates[0], coordinates[1], 0]];
   }
   throw new Error('Label rendering not implemented for geometry type: ' +


### PR DESCRIPTION
Using the y-coordinate of the polygon's bounding box, this
simple algorithm intersects the polygon with the horizontal
center line of its bounding box. The x-coordinate of the label
point is the center of the longest segment of this intersection
that is inside the polygon.
