### PR TITLE
Change default renderer

### DIFF
--- a/examples/center.js
+++ b/examples/center.js
@@ -49,7 +49,6 @@ var map = new ol.Map({
     }),
     vectorLayer
   ],
-  renderer: 'canvas',
   target: 'map',
   view: view
 });

--- a/examples/d3.js
+++ b/examples/d3.js
@@ -19,7 +19,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: ol.proj.transform([-97, 38], 'EPSG:4326', 'EPSG:3857'),

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -103,7 +103,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -38,7 +38,6 @@ var vector = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [-11000000, 4600000],

--- a/examples/dynamic-data.js
+++ b/examples/dynamic-data.js
@@ -14,7 +14,6 @@ var map = new ol.Map({
       source: new ol.source.MapQuest({layer: 'sat'})
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -26,8 +26,6 @@ var map = new ol.Map({
     })
   ]),
   layers: layers,
-  // The OSgeo server does not set cross origin headers, so we cannot use WebGL
-  renderer: ['canvas', 'dom'],
   target: 'map',
   view: new ol.View2D({
     projection: 'EPSG:4326',

--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -10,7 +10,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/fractal.js
+++ b/examples/fractal.js
@@ -25,7 +25,6 @@ var layer = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [layer],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/full-screen-drag-rotate-and-zoom.js
+++ b/examples/full-screen-drag-rotate-and-zoom.js
@@ -24,7 +24,6 @@ var map = new ol.Map({
     })
   ],
   // Use the canvas renderer because it's currently the fastest
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [-33519607, 5616436],

--- a/examples/geojson.js
+++ b/examples/geojson.js
@@ -187,7 +187,6 @@ var map = new ol.Map({
     }),
     vectorLayer
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -20,7 +20,6 @@ var map = new ol.Map({
       source: new ol.source.OSM()
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: view
 });

--- a/examples/getfeatureinfo.js
+++ b/examples/getfeatureinfo.js
@@ -23,7 +23,6 @@ var viewProjection = /** @type {ol.proj.Projection} */
 
 var map = new ol.Map({
   layers: [wmsLayer],
-  renderer: 'canvas',
   target: 'map',
   view: view
 });

--- a/examples/google-map.js
+++ b/examples/google-map.js
@@ -54,7 +54,6 @@ var map = new ol.Map({
     pan: false,
     rotate: false
   }).extend([new ol.interaction.DragPan({kinetic: false})]),
-  renderer: 'canvas',
   target: olMapDiv,
   view: view
 });

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -55,7 +55,6 @@ var vector = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: document.getElementById('map'),
   view: new ol.View2D({
     center: [-7916041.528716288, 5228379.045749711],

--- a/examples/heatmap-earthquakes.js
+++ b/examples/heatmap-earthquakes.js
@@ -31,7 +31,6 @@ var raster = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -46,7 +46,6 @@ var rasterLayer = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [rasterLayer, vectorLayer],
-  renderer: 'canvas',
   target: document.getElementById('map'),
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -82,7 +82,6 @@ var map = new ol.Map({
       style: styleFunction
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [703365.7089403362, 5714629.865071137],

--- a/examples/image-filter.js
+++ b/examples/image-filter.js
@@ -12,7 +12,6 @@ var imagery = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [imagery],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: ol.proj.transform([-120, 50], 'EPSG:4326', 'EPSG:3857'),

--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -34,7 +34,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -53,7 +53,6 @@ var raster = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -60,7 +60,6 @@ var raster = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -21,7 +21,6 @@ var vector = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: document.getElementById('map'),
   view: new ol.View2D({
     center: [876970.8463461736, 5859807.853963373],

--- a/examples/layer-clipping.js
+++ b/examples/layer-clipping.js
@@ -9,7 +9,6 @@ var osm = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [osm],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/layer-spy.js
+++ b/examples/layer-spy.js
@@ -16,7 +16,6 @@ var imagery = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [roads, imagery],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: ol.proj.transform([-109, 46.5], 'EPSG:4326', 'EPSG:3857'),

--- a/examples/layer-swipe.js
+++ b/examples/layer-swipe.js
@@ -16,7 +16,6 @@ var bing = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [osm, bing],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -41,7 +41,6 @@ var map = new ol.Map({
     openCycleMapLayer,
     openSeaMapLayer
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     maxZoom: 18,

--- a/examples/mapguide-untiled.js
+++ b/examples/mapguide-untiled.js
@@ -29,7 +29,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [-87.7302542509315, 43.744459064634],

--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -32,7 +32,6 @@ var modify = new ol.interaction.Modify({
 var map = new ol.Map({
   interactions: ol.interaction.defaults().extend([select, modify]),
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/modify-test.js
+++ b/examples/modify-test.js
@@ -243,7 +243,6 @@ var modify = new ol.interaction.Modify({
 var map = new ol.Map({
   interactions: ol.interaction.defaults().extend([select, modify]),
   layers: [layer],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 1000000],

--- a/examples/rtree.js
+++ b/examples/rtree.js
@@ -97,7 +97,6 @@ var rtree = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [vector, rtree],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -23,7 +23,6 @@ var select = new ol.interaction.Select();
 var map = new ol.Map({
   interactions: ol.interaction.defaults().extend([select]),
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -35,7 +35,6 @@ if (ol.BrowserFeature.HAS_WEBGL) {
 }
 
 var canvasMap = new ol.Map({
-  renderer: 'canvas',
   target: 'canvasMap'
 });
 canvasMap.bindTo('layergroup', domMap);

--- a/examples/static-image.js
+++ b/examples/static-image.js
@@ -32,7 +32,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     projection: pixelProjection,

--- a/examples/synthetic-lines.js
+++ b/examples/synthetic-lines.js
@@ -55,7 +55,6 @@ var view = new ol.View2D({
 
 var map = new ol.Map({
   layers: [vector],
-  renderer: 'canvas',
   target: 'map',
   view: view
 });

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -57,7 +57,6 @@ var popup = new ol.Overlay({
 
 var map = new ol.Map({
   layers: [vector],
-  renderer: 'canvas',
   target: document.getElementById('map'),
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -38,7 +38,6 @@ var vector = new ol.layer.Vector({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -187,7 +187,6 @@ var map = new ol.Map({
     vectorLines,
     vectorPoints
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [-8161939, 6095025],

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -52,7 +52,6 @@ var map = new ol.Map({
     }),
     vectorLayer
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -114,7 +114,6 @@ var raster = new ol.layer.Tile({
 
 var map = new ol.Map({
   layers: [raster, vector],
-  renderer: 'canvas',
   target: document.getElementById('map'),
   view: new ol.View2D({
     center: [739218, 5906096],

--- a/examples/wms-image.js
+++ b/examples/wms-image.js
@@ -20,7 +20,6 @@ var layers = [
   })
 ];
 var map = new ol.Map({
-  renderer: 'canvas',
   layers: layers,
   target: 'map',
   view: new ol.View2D({

--- a/examples/wms-tiled.js
+++ b/examples/wms-tiled.js
@@ -19,7 +19,6 @@ var layers = [
   })
 ];
 var map = new ol.Map({
-  renderer: 'canvas',
   layers: layers,
   target: 'map',
   view: new ol.View2D({

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -43,7 +43,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   target: 'map',
   view: new ol.View2D({
     center: [0, 0],

--- a/examples/xyz-esri.js
+++ b/examples/xyz-esri.js
@@ -22,7 +22,6 @@ var map = new ol.Map({
       })
     })
   ],
-  renderer: 'canvas',
   view: new ol.View2D({
     center: ol.proj.transform([-121.1, 47.5], 'EPSG:4326', 'EPSG:3857'),
     zoom: 7

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -4,7 +4,6 @@
 
 goog.provide('ol.Map');
 goog.provide('ol.MapProperty');
-goog.provide('ol.RendererHint');
 
 goog.require('goog.Uri.QueryData');
 goog.require('goog.array');
@@ -114,8 +113,8 @@ ol.RendererHint = {
  * @type {Array.<ol.RendererHint>}
  */
 ol.DEFAULT_RENDERER_HINTS = [
-  ol.RendererHint.WEBGL,
   ol.RendererHint.CANVAS,
+  ol.RendererHint.WEBGL,
   ol.RendererHint.DOM
 ];
 

--- a/test/spec/ol/interaction/drawinteraction.test.js
+++ b/test/spec/ol/interaction/drawinteraction.test.js
@@ -19,7 +19,6 @@ describe('ol.interaction.Draw', function() {
     var layer = new ol.layer.Vector({source: source});
     map = new ol.Map({
       target: target,
-      renderer: ol.RendererHint.CANVAS,
       layers: [layer],
       view: new ol.View2D({
         projection: 'EPSG:4326',
@@ -447,7 +446,6 @@ goog.require('goog.events.BrowserEvent');
 goog.require('goog.style');
 goog.require('ol.Map');
 goog.require('ol.MapBrowserPointerEvent');
-goog.require('ol.RendererHint');
 goog.require('ol.View2D');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.LineString');


### PR DESCRIPTION
What do folks think about changing the default renderer to Canvas?

I'm occasionally getting ["Rats! WebGL hit a snag"](https://support.google.com/chrome/answer/2905826?p=ib_webgl&rd=1) when browsing in Chrome 28 and more frequently seeing `PERFORMANCE WARNING: Some textures are unrenderable.`.

We could count how many examples work better with which renderer, but I just wanted to hear some opinions first.

These snags are accompanied uncaught assertion errors (will dig for more detail) and this in the console:

```
WebGLRenderingContext: GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glClear: framebuffer incomplete (clear)
WebGLRenderingContext: GL ERROR :GL_INVALID_FRAMEBUFFER_OPERATION : glDrawArrays: framebuffer incomplete (clear)
WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost
```
