### PR TITLE
check-examples target failing because of G+ widgets

### DIFF
--- a/build.py
+++ b/build.py
@@ -669,7 +669,7 @@ def check_examples(t):
         [e + '?mode=raw' for e in examples] + \
         [e + '?mode=whitespace' for e in examples] + \
         [e + '?mode=simple' for e in examples] + \
-        examples
+        [e + '?mode=advanced' for e in examples]
     for example in all_examples:
         t.run('%(PHANTOMJS)s', 'bin/check-example.js', example)
 


### PR DESCRIPTION
G+ widgets should not be loaded when running headless. I am currently working on this.
