### PR TITLE
Move attribution constants to constructors

### DIFF
--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -76,17 +76,6 @@ ol.source.StamenProviderConfig = {
 };
 
 
-/**
- * @const {Array.<ol.Attribution>}
- */
-ol.source.STAMEN_ATTRIBUTIONS = [
-  new ol.Attribution(
-      'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, under ' +
-      '<a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.'),
-  ol.source.OSM.DATA_ATTRIBUTION
-];
-
-
 
 /**
  * @constructor
@@ -108,7 +97,7 @@ ol.source.Stamen = function(options) {
       layerConfig.extension;
 
   goog.base(this, {
-    attributions: ol.source.STAMEN_ATTRIBUTIONS,
+    attributions: ol.source.Stamen.ATTRIBUTIONS,
     crossOrigin: 'anonymous',
     maxZoom: providerConfig.maxZoom,
     // FIXME uncomment the following when tilegrid supports minZoom
@@ -119,3 +108,14 @@ ol.source.Stamen = function(options) {
 
 };
 goog.inherits(ol.source.Stamen, ol.source.XYZ);
+
+
+/**
+ * @const {Array.<ol.Attribution>}
+ */
+ol.source.Stamen.ATTRIBUTIONS = [
+  new ol.Attribution(
+      'Map tiles by <a href="http://stamen.com/">Stamen Design</a>, under ' +
+      '<a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.'),
+  ol.source.OSM.DATA_ATTRIBUTION
+];


### PR DESCRIPTION
Currently, some attribution constants are added to the `ol.source` object (e.g. [`ol.source.STAMEN_ATTRIBUTIONS`](https://github.com/openlayers/ol3/blob/82a158bdd20fbf39f82eeaf35051f7fb37411df2/src/ol/source/stamensource.js#L82)) and others are added to the source constructors (e.g. [`ol.source.OSM.ATTRIBUTIONS`](https://github.com/openlayers/ol3/blob/82a158bdd20fbf39f82eeaf35051f7fb37411df2/src/ol/source/osmsource.js#L68)).  Given the way that provide/require checking works, it would be more consistent to make all attributions properties of the provided constructors.
