### PR TITLE
Don't react to keyboard events when the focus is on editable inputs

### DIFF
--- a/src/ol/interaction/condition.exports
+++ b/src/ol/interaction/condition.exports
@@ -4,3 +4,4 @@
 @exportSymbol ol.interaction.condition.noModifierKeys
 @exportSymbol ol.interaction.condition.platformModifierKeyOnly
 @exportSymbol ol.interaction.condition.shiftKeyOnly
+@exportSymbol ol.interaction.condition.targetNotEditable

--- a/src/ol/interaction/condition.js
+++ b/src/ol/interaction/condition.js
@@ -1,6 +1,7 @@
 goog.provide('ol.interaction.ConditionType');
 goog.provide('ol.interaction.condition');
 
+goog.require('goog.dom.TagName');
 goog.require('goog.functions');
 
 
@@ -74,4 +75,17 @@ ol.interaction.condition.shiftKeyOnly = function(browserEvent) {
       !browserEvent.altKey &&
       !browserEvent.platformModifierKey &&
       browserEvent.shiftKey);
+};
+
+
+/**
+ * @param {goog.events.BrowserEvent} browserEvent Browser event.
+ * @return {boolean} True if the target element is not editable.
+ */
+ol.interaction.condition.targetNotEditable = function(browserEvent) {
+  var tagName = browserEvent.target.tagName;
+  return (
+      tagName !== goog.dom.TagName.INPUT &&
+      tagName !== goog.dom.TagName.SELECT &&
+      tagName !== goog.dom.TagName.TEXTAREA);
 };

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -5,6 +5,7 @@ goog.provide('ol.interaction.KeyboardPan');
 goog.require('goog.asserts');
 goog.require('goog.events.KeyCodes');
 goog.require('goog.events.KeyHandler.EventType');
+goog.require('goog.functions');
 goog.require('ol.View2D');
 goog.require('ol.coordinate');
 goog.require('ol.interaction.ConditionType');
@@ -34,8 +35,9 @@ ol.interaction.KeyboardPan = function(opt_options) {
    * @private
    * @type {ol.interaction.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.noModifierKeys;
+  this.condition_ = goog.isDef(options.condition) ? options.condition :
+      goog.functions.and(ol.interaction.condition.noModifierKeys,
+          ol.interaction.condition.targetNotEditable);
 
   /**
    * @private

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -4,6 +4,7 @@ goog.provide('ol.interaction.KeyboardZoom');
 
 goog.require('goog.asserts');
 goog.require('goog.events.KeyHandler.EventType');
+goog.require('goog.functions');
 goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.interaction.condition');
@@ -31,8 +32,9 @@ ol.interaction.KeyboardZoom = function(opt_options) {
    * @private
    * @type {ol.interaction.ConditionType}
    */
-  this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.noModifierKeys;
+  this.condition_ = goog.isDef(options.condition) ? options.condition :
+      goog.functions.and(ol.interaction.condition.noModifierKeys,
+          ol.interaction.condition.targetNotEditable);
 
   /**
    * @private


### PR DESCRIPTION
Don't pan or zoom when the focus is on an editable inputs (`input`, `select` or `textarea`)
