### PR TITLE
IE10 compatibility: full-screen-drag-rotate-and-zoom.html

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -53,7 +53,7 @@ ol.control.FullScreen = function(opt_options) {
       this.handleFullScreenChange_, false, this);
 
   var element = goog.dom.createDom(goog.dom.TagName.DIV, {
-    'class': this.cssClassName_ + ' ' + ol.css.CLASS_UNSELECTABLE +
+    'class': this.cssClassName_ + ' ' + ol.css.CLASS_UNSELECTABLE + ' ' +
         (!goog.dom.fullscreen.isSupported() ? ol.css.CLASS_UNSUPPORTED : '')
   }, aElement);
 


### PR DESCRIPTION
How to reproduce:
- Use Internet Explorer 10 on windows 7 pro 64b
- Go on page http://ol3js.org/en/r3.0.0-alpha.4/examples/full-screen-drag-rotate-and-zoom.html
- Click on the "full screen" control
- Nothing happens

Expected:
- Click on the "full screen" control
- The map goes full screen

Notes:
- does work well on Chrome
