### PR TITLE
Only check examples in advanced mode

### DIFF
--- a/build.py
+++ b/build.py
@@ -667,9 +667,6 @@ def host_examples(t):
 def check_examples(t):
     examples = ['build/hosted/%(BRANCH)s/' + e for e in EXAMPLES]
     all_examples = \
-        [e + '?mode=raw' for e in examples] + \
-        [e + '?mode=whitespace' for e in examples] + \
-        [e + '?mode=simple' for e in examples] + \
         [e + '?mode=advanced' for e in examples]
     for example in all_examples:
         t.run('%(PHANTOMJS)s', 'bin/check-example.js', example)


### PR DESCRIPTION
Travis builds are currently taking a very long time (40 minutes+). Following a suggestion from @elemoine, this PR reduces the example checking to advanced mode only (previously all of raw, whitespace, simple and advanced modes). This saves about 10 minutes.

@elemoine, I'm particularly interested in your view of this.
