### PR TITLE
Parse literal nodes in expressions in addition to text nodes

### DIFF
--- a/src/ol/parser/ogc/filter_v1.js
+++ b/src/ol/parser/ogc/filter_v1.js
@@ -39,7 +39,7 @@ ol.parser.ogc.Filter_v1 = function() {
               if (obj.property) {
                 expressions.push(obj.property);
               } else if (goog.isDef(obj.value)) {
-                return obj.value;
+                expressions.push(obj.value);
               }
               break;
             case 3: // text node

--- a/test/spec/ol/parser/ogc/filter_v1_0_0.test.js
+++ b/test/spec/ol/parser/ogc/filter_v1_0_0.test.js
@@ -235,21 +235,32 @@ describe('ol.parser.ogc.Filter_v1_0_0', function() {
   });
 
   describe('_expression reader', function() {
-    it('handles combined propertyname and literal',
-        function() {
-          var xml = '<ogc:UpperBoundary xmlns:ogc="' +
-              'http://www.opengis.net/ogc">10</ogc:UpperBoundary>';
-          var reader = parser.readers['http://www.opengis.net/ogc'][
-              '_expression'];
-          var expr = reader.call(parser, goog.dom.xml.loadXml(
-              xml).documentElement);
-          expect(expr).to.be.a(ol.expr.Literal);
-          expect(expr.getValue()).to.equal(10);
-          xml = '<ogc:UpperBoundary xmlns:ogc="http://www.opengis.net/ogc">' +
-              'foo<ogc:PropertyName>x</ogc:PropertyName>bar</ogc:UpperBoundary>';
-          expr = reader.call(parser, goog.dom.xml.loadXml(xml).documentElement);
-          expect(expr.evaluate({x: 4})).to.eql('foo4bar');
-        });
+    it('handles combined propertyname and text', function() {
+      var xml = '<ogc:UpperBoundary xmlns:ogc="' +
+          'http://www.opengis.net/ogc">10</ogc:UpperBoundary>';
+      var reader = parser.readers['http://www.opengis.net/ogc'][
+          '_expression'];
+      var expr = reader.call(parser, goog.dom.xml.loadXml(
+          xml).documentElement);
+      expect(expr).to.be.a(ol.expr.Literal);
+      expect(expr.getValue()).to.equal(10);
+      xml = '<ogc:UpperBoundary xmlns:ogc="http://www.opengis.net/ogc">' +
+          'foo<ogc:PropertyName>x</ogc:PropertyName>bar</ogc:UpperBoundary>';
+      expr = reader.call(parser, goog.dom.xml.loadXml(xml).documentElement);
+      expect(expr.evaluate({x: 4})).to.eql('foo4bar');
+    });
+
+    it('handles combined propertyname and literal', function() {
+      var reader = parser.readers['http://www.opengis.net/ogc'][
+          '_expression'];
+      var xml = '<ogc:UpperBoundary xmlns:ogc="http://www.opengis.net/ogc">' +
+          '<ogc:Literal>bar</ogc:Literal>' +
+          '<ogc:PropertyName>x</ogc:PropertyName>' +
+          '<ogc:Literal>foo</ogc:Literal></ogc:UpperBoundary>';
+      var expr = reader.call(parser, goog.dom.xml.loadXml(xml).documentElement);
+      expect(expr.evaluate({x: 42})).to.eql('bar42foo');
+    });
+
   });
 
 });


### PR DESCRIPTION
The current FE expression reader deals with text nodes that are mixed with `<Property>` nodes, but it doesn't handle `<Literal>` nodes mixed in the same way (see https://github.com/openlayers/ol3/pull/852#issuecomment-22426547).

This small change addresses that.
