### PR TITLE
Export ol.source.Source.prototype.getExtent

### DIFF
--- a/src/ol/source/source.exports
+++ b/src/ol/source/source.exports
@@ -1,0 +1,1 @@
+@exportProperty ol.source.Source.prototype.getExtent


### PR DESCRIPTION
This PR follows up on #860, which suggests exporting the getters of exported constructor options. f4ba19c exports the `ol.source.Source.prototype.getExtent` getter corresponding to the `extent` source option.
