### PR TITLE
Fix unclosed div in examples/icon.html

### DIFF
--- a/examples/icon.html
+++ b/examples/icon.html
@@ -39,7 +39,7 @@
       <div class="row-fluid">
         <div class="span12">
           <div id="map" class="map">
-            <div id="popup"><div>
+            <div id="popup"></div>
           </div>
         </div>        
       </div>


### PR DESCRIPTION
Thanks to IE10 for pointing this out
