### PR TITLE
ol.layer.Vector pass original options to parent

### DIFF
--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -245,11 +245,7 @@ ol.layer.VectorLayerEventObject;
  */
 ol.layer.Vector = function(options) {
 
-  goog.base(this, {
-    opacity: options.opacity,
-    source: options.source,
-    visible: options.visible
-  });
+  goog.base(this, /** @type {ol.layer.LayerOptions} */ (options));
 
   /**
    * @private


### PR DESCRIPTION
This makes it possible to pass arbitrary property to ol.layer.Vector and use layer.get('property_name') to get the value of properties.
