### PR TITLE
ol.Feature.prototype.get need not be exported

### DIFF
--- a/src/ol/feature.exports
+++ b/src/ol/feature.exports
@@ -1,5 +1,4 @@
 @exportSymbol ol.Feature
-@exportProperty ol.Feature.prototype.get
 @exportProperty ol.Feature.prototype.getAttributes
 @exportProperty ol.Feature.prototype.getFeatureId
 @exportProperty ol.Feature.prototype.getGeometry


### PR DESCRIPTION
get is not overridden in ol.Feature.prototype, so there's no need for a specific export.
