### PR TITLE
Limited feature exports

### DIFF
--- a/src/ol/feature.exports
+++ b/src/ol/feature.exports
@@ -2,3 +2,5 @@
 @exportProperty ol.Feature.prototype.getAttributes
 @exportProperty ol.Feature.prototype.getFeatureId
 @exportProperty ol.Feature.prototype.getGeometry
+@exportProperty ol.Feature.prototype.set
+@exportProperty ol.Feature.prototype.setGeometry


### PR DESCRIPTION
We should not export the following:
- [x] `ol.Feature.prototype.setFeatureId`
- [x] `ol.Feature.prototype.setSymbolizers`

These can be added back when they are used in an example.
