### PR TITLE
Remove handleMapPostrender extension point

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -16,13 +16,6 @@ oli.control.Control = function() {};
 
 
 /**
- * @param {ol.MapEvent} mapEvent Map event.
- * @return {undefined} Undefined.
- */
-oli.control.Control.prototype.handleMapPostrender = function(mapEvent) {};
-
-
-/**
  * @param {ol.Map} map Map.
  * @return {undefined} Undefined.
  */

--- a/src/ol/control/control.exports
+++ b/src/ol/control/control.exports
@@ -1,4 +1,3 @@
 @exportClass ol.control.Control ol.control.ControlOptions
-@exportProperty ol.control.Control.prototype.handleMapPostrender
 @exportProperty ol.control.Control.prototype.getMap
 @exportProperty ol.control.Control.prototype.setMap

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -77,7 +77,7 @@ ol.control.Control.prototype.getMap = function() {
  * UI.
  * @param {ol.MapEvent} mapEvent Map event.
  */
-ol.control.Control.prototype.handleMapPostrender = function(mapEvent) {};
+ol.control.Control.prototype.handleMapPostrender = goog.nullFunction;
 
 
 /**
@@ -99,8 +99,7 @@ ol.control.Control.prototype.setMap = function(map) {
     var target = goog.isDef(this.target_) ?
         this.target_ : map.getOverlayContainer();
     goog.dom.appendChild(target, this.element);
-    if (this.handleMapPostrender !==
-        ol.control.Control.prototype.handleMapPostrender) {
+    if (this.handleMapPostrender !== goog.nullFunction) {
       this.listenerKeys.push(goog.events.listen(map,
           ol.MapEventType.POSTRENDER, this.handleMapPostrender, false, this));
     }


### PR DESCRIPTION
This removes the handleMapPostrender extension point for custom controls. See this [comment](https://github.com/openlayers/ol3/pull/946#issuecomment-23614096) for the motivations of this removal.
