### PR TITLE
Out-of-date examples in control api docs

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -17,14 +17,6 @@ goog.require('ol.css');
  * Provides a button that when clicked fills up the full screen with the map.
  * When in full screen mode, a close button is shown to exit full screen mode.
  *
- * Example:
- *
- *     var map = new ol.Map({
- *       controls: ol.control.defaults({}, [
- *         new ol.control.FullScreen()
- *       ]),
- *       ...
- *
  * @constructor
  * @extends {ol.control.Control}
  * @param {ol.control.FullScreenOptions=} opt_options Options.

--- a/src/ol/control/mousepositioncontrol.js
+++ b/src/ol/control/mousepositioncontrol.js
@@ -34,14 +34,6 @@ ol.control.MousePositionProperty = {
  * shown in the top right corner of the map but this can be changed by using
  * a css selector .ol-mouse-position.
  *
- * Example:
- *
- *     var map = new ol.Map({
- *       controls: ol.control.defaults({}, [
- *         new ol.control.MousePosition({projection: ol.proj.get('EPSG:4326')})
- *       ]),
- *       ...
- *
  * @constructor
  * @extends {ol.control.Control}
  * @param {ol.control.MousePositionOptions=} opt_options Mouse position options.

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -43,16 +43,6 @@ ol.control.ScaleLineUnits = {
 /**
  * Create a control to help users estimate distances on a map.
  *
- * Example:
- *
- *     var map = new ol.Map({
- *       controls: ol.control.defaults({}, [
- *         new ol.control.ScaleLine({
- *           units: ol.control.ScaleLineUnits.IMPERIAL
- *         })
- *       ]),
- *       ...
- *
  * @constructor
  * @extends {ol.control.Control}
  * @param {ol.control.ScaleLineOptions=} opt_options Scale line options.


### PR DESCRIPTION
http://ol3js.org/en/master/apidoc/ol.control.FullScreen.html
http://ol3js.org/en/master/apidoc/ol.control.MousePosition.html
http://ol3js.org/en/master/apidoc/ol.control.ScaleLine.html
all give examples which no longer work.
IMO, it would be better not to have examples in the api docs, and instead have a reference to a working example in examples/
