### PR TITLE
Do not include anything in the API docs that isn't exported

### DIFF
--- a/doc/plugins/exports.js
+++ b/doc/plugins/exports.js
@@ -39,27 +39,6 @@ exports.handlers = {
     if (/\.js$/.test(e.filename)) {
       collectExports(e.source);
     }
-  },
-  
-  newDoclet: function(e) {
-    if (api.indexOf(e.doclet.longname) > -1) {
-      // Add params of API symbols to the API
-      var names, name;
-      var params = e.doclet.params;
-      if (params) {
-        for (var i = 0, ii = params.length; i < ii; ++i) {
-          names = params[i].type.names;
-          if (names) {
-            for (var j = 0, jj=names.length; j < jj; ++j) {
-              name = names[j];
-              if (api.indexOf(name) === -1) {
-                api.push(name);
-              }
-            }
-          }
-        }
-      }
-    }
   }
   
 };


### PR DESCRIPTION
Previously we included items that were referenced in the docs of exported items. Now we strictly limit the docs to exported items. This was discussed in the 8/30 hangout.
