### PR TITLE
ol.source.TiledWMS renamed to ol.source.TileWMS

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -5,12 +5,12 @@ goog.require('ol.control.ScaleLine');
 goog.require('ol.control.ScaleLineUnits');
 goog.require('ol.control.defaults');
 goog.require('ol.layer.TileLayer');
-goog.require('ol.source.TiledWMS');
+goog.require('ol.source.TileWMS');
 
 
 var layers = [
   new ol.layer.TileLayer({
-    source: new ol.source.TiledWMS({
+    source: new ol.source.TileWMS({
       url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
       params: {
         'VERSION': '1.1.1',

--- a/examples/getfeatureinfo.js
+++ b/examples/getfeatureinfo.js
@@ -4,14 +4,14 @@ goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.layer.Vector');
 goog.require('ol.parser.GeoJSON');
-goog.require('ol.source.TiledWMS');
+goog.require('ol.source.TileWMS');
 goog.require('ol.source.Vector');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 
 var wms = new ol.layer.TileLayer({
-  source: new ol.source.TiledWMS({
+  source: new ol.source.TileWMS({
     url: 'http://demo.opengeo.org/geoserver/wms',
     params: {'LAYERS': 'ne:ne'}
   })

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -4,11 +4,11 @@ goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.layer.Vector');
 goog.require('ol.parser.KML');
-goog.require('ol.source.TiledWMS');
+goog.require('ol.source.TileWMS');
 goog.require('ol.source.Vector');
 
 var raster = new ol.layer.TileLayer({
-  source: new ol.source.TiledWMS({
+  source: new ol.source.TileWMS({
     url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
     crossOrigin: null,
     params: {

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -7,7 +7,7 @@ goog.require('ol.control.ScaleLineUnits');
 goog.require('ol.control.defaults');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.proj');
-goog.require('ol.source.TiledWMS');
+goog.require('ol.source.TileWMS');
 
 
 var projection = ol.proj.configureProj4jsProjection({
@@ -18,7 +18,7 @@ var projection = ol.proj.configureProj4jsProjection({
 var extent = [420000, 900000, 30000, 350000];
 var layers = [
   new ol.layer.TileLayer({
-    source: new ol.source.TiledWMS({
+    source: new ol.source.TileWMS({
       url: 'http://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions: [new ol.Attribution({
@@ -35,7 +35,7 @@ var layers = [
     })
   }),
   new ol.layer.TileLayer({
-    source: new ol.source.TiledWMS({
+    source: new ol.source.TileWMS({
       url: 'http://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions: [new ol.Attribution({

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -7,12 +7,12 @@ goog.require('ol.View2D');
 goog.require('ol.layer.ImageLayer');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.source.SingleImageWMS');
-goog.require('ol.source.TiledWMS');
+goog.require('ol.source.TileWMS');
 
 
 var layers = [
   new ol.layer.TileLayer({
-    source: new ol.source.TiledWMS({
+    source: new ol.source.TileWMS({
       attributions: [new ol.Attribution({
         html: '&copy; ' +
             '<a href="http://www.geo.admin.ch/internet/geoportal/' +

--- a/examples/wms-tiled.js
+++ b/examples/wms-tiled.js
@@ -3,7 +3,7 @@ goog.require('ol.RendererHint');
 goog.require('ol.View2D');
 goog.require('ol.layer.TileLayer');
 goog.require('ol.source.MapQuestOpenAerial');
-goog.require('ol.source.TiledWMS');
+goog.require('ol.source.TileWMS');
 
 
 var layers = [
@@ -11,7 +11,7 @@ var layers = [
     source: new ol.source.MapQuestOpenAerial()
   }),
   new ol.layer.TileLayer({
-    source: new ol.source.TiledWMS({
+    source: new ol.source.TileWMS({
       url: 'http://demo.opengeo.org/geoserver/wms',
       params: {'LAYERS': 'topp:states', 'TILED': true},
       extent: [-13884991, -7455066, 2870341, 6338219]

--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -528,7 +528,7 @@
  */
 
 /**
- * @typedef {Object} ol.source.TiledWMSOptions
+ * @typedef {Object} ol.source.TileWMSOptions
  * @property {Array.<ol.Attribution>|undefined} attributions Attributions.
  * @property {Object.<string,*>} params WMS request parameters. At least a
  *     `LAYERS` param is required. `STYLES` is '' by default. `VERSION` is

--- a/src/ol/source/tiledwmssource.exports
+++ b/src/ol/source/tiledwmssource.exports
@@ -1,1 +1,0 @@
-@exportClass ol.source.TiledWMS ol.source.TiledWMSOptions

--- a/src/ol/source/tilewmssource.exports
+++ b/src/ol/source/tilewmssource.exports
@@ -1,0 +1,1 @@
+@exportClass ol.source.TileWMS ol.source.TileWMSOptions

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -1,6 +1,6 @@
 // FIXME add minZoom support
 
-goog.provide('ol.source.TiledWMS');
+goog.provide('ol.source.TileWMS');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
@@ -18,9 +18,9 @@ goog.require('ol.source.wms');
  * @constructor
  * @extends {ol.source.ImageTileSource}
  * @implements {ol.source.FeatureInfoSource}
- * @param {ol.source.TiledWMSOptions} options Tiled WMS options.
+ * @param {ol.source.TileWMSOptions} options Tiled WMS options.
  */
-ol.source.TiledWMS = function(options) {
+ol.source.TileWMS = function(options) {
 
   var tileGrid;
   if (goog.isDef(options.tileGrid)) {
@@ -94,13 +94,13 @@ ol.source.TiledWMS = function(options) {
       options.getFeatureInfoOptions : {};
 
 };
-goog.inherits(ol.source.TiledWMS, ol.source.ImageTileSource);
+goog.inherits(ol.source.TileWMS, ol.source.ImageTileSource);
 
 
 /**
  * @inheritDoc
  */
-ol.source.TiledWMS.prototype.getFeatureInfoForPixel =
+ol.source.TileWMS.prototype.getFeatureInfoForPixel =
     function(pixel, map, success, opt_error) {
   var coord = map.getCoordinateFromPixel(pixel),
       view2D = map.getView().getView2D(),
@@ -113,7 +113,7 @@ ol.source.TiledWMS.prototype.getFeatureInfoForPixel =
       offset = map.getPixelFromCoordinate(ol.extent.getTopLeft(tileExtent)),
       url = this.tileUrlFunction(tileCoord, projection);
   goog.asserts.assert(goog.isDef(url),
-      'ol.source.TiledWMS#tileUrlFunction does not return a url');
+      'ol.source.TileWMS#tileUrlFunction does not return a url');
   ol.source.wms.getFeatureInfo(url,
       [pixel[0] - offset[0], pixel[1] - offset[1]], this.getFeatureInfoOptions_,
       success, opt_error);


### PR DESCRIPTION
This PR suggests renaming ol.source.TiledWMS to ol.source.TileWMS. This is to be consistent with the name of base classes (ol.source.TileSource, and ol.ImageTileSource) and of the TileJSON source. It also sounds better to me (yeah, subjective).
