### PR TITLE
Rename addPreRenderFunction to beforeRender and remove the plural

### DIFF
--- a/examples/animation.js
+++ b/examples/animation.js
@@ -41,7 +41,7 @@ rotateLeft.addEventListener('click', function() {
     duration: 2000,
     rotation: -4 * Math.PI
   });
-  map.addPreRenderFunction(rotateLeft);
+  map.beforeRender(rotateLeft);
 }, false);
 var rotateRight = document.getElementById('rotate-right');
 rotateRight.addEventListener('click', function() {
@@ -49,7 +49,7 @@ rotateRight.addEventListener('click', function() {
     duration: 2000,
     rotation: 4 * Math.PI
   });
-  map.addPreRenderFunction(rotateRight);
+  map.beforeRender(rotateRight);
 }, false);
 
 
@@ -59,7 +59,7 @@ panToLondon.addEventListener('click', function() {
     duration: 2000,
     source: view.getCenter()
   });
-  map.addPreRenderFunction(pan);
+  map.beforeRender(pan);
   view.setCenter(london);
 }, false);
 
@@ -70,7 +70,7 @@ elasticToMoscow.addEventListener('click', function() {
     easing: ol.easing.elastic,
     source: view.getCenter()
   });
-  map.addPreRenderFunction(pan);
+  map.beforeRender(pan);
   view.setCenter(moscow);
 }, false);
 
@@ -81,7 +81,7 @@ bounceToIstanbul.addEventListener('click', function() {
     easing: ol.easing.bounce,
     source: view.getCenter()
   });
-  map.addPreRenderFunction(pan);
+  map.beforeRender(pan);
   view.setCenter(istanbul);
 }, false);
 
@@ -99,7 +99,7 @@ spinToRome.addEventListener('click', function() {
     rotation: 2 * Math.PI,
     start: start
   });
-  map.addPreRenderFunctions([pan, rotate]);
+  map.beforeRender(pan, rotate);
   view.setCenter(rome);
 }, false);
 
@@ -117,7 +117,7 @@ flyToBern.addEventListener('click', function() {
     resolution: 4 * view.getResolution(),
     start: start
   });
-  map.addPreRenderFunctions([pan, bounce]);
+  map.beforeRender(pan, bounce);
   view.setCenter(bern);
 }, false);
 
@@ -140,6 +140,6 @@ spiralToMadrid.addEventListener('click', function() {
     rotation: -4 * Math.PI,
     start: start
   });
-  map.addPreRenderFunctions([pan, bounce, rotate]);
+  map.beforeRender(pan, bounce, rotate);
   view.setCenter(madrid);
 }, false);

--- a/src/ol/animation.jsdoc
+++ b/src/ol/animation.jsdoc
@@ -1,11 +1,11 @@
 /**
- * The {ol.animation} static methods are designed to be used with the {@link ol.Map#addPreRenderFunction} and {@link ol.Map#addPreRenderFunctions} methods.  For example:
+ * The {ol.animation} static methods are designed to be used with the {@link ol.Map#beforeRender} method.  For example:
  *
  *     var map = new ol.Map({ ... });
  *     var zoom = ol.animation.zoom({
  *       resolution: map.getView().getResolution()
  *     });
- *     map.addPreRenderFunction(zoom);
+ *     map.beforeRender(zoom);
  *     map.getView().setResolution(map.getView().getResolution() * 2);
  *
  * @namespace ol.animation

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -79,7 +79,7 @@ ol.control.Zoom.prototype.zoomByDelta_ = function(delta, browserEvent) {
   var view = map.getView().getView2D();
   var currentResolution = view.getResolution();
   if (goog.isDef(currentResolution)) {
-    map.addPreRenderFunction(ol.animation.zoom({
+    map.beforeRender(ol.animation.zoom({
       resolution: currentResolution,
       duration: ol.control.ZOOM_DURATION,
       easing: ol.easing.easeOut

--- a/src/ol/control/zoomslidercontrol.js
+++ b/src/ol/control/zoomslidercontrol.js
@@ -275,7 +275,7 @@ ol.control.ZoomSlider.prototype.handleSliderChange_ = function(e) {
     }
   } else {
     goog.asserts.assert(goog.isDef(this.currentResolution_));
-    map.addPreRenderFunction(ol.animation.zoom({
+    map.beforeRender(ol.animation.zoom({
       resolution: this.currentResolution_,
       duration: ol.control.ZOOMSLIDER_ANIMATION_DURATION,
       easing: ol.easing.easeOut

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -87,7 +87,7 @@ ol.interaction.DragPan.prototype.handleDragEnd = function(mapBrowserEvent) {
     var distance = this.kinetic_.getDistance();
     var angle = this.kinetic_.getAngle();
     this.kineticPreRenderFn_ = this.kinetic_.pan(view2DState.center);
-    map.addPreRenderFunction(this.kineticPreRenderFn_);
+    map.beforeRender(this.kineticPreRenderFn_);
 
     var centerpx = map.getPixelFromCoordinate(view2DState.center);
     var dest = map.getCoordinateFromPixel([

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -38,7 +38,7 @@ ol.interaction.Interaction.pan = function(
   var currentCenter = view.getCenter();
   if (goog.isDef(currentCenter)) {
     if (goog.isDef(opt_duration)) {
-      map.addPreRenderFunction(ol.animation.pan({
+      map.beforeRender(ol.animation.pan({
         source: currentCenter,
         duration: opt_duration,
         easing: ol.easing.linear
@@ -78,13 +78,13 @@ ol.interaction.Interaction.rotateWithoutConstraints =
     var currentCenter = view.getCenter();
     if (goog.isDef(currentRotation) && goog.isDef(currentCenter) &&
         goog.isDef(opt_duration)) {
-      map.addPreRenderFunction(ol.animation.rotate({
+      map.beforeRender(ol.animation.rotate({
         rotation: currentRotation,
         duration: opt_duration,
         easing: ol.easing.easeOut
       }));
       if (goog.isDef(opt_anchor)) {
-        map.addPreRenderFunction(ol.animation.pan({
+        map.beforeRender(ol.animation.pan({
           source: currentCenter,
           duration: opt_duration,
           easing: ol.easing.easeOut
@@ -157,13 +157,13 @@ ol.interaction.Interaction.zoomWithoutConstraints =
     var currentCenter = view.getCenter();
     if (goog.isDef(currentResolution) && goog.isDef(currentCenter) &&
         goog.isDef(opt_duration)) {
-      map.addPreRenderFunction(ol.animation.zoom({
+      map.beforeRender(ol.animation.zoom({
         resolution: currentResolution,
         duration: opt_duration,
         easing: ol.easing.easeOut
       }));
       if (goog.isDef(opt_anchor)) {
-        map.addPreRenderFunction(ol.animation.pan({
+        map.beforeRender(ol.animation.pan({
           source: currentCenter,
           duration: opt_duration,
           easing: ol.easing.easeOut

--- a/src/ol/interaction/touchpaninteraction.js
+++ b/src/ol/interaction/touchpaninteraction.js
@@ -87,7 +87,7 @@ ol.interaction.TouchPan.prototype.handleTouchEnd =
       var angle = this.kinetic_.getAngle();
       var center = view.getCenter();
       this.kineticPreRenderFn_ = this.kinetic_.pan(center);
-      map.addPreRenderFunction(this.kineticPreRenderFn_);
+      map.beforeRender(this.kineticPreRenderFn_);
       var centerpx = map.getPixelFromCoordinate(center);
       var dest = map.getCoordinateFromPixel([
         centerpx[0] - distance * Math.cos(angle),

--- a/src/ol/map.exports
+++ b/src/ol/map.exports
@@ -2,8 +2,7 @@
 @exportProperty ol.Map.prototype.addControl
 @exportProperty ol.Map.prototype.addLayer
 @exportProperty ol.Map.prototype.addOverlay
-@exportProperty ol.Map.prototype.addPreRenderFunction
-@exportProperty ol.Map.prototype.addPreRenderFunctions
+@exportProperty ol.Map.prototype.beforeRender
 @exportProperty ol.Map.prototype.getControls
 @exportProperty ol.Map.prototype.getFeatureInfo
 @exportProperty ol.Map.prototype.getFeatures

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -388,27 +388,14 @@ ol.Map.prototype.addOverlay = function(overlay) {
 
 
 /**
- * Add a prerender function. This can be used for attaching animations to
- * be performed before setting the map's center.  The {@link ol.animation}
+ * Add functions to be called before rendering. This can be used for attaching
+ * animations before updating the map's view.  The {@link ol.animation}
  * namespace provides several static methods for creating prerender functions.
- * @param {ol.PreRenderFunction} preRenderFunction Pre-render function.
+ * @param {...ol.PreRenderFunction} var_args Any number of pre-render functions.
  */
-ol.Map.prototype.addPreRenderFunction = function(preRenderFunction) {
+ol.Map.prototype.beforeRender = function(var_args) {
   this.requestRenderFrame();
-  this.preRenderFunctions_.push(preRenderFunction);
-};
-
-
-/**
- * Add prerender functions. This can be used for attaching animations to
- * be performed before setting the map's center.  See {@link ol.animation}
- * @param {Array.<ol.PreRenderFunction>} preRenderFunctions
- *     Pre-render functions.
- */
-ol.Map.prototype.addPreRenderFunctions = function(preRenderFunctions) {
-  this.requestRenderFrame();
-  Array.prototype.push.apply(
-      this.preRenderFunctions_, preRenderFunctions);
+  Array.prototype.push.apply(this.preRenderFunctions_, arguments);
 };
 
 


### PR DESCRIPTION
This removes `addPreRenderFunctions` and renames `addPreRenderFunction` to `beforeRender`.
