### PR TITLE
Rework default style handling

### DIFF
--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -18,6 +18,7 @@ goog.require('ol.layer.Layer');
 goog.require('ol.proj');
 goog.require('ol.source.Vector');
 goog.require('ol.structs.RTree');
+goog.require('ol.style');
 goog.require('ol.style.Style');
 goog.require('ol.style.TextLiteral');
 
@@ -436,12 +437,11 @@ ol.layer.Vector.prototype.groupFeaturesBySymbolizerLiteral =
     if (!goog.isNull(symbolizers)) {
       literals = ol.style.Style.createLiterals(symbolizers, feature);
     } else {
-      if (!goog.isNull(style)) {
-        // layer style second
-        literals = style.createLiterals(feature);
-      } else {
-        literals = ol.style.Style.defaults.createLiterals(feature);
+      // layer style second
+      if (goog.isNull(style)) {
+        style = ol.style.getDefault();
       }
+      literals = style.createLiterals(feature);
     }
     numLiterals = literals.length;
     for (j = 0; j < numLiterals; ++j) {

--- a/src/ol/style/fillsymbolizer.js
+++ b/src/ol/style/fillsymbolizer.js
@@ -123,13 +123,3 @@ ol.style.FillDefaults = {
   color: '#ffffff',
   opacity: 0.4
 };
-
-
-/**
- * @typedef {{color: (string),
- *            opacity: (number)}}
- */
-ol.style.FillDefaultsSelect = {
-  color: '#ffffff',
-  opacity: 0.7
-};

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -1,7 +1,12 @@
+goog.provide('ol.style');
 goog.provide('ol.style.Style');
 
 goog.require('goog.object');
 goog.require('ol.Feature');
+goog.require('ol.expr.Call');
+goog.require('ol.expr.Identifier');
+goog.require('ol.expr.Literal');
+goog.require('ol.expr.functions');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Literal');
@@ -65,30 +70,70 @@ ol.style.Style.prototype.createLiterals = function(feature) {
 /**
  * The default style.
  * @type {ol.style.Style}
+ * @private
  */
-ol.style.Style.defaults = new ol.style.Style({
-  rules: [
-    new ol.style.Rule({
-      filter: 'renderIntent("select")',
+ol.style.default_ = null;
+
+
+/**
+ * Get the default style.
+ * @return {ol.style.Style} The default style.
+ */
+ol.style.getDefault = function() {
+  if (goog.isNull(ol.style.default_)) {
+    ol.style.default_ = new ol.style.Style({
+      rules: [
+        new ol.style.Rule({
+          filter: new ol.expr.Call(
+              new ol.expr.Identifier(ol.expr.functions.RENDER_INTENT),
+              [new ol.expr.Literal('select')]),
+          symbolizers: [
+            new ol.style.Shape({
+              fill: new ol.style.Fill({
+                color: '#ffffff',
+                opacity: 0.7
+              }),
+              stroke: new ol.style.Stroke({
+                color: '#696969',
+                opacity: 0.9,
+                width: 2.0
+              })
+            }),
+            new ol.style.Fill({
+              color: '#ffffff',
+              opacity: 0.7
+            }),
+            new ol.style.Stroke({
+              color: '#696969',
+              opacity: 0.9,
+              width: 2.0
+            })
+          ]
+        })
+      ],
       symbolizers: [
         new ol.style.Shape({
-          fill: new ol.style.Fill(ol.style.FillDefaultsSelect),
-          stroke: new ol.style.Stroke(ol.style.StrokeDefaultsSelect)
+          fill: new ol.style.Fill(),
+          stroke: new ol.style.Stroke()
         }),
-        new ol.style.Fill(ol.style.FillDefaultsSelect),
-        new ol.style.Stroke(ol.style.StrokeDefaultsSelect)
+        new ol.style.Fill(),
+        new ol.style.Stroke()
       ]
-    })
-  ],
-  symbolizers: [
-    new ol.style.Shape({
-      fill: new ol.style.Fill(),
-      stroke: new ol.style.Stroke()
-    }),
-    new ol.style.Fill(),
-    new ol.style.Stroke()
-  ]
-});
+    });
+  }
+  return ol.style.default_;
+};
+
+
+/**
+ * Set the default style.
+ * @param {ol.style.Style} style The new default style.
+ * @return {ol.style.Style} The default style.
+ */
+ol.style.setDefault = function(style) {
+  ol.style.default_ = style;
+  return style;
+};
 
 
 /**

--- a/test/spec/ol/style/style.test.js
+++ b/test/spec/ol/style/style.test.js
@@ -122,56 +122,68 @@ describe('ol.style.Style', function() {
 
   });
 
-  describe('ol.style.Style.defaults.createLiterals(feature)', function() {
-    var feature = new ol.Feature();
+  describe('ol.style.getDefault()', function() {
+    var style = ol.style.getDefault();
 
-    it('returns an empty array for features without geometry', function() {
-      expect(ol.style.Style.defaults.createLiterals(feature))
-          .to.have.length(0);
+    it('is a ol.style.Style instance', function() {
+      expect(style).to.be.a(ol.style.Style);
     });
 
-    it('returns an array with the Shape default for points', function() {
-      feature.setGeometry(new ol.geom.Point([0, 0]));
+    describe('#createLiterals()', function() {
 
-      var literals = ol.style.Style.defaults.createLiterals(feature);
-      expect(literals).to.have.length(1);
+      it('returns an empty array for features without geometry', function() {
+        var feature = new ol.Feature();
+        expect(style.createLiterals(feature))
+            .to.have.length(0);
+      });
 
-      var literal = literals[0];
-      expect(literal).to.be.a(ol.style.ShapeLiteral);
-      expect(literal.type).to.be(ol.style.ShapeDefaults.type);
-      expect(literal.fillColor).to.be(ol.style.FillDefaults.color);
-      expect(literal.fillOpacity).to.be(ol.style.FillDefaults.opacity);
-      expect(literal.strokeColor).to.be(ol.style.StrokeDefaults.color);
-      expect(literal.strokeOpacity).to.be(ol.style.StrokeDefaults.opacity);
-      expect(literal.strokeWidth).to.be(ol.style.StrokeDefaults.width);
-    });
+      it('returns an array with the Shape default for points', function() {
+        var feature = new ol.Feature();
+        feature.setGeometry(new ol.geom.Point([0, 0]));
 
-    it('returns an array with the Line default for lines', function() {
-      feature.setGeometry(new ol.geom.LineString([[0, 0], [1, 1]]));
+        var literals = style.createLiterals(feature);
+        expect(literals).to.have.length(1);
 
-      var literals = ol.style.Style.defaults.createLiterals(feature);
-      expect(literals).to.have.length(1);
+        var literal = literals[0];
+        expect(literal).to.be.a(ol.style.ShapeLiteral);
+        expect(literal.type).to.be(ol.style.ShapeDefaults.type);
+        expect(literal.fillColor).to.be(ol.style.FillDefaults.color);
+        expect(literal.fillOpacity).to.be(ol.style.FillDefaults.opacity);
+        expect(literal.strokeColor).to.be(ol.style.StrokeDefaults.color);
+        expect(literal.strokeOpacity).to.be(ol.style.StrokeDefaults.opacity);
+        expect(literal.strokeWidth).to.be(ol.style.StrokeDefaults.width);
+      });
 
-      var literal = literals[0];
-      expect(literal).to.be.a(ol.style.LineLiteral);
-      expect(literal.color).to.be(ol.style.StrokeDefaults.color);
-      expect(literal.opacity).to.be(ol.style.StrokeDefaults.opacity);
-      expect(literal.width).to.be(ol.style.StrokeDefaults.width);
-    });
+      it('returns an array with the Line default for lines', function() {
+        var feature = new ol.Feature();
+        feature.setGeometry(new ol.geom.LineString([[0, 0], [1, 1]]));
 
-    it('returns an array with the Polygon default for polygons', function() {
-      feature.setGeometry(new ol.geom.Polygon([[[0, 0], [1, 1], [0, 0]]]));
+        var literals = style.createLiterals(feature);
+        expect(literals).to.have.length(1);
 
-      var literals = ol.style.Style.defaults.createLiterals(feature);
-      expect(literals).to.have.length(1);
+        var literal = literals[0];
+        expect(literal).to.be.a(ol.style.LineLiteral);
+        expect(literal.color).to.be(ol.style.StrokeDefaults.color);
+        expect(literal.opacity).to.be(ol.style.StrokeDefaults.opacity);
+        expect(literal.width).to.be(ol.style.StrokeDefaults.width);
+      });
 
-      var literal = literals[0];
-      expect(literal).to.be.a(ol.style.PolygonLiteral);
-      expect(literal.fillColor).to.be(ol.style.FillDefaults.color);
-      expect(literal.fillOpacity).to.be(ol.style.FillDefaults.opacity);
-      expect(literal.strokeColor).to.be(ol.style.StrokeDefaults.color);
-      expect(literal.strokeOpacity).to.be(ol.style.StrokeDefaults.opacity);
-      expect(literal.strokeWidth).to.be(ol.style.StrokeDefaults.width);
+      it('returns an array with the Polygon default for polygons', function() {
+        var feature = new ol.Feature();
+        feature.setGeometry(new ol.geom.Polygon([[[0, 0], [1, 1], [0, 0]]]));
+
+        var literals = style.createLiterals(feature);
+        expect(literals).to.have.length(1);
+
+        var literal = literals[0];
+        expect(literal).to.be.a(ol.style.PolygonLiteral);
+        expect(literal.fillColor).to.be(ol.style.FillDefaults.color);
+        expect(literal.fillOpacity).to.be(ol.style.FillDefaults.opacity);
+        expect(literal.strokeColor).to.be(ol.style.StrokeDefaults.color);
+        expect(literal.strokeOpacity).to.be(ol.style.StrokeDefaults.opacity);
+        expect(literal.strokeWidth).to.be(ol.style.StrokeDefaults.width);
+      });
+
     });
 
   });
@@ -284,6 +296,7 @@ goog.require('ol.expr');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.style');
 goog.require('ol.style.Fill');
 goog.require('ol.style.LineLiteral');
 goog.require('ol.style.PolygonLiteral');


### PR DESCRIPTION
There are a number of issues with the way the default style is handled now.  There is no way for a user to override the defaults with the compiled lib (`ol.style.Style.defaults` is not exported).  In addition, because the default style instance is created unconditionally, all of the style stuff (including expression parsing) is always included in all builds (even those that don't use a vector layer).

This can be improved by adding `ol.style.setDefault` and `ol.style.getDefault` functions (with the default created lazily).
