### PR TITLE
Side-by-side example broken

### DIFF
--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -24,7 +24,7 @@ var webglMap = new ol.Map({
   renderer: ol.RendererHint.WEBGL,
   target: 'webglMap'
 });
-webglMap.bindTo('layers', domMap);
+webglMap.bindTo('layergroup', domMap);
 webglMap.bindTo('view', domMap);
 
 
@@ -32,5 +32,5 @@ var canvasMap = new ol.Map({
   renderer: ol.RendererHint.CANVAS,
   target: 'canvasMap'
 });
-canvasMap.bindTo('layers', domMap);
+canvasMap.bindTo('layergroup', domMap);
 canvasMap.bindTo('view', domMap);


### PR DESCRIPTION
Only the DOM map is rendering currently: http://ol3js.org/en/master/examples/side-by-side.html

Haven't looked into it - just wanted to note it.
