### PR TITLE
IE10 CSS compatibility: custom-controls example

### DIFF
--- a/examples/custom-controls.html
+++ b/examples/custom-controls.html
@@ -17,6 +17,9 @@
         border-radius: 4px;
         padding: 2px;
       }
+      .ol-touch .rotate-north {
+        top: 80px;
+      }
       .rotate-north a {
         display: block;
         color: white;
@@ -30,6 +33,12 @@
         height: 22px;
         width: 22px;
         background: rgba(0,60,136,0.5);
+      }
+      .ol-touch .rotate-north a {
+        font-size: 20px;
+        height: 30px;
+        width: 30px;
+        line-height: 26px;
       }
       .rotate-north a:hover {
         background: rgba(0,60,136,0.7);


### PR DESCRIPTION
How to reproduce:
- Use IE10
- Load http://ol3js.org/en/master/examples/custom-controls.html
- custom control overlays zoom in/out controls

![custom-controls](https://f.cloud.github.com/assets/496153/1094854/c4f57846-16d6-11e3-8797-3d65113682ca.png)
