### PR TITLE
IE10 compatibility: no tooltip on icon.html example

### DIFF
--- a/examples/icon.js
+++ b/examples/icon.js
@@ -85,7 +85,7 @@ map.on('click', function(evt) {
         });
         $(element).popover('show');
       } else {
-        $(element).popover('hide');
+        $(element).popover('destroy');
       }
     }
   });


### PR DESCRIPTION
How to reproduce:
- Open IE10 on Win7 without touch
- Load http://ol3js.org/en/master/examples/icon.html
- click on the icon
- nothing happens

Expected
- Open IE10 on Win7 without touch
- Load http://ol3js.org/en/master/examples/icon.html
- Click on the icon
- A tooltip displaying "Null Island" appears

Note:
- Does work on chrome
