### PR TITLE
Code generation problems

### DIFF
--- a/bin/generate-exports.py
+++ b/bin/generate-exports.py
@@ -300,7 +300,7 @@ def main(argv):
                     object_literal = ObjectLiteral(name, objects)
                     objects[name] = object_literal
                     continue
-                m = re.match(r'\*\s*@property\s*{(?P<type>.*)}\s*(?P<prop>\S+)', line)
+                m = re.match(r'\*\s*@property\s*{(?P<type>.*?)}\s*(?P<prop>\S+)', line)
                 if m:
                     assert object_literal is not None
                     prop = m.group('prop')


### PR DESCRIPTION
I just tried to add the following block to `objectliterals.jsdoc`:

``` js
/**
 * @typedef {Object} ol.source.XYZOptions
 * @property {Array.<ol.Attribution>|undefined} attributions Attributions.
 * @property {null|string|undefined} crossOrigin Cross origin setting for image
 *     requests.
 * @property {ol.Extent|undefined} extent Extent.
 * @property {string|undefined} logo Logo.
 * @property {ol.ProjectionLike} projection Projection.
 * @property {number|undefined} maxZoom Max zoom.
 * @property {ol.TileUrlFunctionType|undefined} tileUrlFunction Optional
 *     function to get tile URL given a tile coordinate and the projection.
 *     Required if url or urls are not provided.
 * @property {string|undefined} url URL template.  Must include '{x}', '{y}',
 *     and '{z}' placeholders.
 * @property {Array.<string>|undefined} urls An array of URL templates.
 */
```

This resulted in the following in `build/src/external/externs/types.js`:

``` js
/**
 * @type {string|undefined} url URL template.  Must include '{x}', '{y}
 */
olx.source.XYZOptionsExtern.prototype.',;
```

I assume there is some greedy pattern matching going on that is consuming everything until the last closing curly brace.
