### PR TITLE
Export ol.source.XYZ.prototype.setUrl

### DIFF
--- a/src/ol/source/xyzsource.exports
+++ b/src/ol/source/xyzsource.exports
@@ -1,1 +1,2 @@
 @exportClass ol.source.XYZ ol.source.XYZOptions
+@exportProperty ol.source.XYZ.prototype.setUrl


### PR DESCRIPTION
The `setUrl` method is used in the `xyz-seturl.html` (from ae6ecb7103ccef97dd70156977f4433ffa7bc5a6) example but not exported.
