### PR TITLE
Use proper extent structure for TileJSON

### DIFF
--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -75,12 +75,9 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function() {
 
   var extent;
   if (goog.isDef(tileJSON.bounds)) {
-    var epsg4326Extent = [
-      tileJSON.bounds.slice(0, 2), tileJSON.bounds.slice(2)
-    ];
     var transform = ol.proj.getTransformFromProjections(
         epsg4326Projection, this.getProjection());
-    extent = ol.extent.transform(epsg4326Extent, transform);
+    extent = ol.extent.transform(tileJSON.bounds, transform);
     this.setExtent(extent);
   }
 


### PR DESCRIPTION
The change in e806f51b3d5ea81c652c6d19ceb2064153501c23 neglected to correct the extent handling for the TileJSON source.
