### PR TITLE
Add a help-target to build.py.

### DIFF
--- a/build.py
+++ b/build.py
@@ -771,7 +771,8 @@ The most common targets are:
   serve            - Serves files through plovr, usually on port 9810.
   lint             - Runs gjslint on all sourcefiles to enforce specific syntax.
   build            - Builds singlefile versions of OpenLayers JavaScript and
-                     CSS.
+                     CSS. This is also the default build target which runs when
+                     no target is specified.
   test             - Runs the testsuite and displays the results.
   check            - Runs the lint-target, builds some OpenLayers files, and
                      then runs test. Many developers call this target often
@@ -792,6 +793,8 @@ Other less frequently used targets are:
   todo             - is an alias for the fixme-target
   plovr            - Fetches the required plovr.jar. Usually called by other
                      targets that depend on plovr.
+
+If no target is given, the build-target will be executed.
 
 The above list is not complete, please see the sourceode for not-mentioned and
 only seldomly called targets.


### PR DESCRIPTION
This is the output of `build.py help` on my machine:

```
build.py - The OpenLayers 3 build script.

Usage:
  ./build.py [options] [target]                         (on Unix-based machines)
  <python-executable.exe> build.py [options] [target]   (on Windows machines)

There is one option:
  -c               - Cleans up the repository from previous builds.

The most common targets are:
  serve            - Serves files through plovr, usually on port 9810.
  lint             - Runs gjslint on all sourcefiles to enforce specific syntax.
  build            - Builds singlefile versions of OpenLayers JavaScript and
                     CSS. This is also the default build target which runs when
                     no target is specified.
  test             - Runs the testsuite and displays the results.
  check            - Runs the lint-target, builds some OpenLayers files, and
                     then runs test. Many developers call this target often
                     while working on the code.
  help             - Shows this help.

Other less frequently used targets are:
  doc              - Builds the API-Documentation using JSDoc3.
  integration-test - Builds all examples in various modes and usually tales a
                     long time to finish. This target calls the following
                     targets: lint, build, build-all, test, build-examples,
                     check-examples and doc.
  reallyclean      - Remove untracked files from the repository.
  checkdeps        - Checks whether all required development software is
                     installed on your machine.
  fixme            - Will print a list of parts of the code that are marked
                     with either TODO or FIXME.
  todo             - is an alias for the fixme-target
  plovr            - Fetches the required plovr.jar. Usually called by other
                     targets that depend on plovr.

If no target is given, the build-target will be executed.

The above list is not complete, please see the sourceode for not-mentioned and
only seldomly called targets.
```

Please review and do not hesitate to comment on wording, grammar, described targets, etc.

Edited to reflect new output after 62a7505.
