### PR TITLE
Remove ol.extent.toString

### DIFF
--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -328,16 +328,6 @@ ol.extent.scaleFromCenter = function(extent, value) {
 
 
 /**
- * @param {ol.Extent} extent Extent.
- * @return {string} String.
- */
-ol.extent.toString = function(extent) {
-  return '(' + [extent[0], extent[2], extent[1],
-    extent[3]].join(', ') + ')';
-};
-
-
-/**
  * @param {ol.Extent} extent1 Extent 1.
  * @param {ol.Extent} extent2 Extent 2.
  * @return {boolean} Touches.

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -212,13 +212,6 @@ describe('ol.extent', function() {
     });
   });
 
-  describe('toString', function() {
-    it('returns the expected string', function() {
-      var extent = [0, 1, 2, 3];
-      expect(ol.extent.toString(extent)).to.eql('(0, 2, 1, 3)');
-    });
-  });
-
   describe('transform', function() {
 
     it('does transform', function() {


### PR DESCRIPTION
This function is only used in the tests and is unnecessary.
