### PR TITLE
Examples are broken

### DIFF
--- a/resources/example-behaviour.js
+++ b/resources/example-behaviour.js
@@ -7,10 +7,10 @@
       select = document.createElement('select'),
       possibleModes = {
         'raw' : 'Development',
-        'compiled': 'Production'
+        'advanced': 'Production'
       },
       urlMode = window.location.href.match(/mode=([a-z0-9\-]+)\&?/i),
-      curMode = urlMode ? urlMode[1] : 'compiled',
+      curMode = urlMode ? urlMode[1] : 'advanced',
       option,
       modeIdx,
       mode,


### PR DESCRIPTION
To reproduce:
- go to http://ol3js.org/en/master/examples/full-screen.html
- set the mode to Development
- set the mode to Production (so that the URL becomes http://ol3js.org/en/master/examples/full-screen.html?mode=compiled)

No map is shown and the console contains:

```
GET http://ol3js.org/en/master/css/ol.css 404 (Not Found) full-screen.html:7
GET http://ol3js.org/en/master/build/ol-compiled.js 404 (Not Found) loader.js?id=full-screen:79
  (anonymous function) loader.js?id=full-screen:79
  (anonymous function) loader.js?id=full-screen:86
Uncaught ReferenceError: ol is not defined full-screen.js:1
  (anonymous function) full-screen.js:1
```

This is probably related to #1038.
