### PR TITLE
Remove 'attribution' option from ol.source.OSMOptions

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -503,7 +503,6 @@
 
 /**
  * @typedef {Object} ol.source.OSMOptions
- * @property {ol.Attribution|undefined} attribution Attribution.
  * @property {Array.<ol.Attribution>|undefined} attributions Attributions.
  * @property {number|undefined} maxZoom Max zoom.
  * @property {string|undefined} url URL.

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -17,8 +17,6 @@ ol.source.OSM = function(opt_options) {
   var attributions;
   if (goog.isDef(options.attributions)) {
     attributions = options.attributions;
-  } else if (goog.isDef(options.attribution)) {
-    attributions = [options.attribution];
   } else {
     attributions = ol.source.OSM.ATTRIBUTIONS;
   }


### PR DESCRIPTION
`attributions` should be used (like all other sources)
