### PR TITLE
Export ol.Overlay#setPositioning

### DIFF
--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -267,11 +267,16 @@ goog.exportProperty(
 
 
 /**
+ * Set the positioning for this overlay.
  * @param {ol.OverlayPositioning|undefined} positioning Positioning.
  */
 ol.Overlay.prototype.setPositioning = function(positioning) {
   this.set(ol.OverlayProperty.POSITIONING, positioning);
 };
+goog.exportProperty(
+    ol.Overlay.prototype,
+    'setPositioning',
+    ol.Overlay.prototype.setPositioning);
 
 
 /**


### PR DESCRIPTION
The method setPositioning in ol.Overlay is not exposed whereas is equivalent
getter getPositioning is visible in the API and the documentation.
The PR add a line of description to the documentation and expose
the method.
