### PR TITLE
Add gjslint to requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 before_install:
-  - "sudo pip install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz"
   - "sudo pip install -r requirements.txt"
   - "git clone --depth=50 https://github.com/jsdoc3/jsdoc build/jsdoc"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
 pystache
 regex


### PR DESCRIPTION
gjslint can be installed via requirements.txt. This means that all the required Python modules can be downloaded with the single command:

```
sudo pip install -r requirements.txt
```

If this PR is accepted, I'll update the Developer Guide to the consequently shorter installation instructions.
