### PR TITLE
Rename ol.renderer.canvas.VectorRenderer

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -16,7 +16,7 @@ goog.require('ol.layer.Vector');
 goog.require('ol.layer.VectorLayerEventType');
 goog.require('ol.layer.VectorLayerRenderIntent');
 goog.require('ol.renderer.canvas.Layer');
-goog.require('ol.renderer.canvas.VectorRenderer');
+goog.require('ol.renderer.canvas.Vector');
 goog.require('ol.tilegrid.TileGrid');
 
 
@@ -450,7 +450,7 @@ ol.renderer.canvas.VectorLayer.prototype.renderFrame =
   sketchCanvas.width = sketchWidth;
   sketchCanvas.height = sketchHeight;
 
-  var sketchCanvasRenderer = new ol.renderer.canvas.VectorRenderer(
+  var sketchCanvasRenderer = new ol.renderer.canvas.Vector(
       sketchCanvas, sketchTransform, this.requestMapRenderFrame_);
 
   // clear/resize final canvas

--- a/src/ol/renderer/canvas/canvasvectorrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorrenderer.js
@@ -1,4 +1,4 @@
-goog.provide('ol.renderer.canvas.VectorRenderer');
+goog.provide('ol.renderer.canvas.Vector');
 
 
 goog.require('goog.asserts');
@@ -36,7 +36,7 @@ goog.require('ol.style.TextLiteral');
  * @param {function()=} opt_iconLoadedCallback Callback for deferred rendering
  *     when images need to be loaded before rendering.
  */
-ol.renderer.canvas.VectorRenderer =
+ol.renderer.canvas.Vector =
     function(canvas, transform, opt_iconLoadedCallback) {
 
   var context = /** @type {CanvasRenderingContext2D} */
@@ -92,7 +92,7 @@ ol.renderer.canvas.VectorRenderer =
 /**
  * @return {Object.<number, Array.<number>>} Symbolizer sizes.
  */
-ol.renderer.canvas.VectorRenderer.prototype.getSymbolSizes = function() {
+ol.renderer.canvas.Vector.prototype.getSymbolSizes = function() {
   return this.symbolSizes_;
 };
 
@@ -100,7 +100,7 @@ ol.renderer.canvas.VectorRenderer.prototype.getSymbolSizes = function() {
 /**
  * @return {Object.<number, Array.<number>>} Symbolizer offsets.
  */
-ol.renderer.canvas.VectorRenderer.prototype.getSymbolOffsets = function() {
+ol.renderer.canvas.Vector.prototype.getSymbolOffsets = function() {
   return this.symbolOffsets_;
 };
 
@@ -108,7 +108,7 @@ ol.renderer.canvas.VectorRenderer.prototype.getSymbolOffsets = function() {
 /**
  * @return {Array.<number>} Maximum symbolizer size.
  */
-ol.renderer.canvas.VectorRenderer.prototype.getMaxSymbolSize = function() {
+ol.renderer.canvas.Vector.prototype.getMaxSymbolSize = function() {
   return this.maxSymbolSize_;
 };
 
@@ -120,7 +120,7 @@ ol.renderer.canvas.VectorRenderer.prototype.getMaxSymbolSize = function() {
  * @param {Array} data Additional data.
  * @return {boolean} true if deferred, false if rendered.
  */
-ol.renderer.canvas.VectorRenderer.prototype.renderFeaturesByGeometryType =
+ol.renderer.canvas.Vector.prototype.renderFeaturesByGeometryType =
     function(type, features, symbolizer, data) {
   var deferred = false;
   if (!(symbolizer instanceof ol.style.TextLiteral)) {
@@ -161,7 +161,7 @@ ol.renderer.canvas.VectorRenderer.prototype.renderFeaturesByGeometryType =
  * @param {ol.style.LineLiteral} symbolizer Line symbolizer.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.prototype.renderLineStringFeatures_ =
+ol.renderer.canvas.Vector.prototype.renderLineStringFeatures_ =
     function(features, symbolizer) {
 
   var context = this.context_,
@@ -219,7 +219,7 @@ ol.renderer.canvas.VectorRenderer.prototype.renderLineStringFeatures_ =
  * @return {boolean} true if deferred, false if rendered.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.prototype.renderPointFeatures_ =
+ol.renderer.canvas.Vector.prototype.renderPointFeatures_ =
     function(features, symbolizer) {
 
   var context = this.context_,
@@ -229,10 +229,10 @@ ol.renderer.canvas.VectorRenderer.prototype.renderPointFeatures_ =
   var xOffset = 0;
   var yOffset = 0;
   if (symbolizer instanceof ol.style.ShapeLiteral) {
-    content = ol.renderer.canvas.VectorRenderer.renderShape(symbolizer);
+    content = ol.renderer.canvas.Vector.renderShape(symbolizer);
     alpha = 1;
   } else if (symbolizer instanceof ol.style.IconLiteral) {
-    content = ol.renderer.canvas.VectorRenderer.renderIcon(
+    content = ol.renderer.canvas.Vector.renderIcon(
         symbolizer, this.iconLoadedCallback_);
     alpha = symbolizer.opacity;
     xOffset = symbolizer.xOffset;
@@ -299,7 +299,7 @@ ol.renderer.canvas.VectorRenderer.prototype.renderPointFeatures_ =
  * @param {Array} texts Label text for each feature.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.prototype.renderText_ =
+ol.renderer.canvas.Vector.prototype.renderText_ =
     function(features, text, texts) {
   var context = this.context_,
       feature, vecs, vec;
@@ -319,7 +319,7 @@ ol.renderer.canvas.VectorRenderer.prototype.renderText_ =
     if (feature.renderIntent === ol.layer.VectorLayerRenderIntent.HIDDEN) {
       continue;
     }
-    vecs = ol.renderer.canvas.VectorRenderer.getLabelVectors(
+    vecs = ol.renderer.canvas.Vector.getLabelVectors(
         feature.getGeometry());
     for (var j = 0, jj = vecs.length; j < jj; ++j) {
       vec = vecs[j];
@@ -336,7 +336,7 @@ ol.renderer.canvas.VectorRenderer.prototype.renderText_ =
  * @param {ol.style.PolygonLiteral} symbolizer Polygon symbolizer.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.prototype.renderPolygonFeatures_ =
+ol.renderer.canvas.Vector.prototype.renderPolygonFeatures_ =
     function(features, symbolizer) {
   var context = this.context_,
       strokeColor = symbolizer.strokeColor,
@@ -445,7 +445,7 @@ ol.renderer.canvas.VectorRenderer.prototype.renderPolygonFeatures_ =
  * @return {!HTMLCanvasElement} Canvas element.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.renderCircle_ = function(circle) {
+ol.renderer.canvas.Vector.renderCircle_ = function(circle) {
   var strokeWidth = circle.strokeWidth || 0,
       size = circle.size + (2 * strokeWidth) + 1,
       mid = size / 2,
@@ -491,14 +491,14 @@ ol.renderer.canvas.VectorRenderer.renderCircle_ = function(circle) {
  * @param {ol.geom.Geometry} geometry Geometry.
  * @return {Array.<goog.vec.Vec3.AnyType>} Renderable geometry vectors.
  */
-ol.renderer.canvas.VectorRenderer.getLabelVectors = function(geometry) {
+ol.renderer.canvas.Vector.getLabelVectors = function(geometry) {
   if (geometry instanceof ol.geom.AbstractCollection) {
     var components = geometry.components;
     var numComponents = components.length;
     var result = [];
     for (var i = 0; i < numComponents; ++i) {
       result.push.apply(result,
-          ol.renderer.canvas.VectorRenderer.getLabelVectors(components[i]));
+          ol.renderer.canvas.Vector.getLabelVectors(components[i]));
     }
     return result;
   }
@@ -519,10 +519,10 @@ ol.renderer.canvas.VectorRenderer.getLabelVectors = function(geometry) {
  * @param {ol.style.ShapeLiteral} shape Shape symbolizer.
  * @return {!HTMLCanvasElement} Canvas element.
  */
-ol.renderer.canvas.VectorRenderer.renderShape = function(shape) {
+ol.renderer.canvas.Vector.renderShape = function(shape) {
   var canvas;
   if (shape.type === ol.style.ShapeType.CIRCLE) {
-    canvas = ol.renderer.canvas.VectorRenderer.renderCircle_(shape);
+    canvas = ol.renderer.canvas.Vector.renderCircle_(shape);
   } else {
     throw new Error('Unsupported shape type: ' + shape);
   }
@@ -536,22 +536,22 @@ ol.renderer.canvas.VectorRenderer.renderShape = function(shape) {
  *     the icon is loaded and rendering will work without deferring.
  * @return {HTMLImageElement} image element of null if deferred.
  */
-ol.renderer.canvas.VectorRenderer.renderIcon = function(icon, opt_callback) {
+ol.renderer.canvas.Vector.renderIcon = function(icon, opt_callback) {
   var url = icon.url;
-  var image = ol.renderer.canvas.VectorRenderer.icons_[url];
+  var image = ol.renderer.canvas.Vector.icons_[url];
   var deferred = false;
   if (!goog.isDef(image)) {
     deferred = true;
     image = /** @type {HTMLImageElement} */
         (goog.dom.createElement(goog.dom.TagName.IMG));
     goog.events.listenOnce(image, goog.events.EventType.ERROR,
-        goog.bind(ol.renderer.canvas.VectorRenderer.handleIconError_, null,
+        goog.bind(ol.renderer.canvas.Vector.handleIconError_, null,
             opt_callback),
-        false, ol.renderer.canvas.VectorRenderer.renderIcon);
+        false, ol.renderer.canvas.Vector.renderIcon);
     goog.events.listenOnce(image, goog.events.EventType.LOAD,
-        goog.bind(ol.renderer.canvas.VectorRenderer.handleIconLoad_, null,
+        goog.bind(ol.renderer.canvas.Vector.handleIconLoad_, null,
             opt_callback),
-        false, ol.renderer.canvas.VectorRenderer.renderIcon);
+        false, ol.renderer.canvas.Vector.renderIcon);
     image.setAttribute('src', url);
   } else if (!goog.isNull(image)) {
     var width = icon.width,
@@ -575,7 +575,7 @@ ol.renderer.canvas.VectorRenderer.renderIcon = function(icon, opt_callback) {
  * @type {Object.<string, HTMLImageElement>}
  * @private
  */
-ol.renderer.canvas.VectorRenderer.icons_ = {};
+ol.renderer.canvas.Vector.icons_ = {};
 
 
 /**
@@ -583,12 +583,12 @@ ol.renderer.canvas.VectorRenderer.icons_ = {};
  * @param {Event=} opt_event Event.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.handleIconError_ =
+ol.renderer.canvas.Vector.handleIconError_ =
     function(opt_callback, opt_event) {
   if (goog.isDef(opt_event)) {
     var url = opt_event.target.getAttribute('src');
-    ol.renderer.canvas.VectorRenderer.icons_[url] = null;
-    ol.renderer.canvas.VectorRenderer.handleIconLoad_(opt_callback, opt_event);
+    ol.renderer.canvas.Vector.icons_[url] = null;
+    ol.renderer.canvas.Vector.handleIconLoad_(opt_callback, opt_event);
   }
 };
 
@@ -598,11 +598,11 @@ ol.renderer.canvas.VectorRenderer.handleIconError_ =
  * @param {Event=} opt_event Event.
  * @private
  */
-ol.renderer.canvas.VectorRenderer.handleIconLoad_ =
+ol.renderer.canvas.Vector.handleIconLoad_ =
     function(opt_callback, opt_event) {
   if (goog.isDef(opt_event)) {
     var url = opt_event.target.getAttribute('src');
-    ol.renderer.canvas.VectorRenderer.icons_[url] =
+    ol.renderer.canvas.Vector.icons_[url] =
         /** @type {HTMLImageElement} */ (opt_event.target);
   }
   if (goog.isDef(opt_callback)) {


### PR DESCRIPTION
To be consistent with our naming convention, this one should be
renamed to ol.renderer.canvas.Vector.
