### PR TITLE
No longer group features by geometry type

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorrenderer.js
@@ -114,42 +114,21 @@ ol.renderer.canvas.Vector.prototype.getMaxSymbolSize = function() {
 
 
 /**
- * @param {ol.geom.GeometryType} type Geometry type.
  * @param {Array.<ol.Feature>} features Array of features.
  * @param {ol.style.Literal} symbolizer Symbolizer.
  * @param {Array} data Additional data.
  * @return {boolean} true if deferred, false if rendered.
  */
-ol.renderer.canvas.Vector.prototype.renderFeaturesByGeometryType =
-    function(type, features, symbolizer, data) {
+ol.renderer.canvas.Vector.prototype.renderFeatures =
+    function(features, symbolizer, data) {
   var deferred = false;
-  if (!(symbolizer instanceof ol.style.TextLiteral)) {
-    switch (type) {
-      case ol.geom.GeometryType.POINT:
-      case ol.geom.GeometryType.MULTIPOINT:
-        goog.asserts.assert(symbolizer instanceof ol.style.PointLiteral,
-            'Expected point symbolizer: ' + symbolizer);
-        deferred = this.renderPointFeatures_(
-            features, /** @type {ol.style.PointLiteral} */ (symbolizer));
-        break;
-      case ol.geom.GeometryType.LINESTRING:
-      case ol.geom.GeometryType.MULTILINESTRING:
-        goog.asserts.assert(symbolizer instanceof ol.style.LineLiteral,
-            'Expected line symbolizer: ' + symbolizer);
-        this.renderLineStringFeatures_(
-            features, /** @type {ol.style.LineLiteral} */ (symbolizer));
-        break;
-      case ol.geom.GeometryType.POLYGON:
-      case ol.geom.GeometryType.MULTIPOLYGON:
-        goog.asserts.assert(symbolizer instanceof ol.style.PolygonLiteral,
-            'Expected polygon symbolizer: ' + symbolizer);
-        this.renderPolygonFeatures_(
-            features, /** @type {ol.style.PolygonLiteral} */ (symbolizer));
-        break;
-      default:
-        throw new Error('Rendering not implemented for geometry type: ' + type);
-    }
-  } else {
+  if (symbolizer instanceof ol.style.PointLiteral) {
+    deferred = this.renderPointFeatures_(features, symbolizer);
+  } else if (symbolizer instanceof ol.style.LineLiteral) {
+    this.renderLineStringFeatures_(features, symbolizer);
+  } else if (symbolizer instanceof ol.style.PolygonLiteral) {
+    this.renderPolygonFeatures_(features, symbolizer);
+  } else if (symbolizer instanceof ol.style.TextLiteral) {
     this.renderText_(features, symbolizer, data);
   }
   return deferred;

--- a/test/spec/ol/layer/vectorlayer.test.js
+++ b/test/spec/ol/layer/vectorlayer.test.js
@@ -24,24 +24,6 @@ describe('ol.layer.Vector', function() {
           g: new ol.geom.Point([16.0, 48.0])
         }),
         new ol.Feature({
-          g: new ol.geom.Point([16.1, 48.1])
-        }),
-        new ol.Feature({
-          g: new ol.geom.Point([16.2, 48.2])
-        }),
-        new ol.Feature({
-          g: new ol.geom.Point([16.3, 48.3])
-        }),
-        new ol.Feature({
-          g: new ol.geom.LineString([[16.4, 48.4], [16.5, 48.5]])
-        }),
-        new ol.Feature({
-          g: new ol.geom.LineString([[16.6, 48.6], [16.7, 48.7]])
-        }),
-        new ol.Feature({
-          g: new ol.geom.LineString([[16.8, 48.8], [16.9, 48.9]])
-        }),
-        new ol.Feature({
           g: new ol.geom.LineString([[17.0, 49.0], [17.1, 49.1]])
         })
       ];
@@ -51,47 +33,9 @@ describe('ol.layer.Vector', function() {
       layer.addFeatures(features);
     });
 
-    var geomFilter = ol.expr.parse('geometryType("linestring")');
-    var extentFilter = ol.expr.parse('extent(16, 48, 16.3, 48.3)');
-
-    it('can filter by geometry type using its GeometryType index', function() {
-      sinon.spy(geomFilter, 'evaluate');
-      var lineStrings = layer.featureCache_.getFeaturesObject(geomFilter);
-      expect(geomFilter.evaluate).to.not.be.called();
-      expect(goog.object.getCount(lineStrings)).to.eql(4);
-      expect(goog.object.getValues(lineStrings)).to.contain(features[4]);
-    });
-
-    it('can filter by extent using its RTree', function() {
-      sinon.spy(extentFilter, 'evaluate');
-      var subset = layer.featureCache_.getFeaturesObject(extentFilter);
-      expect(extentFilter.evaluate).to.not.be.called();
-      expect(goog.object.getCount(subset)).to.eql(4);
-      expect(goog.object.getValues(subset)).not.to.contain(features[7]);
-    });
-
-    it('can filter by extent and geometry type using its index', function() {
-      var filter1 = new ol.expr.Logical(
-          ol.expr.LogicalOp.AND, geomFilter, extentFilter);
-      var filter2 = new ol.expr.Logical(
-          ol.expr.LogicalOp.AND, extentFilter, geomFilter);
-      sinon.spy(filter1, 'evaluate');
-      sinon.spy(filter2, 'evaluate');
-      var subset1 = layer.featureCache_.getFeaturesObject(filter1);
-      var subset2 = layer.featureCache_.getFeaturesObject(filter2);
-      expect(filter1.evaluate).to.not.be.called();
-      expect(filter2.evaluate).to.not.be.called();
-      expect(goog.object.getCount(subset1)).to.eql(0);
-      expect(goog.object.getCount(subset2)).to.eql(0);
-    });
-
-    it('can handle query using the filter\'s evaluate function', function() {
-      var filter = new ol.expr.Logical(
-          ol.expr.LogicalOp.OR, geomFilter, extentFilter);
-      sinon.spy(filter, 'evaluate');
-      var subset = layer.featureCache_.getFeaturesObject(filter);
-      expect(filter.evaluate).to.be.called();
-      expect(goog.object.getCount(subset)).to.eql(8);
+    it('returns the features in an object', function() {
+      var featuresObject = layer.featureCache_.getFeaturesObject();
+      expect(goog.object.getCount(featuresObject)).to.eql(features.length);
     });
 
   });
@@ -181,8 +125,6 @@ goog.require('goog.dispose');
 goog.require('goog.object');
 goog.require('ol.Feature');
 goog.require('ol.expr');
-goog.require('ol.expr.Logical');
-goog.require('ol.expr.LogicalOp');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
 goog.require('ol.proj');


### PR DESCRIPTION
With symbolizer literals now being geometry type specific, we no
longer need the overhead to query the RTree separately for each
geometry type and render symbolizer groups by geometry type.

The geometry type index of the FeatureCache is no longer needed.

The filtering functionality of the FeatureCache's
getFeaturesObject method can be removed because it is no longer
used.
