### PR TITLE
isMouseActionButton on IE10

### DIFF
--- a/src/ol/interaction/doubleclickzoominteraction.js
+++ b/src/ol/interaction/doubleclickzoominteraction.js
@@ -45,8 +45,7 @@ ol.interaction.DoubleClickZoom.prototype.handleMapBrowserEvent =
     function(mapBrowserEvent) {
   var stopEvent = false;
   var browserEvent = mapBrowserEvent.browserEvent;
-  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.DBLCLICK &&
-      ol.MapBrowserEvent.isMouseActionButton(browserEvent)) {
+  if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.DBLCLICK) {
     var map = mapBrowserEvent.map;
     var anchor = mapBrowserEvent.getCoordinate();
     var delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -204,7 +204,7 @@ goog.inherits(ol.MapBrowserEventHandler, goog.events.EventTarget);
  * @private
  */
 ol.MapBrowserEventHandler.prototype.click_ = function(browserEvent) {
-  if (!this.dragged_) {
+  if (!this.dragged_ && ol.MapBrowserEvent.isMouseActionButton(browserEvent)) {
     var newEvent;
     var type = browserEvent.type;
     if (this.timestamp_ === 0 || type == goog.events.EventType.DBLCLICK) {


### PR DESCRIPTION
On IE10, `ol.MapBrowserEvent.prototype.isMouseActionButton` always returns true, even if the pointer is a mouse.
