### PR TITLE
Rely on java in path

### DIFF
--- a/build.py
+++ b/build.py
@@ -72,10 +72,7 @@ if sys.platform == 'win32':
 else:
     variables.GIT = 'git'
     variables.GJSLINT = 'gjslint'
-    if sys.platform == 'darwin':
-        variables.JAVA = '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java'
-    else:
-        variables.JAVA = 'java'
+    variables.JAVA = 'java'
     variables.JAR = 'jar'
     variables.JSDOC = 'jsdoc'
     variables.NODE = 'node'


### PR DESCRIPTION
The [developer guide](https://github.com/openlayers/ol3/wiki/Developer-Guide#development-dependencies) suggests Java 7 must be installed and that `java` must be on the path.  I can confirm that with the following:

``` bash
$ java -version
java version "1.7.0_25"
Java(TM) SE Runtime Environment (build 1.7.0_25-b15)
Java HotSpot(TM) 64-Bit Server VM (build 23.25-b01, mixed mode)
```

Then I run `build.py` with the default target and get the this:

```
$ ./build.py 
2013-10-08 13:42:39,780 build/plovr-81ed862.jar: mkdir -p build
2013-10-08 13:42:39,780 build/plovr-81ed862.jar: downloading 'build/plovr-81ed862.jar'
2013-10-08 13:42:51,780 build/plovr-81ed862.jar: downloaded 'build/plovr-81ed862.jar'
2013-10-08 13:42:51,792 build/src/external/externs/types.js: mkdir -p build/src/external/externs
2013-10-08 13:42:51,793 build/src/external/externs/types.js: python bin/generate-exports.py --externs src/objectliterals.jsdoc
2013-10-08 13:42:51,892 build/src/external/src/exports.js: mkdir -p build/src/external/src
2013-10-08 13:42:51,893 build/src/external/src/exports.js: python bin/generate-exports.py --exports src/objectliterals.jsdoc src/ol/animation.exports src/ol/attribution.exports src/ol/collection.exports src/ol/coordinate.exports src/ol/deviceorientation.exports src/ol/easing.exports src/ol/expr.exports src/ol/extent.exports src/ol/feature.exports src/ol/geolocation.exports src/ol/geom.exports src/ol/imagetile.exports src/ol/kinetic.exports src/ol/map.exports src/ol/mapbrowserevent.exports src/ol/object.exports src/ol/ol.exports src/ol/overlay.exports src/ol/proj.exports src/ol/style.exports src/ol/tile.exports src/ol/tilecoord.exports src/ol/view2d.exports src/ol/control/attributioncontrol.exports src/ol/control/control.exports src/ol/control/controldefaults.exports src/ol/control/fullscreencontrol.exports src/ol/control/logocontrol.exports src/ol/control/mousepositioncontrol.exports src/ol/control/scalelinecontrol.exports src/ol/control/zoomcontrol.exports src/ol/control/zoomslidercontrol.exports src/ol/control/zoomtoextentcontrol.exports src/ol/dom/input.exports src/ol/geom2/linestringcollection.exports src/ol/geom2/pointcollection.exports src/ol/interaction/condition.exports src/ol/interaction/doubleclickzoom.exports src/ol/interaction/dragpan.exports src/ol/interaction/dragrotate.exports src/ol/interaction/dragrotateandzoom.exports src/ol/interaction/dragzoom.exports src/ol/interaction/interactiondefaults.exports src/ol/interaction/keyboardpan.exports src/ol/interaction/keyboardzoom.exports src/ol/interaction/mousewheelzoom.exports src/ol/interaction/selectinteraction.exports src/ol/interaction/touchpan.exports src/ol/interaction/touchrotate.exports src/ol/interaction/touchzoom.exports src/ol/layer/imagelayer.exports src/ol/layer/layer.exports src/ol/layer/layergroup.exports src/ol/layer/tilelayer.exports src/ol/layer/vectorlayer.exports src/ol/layer/vectorlayer2.exports src/ol/parser/geojsonparser.exports src/ol/parser/gpxparser.exports src/ol/parser/kmlparser.exports src/ol/parser/topojsonparser.exports src/ol/parser/wktparser.exports src/ol/parser/ogc/gmlparser.exports src/ol/parser/ogc/wmscapabilitiesparser.exports src/ol/parser/ogc/wmtscapabilitiesparser.exports src/ol/renderer/canvas/canvasmaprenderer.exports src/ol/source/bingmapssource.exports src/ol/source/debugtilesource.exports src/ol/source/imagestaticsource.exports src/ol/source/imagewmssource.exports src/ol/source/mapquestsource.exports src/ol/source/osmsource.exports src/ol/source/source.exports src/ol/source/stamensource.exports src/ol/source/tilejsonsource.exports src/ol/source/tilesource.exports src/ol/source/tilewmssource.exports src/ol/source/vectorsource.exports src/ol/source/vectorsource2.exports src/ol/source/wmssource.exports src/ol/source/wmtssource.exports src/ol/source/xyzsource.exports src/ol/tilegrid/tilegrid.exports src/ol/tilegrid/wmtstilegrid.exports src/ol/tilegrid/xyztilegrid.exports src/ol/webgl/webgl.exports
2013-10-08 13:42:51,994 build/src/external/src/types.js: python bin/generate-exports.py --typedef src/objectliterals.jsdoc
2013-10-08 13:42:52,085 build/ol.js: /Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java -jar build/plovr-81ed862.jar build buildcfg/ol.json
Traceback (most recent call last):
  File "./build.py", line 818, in <module>
    main()
  File "/Users/tschaub/projects/ol3/pake.py", line 339, in main
    target.build(dry_run=options.dry_run)
  File "/Users/tschaub/projects/ol3/pake.py", line 92, in build
    timestamp = max(timestamp, target.build(dry_run=dry_run))
  File "/Users/tschaub/projects/ol3/pake.py", line 92, in build
    timestamp = max(timestamp, target.build(dry_run=dry_run))
  File "/Users/tschaub/projects/ol3/pake.py", line 92, in build
    timestamp = max(timestamp, target.build(dry_run=dry_run))
  File "/Users/tschaub/projects/ol3/pake.py", line 107, in build
    self.action(self)
  File "./build.py", line 193, in build_ol_js
    t.output('%(JAVA)s', '-jar', PLOVR_JAR, 'build', 'buildcfg/ol.json')
  File "/Users/tschaub/projects/ol3/pake.py", line 190, in output
    output = check_output(args, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 537, in check_output
    process = Popen(stdout=PIPE, *popenargs, **kwargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1228, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
