### PR TITLE
Stop base.js from trying to load deps.js

### DIFF
--- a/buildcfg/ol-whitespace.json
+++ b/buildcfg/ol-whitespace.json
@@ -33,10 +33,10 @@
 
   "mode": "WHITESPACE",
 
-  // Note: we can't have a (function(){%output%})() output wrapper with
-  // WHITESPACE and SIMPLE modes. See this link for explanations:
-  // https://groups.google.com/forum/#!topic/plovr/gQyZEa2NpsU
-  "output-wrapper": "%output%",
+  "output-wrapper": [
+    "var CLOSURE_NO_DEPS = true;\n",
+    "%output%"
+  ],
 
   "pretty-print": true
 }


### PR DESCRIPTION
The changes in #673 make it so `goog/base.js` doesn't try to load `deps.js` only when using the loader script in the examples directory.  Instead, `deps.js` should never be loaded when using the whitespace build.  To accomplish this, `CLOSURE_NO_DEPS` should be set within the build itself (see also #667).
