### PR TITLE
Rename offset* attributes to delta*

### DIFF
--- a/src/ol/interaction/draginteraction.js
+++ b/src/ol/interaction/draginteraction.js
@@ -39,12 +39,12 @@ ol.interaction.Drag = function() {
   /**
    * @type {number}
    */
-  this.offsetX = 0;
+  this.deltaX = 0;
 
   /**
    * @type {number}
    */
-  this.offsetY = 0;
+  this.deltaY = 0;
 
   /**
    * @type {ol.Coordinate}


### PR DESCRIPTION
`deltaX` and `deltaY` are used in the class, not `offset*`
