### PR TITLE
Only call lineTo if we are in a new pixel

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorrenderer.js
@@ -364,7 +364,11 @@ ol.renderer.canvas.Vector.prototype.renderPolygonFeatures_ =
       fillOpacity = symbolizer.fillOpacity,
       globalAlpha,
       i, ii, geometry, components, j, jj, poly,
-      rings, numRings, ring, k, kk, vec, feature;
+      rings, numRings, coordinates, coordinate, k, kk, feature;
+
+  var vec = [NaN, NaN, 0];
+  var pixel = [NaN, NaN];
+  var lastPixel = [NaN, NaN];
 
   if (strokeColor) {
     context.strokeStyle = strokeColor;
@@ -405,14 +409,24 @@ ol.renderer.canvas.Vector.prototype.renderPolygonFeatures_ =
       numRings = rings.length;
       if (numRings > 0) {
         // TODO: scenario 4
-        ring = rings[0];
-        for (k = 0, kk = ring.getCount(); k < kk; ++k) {
-          vec = [ring.get(k, 0), ring.get(k, 1), 0];
+        coordinates = rings[0].getCoordinates();
+        for (k = 0, kk = coordinates.length; k < kk; ++k) {
+          coordinate = coordinates[k];
+          vec[0] = coordinate[0];
+          vec[1] = coordinate[1];
           goog.vec.Mat4.multVec3(this.transform_, vec, vec);
           if (k === 0) {
+            lastPixel[0] = NaN;
+            lastPixel[1] = NaN;
             context.moveTo(vec[0], vec[1]);
           } else {
-            context.lineTo(vec[0], vec[1]);
+            pixel[0] = Math.round(vec[0]);
+            pixel[1] = Math.round(vec[1]);
+            if (pixel[0] !== lastPixel[0] || pixel[1] !== lastPixel[1]) {
+              context.lineTo(vec[0], vec[1]);
+              lastPixel[0] = pixel[0];
+              lastPixel[1] = pixel[1];
+            }
           }
         }
         if (fillColor && strokeColor) {


### PR DESCRIPTION
Rendering performance degrades as the context `lineWidth` increases when calling `lineTo` many times for the same pixel coordinate.  This appears to be a widespread performance issue and is very clearly improved by only calling `lineTo` when in a new pixel coordinate.
