### PR TITLE
Use integers when positioning on the target canvas

### DIFF
--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -143,7 +143,7 @@ ol.renderer.canvas.Map.prototype.renderFrame = function(frameState) {
         var dw = image.width * goog.vec.Mat4.getElement(transform, 0, 0);
         var dh = image.height * goog.vec.Mat4.getElement(transform, 1, 1);
         context.drawImage(image, 0, 0, image.width, image.height,
-            dx, dy, dw, dh);
+            Math.round(dx), Math.round(dy), Math.round(dw), Math.round(dh));
       } else {
         context.setTransform(
             goog.vec.Mat4.getElement(transform, 0, 0),


### PR DESCRIPTION
This avoids blurred images after view center changes (dx, dy) and at fractional zoom levels (dw, dh).

Before:
![before](https://f.cloud.github.com/assets/211514/1342068/8c180edc-365a-11e3-87bf-6fc028ff7bea.png)

After:
![after](https://f.cloud.github.com/assets/211514/1342075/c12ad352-365a-11e3-81fa-e2f115569aa0.png)
