### PR TITLE
Fix a bug when frameState is null which occurs in offline mobile devices

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -733,14 +733,15 @@ ol.Map.prototype.handlePostRender = function() {
   if (!tileQueue.isEmpty()) {
     var maxTotalLoading = 16;
     var maxNewLoads = maxTotalLoading;
+    var tileSourceCount = 0;
     if (!goog.isNull(frameState)) {
       var hints = frameState.viewHints;
       if (hints[ol.ViewHint.ANIMATING] || hints[ol.ViewHint.INTERACTING]) {
         maxTotalLoading = 8;
         maxNewLoads = 2;
       }
+      tileSourceCount = goog.object.getCount(frameState.wantedTiles);
     }
-    var tileSourceCount = goog.object.getCount(frameState.wantedTiles);
     maxTotalLoading *= tileSourceCount;
     maxNewLoads *= tileSourceCount;
     if (tileQueue.getTilesLoading() < maxTotalLoading) {


### PR DESCRIPTION
While testing OL3 with an ApplicationCache manifest in offline mode, I found that `frameState` can be `null` in  `Map::handlePostRender`.  There is already an `if` for this but one line that relies on `frameState` being valid is outside this code branch.  With this change, there are no further javascript errors on iOS in offline/airplane mode.
