### PR TITLE
Make sure that ol.MapBrowserEvent#getPixel() always returns a valid value

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -446,8 +446,22 @@ ol.Map.prototype.getEventCoordinate = function(event) {
  * @return {ol.Pixel} Pixel.
  */
 ol.Map.prototype.getEventPixel = function(event) {
-  var eventPosition = goog.style.getRelativePosition(event, this.viewport_);
-  return [eventPosition.x, eventPosition.y];
+  // goog.style.getRelativePosition is based on event.targetTouches,
+  // but touchend and touchcancel events have no targetTouches when
+  // the last finger is removed from the screen.
+  // So we ourselves compute the position of touch events.
+  // See https://code.google.com/p/closure-library/issues/detail?id=588
+  if (goog.isDef(event.changedTouches)) {
+    var touch = event.changedTouches.item(0);
+    var viewportPosition = goog.style.getClientPosition(this.viewport_);
+    return [
+      touch.clientX - viewportPosition.x,
+      touch.clientY - viewportPosition.y
+    ];
+  } else {
+    var eventPosition = goog.style.getRelativePosition(event, this.viewport_);
+    return [eventPosition.x, eventPosition.y];
+  }
 };
 
 


### PR DESCRIPTION
Because of a bug in closure-library [1], `ol.MapBrowserEvent#getPixel()` crash when the event type is `touchend` or `touchcancel`. This PR adds a workaround by computing the `pixel_` attribute in the constructor.

[1] https://code.google.com/p/closure-library/issues/detail?id=588
