### PR TITLE
Rename ol.interaction.condition

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -289,7 +289,7 @@
 /**
  * @typedef {Object} ol.interaction.DragPanOptions
  * @property {ol.Kinetic|undefined} kinetic Kinetic inertia to apply to the pan.
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (i.e. Shift key) that determines if the interaction is active
  *     or not, default is no modifiers.
  * @todo stability experimental
@@ -297,7 +297,7 @@
 
 /**
  * @typedef {Object} ol.interaction.DragRotateOptions
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (i.e. Shift key) that determines if the interaction is active
  *     or not, default is both shift and alt keys.
  * @todo stability experimental
@@ -305,7 +305,7 @@
 
 /**
  * @typedef {Object} ol.interaction.DragRotateAndZoomOptions
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (i.e. Shift key) that determines if the interaction is active
  *     or not, default is shify key.
  * @todo stability experimental
@@ -313,7 +313,7 @@
 
 /**
  * @typedef {Object} ol.interaction.DragZoomOptions
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (i.e. Shift key) that determines if the interaction is active
  *     or not, default is shift key.
  * @todo stability experimental
@@ -344,7 +344,7 @@
 
 /**
  * @typedef {Object} ol.interaction.KeyboardPanOptions
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (i.e. Shift key) that determines if the interaction is active
  *     or not, default is no modifiers.
  * @property {number|undefined} pixelDelta Pixel The amount to pan on each key
@@ -355,7 +355,7 @@
 /**
  * @typedef {Object} ol.interaction.KeyboardZoomOptions
  * @property {number|undefined} duration Animation duration in milliseconds. Default is `100`.
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (i.e. Shift key) that determines if the interaction is active
  *     or not, default is no modifiers.
  * @property {number|undefined} delta The amount to zoom on each key press.
@@ -370,11 +370,11 @@
 
 /**
  * @typedef {Object} ol.interaction.SelectOptions
- * @property {ol.interaction.ConditionType|undefined} addCondition A conditional
+ * @property {ol.events.ConditionType|undefined} addCondition A conditional
  *     modifier (e.g. shift key) that determines if the selection is added to
  *     the current selection. By default, a shift-click adds to the current
  *     selection.
- * @property {ol.interaction.ConditionType|undefined} condition A conditional
+ * @property {ol.events.ConditionType|undefined} condition A conditional
  *     modifier (e.g. shift key) that determines if the interaction is active
  *     (i.e. selection occurs) or not. By default, a click with no modifier keys
  *     toggles the selection.

--- a/src/ol/control/dragboxcontrol.js
+++ b/src/ol/control/dragboxcontrol.js
@@ -11,13 +11,13 @@ goog.require('ol.MapBrowserEvent');
 goog.require('ol.MapBrowserEvent.EventType');
 goog.require('ol.Pixel');
 goog.require('ol.control.Control');
-goog.require('ol.interaction.ConditionType');
-goog.require('ol.interaction.condition');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 
 
 /**
  * @typedef {{startCoordinate: ol.Coordinate,
- *            condition: (ol.interaction.ConditionType|undefined)}}
+ *            condition: (ol.events.ConditionType|undefined)}}
  */
 ol.control.DragBoxOptions;
 
@@ -35,10 +35,10 @@ ol.control.DragBox = function(options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.always;
+      options.condition : ol.events.condition.always;
 
   /**
    * @type {ol.Pixel|undefined}

--- a/src/ol/events/condition.exports
+++ b/src/ol/events/condition.exports
@@ -1,0 +1,7 @@
+@exportSymbol ol.events.condition.altKeyOnly
+@exportSymbol ol.events.condition.altShiftKeysOnly
+@exportSymbol ol.events.condition.always
+@exportSymbol ol.events.condition.noModifierKeys
+@exportSymbol ol.events.condition.platformModifierKeyOnly
+@exportSymbol ol.events.condition.shiftKeyOnly
+@exportSymbol ol.events.condition.targetNotEditable

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -1,5 +1,5 @@
-goog.provide('ol.interaction.ConditionType');
-goog.provide('ol.interaction.condition');
+goog.provide('ol.events.ConditionType');
+goog.provide('ol.events.condition');
 
 goog.require('goog.dom.TagName');
 goog.require('goog.events.EventType');
@@ -9,7 +9,7 @@ goog.require('goog.functions');
 /**
  * @typedef {function(ol.MapBrowserEvent): boolean}
  */
-ol.interaction.ConditionType;
+ol.events.ConditionType;
 
 
 /**
@@ -17,7 +17,7 @@ ol.interaction.ConditionType;
  * @return {boolean} True if only the alt key is pressed.
  * @todo stability experimental
  */
-ol.interaction.condition.altKeyOnly = function(mapBrowserEvent) {
+ol.events.condition.altKeyOnly = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   return (
       browserEvent.altKey &&
@@ -31,7 +31,7 @@ ol.interaction.condition.altKeyOnly = function(mapBrowserEvent) {
  * @return {boolean} True if only the alt and shift keys are pressed.
  * @todo stability experimental
  */
-ol.interaction.condition.altShiftKeysOnly = function(mapBrowserEvent) {
+ol.events.condition.altShiftKeysOnly = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   return (
       browserEvent.altKey &&
@@ -46,7 +46,7 @@ ol.interaction.condition.altShiftKeysOnly = function(mapBrowserEvent) {
  * @return {boolean} True.
  * @todo stability experimental
  */
-ol.interaction.condition.always = goog.functions.TRUE;
+ol.events.condition.always = goog.functions.TRUE;
 
 
 /**
@@ -54,7 +54,7 @@ ol.interaction.condition.always = goog.functions.TRUE;
  * @return {boolean} True if the event is a click event.
  * @todo stability experimental
  */
-ol.interaction.condition.clickOnly = function(mapBrowserEvent) {
+ol.events.condition.clickOnly = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   return browserEvent.type == goog.events.EventType.CLICK;
 };
@@ -65,7 +65,7 @@ ol.interaction.condition.clickOnly = function(mapBrowserEvent) {
  * @return {boolean} True only if there no modifier keys are pressed.
  * @todo stability experimental
  */
-ol.interaction.condition.noModifierKeys = function(mapBrowserEvent) {
+ol.events.condition.noModifierKeys = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   return (
       !browserEvent.altKey &&
@@ -79,7 +79,7 @@ ol.interaction.condition.noModifierKeys = function(mapBrowserEvent) {
  * @return {boolean} True if only the platform modifier key is pressed.
  * @todo stability experimental
  */
-ol.interaction.condition.platformModifierKeyOnly = function(mapBrowserEvent) {
+ol.events.condition.platformModifierKeyOnly = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   return (
       !browserEvent.altKey &&
@@ -93,7 +93,7 @@ ol.interaction.condition.platformModifierKeyOnly = function(mapBrowserEvent) {
  * @return {boolean} True if only the shift key is pressed.
  * @todo stability experimental
  */
-ol.interaction.condition.shiftKeyOnly = function(mapBrowserEvent) {
+ol.events.condition.shiftKeyOnly = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   return (
       !browserEvent.altKey &&
@@ -107,7 +107,7 @@ ol.interaction.condition.shiftKeyOnly = function(mapBrowserEvent) {
  * @return {boolean} True only if the target element is not editable.
  * @todo stability experimental
  */
-ol.interaction.condition.targetNotEditable = function(mapBrowserEvent) {
+ol.events.condition.targetNotEditable = function(mapBrowserEvent) {
   var browserEvent = mapBrowserEvent.browserEvent;
   var tagName = browserEvent.target.tagName;
   return (

--- a/src/ol/events/condition.jsdoc
+++ b/src/ol/events/condition.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace ol.events.condition
+ */

--- a/src/ol/interaction/condition.exports
+++ b/src/ol/interaction/condition.exports
@@ -1,7 +1,0 @@
-@exportSymbol ol.interaction.condition.altKeyOnly
-@exportSymbol ol.interaction.condition.altShiftKeysOnly
-@exportSymbol ol.interaction.condition.always
-@exportSymbol ol.interaction.condition.noModifierKeys
-@exportSymbol ol.interaction.condition.platformModifierKeyOnly
-@exportSymbol ol.interaction.condition.shiftKeyOnly
-@exportSymbol ol.interaction.condition.targetNotEditable

--- a/src/ol/interaction/condition.jsdoc
+++ b/src/ol/interaction/condition.jsdoc
@@ -1,3 +1,0 @@
-/**
- * @namespace ol.interaction.condition
- */

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -7,9 +7,9 @@ goog.require('ol.Kinetic');
 goog.require('ol.PreRenderFunction');
 goog.require('ol.View2D');
 goog.require('ol.coordinate');
-goog.require('ol.interaction.ConditionType');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.Drag');
-goog.require('ol.interaction.condition');
 
 
 
@@ -28,10 +28,10 @@ ol.interaction.DragPan = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.noModifierKeys;
+      options.condition : ol.events.condition.noModifierKeys;
 
   /**
    * @private

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -4,10 +4,10 @@ goog.provide('ol.interaction.DragRotateAndZoom');
 
 goog.require('goog.asserts');
 goog.require('goog.math.Vec2');
-goog.require('ol.interaction.ConditionType');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.Drag');
 goog.require('ol.interaction.Interaction');
-goog.require('ol.interaction.condition');
 
 
 /**
@@ -36,10 +36,10 @@ ol.interaction.DragRotateAndZoom = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.shiftKeyOnly;
+      options.condition : ol.events.condition.shiftKeyOnly;
 
   /**
    * @private

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -1,10 +1,10 @@
 goog.provide('ol.interaction.DragRotate');
 
 goog.require('goog.asserts');
-goog.require('ol.interaction.ConditionType');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.Drag');
 goog.require('ol.interaction.Interaction');
-goog.require('ol.interaction.condition');
 
 
 /**
@@ -16,7 +16,7 @@ ol.interaction.DRAGROTATE_ANIMATION_DURATION = 250;
 
 /**
  * Allows the user to rotate the map by clicking and dragging on the map,
- * normally combined with an {@link ol.interaction.condition} that limits
+ * normally combined with an {@link ol.events.condition} that limits
  * it to when the alt and shift keys are held down.
  * @constructor
  * @extends {ol.interaction.Drag}
@@ -30,10 +30,10 @@ ol.interaction.DragRotate = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.altShiftKeysOnly;
+      options.condition : ol.events.condition.altShiftKeysOnly;
 
   /**
    * @private

--- a/src/ol/interaction/dragzoominteraction.js
+++ b/src/ol/interaction/dragzoominteraction.js
@@ -7,10 +7,10 @@ goog.require('goog.asserts');
 goog.require('ol.Size');
 goog.require('ol.View2D');
 goog.require('ol.control.DragBox');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.extent');
-goog.require('ol.interaction.ConditionType');
 goog.require('ol.interaction.Drag');
-goog.require('ol.interaction.condition');
 
 
 /**
@@ -30,7 +30,7 @@ ol.SHIFT_DRAG_ZOOM_HYSTERESIS_PIXELS_SQUARED =
 
 /**
  * Allows the user to zoom the map by clicking and dragging on the map,
- * normally combined with an {@link ol.interaction.condition} that limits
+ * normally combined with an {@link ol.events.condition} that limits
  * it to when the shift key is held down.
  * @constructor
  * @extends {ol.interaction.Drag}
@@ -45,10 +45,10 @@ ol.interaction.DragZoom = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.shiftKeyOnly;
+      options.condition : ol.events.condition.shiftKeyOnly;
 
   /**
    * @type {ol.control.DragBox}

--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -8,9 +8,9 @@ goog.require('goog.events.KeyHandler.EventType');
 goog.require('goog.functions');
 goog.require('ol.View2D');
 goog.require('ol.coordinate');
-goog.require('ol.interaction.ConditionType');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.Interaction');
-goog.require('ol.interaction.condition');
 
 
 /**
@@ -35,11 +35,11 @@ ol.interaction.KeyboardPan = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ? options.condition :
-      goog.functions.and(ol.interaction.condition.noModifierKeys,
-          ol.interaction.condition.targetNotEditable);
+      goog.functions.and(ol.events.condition.noModifierKeys,
+          ol.events.condition.targetNotEditable);
 
   /**
    * @private

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -4,9 +4,9 @@ goog.provide('ol.interaction.KeyboardZoom');
 
 goog.require('goog.asserts');
 goog.require('goog.events.KeyHandler.EventType');
-goog.require('ol.interaction.ConditionType');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.Interaction');
-goog.require('ol.interaction.condition');
 
 
 
@@ -25,10 +25,10 @@ ol.interaction.KeyboardZoom = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ? options.condition :
-          ol.interaction.condition.targetNotEditable;
+          ol.events.condition.targetNotEditable;
 
   /**
    * @private

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -3,9 +3,9 @@ goog.provide('ol.interaction.Select');
 goog.require('goog.array');
 goog.require('goog.object');
 goog.require('ol.Feature');
-goog.require('ol.interaction.ConditionType');
+goog.require('ol.events.ConditionType');
+goog.require('ol.events.condition');
 goog.require('ol.interaction.Interaction');
-goog.require('ol.interaction.condition');
 goog.require('ol.layer.Vector');
 goog.require('ol.layer.VectorLayerRenderIntent');
 goog.require('ol.source.Vector');
@@ -24,17 +24,17 @@ ol.interaction.Select = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.condition_ = goog.isDef(options.condition) ?
-      options.condition : ol.interaction.condition.clickOnly;
+      options.condition : ol.events.condition.clickOnly;
 
   /**
    * @private
-   * @type {ol.interaction.ConditionType}
+   * @type {ol.events.ConditionType}
    */
   this.addCondition_ = goog.isDef(options.addCondition) ?
-      options.addCondition : ol.interaction.condition.shiftKeyOnly;
+      options.addCondition : ol.events.condition.shiftKeyOnly;
 
   /**
    * Mapping between original features and cloned features on selection layers.


### PR DESCRIPTION
`ol.interaction.condition` functions are only used by the interactions but are not really related to the interactions.

The namespace should be renamed to something like `ol.events.condition` or  `ol.events.function`
