### PR TITLE
Logo given in options not being displayed

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -655,6 +655,7 @@
  * @property {string|null|undefined} crossOrigin crossOrigin setting for image
  *     requests.
  * @property {ol.Extent|undefined} extent Extent.
+ * @property {string|undefined} logo Logo.
  * @property {ol.tilegrid.WMTS} tileGrid Tile grid.
  * @property {ol.proj.ProjectionLike} projection Projection.
  * @property {ol.source.WMTSRequestEncoding|undefined} requestEncoding Request

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -177,6 +177,7 @@ ol.source.WMTS = function(options) {
     attributions: options.attributions,
     crossOrigin: options.crossOrigin,
     extent: options.extent,
+    logo: options.logo,
     projection: options.projection,
     tileGrid: tileGrid,
     tileLoadFunction: options.tileLoadFunction,


### PR DESCRIPTION
See for example the wmts-ign example, which is supposed to display the IGN logo but doesn't.

Not immediately obvious to me why this isn't working; using setLogo() works fine.

While I'm on the subject, logo is not appearing in the options api docs either.
