### PR TITLE
IE 10 Click on popup

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -236,10 +236,12 @@ ol.Map = function(options) {
   goog.events.listen(this.overlayContainerStopEvent_, [
     goog.events.EventType.CLICK,
     goog.events.EventType.DBLCLICK,
-    ol.BrowserFeature.HAS_TOUCH ?
-        goog.events.EventType.TOUCHSTART : goog.events.EventType.MOUSEDOWN,
-    ol.BrowserFeature.HAS_TOUCH ?
-        goog.events.EventType.TOUCHEND : goog.events.EventType.MOUSEUP
+    goog.events.EventType.MOUSEDOWN,
+    goog.events.EventType.MOUSEUP,
+    goog.events.EventType.TOUCHSTART,
+    goog.events.EventType.TOUCHEND,
+    goog.events.EventType.MSPOINTERDOWN,
+    goog.events.EventType.MSPOINTERUP
   ], goog.events.Event.stopPropagation);
   goog.dom.appendChild(this.viewport_, this.overlayContainerStopEvent_);
 


### PR DESCRIPTION
Hi 

Using the example
http://ol3js.org/en/master/examples/popup.html

In IE10 when you click inside the popup a map click event is fired and another popup show 

In Chrome/Firefox the map click event is not fired

Ideally the click event should not propagate to the map in IE

Thanks,
J
