### PR TITLE
Make it possible to synchronize map navigation

### DIFF
--- a/examples/synchronized-maps.html
+++ b/examples/synchronized-maps.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>Synchronized Maps</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>          
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span4">
+          <h4>Map One</h4>
+          <div id="map1" class="map"></div>
+        </div>
+        <div class="span4">
+          <h4>Map Two</h4>
+          <div id="map2" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">Synchronized maps example</h4>
+          <p id="shortdesc">Two maps with different layers and synchronized navigation.</p>
+          <div id="docs">
+            <p>See the <a href="synchronized-maps.js" target="_blank">synchronized-maps.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">synchronized, sync, map</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="loader.js?id=synchronized-maps" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/synchronized-maps.js
+++ b/examples/synchronized-maps.js
@@ -1,0 +1,62 @@
+goog.require('ol.Map');
+goog.require('ol.View2D');
+goog.require('ol.ViewHint');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.MapQuestOSM');
+goog.require('ol.source.MapQuestOpenAerial');
+
+
+var map1 = new ol.Map({
+  target: 'map1',
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.MapQuestOpenAerial()
+    })
+  ],
+  view: new ol.View2D({
+    center: [0, 0],
+    zoom: 1
+  })
+});
+
+var map2 = new ol.Map({
+  target: 'map2',
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.MapQuestOSM()
+    })
+  ],
+  view: new ol.View2D({
+    center: [0, 0],
+    zoom: 1
+  })
+});
+
+
+function matchViewState(map, frame) {
+  var hints = frame.viewHints;
+  if (hints[ol.ViewHint.ANIMATING] || hints[ol.ViewHint.INTERACTING]) {
+    var view = map.getView();
+    var state = frame.view2DState;
+    map.withFrozenRendering(function() {
+      var center = view.getCenter();
+      if (center[0] !== state.center[0] || center[1] !== state.center[1]) {
+        view.setCenter(state.center);
+      }
+      if (view.getResolution() !== state.resolution) {
+        view.setResolution(state.resolution);
+      }
+      if (view.getRotation() !== state.rotation) {
+        view.setRotation(state.rotation);
+      }
+    });
+  }
+}
+
+map1.on('postrender', function(event) {
+  matchViewState(map2, event.frameState);
+});
+
+map2.on('postrender', function(event) {
+  matchViewState(map1, event.frameState);
+});


### PR DESCRIPTION
As the current [side-by-side example](http://ol3js.org/en/master/examples/side-by-side.html) demonstrates, using one view with two maps doesn't work for animated zoom/pan/rotate.

We should be able to provide a way for applications to have more than one map that share the rendered view state.  As the examples below demonstrate, this is possible, but it requires the use of non-exported code and some awkwardness.

This pull request is meant to serve as a discussion point for making map synchronization easier.
