### PR TITLE
exports needed for feature & vectorlayer by mapstraction

### DIFF
--- a/src/ol/feature.exports
+++ b/src/ol/feature.exports
@@ -4,3 +4,4 @@
 @exportProperty ol.Feature.prototype.getGeometry
 @exportProperty ol.Feature.prototype.set
 @exportProperty ol.Feature.prototype.setGeometry
+@exportProperty ol.Feature.prototype.setSymbolizers

--- a/src/ol/layer/vectorlayer.exports
+++ b/src/ol/layer/vectorlayer.exports
@@ -1,1 +1,4 @@
 @exportClass ol.layer.Vector ol.layer.VectorLayerOptions
+@exportProperty ol.layer.Vector.prototype.addFeatures
+@exportProperty ol.layer.Vector.prototype.removeFeatures
+@exportProperty ol.layer.Vector.prototype.clear


### PR DESCRIPTION
Please can we have these 4 exports incorporated so that mapstraction can work with the compiled ol.js file. The latest mxn ol3 implementation is currently here: https://github.com/mapstraction/mxn/blob/release-3.0-tile-layers/source/mxn.openlayersv3.core.js

If you have any suggestions to improve it that would be good too!
