### PR TITLE
removed the symbolizer set to null

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -51,7 +51,7 @@ ol.Feature = function(opt_values) {
    * @type {Array.<ol.style.Symbolizer>}
    * @private
    */
-  this.symbolizers_ = null;
+  this.symbolizers_;
 
 };
 goog.inherits(ol.Feature, ol.Object);


### PR DESCRIPTION
Removed the symbolizer set to null, so that we can pass in symbolizers in the options when instantiating a feature.
