### PR TITLE
Add jsdoc support for indicating API stability with inline documentation

### DIFF
--- a/apidoc/conf.json
+++ b/apidoc/conf.json
@@ -13,10 +13,14 @@
     "plugins": [
         "plugins/markdown",
         "apidoc/plugins/inheritdoc",
-        "apidoc/plugins/exports"
+        "apidoc/plugins/exports",
+        "apidoc/plugins/stability"
     ],
     "markdown": {
         "parser": "gfm"
+    },
+    "stability": {
+      "levels": ["deprecated","experimental","unstable","stable","frozen","locked"]
     },
     "templates": {
         "cleverLinks": false,

--- a/apidoc/plugins/stability.js
+++ b/apidoc/plugins/stability.js
@@ -1,0 +1,20 @@
+var conf = env.conf.stability;
+var defaultLevels = ["deprecated","experimental","unstable","stable","frozen","locked"];
+var levels = conf.levels || defaultLevels;
+var util = require('util');
+exports.defineTags = function(dictionary) {
+  dictionary.defineTag('stability', {
+    mustHaveValue: true,
+    canHaveType: false,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      var level = tag.text;
+      if (levels.indexOf(level) >=0) {
+        doclet.stability = level;
+      } else {
+        var errorText = util.format('Invalid stability level (%s) in %s line %s', tag.text, doclet.meta.filename, doclet.meta.lineno);
+        require('jsdoc/util/error').handle( new Error(errorText) );
+      }
+    }
+  })
+};

--- a/apidoc/template/tmpl/members.tmpl
+++ b/apidoc/template/tmpl/members.tmpl
@@ -2,6 +2,8 @@
 <dt class="<?js= data.access ?>">
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + name + data.signature ?></h4>
     
+    <?js= this.partial('stability.tmpl', data) ?>
+
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>

--- a/apidoc/template/tmpl/method.tmpl
+++ b/apidoc/template/tmpl/method.tmpl
@@ -5,6 +5,8 @@ var self = this;
 <dt>
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind == 'class'? 'new ':'') + name + data.signature ?></h4>
     
+    <?js= this.partial('stability.tmpl', data) ?>
+
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>

--- a/apidoc/template/tmpl/stability.tmpl
+++ b/apidoc/template/tmpl/stability.tmpl
@@ -1,0 +1,9 @@
+<?js
+var data = obj;
+var self = this;
+
+if (data.stability) { ?>
+<div class="stability stability-<?js= stability ?>">Stability: <?js= data.stability ?></div>
+<?js } else { ?>
+<div class="stability">Stability: not documented</div>
+<?js } ?>

--- a/resources/layout.css
+++ b/resources/layout.css
@@ -27,3 +27,40 @@ body, h1, h2, h3, h4, p, li, td, th {
   padding: 5px;
 }
 
+.stability {
+  padding: 8px 35px 8px 14px;
+  margin-bottom: 20px;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+  color: #333;
+  background-color: #fcfcfc;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+}
+
+.stability-deprecated {
+  color: #b94a48;
+  background-color: #f2dede;
+  border-color: #eed3d7;
+}
+
+.stability-experimental {
+  color: #c09853;
+  background-color: #fcf8e3;
+  border-color: #fbeed5;
+}
+
+.stability-unstable {
+  color: #3a87ad;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+
+.stability-stable,
+.stability-locked,
+.stability-locked, {
+  color: #468847;
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+}


### PR DESCRIPTION
In preparation for documenting the stability of API features, this PR adds support for indicating API stability via a new jsdoc tag `@stability`.  There is a small plugin for jsdoc that adds a new tag, `@stability`, with some ability to enforce specific level names.  The templates and css have been updated to include the stability level in the generated documentation.

As written, it will add a 'not documented' stability level to anything that is not specifically set with the `@stability tag`.  It should be usable immediately, however, the `@stability` tag cannot be used in the documentation itself until plovr is removed from the build system or updated to allow custom jsdoc tags to be passed through.  Note that running `build.py apidoc` will work with @stability tags and linking passes, its just building the source that fails.

I snagged the bootstrap alert classes and repurposed them for the display style, changing `alert` to `stability` to give better control over the display of the levels.

The built-in levels are set in the defaults of the plugin itself, with the ability to override them in the `conf.js` file.  The css changes assume the built-in levels.
- `deprecated`, uses alert-error style
- `experimental`, uses alert-warning style
- `unstable`, uses alert-info style
- `stable`, uses alert-success style
- `frozen`, uses alert-success style
- `locked`, uses alert-success style

I took the levels directly from [node.js](http://nodejs.org/api/documentation.html#documentation_stability_index) as discussed.  In thinking more about it, I'm not sure I see the point in having `stable`, `frozen` and `locked` - `stable` seems sufficient to me.
