### PR TITLE
Add jsdoc plugin for documenting observable properties of a class.

### DIFF
--- a/apidoc/conf.json
+++ b/apidoc/conf.json
@@ -13,7 +13,8 @@
     "plugins": [
         "plugins/markdown",
         "apidoc/plugins/inheritdoc",
-        "apidoc/plugins/exports"
+        "apidoc/plugins/exports",
+        "apidoc/plugins/observable"
     ],
     "markdown": {
         "parser": "gfm"

--- a/apidoc/plugins/observable.js
+++ b/apidoc/plugins/observable.js
@@ -1,0 +1,26 @@
+var util = require('util');
+exports.defineTags = function(dictionary) {
+  dictionary.defineTag('observable', {
+    mustHaveValue: true,
+    canHaveType: true,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      if (!doclet.observables) {
+        doclet.observables = [];
+      }
+      var description = tag.value.description;
+      var readonly = description.split(' ').shift() === 'readonly';
+      if (readonly) {
+        description = description.split(' ').slice(1).join(' ');
+      }
+      doclet.observables.push({
+        name: tag.value.name,
+        type: {
+          names: tag.value.type.names
+        },
+        description: description,
+        readonly: readonly
+      });
+    }
+  });
+};

--- a/apidoc/template/tmpl/container.tmpl
+++ b/apidoc/template/tmpl/container.tmpl
@@ -93,6 +93,15 @@
     <?js } ?>
     
     <?js
+        var observables = doc.observables;
+        if (observables && observables.length && observables.forEach) {
+    ?>
+        <h3 class="subsection-title">Observable Properties</h3>
+        <dl><?js= self.partial('observables.tmpl', observables) ?></dl>
+
+    <?js } ?>
+
+    <?js
         var members = self.find({kind: 'member', memberof: title === 'Globals'? {isUndefined: true} : doc.longname});
         if (members && members.length && members.forEach) { 
     ?>

--- a/apidoc/template/tmpl/observables.tmpl
+++ b/apidoc/template/tmpl/observables.tmpl
@@ -1,0 +1,40 @@
+<?js
+    var props = obj;
+?>
+
+<table class="props">
+    <thead>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Get</th>
+    <th>Set</th>
+    <th>Event</th>
+    <th class="last">Description</th>
+  </tr>
+  </thead>
+
+  <tbody>
+  <?js
+      var self = this;
+      props.forEach(function(prop) {
+        if (!prop) { return; }
+        var getter = 'yes';
+        var setter = prop.readonly ? 'no' : 'yes';
+  ?>
+
+    <tr>
+      <td class="name"><code><?js= prop.name ?></code></td>
+      <td class="type">
+      <?js if (prop.type && prop.type.names) {?>
+      <?js= self.partial('type.tmpl', prop.type.names) ?>
+      <?js } ?>
+      </td>
+      <td class="getter"><?js= getter ?></td>
+      <td class="setter"><?js= setter ?></td>
+      <td class="event"><code>change:<?js= prop.name ?></code></td>
+      <td class="description last"><?js= prop.description ?></td>
+    </tr>
+    <?js }); ?>
+  </tbody>
+</table>


### PR DESCRIPTION
This adds a jsdoc plugin for documenting class properties annotated with `@observable`, following similar rules to regular properties for type and name annotations.  For instance, ol.View2D might get something like this:

```
* @observable {ol.Coordinate} center the center of the view
* @observable {ol.proj.Projection} projection the projection of the view
* @observable {number} resolution the resolution of the view
* @observable {number} rotation the rotation of the view in radians
```

In addition, if the description starts with the word `readonly` then the property is documented as not having a setter.  The output contains a section at the same level as members and methods (and before them) with a properties table of these observable properties.  The table, as proposed, contains Name, Type, Get (always yes), Set (no for readonly, yes otherwise), Event (change:<name>) and Description (with readonly removed if it was present).

I will follow up with two other pull requests, one for actually adding the documentation as `@todo observable ...` and a second which will contain another plugin to map `@todo observable` and @todo stability` to the appropriate things as suggested by @tschaub in #1172.
