### PR TITLE
Add jsdoc plugins for stability and observables

### DIFF
--- a/apidoc/conf.json
+++ b/apidoc/conf.json
@@ -13,10 +13,16 @@
     "plugins": [
         "plugins/markdown",
         "apidoc/plugins/inheritdoc",
-        "apidoc/plugins/exports"
+        "apidoc/plugins/exports",
+        "apidoc/plugins/todo",
+        "apidoc/plugins/observable",
+        "apidoc/plugins/stability"
     ],
     "markdown": {
         "parser": "gfm"
+    },
+    "stability": {
+      "levels": ["deprecated","experimental","unstable","stable","frozen","locked"]
     },
     "templates": {
         "cleverLinks": false,

--- a/apidoc/plugins/observable.js
+++ b/apidoc/plugins/observable.js
@@ -1,0 +1,26 @@
+var util = require('util');
+exports.defineTags = function(dictionary) {
+  dictionary.defineTag('observable', {
+    mustHaveValue: true,
+    canHaveType: true,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      if (!doclet.observables) {
+        doclet.observables = [];
+      }
+      var description = tag.value.description;
+      var readonly = description.split(' ').shift() === 'readonly';
+      if (readonly) {
+        description = description.split(' ').slice(1).join(' ');
+      }
+      doclet.observables.push({
+        name: tag.value.name,
+        type: {
+          names: tag.value.type.names
+        },
+        description: description,
+        readonly: readonly
+      });
+    }
+  });
+};

--- a/apidoc/plugins/stability.js
+++ b/apidoc/plugins/stability.js
@@ -1,0 +1,20 @@
+var conf = env.conf.stability;
+var defaultLevels = ["deprecated","experimental","unstable","stable","frozen","locked"];
+var levels = conf.levels || defaultLevels;
+var util = require('util');
+exports.defineTags = function(dictionary) {
+  dictionary.defineTag('stability', {
+    mustHaveValue: true,
+    canHaveType: false,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      var level = tag.text;
+      if (levels.indexOf(level) >=0) {
+        doclet.stability = level;
+      } else {
+        var errorText = util.format('Invalid stability level (%s) in %s line %s', tag.text, doclet.meta.filename, doclet.meta.lineno);
+        require('jsdoc/util/error').handle( new Error(errorText) );
+      }
+    }
+  })
+};

--- a/apidoc/plugins/todo.js
+++ b/apidoc/plugins/todo.js
@@ -1,0 +1,28 @@
+var util = require('util');
+exports.defineTags = function(dictionary) {
+  dictionary.defineTag('todo', {
+    mustHaveValue: true,
+    canHaveType: true,
+    canHaveName: true,
+    onTagged: function(doclet, tag) {
+      var parts = tag.text.split(' ');
+      if (parts[0] === 'stability') {
+        doclet.stability = parts.slice(1).join(' ');
+      } else if (parts[0] === 'observable') {
+        if (!doclet.observables) {
+          doclet.observables = [];
+        }
+        var readonly = parts.length > 3 && parts[3] === 'readonly';
+        var description = (readonly ? parts.slice(4) : parts.slice(3)).join(' ');
+        doclet.observables.push({
+          name: parts[2],
+          type: {
+            names: tag.value.type.names
+          },
+          description: description,
+          readonly: readonly
+        });
+      }
+    }
+  });
+};

--- a/apidoc/template/tmpl/container.tmpl
+++ b/apidoc/template/tmpl/container.tmpl
@@ -93,6 +93,15 @@
     <?js } ?>
     
     <?js
+        var observables = doc.observables;
+        if (observables && observables.length && observables.forEach) {
+    ?>
+        <h3 class="subsection-title">Observable Properties</h3>
+        <dl><?js= self.partial('observables.tmpl', observables) ?></dl>
+
+    <?js } ?>
+
+    <?js
         var members = self.find({kind: 'member', memberof: title === 'Globals'? {isUndefined: true} : doc.longname});
         if (members && members.length && members.forEach) { 
     ?>

--- a/apidoc/template/tmpl/members.tmpl
+++ b/apidoc/template/tmpl/members.tmpl
@@ -2,6 +2,8 @@
 <dt class="<?js= data.access ?>">
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + name + data.signature ?></h4>
     
+    <?js= this.partial('stability.tmpl', data) ?>
+
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>

--- a/apidoc/template/tmpl/method.tmpl
+++ b/apidoc/template/tmpl/method.tmpl
@@ -5,6 +5,8 @@ var self = this;
 <dt>
     <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind == 'class'? 'new ':'') + name + data.signature ?></h4>
     
+    <?js= this.partial('stability.tmpl', data) ?>
+
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>

--- a/apidoc/template/tmpl/observables.tmpl
+++ b/apidoc/template/tmpl/observables.tmpl
@@ -1,0 +1,40 @@
+<?js
+    var props = obj;
+?>
+
+<table class="props">
+    <thead>
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Get</th>
+    <th>Set</th>
+    <th>Event</th>
+    <th class="last">Description</th>
+  </tr>
+  </thead>
+
+  <tbody>
+  <?js
+      var self = this;
+      props.forEach(function(prop) {
+        if (!prop) { return; }
+        var getter = 'yes';
+        var setter = prop.readonly ? 'no' : 'yes';
+  ?>
+
+    <tr>
+      <td class="name"><code><?js= prop.name ?></code></td>
+      <td class="type">
+      <?js if (prop.type && prop.type.names) {?>
+      <?js= self.partial('type.tmpl', prop.type.names) ?>
+      <?js } ?>
+      </td>
+      <td class="getter"><?js= getter ?></td>
+      <td class="setter"><?js= setter ?></td>
+      <td class="event"><code>change:<?js= prop.name ?></code></td>
+      <td class="description last"><?js= prop.description ?></td>
+    </tr>
+    <?js }); ?>
+  </tbody>
+</table>

--- a/apidoc/template/tmpl/stability.tmpl
+++ b/apidoc/template/tmpl/stability.tmpl
@@ -1,0 +1,9 @@
+<?js
+var data = obj;
+var self = this;
+
+if (data.stability) { ?>
+<div class="stability stability-<?js= stability ?>">Stability: <?js= data.stability ?></div>
+<?js } else { ?>
+<div class="stability">Stability: not documented</div>
+<?js } ?>

--- a/resources/layout.css
+++ b/resources/layout.css
@@ -27,3 +27,40 @@ body, h1, h2, h3, h4, p, li, td, th {
   padding: 5px;
 }
 
+.stability {
+  padding: 8px 35px 8px 14px;
+  margin-bottom: 20px;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+  color: #333;
+  background-color: #fcfcfc;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+}
+
+.stability-deprecated {
+  color: #b94a48;
+  background-color: #f2dede;
+  border-color: #eed3d7;
+}
+
+.stability-experimental {
+  color: #c09853;
+  background-color: #fcf8e3;
+  border-color: #fbeed5;
+}
+
+.stability-unstable {
+  color: #3a87ad;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+
+.stability-stable,
+.stability-locked,
+.stability-locked, {
+  color: #468847;
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+}


### PR DESCRIPTION
This pull request supersedes #1172 and #1174 by combining the stability plugin with an observable plugin and a todo plugin.

The stability plugin, will add a 'not documented' stability level to anything that is not specifically set with the `@stability` tag.

I snagged the bootstrap alert classes and repurposed them for the display style, changing alert to stability to give better control over the display of the levels.

The built-in levels are set in the defaults of the plugin itself, with the ability to override them in the conf.js file. The css changes assume the built-in levels.
- deprecated, uses alert-error style
- experimental, uses alert-warning style
- unstable, uses alert-info style
- stable, uses alert-success style
- frozen, uses alert-success style
- locked, uses alert-success style

I took the levels directly from node.js as discussed. In thinking more about it, I'm not sure I see the point in having stable, frozen and locked - stable seems sufficient to me.

The observable plugin allows documenting class properties annotated with @observable, following similar rules to regular properties for type and name annotations. For instance, ol.View2D might get something like this:
- @observable {ol.Coordinate} center the center of the view
- @observable {ol.proj.Projection} projection the projection of the view
- @observable {number} resolution the resolution of the view
- @observable {number} rotation the rotation of the view in radians

In addition, if the description starts with the word `readonly` then the property is documented as not having a setter. The output contains a section at the same level as members and methods (and before them) with a properties table of these observable properties. The table, as proposed, contains Name, Type, Get (always yes), Set (no for readonly, yes otherwise), Event (change:) and Description (with readonly removed if it was present).

The todo plugin provides temporary support for `@todo stability` and `@todo observable` so that we can begin documenting the API using tags that Plovr won't barf on and eventually replace them with the correct version with Plovr is fixed or replaced.

I cherry-picked the original commit from #1172 for the stability plugin, hope that is okay - I tried to collapse it all into a single commit but my git-fu is not strong enough.
