### PR TITLE
Add `@todo observable` documentation for observable properties

### DIFF
--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -67,6 +67,7 @@ ol.CollectionProperty = {
  * @extends {ol.Object}
  * @param {Array=} opt_array Array.
  * @todo stability experimental
+ * @todo observable length {number} readonly the length of the array
  */
 ol.Collection = function(opt_array) {
 

--- a/src/ol/control/mousepositioncontrol.js
+++ b/src/ol/control/mousepositioncontrol.js
@@ -38,6 +38,10 @@ ol.control.MousePositionProperty = {
  * @extends {ol.control.Control}
  * @param {ol.control.MousePositionOptions=} opt_options Mouse position options.
  * @todo stability experimental
+ * @todo observable projection {ol.proj.Projection} the projection to report
+ *       mouse position in
+ * @todo observable coordinateFormat {string} the format to render the current
+ *       position in
  */
 ol.control.MousePosition = function(opt_options) {
 

--- a/src/ol/control/scalelinecontrol.js
+++ b/src/ol/control/scalelinecontrol.js
@@ -51,6 +51,8 @@ ol.control.ScaleLineUnits = {
  * @extends {ol.control.Control}
  * @param {ol.control.ScaleLineOptions=} opt_options Scale line options.
  * @todo stability experimental
+ * @todo observable units {ol.control.ScaleLineUnits} the units to use in the
+ *       scale line
  */
 ol.control.ScaleLine = function(opt_options) {
 

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -69,6 +69,16 @@ ol.DeviceOrientationProperty = {
  * @extends {ol.Object}
  * @param {ol.DeviceOrientationOptions=} opt_options Options.
  * @todo stability experimental
+ * @todo observable alpha {number} readonly the euler angle in radians of the
+ *       device from the standard X axis
+ * @todo observable beta {number} readonly the euler angle in radians of the
+ *       device from the planar Z axis
+ * @todo observable gamma {number} readonly the euler angle in radians of the
+ *       device from the planar X axis
+ * @todo observable heading {number} readonly the euler angle in radians of the
+ *       device from the planar Y axis
+ * @todo observable tracking {boolean} the status of tracking changes to alpha,
+ *       beta and gamma.  If true, changes are tracked and reported immediately.
  */
 ol.DeviceOrientation = function(opt_options) {
 

--- a/src/ol/dom/input.js
+++ b/src/ol/dom/input.js
@@ -30,6 +30,10 @@ ol.dom.InputProperty = {
  * @extends {ol.Object}
  * @param {Element} target Target element.
  * @todo stability experimental
+ * @todo observable value {string} the value of the Input
+ * @todo observable valueAsNumber {number} the value of the Input, converted to
+ *       a number if possible
+ * @todo observable checked {boolean} the checked state of the Input
  */
 ol.dom.Input = function(target) {
   goog.base(this);

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -47,6 +47,23 @@ ol.GeolocationProperty = {
  * @extends {ol.Object}
  * @param {ol.GeolocationOptions=} opt_options Options.
  * @todo stability experimental
+ * @todo observable accuracy {number} readonly the accuracy of the position
+ *       measurement
+ * @todo observable altitude {number} readonly the altitude of the position in
+ *       meters above mean sea level
+ * @todo observable altitudeAccuracy {number} readonly the accuracy of the
+ *       altitude measurement
+ * @todo observable heading {number} readonly the heading of the device in
+ *       radians from norht
+ * @todo observable position {ol.Coordinate} readonly the current position of
+ *       the device reported in the current projection
+ * @todo observable projection {ol.proj.Projection} readonly the projection to
+ *       report the position in
+ * @todo observable speed {number} readonly the instantaneous speed of the
+ *       device in meters per second
+ * @todo observable tracking {number} track the device's position.
+ * @todo observable trackingOptions {number} PositionOptions as defined by the
+ *       HTML5 Geolocation spec at http://dev.w3.org/geo/api/spec-source.html
  */
 ol.Geolocation = function(opt_options) {
 

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -14,6 +14,14 @@ goog.require('ol.source.Source');
  * @extends {ol.layer.Base}
  * @param {ol.layer.LayerOptions} options Layer options.
  * @todo stability experimental
+ * @todo observable brightness {number} the brightness of the layer
+ * @todo observable contrast {number} the contrast of the layer
+ * @todo observable hue {number} the hue of the layer
+ * @todo observable opacity {number} the opacity of the layer
+ * @todo observable saturation {number} the saturation of the layer
+ * @todo observable visible {boolean} the visiblity of the layer
+ * @todo observable maxResolution {number} the maximum resolution of the layer
+ * @todo observable minResolution {number} the minimum resolution of the layer
  */
 ol.layer.Layer = function(options) {
 

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -28,6 +28,8 @@ ol.layer.GroupProperty = {
  * @extends {ol.layer.Base}
  * @param {ol.layer.GroupOptions=} opt_options Layer options.
  * @todo stability experimental
+ * @todo observable layers {ol.Collection} collection of layers that are part
+ *       of this group
  */
 ol.layer.Group = function(opt_options) {
 

--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -18,6 +18,7 @@ ol.layer.TileProperty = {
  * @extends {ol.layer.Layer}
  * @param {ol.layer.TileOptions} options Tile layer options.
  * @todo stability experimental
+ * @todo observable preload {number} the level to preload tiles up to
  */
 ol.layer.Tile = function(options) {
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -143,6 +143,12 @@ ol.MapProperty = {
  * @extends {ol.Object}
  * @param {ol.MapOptions} options Map options.
  * @todo stability experimental
+ * @todo observable layergroup {ol.layer.LayerGroup} a layer group containing
+ *       the layers in this map.
+ * @todo observable size {ol.Size} the size in pixels of the map in the DOM
+ * @todo observable target {string|Element} the Element or id of the Element
+ *       that the map is rendered in.
+ * @todo observable view {ol.IView} the view that controls this map
  */
 ol.Map = function(options) {
 

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -57,6 +57,12 @@ ol.OverlayPositioning = {
  * @extends {ol.Object}
  * @param {ol.OverlayOptions} options Overlay options.
  * @todo stability experimental
+ * @todo observable element {Element} the Element containing the overlay
+ * @todo observable map {ol.Map} the map that the overlay is part of
+ * @todo observable position {ol.Coordinate} the spatial point that the overlay
+ *       is anchored at
+ * @todo observable positioning {ol.OverlayPositioning} how the overlay is
+ *       positioned relative to its point on the map
  */
 ol.Overlay = function(options) {
 

--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -86,6 +86,10 @@ ol.View2DProperty = {
  * @extends {ol.View}
  * @param {ol.View2DOptions=} opt_options View2D options.
  * @todo stability experimental
+ * @todo observable center {ol.Coordinate} the center of the view
+ * @todo observable projection {ol.proj.Projection} the projection of the view
+ * @todo observable resolution {number} the resolution of the view
+ * @todo observable rotation {number} the rotation of the view
  */
 ol.View2D = function(opt_options) {
   goog.base(this);


### PR DESCRIPTION
This PR adds documentation for observable properties, which will then be pulled into the docs correctly once #1180 is merged.  This is a first pass based on searching for definition of observable properties being defined as enums after lines ending with `Property = {`.  If there are observable properties implemented that don't follow this pattern then they are not included.

I've added simple descriptions based on what I know or could easily figure out, there may be some properties (like preload) that are not correctly described.

I've also added `readonly` annotations where I knew that a property was readonly.  I may have missed some readonly properties.

ol.layer.Base has a bunch of properties but I don't think it is exported so the documentation of these properties will not show up, so I added the documentation to ol.layer.Layer instead even though this isn't really where it should be documented.
