### PR TITLE
Fix getImageElement calls in canvas and webgl renderer

### DIFF
--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -43,7 +43,7 @@ goog.inherits(ol.renderer.canvas.ImageLayer, ol.renderer.canvas.Layer);
  */
 ol.renderer.canvas.ImageLayer.prototype.getImage = function() {
   return goog.isNull(this.image_) ?
-      null : this.image_.getImageElement(this);
+      null : this.image_.getImageElement();
 };
 
 

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -47,7 +47,7 @@ ol.renderer.webgl.ImageLayer.prototype.createTexture_ = function(image) {
   // http://www.khronos.org/webgl/wiki/WebGL_and_OpenGL_Differences#Non-Power_of_Two_Texture_Support
   // http://learningwebgl.com/blog/?p=2101
 
-  var imageElement = image.getImageElement(this);
+  var imageElement = image.getImageElement();
   var gl = this.getWebGLMapRenderer().getGL();
 
   var texture = gl.createTexture();


### PR DESCRIPTION
getImageElement(this) function called in canvasimagelayerrenderer and in webglimagelayerrenderer returns an image without width and height, beacuse of cloneNode function in FF and IE.

To call getImageElement without parameters fix the issue.

Thx @elemoine for the solution
