### PR TITLE
Handle dragend after resetting view hint and dragging flag

### DIFF
--- a/src/ol/interaction/draginteraction.js
+++ b/src/ol/interaction/draginteraction.js
@@ -115,9 +115,9 @@ ol.interaction.Drag.prototype.handleMapBrowserEvent =
       goog.asserts.assertInstanceof(browserEvent, goog.events.BrowserEvent);
       this.deltaX = browserEvent.clientX - this.startX;
       this.deltaY = browserEvent.clientY - this.startY;
-      this.handleDragEnd(mapBrowserEvent);
       view.setHint(ol.ViewHint.INTERACTING, -1);
       this.dragging_ = false;
+      this.handleDragEnd(mapBrowserEvent);
     }
   } else if (mapBrowserEvent.type == ol.MapBrowserEvent.EventType.DRAGSTART) {
     goog.asserts.assertInstanceof(browserEvent, goog.events.BrowserEvent);


### PR DESCRIPTION
When we start dragging, we first handle dragstart and then set
the INTERACTING view hint and the dragging flag. To end dragging
in a symmetric manner, we have to first reset the INTERACTING
hint and dragging flag, and then handle dragend.

This flaw becomes obvious when using an interaction where no
animation is performed after the interaction. This can be seen
in the style-rules example when using the dragzoom interaction
(i.e. zoom using a drag box): the vector renderer will not
render the new resolution, because the INTERACTING view hint is
still set when the zoom box dragend is handled.
