### PR TITLE
Terms of Use link missing in Bing attribution

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -26,6 +26,11 @@
 .ol-attribution li:not(:last-child):after {
   content: "\2003";
 }
+.ol-attribution-bing-tos {
+  float:right;
+  padding-top: 2px;
+  white-space: nowrap;
+}
 .ol-dragbox {
   position: absolute;
   border: 2px solid red;

--- a/src/ol/source/bingmapssource.exports
+++ b/src/ol/source/bingmapssource.exports
@@ -1,1 +1,2 @@
 @exportClass ol.source.BingMaps ol.source.BingMapsOptions
+@exportProperty ol.source.BingMaps.TOS_ATTRIBUTION

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -50,6 +50,17 @@ goog.inherits(ol.source.BingMaps, ol.source.TileImage);
 
 
 /**
+ * @const
+ * @type {ol.Attribution}
+ */
+ol.source.BingMaps.TOS_ATTRIBUTION = new ol.Attribution({
+  html: '<a class="ol-attribution-bing-tos" target="_blank" ' +
+      'href="http://www.microsoft.com/maps/product/terms.html">' +
+      'Terms of Use</a>'
+});
+
+
+/**
  * @param {BingMapsImageryMetadataResponse} response Response.
  */
 ol.source.BingMaps.prototype.handleImageryMetadataResponse =
@@ -118,7 +129,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
               var minZ = coverageArea.zoomMin;
               var maxZ = coverageArea.zoomMax;
               var bbox = coverageArea.bbox;
-              var epsg4326Extent = [bbox[1], bbox[3], bbox[0], bbox[2]];
+              var epsg4326Extent = [bbox[1], bbox[0], bbox[3], bbox[2]];
               var extent = ol.extent.transform(epsg4326Extent, transform);
               var tileRange, z, zKey;
               for (z = minZ; z <= maxZ; ++z) {
@@ -133,6 +144,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
             });
         return new ol.Attribution({html: html, tileRanges: tileRanges});
       });
+  attributions.push(ol.source.BingMaps.TOS_ATTRIBUTION);
   this.setAttributions(attributions);
 
   this.setLogo(brandLogoUri);


### PR DESCRIPTION
Not sure if this is an issue, or something changed in the way we are using Bing. But compare:

```
<!doctype html>
<html lang="en">
  <head>
    <link rel="stylesheet" href="http://ol3js.org/en/master/build/ol.css" type="text/css">
    <style>
      .map {
        height: 256px;
        width: 512px;
      }
      .ol-attribution ul, .ol-attribution a {
        color: black;
      }
    </style>
    <script src="http://ol3js.org/en/master/build/ol-simple.js" type="text/javascript"></script>
    <title>OpenLayers 3 example</title>
  </head>
  <body>
    <h1>My Map</h1>
    <div id="map" class="map"></div>
    <script type="text/javascript">
      var map = new ol.Map({
        target: 'map',
        renderer: ol.RendererHint.CANVAS,
        layers: [
          new ol.layer.Tile({
            source: new ol.source.BingMaps({
              style: 'Road',
              key: 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3'
            })
          })
        ],
        view: new ol.View2D({
          center: ol.proj.transform([-71.147, 42.47], 'EPSG:4326', 'EPSG:3857'),
          zoom: 11
        })
      });
    </script>
  </body>
</html>
```

with: http://dev.openlayers.org/releases/OpenLayers-2.13.1/examples/bing-tiles.html
