### PR TITLE
Add support for passing interactions as an array for consistency.

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -57,9 +57,8 @@
  * @typedef {Object} ol.MapOptions
  * @property {ol.Collection|Array.<ol.control.Control>|undefined} controls
  *     Controls initially added to the map.
- * @property {ol.Collection|undefined} interactions A collection of
- *     {@link ol.interaction|ol.interaction.Interaction} instances that allow the user to interact with
- *     the map.
+ * @property {ol.Collection|Array.<ol.interaction.Interaction>|undefined}
+ *     interactions Interactions that are initially added to the map.
  * @property {Array.<ol.layer.Base>|ol.Collection|undefined} layers Layers.
  * @property {ol.Collection|Array.<ol.Overlay>|undefined} overlays
  *     Overlays initially added to the map.

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1274,8 +1274,17 @@ ol.Map.createOptionsInternal = function(options) {
     controls = ol.control.defaults();
   }
 
-  var interactions = goog.isDef(options.interactions) ?
-      options.interactions : ol.interaction.defaults();
+  var interactions;
+  if (goog.isDef(options.interactions)) {
+    if (goog.isArray(options.interactions)) {
+      interactions = new ol.Collection(goog.array.clone(options.interactions));
+    } else {
+      goog.asserts.assertInstanceof(options.interactions, ol.Collection);
+      interactions = options.interactions;
+    }
+  } else {
+    interactions = ol.interaction.defaults();
+  }
 
   var overlays;
   if (goog.isDef(options.overlays)) {


### PR DESCRIPTION
This adds support for passing `interactions` in `ol.MapOptions` as an array as well as an `ol.Collection` for consistency with `controls`.  
