### PR TITLE
MousePosition example issues

### DIFF
--- a/examples/mouse-position.js
+++ b/examples/mouse-position.js
@@ -39,9 +39,8 @@ projectionSelect.on('change:value', function() {
   mousePositionControl.setProjection(ol.proj.get(projectionSelect.getValue()));
 });
 
-var precisionInput = new ol.dom.Input(document.getElementById('precision'));
-precisionInput.on('change:value', function() {
-  var precision = /** @type {number} */ (precisionInput.getValueAsNumber());
-  var format = ol.coordinate.createStringXY(precision);
+var precisionInput = document.getElementById('precision');
+precisionInput.addEventListener('change', function() {
+  var format = ol.coordinate.createStringXY(precisionInput.valueAsNumber);
   mousePositionControl.setCoordinateFormat(format);
-});
+}, false);


### PR DESCRIPTION
See http://ol3js.org/en/master/examples/mouse-position.html

In Firefox 24 (Ubuntu Linux):
- Entering a number in the precision field results in `NaN` being displayed in the field and the precision being interpretted as `0` (only integer coordinates)

In Chrome 30 (Ubuntu Linux);
- Using the arrow up on the precision-numberfield (e.g. to `5`) will lead to to only integer coordinates
- If you enter `0` manually directly afterwards in the field and hover again, you get 5 digits after the comma for the coordinates
- Increasing / decreasing now always show the value previously entered

See also #1186
