### PR TITLE
Add ability to register multiple events with on.

### DIFF
--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -231,15 +231,31 @@ ol.Object.prototype.notifyInternal_ = function(key) {
 
 /**
  * Listen for a certain type of event.
- * @param {string|Array.<string>} type The event type or array of event types.
+ * @param {string|Array.<string>|Object} type The event type or array of event
+ *     types.
  * @param {Function} listener The listener function.
- * @param {Object=} opt_scope Object is whose scope to call
- *     the listener.
- * @return {goog.events.Key} Unique key for the listener.
+ * @param {Object=} opt_scope Object is whose scope to call the listener.
+ * @return {goog.events.Key|Object} Unique key for the listener, or an object
+ *     of keys by event type if called with an object literal for the type
+ *     parameter.
  * @todo stability experimental
  */
 ol.Object.prototype.on = function(type, listener, opt_scope) {
-  return goog.events.listen(this, type, listener, false, opt_scope);
+  if (goog.isObject(type) && !goog.isArray(type)) {
+    var keys = {};
+    goog.object.forEach(type, function(obj, type) {
+      var listener = goog.isFunction(obj) ?
+          obj : goog.object.containsKey(obj, 'fn') ? obj['fn'] : null;
+      if (listener) {
+        var scope = goog.isObject(obj) &&
+                    goog.object.containsKey(obj, 'scope') ? obj['scope'] : null;
+      }
+      keys[type] = this.on(type, listener, scope);
+    }, this);
+    return keys;
+  } else {
+    return goog.events.listen(this, type, listener, false, opt_scope);
+  }
 };
 
 

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -7,6 +7,141 @@ describe('ol.Object', function() {
     o = new ol.Object();
   });
 
+  describe('using on to', function() {
+
+    var listener1, listener2;
+    var scope;
+    var event;
+
+    beforeEach(function() {
+      listener1 = sinon.spy();
+      listener2 = sinon.spy();
+      event = {};
+      scope = {};
+    });
+
+    describe('add one listener', function() {
+
+      it('should return a key', function() {
+        expect(o.on('add', function() {})).to.not.be(undefined);
+      });
+
+      it('should notify a listener when called', function() {
+        o.on('add', listener1);
+        o.dispatchEvent('add', event);
+        expect(listener1).to.be.called();
+        expect(listener1.calledWith(event)).to.be.true;
+      });
+
+      it('should notify a listener each time it is called', function() {
+        o.on('add', listener1);
+        o.dispatchEvent('add', event);
+        o.dispatchEvent('add', event);
+        expect(listener1).to.be.called();
+        expect(listener1.calledWith(event)).to.be.true;
+        expect(listener1.callCount).to.be(2);
+      });
+
+      it('should have the correct scope', function() {
+        o.on('add', listener1, scope);
+        o.dispatchEvent('add', event);
+        expect(listener1.calledOn(scope)).to.be.true;
+        expect(listener1.calledOn(event)).to.be.false;
+      });
+
+    });
+
+    describe('add multiple listeners to the same event', function() {
+
+      it('should call them all', function() {
+        o.on('add', listener1);
+        o.on('add', listener2);
+        o.dispatchEvent('add', {});
+        expect(listener1).to.be.called();
+        expect(listener2).to.be.called();
+      });
+
+    });
+
+    describe('add listeners by object literal', function() {
+
+      it('should call them correctly', function() {
+        o.on({
+          'add': listener1,
+          'remove': listener2
+        });
+        o.dispatchEvent('add', {});
+        expect(listener1).to.be.called();
+        expect(listener2).to.not.be.called();
+
+        o.dispatchEvent('remove', {});
+        expect(listener2).to.be.called();
+      });
+
+      it('should call them with the right scope', function() {
+        o.on({
+          'add': {'fn': listener1, 'scope': scope}
+        });
+        o.dispatchEvent('add', event);
+        expect(listener1).to.be.called();
+        expect(listener1.calledWith(event)).to.be.true;
+        expect(listener1.calledOn(scope)).to.be.true;
+      });
+
+    });
+
+    describe('add listeners once', function() {
+
+      it('should only call them once', function() {
+        o.once('add', listener1);
+        o.dispatchEvent('add', {});
+        expect(listener1).to.be.called();
+        expect(listener1.callCount).to.be(1);
+      });
+
+    });
+
+  });
+
+  describe('using un', function() {
+
+    var listener1, listener2;
+
+    beforeEach(function() {
+      listener1 = sinon.spy();
+      listener2 = sinon.spy();
+    });
+
+    describe('remove listeners', function() {
+
+      it('by key should not call them', function() {
+        o.on('add', listener1);
+        o.on('add', listener2);
+        o.dispatchEvent('add', {});
+        expect(listener1).to.be.called();
+        expect(listener2).to.be.called();
+        o.un('add', listener1);
+        o.dispatchEvent('add', {});
+        expect(listener2.callCount).to.be(2);
+        expect(listener1.callCount).to.be(1);
+      });
+
+      it('by key should not call them', function() {
+        var key1 = o.on('add', listener1);
+        o.on('add', listener2);
+        o.dispatchEvent('add', {});
+        expect(listener1).to.be.called();
+        expect(listener2).to.be.called();
+        o.unByKey(key1);
+        o.dispatchEvent('add', {});
+        expect(listener2.callCount).to.be(2);
+        expect(listener1.callCount).to.be(1);
+      });
+
+    });
+
+  });
+
   describe('get and set', function() {
 
     describe('get an unset property', function() {


### PR DESCRIPTION
Pulling the discussion out of #1206 about registering multiple events in a single call to `on`.

Tests include ones missing for `on`/`once`/`un`/`unByKey` that I think should probably be in there regardless of whether this gets merged or not.  If changing `on` is ultimately undesirable, I'll add the tests in a separate PR.

/cc @elemoine
