### PR TITLE
convert element accessor method into an attribute.

### DIFF
--- a/src/ol/collection.exports
+++ b/src/ol/collection.exports
@@ -11,5 +11,3 @@
 @exportProperty ol.Collection.prototype.remove
 @exportProperty ol.Collection.prototype.removeAt
 @exportProperty ol.Collection.prototype.setAt
-
-@exportProperty ol.CollectionEvent.prototype.getElement

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -22,6 +22,14 @@ ol.CollectionEventType = {
 };
 
 
+/**
+ * @enum {string}
+ */
+ol.CollectionEventProperty = {
+  ELEMENT: 'element'
+};
+
+
 
 /**
  * @constructor
@@ -34,22 +42,14 @@ ol.CollectionEvent = function(type, opt_elem, opt_target) {
 
   goog.base(this, type, opt_target);
 
-  /**
-   * @private
-   * @type {*}
-   */
-  this.elem_ = opt_elem;
+  this[ol.CollectionEventProperty.ELEMENT] = opt_elem;
 
 };
 goog.inherits(ol.CollectionEvent, goog.events.Event);
-
-
-/**
- * @return {*} The element to which this event pertains.
- */
-ol.CollectionEvent.prototype.getElement = function() {
-  return this.elem_;
-};
+goog.exportProperty(
+    ol.CollectionEvent.prototype,
+    ol.CollectionEventProperty.ELEMENT,
+    ol.CollectionEvent.prototype[ol.CollectionEventProperty]);
 
 
 /**

--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -126,7 +126,8 @@ ol.layer.Group.prototype.handleLayersChanged_ = function(event) {
  * @private
  */
 ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
-  var layer = /** @type {ol.layer.Base} */ (collectionEvent.getElement());
+  var layer = /** @type {ol.layer.Base} */
+              (collectionEvent[ol.CollectionEventProperty.ELEMENT]);
   this.listenerKeys_[goog.getUid(layer).toString()] = goog.events.listen(
       layer, goog.events.EventType.CHANGE, this.handleLayerChange, false,
       this);
@@ -139,7 +140,8 @@ ol.layer.Group.prototype.handleLayersAdd_ = function(collectionEvent) {
  * @private
  */
 ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
-  var layer = /** @type {ol.layer.Base} */ (collectionEvent.getElement());
+  var layer = /** @type {ol.layer.Base} */
+              (collectionEvent[ol.CollectionEventProperty.ELEMENT]);
   var key = goog.getUid(layer).toString();
   goog.events.unlistenByKey(this.listenerKeys_[key]);
   delete this.listenerKeys_[key];

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -117,7 +117,7 @@ describe('ol.collection', function() {
       goog.events.listen(collection, ol.CollectionEventType.REMOVE, cb);
       expect(collection.remove(1)).to.eql(1);
       expect(cb).to.be.called();
-      expect(cb.lastCall.args[0].getElement()).to.eql(1);
+      expect(cb.lastCall.args[0].element).to.eql(1);
     });
     it('does not remove more than one matching element', function() {
       var collection = new ol.Collection([0, 1, 1, 2]);
@@ -138,11 +138,11 @@ describe('ol.collection', function() {
       var collection = new ol.Collection(['a', 'b']);
       var added, removed;
       goog.events.listen(collection, ol.CollectionEventType.ADD, function(e) {
-        added = e.getElement();
+        added = e.element;
       });
       goog.events.listen(
           collection, ol.CollectionEventType.REMOVE, function(e) {
-            removed = e.getElement();
+            removed = e.element;
           });
       collection.setAt(1, 1);
       expect(added).to.eql(1);
@@ -156,7 +156,7 @@ describe('ol.collection', function() {
       var removed;
       goog.events.listen(
           collection, ol.CollectionEventType.REMOVE, function(e) {
-            removed = e.getElement();
+            removed = e.element;
           });
       collection.pop();
       expect(removed).to.eql('a');
@@ -169,7 +169,7 @@ describe('ol.collection', function() {
       var added;
       goog.events.listen(
           collection, ol.CollectionEventType.ADD, function(e) {
-            added = e.getElement();
+            added = e.element;
           });
       collection.insertAt(1, 1);
       expect(added).to.eql(1);
@@ -181,7 +181,7 @@ describe('ol.collection', function() {
       var added = [];
       goog.events.listen(
           collection, ol.CollectionEventType.ADD, function(e) {
-            added.push(e.getElement());
+            added.push(e.element);
           });
       collection.setAt(2, 0);
       expect(collection.getLength()).to.eql(3);
@@ -230,7 +230,7 @@ describe('ol.collection', function() {
       var collection = new ol.Collection();
       var elem;
       goog.events.listen(collection, ol.CollectionEventType.ADD, function(e) {
-        elem = e.getElement();
+        elem = e.element;
       });
       collection.push(1);
       expect(elem).to.eql(1);
@@ -249,15 +249,15 @@ describe('ol.collection', function() {
         goog.events.listen(collection, ol.CollectionEventType.ADD, cb1);
         goog.events.listen(collection, ol.CollectionEventType.REMOVE, cb2);
         collection.setAt(0, 2);
-        expect(cb2.lastCall.args[0].getElement()).to.eql(1);
-        expect(cb1.lastCall.args[0].getElement()).to.eql(2);
+        expect(cb2.lastCall.args[0].element).to.eql(1);
+        expect(cb1.lastCall.args[0].element).to.eql(2);
       });
     });
     describe('pop', function() {
       it('triggers remove', function() {
         goog.events.listen(collection, ol.CollectionEventType.REMOVE, cb1);
         collection.pop();
-        expect(cb1.lastCall.args[0].getElement()).to.eql(1);
+        expect(cb1.lastCall.args[0].element).to.eql(1);
       });
     });
   });
@@ -274,7 +274,7 @@ describe('ol.collection', function() {
       var collection = new ol.Collection();
       var elems = [];
       goog.events.listen(collection, ol.CollectionEventType.ADD, function(e) {
-        elems.push(e.getElement());
+        elems.push(e.element);
       });
       collection.extend([1, 2]);
       expect(elems).to.eql([1, 2]);


### PR DESCRIPTION
In the last hangout, I asked about why `ol.CollectionEvent` has a `getElement` method rather than an `element` attribute (like `type` and `target`).  The answer was two-fold:
1. `type` and `target` are Event properties and `goog` doesn't rename Event properties.
2. advanced compilation renames everything that isn't exported
3. there doesn't seem to be a mechanism for exporting attributes

I think that this PR represents a way to export object properties in a way that is safe with advanced compilation.  It is presented primarily for discussion.

Some thoughts about this:
- any code compiled with ol3 needs to use `obj['name']` (or more compressable `obj[symbolRepresentingName]` instead of `obj.name` when accessing properties this ways.
  - this isn't a problem inside ol3 but it is a documentation issue for developers using ol3 and compiling their applications with ol3 in advanced mode (if they get used to obj.name)
    - documentation with the property and in a FAQ (why does my code fail in advanced mode?) _should_ address this I think
- it is much clearer for casual and non-advanced compilation to access object properties this way
- it is much easier to document events that are set up this way

I have an idea about a more complicated internal mechanism that might avoid the need to use `obj['name']` with advanced compilation.

``` javascript
  this.element = opt_elem;

  if (!goog.isDef(this['element'])) {
    var self = this;
    Object.defineProperty(self, 'element', {
      get: function() { return self.element; },
      enumerable: true
    });
  }
```

Using this code inside the `ol.CollectionEvent` constructor avoids the need to export the property at all so there is no `ol.CollectionEventType` enum and no `goog.defineProperty`.  Accessing the property with `event.element` works in advanced compiled code (element gets renamed to an internal value) and external, uncompiled code (via the getter) and in whitespace code (no renaming, no property gets defined).

One test for `ol.Collection` fails with this, I haven't figured out why yet so I didn't push the change.
