### PR TITLE
Correct docs for map.getTarget

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -514,7 +514,9 @@ ol.Map.prototype.getRenderer = function() {
 
 
 /**
- * Get the element in which this map is rendered.
+ * Get the target in which this map is rendered.
+ * Note that this returns what is entered as an option or in setTarget:
+ * if that was an element, it returns an element; if a string, it returns that.
  * @return {Element|string|undefined} Target.
  * @todo stability experimental
  */


### PR DESCRIPTION
A follow-up to #971. Like @tschaub I too would have thought this function should always return an element, but this PR changes the api docs to reflect what the code currently does.
