### PR TITLE
Interactions option not respected

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -57,8 +57,8 @@
  * @typedef {Object} ol.MapOptions
  * @property {ol.Collection|Array.<ol.control.Control>|undefined} controls
  *     Controls initially added to the map.
- * @property {ol.Collection|Array.<ol.interaction.Interaction>|undefined}
- *     interactions Interactions that are initially added to the map.
+ * @property {ol.Collection|Array.<ol.interaction.Interaction>|undefined} interactions
+ *     Interactions that are initially added to the map.
  * @property {Array.<ol.layer.Base>|ol.Collection|undefined} layers Layers.
  * @property {ol.Collection|Array.<ol.Overlay>|undefined} overlays
  *     Overlays initially added to the map.


### PR DESCRIPTION
Without this change, the `interactions` property is renamed on map options (see #1210).  The following examples demonstrate the problem:
- http://ol3js.org/en/master/examples/drag-rotate-and-zoom.html
- http://ol3js.org/en/master/examples/full-screen-drag-rotate-and-zoom.html
- http://ol3js.org/en/master/examples/select-features.html
