### PR TITLE
Use describe instead of describe.only

### DIFF
--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -1,6 +1,6 @@
 goog.provide('ol.test.coordinate');
 
-describe.only('ol.coordinate', function() {
+describe('ol.coordinate', function() {
 
   describe('#closestOnSegment', function() {
     it('can handle points where the foot of the perpendicular is closest',


### PR DESCRIPTION
See https://groups.google.com/d/msg/ol3-dev/hXtY3xY3dJU/CUQ70gpb3_kJ

Without this change, only the 4 ol.coordinate tests are run
