### PR TITLE
Implement new VectorLayer methods in SelectInteraction

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -164,10 +164,8 @@ ol.interaction.Select.prototype.select =
       }
     }
     if (goog.isFunction(layer.setRenderIntent)) {
-      layer.setRenderIntent(ol.layer.VectorLayerRenderIntent.HIDDEN,
-          selectedFeatures);
-      layer.setRenderIntent(ol.layer.VectorLayerRenderIntent.DEFAULT,
-          unselectedFeatures);
+      layer.selectFeatures(selectedFeatures, true);
+      layer.unselectFeatures(unselectedFeatures);
     }
     selectionLayer.removeFeatures(featuresToRemove);
     selectionLayer.addFeatures(featuresToAdd);
@@ -176,6 +174,5 @@ ol.interaction.Select.prototype.select =
       delete this.selectionLayers[mapId].layers[layerId];
       delete this.featureMap_[layerId];
     }
-    // TODO: Dispatch an event with selectedFeatures and unselectedFeatures
   }
 };


### PR DESCRIPTION
Add select feature event handling

I'll preface this by saying that I don't expect this PR to stick but would like to see a discussion about where events such as this should originate from. This is my attempt at addressing [Issue 1234](https://github.com/openlayers/ol3/issues/1234)

I created two new methods in VectorLayer, selectFeatures and unselectFeatures and modified the select interaction to call them instead of calling setRenderIntent. Both methods call setRenderIntent but selectFeatures gets a little messy. While the select interaction manages its own temporary selected features layer, I would like to be able to select (set the render intent) of the features in place. To accomplish this, I have an optional boolean on select features that indicates that the selection is maintained by cloned features on a temporary layer and that selected features on the layer should be hidden.

Additionally, as setRenderIntent as well as the new methods create a new extent to be passed to the respective VectorEvent constructor, the extent is created twice every time a feature is selected or unselected; a minor performance hit but something to mention.

To sum up, I'd like to see comments on where these events should originate from. It seems logical to me to listen to events from a vector layer rather than the select interaction. Finally, please be patient with an open source noob. If PRs are not to be used as a forum for suggestions such as this, feel free to let me know.
