### PR TITLE
Fewer feature.getAttributes() calls

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -18,14 +18,11 @@ goog.require('ol.geom.GeometryType');
  *
  * @param {ol.expr.Expression} expr The expression.
  * @param {ol.Feature=} opt_feature The feature.
+ * @param {Object.<string, *>=} opt_attributes The feature attributes.
  * @return {*} The result of the expression.
  */
-ol.expr.evaluateFeature = function(expr, opt_feature) {
-  var scope;
-  if (goog.isDef(opt_feature)) {
-    scope = opt_feature.getAttributes();
-  }
-  return expr.evaluate(scope, ol.expr.lib, opt_feature);
+ol.expr.evaluateFeature = function(expr, opt_feature, opt_attributes) {
+  return expr.evaluate(opt_attributes, ol.expr.lib, opt_feature);
 };
 
 

--- a/src/ol/style/fillsymbolizer.js
+++ b/src/ol/style/fillsymbolizer.js
@@ -57,10 +57,11 @@ goog.inherits(ol.style.Fill, ol.style.Symbolizer);
  * @return {ol.style.PolygonLiteral} Literal shape symbolizer.
  */
 ol.style.Fill.prototype.createLiteral = function(featureOrType) {
-  var feature, type;
+  var attributes, geometry, feature, type;
   if (featureOrType instanceof ol.Feature) {
     feature = featureOrType;
-    var geometry = feature.getGeometry();
+    attributes = feature.getAttributes();
+    geometry = feature.getGeometry();
     type = geometry ? geometry.getType() : null;
   } else {
     type = featureOrType;
@@ -70,14 +71,16 @@ ol.style.Fill.prototype.createLiteral = function(featureOrType) {
   if (type === ol.geom.GeometryType.POLYGON ||
       type === ol.geom.GeometryType.MULTIPOLYGON) {
 
-    var color = ol.expr.evaluateFeature(this.color_, feature);
+    var color = ol.expr.evaluateFeature(this.color_, feature, attributes);
     goog.asserts.assertString(
         color, 'color must be a string');
 
-    var opacity = Number(ol.expr.evaluateFeature(this.opacity_, feature));
+    var opacity = Number(ol.expr.evaluateFeature(this.opacity_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(opacity), 'opacity must be a number');
 
-    var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature));
+    var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(zIndex), 'zIndex must be a number');
 
     literal = new ol.style.PolygonLiteral({

--- a/src/ol/style/iconsymbolizer.js
+++ b/src/ol/style/iconsymbolizer.js
@@ -101,10 +101,11 @@ goog.inherits(ol.style.Icon, ol.style.Point);
  * @return {ol.style.IconLiteral} Literal shape symbolizer.
  */
 ol.style.Icon.prototype.createLiteral = function(featureOrType) {
-  var feature, type;
+  var attributes, geometry, feature, type;
   if (featureOrType instanceof ol.Feature) {
     feature = featureOrType;
-    var geometry = feature.getGeometry();
+    attributes = feature.getAttributes();
+    geometry = feature.getGeometry();
     type = geometry ? geometry.getType() : null;
   } else {
     type = featureOrType;
@@ -114,35 +115,42 @@ ol.style.Icon.prototype.createLiteral = function(featureOrType) {
   if (type === ol.geom.GeometryType.POINT ||
       type === ol.geom.GeometryType.MULTIPOINT) {
 
-    var url = ol.expr.evaluateFeature(this.url_, feature);
+    var url = ol.expr.evaluateFeature(this.url_, feature, attributes);
     goog.asserts.assertString(url, 'url must be a string');
     goog.asserts.assert(url != '#', 'url must not be "#"');
 
     var width;
     if (!goog.isNull(this.width_)) {
-      width = Number(ol.expr.evaluateFeature(this.width_, feature));
+      width = Number(ol.expr.evaluateFeature(this.width_, feature,
+          attributes));
       goog.asserts.assert(!isNaN(width), 'width must be a number');
     }
 
     var height;
     if (!goog.isNull(this.height_)) {
-      height = Number(ol.expr.evaluateFeature(this.height_, feature));
+      height = Number(ol.expr.evaluateFeature(this.height_, feature,
+          attributes));
       goog.asserts.assertNumber(height, 'height must be a number');
     }
 
-    var opacity = Number(ol.expr.evaluateFeature(this.opacity_, feature));
+    var opacity = Number(ol.expr.evaluateFeature(this.opacity_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(opacity), 'opacity must be a number');
 
-    var rotation = Number(ol.expr.evaluateFeature(this.rotation_, feature));
+    var rotation = Number(ol.expr.evaluateFeature(this.rotation_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(rotation), 'rotation must be a number');
 
-    var xOffset = Number(ol.expr.evaluateFeature(this.xOffset_, feature));
+    var xOffset = Number(ol.expr.evaluateFeature(this.xOffset_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(xOffset), 'xOffset must be a number');
 
-    var yOffset = Number(ol.expr.evaluateFeature(this.yOffset_, feature));
+    var yOffset = Number(ol.expr.evaluateFeature(this.yOffset_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(yOffset), 'yOffset must be a number');
 
-    var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature));
+    var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(zIndex), 'zIndex must be a number');
 
     literal = new ol.style.IconLiteral({

--- a/src/ol/style/rule.js
+++ b/src/ol/style/rule.js
@@ -66,7 +66,8 @@ ol.style.Rule.prototype.applies = function(feature, resolution) {
   var applies = resolution >= this.minResolution_ &&
       resolution < this.maxResolution_;
   if (applies && !goog.isNull(this.filter_)) {
-    applies = !!ol.expr.evaluateFeature(this.filter_, feature);
+    applies = !!ol.expr.evaluateFeature(this.filter_, feature,
+        feature.getAttributes());
   }
   return applies;
 };

--- a/src/ol/style/shapesymbolizer.js
+++ b/src/ol/style/shapesymbolizer.js
@@ -73,10 +73,11 @@ goog.inherits(ol.style.Shape, ol.style.Point);
  * @return {ol.style.ShapeLiteral} Literal shape symbolizer.
  */
 ol.style.Shape.prototype.createLiteral = function(featureOrType) {
-  var feature, type;
+  var attributes, geometry, feature, type;
   if (featureOrType instanceof ol.Feature) {
     feature = featureOrType;
-    var geometry = feature.getGeometry();
+    attributes = feature.getAttributes();
+    geometry = feature.getGeometry();
     type = geometry ? geometry.getType() : null;
   } else {
     type = featureOrType;
@@ -85,34 +86,37 @@ ol.style.Shape.prototype.createLiteral = function(featureOrType) {
   var literal = null;
   if (type === ol.geom.GeometryType.POINT ||
       type === ol.geom.GeometryType.MULTIPOINT) {
-    var size = Number(ol.expr.evaluateFeature(this.size_, feature));
+    var size = Number(ol.expr.evaluateFeature(this.size_, feature, attributes));
     goog.asserts.assert(!isNaN(size), 'size must be a number');
 
     var fillColor, fillOpacity;
     if (!goog.isNull(this.fill_)) {
-      fillColor = ol.expr.evaluateFeature(this.fill_.getColor(), feature);
+      fillColor = ol.expr.evaluateFeature(this.fill_.getColor(), feature,
+          attributes);
       goog.asserts.assertString(
           fillColor, 'fillColor must be a string');
-      fillOpacity = Number(ol.expr.evaluateFeature(
-          this.fill_.getOpacity(), feature));
+      fillOpacity = Number(ol.expr.evaluateFeature(this.fill_.getOpacity(),
+          feature, attributes));
       goog.asserts.assert(!isNaN(fillOpacity), 'fillOpacity must be a number');
     }
 
     var strokeColor, strokeOpacity, strokeWidth;
     if (!goog.isNull(this.stroke_)) {
-      strokeColor = ol.expr.evaluateFeature(this.stroke_.getColor(), feature);
+      strokeColor = ol.expr.evaluateFeature(this.stroke_.getColor(), feature,
+          attributes);
       goog.asserts.assertString(
           strokeColor, 'strokeColor must be a string');
       strokeOpacity = Number(ol.expr.evaluateFeature(
-          this.stroke_.getOpacity(), feature));
+          this.stroke_.getOpacity(), feature, attributes));
       goog.asserts.assert(!isNaN(strokeOpacity),
           'strokeOpacity must be a number');
       strokeWidth = Number(ol.expr.evaluateFeature(
-          this.stroke_.getWidth(), feature));
+          this.stroke_.getWidth(), feature, attributes));
       goog.asserts.assert(!isNaN(strokeWidth), 'strokeWidth must be a number');
     }
 
-    var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature));
+    var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature,
+        attributes));
     goog.asserts.assert(!isNaN(zIndex), 'zIndex must be a number');
 
     literal = new ol.style.ShapeLiteral({

--- a/src/ol/style/strokesymbolizer.js
+++ b/src/ol/style/strokesymbolizer.js
@@ -68,28 +68,30 @@ goog.inherits(ol.style.Stroke, ol.style.Symbolizer);
  * @return {ol.style.LineLiteral|ol.style.PolygonLiteral} Symbolizer literal.
  */
 ol.style.Stroke.prototype.createLiteral = function(featureOrType) {
-  var feature, type;
+  var attributes, geometry, feature, type;
   if (featureOrType instanceof ol.Feature) {
     feature = featureOrType;
-    var geometry = feature.getGeometry();
+    attributes = feature.getAttributes();
+    geometry = feature.getGeometry();
     type = geometry ? geometry.getType() : null;
   } else {
     type = featureOrType;
   }
 
   var color = ol.expr.evaluateFeature(
-      this.color_, feature);
+      this.color_, feature, attributes);
   goog.asserts.assertString(color, 'color must be a string');
 
   var opacity = Number(ol.expr.evaluateFeature(
-      this.opacity_, feature));
+      this.opacity_, feature, attributes));
   goog.asserts.assert(!isNaN(opacity), 'opacity must be a number');
 
   var width = Number(ol.expr.evaluateFeature(
-      this.width_, feature));
+      this.width_, feature, attributes));
   goog.asserts.assert(!isNaN(width), 'width must be a number');
 
-  var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature));
+  var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature,
+      attributes));
   goog.asserts.assert(!isNaN(zIndex), 'zIndex must be a number');
 
   var literal = null;

--- a/src/ol/style/textsymbolizer.js
+++ b/src/ol/style/textsymbolizer.js
@@ -93,48 +93,55 @@ goog.inherits(ol.style.Text, ol.style.Symbolizer);
  * @return {ol.style.TextLiteral} Literal text symbolizer.
  */
 ol.style.Text.prototype.createLiteral = function(featureOrType) {
-  var feature, type;
+  var attributes, geometry, feature, type;
   if (featureOrType instanceof ol.Feature) {
     feature = featureOrType;
-    var geometry = feature.getGeometry();
+    attributes = feature.getAttributes();
+    geometry = feature.getGeometry();
     type = geometry ? geometry.getType() : null;
   } else {
     type = featureOrType;
   }
 
-  var color = ol.expr.evaluateFeature(this.color_, feature);
+  var color = ol.expr.evaluateFeature(this.color_, feature, attributes);
   goog.asserts.assertString(color, 'color must be a string');
 
-  var fontFamily = ol.expr.evaluateFeature(this.fontFamily_, feature);
+  var fontFamily = ol.expr.evaluateFeature(this.fontFamily_, feature,
+      attributes);
   goog.asserts.assertString(fontFamily, 'fontFamily must be a string');
 
-  var fontSize = Number(ol.expr.evaluateFeature(this.fontSize_, feature));
+  var fontSize = Number(ol.expr.evaluateFeature(this.fontSize_, feature,
+      attributes));
   goog.asserts.assert(!isNaN(fontSize), 'fontSize must be a number');
 
-  var fontWeight = ol.expr.evaluateFeature(this.fontWeight_, feature);
+  var fontWeight = ol.expr.evaluateFeature(this.fontWeight_, feature,
+      attributes);
   goog.asserts.assertString(fontWeight, 'fontWeight must be a string');
 
-  var text = ol.expr.evaluateFeature(this.text_, feature);
+  var text = ol.expr.evaluateFeature(this.text_, feature, attributes);
   goog.asserts.assertString(text, 'text must be a string');
 
-  var opacity = Number(ol.expr.evaluateFeature(this.opacity_, feature));
+  var opacity = Number(ol.expr.evaluateFeature(this.opacity_, feature,
+      attributes));
   goog.asserts.assert(!isNaN(opacity), 'opacity must be a number');
 
   var strokeColor, strokeOpacity, strokeWidth;
   if (!goog.isNull(this.stroke_)) {
-    strokeColor = ol.expr.evaluateFeature(this.stroke_.getColor(), feature);
+    strokeColor = ol.expr.evaluateFeature(this.stroke_.getColor(), feature,
+        attributes);
     goog.asserts.assertString(
         strokeColor, 'strokeColor must be a string');
     strokeOpacity = Number(ol.expr.evaluateFeature(
-        this.stroke_.getOpacity(), feature));
+        this.stroke_.getOpacity(), feature, attributes));
     goog.asserts.assert(!isNaN(strokeOpacity),
         'strokeOpacity must be a number');
     strokeWidth = Number(ol.expr.evaluateFeature(
-        this.stroke_.getWidth(), feature));
+        this.stroke_.getWidth(), feature, attributes));
     goog.asserts.assert(!isNaN(strokeWidth), 'strokeWidth must be a number');
   }
 
-  var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature));
+  var zIndex = Number(ol.expr.evaluateFeature(this.zIndex_, feature,
+      attributes));
   goog.asserts.assert(!isNaN(zIndex), 'zIndex must be a number');
 
   return new ol.style.TextLiteral({

--- a/test/spec/ol/expr/expression.test.js
+++ b/test/spec/ol/expr/expression.test.js
@@ -637,39 +637,39 @@ describe('ol.expr.lib', function() {
     });
 
     it('concatenates strings', function() {
-      expect(evaluate(parse('concat(str, "after")'), feature))
-          .to.be('barafter');
-      expect(evaluate(parse('concat("before", str)'), feature))
-          .to.be('beforebar');
-      expect(evaluate(parse('concat("a", str, "b")'), feature))
-          .to.be('abarb');
+      expect(evaluate(parse('concat(str, "after")'), feature,
+          feature.getAttributes())).to.be('barafter');
+      expect(evaluate(parse('concat("before", str)'), feature,
+          feature.getAttributes())).to.be('beforebar');
+      expect(evaluate(parse('concat("a", str, "b")'), feature,
+          feature.getAttributes())).to.be('abarb');
     });
 
     it('concatenates numbers as strings', function() {
-      expect(evaluate(parse('concat(num, 0)'), feature))
-          .to.be('420');
-      expect(evaluate(parse('concat(0, num)'), feature))
-          .to.be('042');
-      expect(evaluate(parse('concat(42, 42)'), feature))
-          .to.be('4242');
-      expect(evaluate(parse('concat(str, num)'), feature))
-          .to.be('bar42');
+      expect(evaluate(parse('concat(num, 0)'), feature,
+          feature.getAttributes())).to.be('420');
+      expect(evaluate(parse('concat(0, num)'), feature,
+          feature.getAttributes())).to.be('042');
+      expect(evaluate(parse('concat(42, 42)'), feature,
+          feature.getAttributes())).to.be('4242');
+      expect(evaluate(parse('concat(str, num)'), feature,
+          feature.getAttributes())).to.be('bar42');
     });
 
     it('concatenates booleans as strings', function() {
-      expect(evaluate(parse('concat(bool, "foo")'), feature))
-          .to.be('falsefoo');
-      expect(evaluate(parse('concat(true, str)'), feature))
-          .to.be('truebar');
-      expect(evaluate(parse('concat(true, false)'), feature))
-          .to.be('truefalse');
+      expect(evaluate(parse('concat(bool, "foo")'), feature,
+          feature.getAttributes())).to.be('falsefoo');
+      expect(evaluate(parse('concat(true, str)'), feature,
+          feature.getAttributes())).to.be('truebar');
+      expect(evaluate(parse('concat(true, false)'), feature,
+          feature.getAttributes())).to.be('truefalse');
     });
 
     it('concatenates nulls as strings', function() {
-      expect(evaluate(parse('concat(nul, "foo")'), feature))
-          .to.be('nullfoo');
-      expect(evaluate(parse('concat(str, null)'), feature))
-          .to.be('barnull');
+      expect(evaluate(parse('concat(nul, "foo")'), feature,
+          feature.getAttributes())).to.be('nullfoo');
+      expect(evaluate(parse('concat(str, null)'), feature,
+          feature.getAttributes())).to.be('barnull');
     });
 
   });
@@ -832,23 +832,23 @@ describe('ol.expr.lib', function() {
     var like = parse('like(foo, "ba")');
 
     it('First and second feature match, third does not', function() {
-      expect(evaluate(like, one), true);
-      expect(evaluate(like, two), true);
-      expect(evaluate(like, three), false);
+      expect(evaluate(like, one, one.getAttributes()), true);
+      expect(evaluate(like, two, two.getAttributes()), true);
+      expect(evaluate(like, three, three.getAttributes()), false);
     });
 
     var uclike = parse('like(foo, "BA")');
     it('Matchcase is true by default', function() {
-      expect(evaluate(uclike, one), false);
-      expect(evaluate(uclike, two), false);
-      expect(evaluate(uclike, three), false);
+      expect(evaluate(uclike, one, one.getAttributes()), false);
+      expect(evaluate(uclike, two, two.getAttributes()), false);
+      expect(evaluate(uclike, three, three.getAttributes()), false);
     });
 
     var ilike = parse('like(foo, "BA", "*", ".", "!", false)');
     it('Using matchcase false, first two features match again', function() {
-      expect(evaluate(ilike, one), true);
-      expect(evaluate(ilike, two), true);
-      expect(evaluate(uclike, three), false);
+      expect(evaluate(ilike, one, one.getAttributes()), true);
+      expect(evaluate(ilike, two, two.getAttributes()), true);
+      expect(evaluate(uclike, three, three.getAttributes()), false);
     });
 
   });
@@ -862,12 +862,12 @@ describe('ol.expr.lib', function() {
     var ieq2 = parse('ieq("foo", bar)');
 
     it('case-insensitive equality for an attribute', function() {
-      expect(evaluate(ieq1, one), true);
+      expect(evaluate(ieq1, one, one.getAttributes()), true);
     });
 
     it('case-insensitive equality for an attribute as second argument',
         function() {
-          expect(evaluate(ieq2, two), true);
+          expect(evaluate(ieq2, two, two.getAttributes()), true);
         });
 
   });
@@ -881,12 +881,12 @@ describe('ol.expr.lib', function() {
     var ieq2 = parse('ineq("foo", bar)');
 
     it('case-insensitive non-equality for an attribute', function() {
-      expect(evaluate(ieq1, one), false);
+      expect(evaluate(ieq1, one, one.getAttributes()), false);
     });
 
     it('case-insensitive non-equality for an attribute as second argument',
         function() {
-          expect(evaluate(ieq2, two), false);
+          expect(evaluate(ieq2, two, two.getAttributes()), false);
         });
 
   });

--- a/test/spec/ol/parser/ogc/filter_v1_0_0.test.js
+++ b/test/spec/ol/parser/ogc/filter_v1_0_0.test.js
@@ -249,7 +249,9 @@ describe('ol.parser.ogc.Filter_v1_0_0', function() {
       xml = '<ogc:UpperBoundary xmlns:ogc="http://www.opengis.net/ogc">' +
           'foo<ogc:PropertyName>x</ogc:PropertyName>bar</ogc:UpperBoundary>';
       expr = reader.call(parser, goog.dom.xml.loadXml(xml).documentElement);
-      expect(evaluate(expr, new ol.Feature({x: 4}))).to.eql('foo4bar');
+      var feature = new ol.Feature({x: 4});
+      expect(evaluate(expr, feature, feature.getAttributes()))
+          .to.eql('foo4bar');
     });
 
     it('handles combined propertyname and literal', function() {
@@ -260,7 +262,9 @@ describe('ol.parser.ogc.Filter_v1_0_0', function() {
           '<ogc:PropertyName>x</ogc:PropertyName>' +
           '<ogc:Literal>foo</ogc:Literal></ogc:UpperBoundary>';
       var expr = reader.call(parser, goog.dom.xml.loadXml(xml).documentElement);
-      expect(evaluate(expr, new ol.Feature({x: 42}))).to.eql('bar42foo');
+      var feature = new ol.Feature({x: 42});
+      expect(evaluate(expr, feature, feature.getAttributes()))
+          .to.eql('bar42foo');
     });
 
   });


### PR DESCRIPTION
This PR makes the canvas vector layer renderer perform better by decreasing the number of calls to ol.Feature#getAttributes() per rendering pass. Is is a follow-up PR for https://github.com/openlayers/ol3/pull/1224.

With the [synthetic-data](https://github.com/elemoine/ol3/compare/synthetic-data) example and current master I get the following CPU profile if I constantly zoom in and out using the mousewheel and/or the +/- zoom buttons:

![synthetic-data-profile-master](https://f.cloud.github.com/assets/76594/1490148/530c8742-478c-11e3-9350-5895f9154809.png)

The getAttributes function accounts for a significant percentage of CPU time.

With my style-perf branch the profile looks like this:

![synthetic-data-profile-style-perf](https://f.cloud.github.com/assets/76594/1490188/fe3f4730-478c-11e3-95dc-29e9c5e031df.png)
