### PR TITLE
Add a getter for the most recent down event

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -186,6 +186,17 @@ goog.inherits(ol.MapBrowserEventHandler, goog.events.EventTarget);
 
 
 /**
+ * Get the last "down" type event.  This will be set on mousedown,
+ * touchstart, and pointerdown.
+ * @return {goog.events.BrowserEvent} The most recent "down" type event (or null
+ * if none have occurred).
+ */
+ol.MapBrowserEventHandler.prototype.getDown = function() {
+  return this.down_;
+};
+
+
+/**
  * @param {goog.events.BrowserEvent} browserEvent Browser event.
  * @private
  */

--- a/test/spec/ol/mapbrowserevent.test.js
+++ b/test/spec/ol/mapbrowserevent.test.js
@@ -51,8 +51,40 @@ describe('ol.MapBrowserEventHandler', function() {
     });
 
   });
+
+  describe('#getDown()', function() {
+
+    var handler;
+    beforeEach(function() {
+      handler = new ol.MapBrowserEventHandler(new ol.Map({}));
+    });
+
+    it('returns null if no "down" type event has been handled', function() {
+      expect(handler.getDown()).to.be(null);
+    });
+
+    it('returns an event after handleMouseDown_ has been called', function() {
+      var event = new goog.events.BrowserEvent({});
+      handler.handleMouseDown_(event);
+      expect(handler.getDown()).to.be(event);
+    });
+
+    it('returns an event after handlePointerDown_ has been called', function() {
+      var event = new goog.events.BrowserEvent({});
+      handler.handlePointerDown_(event);
+      expect(handler.getDown()).to.be(event);
+    });
+
+    it('returns an event after handleTouchStart_ has been called', function() {
+      var event = new goog.events.BrowserEvent({});
+      handler.handleTouchStart_(event);
+      expect(handler.getDown()).to.be(event);
+    });
+
+  });
 });
 
 goog.require('goog.events');
+goog.require('goog.events.BrowserEvent');
 goog.require('ol.Map');
 goog.require('ol.MapBrowserEventHandler');


### PR DESCRIPTION
This will allow interactions to conditionally handle later events based on the down type event.
