### PR TITLE
Make interactions event targets

### DIFF
--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -2,6 +2,7 @@
 
 goog.provide('ol.interaction.Interaction');
 
+goog.require('goog.events.EventTarget');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.animation');
 goog.require('ol.easing');
@@ -10,8 +11,10 @@ goog.require('ol.easing');
 
 /**
  * @constructor
+ * @extends {goog.events.EventTarget}
  */
 ol.interaction.Interaction = function() {
+  goog.base(this);
 
   /**
    * @private
@@ -20,6 +23,7 @@ ol.interaction.Interaction = function() {
   this.map_ = null;
 
 };
+goog.inherits(ol.interaction.Interaction, goog.events.EventTarget);
 
 
 /**

--- a/test/spec/ol/interaction/interaction.test.js
+++ b/test/spec/ol/interaction/interaction.test.js
@@ -7,6 +7,7 @@ describe('ol.interaction.Interaction', function() {
     it('creates a new interaction', function() {
       var interaction = new ol.interaction.Interaction();
       expect(interaction).to.be.a(ol.interaction.Interaction);
+      expect(interaction).to.be.a(goog.events.EventTarget);
     });
 
   });
@@ -46,5 +47,6 @@ describe('ol.interaction.Interaction', function() {
 
 });
 
+goog.require('goog.events.EventTarget');
 goog.require('ol.Map');
 goog.require('ol.interaction.Interaction');


### PR DESCRIPTION
As discussed in dev meetings.

The justification for this is that it gives applications, controls, or other components a direct way to receive feedback and take some action (like removing an interaction).
