### PR TITLE
ol.Object.getChangeEventType and key.toLowerCase

### DIFF
--- a/apidoc/template/tmpl/observables.tmpl
+++ b/apidoc/template/tmpl/observables.tmpl
@@ -29,7 +29,7 @@
       <?js } ?>
       </td>
       <td class="setter"><?js= setter ?></td>
-      <td class="event"><code>change:<?js= prop.name ?></code></td>
+      <td class="event"><code>change:<?js= prop.name.toLowerCase() ?></code></td>
       <td class="description last"><?js= prop.description ?></td>
     </tr>
     <?js }); ?>


### PR DESCRIPTION
`key.toLowerCase` is used in `ol.Object.getChangeEventType`: when a `fooBar` property change, a `change:foobar` event is fired.
Any reason for that?
