### PR TITLE
Simplify Select interaction and prepare for programmatic feature selection without interaction

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -277,7 +277,7 @@ ol.expr.lib[ol.expr.functions.GEOMETRY_TYPE] = function(type) {
  * @this {ol.Feature}
  */
 ol.expr.lib[ol.expr.functions.RENDER_INTENT] = function(renderIntent) {
-  return this.renderIntent == renderIntent;
+  return this.getRenderIntent() == renderIntent;
 };
 
 

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -45,8 +45,9 @@ ol.Feature = function(opt_values) {
   /**
    * The render intent for this feature.
    * @type {ol.layer.VectorLayerRenderIntent|string}
+   * @private
    */
-  this.renderIntent = ol.layer.VectorLayerRenderIntent.DEFAULT;
+  this.renderIntent_ = ol.layer.VectorLayerRenderIntent.DEFAULT;
 
   /**
    * @type {Array.<ol.style.Symbolizer>}
@@ -176,11 +177,20 @@ ol.Feature.prototype.setGeometry = function(geometry) {
 
 
 /**
+ * Gets the renderIntent for this feature.
+ * @return {string} Render intent.
+ */
+ol.Feature.prototype.getRenderIntent = function() {
+  return this.renderIntent_;
+};
+
+
+/**
  * Changes the renderIntent for this feature.
  * @param {string} renderIntent Render intent.
  */
 ol.Feature.prototype.setRenderIntent = function(renderIntent) {
-  this.renderIntent = renderIntent;
+  this.renderIntent_ = renderIntent;
   var geometry = this.getGeometry();
   if (!goog.isNull(geometry)) {
     this.dispatchEvent(new ol.FeatureEvent(

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -102,8 +102,8 @@ ol.interaction.Select.prototype.select =
     for (var j = featuresToSelect.length - 1; j >= 0; --j) {
       var feature = featuresToSelect[j];
       // TODO: Make toggle configurable
-      feature.setRenderIntent(
-          feature.renderIntent == ol.layer.VectorLayerRenderIntent.SELECTED ?
+      feature.setRenderIntent(feature.getRenderIntent() ==
+          ol.layer.VectorLayerRenderIntent.SELECTED ?
               ol.layer.VectorLayerRenderIntent.DEFAULT :
               ol.layer.VectorLayerRenderIntent.SELECTED);
     }

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -483,7 +483,7 @@ ol.layer.Vector.uidTransformFeatureInfo = function(features) {
  * @return {boolean} Whether the feature is selected.
  */
 ol.layer.Vector.selectedFeaturesFilter = function(feature) {
-  return feature.renderIntent == ol.layer.VectorLayerRenderIntent.SELECTED;
+  return feature.getRenderIntent() == ol.layer.VectorLayerRenderIntent.SELECTED;
 };
 
 

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -275,7 +275,8 @@ ol.renderer.canvas.VectorLayer.prototype.getFeaturesForPixel =
         halfWidth, halfHeight, uid, coordinates, j;
     for (var id in candidates) {
       candidate = candidates[id];
-      if (candidate.renderIntent == ol.layer.VectorLayerRenderIntent.HIDDEN) {
+      if (candidate.getRenderIntent() ==
+          ol.layer.VectorLayerRenderIntent.HIDDEN) {
         continue;
       }
       geom = candidate.getGeometry();

--- a/src/ol/renderer/canvas/canvasvectorrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorrenderer.js
@@ -160,7 +160,7 @@ ol.renderer.canvas.Vector.prototype.renderLineStringFeatures_ =
   context.beginPath();
   for (i = 0, ii = features.length; i < ii; ++i) {
     feature = features[i];
-    if (feature.renderIntent === ol.layer.VectorLayerRenderIntent.HIDDEN) {
+    if (feature.getRenderIntent() == ol.layer.VectorLayerRenderIntent.HIDDEN) {
       continue;
     }
     id = goog.getUid(feature);
@@ -249,7 +249,7 @@ ol.renderer.canvas.Vector.prototype.renderPointFeatures_ =
   context.globalAlpha = alpha;
   for (i = 0, ii = features.length; i < ii; ++i) {
     feature = features[i];
-    if (feature.renderIntent === ol.layer.VectorLayerRenderIntent.HIDDEN) {
+    if (feature.getRenderIntent() == ol.layer.VectorLayerRenderIntent.HIDDEN) {
       continue;
     }
     id = goog.getUid(feature);
@@ -325,7 +325,7 @@ ol.renderer.canvas.Vector.prototype.renderText_ =
 
   for (var i = 0, ii = features.length; i < ii; ++i) {
     feature = features[i];
-    if (feature.renderIntent === ol.layer.VectorLayerRenderIntent.HIDDEN) {
+    if (feature.getRenderIntent() == ol.layer.VectorLayerRenderIntent.HIDDEN) {
       continue;
     }
     vecs = ol.renderer.canvas.Vector.getLabelVectors(
@@ -393,7 +393,7 @@ ol.renderer.canvas.Vector.prototype.renderPolygonFeatures_ =
   context.beginPath();
   for (i = 0, ii = features.length; i < ii; ++i) {
     feature = features[i];
-    if (feature.renderIntent === ol.layer.VectorLayerRenderIntent.HIDDEN) {
+    if (feature.getRenderIntent() == ol.layer.VectorLayerRenderIntent.HIDDEN) {
       continue;
     }
     geometry = feature.getGeometry();

--- a/test/spec/ol/expr/expression.test.js
+++ b/test/spec/ol/expr/expression.test.js
@@ -894,7 +894,7 @@ describe('ol.expr.lib', function() {
   describe('renderIntent()', function() {
 
     var feature = new ol.Feature();
-    feature.renderIntent = 'foo';
+    feature.setRenderIntent('foo');
 
     var isFoo = parse('renderIntent("foo")');
     var isBar = parse('renderIntent("bar")');

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -47,7 +47,7 @@ describe('ol.interaction.Select', function() {
   describe('#select', function() {
 
     var selectedFeaturesFilter = function(feature) {
-      return feature.renderIntent == 'selected';
+      return feature.getRenderIntent() == 'selected';
     };
 
     it('toggles selection of features', function() {


### PR DESCRIPTION
As discussed in the weekly hangouts this and last week, this pull request simplifies the Select interaction by not using a temporary layer any more. Further simplifications are accomplished by providing a `setRenderIntent` method on the feature (instead of the layer), and adding a `getFeatures` method to the layer (to be moved to the source when we move the feature cache from the layer to the source).

After this change, if we decide to expose `setRenderIntent` and `getFeatures`, applications will be able to select features without using a select interaction.
