### PR TITLE
add drag and drop vector files example

### DIFF
--- a/examples/vector-dragdrop.html
+++ b/examples/vector-dragdrop.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>Drag and drop of vector data example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>          
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span4">
+          <h4 id="title">Drag and drop vector data example</h4>
+          <p id="shortdesc">Drag and drop vector data on the map and have it rendered. Currently supported are: GeoJSON, GML3, KML and GPX.</p>
+          <div id="docs">
+            <p>See the <a href="vector-dragdrop.js" target="_blank">vector-dragdrop.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">vector, geojson, style</div>
+        </div>
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="loader.js?id=vector-dragdrop" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/vector-dragdrop.js
+++ b/examples/vector-dragdrop.js
@@ -1,0 +1,87 @@
+goog.require('ol.Map');
+goog.require('ol.RendererHint');
+goog.require('ol.View2D');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.parser.GPX');
+goog.require('ol.parser.GeoJSON');
+goog.require('ol.parser.KML');
+goog.require('ol.parser.ogc.GML_v3');
+goog.require('ol.source.MapQuestOpenAerial');
+goog.require('ol.source.Vector');
+
+
+// Check for the various File API support.
+if (window.File && window.FileReader && window.FileList && window.Blob) {
+  // Great success! All the File APIs are supported.
+} else {
+  alert('The File APIs are not fully supported in this browser.');
+}
+
+function handleFileSelect(evt) {
+  evt.stopPropagation();
+  evt.preventDefault();
+
+  var files = evt.dataTransfer.files; // FileList object.
+  for (var i = 0, f; f = files[i]; i++) {
+    var type = files[i].type;
+    var name = files[i].name;
+    var reader = new FileReader();
+    // Closure to capture the file information.
+    reader.onload = (function(theFile) {
+      return function(e) {
+        var text = e.target.result;
+        var parser;
+        if (type === 'text/xml') {
+          if (text.indexOf('<gpx') !== -1) {
+            parser = new ol.parser.GPX();
+          } else if (text.indexOf('FeatureCollection') !== -1) {
+            // TODO how to detect v2 or v3
+            parser = new ol.parser.ogc.GML_v3();
+          }
+        }
+        if (type === 'application/vnd.google-earth.kml+xml') {
+          parser = new ol.parser.KML();
+        } else if (type === '' && name.indexOf('json') !== -1) {
+          parser = new ol.parser.GeoJSON();
+        }
+        if (goog.isDef(parser)) {
+          var lyr = new ol.layer.Vector({
+            source: new ol.source.Vector({
+              data: text,
+              parser: parser
+            })
+          });
+          // TODO zoom to data extent
+          map.getLayers().push(lyr);
+        }
+      };
+    })(f);
+    reader.readAsText(f);
+  }
+}
+
+function handleDragOver(evt) {
+  evt.stopPropagation();
+  evt.preventDefault();
+  evt.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
+}
+
+// Setup the dnd listeners.
+var dropZone = document.getElementById('map');
+dropZone.addEventListener('dragover', handleDragOver, false);
+dropZone.addEventListener('drop', handleFileSelect, false);
+
+var raster = new ol.layer.Tile({
+  source: new ol.source.MapQuestOpenAerial()
+});
+
+var map = new ol.Map({
+  layers: [raster],
+  renderer: ol.RendererHint.CANVAS,
+  target: 'map',
+  view: new ol.View2D({
+    center: [0, 0],
+    zoom: 1
+  })
+});


### PR DESCRIPTION
Adds an example to drag and drop a vector data file on the map and show it.

Not done as yet is zooming to the extent of the data, see also #1259
