### PR TITLE
Deep clone geometry coordinates

### DIFF
--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -4,6 +4,7 @@ goog.provide('ol.geom.GeometryType');
 
 goog.require('goog.events.Event');
 goog.require('goog.events.EventTarget');
+goog.require('goog.object');
 goog.require('ol.Extent');
 goog.require('ol.TransformFunction');
 
@@ -25,7 +26,7 @@ goog.inherits(ol.geom.Geometry, goog.events.EventTarget);
  * @return {ol.geom.Geometry} The cloned geometry.
  */
 ol.geom.Geometry.prototype.clone = function() {
-  return new this.constructor(this.getCoordinates());
+  return new this.constructor(goog.object.unsafeClone(this.getCoordinates()));
 };
 
 

--- a/test/spec/ol/geom/geometry.test.js
+++ b/test/spec/ol/geom/geometry.test.js
@@ -10,6 +10,20 @@ describe('ol.geom.Geometry', function() {
     });
   });
 
+  describe('#clone()', function() {
+    it('clones a geometry', function() {
+      var line = new ol.geom.LineString([[0, 0], [1, 1]]);
+      var clone = line.clone();
+      expect(clone.getCoordinates().length).to.be(2);
+      expect(clone.getCoordinates()[0]).to.eql(line.getCoordinates()[0]);
+      expect(clone.getCoordinates()[0]).to.not.be(line.getCoordinates()[0]);
+      var coordinates = clone.getCoordinates();
+      coordinates[0] = [2, 2];
+      clone.setCoordinates(coordinates);
+      expect(clone.getCoordinates()[0]).to.not.eql(line.getCoordinates()[0]);
+    });
+  });
+
 });
 
 describe('ol.geom.GeometryEvent', function() {
@@ -35,3 +49,4 @@ goog.require('goog.events.EventTarget');
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.GeometryEvent');
 goog.require('ol.geom.Point');
+goog.require('ol.geom.LineString');


### PR DESCRIPTION
Our geometries are mutable, so they can be modified without
creating garbage by changing coordinates in place and calling
setGeometry afterwards. But this also means that we need to
create a deep clone of the coordinates.
