### PR TITLE
initialising Bing source without api key results in error

### DIFF
--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -23,6 +23,15 @@ goog.require('ol.tilegrid.XYZ');
  */
 ol.source.BingMaps = function(options) {
 
+  if (!goog.isDef(options.key)) {
+    throw new Error('Bing Maps source needs an API key, see ' +
+        'http://msdn.microsoft.com/en-us/library/ff428642.aspx for more info');
+  }
+
+  if (!goog.isDef(options.style)) {
+    options.style = 'Road';
+  }
+
   goog.base(this, {
     crossOrigin: 'anonymous',
     opaque: true,


### PR DESCRIPTION
Not sure if this was tackled by @twpayne and @tschaub on the recent Bing work and hasn't made it into the online build. This is totally user-error but it's about the way we handle it currently.

So if I do this:

```
      var map = new ol.Map({
        target: 'map',
        renderer: ol.RendererHint.CANVAS,
        layers: [
          new ol.layer.Tile({
            source: new ol.source.BingMaps()
          })
        ],
        view: new ol.View2D({
          center: ol.proj.transform([-93.27, 44.98], 'EPSG:4326', 'EPSG:3857'),
          zoom: 9
        })
      });
```

I end up with a JS error:

Uncaught TypeError: Cannot read property 'tileLoadFunction' of undefined 

Maybe the BingMaps source should be protected against getting instantiated without an api key?
