### PR TITLE
Rename layerFilter option to layers and accept array for select interaction

### DIFF
--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -92,13 +92,14 @@ var vector = new ol.layer.Vector({
   })
 });
 
-var selectInteraction = new ol.interaction.Select({
-  layerFilter: function(layer) { return layer.get('id') == 'vector'; }
+var select = new ol.interaction.Select({
+  layers: [vector]
 });
 
+var modify = new ol.interaction.Modify();
+
 var map = new ol.Map({
-  interactions: ol.interaction.defaults().extend(
-      [selectInteraction, new ol.interaction.Modify()]),
+  interactions: ol.interaction.defaults().extend([select, modify]),
   layers: [raster, vector],
   renderer: ol.RendererHint.CANVAS,
   target: 'map',

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -47,12 +47,12 @@ var vector = new ol.layer.Vector({
   })
 });
 
-var selectInteraction = new ol.interaction.Select({
-  layerFilter: function(layer) { return layer.get('id') == 'vector'; }
+var select = new ol.interaction.Select({
+  layers: [vector]
 });
 
 var map = new ol.Map({
-  interactions: ol.interaction.defaults().extend([selectInteraction]),
+  interactions: ol.interaction.defaults().extend([select]),
   layers: [raster, vector],
   renderer: ol.RendererHint.CANVAS,
   target: 'map',

--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -395,8 +395,8 @@
  *     modifier (e.g. shift key) that determines if the interaction is active
  *     (i.e. selection occurs) or not. By default, a click with no modifier keys
  *     toggles the selection.
- * @property {undefined|function(ol.layer.Layer):boolean} layerFilter Filter
- *     function to restrict selection to a subset of layers.
+ * @property {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer):boolean} layers
+ *     Layers or filter function to restrict selection to a subset of layers.
  * @todo stability experimental
  */
 

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -30,7 +30,7 @@ describe('ol.interaction.Select', function() {
     vector = new ol.layer.Vector({source: new ol.source.Vector({})});
     vector.addFeatures(features);
     select = new ol.interaction.Select({
-      layerFilter: function(layer) { return layer === vector; }
+      layers: [vector]
     });
     map.getInteractions().push(select);
   });


### PR DESCRIPTION
This brings the select interaction in line with the modify interaction (which also accepts a `layers` option).  See also #1233.
