### PR TITLE
Issue calls to get feature/info for all layers

### DIFF
--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -92,9 +92,7 @@ var vector = new ol.layer.Vector({
   })
 });
 
-var select = new ol.interaction.Select({
-  layers: [vector]
-});
+var select = new ol.interaction.Select();
 
 var modify = new ol.interaction.Modify();
 

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -47,9 +47,7 @@ var vector = new ol.layer.Vector({
   })
 });
 
-var select = new ol.interaction.Select({
-  layers: [vector]
-});
+var select = new ol.interaction.Select();
 
 var map = new ol.Map({
   interactions: ol.interaction.defaults().extend([select]),

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -113,10 +113,11 @@ ol.renderer.Map.prototype.getFeatureInfoForPixel =
     function(pixel, layers, success, opt_error) {
   var numLayers = layers.length;
   var featureInfo = new Array(numLayers);
+  var callbackCount = 0;
   var callback = function(layerFeatureInfo, layer) {
     featureInfo[goog.array.indexOf(layers, layer)] = layerFeatureInfo;
-    --numLayers;
-    if (!numLayers) {
+    --callbackCount;
+    if (callbackCount <= 0) {
       success(featureInfo);
     }
   };
@@ -126,9 +127,8 @@ ol.renderer.Map.prototype.getFeatureInfoForPixel =
     layer = layers[i];
     layerRenderer = this.getLayerRenderer(layer);
     if (goog.isFunction(layerRenderer.getFeatureInfoForPixel)) {
+      ++callbackCount;
       layerRenderer.getFeatureInfoForPixel(pixel, callback, opt_error);
-    } else {
-      --numLayers;
     }
   }
 };
@@ -149,10 +149,11 @@ ol.renderer.Map.prototype.getFeaturesForPixel =
     function(pixel, layers, success, opt_error) {
   var numLayers = layers.length;
   var features = new Array(numLayers);
+  var callbackCount = 0;
   var callback = function(layerFeatures, layer) {
     features[goog.array.indexOf(layers, layer)] = layerFeatures;
-    --numLayers;
-    if (!numLayers) {
+    --callbackCount;
+    if (callbackCount <= 0) {
       success(features);
     }
   };
@@ -162,9 +163,8 @@ ol.renderer.Map.prototype.getFeaturesForPixel =
     layer = layers[i];
     layerRenderer = this.getLayerRenderer(layer);
     if (goog.isFunction(layerRenderer.getFeaturesForPixel)) {
+      ++callbackCount;
       layerRenderer.getFeaturesForPixel(pixel, callback, opt_error);
-    } else {
-      --numLayers;
     }
   }
 };


### PR DESCRIPTION
Currently, all layers passed to `ol.renderer.Map.prototype.getFeaturesForPixel` and `ol.renderer.Map.prototype.getFeatureInfoForPixel` are not called for feature/info because the loop count is being decremented during the iterations.  (This is the reason for one of the issues mentioned in #1233.)

This is based on the commits in #1273.  I'll rebase once that is resolved.
