### PR TITLE
Remove '(Optional)' from Description

### DIFF
--- a/apidoc/template/tmpl/params.tmpl
+++ b/apidoc/template/tmpl/params.tmpl
@@ -97,7 +97,7 @@
                 </td>
             <?js } ?>
             
-            <td class="description last"><?js= (param.optional ? "(Optional) " : "") + param.description ?><?js if (param.subparams) { ?>
+            <td class="description last"><?js= param.description ?><?js if (param.subparams) { ?>
                 <h6>Properties</h6>
                 <?js= self.partial('params.tmpl', param.subparams) ?>
             <?js } ?></td>


### PR DESCRIPTION
`<optional>` is already present in the `Argument` column. `(Optional)` can be removed from `Description`.

(Example: http://ol3js.org/en/master/apidoc/ol.Geolocation.html)
