### PR TITLE
Default projection does not need to be provided

### DIFF
--- a/examples/wmts-from-capabilities.js
+++ b/examples/wmts-from-capabilities.js
@@ -34,7 +34,6 @@ xhr.onload = function() {
       target: 'map',
       view: new ol.View2D({
         center: [1823849, 6143760],
-        projection: 'EPSG:3857',
         zoom: 11
       })
     });


### PR DESCRIPTION
The wmts-from-capabilities example should focus on creating a
WMTS source from capabilities, so it should not distract by
configuring a projection that does not need to be configured.
