### PR TITLE
ol.interaction.Drag should not set interacting hint

### DIFF
--- a/src/ol/interaction/draginteraction.js
+++ b/src/ol/interaction/draginteraction.js
@@ -6,7 +6,6 @@ goog.require('goog.functions');
 goog.require('ol.Coordinate');
 goog.require('ol.MapBrowserEvent');
 goog.require('ol.MapBrowserEvent.EventType');
-goog.require('ol.ViewHint');
 goog.require('ol.interaction.Interaction');
 
 
@@ -25,13 +24,6 @@ ol.interaction.Drag = function() {
    * @type {boolean}
    */
   this.dragging_ = false;
-
-  /**
-   * Delta for INTERACTING view hint. Subclasses that do not want the
-   * INTERACTING hint to be set should override this to 0.
-   * @type {number}
-   */
-  this.interactingHint = 1;
 
   /**
    * @type {number}
@@ -130,7 +122,6 @@ ol.interaction.Drag.prototype.handleMapBrowserEvent =
       goog.asserts.assertInstanceof(browserEvent, goog.events.BrowserEvent);
       this.deltaX = browserEvent.clientX - this.startX;
       this.deltaY = browserEvent.clientY - this.startY;
-      view.setHint(ol.ViewHint.INTERACTING, -this.interactingHint);
       this.dragging_ = false;
       this.handleDragEnd(mapBrowserEvent);
     }
@@ -146,7 +137,6 @@ ol.interaction.Drag.prototype.handleMapBrowserEvent =
         (mapBrowserEvent.getCoordinate());
     var handled = this.handleDragStart(mapBrowserEvent);
     if (handled) {
-      view.setHint(ol.ViewHint.INTERACTING, this.interactingHint);
       this.dragging_ = true;
       mapBrowserEvent.preventDefault();
       stopEvent = true;

--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -6,6 +6,7 @@ goog.require('goog.asserts');
 goog.require('ol.Kinetic');
 goog.require('ol.PreRenderFunction');
 goog.require('ol.View2D');
+goog.require('ol.ViewHint');
 goog.require('ol.coordinate');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.condition');
@@ -84,6 +85,7 @@ ol.interaction.DragPan.prototype.handleDragEnd = function(mapBrowserEvent) {
 
   var map = mapBrowserEvent.map;
   var view = map.getView().getView2D();
+  view.setHint(ol.ViewHint.INTERACTING, -1);
 
   if (this.kinetic_ && this.kinetic_.end()) {
     var view2DState = view.getView2DState();
@@ -115,6 +117,7 @@ ol.interaction.DragPan.prototype.handleDragStart = function(mapBrowserEvent) {
       this.kinetic_.update(browserEvent.clientX, browserEvent.clientY);
     }
     var map = mapBrowserEvent.map;
+    map.getView().setHint(ol.ViewHint.INTERACTING, 1);
     map.requestRenderFrame();
     return true;
   } else {

--- a/src/ol/interaction/dragrotateandzoominteraction.js
+++ b/src/ol/interaction/dragrotateandzoominteraction.js
@@ -4,6 +4,7 @@ goog.provide('ol.interaction.DragRotateAndZoom');
 
 goog.require('goog.asserts');
 goog.require('goog.math.Vec2');
+goog.require('ol.ViewHint');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.condition');
 goog.require('ol.interaction.Drag');
@@ -105,6 +106,7 @@ ol.interaction.DragRotateAndZoom.prototype.handleDragEnd =
   var map = mapBrowserEvent.map;
   // FIXME works for View2D only
   var view = map.getView().getView2D();
+  view.setHint(ol.ViewHint.INTERACTING, -1);
   var view2DState = view.getView2DState();
   var direction = this.lastScaleDelta_ - 1;
   map.withFrozenRendering(function() {
@@ -124,6 +126,7 @@ ol.interaction.DragRotateAndZoom.prototype.handleDragEnd =
 ol.interaction.DragRotateAndZoom.prototype.handleDragStart =
     function(mapBrowserEvent) {
   if (this.condition_(mapBrowserEvent)) {
+    mapBrowserEvent.map.getView().setHint(ol.ViewHint.INTERACTING, 1);
     this.lastAngle_ = undefined;
     this.lastMagnitude_ = undefined;
     return true;

--- a/src/ol/interaction/dragrotateinteraction.js
+++ b/src/ol/interaction/dragrotateinteraction.js
@@ -1,6 +1,7 @@
 goog.provide('ol.interaction.DragRotate');
 
 goog.require('goog.asserts');
+goog.require('ol.ViewHint');
 goog.require('ol.events.ConditionType');
 goog.require('ol.events.condition');
 goog.require('ol.interaction.Drag');
@@ -74,6 +75,7 @@ ol.interaction.DragRotate.prototype.handleDragEnd = function(mapBrowserEvent) {
   var map = mapBrowserEvent.map;
   // FIXME works for View2D only
   var view = map.getView().getView2D();
+  view.setHint(ol.ViewHint.INTERACTING, -1);
   var view2DState = view.getView2DState();
   ol.interaction.Interaction.rotate(map, view, view2DState.rotation, undefined,
       ol.interaction.DRAGROTATE_ANIMATION_DURATION);
@@ -88,6 +90,7 @@ ol.interaction.DragRotate.prototype.handleDragStart =
   var browserEvent = mapBrowserEvent.browserEvent;
   if (browserEvent.isMouseActionButton() && this.condition_(mapBrowserEvent)) {
     var map = mapBrowserEvent.map;
+    map.getView().setHint(ol.ViewHint.INTERACTING, 1);
     map.requestRenderFrame();
     this.lastAngle_ = undefined;
     return true;

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -100,7 +100,6 @@ ol.interaction.Modify = function(opt_options) {
    */
   this.dragSegments_ = null;
 
-  this.interactingHint = 0;
 };
 goog.inherits(ol.interaction.Modify, ol.interaction.Drag);
 


### PR DESCRIPTION
The drag interaction sets the interacting hint on the view.  It makes more sense that this hint would only be set an interaction is responding by changing the view in some way.  For example, `ol.interaction.DragPan` would set the interaction hint, but the `ol.interaction.DragZoom` would not.
