### PR TITLE
STYLES parameter duplicated on getFeatureInfo 

### DIFF
--- a/src/ol/source/wmssource.js
+++ b/src/ol/source/wmssource.js
@@ -1,6 +1,7 @@
 goog.provide('ol.source.WMSGetFeatureInfoMethod');
 goog.provide('ol.source.wms');
 
+goog.require('goog.Uri');
 goog.require('goog.net.XhrIo');
 goog.require('goog.object');
 goog.require('goog.uri.utils');
@@ -95,12 +96,11 @@ ol.source.wms.getFeatureInfo =
     goog.object.extend(params, {'X': x, 'Y': y});
   }
   goog.object.extend(params, localOptions.params);
+  var uri = new goog.Uri(url, true);
   for (var key in params) {
-    if (goog.uri.utils.hasParam(url, key)) {
-      url = goog.uri.utils.removeParam(url, key);
-    }
+    uri.setParameterValue(key, params[key]);
   }
-  url = goog.uri.utils.appendParamsFromMap(url, params);
+  url = uri.toString();
   if (localOptions.method == ol.source.WMSGetFeatureInfoMethod.IFRAME) {
     goog.global.setTimeout(function() {
       success('<iframe seamless src="' + url + '"></iframe>');

--- a/test/spec/ol/source/wmssource.test.js
+++ b/test/spec/ol/source/wmssource.test.js
@@ -32,8 +32,8 @@ describe('ol.source.wms', function() {
           [5, 10], {params: {'INFO_FORMAT': 'text/plain'}},
           function(info) {
             expect(info).to.eql('<iframe seamless src="' +
-                '?REQUEST=GetFeatureInfo&VERSION=1.3&LAYERS=foo&QUERY_LAYERS=' +
-                'foo&INFO_FORMAT=text%2Fplain&I=5&J=10"></iframe>');
+                '?request=GetFeatureInfo&version=1.3&layers=foo&query_layers=' +
+                'foo&info_format=text%2Fplain&i=5&j=10"></iframe>');
             done();
           });
     });
@@ -47,12 +47,12 @@ describe('ol.source.wms', function() {
     });
     it('overrides any existing parameters', function(done) {
       ol.source.wms.getFeatureInfo('?REQUEST=GetMap&VERSION=1.3&LAYERS=' +
-          'foo&STYLES=x',
+          'foo&styles=x',
           [5, 10], {params: {'INFO_FORMAT': 'text/plain', STYLES: 'y'}},
           function(info) {
             expect(info).to.eql('<iframe seamless src="' +
-                '?REQUEST=GetFeatureInfo&VERSION=1.3&LAYERS=foo&QUERY_LAYERS=' +
-                'foo&INFO_FORMAT=text%2Fplain&I=5&J=10&STYLES=y"></iframe>');
+                '?request=GetFeatureInfo&version=1.3&layers=foo&query_layers=' +
+                'foo&styles=y&info_format=text%2Fplain&i=5&j=10"></iframe>');
             done();
           });
     });


### PR DESCRIPTION
Hi,

With the code sample below an extra STYLES paramater is added to the getFeatureInfo request instead of replacing the default paramater 

The following request is submitted

/geoserver/VO/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&WIDTH=256&HEIGHT=256&LAYERS=HO%3APost%20Visit&QUERY_LAYERS=HO%3APost%2Visit&**STYLES**=&CRS=EPSG%3A2157&BBOX=559483.5961953121%2C572078.5322421874%2C562977.9180781246%2C575572.854125&INFO_FORMAT=application%2Fjson&I=213&J=187&FEATURE_COUNT=999&**STYLES**=point

``` javascript
var layers = [
  new ol.layer.Tile({
    source: new ol.source.TileWMS({
      url: gsURL,
      crossOrigin: 'anonymous',
      attributions: [new ol.Attribution({
        html: '&copy; HO ' 
      })],
      params: {
        'LAYERS': 'HO:Post Visit',
        'FORMAT': 'image/png'
      },
      extent: ITM_EXTENT,
      getFeatureInfoOptions: {
          method: 'xhr_get',
          params: {
            'INFO_FORMAT': 'application/json',
            'FEATURE_COUNT': '999',
            'STYLES' : 'point'
          }
        }
    })
  })
];
```
