### PR TITLE
The source determines who can do GetFeatureInfo

### DIFF
--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -48,17 +48,21 @@ goog.inherits(ol.renderer.Layer, goog.Disposable);
  *     successful queries. The passed arguments are the resulting feature
  *     information and the layer.
  * @param {function()=} opt_error Callback for unsuccessful queries.
+ * @return {boolean} Whether getFeatureInfoForPixel was called on the source.
  */
 ol.renderer.Layer.prototype.getFeatureInfoForPixel =
     function(pixel, success, opt_error) {
   var layer = this.getLayer();
   var source = layer.getSource();
+  var haveGetFeatureInfo = false;
   if (goog.isFunction(source.getFeatureInfoForPixel)) {
     var callback = function(layerFeatureInfo) {
       success(layerFeatureInfo, layer);
     };
     source.getFeatureInfoForPixel(pixel, this.getMap(), callback, opt_error);
+    haveGetFeatureInfo = true;
   }
+  return haveGetFeatureInfo;
 };
 
 

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -122,14 +122,11 @@ ol.renderer.Map.prototype.getFeatureInfoForPixel =
     }
   };
 
-  var layer, layerRenderer, source;
+  var layerRenderer;
   for (var i = 0; i < numLayers; ++i) {
-    layer = layers[i];
-    source = layer.getSource();
-    if (goog.isFunction(source.getFeatureInfoForPixel)) {
+    layerRenderer = this.getLayerRenderer(layers[i]);
+    if (layerRenderer.getFeatureInfoForPixel(pixel, callback, opt_error)) {
       ++callbackCount;
-      layerRenderer = this.getLayerRenderer(layer);
-      layerRenderer.getFeatureInfoForPixel(pixel, callback, opt_error);
     }
   }
 };


### PR DESCRIPTION
Now that the ol.renderer.Layer base class has a
getFeatureInfoForPixel method, we have to check whether the
source supports GetFeatureInfo, not the layer renderer.
