### PR TITLE
Better formatted output for formatted sizes.

### DIFF
--- a/build.py
+++ b/build.py
@@ -153,13 +153,16 @@ PROJ4JS_ZIP_MD5 = '17caad64cf6ebc6e6fe62f292b134897'
 
 
 def report_sizes(t):
-    t.info('uncompressed: %d bytes', os.stat(t.name).st_size)
     stringio = StringIO()
     gzipfile = gzip.GzipFile(t.name, 'w', 9, stringio)
     with open(t.name) as f:
         shutil.copyfileobj(f, gzipfile)
     gzipfile.close()
-    t.info('  compressed: %d bytes', len(stringio.getvalue()))
+    rawsize = os.stat(t.name).st_size
+    gzipsize = len(stringio.getvalue())
+    savings = '{:.2%}'.format((rawsize - gzipsize)/float(rawsize))
+    t.info('uncompressed: %8d bytes', rawsize)
+    t.info('  compressed: %8d bytes, (saved %s)', gzipsize, savings)
 
 
 virtual('default', 'build')


### PR DESCRIPTION
This tiny PR improves IMHO the rendering of `report_sizes(t)`:

Before:

```
2013-11-21 22:28:04,684 build/ol-whitespace.js: <<command>>
2013-11-21 22:28:09,757 build/ol-whitespace.js: uncompressed: 1859204 bytes
2013-11-21 22:28:09,897 build/ol-whitespace.js:   compressed: 299023 bytes
```

After:

```
2013-11-21 22:31:30,042 build/ol-whitespace.js: <<command>>
2013-11-21 22:31:34,611 build/ol-whitespace.js: uncompressed:  1859204 bytes
2013-11-21 22:31:34,611 build/ol-whitespace.js:   compressed:   299023 bytes, (saved 83.92%)
```
