### PR TITLE
Add missing WMSGetFeatureInfo exports

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -630,8 +630,8 @@
  * @property {null|string|undefined} crossOrigin crossOrigin setting for image
  *     requests.
  * @property {ol.Extent|undefined} extent Extent.
- * @property {ol.source.WMSGetFeatureInfoOptions|undefined}
- *     getFeatureInfoOptions Options for GetFeatureInfo.
+ * @property {ol.source.WMSGetFeatureInfoOptions|undefined} getFeatureInfoOptions
+ *     Options for GetFeatureInfo.
  * @property {Object.<string,*>} params WMS request parameters. At least a
  *     `LAYERS` param is required. `STYLES` is `` by default. `VERSION` is
  *     `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX` and `CRS` (`SRS` for WMS
@@ -692,8 +692,8 @@
  * @property {null|string|undefined} crossOrigin crossOrigin setting for image
  *     requests.
  * @property {ol.Extent|undefined} extent Extent.
- * @property {ol.source.WMSGetFeatureInfoOptions|undefined}
- *     getFeatureInfoOptions Options for GetFeatureInfo.
+ * @property {ol.source.WMSGetFeatureInfoOptions|undefined} getFeatureInfoOptions
+ *     Options for GetFeatureInfo.
  * @property {string|undefined} logo Logo.
  * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid.
  * @property {number|undefined} maxZoom Maximum zoom.
@@ -721,17 +721,6 @@
  * @property {string|undefined} url Server url providing the vector data.
  * @todo stability experimental
  */
-
-
-/**
- * @typedef {Object} ol.source.WMSGetFeatureInfoOptions
- * @property {ol.source.WMSGetFeatureInfoMethod} method Method for requesting
- *     GetFeatureInfo. Default is `ol.source.WMSGetFeatureInfoMethod.IFRAME`.
- * @property {Object} params Params for the GetFeatureInfo request. Default is
- *     `{'INFO_FORMAT': 'text/html'}`.
- * @todo stability experimental
- */
-
 
 /**
  * @typedef {Object} ol.source.WMTSOptions

--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -45,7 +45,8 @@ ol.source.ImageWMS = function(options) {
    * @type {ol.source.WMSGetFeatureInfoOptions}
    */
   this.getFeatureInfoOptions_ = goog.isDef(options.getFeatureInfoOptions) ?
-      options.getFeatureInfoOptions : {};
+      options.getFeatureInfoOptions :
+      /** @type {ol.source.WMSGetFeatureInfoOptions} */ ({});
 
   /**
    * @private

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -110,7 +110,8 @@ ol.source.TileWMS = function(options) {
    * @type {ol.source.WMSGetFeatureInfoOptions}
    */
   this.getFeatureInfoOptions_ = goog.isDef(options.getFeatureInfoOptions) ?
-      options.getFeatureInfoOptions : {};
+      options.getFeatureInfoOptions :
+      /** @type {ol.source.WMSGetFeatureInfoOptions} */ ({});
 
 };
 goog.inherits(ol.source.TileWMS, ol.source.TileImage);

--- a/src/ol/source/wmssource.exports
+++ b/src/ol/source/wmssource.exports
@@ -1,1 +1,3 @@
 @exportSymbol ol.source.WMSGetFeatureInfoMethod
+@exportProperty ol.source.WMSGetFeatureInfoMethod.IFRAME
+@exportProperty ol.source.WMSGetFeatureInfoMethod.XHR_GET

--- a/src/ol/source/wmssource.js
+++ b/src/ol/source/wmssource.js
@@ -7,6 +7,13 @@ goog.require('goog.uri.utils');
 
 
 /**
+ * @typedef {{method: (ol.source.WMSGetFeatureInfoMethod|undefined),
+ *            params: (Object.<string,string>|undefined)}}
+ */
+ol.source.WMSGetFeatureInfoOptions;
+
+
+/**
  * Method to use to get WMS feature info.
  * @enum {string}
  * @todo stability experimental


### PR DESCRIPTION
The idea when adding `getFeatureInfoOptions` to `ol.source.TileWMSSource` and `ol.source.ImageWMSSource` was to provide an easy way to configure the method and additional parameters that should be used for GetFeatureInfo. As it turns out, this does not work in the built version because `objectliterals.jsdoc` needs the property name on the first line of the property definition.
