### PR TITLE
Return for getFeatureInfoForPixel

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -220,10 +220,7 @@ ol.renderer.canvas.VectorLayer.prototype.getTransform = function() {
 
 
 /**
- * @param {ol.Pixel} pixel Pixel coordinate relative to the map viewport.
- * @param {function(string, ol.layer.Layer)} success Callback for
- *     successful queries. The passed arguments are the resulting feature
- *     information and the layer.
+ * @inheritDoc
  */
 ol.renderer.canvas.VectorLayer.prototype.getFeatureInfoForPixel =
     function(pixel, success) {
@@ -231,6 +228,7 @@ ol.renderer.canvas.VectorLayer.prototype.getFeatureInfoForPixel =
     success(layer.getTransformFeatureInfo()(features), layer);
   };
   this.getFeaturesForPixel(pixel, callback);
+  return true;
 };
 
 


### PR DESCRIPTION
In b8a9aeb14ed6089d9d676c7e8682f0db5a6d5304 a return was added to `ol.renderer.Layer.prototype.getFeatureInfoForPixel`.  The `ol.renderer.canvas.VectorLayer.prototype.getFeatureInfoForPixel` method needs the same.

This gets rid of the following build warning:

```
../src/ol/renderer/canvas/canvasvectorlayerrenderer.js:229: WARNING - Missing return statement. Function expected to return boolean.
    function(pixel, success) {
    ^
```
