### PR TITLE
Descending loop counter for forEach safety

### DIFF
--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -401,12 +401,12 @@ ol.structs.RBush.prototype.forEach_ = function(node, callback, opt_obj) {
   goog.asserts.assert(!node.isLeaf());
   /** @type {Array.<ol.structs.RBushNode.<T>>} */
   var toVisit = [node];
-  var children, i, ii, result;
+  var children, i, result;
   while (toVisit.length > 0) {
     node = toVisit.pop();
     children = node.children;
     if (node.height == 1) {
-      for (i = 0, ii = children.length; i < ii; ++i) {
+      for (i = children.length - 1; i >= 0; --i) {
         result = callback.call(opt_obj, children[i].value);
         if (result) {
           return result;


### PR DESCRIPTION
When ascending i, removing the current node from the RBush in
the forEach callback will result in the loop trying to access
the array with an out of bounds i. When descending i in the
loop, this cannot happen.
