### PR TITLE
KML Parsing issue

### DIFF
--- a/src/ol/parser/kmlparser.js
+++ b/src/ol/parser/kmlparser.js
@@ -75,7 +75,7 @@ ol.parser.KML = function(opt_options) {
       '*': function(node, obj) {
         if (this.extractAttributes === true) {
           var len = node.childNodes.length;
-          if ((len === 1 || len === 2) && (node.firstChild.nodeType === 3 ||
+          if (len > 0 && (node.firstChild.nodeType === 3 ||
               node.firstChild.nodeType === 4)) {
             var readers = this.readers[this.defaultNamespaceURI];
             readers['_attribute'].apply(this, arguments);

--- a/test/spec/ol/parser/kml.test.js
+++ b/test/spec/ol/parser/kml.test.js
@@ -163,6 +163,19 @@ describe('ol.parser.KML', function() {
       expect(obj.features[0].get('description')).to.eql('Full of text.');
       expect(obj.features[0].get('name')).to.eql('Pezinok');
     });
+    it('Test CDATA attributes with newlines', function() {
+      var cdata = '<kml xmlns="http://earth.google.com/kml/2.0"><Document>' +
+          '<Placemark><name><![CDATA[Pezinok]]> </name><description>' +
+          '\n' +
+          '<![CDATA[Full of text.]]>' +
+          '\n' +
+          '</description><styleUrl>#rel1.0' +
+          '</styleUrl><Point> <coordinates>17.266666, 48.283333</coordinates>' +
+          '</Point></Placemark></Document></kml>';
+      var obj = parser.read(cdata);
+      expect(obj.features[0].get('description')).to.eql('Full of text.');
+      expect(obj.features[0].get('name')).to.eql('Pezinok');
+    });
 
     it('handles line style (read / write)', function() {
       var kml = '<kml xmlns="http://www.opengis.net/kml/2.2" ' +


### PR DESCRIPTION
If a KML file has break line, then it's parsed as a node and the description parsing doesn't work (error at this line https://github.com/openlayers/ol3/blob/master/src/ol/parser/kmlparser.js#L78 ) 
