### PR TITLE
Fix map navigation on some android native browsers

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -411,6 +411,12 @@ ol.MapBrowserEventHandler.prototype.handleTouchMove_ = function(browserEvent) {
   var newEvent = new ol.MapBrowserEvent(
       ol.MapBrowserEvent.EventType.TOUCHMOVE, this.map_, browserEvent);
   this.dispatchEvent(newEvent);
+
+  // Some native android browser triggers mousemove events during small period
+  // of time. See: https://code.google.com/p/android/issues/detail?id=5491 or
+  // https://code.google.com/p/android/issues/detail?id=19827
+  // ex: Galaxy Tab P3110 + Android 4.1.1
+  browserEvent.preventDefault();
 };
 
 


### PR DESCRIPTION
Mouse move event is triggered only once on some android browser, for example on Galaxy Tab P3110 + Android 4.1.1

I think it's related to these bugs: 
https://code.google.com/p/android/issues/detail?id=5491
https://code.google.com/p/android/issues/detail?id=19827

Prevent default mouse event behavior fixes the issue.
