### PR TITLE
Don't build ol.css in check target

### DIFF
--- a/build.py
+++ b/build.py
@@ -176,7 +176,7 @@ virtual('build', 'build/ol.css', 'build/ol.js',
         'build/ol-simple.js', 'build/ol-whitespace.js')
 
 
-virtual('check', 'lint', 'build/ol.css', 'build/ol-all.js', 'test')
+virtual('check', 'lint', 'build/ol-all.js', 'test')
 
 
 virtual('todo', 'fixme')


### PR DESCRIPTION
Currently the `check` build target builds `build/ol.css`.
`build/ol.css` is a side effect of building `build/ol.js`.
`build/ol.js` takes time and only compiles code that is reachable from exported functions.

`build/ol-all.js` attempts to compile all code, and therefore has better coverage that `build/ol.js`.

This PR changes the `check` target so that it builds `build/ol-all.js` only.
