### PR TITLE
Proper namespace and sub-parser management in OGC parsers

### DIFF
--- a/src/ol/parser/ogc/filterparser_v1.js
+++ b/src/ol/parser/ogc/filterparser_v1.js
@@ -596,6 +596,9 @@ ol.parser.ogc.Filter_v1.prototype.getGmlParser = function() {
  */
 ol.parser.ogc.Filter_v1.prototype.setGmlParser = function(gml) {
   this.gmlParser_ = gml;
+  if (this.featureNS) {
+    gml.setFeatureNS(this.featureNS);
+  }
   for (var uri in this.gmlParser_.readers) {
     for (var key in this.gmlParser_.readers[uri]) {
       if (!goog.isDef(this.readers[uri])) {
@@ -613,5 +616,38 @@ ol.parser.ogc.Filter_v1.prototype.setGmlParser = function(gml) {
       this.writers[uri][key] = goog.bind(this.gmlParser_.writers[uri][key],
           this.gmlParser_);
     }
+  }
+};
+
+
+/**
+ * @param {string} featureNS Feature namespace.
+ */
+ol.parser.ogc.Filter_v1.prototype.setFeatureNS = function(featureNS) {
+  this.featureNS = featureNS;
+  if (goog.isDefAndNotNull(this.gmlParser_)) {
+    this.setGmlParser(this.gmlParser_);
+  }
+};
+
+
+/**
+ * @param {string} featureType Feature type.
+ */
+ol.parser.ogc.Filter_v1.prototype.setFeatureType = function(featureType) {
+  this.featureType = featureType;
+  if (goog.isDefAndNotNull(this.gmlParser_)) {
+    this.gmlParser_.featureType = featureType;
+  }
+};
+
+
+/**
+ * @param {string} srsName SRS name.
+ */
+ol.parser.ogc.Filter_v1.prototype.setSrsName = function(srsName) {
+  this.srsName = srsName;
+  if (goog.isDefAndNotNull(this.gmlParser_)) {
+    this.gmlParser_.srsName = this.srsName;
   }
 };

--- a/src/ol/parser/ogc/filterparser_v1_0_0.js
+++ b/src/ol/parser/ogc/filterparser_v1_0_0.js
@@ -114,7 +114,7 @@ ol.parser.ogc.Filter_v1_0_0 = function() {
       return node;
     }
   });
-  this.setGmlParser(new ol.parser.ogc.GML_v2({featureNS: 'http://foo'}));
+  this.setGmlParser(new ol.parser.ogc.GML_v2());
 };
 goog.inherits(ol.parser.ogc.Filter_v1_0_0,
     ol.parser.ogc.Filter_v1);
@@ -168,8 +168,7 @@ ol.parser.ogc.Filter_v1_0_0.prototype.writeSpatial_ = function(filter, name) {
   } else {
     var child;
     if (geom !== null) {
-      child = this.writeNode('_geometry', {value: geom},
-          this.gmlParser_.featureNS).firstChild;
+      child = this.gmlParser_.writeGeometry(geom);
     } else if (bbox.length === 4) {
       child = this.writeNode('Box', bbox,
           'http://www.opengis.net/gml');

--- a/src/ol/parser/ogc/gmlparser.js
+++ b/src/ol/parser/ogc/gmlparser.js
@@ -480,6 +480,16 @@ goog.inherits(ol.parser.ogc.GML, ol.parser.XML);
 
 
 /**
+ * @param {ol.geom.Geometry} geometry Geometry.
+ * @return {Element} XML node representing the geometry.
+ */
+ol.parser.ogc.GML.prototype.writeGeometry = function(geometry) {
+  return this.featureNSWriters_['_geometry'].call(this, {value: geometry})
+      .firstChild;
+};
+
+
+/**
  * @param {string|Document|Element|Object} data Data to read.
  * @param {ol.parser.GMLReadOptions=} opt_options Read options.
  * @return {ol.parser.ReadFeaturesResult} An object representing the document.
@@ -644,4 +654,14 @@ ol.parser.ogc.GML.prototype.applyWriteOptions = function(obj, opt_options) {
   } else {
     this.axisOrientation = ol.proj.get(this.srsName).getAxisOrientation();
   }
+};
+
+
+/**
+ * @param {string} featureNS Feature namespace.
+ */
+ol.parser.ogc.GML.prototype.setFeatureNS = function(featureNS) {
+  this.featureNS = featureNS;
+  this.readers[featureNS] = this.featureNSReaders_;
+  this.writers[featureNS] = this.featureNSWriters_;
 };

--- a/src/ol/parser/ogc/wfsparser_v1.js
+++ b/src/ol/parser/ogc/wfsparser_v1.js
@@ -122,8 +122,12 @@ ol.parser.ogc.WFS_v1.prototype.getFilterParser = function() {
  */
 ol.parser.ogc.WFS_v1.prototype.setFilterParser = function(filter) {
   this.filter_ = filter;
-  for (var uri in this.filter_.readers) {
-    for (var key in this.filter_.readers[uri]) {
+  if (goog.isDefAndNotNull(this.featureNS)) {
+    filter.setFeatureNS(this.featureNS);
+  }
+  var uri, key;
+  for (uri in this.filter_.readers) {
+    for (key in this.filter_.readers[uri]) {
       if (!goog.isDef(this.readers[uri])) {
         this.readers[uri] = {};
       }
@@ -145,6 +149,39 @@ ol.parser.ogc.WFS_v1.prototype.setFilterParser = function(filter) {
             this.filter_);
       }
     }
+  }
+};
+
+
+/**
+ * @param {string} featureType Feature type.
+ */
+ol.parser.ogc.WFS_v1.prototype.setFeatureType = function(featureType) {
+  this.featureType = featureType;
+  if (goog.isDefAndNotNull(this.filter_)) {
+    this.filter_.setFeatureType(featureType);
+  }
+};
+
+
+/**
+ * @param {string} featureNS Feature namespace.
+ */
+ol.parser.ogc.WFS_v1.prototype.setFeatureNS = function(featureNS) {
+  this.featureNS = featureNS;
+  if (goog.isDefAndNotNull(this.filter_)) {
+    this.setFilterParser(this.filter_);
+  }
+};
+
+
+/**
+ * @param {string} srsName SRS name.
+ */
+ol.parser.ogc.WFS_v1.prototype.setSrsName = function(srsName) {
+  this.srsName = srsName;
+  if (goog.isDefAndNotNull(this.filter_)) {
+    this.filter_.setSrsName(this.srsName);
   }
 };
 

--- a/src/ol/parser/ogc/wfsparser_v1_0_0.js
+++ b/src/ol/parser/ogc/wfsparser_v1_0_0.js
@@ -72,7 +72,6 @@ ol.parser.ogc.WFS_v1_0_0 = function() {
     }
   });
   var filter = new ol.parser.ogc.Filter_v1_0_0();
-  delete filter.getGmlParser().featureNS;
   this.setFilterParser(filter);
 };
 goog.inherits(ol.parser.ogc.WFS_v1_0_0,


### PR DESCRIPTION
Instead of setting a dummy namespace, we can have setter methods for the featureNS property to propagate it to sub-parsers. The srsName is also a property which needs to be propagated for correct coordinate serialization.
