### PR TITLE
Tidy up ol.source.MapGuide and add ratio option

### DIFF
--- a/examples/mapguide-untiled.js
+++ b/examples/mapguide-untiled.js
@@ -25,6 +25,7 @@ var map = new ol.Map({
           MAPDEFINITION: mdf,
           FORMAT: 'PNG'
         },
+        ratio: 2,
         extent: bounds
       })
     })

--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -608,14 +608,18 @@
 
 /**
  * @typedef {Object} ol.source.MapGuideOptions
- * @property {string} url The mapagent url
- * @property {number} metersPerUnit The meters-per-unit value
- * @property {ol.Extent|undefined} extent Extent.
- * @property {boolean} useOverlay If true, will use GETDYNAMICMAPOVERLAYIMAGE
+ * @property {string|undefined} url The mapagent url.
+ * @property {number|undefined} metersPerUnit The meters-per-unit value.
+ * @property {ol.Extent|undefined} extent Extent..
+ * @property {boolean|undefined} useOverlay If true, will use
+ *     GETDYNAMICMAPOVERLAYIMAGE.
  * @property {ol.proj.ProjectionLike} projection Projection.
+ * @property {number|undefined} ratio Ratio. 1 means image requests are the size
+ *     of the map viewport, 2 means twice the size of the map viewport, and so
+ *     on.
  * @property {Array.<number>|undefined} resolutions Resolutions. If specified,
  *     requests will be made for these resolutions only.
- * @property {Object} params additional parameters
+ * @property {Object|undefined} params Additional parameters.
  */
 
 /**


### PR DESCRIPTION
This tidies up a few things in `ol.source.MapGuide` added in #1236, including calling `goog.base` before initialising properties in the constructor, allowing option values to be `undefined`, coding style, punctuation, and capitalisation. It also adds a `ratio` option (defaults to 1).
