### PR TITLE
unable to removeInteration in modify-features example

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -252,9 +252,9 @@ ol.interaction.Modify.prototype.removeIndex_ = function(features) {
         nodesToRemove.push(node);
       }
     });
-  }
-  for (i = nodesToRemove.length - 1; i >= 0; --i) {
-    rBush.remove(nodesToRemove[i]);
+    for (i = nodesToRemove.length - 1; i >= 0; --i) {
+      rBush.remove(nodesToRemove[i]);
+    }
   }
 };
 


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/6138648/1703433/912bc8de-60b5-11e3-89d7-1f035cbcb4b2.png)
## I type this in console

map.removeInteraction(modify)
## console error log

TypeError: Cannot read property 'length' of undefined
Uncaught AssertionError: Assertion failed: instanceof check failed. asserts.js:102
Uncaught AssertionError: Assertion failed: instanceof check failed. asserts.js:102
Uncaught AssertionError: Assertion failed: instanceof check failed. asserts.js:102
GET http://ol3js.org/en/master/css/ol.css 404 (Not Found) modify-features.html:7

And the modify handler is still active.
