### PR TITLE
Remove original handling on ol.Feature

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -43,13 +43,6 @@ ol.Feature = function(opt_values) {
   this.geometryName_;
 
   /**
-   * Original of this feature when it was modified.
-   * @type {ol.Feature}
-   * @private
-   */
-  this.original_ = null;
-
-  /**
    * The render intent for this feature.
    * @type {ol.FeatureRenderIntent|string}
    * @private
@@ -111,15 +104,6 @@ ol.Feature.prototype.getGeometry = function() {
   return goog.isDef(this.geometryName_) ?
       /** @type {ol.geom.Geometry} */ (this.get(this.geometryName_)) :
       null;
-};
-
-
-/**
- * Get the original of this feature when it was modified.
- * @return {ol.Feature} Original.
- */
-ol.Feature.prototype.getOriginal = function() {
-  return this.original_;
 };
 
 
@@ -195,15 +179,6 @@ ol.Feature.prototype.setGeometry = function(geometry) {
     this.geometryName_ = ol.Feature.DEFAULT_GEOMETRY;
   }
   this.set(this.geometryName_, geometry);
-};
-
-
-/**
- * Set the original of this feature when it was modified.
- * @param {ol.Feature} original Original.
- */
-ol.Feature.prototype.setOriginal = function(original) {
-  this.original_ = original;
 };
 
 

--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -368,12 +368,6 @@ ol.interaction.Modify.prototype.handleDragStart = function(evt) {
       if (!(goog.getUid(node.feature) in distinctFeatures)) {
         var feature = node.feature;
         distinctFeatures[goog.getUid(feature)] = true;
-        var original = new ol.Feature(feature.getAttributes());
-        original.setGeometry(feature.getGeometry().clone());
-        original.setId(feature.getId());
-        original.setOriginal(feature.getOriginal());
-        original.setSymbolizers(feature.getSymbolizers());
-        feature.setOriginal(original);
       }
       if (renderIntent == ol.FeatureRenderIntent.TEMPORARY) {
         if (ol.coordinate.equals(segment[0], vertex)) {

--- a/src/ol/parser/ogc/wfsparser_v1.js
+++ b/src/ol/parser/ogc/wfsparser_v1.js
@@ -157,17 +157,12 @@ ol.parser.ogc.WFS_v1 = function(opt_options) {
       }
 
       // add in fields
-      var original = feature.getOriginal();
-      var originalAttributes = goog.isNull(original) ?
-          undefined : original.getAttributes();
       var attributes = feature.getAttributes();
       var attribute;
       for (var key in attributes) {
         attribute = attributes[key];
         // TODO Only add geometries whose values have changed
-        if (goog.isDef(attribute) && (attribute instanceof ol.geom.Geometry ||
-            (!goog.isDef(originalAttributes) ||
-            attribute != originalAttributes[key]))) {
+        if (goog.isDef(attribute)) {
           this.writeNode('Property', {name: key, value: attribute}, null, node);
         }
       }


### PR DESCRIPTION
This is another attempt to bring master closer to the
vector-api branch. In anticipation of the ability to keep track
of modifications on ol.Object through a beforechange event
(d7e4be0), we will be able to manage originals on the
application level or in a separate component outside of
ol.Feature.
