### PR TITLE
[vector-api] Exporting ol.render.DragBox

### DIFF
--- a/src/ol/render/dragbox.exports
+++ b/src/ol/render/dragbox.exports
@@ -1,0 +1,3 @@
+@exportSymbol ol.render.DragBox
+@exportProperty ol.render.DragBox.prototype.setCoordinates
+@exportProperty ol.render.DragBox.prototype.setMap


### PR DESCRIPTION
It would be nice to export DragBox, as it can be used outside of ol3.
