### PR TITLE
Unnest loops

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -243,18 +243,18 @@ ol.interaction.Modify.prototype.addIndex_ = function(features, layer) {
  */
 ol.interaction.Modify.prototype.removeIndex_ = function(features) {
   var rBush = this.rBush_;
-  var i, feature, nodesToRemove;
+  var nodesToRemove = [];
+  var i, feature;
   for (i = features.length - 1; i >= 0; --i) {
     feature = features[i];
-    nodesToRemove = [];
     rBush.forEachInExtent(feature.getGeometry().getBounds(), function(node) {
       if (feature === node.feature) {
         nodesToRemove.push(node);
       }
     });
-    for (i = nodesToRemove.length - 1; i >= 0; --i) {
-      rBush.remove(nodesToRemove[i]);
-    }
+  }
+  for (i = nodesToRemove.length - 1; i >= 0; --i) {
+    rBush.remove(nodesToRemove[i]);
   }
 };
 


### PR DESCRIPTION
Reusing the same iterator variable in a nested loop is a bug. In this case it is better to not have nested loops at all, because we only have to create one array.
