### PR TITLE
Add ol.MapBrowserEvent#getBrowserEvent

### DIFF
--- a/src/ol/mapbrowserevent.exports
+++ b/src/ol/mapbrowserevent.exports
@@ -1,3 +1,4 @@
+@exportProperty ol.MapBrowserEvent.prototype.getBrowserEvent
 @exportProperty ol.MapBrowserEvent.prototype.getCoordinate
 @exportProperty ol.MapBrowserEvent.prototype.getPixel
 @exportProperty ol.MapBrowserEvent.prototype.preventDefault

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -50,6 +50,14 @@ goog.inherits(ol.MapBrowserEvent, ol.MapEvent);
 
 
 /**
+ * @return {Event} The underlying browser event object.
+ */
+ol.MapBrowserEvent.prototype.getBrowserEvent = function() {
+  return this.browserEvent.getBrowserEvent();
+};
+
+
+/**
  * @return {ol.Coordinate} Coordinate.
  * @todo stability experimental
  */


### PR DESCRIPTION
This function makes the underlying native/browser event available to map browser event listeners.
