### PR TITLE
[vector-api] Fix forEachFeatureAtPixel bug

### DIFF
--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -93,19 +93,16 @@ ol.renderer.Map.prototype.forEachFeatureAtPixel =
     function(pixel, callback, opt_obj, opt_layerFunction, opt_obj2) {
   var layerFunction = goog.isDef(opt_layerFunction) ?
       opt_layerFunction : goog.functions.TRUE;
-  var layers = this.map_.getLayers();
-  if (goog.isDef(layers)) {
-    var layersArray = layers.getArray();
-    var i;
-    for (i = layersArray.length - 1; i >= 0; --i) {
-      var layer = layersArray[i];
-      if (layer.getVisible() && layerFunction.call(opt_obj2, layer)) {
-        var layerRenderer = this.getLayerRenderer(layer);
-        var result =
-            layerRenderer.forEachFeatureAtPixel(pixel, callback, opt_obj);
-        if (result) {
-          return result;
-        }
+  var layersArray = this.map_.getLayerGroup().getLayersArray();
+  var i;
+  for (i = layersArray.length - 1; i >= 0; --i) {
+    var layer = layersArray[i];
+    if (layer.getVisible() && layerFunction.call(opt_obj2, layer)) {
+      var layerRenderer = this.getLayerRenderer(layer);
+      var result =
+          layerRenderer.forEachFeatureAtPixel(pixel, callback, opt_obj);
+      if (result) {
+        return result;
       }
     }
   }


### PR DESCRIPTION
This PR fixes a bug in the hit detection code. The bug triggers when the map includes layer groups. An [assertion](https://github.com/openlayers/ol3/blob/vector-api/src/ol/renderer/canvas/canvasmaprenderer.js#L74) fails because getLayerRenderer attemps to create a layer renderer for a layer group.

@oterral, can you please verify that this fixes the bug for you?
