### PR TITLE
Make Interaction inherit from Observable

### DIFF
--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -3,8 +3,8 @@
 goog.provide('ol.interaction.Interaction');
 
 goog.require('goog.asserts');
-goog.require('goog.events.EventTarget');
 goog.require('ol.MapBrowserEvent');
+goog.require('ol.Observable');
 goog.require('ol.View2D');
 goog.require('ol.animation');
 goog.require('ol.easing');
@@ -13,7 +13,7 @@ goog.require('ol.easing');
 
 /**
  * @constructor
- * @extends {goog.events.EventTarget}
+ * @extends {ol.Observable}
  */
 ol.interaction.Interaction = function() {
   goog.base(this);
@@ -25,7 +25,7 @@ ol.interaction.Interaction = function() {
   this.map_ = null;
 
 };
-goog.inherits(ol.interaction.Interaction, goog.events.EventTarget);
+goog.inherits(ol.interaction.Interaction, ol.Observable);
 
 
 /**


### PR DESCRIPTION
Interactions are objects of the API, so the `ol.interaction.Interaction` class should inherit from `ol.Observable` rathen than `goog.events.EventTarget`.

Please review.
