### PR TITLE
Only set interacting hint when modifying the view

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -398,12 +398,15 @@ ol.MapBrowserEventHandler.prototype.handleTouchStart_ = function(browserEvent) {
 
   this.down_ = browserEvent;
   this.dragged_ = false;
-  this.dragListenerKeys_ = [
-    goog.events.listen(goog.global.document, goog.events.EventType.TOUCHMOVE,
-        this.handleTouchMove_, false, this),
-    goog.events.listen(goog.global.document, goog.events.EventType.TOUCHEND,
-        this.handleTouchEnd_, false, this)
-  ];
+
+  if (goog.isNull(this.dragListenerKeys_)) {
+    this.dragListenerKeys_ = [
+      goog.events.listen(goog.global.document, goog.events.EventType.TOUCHMOVE,
+          this.handleTouchMove_, false, this),
+      goog.events.listen(goog.global.document, goog.events.EventType.TOUCHEND,
+          this.handleTouchEnd_, false, this)
+    ];
+  }
 
   // FIXME check if/when this is necessary
   browserEvent.preventDefault();
@@ -436,7 +439,10 @@ ol.MapBrowserEventHandler.prototype.handleTouchEnd_ = function(browserEvent) {
   var newEvent = new ol.MapBrowserEvent(
       ol.MapBrowserEvent.EventType.TOUCHEND, this.map_, browserEvent);
   this.dispatchEvent(newEvent);
-  goog.array.forEach(this.dragListenerKeys_, goog.events.unlistenByKey);
+  if (browserEvent.getBrowserEvent().targetTouches.length === 0) {
+    goog.array.forEach(this.dragListenerKeys_, goog.events.unlistenByKey);
+    this.dragListenerKeys_ = null;
+  }
   if (!this.dragged_) {
     goog.asserts.assert(!goog.isNull(this.down_));
     this.emulateClick_(this.down_);


### PR DESCRIPTION
This PR follows up on https://github.com/openlayers/ol3/pull/1277 by applying the same changes to the touch interaction.

This should also fix a bug in the vector-api branch where vector layers are not redrawn after pinch-zooming. @oterral, you can use my [`vector-api-interaction-hint`](https://github.com/elemoine/ol3/compare/openlayers:vector-api...vector-api-interaction-hint) if you want to test my commit with the vector-api branch.

Please test and review.
