### PR TITLE
fix hover style on zoom buttons in examples

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -165,6 +165,8 @@ a.ol-full-screen-true:after {
   line-height: 26px;
 }
 .ol-zoom a:hover {
+  color: #fff;
+  text-decoration: none;
   background: rgba(0,60,136,0.7);
 }
 


### PR DESCRIPTION
`color` & `text-decoration` is actually set by bootstrap, let’s fix it.

Before:
![capture decran 2013-12-18 a 14 29 13](https://f.cloud.github.com/assets/21686/1773487/b24bc50c-67e8-11e3-9e61-c1e285d782eb.png)

After:
![capture decran 2013-12-18 a 14 32 39](https://f.cloud.github.com/assets/21686/1773494/097517de-67e9-11e3-997c-1c25a7c9da05.png)
