### PR TITLE
Conditionally deregister touchend listener

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -398,12 +398,15 @@ ol.MapBrowserEventHandler.prototype.handleTouchStart_ = function(browserEvent) {
 
   this.down_ = browserEvent;
   this.dragged_ = false;
-  this.dragListenerKeys_ = [
-    goog.events.listen(goog.global.document, goog.events.EventType.TOUCHMOVE,
-        this.handleTouchMove_, false, this),
-    goog.events.listen(goog.global.document, goog.events.EventType.TOUCHEND,
-        this.handleTouchEnd_, false, this)
-  ];
+
+  if (goog.isNull(this.dragListenerKeys_)) {
+    this.dragListenerKeys_ = [
+      goog.events.listen(goog.global.document, goog.events.EventType.TOUCHMOVE,
+          this.handleTouchMove_, false, this),
+      goog.events.listen(goog.global.document, goog.events.EventType.TOUCHEND,
+          this.handleTouchEnd_, false, this)
+    ];
+  }
 
   // FIXME check if/when this is necessary
   browserEvent.preventDefault();
@@ -436,7 +439,10 @@ ol.MapBrowserEventHandler.prototype.handleTouchEnd_ = function(browserEvent) {
   var newEvent = new ol.MapBrowserEvent(
       ol.MapBrowserEvent.EventType.TOUCHEND, this.map_, browserEvent);
   this.dispatchEvent(newEvent);
-  goog.array.forEach(this.dragListenerKeys_, goog.events.unlistenByKey);
+  if (browserEvent.getBrowserEvent().targetTouches.length === 0) {
+    goog.array.forEach(this.dragListenerKeys_, goog.events.unlistenByKey);
+    this.dragListenerKeys_ = null;
+  }
   if (!this.dragged_) {
     goog.asserts.assert(!goog.isNull(this.down_));
     this.emulateClick_(this.down_);


### PR DESCRIPTION
This PR supersedes #1398. It fixes a bug in the vector-api branch where vector layers are not redrawn after pinch-zooming on touch devices.

Previously, the touchend and touchmove listeners were unconditionally deregistered on touchend, which resulted in missed touchend and touchmove events. We now deregister the touchend and touchmove listeners only when there is no finger on the screen.

Note that the same sort of fix should be made for pointer events/devices. I haven't changed the pointer-related code because I don't have a "multi-pointer" device at hand.
