### PR TITLE
Fix bug in ol.structs.RBush#clear

### DIFF
--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -26,6 +26,7 @@ goog.provide('ol.structs.RBush');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
+goog.require('goog.object');
 goog.require('ol.extent');
 
 
@@ -331,6 +332,7 @@ ol.structs.RBush.prototype.clear = function() {
   node.height = 1;
   node.children.length = 0;
   node.value = null;
+  goog.object.clear(this.valueExtent_);
 };
 
 


### PR DESCRIPTION
`ol.structs.RBush#clear` forgot to clear the value extents. This fix is back-ported to `master` from the `vector-api` branch.
