### PR TITLE
[vector-api] Set default canvas lineJoin and lineCap to 'round'

### DIFF
--- a/examples/igc.js
+++ b/examples/igc.js
@@ -39,8 +39,6 @@ var styleFunction = function(feature, resolution) {
     styleArray = [new ol.style.Style({
       stroke: new ol.style.Stroke({
         color: color,
-        lineCap: 'round',
-        lineJoin: 'round',
         width: 3
       })
     })];

--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -743,8 +743,8 @@
 /**
  * @typedef {Object} olx.style.StrokeOptions
  * @property {ol.Color|string|undefined} color Color.
- * @property {string|undefined} lineCap Line cap style: `butt`, `round`, or `square`. Default is `butt`.
- * @property {string|undefined} lineJoin Line join style: `bevel`, `round`, or `miter`. Default is `miter`.
+ * @property {string|undefined} lineCap Line cap style: `butt`, `round`, or `square`. Default is `round`.
+ * @property {string|undefined} lineJoin Line join style: `bevel`, `round`, or `miter`. Default is `round`.
  * @property {Array.<number>|undefined} lineDash Line dash pattern. Default is `undefined` (no dash).
  * @property {number|undefined} miterLimit Miter limit. Default is `10`.
  * @property {number|undefined} width Width.

--- a/src/ol/render/canvas/canvas.js
+++ b/src/ol/render/canvas/canvas.js
@@ -18,7 +18,7 @@ ol.render.canvas.defaultFillStyle = ol.color.fromString('black');
 /**
  * @const {string}
  */
-ol.render.canvas.defaultLineCap = 'butt';
+ol.render.canvas.defaultLineCap = 'round';
 
 
 /**
@@ -30,7 +30,7 @@ ol.render.canvas.defaultLineDash = [];
 /**
  * @const {string}
  */
-ol.render.canvas.defaultLineJoin = 'miter';
+ol.render.canvas.defaultLineJoin = 'round';
 
 
 /**


### PR DESCRIPTION
As discussed with @twpayne some times ago 
