### PR TITLE
[master] Don't attempt to fit views to empty extents

### DIFF
--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -416,10 +416,12 @@ ol.View2D.prototype.getZoom = function() {
  * @todo stability experimental
  */
 ol.View2D.prototype.fitExtent = function(extent, size) {
-  this.setCenter(ol.extent.getCenter(extent));
-  var resolution = this.getResolutionForExtent(extent, size);
-  resolution = this.constrainResolution(resolution, 0, 0);
-  this.setResolution(resolution);
+  if (!ol.extent.isEmpty(extent)) {
+    this.setCenter(ol.extent.getCenter(extent));
+    var resolution = this.getResolutionForExtent(extent, size);
+    resolution = this.constrainResolution(resolution, 0, 0);
+    this.setResolution(resolution);
+  }
 };
 
 


### PR DESCRIPTION
This PR fixes a bug where calling `ol.View2D#fitExtent`, when called with the default empty extent, would result in the view's center being set to `[NaN, NaN]`, which, in turn, caused lots of breakage elsewhere.
