### PR TITLE
Make build.py compatible with Python 2.6

### DIFF
--- a/build.py
+++ b/build.py
@@ -159,7 +159,7 @@ def report_sizes(t):
     gzipfile.close()
     rawsize = os.stat(t.name).st_size
     gzipsize = len(stringio.getvalue())
-    savings = '{:.2%}'.format((rawsize - gzipsize)/float(rawsize))
+    savings = '{0:.2%}'.format((rawsize - gzipsize)/float(rawsize))
     t.info('uncompressed: %8d bytes', rawsize)
     t.info('  compressed: %8d bytes, (saved %s)', gzipsize, savings)
 


### PR DESCRIPTION
Developer guide says compatible with 2.6 or 2.7, but this type of formatting with auto numbering was only introduced in 2.7
