### PR TITLE
Use goog.style.getContentBoxSize to calculate map size

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1212,7 +1212,7 @@ ol.Map.prototype.updateSize = function() {
   if (goog.isNull(targetElement)) {
     this.setSize(undefined);
   } else {
-    var size = goog.style.getSize(targetElement);
+    var size = goog.style.getContentBoxSize(targetElement);
     this.setSize([size.width, size.height]);
   }
 };


### PR DESCRIPTION
This takes into account any border.

This fixes the problem reported by @bartvde in #1440.
