### PR TITLE
[vector-api] Multiple render geometry functions

### DIFF
--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -8,7 +8,7 @@ goog.require('ol.layer.Layer');
  * @enum {string}
  */
 ol.layer.VectorProperty = {
-  RENDER_GEOMETRY_FUNCTION: 'renderGeometryFunction',
+  RENDER_GEOMETRY_FUNCTIONS: 'renderGeometryFunctions',
   STYLE_FUNCTION: 'styleFunction'
 };
 
@@ -36,17 +36,16 @@ goog.inherits(ol.layer.Vector, ol.layer.Layer);
 
 
 /**
- * @return {function(ol.geom.Geometry): boolean|undefined} Render geometry
- *     function.
+ * @return {ol.Collection|undefined} Render geometry functions.
  */
-ol.layer.Vector.prototype.getRenderGeometryFunction = function() {
-  return /** @type {function(ol.geom.Geometry): boolean|undefined} */ (
-      this.get(ol.layer.VectorProperty.RENDER_GEOMETRY_FUNCTION));
+ol.layer.Vector.prototype.getRenderGeometryFunctions = function() {
+  return /** @type {ol.Collection|undefined} */ (
+      this.get(ol.layer.VectorProperty.RENDER_GEOMETRY_FUNCTIONS));
 };
 goog.exportProperty(
     ol.layer.Vector.prototype,
-    'getRenderGeometryFunction',
-    ol.layer.Vector.prototype.getRenderGeometryFunction);
+    'getRenderGeometryFunctions',
+    ol.layer.Vector.prototype.getRenderGeometryFunctions);
 
 
 /**
@@ -63,18 +62,18 @@ goog.exportProperty(
 
 
 /**
- * @param {function(ol.geom.Geometry): boolean|undefined} renderGeometryFunction
- *     Render geometry function.
+ * @param {ol.Collection|undefined} renderGeometryFunctions Render geometry
+ *     functions.
  */
-ol.layer.Vector.prototype.setRenderGeometryFunction =
-    function(renderGeometryFunction) {
-  this.set(
-      ol.layer.VectorProperty.RENDER_GEOMETRY_FUNCTION, renderGeometryFunction);
+ol.layer.Vector.prototype.setRenderGeometryFunctions =
+    function(renderGeometryFunctions) {
+  this.set(ol.layer.VectorProperty.RENDER_GEOMETRY_FUNCTIONS,
+      renderGeometryFunctions);
 };
 goog.exportProperty(
     ol.layer.Vector.prototype,
-    'setRenderGeometryFunction',
-    ol.layer.Vector.prototype.setRenderGeometryFunction);
+    'setRenderGeometryFunctions',
+    ol.layer.Vector.prototype.setRenderGeometryFunctions);
 
 
 /**

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -117,18 +117,38 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtPixel =
 
 /**
  * @private
- * @return {function(ol.geom.Geometry): boolean|undefined} Render geometry
- *     function.
+ * @return {function(ol.geom.Geometry): boolean} Render geometry function.
  */
 ol.renderer.canvas.VectorLayer.prototype.getRenderGeometryFunction_ =
     function() {
   var vectorLayer = this.getLayer();
   goog.asserts.assertInstanceof(vectorLayer, ol.layer.Vector);
-  var renderGeometryFunction = vectorLayer.getRenderGeometryFunction();
-  if (!goog.isDef(renderGeometryFunction)) {
-    renderGeometryFunction = goog.functions.TRUE;
+  var renderGeometryFunctions = vectorLayer.getRenderGeometryFunctions();
+  if (!goog.isDef(renderGeometryFunctions)) {
+    return goog.functions.TRUE;
   }
-  return renderGeometryFunction;
+  var renderGeometryFunctionsArray = renderGeometryFunctions.getArray();
+  switch (renderGeometryFunctionsArray.length) {
+    case 0:
+      return goog.functions.TRUE;
+    case 1:
+      return renderGeometryFunctionsArray[0];
+    default:
+      return (
+          /**
+           * @param {ol.geom.Geometry} geometry Geometry.
+           * @return {boolean} Render geometry.
+           */
+          function(geometry) {
+            var i, ii;
+            for (i = 0, ii = renderGeometryFunctionsArray.length; i < ii; ++i) {
+              if (!renderGeometryFunctionsArray[i](geometry)) {
+                return false;
+              }
+            }
+            return true;
+          });
+  }
 };
 
 


### PR DESCRIPTION
This PR allows an `ol.layer.Vector` to have multiple `renderGeometryFunctions`.

It adds a `revision` property to `ol.Collection` to avoid having to listen on the `ol.Collection` of `renderGeometryFunction`'s events.
