### PR TITLE
[vector-api] Add StyleFunction types

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -473,7 +473,7 @@
  * @property {number|undefined} opacity Opacity. 0-1. Default is `1`.
  * @property {number|undefined} saturation Saturation.
  * @property {ol.source.Vector} source Source.
- * @property {ol.style.StyleFunction|undefined} styleFunction Style function.
+ * @property {ol.feature.StyleFunction|undefined} styleFunction Style function.
  * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
  * @todo stability experimental
  */

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -1,8 +1,10 @@
 goog.provide('ol.Feature');
+goog.provide('ol.feature');
 
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('goog.functions');
 goog.require('ol.Object');
 goog.require('ol.geom.Geometry');
 goog.require('ol.style.Style');
@@ -14,12 +16,6 @@ goog.require('ol.style.Style');
 ol.FeatureProperty = {
   STYLE_FUNCTION: 'styleFunction'
 };
-
-
-/**
- * @typedef {function(this: ol.Feature, number): Array.<ol.style.Style>}
- */
-ol.FeatureStyleFunction;
 
 
 
@@ -127,10 +123,10 @@ ol.Feature.prototype.getRevision = function() {
 
 
 /**
- * @return {ol.FeatureStyleFunction|undefined} Style function.
+ * @return {ol.feature.FeatureStyleFunction|undefined} Style function.
  */
 ol.Feature.prototype.getStyleFunction = function() {
-  return /** @type {ol.FeatureStyleFunction|undefined} */ (
+  return /** @type {ol.feature.FeatureStyleFunction|undefined} */ (
       this.get(ol.FeatureProperty.STYLE_FUNCTION));
 };
 goog.exportProperty(
@@ -185,7 +181,8 @@ goog.exportProperty(
 
 
 /**
- * @param {ol.FeatureStyleFunction|undefined} styleFunction Style function.
+ * @param {ol.feature.FeatureStyleFunction|undefined} styleFunction Style
+ *     function.
  */
 ol.Feature.prototype.setStyleFunction = function(styleFunction) {
   this.set(ol.FeatureProperty.STYLE_FUNCTION, styleFunction);
@@ -216,4 +213,38 @@ ol.Feature.prototype.setGeometryName = function(name) {
       this, ol.Object.getChangeEventType(this.geometryName_),
       this.handleGeometryChanged_, false, this);
   this.handleGeometryChanged_();
+};
+
+
+/**
+ * @typedef {function(this: ol.Feature, number): Array.<ol.style.Style>}
+ */
+ol.feature.FeatureStyleFunction;
+
+
+/**
+ * @param {number} resolution Resolution.
+ * @return {Array.<ol.style.Style>} Style.
+ * @this {ol.Feature}
+ */
+ol.feature.defaultFeatureStyleFunction = goog.functions.constant([]);
+
+
+/**
+ * @typedef {function(ol.Feature, number): Array.<ol.style.Style>}
+ */
+ol.feature.StyleFunction;
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @param {number} resolution Resolution.
+ * @return {Array.<ol.style.Style>} Style.
+ */
+ol.feature.defaultStyleFunction = function(feature, resolution) {
+  var featureStyleFunction = feature.getStyleFunction();
+  if (!goog.isDef(featureStyleFunction)) {
+    featureStyleFunction = ol.feature.defaultFeatureStyleFunction;
+  }
+  return featureStyleFunction.call(feature, resolution);
 };

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -18,6 +18,7 @@ goog.require('goog.math');
 goog.require('goog.object');
 goog.require('goog.string');
 goog.require('ol.Feature');
+goog.require('ol.feature');
 goog.require('ol.format.XML');
 goog.require('ol.geom.GeometryCollection');
 goog.require('ol.geom.LineString');
@@ -78,7 +79,7 @@ ol.format.KML = function(opt_options) {
 
   /**
    * @private
-   * @type {function(this: ol.Feature, number): Array.<ol.style.Style>}
+   * @type {ol.feature.FeatureStyleFunction}
    */
   this.sharedStyleFeatureStyleFunction_ =
       /**
@@ -238,8 +239,7 @@ ol.format.KML.defaultFeatureStyleFunction_ = function(resolution) {
 /**
  * @param {ol.style.Style} style Style.
  * @private
- * @return {function(this: ol.Feature, number): Array.<ol.style.Style>} Feature
- *     style function.
+ * @return {ol.feature.FeatureStyleFunction} Feature style function.
  */
 ol.format.KML.makeFeatureStyleFunction_ = function(style) {
   // FIXME handle styleMap?

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -1,5 +1,6 @@
 goog.provide('ol.layer.Vector');
 
+goog.require('ol.feature');
 goog.require('ol.layer.Layer');
 goog.require('ol.source.Vector');
 
@@ -36,21 +37,6 @@ goog.inherits(ol.layer.Vector, ol.layer.Layer);
 
 
 /**
- * @param {ol.Feature} feature Feature.
- * @param {number} resolution Resolution.
- * @return {Array.<ol.style.Style>} Styles.
- */
-ol.layer.Vector.defaultStyleFunction = function(feature, resolution) {
-  var featureStyleFunction = feature.getStyleFunction();
-  if (goog.isDef(featureStyleFunction)) {
-    return featureStyleFunction.call(feature, resolution);
-  } else {
-    return null;
-  }
-};
-
-
-/**
  * @return {function(ol.geom.Geometry): boolean|undefined} Render geometry
  *     function.
  */
@@ -65,10 +51,10 @@ goog.exportProperty(
 
 
 /**
- * @return {ol.style.StyleFunction|undefined} Style function.
+ * @return {ol.feature.StyleFunction|undefined} Style function.
  */
 ol.layer.Vector.prototype.getStyleFunction = function() {
-  return /** @type {ol.style.StyleFunction|undefined} */ (
+  return /** @type {ol.feature.StyleFunction|undefined} */ (
       this.get(ol.layer.VectorProperty.STYLE_FUNCTION));
 };
 goog.exportProperty(
@@ -101,7 +87,7 @@ goog.exportProperty(
 
 
 /**
- * @param {ol.style.StyleFunction|undefined} styleFunction Style function.
+ * @param {ol.feature.StyleFunction|undefined} styleFunction Style function.
  */
 ol.layer.Vector.prototype.setStyleFunction = function(styleFunction) {
   this.set(ol.layer.VectorProperty.STYLE_FUNCTION, styleFunction);

--- a/src/ol/render/featuresoverlay.js
+++ b/src/ol/render/featuresoverlay.js
@@ -8,8 +8,8 @@ goog.require('goog.object');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
+goog.require('ol.feature');
 goog.require('ol.render.EventType');
-goog.require('ol.style.StyleFunction');
 
 
 
@@ -50,7 +50,7 @@ ol.render.FeaturesOverlay = function() {
 
   /**
    * @private
-   * @type {ol.style.StyleFunction|undefined}
+   * @type {ol.feature.StyleFunction|undefined}
    */
   this.styleFunction_ = undefined;
 
@@ -191,7 +191,7 @@ ol.render.FeaturesOverlay.prototype.setMap = function(map) {
 
 
 /**
- * @param {ol.style.StyleFunction} styleFunction Style function.
+ * @param {ol.feature.StyleFunction} styleFunction Style function.
  */
 ol.render.FeaturesOverlay.prototype.setStyleFunction = function(styleFunction) {
   this.styleFunction_ = styleFunction;

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -6,6 +6,7 @@ goog.require('goog.events.EventType');
 goog.require('goog.functions');
 goog.require('ol.ViewHint');
 goog.require('ol.extent');
+goog.require('ol.feature');
 goog.require('ol.layer.Vector');
 goog.require('ol.render.canvas.ReplayGroup');
 goog.require('ol.renderer.canvas.Layer');
@@ -197,7 +198,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
 
   var styleFunction = vectorLayer.getStyleFunction();
   if (!goog.isDef(styleFunction)) {
-    styleFunction = ol.layer.Vector.defaultStyleFunction;
+    styleFunction = ol.feature.defaultStyleFunction;
   }
   var tolerance = frameStateResolution / (2 * pixelRatio);
   var replayGroup = new ol.render.canvas.ReplayGroup(pixelRatio, tolerance);
@@ -226,7 +227,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
  * @param {ol.Feature} feature Feature.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {ol.style.StyleFunction} styleFunction Style function.
+ * @param {ol.feature.StyleFunction} styleFunction Style function.
  * @param {ol.render.canvas.ReplayGroup} replayGroup Replay group.
  * @return {boolean} `true` if an image is loading.
  */

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -1,5 +1,4 @@
 goog.provide('ol.style.Style');
-goog.provide('ol.style.StyleFunction');
 
 goog.require('ol.style.Fill');
 goog.require('ol.style.Image');
@@ -86,9 +85,3 @@ ol.style.Style.prototype.getText = function() {
 ol.style.Style.prototype.getZIndex = function() {
   return this.zIndex_;
 };
-
-
-/**
- * @typedef {function(ol.Feature, number): Array.<ol.style.Style>}
- */
-ol.style.StyleFunction;


### PR DESCRIPTION
This PR adds a type `ol.style.FeatureStyleFunction`, and moves both it, and `ol.style.defaultStyleFunction` into `ol.style`.

@elemoine, do you think `ol.style.FeatureStyleFunction` should be moved to `ol.feature.defaultStyleFunction`?
