### PR TITLE
Fix bug in ol.structs.RBush#update

### DIFF
--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -555,7 +555,6 @@ ol.structs.RBush.prototype.insert = function(extent, value) {
   var key = this.getKey_(value);
   goog.asserts.assert(!this.valueExtent_.hasOwnProperty(key));
   this.insert_(extent, value, this.root_.height - 1);
-  this.valueExtent_[key] = ol.extent.clone(extent);
 };
 
 
@@ -583,6 +582,8 @@ ol.structs.RBush.prototype.insert_ = function(extent, value, level) {
   for (; i >= 0; --i) {
     ol.extent.extend(path[i].extent, extent);
   }
+  var key = this.getKey_(value);
+  this.valueExtent_[key] = ol.extent.clone(extent);
   return node;
 };
 


### PR DESCRIPTION
Due to PR #1415, if clear() is called during an update(), the valueExtents_ object is cleared, but the updated extent is never re-added (like during insert()). Instead, always add the new extent to valueExtents_ during insert_().

This situation arose when updating the coordinates of an ol.Feature that had already been added to an ol.source.Vector.
