### PR TITLE
[vector-api] KML LinearRing support

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -710,6 +710,28 @@ ol.format.KML.readLineString_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
+ * @return {ol.geom.Polygon|undefined} Polygon.
+ */
+ol.format.KML.readLinearRing_ = function(node, objectStack) {
+  goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
+  goog.asserts.assert(node.localName == 'LinearRing');
+  var flatCoordinates =
+      ol.format.KML.readFlatCoordinatesFromNode_(node, objectStack);
+  if (goog.isDef(flatCoordinates)) {
+    var polygon = new ol.geom.Polygon(null);
+    polygon.setFlatCoordinates(ol.geom.GeometryLayout.XYZ, flatCoordinates,
+        [flatCoordinates.length]);
+    return polygon;
+  } else {
+    return undefined;
+  }
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {Array.<*>} objectStack Object stack.
+ * @private
  * @return {ol.geom.Geometry} Geometry.
  */
 ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
@@ -1206,6 +1228,7 @@ ol.format.KML.LINE_STYLE_PARSERS_ = ol.xml.makeParsersNS(
 ol.format.KML.MULTI_GEOMETRY_PARSERS_ = ol.xml.makeParsersNS(
     ol.format.KML.NAMESPACE_URIS_, {
       'LineString': ol.xml.makeArrayPusher(ol.format.KML.readLineString_),
+      'LinearRing': ol.xml.makeArrayPusher(ol.format.KML.readLinearRing_),
       'MultiGeometry': ol.xml.makeArrayPusher(ol.format.KML.readMultiGeometry_),
       'Point': ol.xml.makeArrayPusher(ol.format.KML.readPoint_),
       'Polygon': ol.xml.makeArrayPusher(ol.format.KML.readPolygon_)
@@ -1255,6 +1278,8 @@ ol.format.KML.PLACEMARK_PARSERS_ = ol.xml.makeParsersNS(
           ol.format.KML.readMultiGeometry_, 'geometry'),
       'LineString': ol.xml.makeObjectPropertySetter(
           ol.format.KML.readLineString_, 'geometry'),
+      'LinearRing': ol.xml.makeObjectPropertySetter(
+          ol.format.KML.readLinearRing_, 'geometry'),
       'Point': ol.xml.makeObjectPropertySetter(
           ol.format.KML.readPoint_, 'geometry'),
       'Polygon': ol.xml.makeObjectPropertySetter(

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -89,6 +89,24 @@ describe('ol.format.KML', function() {
         expect(g.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
       });
 
+      it('can read LinearRing geometries', function() {
+        var text =
+            '<kml xmlns="http://earth.google.com/kml/2.2">' +
+            '  <Placemark>' +
+            '    <LinearRing>' +
+            '      <coordinates>1,2,3 4,5,6 7,8,9</coordinates>' +
+            '    </LinearRing>' +
+            '  </Placemark>' +
+            '</kml>';
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.an(ol.Feature);
+        var g = f.getGeometry();
+        expect(g).to.be.an(ol.geom.Polygon);
+        expect(g.getCoordinates()).to.eql([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]);
+      });
+
       it('can read Polygon geometries', function() {
         var text =
             '<kml xmlns="http://earth.google.com/kml/2.2">' +
@@ -255,6 +273,9 @@ describe('ol.format.KML', function() {
             '      <LineString>' +
             '        <coordinates>1,2,3 4,5,6</coordinates>' +
             '      </LineString>' +
+            '      <LinearRing>' +
+            '        <coordinates>1,2,3 4,5,6 7,8,9</coordinates>' +
+            '      </LinearRing>' +
             '      <Polygon>' +
             '        <outerBoundaryIs>' +
             '          <LinearRing>' +
@@ -272,10 +293,11 @@ describe('ol.format.KML', function() {
         var g = f.getGeometry();
         expect(g).to.be.an(ol.geom.GeometryCollection);
         var gs = g.getGeometries();
-        expect(gs).to.have.length(3);
+        expect(gs).to.have.length(4);
         expect(gs[0]).to.be.an(ol.geom.Point);
         expect(gs[1]).to.be.an(ol.geom.LineString);
         expect(gs[2]).to.be.an(ol.geom.Polygon);
+        expect(gs[3]).to.be.an(ol.geom.Polygon);
       });
 
       it('can read nested GeometryCollection geometries', function() {


### PR DESCRIPTION
[KML supports LinearRings as geometry type](https://developers.google.com/kml/documentation/kmlreference#linearring), but ol3's geometry model is based on GeoJSON which [does not have an explicit LinearRing geometry type](http://geojson.org/geojson-spec.html#linestring).

This PR adds support for KML LinearRings by reading them as Polygons.
