### PR TITLE
[vector-api] Add comment about the rtree example not working when hosted

### DIFF
--- a/examples/rtree.html
+++ b/examples/rtree.html
@@ -32,7 +32,7 @@
 
         <div class="span12">
           <h4 id="title">R-Tree example</h4>
-          <p id="shortdesc">R-Tree example.</p>
+          <p id="shortdesc">R-Tree example. Please note that this example only works locally, it does not work when the examples are hosted.  This is because it accesses internals the R-Tree data structure, which are not exported in the API.</p>
           <div id="docs">
             <p>See the <a href="rtree.js" target="_blank">rtree.js source</a> to see how this is done.</p>
           </div>


### PR DESCRIPTION
The rtree example [does not work in hosted mode](http://ol3js.org/en/vector-api/examples/rtree.html). This PR adds a comment explaining why.

CC @ebelo
