### PR TITLE
Fix 'singleclick' in kml-timezones and kml-earthquakes examples

### DIFF
--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -68,8 +68,7 @@ info.tooltip({
   trigger: 'manual'
 });
 
-var displayFeatureInfo = function(evt) {
-  var pixel = map.getEventPixel(evt.originalEvent);
+var displayFeatureInfo = function(pixel) {
   info.css({
     left: pixel[0] + 'px',
     top: (pixel[1] - 15) + 'px'
@@ -88,9 +87,9 @@ var displayFeatureInfo = function(evt) {
 };
 
 $(map.getViewport()).on('mousemove', function(evt) {
-  displayFeatureInfo(evt);
+  displayFeatureInfo(map.getEventPixel(evt.originalEvent));
 });
 
 map.on('singleclick', function(evt) {
-  displayFeatureInfo(evt);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -74,8 +74,7 @@ info.tooltip({
   trigger: 'manual'
 });
 
-var displayFeatureInfo = function(evt) {
-  var pixel = map.getEventPixel(evt.originalEvent);
+var displayFeatureInfo = function(pixel) {
   info.css({
     left: pixel[0] + 'px',
     top: (pixel[1] - 15) + 'px'
@@ -94,9 +93,9 @@ var displayFeatureInfo = function(evt) {
 };
 
 $(map.getViewport()).on('mousemove', function(evt) {
-  displayFeatureInfo(evt);
+  displayFeatureInfo(map.getEventPixel(evt.originalEvent));
 });
 
 map.on('singleclick', function(evt) {
-  displayFeatureInfo(evt);
+  displayFeatureInfo(evt.getPixel());
 });


### PR DESCRIPTION
The issue is visible in http://ol3js.org/en/vector-api/examples/kml-timezones.html, http://ol3js.org/en/vector-api/examples/kml-earthquakes.html (`singleclick` event)
