### PR TITLE
[vector-api] Fix ol.geom.flat.linearRingContainsXY

### DIFF
--- a/src/ol/geom/flatgeom.js
+++ b/src/ol/geom/flatgeom.js
@@ -344,9 +344,9 @@ ol.geom.flat.linearRingContainsXY =
     function(flatCoordinates, offset, end, stride, x, y) {
   // http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
   var contains = false;
-  var x1 = flatCoordinates[offset];
-  var y1 = flatCoordinates[offset + 1];
-  for (offset += stride; offset < end; offset += stride) {
+  var x1 = flatCoordinates[end - stride];
+  var y1 = flatCoordinates[end - stride + 1];
+  for (; offset < end; offset += stride) {
     var x2 = flatCoordinates[offset];
     var y2 = flatCoordinates[offset + 1];
     var intersect = ((y1 > y) != (y2 > y)) &&

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -1,5 +1,3 @@
-// FIXME why do the skip tests below fail? I don't understand!
-
 goog.provide('ol.test.geom.Polygon');
 
 
@@ -291,7 +289,7 @@ describe('ol.geom.Polygon', function() {
       expect(polygon.getFlatCoordinates()).to.eql(flatCoordinates);
     });
 
-    it.skip('does not contain outside coordinates', function() {
+    it('does not contain outside coordinates', function() {
       expect(polygon.containsCoordinate(outsideOuter)).to.be(false);
     });
 
@@ -302,10 +300,6 @@ describe('ol.geom.Polygon', function() {
     it('does not contain inside inner coordinates', function() {
       expect(polygon.containsCoordinate(insideInner1)).to.be(false);
       expect(polygon.containsCoordinate(insideInner2)).to.be(false);
-    });
-
-    it.skip('fails in strange ways', function() {
-      expect(polygon.containsCoordinate([0, 0])).to.be(false);
     });
 
   });


### PR DESCRIPTION
This PR fixes a bug in point-in-linear ring tests. The point-in-linear ring test was not taking into account the closing edge of the linear ring (i.e. from the last coordinate to the first).

Note: `master` may or may not contain the same bug. If `master` ensures that all linear rings are closed (i.e. that for every linear ring, the last vertex is equal to the first) then `master` does not have this bug. If `master` does not ensure this, then `master` has this bug.
