### PR TITLE
Source state of a layer doesn't depend on group

### DIFF
--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -205,7 +205,6 @@ ol.layer.Group.prototype.getLayerStatesArray = function(opt_obj) {
     layerState.hue += ownLayerState.hue;
     layerState.opacity *= ownLayerState.opacity;
     layerState.saturation *= ownLayerState.saturation;
-    layerState.sourceState = this.getSourceState();
     layerState.visible = layerState.visible && ownLayerState.visible;
     layerState.maxResolution = Math.min(
         layerState.maxResolution, ownLayerState.maxResolution);
@@ -221,30 +220,5 @@ ol.layer.Group.prototype.getLayerStatesArray = function(opt_obj) {
  * @inheritDoc
  */
 ol.layer.Group.prototype.getSourceState = function() {
-  // Return the layer group's source state based on the best source state of its
-  // children:
-  // - if any child is READY, return READY
-  // - otherwise, if any child is LOADING, return LOADING
-  // - otherwise, all children must be in ERROR, return ERROR
-  // - otherwise, there are no children, return READY
-  var layerSourceStates = [0, 0, 0];
-  var layers = this.getLayers().getArray();
-  var n = layers.length;
-  var i;
-  for (i = 0; i < n; ++i) {
-    var layerSourceState = layers[i].getSourceState();
-    goog.asserts.assert(layerSourceState < layerSourceStates.length);
-    ++layerSourceStates[layerSourceState];
-  }
-  if (layerSourceStates[ol.source.State.READY]) {
-    return ol.source.State.READY;
-  } else if (layerSourceStates[ol.source.State.LOADING]) {
-    return ol.source.State.LOADING;
-  } else if (layerSourceStates[ol.source.State.ERROR]) {
-    goog.asserts.assert(layerSourceStates[ol.source.State.ERROR] == n);
-    return ol.source.State.ERROR;
-  } else {
-    goog.asserts.assert(n === 0);
-    return ol.source.State.READY;
-  }
+  return ol.source.State.READY;
 };


### PR DESCRIPTION
With this PR the source states of layers no longer depends on theirs groups. This fixes a major bug where as soon as one layer of a group was ready then all the other layers of that group were considered ready as well.
