### PR TITLE
[vector-api] Change default anchor for KML icons from Google Maps

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -461,6 +461,8 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
     anchor = [hotSpot.x, hotSpot.y];
   } else if (src === ol.format.KML.DEFAULT_IMAGE_STYLE_SRC_) {
     anchor = ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_;
+  } else if (/^http:\/\/maps\.(?:google|gstatic)\.com\//.test(src)) {
+    anchor = [16, 32];
   } else {
     anchor = null;
   }


### PR DESCRIPTION
This PR is potentially contentious.

The [KML specification of IconStyle](https://developers.google.com/kml/documentation/kmlreference#iconstyle) does not clearly specify a default hotSpot (anchor). Many KML files use icons from Google Maps, and from [looking at them](http://ex-ample.blogspot.fr/2011/08/all-url-of-markers-used-by-google-maps.html) it seems that the default anchor is [16, 32]. This PR includes a hack to override the anchors of such markers.

Before:
![before](https://f.cloud.github.com/assets/6942/1859673/75aefc08-77a7-11e3-8ffc-c7d700737162.png)

After:
![after](https://f.cloud.github.com/assets/6942/1859684/9f02ec18-77a7-11e3-8983-fbc8b1539019.png)

cc @oterral
