### PR TITLE
Only create a frame state if the map has non-zero size

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1044,12 +1044,27 @@ ol.Map.prototype.renderFrame_ = function(time) {
     return;
   }
 
+  /**
+   * Check whether a size has non-zero width and height.  Note that this
+   * function is here because the compiler doesn't recognize that size is
+   * defined in the frameState assignment below when the same code is inline in
+   * the condition below.  The compiler inlines this function itself, so the
+   * resulting code is the same.
+   *
+   * @param {ol.Size} size The size to test.
+   * @return {boolean} Has non-zero width and height.
+   */
+  function hasArea(size) {
+    return size[0] > 0 && size[1] > 0;
+  }
+
   var size = this.getSize();
   var view = this.getView();
   var view2D = goog.isDef(view) ? this.getView().getView2D() : undefined;
   /** @type {?ol.FrameState} */
   var frameState = null;
-  if (goog.isDef(size) && goog.isDef(view2D) && view2D.isDef()) {
+  if (goog.isDef(size) && hasArea(size) &&
+      goog.isDef(view2D) && view2D.isDef()) {
     var viewHints = view.getHints();
     var obj = this.getLayerGroup().getLayerStatesArray();
     var layersArray = obj.layers;

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -97,6 +97,76 @@ describe('ol.Map', function() {
     });
   });
 
+  describe('#requestRenderFrame()', function() {
+
+    var target, map;
+
+    beforeEach(function() {
+      target = document.createElement('div');
+      var style = target.style;
+      style.position = 'absolute';
+      style.left = '-1000px';
+      style.top = '-1000px';
+      style.width = '360px';
+      style.height = '180px';
+      document.body.appendChild(target);
+      map = new ol.Map({
+        target: target,
+        view: new ol.View2D({
+          projection: 'EPSG:4326',
+          center: [0, 0],
+          resolution: 1
+        })
+      });
+    });
+
+    afterEach(function() {
+      goog.dispose(map);
+      document.body.removeChild(target);
+    });
+
+    it('results in an postrender event', function(done) {
+
+      map.requestRenderFrame();
+      map.on('postrender', function(event) {
+        expect(event).to.be.a(ol.MapEvent);
+        var frameState = event.frameState;
+        expect(frameState).not.to.be(null);
+        done();
+      });
+
+    });
+
+    it('results in an postrender event (for zero height map)', function(done) {
+      target.style.height = '0px';
+      map.updateSize();
+
+      map.requestRenderFrame();
+      map.on('postrender', function(event) {
+        expect(event).to.be.a(ol.MapEvent);
+        var frameState = event.frameState;
+        expect(frameState).to.be(null);
+        done();
+      });
+
+    });
+
+    it('results in an postrender event (for zero width map)', function(done) {
+      target.style.width = '0px';
+      map.updateSize();
+
+      map.requestRenderFrame();
+      map.on('postrender', function(event) {
+        expect(event).to.be.a(ol.MapEvent);
+        var frameState = event.frameState;
+        expect(frameState).to.be(null);
+        done();
+      });
+
+    });
+
+  });
+
   describe('dispose', function() {
     var map;
 
@@ -171,8 +241,10 @@ describe('ol.Map', function() {
 goog.require('goog.dispose');
 goog.require('goog.dom');
 goog.require('ol.Map');
+goog.require('ol.MapEvent');
 goog.require('ol.RendererHint');
 goog.require('ol.RendererHints');
+goog.require('ol.View2D');
 goog.require('ol.interaction');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.interaction.DoubleClickZoom');


### PR DESCRIPTION
This is an alternative to #1490.

With this approach, event listeners get called with `null` frame state when the map has zero width or height.

As noted in the comments, I resorted to adding the `hasArea` function as a way to appease the compiler.  If the same code is placed inline in the condition for `frameState` assignment, the compiler thinks that `size` might again be `undefined`.  I'd prefer an alternative, and am open to suggestions, but the compiler also inlines this function (the resulting condition is `if (r(e) && 0 < e[0] && 0 < e[1] && r(f) && f.ud())`), so the result is the same.
