### PR TITLE
[vector-api] Only use color arrays in the library

### DIFF
--- a/src/ol/interaction/dragzoominteraction.js
+++ b/src/ol/interaction/dragzoominteraction.js
@@ -38,7 +38,7 @@ ol.interaction.DragZoom = function(opt_options) {
   var style = goog.isDef(options.style) ?
       options.style : new ol.style.Style({
         stroke: new ol.style.Stroke({
-          color: 'blue'
+          color: [0, 0, 255, 1]
         })
       });
 

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -127,7 +127,7 @@ ol.interaction.Draw.defaultStyleFunction = (function() {
   styles[ol.geom.GeometryType.POLYGON] = [
     new ol.style.Style({
       fill: new ol.style.Fill({
-        color: 'rgba(255, 255, 255, 0.5)'
+        color: [255, 255, 255, 0.5]
       })
     })
   ];
@@ -137,13 +137,13 @@ ol.interaction.Draw.defaultStyleFunction = (function() {
   styles[ol.geom.GeometryType.LINE_STRING] = [
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color: 'white',
+        color: [255, 255, 255, 1],
         width: 5
       })
     }),
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color: '#0099ff',
+        color: [0, 153, 255, 1],
         width: 3
       })
     })
@@ -156,10 +156,10 @@ ol.interaction.Draw.defaultStyleFunction = (function() {
       image: new ol.style.Circle({
         radius: 7,
         fill: new ol.style.Fill({
-          color: '#0099ff'
+          color: [0, 153, 255, 1]
         }),
         stroke: new ol.style.Stroke({
-          color: 'rgba(255, 255, 255, 0.75)',
+          color: [255, 255, 255, 0.75],
           width: 1.5
         })
       }),


### PR DESCRIPTION
Since `vector-api` is designed to support WebGL, it cannot rely on Canvas's parsing of named colours. So, by default, it [includes `goog.color.names`](https://github.com/openlayers/ol3/blob/vector-api/src/ol/color/color.js#L16-21) which adds about ~1.5KB to the compressed library size (3KB uncompressed).

Since some users might build ol3 without named colour support, we should not rely on their presence. This PR goes one step further and uses `ol.Color` values for all colours defined in the library.
