### PR TITLE
Documentation error

### DIFF
--- a/src/olx.jsdoc
+++ b/src/olx.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace olx
+ */


### PR DESCRIPTION
There is a broken link on the page : 
http://ol3js.org/en/master/apidoc/ol.source.TileWMS.html

There is `olx.source.TileWMSOption` instead of `ol.source.TileWMSOption`
