### PR TITLE
[vector-api] Remove social links from d3 example

### DIFF
--- a/examples/d3.html
+++ b/examples/d3.html
@@ -15,7 +15,7 @@
     <div class="navbar navbar-inverse navbar-fixed-top">
       <div class="navbar-inner">
         <div class="container">
-          <a class="brand" href="./">OpenLayers 3 Examples</a>
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The original d3 example work was done before #1050 was merged. This PR removes the old social links from the d3 example.
