### PR TITLE
Handle case where Bing resource has no imagery providers

### DIFF
--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -115,37 +115,40 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
                     });
               })));
 
-  var transform = ol.proj.getTransformFromProjections(
-      ol.proj.get('EPSG:4326'), this.getProjection());
-  var attributions = goog.array.map(
-      resource.imageryProviders,
-      function(imageryProvider) {
-        var html = imageryProvider.attribution;
-        /** @type {Object.<string, Array.<ol.TileRange>>} */
-        var tileRanges = {};
-        goog.array.forEach(
-            imageryProvider.coverageAreas,
-            function(coverageArea) {
-              var minZ = coverageArea.zoomMin;
-              var maxZ = coverageArea.zoomMax;
-              var bbox = coverageArea.bbox;
-              var epsg4326Extent = [bbox[1], bbox[0], bbox[3], bbox[2]];
-              var extent = ol.extent.transform(epsg4326Extent, transform);
-              var tileRange, z, zKey;
-              for (z = minZ; z <= maxZ; ++z) {
-                zKey = z.toString();
-                tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
-                if (zKey in tileRanges) {
-                  tileRanges[zKey].push(tileRange);
-                } else {
-                  tileRanges[zKey] = [tileRange];
+  if (resource.imageryProviders) {
+    var transform = ol.proj.getTransformFromProjections(
+        ol.proj.get('EPSG:4326'), this.getProjection());
+
+    var attributions = goog.array.map(
+        resource.imageryProviders,
+        function(imageryProvider) {
+          var html = imageryProvider.attribution;
+          /** @type {Object.<string, Array.<ol.TileRange>>} */
+          var tileRanges = {};
+          goog.array.forEach(
+              imageryProvider.coverageAreas,
+              function(coverageArea) {
+                var minZ = coverageArea.zoomMin;
+                var maxZ = coverageArea.zoomMax;
+                var bbox = coverageArea.bbox;
+                var epsg4326Extent = [bbox[1], bbox[0], bbox[3], bbox[2]];
+                var extent = ol.extent.transform(epsg4326Extent, transform);
+                var tileRange, z, zKey;
+                for (z = minZ; z <= maxZ; ++z) {
+                  zKey = z.toString();
+                  tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
+                  if (zKey in tileRanges) {
+                    tileRanges[zKey].push(tileRange);
+                  } else {
+                    tileRanges[zKey] = [tileRange];
+                  }
                 }
-              }
-            });
-        return new ol.Attribution({html: html, tileRanges: tileRanges});
-      });
-  attributions.push(ol.source.BingMaps.TOS_ATTRIBUTION);
-  this.setAttributions(attributions);
+              });
+          return new ol.Attribution({html: html, tileRanges: tileRanges});
+        });
+    attributions.push(ol.source.BingMaps.TOS_ATTRIBUTION);
+    this.setAttributions(attributions);
+  }
 
   this.setLogo(brandLogoUri);
 


### PR DESCRIPTION
This avoids an Uncaught TypeError: Array.prototype.map called on null or undefined.

See the [bing-maps.html](http://ol3js.org/en/master/examples/bing-maps.html) example.  It looks like the Collins Bart and Ordnance Survey metadata is returned with `null` `imageryProviders`.  I haven't checked to see if a different attribution source should be used.
