### PR TITLE
[vector-api] ol.source.ImageVector improvements

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -651,6 +651,8 @@
  *     new canvases will be created for these resolutions only.
  * @property {ol.source.Vector} source The vector source from which the vector
  *     features drawn in canvas elements are read.
+ * @property {ol.feature.StyleFunction|undefined} styleFunction Style function
+ *     providing the styles to use when rendering features to the canvas.
  */
 
 /**

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -7,6 +7,7 @@ goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.vec.Mat4');
 goog.require('ol.extent');
+goog.require('ol.feature');
 goog.require('ol.render.canvas.ReplayGroup');
 goog.require('ol.renderer.vector');
 goog.require('ol.source.ImageCanvas');
@@ -41,9 +42,10 @@ ol.source.ImageVector = function(options) {
 
   /**
    * @private
-   * @type {ol.feature.StyleFunction}
+   * @type {!ol.feature.StyleFunction}
    */
-  this.styleFunction_ = options.styleFunction;
+  this.styleFunction_ = goog.isDef(options.styleFunction) ?
+      options.styleFunction : ol.feature.defaultStyleFunction;
 
   /**
    * @private


### PR DESCRIPTION
This PR adds more docs for `ol.source.ImageVector` and correctly exports the `styleFunction` option.
