### PR TITLE
[vector-api] Fix hit detection on retina displays

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -88,7 +88,8 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
     goog.asserts.assert(goog.isFunction(renderGeometryFunction));
     context.globalAlpha = layerState.opacity;
     replayGroup.replay(
-        context, frameState.extent, transform, renderGeometryFunction);
+        context, frameState.extent, frameState.devicePixelRatio, transform,
+        renderGeometryFunction);
   }
 
   this.dispatchPostComposeEvent(context, frameState, transform);
@@ -210,7 +211,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
     styleFunction = ol.feature.defaultStyleFunction;
   }
   var tolerance = frameStateResolution / (2 * pixelRatio);
-  var replayGroup = new ol.render.canvas.ReplayGroup(pixelRatio, tolerance);
+  var replayGroup = new ol.render.canvas.ReplayGroup(tolerance);
   vectorSource.forEachFeatureInExtent(extent,
       /**
        * @param {ol.Feature} feature Feature.

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -104,8 +104,7 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
     function(extent, resolution, pixelRatio, size, projection) {
 
   var tolerance = resolution / (2 * pixelRatio);
-  var replayGroup = new ol.render.canvas.ReplayGroup(
-      pixelRatio, tolerance);
+  var replayGroup = new ol.render.canvas.ReplayGroup(tolerance);
 
   var loading = false;
   this.source_.forEachFeatureInExtent(extent,
@@ -133,7 +132,7 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
 
   var transform = this.getTransform_(ol.extent.getCenter(extent),
       resolution, pixelRatio, size);
-  replayGroup.replay(this.canvasContext_, extent, transform,
+  replayGroup.replay(this.canvasContext_, extent, pixelRatio, transform,
       goog.functions.TRUE);
 
   return this.canvasElement_;


### PR DESCRIPTION
This PR fixes hit detection on retina devices (devices with `devicePixelRatio` > 1). The fix involves using 1 as `pixelRatio` for hit detection.
