### PR TITLE
[vector-api] Fix date calculation in ol.format.IGC

### DIFF
--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -127,8 +127,8 @@ ol.format.IGC.prototype.readFeatureFromText = function(text) {
           }
           flatCoordinates.push(z);
         }
-        var date = new Date(year, month, day, hour, minute, second, 0);
-        flatCoordinates.push(date.getTime() / 1000);
+        var dateTime = Date.UTC(year, month, day, hour, minute, second, 0);
+        flatCoordinates.push(dateTime / 1000);
       }
     } else if (line.charAt(0) == 'H') {
       m = ol.format.IGC.HFDTE_RECORD_RE_.exec(line);


### PR DESCRIPTION
The date was being calculated in local time, not UTC.
