### PR TITLE
Add readFeatures and readProjection options to ol.format.JSON

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -256,6 +256,12 @@
  */
 
 /**
+ * @typedef {Object} olx.format.JSONOptions
+ * @property {function(Object): Array.<ol.Feature>} readFeatures Feature reader function.
+ * @property {function(Object): ol.proj.Projection} readProjection Projection reader function.
+ */
+
+/**
  * @typedef {Object} olx.format.TopoJSONOptions
  * @property {ol.proj.ProjectionLike} defaultProjection Default projection.
  */

--- a/src/ol/format/jsonformat.js
+++ b/src/ol/format/jsonformat.js
@@ -10,9 +10,20 @@ goog.require('ol.format.FormatType');
 /**
  * @constructor
  * @extends {ol.format.Format}
+ * @param {olx.format.JSONOptions=} opt_options Options.
  */
-ol.format.JSON = function() {
+ol.format.JSON = function(opt_options) {
+
+  var options = goog.isDef(opt_options) ? opt_options : {};
+
   goog.base(this);
+
+  if (goog.isDef(options.readFeatures)) {
+    this.readFeaturesFromObject = options.readFeatures;
+  }
+  if (goog.isDef(options.readProjection)) {
+    this.readProjectionFromObject = options.readProjection;
+  }
 };
 goog.inherits(ol.format.JSON, ol.format.Format);
 


### PR DESCRIPTION
To be able to create custom `ol.format.JSON` format.

For example, to read elasticsearch query results:

``` javascript
var source = new ol.source.VectorFile({
  url: '...',
  format: new ol.format.JSON({
    readFeatures: function(object) {
      var features = [];
      var hits = object.hits.hits;

      for (var i = 0, ii = hits.length; i < ii; i++) {
        var hit = hits[i];
        var feature = new ol.Feature();
        var geom = new ol.geom.Point(hit._source.geoip.location);
        feature.setGeometry(geom);
        features.push(feature);
      }
      return features;
    },
    readProjection: function(object) {
      return ol.proj.get('EPSG:4326');
    }
  })
});
```
