### PR TITLE
Export ol.source.Vector#getExtent

### DIFF
--- a/src/ol/source/vectorsource.exports
+++ b/src/ol/source/vectorsource.exports
@@ -2,6 +2,7 @@
 @exportProperty ol.source.Vector.prototype.addFeature
 @exportProperty ol.source.Vector.prototype.addFeatures
 @exportProperty ol.source.Vector.prototype.getClosestFeatureToCoordinate
+@exportProperty ol.source.Vector.prototype.getExtent
 @exportProperty ol.source.Vector.prototype.forEachFeature
 @exportProperty ol.source.Vector.prototype.forEachFeatureInExtent
 @exportProperty ol.source.Vector.prototype.getAllFeatures


### PR DESCRIPTION
As requested by @bartvde in #1259.

Note that `ol.source.Vector#getExtent` is implemented here: https://github.com/openlayers/ol3/blob/master/src/ol/source/vectorsource.js#L268-273
