### PR TITLE
Configure draw interaction with a vector source instead of a layer

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -363,7 +363,7 @@
 
 /**
  * @typedef {Object} olx.interaction.DrawOptions
- * @property {ol.layer.Vector|undefined} layer Destination layer for the features.
+ * @property {ol.source.Vector|undefined} source Destination source for the features.
  * @property {number|undefined} snapTolerance Pixel distance for snapping to the
  *     drawing finish (default is 12).
  * @property {ol.geom.GeometryType} type Drawing type ('Point', 'LineString',

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -75,11 +75,11 @@ ol.interaction.Draw = function(opt_options) {
   goog.base(this);
 
   /**
-   * Target layer for drawn features.
-   * @type {ol.layer.Vector}
+   * Target source for drawn features.
+   * @type {ol.source.Vector}
    * @private
    */
-  this.layer_ = goog.isDef(opt_options.layer) ? opt_options.layer : null;
+  this.source_ = goog.isDef(opt_options.source) ? opt_options.source : null;
 
   /**
    * Pixel distance for snapping.
@@ -467,10 +467,8 @@ ol.interaction.Draw.prototype.finishDrawing_ = function(event) {
     sketchFeature.setGeometry(new ol.geom.MultiPolygon([coordinates]));
   }
 
-  if (!goog.isNull(this.layer_)) {
-    var vectorSource = this.layer_.getSource();
-    goog.asserts.assertInstanceof(vectorSource, ol.source.Vector);
-    vectorSource.addFeature(sketchFeature);
+  if (!goog.isNull(this.source_)) {
+    this.source_.addFeature(sketchFeature);
   }
   this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWEND,
       this.sketchFeature_));

--- a/test/spec/ol/interaction/drawinteraction.test.js
+++ b/test/spec/ol/interaction/drawinteraction.test.js
@@ -1,7 +1,7 @@
 goog.provide('ol.test.interaction.Draw');
 
 describe('ol.interaction.Draw', function() {
-  var target, map, source, layer;
+  var target, map, source;
 
   var width = 360;
   var height = 180;
@@ -16,7 +16,7 @@ describe('ol.interaction.Draw', function() {
     style.height = height + 'px';
     document.body.appendChild(target);
     source = new ol.source.Vector();
-    layer = new ol.layer.Vector({source: source});
+    var layer = new ol.layer.Vector({source: source});
     map = new ol.Map({
       target: target,
       renderer: ol.RendererHint.CANVAS,
@@ -57,7 +57,7 @@ describe('ol.interaction.Draw', function() {
 
     it('creates a new interaction', function() {
       var draw = new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.POINT
       });
       expect(draw).to.be.a(ol.interaction.Draw);
@@ -71,7 +71,7 @@ describe('ol.interaction.Draw', function() {
 
     beforeEach(function() {
       draw = new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.POINT
       });
       map.addInteraction(draw);
@@ -119,7 +119,7 @@ describe('ol.interaction.Draw', function() {
 
     beforeEach(function() {
       map.addInteraction(new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.MULTI_POINT
       }));
     });
@@ -143,7 +143,7 @@ describe('ol.interaction.Draw', function() {
 
     beforeEach(function() {
       draw = new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.LINE_STRING
       });
       map.addInteraction(draw);
@@ -241,7 +241,7 @@ describe('ol.interaction.Draw', function() {
 
     beforeEach(function() {
       map.addInteraction(new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.MULTI_LINE_STRING
       }));
     });
@@ -278,7 +278,7 @@ describe('ol.interaction.Draw', function() {
 
     beforeEach(function() {
       draw = new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.POLYGON
       });
       map.addInteraction(draw);
@@ -360,7 +360,7 @@ describe('ol.interaction.Draw', function() {
 
     beforeEach(function() {
       map.addInteraction(new ol.interaction.Draw({
-        layer: layer,
+        source: source,
         type: ol.geom.GeometryType.MULTI_POLYGON
       }));
     });


### PR DESCRIPTION
This would make it work with both a vector layer and an image layer with a vector image source.
