### PR TITLE
KML: Add parsing of <gx:Track> in <Placemark>

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1369,7 +1369,9 @@ ol.format.KML.PLACEMARK_PARSERS_ = ol.xml.makeParsersNS(
     }, ol.xml.makeParsersNS(
         ol.format.KML.GX_NAMESPACE_URIS_, {
           'MultiTrack': ol.xml.makeObjectPropertySetter(
-              ol.format.KML.readGxMultiTrack_, 'geometry')
+              ol.format.KML.readGxMultiTrack_, 'geometry'),
+          'Track': ol.xml.makeObjectPropertySetter(
+              ol.format.KML.readGxTrack_, 'geometry')
         }
     ));
 

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -321,6 +321,58 @@ describe('ol.format.KML', function() {
         expect(gs[0]).to.be.an(ol.geom.GeometryCollection);
       });
 
+      it('can read gx:Track', function() {
+        var text =
+            '<kml xmlns="http://earth.google.com/kml/2.2"' +
+            '     xmlns:gx="http://www.google.com/kml/ext/2.2">' +
+            '  <Placemark>' +
+            '    <gx:Track>' +
+            '      <when>2014-01-06T19:38:55Z</when>' +
+            '      <when>2014-01-06T19:39:03Z</when>' +
+            '      <when>2014-01-06T19:39:10Z</when>' +
+            '      <gx:coord>8.1 46.1 1909.9</gx:coord>' +
+            '      <gx:coord>8.2 46.2 1925.2</gx:coord>' +
+            '      <gx:coord>8.3 46.3 1926.2</gx:coord>' +
+            '    </gx:Track>' +
+            '  </Placemark>' +
+            '</kml>';
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.an(ol.Feature);
+        var g = f.getGeometry();
+        expect(g).to.be.an(ol.geom.LineString);
+      });
+
+      it('can read gx:MultiTrack', function() {
+        var text =
+            '<kml xmlns="http://earth.google.com/kml/2.2"' +
+            '     xmlns:gx="http://www.google.com/kml/ext/2.2">' +
+            '  <Placemark>' +
+            '    <gx:MultiTrack>' +
+            '      <gx:Track>' +
+            '        <when>2014-01-06T19:38:55Z</when>' +
+            '        <gx:coord>8.1 46.1 1909.9</gx:coord>' +
+            '      </gx:Track>' +
+            '      <gx:Track>' +
+            '        <when>2014-01-06T19:38:55Z</when>' +
+            '        <when>2014-01-06T19:39:10Z</when>' +
+            '        <gx:coord>8.1 46.1 1909.9</gx:coord>' +
+            '        <gx:coord>8.2 46.2 1925.2</gx:coord>' +
+            '      </gx:Track>' +
+            '    </gx:MultiTrack>' +
+            '  </Placemark>' +
+            '</kml>';
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.an(ol.Feature);
+        var g = f.getGeometry();
+        expect(g).to.be.an(ol.geom.MultiLineString);
+        var gs = g.getLineStrings();
+        expect(gs).to.have.length(2);
+        expect(gs[0]).to.be.an(ol.geom.LineString);
+      });
     });
 
     describe('attributes', function() {


### PR DESCRIPTION
Add parsing of of gx:Track in <Placemark>

Example of file using this: https://drive.google.com/file/d/0B4uRuJ1hajZmc1U4VTh2RXEzcDg/edit?usp=sharing

This PR add tests for parsing gx:MutliTrack  and gx:Track
