### PR TITLE
Rename ol.xml.pushAndParse to ol.xml.pushParseAndPop

### DIFF
--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -92,7 +92,7 @@ ol.format.GPX.parseLink_ = function(node, objectStack) {
 ol.format.GPX.parseRtePt_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'rtept');
-  var values = ol.xml.pushAndParse(
+  var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.RTEPT_PARSERS_, node, objectStack);
   if (goog.isDef(values)) {
     var rteValues = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -111,7 +111,7 @@ ol.format.GPX.parseRtePt_ = function(node, objectStack) {
 ol.format.GPX.parseTrkPt_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'trkpt');
-  var values = ol.xml.pushAndParse(
+  var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.TRKPT_PARSERS_, node, objectStack);
   if (goog.isDef(values)) {
     var trkValues = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -148,7 +148,7 @@ ol.format.GPX.parseTrkSeg_ = function(node, objectStack) {
 ol.format.GPX.readRte_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'rte');
-  var values = ol.xml.pushAndParse({
+  var values = ol.xml.pushParseAndPop({
     'flatCoordinates': []
   }, ol.format.GPX.RTE_PARSERS_, node, objectStack);
   if (!goog.isDef(values)) {
@@ -174,7 +174,7 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
 ol.format.GPX.readTrk_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'trk');
-  var values = ol.xml.pushAndParse({
+  var values = ol.xml.pushParseAndPop({
     'flatCoordinates': [],
     'ends': []
   }, ol.format.GPX.TRK_PARSERS_, node, objectStack);
@@ -204,7 +204,7 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
 ol.format.GPX.readWpt_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'wpt');
-  var values = ol.xml.pushAndParse(
+  var values = ol.xml.pushParseAndPop(
       {}, ol.format.GPX.WPT_PARSERS_, node, objectStack);
   if (!goog.isDef(values)) {
     return undefined;
@@ -392,8 +392,9 @@ ol.format.GPX.prototype.readFeaturesFromNode = function(node) {
     return [];
   }
   if (node.localName == 'gpx') {
-    var features = ol.xml.pushAndParse(/** @type {Array.<ol.Feature>} */ ([]),
-        ol.format.GPX.GPX_PARSERS_, node, []);
+    var features = ol.xml.pushParseAndPop(
+        /** @type {Array.<ol.Feature>} */ ([]), ol.format.GPX.GPX_PARSERS_,
+        node, []);
     if (goog.isDef(features)) {
       return features;
     } else {

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -487,7 +487,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
   // FIXME viewBoundScale
   // FIXME viewFormat
   // FIXME httpQuery
-  var object = ol.xml.pushAndParse(
+  var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.ICON_STYLE_PARSERS_, node, objectStack);
   if (!goog.isDef(object)) {
     return;
@@ -564,7 +564,7 @@ ol.format.KML.LineStyleParser_ = function(node, objectStack) {
   // FIXME gx:outerWidth
   // FIXME gx:physicalWidth
   // FIXME gx:labelVisibility
-  var object = ol.xml.pushAndParse(
+  var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.LINE_STYLE_PARSERS_, node, objectStack);
   if (!goog.isDef(object)) {
     return;
@@ -589,7 +589,7 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'PolyStyle');
   // FIXME colorMode
-  var object = ol.xml.pushAndParse(
+  var object = ol.xml.pushParseAndPop(
       {}, ol.format.KML.POLY_STYLE_PARSERS_, node, objectStack);
   if (!goog.isDef(object)) {
     return;
@@ -622,7 +622,7 @@ ol.format.KML.PolyStyleParser_ = function(node, objectStack) {
 ol.format.KML.readFlatLinearRing_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'LinearRing');
-  return /** @type {Array.<number>} */ (ol.xml.pushAndParse(
+  return /** @type {Array.<number>} */ (ol.xml.pushParseAndPop(
       null, ol.format.KML.FLAT_LINEAR_RING_PARSERS_, node, objectStack));
 };
 
@@ -667,7 +667,7 @@ ol.format.KML.readGxMultiTrack_ = function(node, objectStack) {
   goog.asserts.assert(goog.array.indexOf(
       ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI) != -1);
   goog.asserts.assert(node.localName == 'MultiTrack');
-  var lineStrings = ol.xml.pushAndParse(
+  var lineStrings = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.LineString>} */ ([]),
       ol.format.KML.GX_MULTITRACK_GEOMETRY_PARSERS_, node, objectStack);
   if (!goog.isDef(lineStrings)) {
@@ -690,7 +690,7 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
   goog.asserts.assert(goog.array.indexOf(
       ol.format.KML.GX_NAMESPACE_URIS_, node.namespaceURI) != -1);
   goog.asserts.assert(node.localName == 'Track');
-  var gxTrackObject = ol.xml.pushAndParse(
+  var gxTrackObject = ol.xml.pushParseAndPop(
       /** @type {ol.format.KMLGxTrackObject_} */ ({
         flatCoordinates: [],
         whens: []
@@ -721,7 +721,7 @@ ol.format.KML.readGxTrack_ = function(node, objectStack) {
 ol.format.KML.readIcon_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'Icon');
-  var iconObject = ol.xml.pushAndParse(
+  var iconObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.ICON_PARSERS_, node, objectStack);
   if (goog.isDef(iconObject)) {
     return iconObject;
@@ -739,7 +739,7 @@ ol.format.KML.readIcon_ = function(node, objectStack) {
  */
 ol.format.KML.readFlatCoordinatesFromNode_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
-  return /** @type {Array.<number>} */ (ol.xml.pushAndParse(null,
+  return /** @type {Array.<number>} */ (ol.xml.pushParseAndPop(null,
       ol.format.KML.GEOMETRY_FLAT_COORDINATES_PARSERS_, node, objectStack));
 };
 
@@ -796,7 +796,7 @@ ol.format.KML.readLinearRing_ = function(node, objectStack) {
 ol.format.KML.readMultiGeometry_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'MultiGeometry');
-  var geometries = ol.xml.pushAndParse(
+  var geometries = ol.xml.pushParseAndPop(
       /** @type {Array.<ol.geom.Geometry>} */ ([]),
       ol.format.KML.MULTI_GEOMETRY_PARSERS_, node, objectStack);
   if (!goog.isDef(geometries)) {
@@ -919,7 +919,7 @@ ol.format.KML.readPoint_ = function(node, objectStack) {
 ol.format.KML.readPolygon_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'Polygon');
-  var flatLinearRings = ol.xml.pushAndParse(
+  var flatLinearRings = ol.xml.pushParseAndPop(
       /** @type {Array.<Array.<number>>} */ ([null]),
       ol.format.KML.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack);
   if (goog.isDefAndNotNull(flatLinearRings) &&
@@ -950,7 +950,7 @@ ol.format.KML.readPolygon_ = function(node, objectStack) {
 ol.format.KML.readStyle_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'Style');
-  var styleObject = ol.xml.pushAndParse(
+  var styleObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.STYLE_PARSERS_, node, objectStack);
   if (!goog.isDef(styleObject)) {
     return null;
@@ -992,7 +992,7 @@ ol.format.KML.DataParser_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'Data');
   var name = node.getAttribute('name');
   if (!goog.isNull(name)) {
-    var data = ol.xml.pushAndParse(
+    var data = ol.xml.pushParseAndPop(
         undefined, ol.format.KML.DATA_PARSERS_, node, objectStack);
     if (goog.isDef(data)) {
       var featureObject =
@@ -1024,7 +1024,7 @@ ol.format.KML.ExtendedDataParser_ = function(node, objectStack) {
 ol.format.KML.PairDataParser_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'Pair');
-  var pairObject = ol.xml.pushAndParse(
+  var pairObject = ol.xml.pushParseAndPop(
       {}, ol.format.KML.PAIR_PARSERS_, node, objectStack);
   if (!goog.isDef(pairObject)) {
     return;
@@ -1098,7 +1098,7 @@ ol.format.KML.StyleMapParser_ = function(node, objectStack) {
 ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'innerBoundaryIs');
-  var flatLinearRing = ol.xml.pushAndParse(
+  var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       ol.format.KML.INNER_BOUNDARY_IS_PARSERS_, node, objectStack);
   if (goog.isDef(flatLinearRing)) {
@@ -1119,7 +1119,7 @@ ol.format.KML.innerBoundaryIsParser_ = function(node, objectStack) {
 ol.format.KML.outerBoundaryIsParser_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'outerBoundaryIs');
-  var flatLinearRing = ol.xml.pushAndParse(
+  var flatLinearRing = ol.xml.pushParseAndPop(
       /** @type {Array.<number>|undefined} */ (undefined),
       ol.format.KML.OUTER_BOUNDARY_IS_PARSERS_, node, objectStack);
   if (goog.isDef(flatLinearRing)) {
@@ -1448,7 +1448,7 @@ ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
         'Style': goog.bind(this.readSharedStyle_, this),
         'StyleMap': goog.bind(this.readSharedStyleMap_, this)
       });
-  var features = ol.xml.pushAndParse(/** @type {Array.<ol.Feature>} */ ([]),
+  var features = ol.xml.pushParseAndPop(/** @type {Array.<ol.Feature>} */ ([]),
       parsersNS, node, objectStack, this);
   if (goog.isDef(features)) {
     return features;
@@ -1467,7 +1467,7 @@ ol.format.KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
 ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
   goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
   goog.asserts.assert(node.localName == 'Placemark');
-  var object = ol.xml.pushAndParse({'geometry': null},
+  var object = ol.xml.pushParseAndPop({'geometry': null},
       ol.format.KML.PLACEMARK_PARSERS_, node, objectStack);
   if (!goog.isDef(object)) {
     return undefined;
@@ -1525,7 +1525,7 @@ ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
   goog.asserts.assert(node.localName == 'StyleMap');
   var id = node.getAttribute('id');
   if (!goog.isNull(id)) {
-    var styleObject = ol.xml.pushAndParse(/** @type {Object} */ ({}),
+    var styleObject = ol.xml.pushParseAndPop(/** @type {Object} */ ({}),
         ol.format.KML.STYLE_MAP_PARSERS_, node, objectStack);
     if (!goog.isDef(styleObject)) {
       return;

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -196,7 +196,8 @@ ol.xml.parse = function(parsersNS, node, objectStack, opt_this) {
  * @return {T|undefined} Object.
  * @template T
  */
-ol.xml.pushAndParse = function(object, parsersNS, node, objectStack, opt_this) {
+ol.xml.pushParseAndPop = function(
+    object, parsersNS, node, objectStack, opt_this) {
   objectStack.push(object);
   ol.xml.parse(parsersNS, node, objectStack, opt_this);
   return objectStack.pop();


### PR DESCRIPTION
Following discussions with @fredj, we agreed that `pushParseAndPop` is a better name given [what this function does](https://github.com/twpayne/ol3/blob/432d10a45718b8f798fbf2bdce6f7bb9f05de450/src/ol/xml.js#L203).
