### PR TITLE
Render other features when dirty

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -222,9 +222,10 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
        * @param {ol.Feature} feature Feature.
        */
       function(feature) {
-        this.dirty_ = this.dirty_ ||
+        var dirty =
             this.renderFeature(feature, frameStateResolution, pixelRatio,
                 styleFunction, replayGroup);
+        this.dirty_ = this.dirty_ || dirty;
       }, this);
   replayGroup.finish();
 


### PR DESCRIPTION
This fixes a bug where the rendering of features is stopped as soon as an icon is being loaded. With this fix the icons are more rapidly displayed in the kml example.

Thanks @twpayne for catching this.
