### PR TITLE
Remove ol.DragBoxEvent, ol.DrawEvent, ol.ObjectEvent, ol.source.VectorEvent symbols

### DIFF
--- a/src/ol/interaction/dragboxinteraction.exports
+++ b/src/ol/interaction/dragboxinteraction.exports
@@ -1,5 +1,4 @@
 @exportSymbol ol.interaction.DragBox
 @exportProperty ol.interaction.DragBox.prototype.getGeometry
 
-@exportSymbol ol.DragBoxEvent
 @exportProperty ol.DragBoxEvent.prototype.getCoordinate

--- a/src/ol/interaction/drawinteraction.exports
+++ b/src/ol/interaction/drawinteraction.exports
@@ -1,4 +1,3 @@
 @exportSymbol ol.interaction.Draw
 
-@exportSymbol ol.DrawEvent
 @exportProperty ol.DrawEvent.prototype.getFeature

--- a/src/ol/object.exports
+++ b/src/ol/object.exports
@@ -8,5 +8,4 @@
 @exportProperty ol.Object.prototype.unbind
 @exportProperty ol.Object.prototype.unbindAll
 
-@exportSymbol ol.ObjectEvent
 @exportProperty ol.ObjectEvent.prototype.getKey

--- a/src/ol/source/vectorsource.exports
+++ b/src/ol/source/vectorsource.exports
@@ -9,5 +9,4 @@
 @exportProperty ol.source.Vector.prototype.getAllFeaturesAtCoordinate
 @exportProperty ol.source.Vector.prototype.removeFeature
 
-@exportSymbol ol.source.VectorEvent
 @exportProperty ol.source.VectorEvent.prototype.getFeature


### PR DESCRIPTION
These objects will never be constructed by the application
