### PR TITLE
Fix case when pixel is null in ol.Overlay#updatePixelPosition_

### DIFF
--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -335,6 +335,10 @@ ol.Overlay.prototype.updatePixelPosition_ = function() {
   }
 
   var pixel = map.getPixelFromCoordinate(position);
+  if (!goog.isDefAndNotNull(pixel)) {
+    return;
+  }
+
   var mapSize = map.getSize();
   goog.asserts.assert(goog.isDef(mapSize));
   var style = this.element_.style;


### PR DESCRIPTION
This happens when the current map frameState is null, which appears to happen in some cases when overlays are added to the map before the map target is set.
