### PR TITLE
Ensure that entire extent is visible in ol.View2D#fitExtent

### DIFF
--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -419,8 +419,12 @@ ol.View2D.prototype.fitExtent = function(extent, size) {
   if (!ol.extent.isEmpty(extent)) {
     this.setCenter(ol.extent.getCenter(extent));
     var resolution = this.getResolutionForExtent(extent, size);
-    resolution = this.constrainResolution(resolution, 0, 0);
-    this.setResolution(resolution);
+    var constrainedResolution = this.constrainResolution(resolution, 0, 0);
+    if (constrainedResolution < resolution) {
+      constrainedResolution =
+          this.constrainResolution(constrainedResolution, -1, 0);
+    }
+    this.setResolution(constrainedResolution);
   }
 };
 


### PR DESCRIPTION
This PR fixes a bug in `ol.View2D#fitExtent`.

Previously, the resolution required to fit the extent was calculated, and then this was rounded to the _nearest_ constrained resolution (zoom level). If this nearest zoom level had a lower resolution (i.e. a higher zoom level), then this resulted in the view being too "zoomed in" and not fitting the passed extent.

The fix here is to round to the higher resolution if needed.
