### PR TITLE
Use event properties in ol.interaction.Select

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -91,7 +91,7 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
        */
       function() {
         if (add) {
-          map.forEachFeatureAtPixel(mapBrowserEvent.getPixel(),
+          map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
               /**
                * @param {ol.Feature} feature Feature.
                * @param {ol.layer.Layer} layer Layer.
@@ -102,7 +102,7 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
                 }
               }, undefined, this.layerFilter_);
         } else {
-          var feature = map.forEachFeatureAtPixel(mapBrowserEvent.getPixel(),
+          var feature = map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
               /**
                * @param {ol.Feature} feature Feature.
                * @param {ol.layer.Layer} layer Layer.


### PR DESCRIPTION
This fixes `ol.interaction.Select` from #1613 following #1588 (too many parallel branches...). As `master` is currently broken, I'll merge this as soon as Travis passes.
