### PR TITLE
Minor ol.geom.Circle clean-ups

### DIFF
--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -71,8 +71,7 @@ ol.geom.Circle.prototype.containsXY = function(x, y) {
   var flatCoordinates = this.flatCoordinates;
   var dx = x - flatCoordinates[0];
   var dy = y - flatCoordinates[1];
-  var r = flatCoordinates[this.stride] - flatCoordinates[0];
-  return Math.sqrt(dx * dx + dy * dy) <= r;
+  return dx * dx + dy * dy <= this.getRadiusSquared_();
 };
 
 


### PR DESCRIPTION
This PR cleans up a couple of things in `ol.geom.Circle`:
- It corrects the radius calculation in `ol.geom.Circle#containsXY`. A circle is represented by two points: its center and an arbitrary control point on its circumference. This allows a circle to maintain its dimensions even when transformed or reprojected. The previous code assumed that the control point's x coordinate was always zero, which is not necessarily the case if the circle has been reprojected.
- Two `Math.sqrt`s are elminated in `containsXY`.
