### PR TITLE
Don't fail when no featues are found in ol.format.TopoJSON

### DIFF
--- a/src/ol/format/topojsonformat.js
+++ b/src/ol/format/topojsonformat.js
@@ -302,7 +302,6 @@ ol.format.TopoJSON.prototype.readFeaturesFromObject = function(object) {
     }
     return features;
   } else {
-    goog.asserts.fail();
     return [];
   }
 };


### PR DESCRIPTION
With this PR, `ol.format.TopoJSON` no longer raises an exception if no features can be found. This is so that `ol.interaction.DragAndDrop`, which tries multiple formats in succession, can function correctly. With the `goog.asserts.fail()` in place, `ol.format.TopoJSON` raises an exception if it's given data in a different format (like GeoJSON).
