### PR TITLE
Fix use of drawText in ol.render.canvas.Immediate

### DIFF
--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -432,7 +432,7 @@ ol.render.canvas.Immediate.prototype.drawPointGeometry =
     this.drawImages_(flatCoordinates, 0, flatCoordinates.length, stride);
   }
   if (this.text_ !== '') {
-    this.drawImages_(flatCoordinates, 0, flatCoordinates.length, stride);
+    this.drawText_(flatCoordinates, 0, flatCoordinates.length, stride);
   }
 };
 


### PR DESCRIPTION
Testing the text rendering, I've seen of bad use of `drawImages`  in the `ol.render.canvas.Immediate`.

This PR replaces the use a `drawImages_` by the wanted `drawText_` function
