### PR TITLE
Fix typo in text rendering

### DIFF
--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -432,7 +432,7 @@ ol.render.canvas.Immediate.prototype.drawPointGeometry =
     this.drawImages_(flatCoordinates, 0, flatCoordinates.length, stride);
   }
   if (this.text_ !== '') {
-    this.drawImages_(flatCoordinates, 0, flatCoordinates.length, stride);
+    this.drawText_(flatCoordinates, 0, flatCoordinates.length, stride);
   }
 };
 


### PR DESCRIPTION
This PR fixes a typo spotted fixed by Nicolas Brandli in the immediate rendering of point geometries with text.
