### PR TITLE
ol.interaction.DragBox.getGeometry returns non-closed polygon

### DIFF
--- a/src/ol/render/box.js
+++ b/src/ol/render/box.js
@@ -69,14 +69,12 @@ ol.render.Box.prototype.createGeometry_ = function() {
   var startPixel = this.startPixel_;
   var endPixel = this.endPixel_;
   var pixels = [
-    [
-      startPixel,
-      [startPixel[0], endPixel[1]],
-      endPixel,
-      [endPixel[0], startPixel[1]]
-    ]
+    startPixel,
+    [startPixel[0], endPixel[1]],
+    endPixel,
+    [endPixel[0], startPixel[1]]
   ];
-  var coordinates = goog.array.map(pixels[0],
+  var coordinates = goog.array.map(pixels,
       this.map_.getCoordinateFromPixel, this.map_);
   // close the polygon
   coordinates[4] = coordinates[0].slice();


### PR DESCRIPTION
Reproduce:

``` javascript
var box = new ol.interaction.DragBox();
box.on('boxend',function(){
  console.log(box.getGeometry().getCoordinates());
});
```

It output array of 4 pairs of coordinates, that indicate all 4 corner points, but it should contain also 5th pair of coordinates that is equal to first pair of coordinates.
