### PR TITLE
Use projection option instead of reprojectTo

### DIFF
--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -46,7 +46,7 @@ var style = {
 
 var vector = new ol.layer.Vector({
   source: new ol.source.GPX({
-    reprojectTo: 'EPSG:3857',
+    projection: 'EPSG:3857',
     url: 'data/gpx/fells_loop.gpx'
   }),
   styleFunction: function(feature, resolution) {

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -40,7 +40,7 @@ var styleFunction = function(feature, resolution) {
 
 var vector = new ol.layer.Vector({
   source: new ol.source.KML({
-    reprojectTo: 'EPSG:3857',
+    projection: 'EPSG:3857',
     url: 'data/kml/2012_Earthquakes_Mag5.kml'
   }),
   styleFunction: styleFunction

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -15,7 +15,7 @@ var raster = new ol.layer.Tile({
 
 var vector = new ol.layer.Vector({
   source: new ol.source.KML({
-    reprojectTo: 'EPSG:3857',
+    projection: 'EPSG:3857',
     url: 'data/kml/2012-02-10.kml'
   })
 });

--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -571,8 +571,9 @@
  * @property {ol.Extent|undefined} extent Extent.
  * @property {string|undefined} logo Logo.
  * @property {GeoJSONObject|undefined} object Object.
- * @property {ol.proj.ProjectionLike} projection Projection.
- * @property {ol.proj.ProjectionLike} reprojectTo Re-project to.
+ * @property {ol.proj.ProjectionLike} projection Destination projection.  If
+ *     provided, features will be transformed to this projection.  If not
+ *     provided, features will not be transformed.
  * @property {string|undefined} text Text.
  * @property {string|undefined} url URL.
  * @property {Array.<string>|undefined} urls URLs.
@@ -585,8 +586,9 @@
  * @property {ol.Extent|undefined} extent Extent.
  * @property {string|undefined} logo Logo.
  * @property {Node|undefined| node Node.
- * @property {ol.proj.ProjectionLike} projection Projection.
- * @property {ol.proj.ProjectionLike} reprojectTo Re-project to.
+ * @property {ol.proj.ProjectionLike} projection Destination projection.  If
+ *     provided, features will be transformed to this projection.  If not
+ *     provided, features will not be transformed.
  * @property {string|undefined} text Text.
  * @property {string|undefined} url URL.
  * @property {Array.<string>|undefined} urls URLs.
@@ -599,8 +601,9 @@
  * @property {ol.Extent|undefined} extent Extent.
  * @property {string|undefined} logo Logo.
  * @property {GeoJSONObject|undefined} object Object.
- * @property {ol.proj.ProjectionLike} projection Projection.
- * @property {ol.proj.ProjectionLike} reprojectTo Re-project to.
+ * @property {ol.proj.ProjectionLike} projection Destination projection.  If
+ *     provided, features will be transformed to this projection.  If not
+ *     provided, features will not be transformed.
  * @property {string|undefined} text Text.
  * @property {string|undefined} url URL.
  */
@@ -641,8 +644,9 @@
  * @property {ol.Extent|undefined} extent Extent.
  * @property {string|undefined} logo Logo.
  * @property {Node|undefined| node Node.
- * @property {ol.proj.ProjectionLike} projection Projection.
- * @property {ol.proj.ProjectionLike} reprojectTo Re-project to.
+ * @property {ol.proj.ProjectionLike} projection Destination projection.  If
+ *     provided, features will be transformed to this projection.  If not
+ *     provided, features will not be transformed.
  * @property {string|undefined} text Text.
  * @property {string|undefined} url URL.
  * @property {Array.<string>|undefined} urls URLs.

--- a/src/ol/source/geojsonsource.js
+++ b/src/ol/source/geojsonsource.js
@@ -24,7 +24,6 @@ ol.source.GeoJSON = function(opt_options) {
     logo: options.logo,
     object: options.object,
     projection: options.projection,
-    reprojectTo: options.reprojectTo,
     text: options.text,
     url: options.url,
     urls: options.urls

--- a/src/ol/source/gpxsource.js
+++ b/src/ol/source/gpxsource.js
@@ -23,7 +23,6 @@ ol.source.GPX = function(opt_options) {
     logo: options.logo,
     node: options.node,
     projection: options.projection,
-    reprojectTo: options.reprojectTo,
     text: options.text,
     url: options.url,
     urls: options.urls

--- a/src/ol/source/kmlsource.js
+++ b/src/ol/source/kmlsource.js
@@ -25,7 +25,6 @@ ol.source.KML = function(opt_options) {
     logo: options.logo,
     node: options.node,
     projection: options.projection,
-    reprojectTo: options.reprojectTo,
     text: options.text,
     url: options.url,
     urls: options.urls

--- a/src/ol/source/topojsonsource.js
+++ b/src/ol/source/topojsonsource.js
@@ -24,7 +24,6 @@ ol.source.TopoJSON = function(opt_options) {
     logo: options.logo,
     object: options.object,
     projection: options.projection,
-    reprojectTo: options.reprojectTo,
     text: options.text,
     url: options.url
   });

--- a/src/ol/source/vectorfilesource.js
+++ b/src/ol/source/vectorfilesource.js
@@ -1,4 +1,5 @@
-// FIXME remove reprojectTo
+// FIXME consider delaying feature reading so projection can be provided by
+// consumer (e.g. the view)
 
 goog.provide('ol.source.VectorFile');
 
@@ -34,13 +35,6 @@ ol.source.VectorFile = function(opt_options) {
    * @protected
    */
   this.format = options.format;
-
-  /**
-   * @type {ol.proj.Projection}
-   * @private
-   */
-  this.reprojectTo_ = goog.isDef(options.reprojectTo) ?
-      ol.proj.get(options.reprojectTo) : ol.proj.get('EPSG:3857');
 
   if (goog.isDef(options.doc)) {
     this.readFeatures_(options.doc);
@@ -121,14 +115,17 @@ ol.source.VectorFile.prototype.readFeatures_ = function(source) {
   var format = this.format;
   var features = format.readFeatures(source);
   var featureProjection = format.readProjection(source);
-  if (!ol.proj.equivalent(featureProjection, this.reprojectTo_)) {
-    var transform = ol.proj.getTransform(featureProjection, this.reprojectTo_);
-    var i, ii;
-    for (i = 0, ii = features.length; i < ii; ++i) {
-      var feature = features[i];
-      var geometry = feature.getGeometry();
-      if (!goog.isNull(geometry)) {
-        geometry.transform(transform);
+  var projection = this.getProjection();
+  if (!goog.isNull(projection)) {
+    if (!ol.proj.equivalent(featureProjection, projection)) {
+      var transform = ol.proj.getTransform(featureProjection, projection);
+      var i, ii;
+      for (i = 0, ii = features.length; i < ii; ++i) {
+        var feature = features[i];
+        var geometry = feature.getGeometry();
+        if (!goog.isNull(geometry)) {
+          geometry.transform(transform);
+        }
       }
     }
   }


### PR DESCRIPTION
The `projection` option for vector file sources currently has no good meaning.  The `reprojectTo` option is used to set the projection for cached features.  This change makes it so the projection option is used for this purpose.  The `getProjection` method (not currently exported) can then be used to get the cached feature projection.

This also removes the default of `EPSG:3857` for vector file sources.  If a projection is not configured, features will not be transformed.

Fixes #1631.
