### PR TITLE
Support parsing of kml:datetime

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1102,21 +1102,21 @@ ol.format.KML.whenParser_ = function(node, objectStack) {
   var whens = gxTrackObject.whens;
   var s = ol.xml.getAllTextContent(node, false);
   var re =
-      /^\s*(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(Z|(?:([+\-])(\d{2})(?::(\d{2}))?))\s*$/;
+      /^\s*(\d{4})($|-(\d{2})($|-(\d{2})($|T(\d{2}):(\d{2}):(\d{2})(Z|(?:([+\-])(\d{2})(?::(\d{2}))?)))))\s*$/;
   var m = re.exec(s);
   if (m) {
     var year = parseInt(m[1], 10);
-    var month = parseInt(m[2], 10) - 1;
-    var day = parseInt(m[3], 10);
-    var hour = parseInt(m[4], 10);
-    var minute = parseInt(m[5], 10);
-    var second = parseInt(m[6], 10);
+    var month = goog.isDef(m[3]) ? parseInt(m[3], 10) - 1 : 0;
+    var day = goog.isDef(m[5]) ? parseInt(m[5], 10) : 1;
+    var hour = goog.isDef(m[7]) ? parseInt(m[7], 10) : 0;
+    var minute = goog.isDef(m[8]) ? parseInt(m[8], 10) : 0;
+    var second = goog.isDef(m[9]) ? parseInt(m[9], 10) : 0;
     var when = Date.UTC(year, month, day, hour, minute, second);
-    if (m[7] != 'Z') {
-      var sign = m[8] == '-' ? -1 : 1;
-      when += sign * 60 * parseInt(m[9], 10);
-      if (goog.isDef(m[10])) {
-        when += sign * 60 * 60 * parseInt(m[10], 10);
+    if (goog.isDef(m[10]) && m[10] != 'Z') {
+      var sign = m[11] == '-' ? -1 : 1;
+      when += sign * 60 * parseInt(m[12], 10);
+      if (goog.isDef(m[13])) {
+        when += sign * 60 * 60 * parseInt(m[13], 10);
       }
     }
     whens.push(when);

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -373,6 +373,39 @@ describe('ol.format.KML', function() {
         expect(gs).to.have.length(2);
         expect(gs[0]).to.be.an(ol.geom.LineString);
       });
+
+      it('can read dateTime', function() {
+        var text =
+            '<kml xmlns="http://earth.google.com/kml/2.2"' +
+            '     xmlns:gx="http://www.google.com/kml/ext/2.2">' +
+            '  <Placemark>' +
+            '    <gx:Track>' +
+            '      <when>2014</when>' +
+            '      <when>2014-02</when>' +
+            '      <when>2014-02-06</when>' +
+            '      <when>2014-02-06T19:39:03Z</when>' +
+            '      <when>2014-02-06T19:39:10+03:00</when>' +
+            '      <gx:coord>8.1 46.1 1909.9</gx:coord>' +
+            '      <gx:coord>8.2 46.2 1925.2</gx:coord>' +
+            '      <gx:coord>8.3 46.3 1926.2</gx:coord>' +
+            '      <gx:coord>8.4 46.4 1927.2</gx:coord>' +
+            '      <gx:coord>8.5 46.5 1928.2</gx:coord>' +
+            '    </gx:Track>' +
+            '  </Placemark>' +
+            '</kml>';
+        var fs = format.readFeatures(text);
+        var f = fs[0];
+        var g = f.getGeometry();
+        var flatCoordinates = g.flatCoordinates;
+        expect(flatCoordinates[3]).to.be.eql(Date.UTC(2014, 0, 1, 0, 0, 0));
+        expect(flatCoordinates[7]).to.be.eql(Date.UTC(2014, 1, 1, 0, 0, 0));
+        expect(flatCoordinates[11]).to.be.eql(Date.UTC(2014, 1, 6, 0, 0, 0));
+        expect(flatCoordinates[15]).to.be.eql(Date.UTC(2014, 1, 6, 19, 39, 3));
+        expect(flatCoordinates[19]).to.be.eql(
+            Date.UTC(2014, 1, 6, 19, 39, 10) + 3 * 60
+        );
+      });
+
     });
 
     describe('attributes', function() {


### PR DESCRIPTION
This commit modifies the previous regex in order to match 
following datetimes:
- 2014
- 2014-02
- 2014-02-15

The new regex also matches dates that were matched by the previous
regex.

This commit also include a unit test for kml:dateTime parsing.

This commit referes to  #1585
