### PR TITLE
Fix capitalisation of ol.Map in docs

### DIFF
--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -26,7 +26,7 @@ ol.interaction.KEYBOARD_PAN_DURATION = 100;
  * the keys can only be used when browser focus is on the element to which
  * the keyboard events are attached. By default, this is the map div,
  * though you can change this with the `keyboardTargetElement` in
- * {@link ol.map}. `document` never loses focus but, for any other element,
+ * {@link ol.Map}. `document` never loses focus but, for any other element,
  * focus will have to be on, and returned to, this element if the keys are to
  * function.
  * See also {@link ol.interaction.KeyboardZoom}.

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -16,7 +16,7 @@ goog.require('ol.interaction.Interaction');
  * the keys can only be used when browser focus is on the element to which
  * the keyboard events are attached. By default, this is the map div,
  * though you can change this with the `keyboardTargetElement` in
- * {@link ol.map}. `document` never loses focus but, for any other element,
+ * {@link ol.Map}. `document` never loses focus but, for any other element,
  * focus will have to be on, and returned to, this element if the keys are to
  * function.
  * See also {@link ol.interaction.KeyboardPan}.


### PR DESCRIPTION
This PR fixes the `{@link}` tags in the enhanced keyboard interaction documentation added in #1216. Without it, `jsdoc` does not create the link to `ol.Map`.
