### PR TITLE
Vector examples are broken

### DIFF
--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -30,6 +30,7 @@ var map = new ol.Map({
     new ol.layer.Image({
       source: new ol.source.ImageVector({
         source: new ol.source.GeoJSON({
+          projection: 'EPSG:3857',
           url: 'data/geojson/countries.geojson'
         }),
         styleFunction: function(feature, resolution) {

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -47,6 +47,7 @@ var styleFunction = function(feature, resolution) {
 
 var vector = new ol.layer.Vector({
   source: new ol.source.KML({
+    projection: 'EPSG:3857',
     url: 'data/kml/timezones.kml'
   }),
   styleFunction: styleFunction

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -33,6 +33,7 @@ var selectedStyle = [new ol.style.Style({
 
 var vector = new ol.layer.Vector({
   source: new ol.source.GeoJSON({
+    projection: 'EPSG:3857',
     url: 'data/geojson/countries.geojson'
   }),
   styleFunction: function(feature, layer) {

--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -19,6 +19,7 @@ var raster = new ol.layer.Tile({
 
 var vector = new ol.layer.Vector({
   source: new ol.source.TopoJSON({
+    projection: 'EPSG:3857',
     url: 'data/topojson/world-110m.json'
   }),
   styleFunction: function(feature, resolution) {

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -15,6 +15,7 @@ goog.require('ol.style.Text');
 var styleCache = {};
 var vectorLayer = new ol.layer.Vector({
   source: new ol.source.GeoJSON({
+    projection: 'EPSG:3857',
     url: 'data/geojson/countries.geojson'
   }),
   styleFunction: function(feature, resolution) {


### PR DESCRIPTION
The vector-layer example is broken – the vector layer does is not displayed on the map. `git bisect` tells me that d2cd0808a8127197de0de8acb3ac840642be037a is the (first) bad commit.
