### PR TITLE
Ensure MultiPolygons are rendered if only one of fill and stroke are set

### DIFF
--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -195,7 +195,7 @@ ol.renderer.vector.renderMultiPolygonGeometry_ =
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPolygon);
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
-  if (!goog.isNull(strokeStyle) && !goog.isNull(fillStyle)) {
+  if (!goog.isNull(strokeStyle) || !goog.isNull(fillStyle)) {
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);


### PR DESCRIPTION
This fixes the [bug reported on the mailing list](https://groups.google.com/d/msg/ol3-dev/FHX5GvM4P14/nJ5_A540lNQJ) by @bartvde.

@elemoine in parallel found the same bug and developed the same fix at exactly the same time :)
