### PR TITLE
Fix the feature sent  with the drawend event

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -477,8 +477,7 @@ ol.interaction.Draw.prototype.finishDrawing_ = function(event) {
   if (!goog.isNull(this.source_)) {
     this.source_.addFeature(sketchFeature);
   }
-  this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWEND,
-      this.sketchFeature_));
+  this.dispatchEvent(new ol.DrawEvent(ol.DrawEventType.DRAWEND, sketchFeature));
 };
 
 


### PR DESCRIPTION
The property `this.sketchFeature_` is null when the `drawend` event is triggered.

So this PR attach the feature just drawn to this event.
