### PR TITLE
Fix popup anchor in icon example

### DIFF
--- a/examples/icon.html
+++ b/examples/icon.html
@@ -13,7 +13,7 @@
         position: relative;
       }
       #popup {
-        padding-bottom: 24px;
+        padding-bottom: 45px;
       }
     </style>
   </head>


### PR DESCRIPTION
In the [icon example](http://ol3js.org/en/master/examples/icon.html), the popup [used to be](9c824584b3fac91023a1c9cad3d2cfc5a271872b) anchored to the top of the icon.  It is currently anchored to the center of the icon.
