### PR TITLE
Don't render feature with all countries

### DIFF
--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -15,6 +15,15 @@ var raster = new ol.layer.Tile({
   })
 });
 
+var styleArray = [new ol.style.Style({
+  fill: new ol.style.Fill({
+    color: 'rgba(255, 255, 255, 0.6)'
+  }),
+  stroke: new ol.style.Stroke({
+    color: '#319FD3',
+    width: 1
+  })
+})];
 
 var vector = new ol.layer.Vector({
   source: new ol.source.TopoJSON({
@@ -22,17 +31,8 @@ var vector = new ol.layer.Vector({
     url: 'data/topojson/world-110m.json'
   }),
   styleFunction: function(feature, resolution) {
-    var styleArray = [new ol.style.Style({
-      fill: new ol.style.Fill({
-        color: 'rgba(255, 255, 255, 0.6)'
-      }),
-      stroke: new ol.style.Stroke({
-        color: '#319FD3',
-        width: 1
-      }),
-      zIndex: (feature.getGeometry().getType() !== 'MultiPolygon') ? 2 : 1
-    })];
-    return styleArray;
+    // don't want to render the full world polygon, which repeats all countries
+    return feature.getId() !== undefined ? styleArray : null;
   }
 });
 


### PR DESCRIPTION
The feature with `undefined` id is a multi-polygon representing all countries.  Instead of rendering all multi-polygons with a lower z-index, we just avoid rendering this single feature.
