### PR TITLE
Options to draw interaction are not optional

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -60,10 +60,10 @@ goog.inherits(ol.DrawEvent, goog.events.Event);
  * Interaction that allows drawing geometries
  * @constructor
  * @extends {ol.interaction.Interaction}
- * @param {olx.interaction.DrawOptions=} opt_options Options.
+ * @param {olx.interaction.DrawOptions} options Options.
  * @todo stability experimental
  */
-ol.interaction.Draw = function(opt_options) {
+ol.interaction.Draw = function(options) {
 
   goog.base(this);
 
@@ -72,22 +72,22 @@ ol.interaction.Draw = function(opt_options) {
    * @type {ol.source.Vector}
    * @private
    */
-  this.source_ = goog.isDef(opt_options.source) ? opt_options.source : null;
+  this.source_ = goog.isDef(options.source) ? options.source : null;
 
   /**
    * Pixel distance for snapping.
    * @type {number}
    * @private
    */
-  this.snapTolerance_ = goog.isDef(opt_options.snapTolerance) ?
-      opt_options.snapTolerance : 12;
+  this.snapTolerance_ = goog.isDef(options.snapTolerance) ?
+      options.snapTolerance : 12;
 
   /**
    * Geometry type.
    * @type {ol.geom.GeometryType}
    * @private
    */
-  this.type_ = opt_options.type;
+  this.type_ = options.type;
 
   /**
    * Drawing mode (derived from geometry type.
@@ -147,8 +147,8 @@ ol.interaction.Draw = function(opt_options) {
    * @private
    */
   this.overlay_ = new ol.FeatureOverlay();
-  this.overlay_.setStyleFunction(goog.isDef(opt_options.styleFunction) ?
-      opt_options.styleFunction : ol.interaction.Draw.defaultStyleFunction
+  this.overlay_.setStyleFunction(goog.isDef(options.styleFunction) ?
+      options.styleFunction : ol.interaction.Draw.defaultStyleFunction
   );
 };
 goog.inherits(ol.interaction.Draw, ol.interaction.Interaction);


### PR DESCRIPTION
The constructor accesses properties of `opt_options`.

The draw interaction could be made to work with a default geometry type, but as it is, it requires configuration.
