### PR TITLE
Changing pointer cursor in examples is broken

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -159,12 +159,8 @@ a.ol-full-screen-true:after {
   -ms-user-select: none;
   user-select: none;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
+}
 
-  cursor: default;
-}
-.ol-viewport .ol-unselectable:not([ie8andbelow]) {
-  cursor: auto;
-}
 .ol-zoom {
   position: absolute;
   top: 8px;


### PR DESCRIPTION
As reported on the [mailing list](https://groups.google.com/d/msg/ol3-dev/2E7I5dQPls0/XvluAXizpMAJ) changing the pointer cursor with

``` js
map.getTarget().style.cursor = 'select'
```

as done in the icon example, no longer works. Commit d3b2b1cd9e3d446c2cf4f75f205b16c436d45fb8 (the changes to the CSS file) broke it.

@austinhyde, any idea on how to fix that?
