### PR TITLE
Turn off rotation because Google does not support it

### DIFF
--- a/examples/google-map.js
+++ b/examples/google-map.js
@@ -53,8 +53,11 @@ google.maps.event.addListenerOnce(gmap, 'tilesloaded', function() {
   var center = gmap.getCenter();
   var map = new ol.Map({
     layers: [vector],
-    interactions: ol.interaction.defaults({dragPan: false})
-        .extend([new ol.interaction.DragPan({kinetic: false})]),
+    interactions: ol.interaction.defaults({
+      altShiftDragRotate: false,
+      dragPan: false,
+      touchRotate: false
+    }).extend([new ol.interaction.DragPan({kinetic: false})]),
     renderer: 'canvas',
     target: olmap,
     view: new ol.View2D({


### PR DESCRIPTION
This change suggests to disable rotate interactions in the google-map example, because applying rotation would bring the ol map out of sync with the Google map.
