### PR TITLE
Save replay group, even if empty

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -69,7 +69,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
   this.dispatchPreComposeEvent(context, frameState, transform);
 
   var replayGroup = this.replayGroup_;
-  if (!goog.isNull(replayGroup)) {
+  if (!goog.isNull(replayGroup) && !replayGroup.isEmpty()) {
     var renderGeometryFunction = this.getRenderGeometryFunction_();
     goog.asserts.assert(goog.isFunction(renderGeometryFunction));
     context.globalAlpha = layerState.opacity;


### PR DESCRIPTION
This PR comes from an investigation into a potential memory leak with @fredj.

@fredj observed that the rendering of an empty vector source would leak a DOM Node each frame. Further investigation revealed that these were `<canvas>` elements allocated for the hit detection canvas.

The problem turned out to be that replay groups were not being saved if they were empty. This meant that a new replay group was created each frame, which resulted in the allocation of a `<canvas>` element for hit detection each frame.

This PR fixes the problem by ensuring that empty replay groups are re-used.
