### PR TITLE
Prevent OSX Safari to display distorted map

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -104,9 +104,13 @@ ol.control.FullScreen.prototype.handleFullScreenChange_ = function() {
   var opened = this.cssClassName_ + '-true';
   var closed = this.cssClassName_ + '-false';
   var anchor = goog.dom.getFirstElementChild(this.element);
+  var map = this.getMap();
   if (goog.dom.fullscreen.isFullScreen()) {
     goog.dom.classes.swap(anchor, closed, opened);
   } else {
     goog.dom.classes.swap(anchor, opened, closed);
+  }
+  if (!goog.isNull(map)) {
+    map.updateSize();
   }
 };


### PR DESCRIPTION
This PR fixes #1698.

Safari isn’t really fullscreen when the `resize` event is triggered ; the following code:

``` javascript
var resize = function() {
  console.log(document.webkitIsFullScreen);
  console.log(document.mozFullScreen);
  setTimeout(function() {
    console.log(document.webkitIsFullScreen);
    console.log(document.mozFullScreen);
  }, 0);
};
window.addEventListener('resize', resize, false);
```

returns `true,true` on Firefox and `false,true` on safari when going fullscreen.

A call to `updateSize` in the `handleFullScreenChange_`, triggered when the page really have its new dimension, fixes Safari’s bad behavior.
