### PR TITLE
CSS transform detection when DOM is ready

### DIFF
--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -54,8 +54,7 @@ ol.dom.canUseCssTransform = (function() {
         }
         goog.dom.removeNode(el);
 
-        canUseCssTransform = (goog.isDefAndNotNull(has2d) && has2d.length > 0 &&
-            has2d !== 'none');
+        canUseCssTransform = (has2d && has2d !== 'none');
       }
     }
     return canUseCssTransform;
@@ -97,8 +96,7 @@ ol.dom.canUseCssTransform3D = (function() {
         }
         goog.dom.removeNode(el);
 
-        canUseCssTransform3D = (goog.isDefAndNotNull(has3d) &&
-            has3d.length > 0 && has3d !== 'none');
+        canUseCssTransform3D = (has3d && has3d !== 'none');
       }
     }
     return canUseCssTransform3D;


### PR DESCRIPTION
The code to detect CSS transforms requires a DOM to append an
element to. By performing this action when first called instead
of unconditionally upon library load, we can load OpenLayers in
the document's head again.
