### PR TITLE
use button elements instead of anchor elements and add tooltips to zoomcontrol

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -228,7 +228,7 @@ a.ol-full-screen-true:after {
 }
 
 /* invisible but not hidden */
-.olHasToolTip span, .olHasTooltip_b_r span {
+.olHasToolTip span, .olHasToolTip_b_r span {
   position: absolute;
   clip: rect(1px 1px 1px 1px); /* < IE8 */
   clip: rect(1px, 1px, 1px, 1px);
@@ -243,7 +243,7 @@ a.ol-full-screen-true:after {
 
 /* show a tooltip offset to below and right */
 .olHasToolTip:hover span, .olHasToolTip:focus span ,
-.olHasTooltip_b_r:hover span , .olHasTooltip_b_r:focus span  {
+.olHasToolTip_b_r:hover span , .olHasToolTip_b_r:focus span  {
   clip: auto;
   padding: 3px;
   height: auto;

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -37,26 +37,28 @@ ol.control.Zoom = function(opt_options) {
           goog.isDef(options.zoomOutLabel) ? options.zoomOutLabel : '-';
 
   var tTipZoomIn = goog.dom.createDom(goog.dom.TagName.SPAN, {
-          'class':'', 
-          'role':'tooltip'
-      },"Zoom in");
+    'class': '',
+    'role' : 'tooltip'
+  }, 'Zoom in');
   var inElement = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': className + '-in olHasToolTip',
-    'name' : 'zoomIn'
+    'name' : 'ZoomIn',
+    'type' : 'button'
   }, tTipZoomIn, zoomInLabel);
-  
+
   goog.events.listen(inElement, [
     goog.events.EventType.TOUCHEND,
     goog.events.EventType.CLICK
   ], goog.partial(ol.control.Zoom.prototype.zoomByDelta_, delta), false, this);
 
   var tTipsZoomOut = goog.dom.createDom(goog.dom.TagName.SPAN, {
-          'class':'', 
-          'role':'tooltip'
-      }, "Zoom out");
+    'class': '',
+    'role' : 'tooltip',
+    'type' : 'button'
+  }, 'Zoom out');
   var outElement = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': className + '-out  olHasToolTip',
-    'name' : 'zoomOut'
+    'name' : 'ZoomOut'
   }, tTipsZoomOut, zoomOutLabel);
   goog.events.listen(outElement, [
     goog.events.EventType.TOUCHEND,


### PR DESCRIPTION
TL;DR: if it is a button it should be a button.

Using the correct semantics serves accessiblity and adding a tooltip (which is screen reader accessible) makes the button easier to understand for everyone. Also proper focus handling is important for keyboard users since the have no `:hover` event

the tooltip can be easily disabled by removing the `:focus` and `:hover` pseudo classes or  using some simple css to override those.

more background in: http://www.geodienstencentrum.nl/blog/accessibility/webmapping/2014-02-14/enhancing-openlayers-controls.html
