### PR TITLE
Set text style in ol.render.canvas.Immediate

### DIFF
--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -255,6 +255,7 @@ ol.render.canvas.Immediate.prototype.drawText_ =
   if (!goog.isNull(this.textStrokeState_)) {
     this.setContextStrokeState_(this.textStrokeState_);
   }
+  this.setContextTextState_(this.textState_);
   goog.asserts.assert(offset === 0);
   goog.asserts.assert(end == flatCoordinates.length);
   var pixelCoordinates = ol.geom.flat.transform2D(


### PR DESCRIPTION
This fixes an oversight in `ol.render.canvas.Immediate`. Previously, the text style (font, baseline, align, etc.) was not being set.
