### PR TITLE
Handle null line dashes for text stroke styles in ol.render.canvas.Immediate

### DIFF
--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -816,7 +816,7 @@ ol.render.canvas.Immediate.prototype.setTextStyle = function(textStyle) {
       this.textStrokeState_ = {
         lineCap: goog.isDef(textStrokeStyleLineCap) ?
             textStrokeStyleLineCap : ol.render.canvas.defaultLineCap,
-        lineDash: goog.isDef(textStrokeStyleLineDash) ?
+        lineDash: goog.isDefAndNotNull(textStrokeStyleLineDash) ?
             textStrokeStyleLineDash : ol.render.canvas.defaultLineDash,
         lineJoin: goog.isDef(textStrokeStyleLineJoin) ?
             textStrokeStyleLineJoin : ol.render.canvas.defaultLineJoin,


### PR DESCRIPTION
This fixes the issue identified by @bentrm in #1710.
