### PR TITLE
Use minus sign as zoom out label

### DIFF
--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -32,9 +32,10 @@ ol.control.Zoom = function(opt_options) {
 
   var delta = goog.isDef(options.delta) ? options.delta : 1;
 
-  var zoomInLabel = goog.isDef(options.zoomInLabel) ? options.zoomInLabel : '+',
-      zoomOutLabel =
-          goog.isDef(options.zoomOutLabel) ? options.zoomOutLabel : '\u2212';
+  var zoomInLabel = goog.isDef(options.zoomInLabel) ?
+      options.zoomInLabel : '+';
+  var zoomOutLabel = goog.isDef(options.zoomOutLabel) ?
+      options.zoomOutLabel : '\u2212';
 
   var inElement = goog.dom.createDom(goog.dom.TagName.A, {
     'href': '#zoomIn',


### PR DESCRIPTION
This fixes an issue raised by @sbrunner in https://github.com/openlayers/ol3/commit/1215f582414d34d64485482a1ec7946de4bd0fe5#commitcomment-5389801.
