### PR TITLE
Initialize properties in the constructor

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -46,7 +46,7 @@ ol.Feature = function(opt_geometryOrValues) {
    * @private
    * @type {ol.feature.FeatureStyleFunction|undefined}
    */
-  this.styleFunction_;
+  this.styleFunction_ = undefined;
 
   /**
    * @private

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -40,10 +40,10 @@ ol.layer.Vector = function(opt_options) {
 
   /**
    * Style function for use within the library.
-   * @type {ol.feature.StyleFunction}
+   * @type {ol.feature.StyleFunction|undefined}
    * @private
    */
-  this.styleFunction_;
+  this.styleFunction_ = undefined;
 
   if (goog.isDef(options.style)) {
     this.setStyle(options.style);
@@ -80,7 +80,7 @@ ol.layer.Vector.prototype.getStyle = function() {
 
 /**
  * Get the style function.
- * @return {ol.feature.StyleFunction} Layer style function.
+ * @return {ol.feature.StyleFunction|undefined} Layer style function.
  * @todo stability experimental
  */
 ol.layer.Vector.prototype.getStyleFunction = function() {


### PR DESCRIPTION
This PR initializes the styleFunction_ property in the ol.layer.Vector constructor.
