### PR TITLE
Fix handling of the color cache

### DIFF
--- a/src/ol/color/color.js
+++ b/src/ol/color/color.js
@@ -186,7 +186,7 @@ ol.color.fromString = (
                 var i = 0;
                 var key;
                 for (key in cache) {
-                  if (i++ & 3 === 0) {
+                  if ((i++ & 3) === 0) {
                     delete cache[key];
                     --cacheSize;
                   }


### PR DESCRIPTION
When the size of the color cache exceeds the limit we're supposed to delete 25% of the entries. Currently this does not work – the cache keeps growing.

This is because `(i++ & 3 === 0)` always evaluates to 0 (which is a falsy value). This expression always evaluates to 0 because the `===` operator has precedence over the `&` operator.

This PR fixes the bug by using brackets around the `i++ & 3` expression.
