### PR TITLE
Add an alternative algorithm for zoomify tier size calculation

### DIFF
--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -44,8 +44,8 @@ ol.source.Zoomify = function(opt_options) {
         Math.ceil(width / tileSize),
         Math.ceil(height / tileSize)
       ]);
-      width = parseInt(width / 2, 10);
-      height = parseInt(height / 2, 10);
+      width >>= 1;
+      height >>= 1;
     }
   } else {
     while (imageWidth > tileSize || imageHeight > tileSize) {


### PR DESCRIPTION
Zoomify uses a different algorithm than ol3 to calculate the number of tiles per tier.
These algorithms are compatible in most cases, but they will lead to different results with some particular image sizes.

This update provides an option for the zoomify source to use one of these two algorithms.

Basically, zoomify rounds its calculations, leading to odd results for images sizes near to powers of 2.
For example, results will be different on those sizes:

```
513px
1025px to 1027px
2049px to 2055px
4097px to 4111px
...
```

The formula below gives the error margin for each power of 2, depending on the tile size:

``` javascript
function errorMargin(x) {
  Math.pow(2, Math.floor(Math.log(x) / Math.log(2)) - Math.log(tileSize) / Math.log(2)) - 1
}

errorMargin(1024) // -> 3 -> from 1025 to 1027
errorMargin(2048) // -> 7 -> from 2049 to 2055
...
```

I made a simple gist to show the differences: https://gist.github.com/felixgirault/9110910
I hope the above explanations are clear enough for you to understand, thank you for your time.
