### PR TITLE
Move preload default value to where it is used

### DIFF
--- a/src/ol/layer/tilelayer.js
+++ b/src/ol/layer/tilelayer.js
@@ -20,22 +20,19 @@ ol.layer.TileProperty = {
  * @todo observable preload {number} the level to preload tiles up to
  */
 ol.layer.Tile = function(options) {
-
   goog.base(this, options);
-
-  this.setPreload(
-      goog.isDef(options.preload) ? options.preload : 0);
 
 };
 goog.inherits(ol.layer.Tile, ol.layer.Layer);
 
 
 /**
- * @return {number} Preload.
+ * @return {number|undefined} Preload.
  * @todo stability experimental
  */
 ol.layer.Tile.prototype.getPreload = function() {
-  return /** @type {number} */ (this.get(ol.layer.TileProperty.PRELOAD));
+  return /** @type {number|undefined} */ (
+      this.get(ol.layer.TileProperty.PRELOAD));
 };
 goog.exportProperty(
     ol.layer.Tile.prototype,

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -249,7 +249,8 @@ ol.renderer.Layer.prototype.snapCenterToPixel =
  * @param {ol.proj.Projection} projection Projection.
  * @param {ol.Extent} extent Extent.
  * @param {number} currentZ Current Z.
- * @param {number} preload Load low resolution tiles up to 'preload' levels.
+ * @param {number|undefined} preload Load low resolution tiles up to 'preload'
+ *     levels.
  * @param {function(this: T, ol.Tile)=} opt_tileCallback Tile callback.
  * @param {T=} opt_this Object to use as `this` in `opt_tileCallback`.
  * @protected
@@ -266,6 +267,9 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
   var tileQueue = frameState.tileQueue;
   var minZoom = tileGrid.getMinZoom();
   var tile, tileRange, tileResolution, x, y, z;
+  if (!goog.isDef(preload)) {
+    preload = 0;
+  }
   for (z = currentZ; z >= minZoom; --z) {
     tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
     tileResolution = tileGrid.getResolution(z);


### PR DESCRIPTION
This avoids the need to call to `setPreload` in the `ol.layer.Tile` constructor and generally makes things tidier.
