### PR TITLE
Fix zoom in/out tooltip sizing for box-sizing css resets

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -198,6 +198,9 @@ button.ol-full-screen-true:after {
 
 /* show a tooltip offset to below and right */
 .ol-has-tooltip:hover [role=tooltip], .ol-has-tooltip:focus [role=tooltip] {
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
   clip: auto;
   padding: 0 .4em;
   font-size: .8em;


### PR DESCRIPTION
The zoom in/out tooltips are clipped when a css reset sets the
box-sizing to anything other than content-box. This breaks the
sizing of these tooltips, because they rely on content-box
sizing. This issue can e.g. be seen when using a bootstrap 3.x
bootstrap.css
