### PR TITLE
Don't check for full screen support at load time

### DIFF
--- a/src/ol/browserfeature.exports
+++ b/src/ol/browserfeature.exports
@@ -3,6 +3,5 @@
 @exportProperty ol.BrowserFeature.HAS_CANVAS
 @exportProperty ol.BrowserFeature.HAS_DEVICE_ORIENTATION
 @exportProperty ol.BrowserFeature.HAS_GEOLOCATION
-@exportProperty ol.BrowserFeature.HAS_FULLSCREEN
 @exportProperty ol.BrowserFeature.HAS_TOUCH
 @exportProperty ol.BrowserFeature.HAS_WEBGL

--- a/src/ol/browserfeature.js
+++ b/src/ol/browserfeature.js
@@ -3,7 +3,6 @@ goog.provide('ol.BrowserFeature');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.userAgent');
-goog.require('googx.dom.fullscreen');
 goog.require('ol.webgl');
 
 
@@ -140,15 +139,6 @@ ol.BrowserFeature.HAS_DEVICE_ORIENTATION =
  * @todo stability experimental
  */
 ol.BrowserFeature.HAS_DOM = ol.ENABLE_DOM;
-
-
-/**
- * True if browser supports the fullscreen API.
- * @const
- * @type {boolean}
- * @todo stability experimental
- */
-ol.BrowserFeature.HAS_FULLSCREEN = googx.dom.fullscreen.isSupported();
 
 
 /**

--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -8,7 +8,6 @@ goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('googx.dom.fullscreen');
 goog.require('googx.dom.fullscreen.EventType');
-goog.require('ol.BrowserFeature');
 goog.require('ol.control.Control');
 goog.require('ol.css');
 
@@ -66,7 +65,7 @@ ol.control.FullScreen = function(opt_options) {
 
   var element = goog.dom.createDom(goog.dom.TagName.DIV, {
     'class': this.cssClassName_ + ' ' + ol.css.CLASS_UNSELECTABLE + ' ' +
-        (!ol.BrowserFeature.HAS_FULLSCREEN ? ol.css.CLASS_UNSUPPORTED : '')
+        (!googx.dom.fullscreen.isSupported() ? ol.css.CLASS_UNSUPPORTED : '')
   }, button);
 
   goog.base(this, {
@@ -89,7 +88,7 @@ goog.inherits(ol.control.FullScreen, ol.control.Control);
  * @private
  */
 ol.control.FullScreen.prototype.handleClick_ = function(browserEvent) {
-  if (!ol.BrowserFeature.HAS_FULLSCREEN) {
+  if (!googx.dom.fullscreen.isSupported()) {
     return;
   }
   browserEvent.preventDefault();


### PR DESCRIPTION
Detection of full screeen support requires the document to have a body. This is not the case if ol3 is loaded in the head.  Therefore, defer the test for full screen support to when it is needed.

Refs #1767 and [the mailing list](https://groups.google.com/d/msg/ol3-dev/SEu5Js8OurU/MQgZ8WM4ER8J).
