### PR TITLE
Add support for Carmenta Server hi-DPI WMS requests

### DIFF
--- a/src/ol/source/imagewmssource.js
+++ b/src/ol/source/imagewmssource.js
@@ -284,6 +284,7 @@ ol.source.ImageWMS.prototype.getRequestUrl_ =
       case ol.source.wms.ServerType.MAPSERVER:
         goog.object.set(params, 'MAP_RESOLUTION', 90 * pixelRatio);
         break;
+      case ol.source.wms.ServerType.CARMENTA_SERVER:
       case ol.source.wms.ServerType.QGIS:
         goog.object.set(params, 'DPI', 90 * pixelRatio);
         break;

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -249,6 +249,7 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
       case ol.source.wms.ServerType.MAPSERVER:
         goog.object.set(params, 'MAP_RESOLUTION', 90 * pixelRatio);
         break;
+      case ol.source.wms.ServerType.CARMENTA_SERVER:
       case ol.source.wms.ServerType.QGIS:
         goog.object.set(params, 'DPI', 90 * pixelRatio);
         break;

--- a/src/ol/source/wmssource.js
+++ b/src/ol/source/wmssource.js
@@ -12,6 +12,7 @@ ol.source.wms.DEFAULT_VERSION = '1.3.0';
  * @enum {string}
  */
 ol.source.wms.ServerType = {
+  CARMENTA_SERVER: 'carmentaserver',
   GEOSERVER: 'geoserver',
   MAPSERVER: 'mapserver',
   QGIS: 'qgis'


### PR DESCRIPTION
Carmenta Server uses the same request parameter as QGIS.
