### PR TITLE
Get first and last coordinate

### DIFF
--- a/src/ol/geom/simplegeometry.exports
+++ b/src/ol/geom/simplegeometry.exports
@@ -1,6 +1,7 @@
 @exportSymbol ol.geom.SimpleGeometry
 @exportProperty ol.geom.SimpleGeometry.prototype.getExtent
 @exportProperty ol.geom.SimpleGeometry.prototype.getFirstCoordinate
+@exportProperty ol.geom.SimpleGeometry.prototype.getLastCoordinate
 @exportProperty ol.geom.SimpleGeometry.prototype.getLayout
 @exportProperty ol.geom.SimpleGeometry.prototype.getSimplifiedGeometry
 @exportProperty ol.geom.SimpleGeometry.prototype.transform

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -116,6 +116,14 @@ ol.geom.SimpleGeometry.prototype.getFlatCoordinates = function() {
 
 
 /**
+ * @return {ol.Coordinate} Last point.
+ */
+ol.geom.SimpleGeometry.prototype.getLastCoordinate = function() {
+  return this.flatCoordinates.slice(this.flatCoordinates.length - this.stride);
+};
+
+
+/**
  * @return {ol.geom.GeometryLayout} Layout.
  * @todo stability experimental
  */

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -184,6 +184,14 @@ describe('ol.geom.LineString', function() {
 
     });
 
+    describe('#getLastCoordinate', function() {
+
+      it('returns the expected result', function() {
+        expect(lineString.getLastCoordinate()).to.eql([7, 5]);
+      });
+
+    });
+
     describe('#getSimplifiedGeometry', function() {
 
       it('returns the expectedResult', function() {


### PR DESCRIPTION
This adds a couple of small functions `getFirstCoordinate` and `getLastCoordinate` to all simple geometry types. They're roughly equivalent to PostGIS's `ST_StartPoint` and `ST_EndPoint` functions, except they work on all simple geometry types and return an raw array instead of an `ol.geom.Point`. The reason for returning the raw array is that returning an `ol.geom.Point` would currently cause a circular dependency between `ol.geom.SimpleGeometry` and `ol.geom.Point`.
