### PR TITLE
Catch CORS exceptions when loading icons

### DIFF
--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -429,7 +429,11 @@ ol.style.IconImage_.prototype.load = function() {
       goog.events.listenOnce(this.image_, goog.events.EventType.LOAD,
           this.handleImageLoad_, false, this)
     ];
-    this.image_.src = this.src_;
+    try {
+      this.image_.src = this.src_;
+    } catch (e) {
+      this.handleImageError_();
+    }
   }
 };
 


### PR DESCRIPTION
When an image load causes a CORS violation, it seems to raise an exception at the line that triggered the load, rather than firing an `error` event. This exception is not caught, and ends up aborting the entire render. This PR catches the exception when it occurs and treats it as an error, preventing CORS exceptions from breaking the render.
