### PR TITLE
Example applying a convolution kernel to an image

### DIFF
--- a/examples/image-filter.html
+++ b/examples/image-filter.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>Image Filter Example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">Image filter example</h4>
+          <p id="shortdesc">Apply a filter to imagery</p>
+          <select id="kernel" name="kernel">
+            <option>none</option>
+            <option selected>sharpen</option>
+            <option value="sharpenless">sharpen less</option>
+            <option>blur</option>
+            <option>shadow</option>
+            <option>emboss</option>
+            <option value="edge">edge detect</option>
+          </select>
+          <div id="docs">
+            <p>
+              Layer rendering can be manipulated in <code>precompose</code> and <code>postcompose</code> event listeners.
+              These listeners get an event with a reference to the Canvas rendering context.
+              In this example, the <code>postcompose</code> listener applies a filter to the image data.
+            </p>
+            <p>See the <a href="image-filter.js" target="_blank">image-filter.js source</a> for details on how this is done.</p>
+          </div>
+          <div id="tags">filter, image manipulation</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=image-filter" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/image-filter.js
+++ b/examples/image-filter.js
@@ -1,0 +1,147 @@
+goog.require('ol.Map');
+goog.require('ol.View2D');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.BingMaps');
+
+var key = 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3';
+
+var imagery = new ol.layer.Tile({
+  source: new ol.source.BingMaps({key: key, imagerySet: 'Aerial'})
+});
+
+var map = new ol.Map({
+  layers: [imagery],
+  renderer: 'canvas',
+  target: 'map',
+  view: new ol.View2D({
+    center: ol.proj.transform([-120, 50], 'EPSG:4326', 'EPSG:3857'),
+    zoom: 6
+  })
+});
+
+var kernels = {
+  none: [
+    0, 0, 0,
+    0, 1, 0,
+    0, 0, 0
+  ],
+  sharpen: [
+    0, -1, 0,
+    -1, 5, -1,
+    0, -1, 0
+  ],
+  sharpenless: [
+    0, -1, 0,
+    -1, 10, -1,
+    0, -1, 0
+  ],
+  blur: [
+    1, 1, 1,
+    1, 1, 1,
+    1, 1, 1
+  ],
+  shadow: [
+    1, 2, 1,
+    0, 1, 0,
+    -1, -2, -1
+  ],
+  emboss: [
+    -2, 1, 0,
+    -1, 1, 1,
+    0, 1, 2
+  ],
+  edge: [
+    0, 1, 0,
+    1, -4, 1,
+    0, 1, 0
+  ]
+};
+
+function normalize(kernel) {
+  var len = kernel.length;
+  var normal = new Array(len);
+  var i, sum = 0;
+  for (i = 0; i < len; ++i) {
+    sum += kernel[i];
+  }
+  if (sum <= 0) {
+    normal.normalized = false;
+    sum = 1;
+  } else {
+    normal.normalized = true;
+  }
+  for (i = 0; i < len; ++i) {
+    normal[i] = kernel[i] / sum;
+  }
+  return normal;
+}
+
+var select = document.getElementById('kernel');
+var selectedKernel = normalize(kernels[select.value]);
+
+
+/**
+ * Update the kernel and re-render on change.
+ */
+select.onchange = function() {
+  selectedKernel = normalize(kernels[select.value]);
+  map.render();
+};
+
+
+/**
+ * Apply a filter on "postcompose" events.
+ * @param {ol.render.Event} event Render event.
+ */
+imagery.on('postcompose', function(event) {
+  convolve(event.context, selectedKernel);
+});
+
+
+/**
+ * Apply a convolution kernel to canvas.  This works for any size kernel, but
+ * performance starts degrading above 3 x 3.
+ * @param {CanvasRenderingContext2D} context Canvas 2d context.
+ * @param {Array.<number>} kernel Kernel.
+ */
+function convolve(context, kernel) {
+  var canvas = context.canvas;
+  var width = canvas.width;
+  var height = canvas.height;
+
+  var size = Math.sqrt(kernel.length);
+  var half = Math.floor(size / 2);
+
+  var inputData = context.getImageData(0, 0, width, height).data;
+
+  var output = context.createImageData(width, height);
+  var outputData = output.data;
+
+  for (var pixelY = 0; pixelY < height; ++pixelY) {
+    var pixelsAbove = pixelY * width;
+    for (var pixelX = 0; pixelX < width; ++pixelX) {
+      var r = 0, g = 0, b = 0, a = 0;
+      for (var kernelY = 0; kernelY < size; ++kernelY) {
+        for (var kernelX = 0; kernelX < size; ++kernelX) {
+          var weight = kernel[kernelY * size + kernelX];
+          var neighborY = Math.min(
+              height - 1, Math.max(0, pixelY + kernelY - half));
+          var neighborX = Math.min(
+              width - 1, Math.max(0, pixelX + kernelX - half));
+          var inputIndex = (neighborY * width + neighborX) * 4;
+          r += inputData[inputIndex] * weight;
+          g += inputData[inputIndex + 1] * weight;
+          b += inputData[inputIndex + 2] * weight;
+          a += inputData[inputIndex + 3] * weight;
+        }
+      }
+      var outputIndex = (pixelsAbove + pixelX) * 4;
+      outputData[outputIndex] = r;
+      outputData[outputIndex + 1] = g;
+      outputData[outputIndex + 2] = b;
+      outputData[outputIndex + 3] = kernel.normalized ? a : 255;
+    }
+  }
+  context.putImageData(output, 0, 0);
+}


### PR DESCRIPTION
This example was basically to see how much image data manipulation could be done while still getting a high frame rate.

For those that have experimented with this kind of thing, I was surprised to find that working with `Uint32Array` views of the data was _not_ universally faster.  In this particular example, I think the extra clamping operations are a hit (where we get this with no extra JS processing using the `Uint8ClampedArray` view).

If anybody has any additional ideas of faster convolution strategies, let me know.  See this [performance test](http://jsperf.com/canvas-convolution/4) for a comparison of a few Uint8/Uint32 read/write alternatives.
