### PR TITLE
setState never occures

### DIFF
--- a/src/ol/source/vectorfilesource.js
+++ b/src/ol/source/vectorfilesource.js
@@ -128,11 +128,11 @@ ol.source.VectorFile.prototype.handleXhrIo_ = function(event) {
       goog.asserts.fail();
     }
     goog.dispose(xhrIo);
-    if (goog.isDef(source)) {
+    if (goog.isDefAndNotNull(source)) {
       this.readFeatures_(source);
     } else {
-      goog.asserts.fail();
       this.setState(ol.source.State.ERROR);
+      goog.asserts.fail();
     }
   } else {
     this.setState(ol.source.State.ERROR);


### PR DESCRIPTION
Two changes for better parsing of non-existing input sources:

1 - use goog.isDefAndNotNull(source) in the condition (null is also considered as valid source now)
2 - call setState before goog.asserts.fail
