### PR TITLE
Set way ids in ol.format.OSMXML

### DIFF
--- a/src/ol/format/osmxmlformat.js
+++ b/src/ol/format/osmxmlformat.js
@@ -89,13 +89,14 @@ ol.format.OSMXML.readWay_ = function(node, objectStack) {
     var point = goog.object.get(state.nodes, values.ndrefs[i]);
     goog.array.extend(flatCoordinates, point);
   }
+  var geometry;
   if (values.ndrefs[0] == values.ndrefs[values.ndrefs.length - 1]) {
     // closed way
-    var geometry = new ol.geom.Polygon(null);
+    geometry = new ol.geom.Polygon(null);
     geometry.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates,
         [flatCoordinates.length]);
   } else {
-    var geometry = new ol.geom.LineString(null);
+    geometry = new ol.geom.LineString(null);
     geometry.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);
   }
   var feature = new ol.Feature(geometry);


### PR DESCRIPTION
This sets feature ids for non-point features read by `ol.format.OSMXML`.
