### PR TITLE
Add GitEye .project file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /examples/example-list.js
 /examples/example-list.xml
 /node_modules/
+/.project


### PR DESCRIPTION
I sometimes use GitEye GUI tool to work. It requires to add an .project file at the root of the repo. This PR just add this file to .gitignore

Is it possible to have it merged?

Thanks
