### PR TITLE
Revisit decision to allow draw interaction to draw rings with two points

### DIFF
--- a/src/objectliterals.jsdoc
+++ b/src/objectliterals.jsdoc
@@ -415,6 +415,8 @@
  *     drawing finish (default is 12).
  * @property {ol.geom.GeometryType} type Drawing type ('Point', 'LineString',
  *     'Polygon', 'MultiPoint', 'MultiLineString', or 'MultiPolygon').
+ * @property {number|undefined} minPointsPerRing The number of points that must
+ *     be drawn before a polygon ring can be finished (default is 3).
  * @property {ol.style.Style|Array.<ol.style.Style>|ol.feature.StyleFunction|undefined} style
  *     Style for sketch features.
  * @todo stability experimental

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -90,6 +90,15 @@ ol.interaction.Draw = function(options) {
       options.snapTolerance : 12;
 
   /**
+   * The number of points that must be drawn before a polygon ring can be
+   * finished.  The default is 3.
+   * @type {number}
+   * @private
+   */
+  this.minPointsPerRing_ = goog.isDef(options.minPointsPerRing) ?
+      options.minPointsPerRing : 3;
+
+  /**
    * Geometry type.
    * @type {ol.geom.GeometryType}
    * @private
@@ -314,7 +323,8 @@ ol.interaction.Draw.prototype.atFinish_ = function(event) {
       potentiallyDone = geometry.getCoordinates().length > 2;
     } else if (this.mode_ === ol.interaction.DrawMode.POLYGON) {
       goog.asserts.assertInstanceof(geometry, ol.geom.Polygon);
-      potentiallyDone = geometry.getCoordinates()[0].length > 2;
+      potentiallyDone = geometry.getCoordinates()[0].length >
+          this.minPointsPerRing_;
       potentiallyFinishCoordinates = [this.sketchRawPolygon_[0][0],
         this.sketchRawPolygon_[0][this.sketchRawPolygon_[0].length - 2]];
     }


### PR DESCRIPTION
In my opinion, the default should be to not finish ring drawing on the second point.  An option could be provided in applications where this behavior is needed.
