### PR TITLE
Internet Explorer 11 causes Access Denied error in OpenLayers.Format.XML

### DIFF
--- a/lib/OpenLayers/Format/XML.js
+++ b/lib/OpenLayers/Format/XML.js
@@ -81,8 +81,11 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
      *     the object.
      */
     initialize: function(options) {
-        if(window.ActiveXObject) {
-            this.xmldom = new ActiveXObject("Microsoft.XMLDOM");
+        if (!(document.implementation &&
+                document.implementation.createDocument) &&
+                typeof ActiveXObject != 'undefined') {
+            this.xmldom = new ActiveXObject("MSXML2.DOMDocument");
+            this.xmldom.setProperty('ProhibitDTD', true);
         }
         OpenLayers.Format.prototype.initialize.apply(this, [options]);
         // clone the namespace object and set all namespace aliases
@@ -138,8 +141,11 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
                      * Since we want to be able to call this method on the prototype
                      * itself, this.xmldom may not exist even if in IE.
                      */
-                    if(window.ActiveXObject && !this.xmldom) {
-                        xmldom = new ActiveXObject("Microsoft.XMLDOM");
+                    if(!(document.implementation &&
+                            document.implementation.createDocument) &&
+                            typeof ActiveXObject != 'undefined') {
+                        this.xmldom = new ActiveXObject("MSXML2.DOMDocument");
+                        this.xmldom.setProperty('ProhibitDTD', true);
                     } else {
                         xmldom = this.xmldom;
                         


### PR DESCRIPTION
Internet Explorer 11 causes a 0x80070005 - JavaScript runtime error: Access is denied.
in the OpenLayers.Format.XML class when the browser tries to open an XMLHttpRequest at the req.open(... statement.

...
function() {
    var req = new XMLHttpRequest();
    req.open("GET", "data:" + "text/xml" +
                         ";charset=utf-8," + encodeURIComponent(text), false);