### PR TITLE
Rename ol.structs.RBush#getAllInExtent to getInExtent

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -500,7 +500,7 @@ ol.interaction.Modify.prototype.handleMouseAtPixel_ = function(pixel, map) {
 
   this.modifiable_ = false;
   var rBush = this.rBush_;
-  var nodes = rBush.getAllInExtent(box);
+  var nodes = rBush.getInExtent(box);
   if (nodes.length > 0) {
     nodes.sort(sortByDistance);
     var node = nodes[0];

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -223,7 +223,7 @@ ol.source.Vector.prototype.getFeaturesAtCoordinate = function(coordinate) {
  * @todo stability experimental
  */
 ol.source.Vector.prototype.getFeaturesInExtent = function(extent) {
-  return this.rBush_.getAllInExtent(extent);
+  return this.rBush_.getInExtent(extent);
 };
 
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -546,7 +546,7 @@ ol.structs.RBush.prototype.getAll = function() {
  * @param {ol.Extent} extent Extent.
  * @return {Array.<T>} All in extent.
  */
-ol.structs.RBush.prototype.getAllInExtent = function(extent) {
+ol.structs.RBush.prototype.getInExtent = function(extent) {
   var values = [];
   this.forEachInExtent(extent,
       /**

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -37,11 +37,11 @@ describe('ol.structs.RBush', function() {
     });
 
     it('can update the object', function() {
-      expect(rBush.getAllInExtent([0, 0, 1, 1])).to.eql([obj]);
+      expect(rBush.getInExtent([0, 0, 1, 1])).to.eql([obj]);
       rBush.update([2, 2, 3, 3], obj);
-      expect(rBush.getAllInExtent([0, 0, 1, 1])).to.be.empty();
+      expect(rBush.getInExtent([0, 0, 1, 1])).to.be.empty();
       expect(rBush.getAll()).to.eql([obj]);
-      expect(rBush.getAllInExtent([2, 2, 3, 3])).to.eql([obj]);
+      expect(rBush.getInExtent([2, 2, 3, 3])).to.eql([obj]);
     });
 
   });
@@ -64,15 +64,15 @@ describe('ol.structs.RBush', function() {
       rBush.insert([-3, -3, -2, -2], objs[10]);
     });
 
-    describe('#getAllInExtent', function() {
+    describe('#getInExtent', function() {
 
       it('returns the expected objects', function() {
         var result;
-        result = rBush.getAllInExtent([2, 2, 3, 3]);
+        result = rBush.getInExtent([2, 2, 3, 3]);
         expect(result).to.contain(objs[1]);
         expect(result).to.contain(objs[2]);
         expect(result.length).to.be(2);
-        result = rBush.getAllInExtent([-1, -1, 2, 2]);
+        result = rBush.getInExtent([-1, -1, 2, 2]);
         expect(result).to.contain(objs[0]);
         expect(result).to.contain(objs[1]);
         expect(result).to.contain(objs[2]);
@@ -81,7 +81,7 @@ describe('ol.structs.RBush', function() {
       });
 
       it('returns an empty array when given a disjoint extent', function() {
-        expect(rBush.getAllInExtent([5, 5, 6, 6]).length).to.be(0);
+        expect(rBush.getInExtent([5, 5, 6, 6]).length).to.be(0);
       });
 
     });
@@ -183,12 +183,12 @@ describe('ol.structs.RBush', function() {
       }
     });
 
-    describe('#getAllInExtent', function() {
+    describe('#getInExtent', function() {
 
       it('returns the expected objects', function() {
         var i, ii;
         for (i = 0, ii = objs.length; i < ii; ++i) {
-          expect(rBush.getAllInExtent(extents[i])).to.eql([objs[i]]);
+          expect(rBush.getInExtent(extents[i])).to.eql([objs[i]]);
         }
       });
 
@@ -207,9 +207,9 @@ describe('ol.structs.RBush', function() {
       it('can remove each object in turn', function() {
         var i, ii;
         for (i = 0, ii = objs.length; i < ii; ++i) {
-          expect(rBush.getAllInExtent(extents[i])).to.eql([objs[i]]);
+          expect(rBush.getInExtent(extents[i])).to.eql([objs[i]]);
           rBush.remove(objs[i]);
-          expect(rBush.getAllInExtent(extents[i])).to.be.empty();
+          expect(rBush.getInExtent(extents[i])).to.be.empty();
         }
         expect(rBush.getAll()).to.be.empty();
         expect(rBush.isEmpty()).to.be(true);
@@ -226,9 +226,9 @@ describe('ol.structs.RBush', function() {
         }
         for (i = 0, ii = objs.length; i < ii; ++i) {
           var index = indexes[i];
-          expect(rBush.getAllInExtent(extents[index])).to.eql([objs[index]]);
+          expect(rBush.getInExtent(extents[index])).to.eql([objs[index]]);
           rBush.remove(objs[index]);
-          expect(rBush.getAllInExtent(extents[index])).to.be.empty();
+          expect(rBush.getInExtent(extents[index])).to.be.empty();
         }
         expect(rBush.getAll()).to.be.empty();
         expect(rBush.isEmpty()).to.be(true);
@@ -258,10 +258,10 @@ describe('ol.structs.RBush', function() {
 
     });
 
-    describe('#getAllInExtent', function() {
+    describe('#getInExtent', function() {
 
       it('returns the expected number of objects', function() {
-        expect(rBush.getAllInExtent([0, 0, 10600, 10600]).length).to.be(1000);
+        expect(rBush.getInExtent([0, 0, 10600, 10600]).length).to.be(1000);
       });
 
       it('can perform 1000 in-extent searches', function() {
@@ -272,7 +272,7 @@ describe('ol.structs.RBush', function() {
           var max = [min[0] + Math.random() * 500,
                      min[1] + Math.random() * 500];
           var extent = [min[0], min[1], max[0], max[1]];
-          n += rBush.getAllInExtent(extent).length;
+          n += rBush.getInExtent(extent).length;
         }
         expect(n).not.to.be(0);
       });
@@ -286,7 +286,7 @@ describe('ol.structs.RBush', function() {
           var max = [min[0] + Math.random() * 500,
                      min[1] + Math.random() * 500];
           var extent = [min[0], min[1], max[0], max[1]];
-          n += rBush.getAllInExtent(extent).length;
+          n += rBush.getInExtent(extent).length;
         }
         expect(n).to.be(0);
       });
@@ -304,7 +304,7 @@ describe('ol.structs.RBush', function() {
           var extent = [min[0], min[1], max[0], max[1]];
           rBush.insert(extent, {id: i});
         }
-        expect(rBush.getAllInExtent([0, 0, 10600, 10600]).length).to.be(2000);
+        expect(rBush.getInExtent([0, 0, 10600, 10600]).length).to.be(2000);
       });
 
     });


### PR DESCRIPTION
In the same vein as #1758, this renames `getAllInExtent` to `getInExtent` in `ol.structs.RBush`.
