### PR TITLE
Add @namespace annotation for dom/fullscreen.js.

### DIFF
--- a/src/googx/dom/fullscreen.js
+++ b/src/googx/dom/fullscreen.js
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview Functions for managing full screen status of the DOM.
- *
+ * @namespace googx
  */
 
 goog.provide('googx.dom.fullscreen');


### PR DESCRIPTION
This removes the block below from startpage of the API-docs:

![api-doc-fullscreen-on-startpage](https://f.cloud.github.com/assets/227934/2345855/46c8472a-a53b-11e3-8ccb-58d2caa14620.png)

Please review.
