### PR TITLE
Lazily create ol.defaultFeatureStyleFunction

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -222,7 +222,7 @@ ol.feature.FeatureStyleFunction;
  * @this {ol.Feature}
  * @todo stability experimental
  */
-ol.feature.defaultFeatureStyleFunction = (function() {
+ol.feature.defaultFeatureStyleFunction = function(resolution) {
   var fill = new ol.style.Fill({
     color: 'rgba(255,255,255,0.4)'
   });
@@ -241,10 +241,17 @@ ol.feature.defaultFeatureStyleFunction = (function() {
       stroke: stroke
     })
   ];
-  return function(resolution) {
-    return styles;
-  };
-})();
+
+  // now that we've run it the first time,
+  // replace the function with a constant version
+  ol.feature.defaultFeatureStyleFunction =
+      /** @type {function(this:ol.Feature):Array.<ol.style.Style>} */(
+      function(resolution) {
+        return styles;
+      });
+
+  return styles;
+};
 
 
 /**


### PR DESCRIPTION
Besides the slight performance benefit of not prerendering the default
circle style until we need to, this change also allows loading OL3
in browsers that don't support the canvas API (IE 7-8). If the circle
style is rendered on load, the lack of HTMLCanvasElement#getContext
causes IE 7-8 to bomb, regardless of if vector styles are used at all.
