### PR TITLE
Close polygon in modify-feature example.

### DIFF
--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -148,7 +148,9 @@ var vectorSource = new ol.source.GeoJSON(
                 },
                 {
                   'type': 'Polygon',
-                  'coordinates': [[[1e6, -6e6], [2e6, -4e6], [3e6, -6e6]]]
+                  'coordinates': [
+                    [[1e6, -6e6], [2e6, -4e6], [3e6, -6e6], [1e6, -6e6]]
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
This allows to modify every edge of the triangle polygon in the modify-feature example, see also #1807.
