### PR TITLE
Fix anchor origin calculation

### DIFF
--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -450,7 +450,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
     anchorXUnits = ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS_;
     anchorYUnits = ol.format.KML.DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS_;
   } else if (/^http:\/\/maps\.(?:google|gstatic)\.com\//.test(src)) {
-    anchor = [0.5, 1];
+    anchor = [0.5, 0];
     anchorXUnits = ol.style.IconAnchorUnits.FRACTION;
     anchorYUnits = ol.style.IconAnchorUnits.FRACTION;
   }
@@ -471,7 +471,7 @@ ol.format.KML.IconStyleParser_ = function(node, objectStack) {
 
   var imageStyle = new ol.style.Icon({
     anchor: anchor,
-    anchorOrigin: ol.style.IconAnchorOrigin.TOP_LEFT,
+    anchorOrigin: ol.style.IconAnchorOrigin.BOTTOM_LEFT,
     anchorXUnits: anchorXUnits,
     anchorYUnits: anchorYUnits,
     crossOrigin: 'anonymous', // FIXME should this be configurable?

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -157,7 +157,7 @@ ol.style.Icon.prototype.getAnchor = function() {
     }
     if (this.anchorOrigin_ == ol.style.IconAnchorOrigin.BOTTOM_LEFT ||
         this.anchorOrigin_ == ol.style.IconAnchorOrigin.BOTTOM_RIGHT) {
-      anchor[1] += size[1];
+      anchor[1] = -anchor[1] + size[1];
     }
   }
   return anchor;


### PR DESCRIPTION
This PR is an alternative to this fix: https://github.com/openlayers/ol3/pull/1802 , because it breaks some others KML files.

According to the KML spec the origin of anchor is bottom-left, the bug mentioned [in the mailing list ](https://groups.google.com/d/msg/ol3-dev/jr6f2s0k1wU/jRzhgBBWca0J)  was caused by a miscalculation of the y coordinate of the anchor.

So this PR revert the fix and fix the calculation.

I've tested with these files:

[FullCourse.kml ](https://docs.google.com/file/d/0B4uRuJ1hajZmbVA4dWUzUmhfR1VTRlMwdVV5YjZxakRoMEJn/edit)

[Swissmetnet.kml ](https://docs.google.com/file/d/0B4uRuJ1hajZmS3RTWUM4SmthMzg/edit)

Hope this makes sense.
