### PR TITLE
Fix calculation of ends in ol.geom.MultiPolygon#getPolygons

### DIFF
--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -215,13 +215,19 @@ ol.geom.MultiPolygon.prototype.getPolygons = function() {
   var endss = this.endss_;
   var polygons = [];
   var offset = 0;
-  var i, ii;
+  var i, ii, j, jj;
   for (i = 0, ii = endss.length; i < ii; ++i) {
     var ends = endss[i];
     var end = ends[ends.length - 1];
     var polygon = new ol.geom.Polygon(null);
+    var polygonEnds = ends.slice();
+    if (offset !== 0) {
+      for (j = 0, jj = polygonEnds.length; j < jj; ++j) {
+        polygonEnds[j] = polygonEnds[j] - offset;
+      }
+    }
     polygon.setFlatCoordinates(
-        layout, flatCoordinates.slice(offset, end), ends.slice());
+        layout, flatCoordinates.slice(offset, end), polygonEnds);
     polygons.push(polygon);
     offset = end;
   }


### PR DESCRIPTION
This fixes a bug reported by @pagameba [on the mailing list](https://groups.google.com/d/msg/ol3-dev/mHUxePnRCC8/CQiK1Tr7zNIJ). The polygons returned by `ol.geom.MultiPolygon#getPolygons` were invalid.

@ahocevar I suspect that this same bug is present in other `ol.geom` classes, which in turn might be causing #1808. Will investigate.
