### PR TITLE
Iterating through the hit detection replay batch fails when geometryRenderFunction returns false

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -449,6 +449,7 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions_ =
       goog.asserts.assert(begin == -1);
       begin = i;
     } else if (type == ol.render.canvas.Instruction.BEGIN_GEOMETRY) {
+      instruction[2] = i + 1;
       goog.asserts.assert(begin >= 0);
       ol.array.reverseSubArray(this.hitDetectionInstructions, begin, i);
       begin = -1;


### PR DESCRIPTION
Just reversing the array is not enough, the pointers to the end of the block must be changed to the reversed array index. The issue is revealed only when a `renderGeometryFunction` returns false, because then the correct pointer is needed. See [canvasreplay.js#L240](https://github.com/openlayers/ol3/blob/8317317127cb424dbd883c80dc301106df3d6e2a/src/ol/render/canvas/canvasreplay.js#L240).
