### PR TITLE
Use default style function in FeatureOverlay

### DIFF
--- a/src/ol/featureoverlay.js
+++ b/src/ol/featureoverlay.js
@@ -144,14 +144,18 @@ ol.FeatureOverlay.prototype.handleFeaturesRemove_ =
  * @private
  */
 ol.FeatureOverlay.prototype.handleMapPostCompose_ = function(event) {
-  if (goog.isNull(this.features_) || !goog.isDef(this.styleFunction_)) {
+  if (goog.isNull(this.features_)) {
     return;
+  }
+  var styleFunction = this.styleFunction_;
+  if (!goog.isDef(styleFunction)) {
+    styleFunction = ol.feature.defaultStyleFunction;
   }
   var resolution = event.frameState.view2DState.resolution;
   var vectorContext = event.vectorContext;
   var i, ii, feature, styles;
   this.features_.forEach(function(feature) {
-    styles = this.styleFunction_(feature, resolution);
+    styles = styleFunction(feature, resolution);
     if (!goog.isDefAndNotNull(styles)) {
       return;
     }


### PR DESCRIPTION
With this PR the FeatureOverlay uses the default style function is no style is provided by the user.

An alternative patch would be to always set style function in the FeatureOverlay (and effectively use ol.feature.defaultStyleFunction when no style is provided by the user). In this way getStyleFunction would never return undefined. But I did not do this to be consistent with ol.layer.Vector and its renderer.
