### PR TITLE
Fix the pointer index

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -490,7 +490,7 @@ ol.render.canvas.Replay.prototype.reverseHitDetectionInstructions_ =
       goog.asserts.assert(begin == -1);
       begin = i;
     } else if (type == ol.render.canvas.Instruction.BEGIN_GEOMETRY) {
-      instruction[2] = i + 1;
+      instruction[2] = i;
       goog.asserts.assert(begin >= 0);
       ol.array.reverseSubArray(this.hitDetectionInstructions, begin, i);
       begin = -1;


### PR DESCRIPTION
The replay block poiner has to point to the end of the current block, not to the beginning of the next block. See https://github.com/openlayers/ol3/blob/97da6b48741cafcbe7d2e153ac4498c91e063505/src/ol/render/canvas/canvasreplay.js#L581.
