### PR TITLE
Fix modifyinteraction

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -67,7 +67,7 @@ ol.interaction.Modify = function(options) {
    * @type {ol.Pixel}
    * @private
    */
-  this.lastPixel_ = null;
+  this.lastPixel_ = [0, 0];
 
   /**
    * Segment RTree for each layer
@@ -158,9 +158,7 @@ ol.interaction.Modify.prototype.addFeature_ = function(evt) {
   if (goog.isDef(this.SEGMENT_WRITERS_[geometry.getType()])) {
     this.SEGMENT_WRITERS_[geometry.getType()].call(this, feature, geometry);
   }
-  if (!goog.isNull(this.lastPixel_)) {
-    this.handlePointerAtPixel_(this.lastPixel_, this.getMap());
-  }
+  this.handlePointerAtPixel_(this.lastPixel_, this.getMap());
 };
 
 


### PR DESCRIPTION
Make sure lastPixel_ is set before calling handleMouseAtPixel.

This fixes the issue I've been having: define modify interaction and features to it, this without having the mouse hover the map once.  If I mouse hovered the map before adding the features to the modify interaction, then it would be fine since lastPixel_ would be set.
