### PR TITLE
Re-render on feature changes

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -149,7 +149,6 @@ ol.Feature.prototype.handleGeometryChanged_ = function() {
     this.geometryChangeKey_ = goog.events.listen(geometry,
         goog.events.EventType.CHANGE, this.handleGeometryChange_, false, this);
   }
-  this.dispatchChangeEvent();
 };
 
 

--- a/test/spec/ol/source/vectorsource.test.js
+++ b/test/spec/ol/source/vectorsource.test.js
@@ -233,6 +233,15 @@ describe('ol.source.Vector', function() {
       expect(vectorSource.getFeatures()).to.eql([feature]);
     });
 
+    it('fires a change event when setting a feature\'s property', function() {
+      var feature = new ol.Feature(new ol.geom.Point([1, 1]));
+      vectorSource.addFeature(feature);
+      var listener = sinon.spy();
+      goog.events.listen(vectorSource, 'change', listener);
+      feature.set('foo', 'bar');
+      expect(listener).to.be.called();
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR fixes #1798. It should also fix a bug that was reported on the [mailing list](https://groups.google.com/d/msg/ol3-dev/AqbeFEwttuM/ke2ebsX9GzMJ).

The vector source now listens to both "change" and "propertychange" from its features. And with this there's no need to trigger a "change" event when the geometry is changed on the feature – the "propertychange" event is sufficient.
