### PR TITLE
Don't use the regex module

### DIFF
--- a/build.py
+++ b/build.py
@@ -5,7 +5,7 @@ import gzip
 import json
 import os
 import glob
-import regex as re
+import re
 import shutil
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
 pystache
-regex


### PR DESCRIPTION
This PR removes the dependency on the Python `regex` module, which has caused problems for many people.

A little bit of history:

Regular expressions are a key part of the the code that checks for missing or unnecessary `goog.require`s. The regular expressions are generated automatically and make significant use of nested subgroups for efficiency. The number of subgroups can grow quite large, and is related to the structure of the `goog.require` dependency graph.

Unfortunately, Python's default `re` module has a completely arbitrary hard-coded limit on the maximum number of subgroups, and the automatically generated regular expressions hit this limit. Python's replacement regular expression library, `regex`, does not have this arbitrary hard-coded limit, and so works.

However, it seems that current `goog.require` dependency graph means that the automatically generated regular expressions have stopped exceeded the hard-coded limits of `re`.

This PR switches back from `regex` to `re`.
