### PR TITLE
Track replay group resolution and buffer max extent to capture strokes

### DIFF
--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -243,7 +243,8 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
     styleFunction = ol.feature.defaultStyleFunction;
   }
   var tolerance = frameStateResolution / (2 * pixelRatio);
-  var replayGroup = new ol.render.canvas.ReplayGroup(tolerance, extent);
+  var replayGroup = new ol.render.canvas.ReplayGroup(tolerance, extent,
+      frameStateResolution);
   vectorSource.forEachFeatureInExtent(extent,
       /**
        * @param {ol.Feature} feature Feature.

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -111,7 +111,8 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
     function(extent, resolution, pixelRatio, size, projection) {
 
   var tolerance = resolution / (2 * pixelRatio);
-  var replayGroup = new ol.render.canvas.ReplayGroup(tolerance, extent);
+  var replayGroup = new ol.render.canvas.ReplayGroup(tolerance, extent,
+      resolution);
 
   var loading = false;
   this.source_.forEachFeatureInExtent(extent,

--- a/test/spec/ol/renderer/canvas/canvasreplay.test.js
+++ b/test/spec/ol/renderer/canvas/canvasreplay.test.js
@@ -7,7 +7,7 @@ describe('ol.render.canvas.Replay', function() {
     it('creates a new replay batch', function() {
       var tolerance = 10;
       var extent = [-180, -90, 180, 90];
-      var replay = new ol.render.canvas.Replay(tolerance, extent);
+      var replay = new ol.render.canvas.Replay(tolerance, extent, 1);
       expect(replay).to.be.a(ol.render.canvas.Replay);
     });
 
@@ -17,7 +17,7 @@ describe('ol.render.canvas.Replay', function() {
 
     var replay;
     beforeEach(function() {
-      replay = new ol.render.canvas.Replay(1, [-180, -90, 180, 90]);
+      replay = new ol.render.canvas.Replay(1, [-180, -90, 180, 90], 1);
     });
 
     it('appends coordinates that are within the max extent', function() {
@@ -78,4 +78,49 @@ describe('ol.render.canvas.Replay', function() {
 
 });
 
+describe('ol.render.canvas.LineStringReplay', function() {
+
+  describe('#getBufferedMaxExtent()', function() {
+
+    it('buffers the max extent to accomodate stroke width', function() {
+      var tolerance = 1;
+      var extent = [-180, -90, 180, 90];
+      var resolution = 10;
+      var replay = new ol.render.canvas.LineStringReplay(tolerance, extent,
+          resolution);
+      var stroke = new ol.style.Stroke({
+        width: 2
+      });
+      replay.setFillStrokeStyle(null, stroke);
+      var buffered = replay.getBufferedMaxExtent();
+      expect(buffered).to.eql([-195, -105, 195, 105]);
+    });
+
+  });
+
+});
+
+describe('ol.render.canvas.PolygonReplay', function() {
+
+  describe('#getBufferedMaxExtent()', function() {
+
+    it('buffers the max extent to accomodate stroke width', function() {
+      var tolerance = 1;
+      var extent = [-180, -90, 180, 90];
+      var resolution = 10;
+      var replay = new ol.render.canvas.PolygonReplay(tolerance, extent,
+          resolution);
+      var stroke = new ol.style.Stroke({
+        width: 5
+      });
+      replay.setFillStrokeStyle(null, stroke);
+      var buffered = replay.getBufferedMaxExtent();
+      expect(buffered).to.eql([-210, -120, 210, 120]);
+    });
+
+  });
+
+});
+
 goog.require('ol.render.canvas.Replay');
+goog.require('ol.style.Stroke');


### PR DESCRIPTION
With 36204faf2fdc00cb2455397ef31ad876bf888f55 canvas vector rendering is clipped to the extent requested by the layer.  This can leave partial strokes rendered for geometry segments that fall just outside the max extent.  To avoid this, points are only eliminated if they fall outside of the max extent buffered by the current stroke width \* resolution.
