### PR TITLE
Modify interaction allows vertices to be added where they shouldn't be

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -582,6 +582,7 @@ ol.interaction.Modify.prototype.insertVertex_ = function(segmentData, vertex) {
   for (var i = 0, ii = segmentDataMatches.length; i < ii; ++i) {
     var segmentDataMatch = segmentDataMatches[i];
     if (segmentDataMatch.geometry === geometry &&
+        segmentDataMatch.depth[0] == depth[0] &&
         segmentDataMatch.index > index) {
       ++segmentDataMatch.index;
     }


### PR DESCRIPTION
With the [modify features](http://ol3js.org/en/master/examples/modify-features.html) example, it is possible to get into a weird editing state where vertices are added where they shouldn't be.

![modify](https://f.cloud.github.com/assets/41094/2336801/a6ff96f4-a494-11e3-974e-70b816eb43c3.png)

The easiest way I've found to reproduce this is below:
- select the top multi-polygon for editing
- add a vertex to the left edge of the right box
- try to add a vertex to the right edge of the left box

Instead of a vertex getting added to the right edge of the left box, it gets added to the bottom edge.  After this, vertices can be added at unexpected locations (e.g. outside the geometry altogether).

This may or not have the same cause as #1807.
