### PR TITLE
Don't compare floating point numbers for exact equality

### DIFF
--- a/test/spec/ol/view2d.test.js
+++ b/test/spec/ol/view2d.test.js
@@ -167,9 +167,9 @@ describe('ol.View2D', function() {
             constrainResolution: false
           }
       );
-      expect(view.getResolution()).to.be(14.849242404917458);
-      expect(view.getCenter()[0]).to.be(5200.000000000011);
-      expect(view.getCenter()[1]).to.be(46300);
+      expect(view.getResolution()).to.roughlyEqual(14.849242404917458, 1e-9);
+      expect(view.getCenter()[0]).to.roughlyEqual(5200, 1e-9);
+      expect(view.getCenter()[1]).to.roughlyEqual(46300, 1e-9);
     });
   });
 
@@ -196,8 +196,8 @@ describe('ol.View2D', function() {
           [400, 400],
           [300, 300]
       );
-      expect(view.getCenter()[0]).to.be(4585.78643762691);
-      expect(view.getCenter()[1]).to.be(46000);
+      expect(view.getCenter()[0]).to.roughlyEqual(4585.78643762691, 1e-9);
+      expect(view.getCenter()[1]).to.roughlyEqual(46000, 1e-9);
     });
   });
 });


### PR DESCRIPTION
A couple of the tests added in #1746 compared floating point numbers for exact equality. On my browser (Chrome 33 on Mac OS X) the results aren't quite the same, e.g.:

```
Error: expected 14.849242404917495 to equal 14.849242404917458
Error: expected 4585.786437626903 to equal 4585.78643762691
```

This PR uses `roughlyEqual` to add a small tolerance to the tests.
