### PR TITLE
Mousewheel zoom broken and resolution constraints not respected in Firefox

### DIFF
--- a/src/ol/interaction/mousewheelzoominteraction.js
+++ b/src/ol/interaction/mousewheelzoominteraction.js
@@ -83,7 +83,7 @@ ol.interaction.MouseWheelZoom.prototype.handleMapBrowserEvent =
     goog.asserts.assertInstanceof(mouseWheelEvent, goog.events.MouseWheelEvent);
 
     this.lastAnchor_ = mapBrowserEvent.coordinate;
-    this.delta_ += mouseWheelEvent.deltaY / 3;
+    this.delta_ += mouseWheelEvent.deltaY;
 
     if (!goog.isDef(this.startTime_)) {
       this.startTime_ = goog.now();


### PR DESCRIPTION
I was unable to figure out what is wrong, but this issue can be easily reproduced. It only happens in Firefox:
1. Open http://ol3js.org/en/master/examples/simple.html
2. Try to mousweheel-zoom in. Only works for me after several attempts, and only after mousewheel-zooming out.
3. Open the console and check `map.getView().getView2D().getZoom()`. You are very likely to get `undefined`, which means we have an unconstrained resolution.

Any ideas?
