### PR TITLE
Mark parts of control and overlay as stable

### DIFF
--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -16,7 +16,7 @@ goog.require('ol.Object');
  * @extends {ol.Object}
  * @implements {oli.control.Control}
  * @param {olx.control.ControlOptions} options Control options.
- * @todo stability experimental
+ * @todo stability stable
  */
 ol.control.Control = function(options) {
 
@@ -84,7 +84,7 @@ ol.control.Control.prototype.handleMapPostrender = goog.nullFunction;
  * Subclasses may set up event handlers to get notified about changes to
  * the map here.
  * @param {ol.Map} map Map.
- * @todo stability experimental
+ * @todo stability stable
  */
 ol.control.Control.prototype.setMap = function(map) {
   if (!goog.isNull(this.map_)) {

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -56,7 +56,7 @@ ol.OverlayPositioning = {
  * @constructor
  * @extends {ol.Object}
  * @param {olx.OverlayOptions} options Overlay options.
- * @todo stability experimental
+ * @todo stability stable
  * @todo observable element {Element} the Element containing the overlay
  * @todo observable map {ol.Map} the map that the overlay is part of
  * @todo observable position {ol.Coordinate} the spatial point that the overlay
@@ -307,7 +307,7 @@ goog.exportProperty(
 /**
  * Set the position for this overlay.
  * @param {ol.Coordinate|undefined} position Position.
- * @todo stability experimental
+ * @todo stability stable
  */
 ol.Overlay.prototype.setPosition = function(position) {
   this.set(ol.OverlayProperty.POSITION, position);


### PR DESCRIPTION
This suggests marking parts of ol.control.Control and ol.Overlay as stable. These were the classes and methods I need to write a simple application with a layer switcher and a feature popup.
