### PR TITLE
Fix ol.BrowserFeature.HAS_TOUCH detection code

### DIFF
--- a/src/ol/browserfeature.js
+++ b/src/ol/browserfeature.js
@@ -157,9 +157,7 @@ ol.BrowserFeature.HAS_GEOLOCATION = 'geolocation' in goog.global.navigator;
  * @type {boolean}
  * @todo stability experimental
  */
-ol.BrowserFeature.HAS_TOUCH = ol.ASSUME_TOUCH ||
-    (goog.global.document &&
-    'ontouchstart' in goog.global.document.documentElement);
+ol.BrowserFeature.HAS_TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in goog.global;
 
 
 /**


### PR DESCRIPTION
Use goog.global instead goog.global.document.documentElement to avoid
false negative results when using the chrome development tools (Touch
Events emulation).

Code borrowed from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touchevents.js
except for the DocumentTouch part which is deprecated (https://developer.mozilla.org/en-US/docs/Web/API/DocumentTouch)

Fixes #1869
