### PR TITLE
Do not update RTree while dragging vertices

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -448,10 +448,7 @@ ol.interaction.Modify.prototype.handlePointerDrag = function(evt) {
     }
 
     geometry.setCoordinates(coordinates);
-    var newBounds = ol.extent.boundingExtent(segment);
     this.createOrUpdateVertexFeature_(vertex);
-    this.rBush_.remove(segmentData);
-    this.rBush_.insert(newBounds, segmentData);
   }
 };
 


### PR DESCRIPTION
This pull request improves editing performance during dragging: as long as we are dragging a vertex, we do not need to update the structure that is used to determine which segments to prepare for vertex dragging.
