### PR TITLE
Zoom happens twice on Android browser

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -48,7 +48,9 @@ ol.control.FullScreen = function(opt_options) {
         ' ol-has-tooltip'
   });
   goog.dom.appendChild(button, tip);
-  goog.events.listen(new ol.pointer.PointerEventHandler(button),
+  var buttonHandler = new ol.pointer.PointerEventHandler(button);
+  this.registerDisposable(buttonHandler);
+  goog.events.listen(buttonHandler,
       ol.pointer.EventType.POINTERUP, this.handleClick_, false, this);
 
   goog.events.listen(button, [

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -52,7 +52,9 @@ ol.control.Zoom = function(opt_options) {
     'type' : 'button'
   }, tTipZoomIn, zoomInLabel);
 
-  goog.events.listen(new ol.pointer.PointerEventHandler(inElement),
+  var inElementHandler = new ol.pointer.PointerEventHandler(inElement);
+  this.registerDisposable(inElementHandler);
+  goog.events.listen(inElementHandler,
       ol.pointer.EventType.POINTERUP, goog.partial(
           ol.control.Zoom.prototype.zoomByDelta_, delta), false, this);
 
@@ -72,7 +74,9 @@ ol.control.Zoom = function(opt_options) {
     'name' : 'ZoomOut'
   }, tTipsZoomOut, zoomOutLabel);
 
-  goog.events.listen(new ol.pointer.PointerEventHandler(outElement),
+  var outElementHandler = new ol.pointer.PointerEventHandler(outElement);
+  this.registerDisposable(outElementHandler);
+  goog.events.listen(outElementHandler,
       ol.pointer.EventType.POINTERUP, goog.partial(
           ol.control.Zoom.prototype.zoomByDelta_, -delta), false, this);
 

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -48,8 +48,9 @@ ol.control.ZoomToExtent = function(opt_options) {
   goog.dom.appendChild(button, tip);
   goog.dom.appendChild(element, button);
 
-  goog.events.listen(new ol.pointer.PointerEventHandler(button),
-      ol.pointer.EventType.POINTERUP,
+  var buttonHandler = new ol.pointer.PointerEventHandler(button);
+  this.registerDisposable(buttonHandler);
+  goog.events.listen(buttonHandler, ol.pointer.EventType.POINTERUP,
       this.handleZoomToExtent_, false, this);
 
   goog.events.listen(button, [


### PR DESCRIPTION
On the Android browser when you click on the zoom in or zoom out button, it is zoomed in/out twice. It was reproduced with Android 4.1 on a real device and 2.3.3 via Cordova in the emulator.

It looks like the events are fired twice. [Issue #71](https://github.com/ftlabs/fastclick/issues/71) from FastClick might give hints.
