### PR TITLE
MapQuest HTTPS problem

### DIFF
--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -20,7 +20,7 @@ ol.source.MapQuest = function(opt_options) {
 
   var layerConfig = ol.source.MapQuestConfig[options.layer];
 
-  var url = '//otile{1-4}.mqcdn.com/tiles/1.0.0/' +
+  var url = '//otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
       options.layer + '/{z}/{x}/{y}.jpg';
 
   goog.base(this, {


### PR DESCRIPTION
The MapQuest servers don't provide a valid HTTPS certificate. It would be better to force a unsecure connection until MapQuest officially provides a HTTPS API.

**Technical Details:**
MapQuest is driven by Akamai. Their servers currently only provide certificates for Akamai domains (and not for the MapQuest alias domain). The result is that the browser rejects the connection because of a domain mismatch.
