### PR TITLE
Take pixel ratio into account in layer-spy example

### DIFF
--- a/examples/layer-spy.js
+++ b/examples/layer-spy.js
@@ -48,12 +48,14 @@ $(map.getViewport()).on('mousemove', function(evt) {
 // before rendering the layer, do some clipping
 imagery.on('precompose', function(event) {
   var ctx = event.context;
+  var pixelRatio = event.frameState.pixelRatio;
   ctx.save();
   ctx.beginPath();
   if (mousePosition) {
     // only show a circle around the mouse
-    ctx.arc(mousePosition[0], mousePosition[1], radius, 0, 2 * Math.PI);
-    ctx.lineWidth = 5;
+    ctx.arc(mousePosition[0] * pixelRatio, mousePosition[1] * pixelRatio,
+        radius * pixelRatio, 0, 2 * Math.PI);
+    ctx.lineWidth = 5 * pixelRatio;
     ctx.strokeStyle = 'rgba(0,0,0,0.5)';
     ctx.stroke();
   }


### PR DESCRIPTION
The layer-spy example does not take into account the pixel ratio on retina devices. This PR fixes that.
