### PR TITLE
Don't use protocol relative URLs

### DIFF
--- a/src/ol/browserfeature.js
+++ b/src/ol/browserfeature.js
@@ -55,6 +55,14 @@ ol.LEGACY_IE_SUPPORT = false;
 
 
 /**
+ * The page is loaded using HTTPS.
+ * @const
+ * @type {boolean}
+ */
+ol.IS_HTTPS = goog.global.location.protocol === 'https:';
+
+
+/**
  * Whether the current browser is legacy IE
  * @const
  * @type {boolean}

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -37,8 +37,11 @@ ol.source.BingMaps = function(options) {
    */
   this.culture_ = goog.isDef(options.culture) ? options.culture : 'en-us';
 
+  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var uri = new goog.Uri(
-      '//dev.virtualearth.net/REST/v1/Imagery/Metadata/' + options.imagerySet);
+      protocol + '//dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
+      options.imagerySet);
+
   var jsonp = new goog.net.Jsonp(uri, 'jsonp');
   jsonp.send({
     'include': 'ImageryProviders',

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -20,7 +20,8 @@ ol.source.MapQuest = function(opt_options) {
 
   var layerConfig = ol.source.MapQuestConfig[options.layer];
 
-  var url = '//otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
+  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
+  var url = protocol + '//otile{1-4}-s.mqcdn.com/tiles/1.0.0/' +
       options.layer + '/{z}/{x}/{y}.jpg';
 
   goog.base(this, {

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -25,8 +25,9 @@ ol.source.OSM = function(opt_options) {
   var crossOrigin = goog.isDef(options.crossOrigin) ?
       options.crossOrigin : 'anonymous';
 
+  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var url = goog.isDef(options.url) ?
-      options.url : '//{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+      options.url : protocol + '//{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 
   goog.base(this, {
     attributions: attributions,

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -93,8 +93,9 @@ ol.source.Stamen = function(options) {
   goog.asserts.assert(options.layer in ol.source.StamenLayerConfig);
   var layerConfig = ol.source.StamenLayerConfig[options.layer];
 
+  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
   var url = goog.isDef(options.url) ? options.url :
-      '//{a-d}.tile.stamen.com/' + options.layer + '/{z}/{x}/{y}.' +
+      protocol + '//{a-d}.tile.stamen.com/' + options.layer + '/{z}/{x}/{y}.' +
       layerConfig.extension;
 
   goog.base(this, {


### PR DESCRIPTION
We currently use protocol relative URLs in OSM, MapQuest, Bing, and Stamen sources.  This causes issues where apps are loaded with the file "protocol" (PhoneGap/Cordova, some mobile apps).

An alternative is to use `window.location.protocol` if it starts with `http` and fall back to `http` if not.
