### PR TITLE
IE11 can't interpret window.ActiveXObject correctly anymore

### DIFF
--- a/lib/OpenLayers/Format/WPSExecute.js
+++ b/lib/OpenLayers/Format/WPSExecute.js
@@ -80,10 +80,10 @@ OpenLayers.Format.WPSExecute = OpenLayers.Class(OpenLayers.Format.XML,
      */
     write: function(options) {
         var doc;
-        if (window.ActiveXObject) {
+        try {
             doc = new ActiveXObject("Microsoft.XMLDOM");
             this.xmldom = doc;
-        } else {
+        } catch(e) {
             doc = document.implementation.createDocument("", "", null);
         }
         var node = this.writeNode("wps:Execute", options, doc);

--- a/lib/OpenLayers/Format/XML.js
+++ b/lib/OpenLayers/Format/XML.js
@@ -81,8 +81,9 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
      *     the object.
      */
     initialize: function(options) {
-        if(window.ActiveXObject) {
+        try {
             this.xmldom = new ActiveXObject("Microsoft.XMLDOM");
+        } catch(e) {
         }
         OpenLayers.Format.prototype.initialize.apply(this, [options]);
         // clone the namespace object and set all namespace aliases
@@ -138,7 +139,7 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
                      * Since we want to be able to call this method on the prototype
                      * itself, this.xmldom may not exist even if in IE.
                      */
-                    if(window.ActiveXObject && !this.xmldom) {
+                    if (!this.xmldom) {
                         xmldom = new ActiveXObject("Microsoft.XMLDOM");
                     } else {
                         xmldom = this.xmldom;
@@ -871,7 +872,7 @@ OpenLayers.Format.XML = OpenLayers.Class(OpenLayers.Format, {
             if (document.implementation && document.implementation.createDocument) {
                 OpenLayers.Format.XML.document =
                     document.implementation.createDocument("", "", null);
-            } else if (!this.xmldom && window.ActiveXObject) {
+            } else if (!this.xmldom) {
                 this.xmldom = new ActiveXObject("Microsoft.XMLDOM");
             }
         }


### PR DESCRIPTION
As in IE11 it is not possible to use window.ActiveXObject for checking for IE anymore (see http://msdn.microsoft.com/en-us/library/ie/dn423948%28v=vs.85%29.aspx ), it is only possible to use a try-catch instead.

May be the intention of  pull request #1210