### PR TITLE
Do not export the ol.render.canvas.Immediate constructor

### DIFF
--- a/src/ol/render/canvas/canvasimmediate.exports
+++ b/src/ol/render/canvas/canvasimmediate.exports
@@ -1,4 +1,3 @@
-@exportSymbol ol.render.canvas.Immediate
 @exportProperty ol.render.canvas.Immediate.prototype.drawAsync
 @exportProperty ol.render.canvas.Immediate.prototype.drawCircleGeometry
 @exportProperty ol.render.canvas.Immediate.prototype.drawFeature


### PR DESCRIPTION
I do not think we want developers to create instances of `ol.render.canvas.Immediate`.
