### PR TITLE
Use native JSON.parse function

### DIFF
--- a/src/ol/browserfeature.js
+++ b/src/ol/browserfeature.js
@@ -152,6 +152,15 @@ ol.BrowserFeature.HAS_GEOLOCATION = 'geolocation' in goog.global.navigator;
 
 
 /**
+ * @const
+ * @type {boolean}
+ * @todo stability experimental
+ */
+ol.BrowserFeature.HAS_JSON_PARSE =
+    'JSON' in goog.global && 'parse' in goog.global.JSON;
+
+
+/**
  * True if browser supports touch events.
  * @const
  * @type {boolean}

--- a/src/ol/format/jsonfeatureformat.js
+++ b/src/ol/format/jsonfeatureformat.js
@@ -2,6 +2,7 @@ goog.provide('ol.format.JSONFeature');
 
 goog.require('goog.asserts');
 goog.require('goog.json');
+goog.require('ol.BrowserFeature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.FormatType');
 
@@ -26,7 +27,12 @@ ol.format.JSONFeature.prototype.getObject_ = function(source) {
   if (goog.isObject(source)) {
     return source;
   } else if (goog.isString(source)) {
-    var object = goog.json.parse(source);
+    var object;
+    if (ol.BrowserFeature.HAS_JSON_PARSE) {
+      object = /** @type {Object} */ (JSON.parse(source));
+    } else {
+      object = goog.json.parse(source);
+    }
     return goog.isDef(object) ? object : null;
   } else {
     goog.asserts.fail();

--- a/src/ol/source/vectorfilesource.js
+++ b/src/ol/source/vectorfilesource.js
@@ -115,7 +115,7 @@ ol.source.VectorFile.prototype.handleXhrIo_ = function(event) {
       source = xhrIo.getResponse();
       goog.asserts.assertInstanceof(source, ArrayBuffer);
     } else if (type == ol.format.FormatType.JSON) {
-      source = xhrIo.getResponseJson();
+      source = xhrIo.getResponseText();
     } else if (type == ol.format.FormatType.TEXT) {
       source = xhrIo.getResponseText();
     } else if (type == ol.format.FormatType.XML) {


### PR DESCRIPTION
Use the native `JSON.parse` function instead of (the slow) `goog.json.parse`
