### PR TITLE
Add style and condition for multiple selection to modify example

### DIFF
--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -32,6 +32,7 @@ var vector = new ol.layer.Vector({
 
 var select = new ol.interaction.Select({
   addCondition: ol.events.condition.shiftKeyOnly,
+  toggleCondition: ol.events.condition.always,
   style: new ol.style.Style({
     stroke: new ol.style.Stroke({
       color: '#3399CC',


### PR DESCRIPTION
Prior to #1877, it looked like selected features had a distinct style because they were being rendered on top of their unselected counterparts.  The change in 1e0d2af0f0aac7f87420cbd40e725669af6b87de gives the select interaction a distinct style to achieve the same.

The changes in #1877 also made it so the shift modifier didn't add to a selection by default.  The remaining changes here allow addition to and removal from the selection (with shift-click and any click respectively).
