### PR TITLE
Update node packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "url": "https://github.com/openlayers/ol3/issues"
   },
   "devDependencies": {
-    "closure-util": "~0.8.2",
+    "closure-util": "~0.9.0",
     "async": "~0.2.10",
-    "htmlparser2": "~3.4.0",
+    "htmlparser2": "~3.7.1",
     "jshint": "~2.4.4"
   }
 }


### PR DESCRIPTION
- `closure-util` - Driving the compiler, not watching spurious files
- `async` - Bugfixes not related to our use, but this may sidestep the Travis errors we're seeing

I'll write up documentation on driving the compiler with the `closure-util` package after making it a bit easier.
