### PR TITLE
Fixes to modify interaction

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -156,7 +156,10 @@ ol.interaction.Modify.prototype.addFeature_ = function(evt) {
   if (goog.isDef(this.SEGMENT_WRITERS_[geometry.getType()])) {
     this.SEGMENT_WRITERS_[geometry.getType()].call(this, feature, geometry);
   }
-  this.handlePointerAtPixel_(this.lastPixel_, this.getMap());
+  var map = this.getMap();
+  if (!goog.isNull(map)) {
+    this.handlePointerAtPixel_(this.lastPixel_, map);
+  }
 };
 
 


### PR DESCRIPTION
This PR fixes two issues in the modify interaction. The first issue is that the interaction does not correctly initialize itself when the features collection it's passed includes features already. The second issue is that adding features while the interaction does not have a map currently causes js errors.
