### PR TITLE
Correct documentation for `keyboardEventTarget`.

### DIFF
--- a/src/ol/interaction/keyboardpaninteraction.js
+++ b/src/ol/interaction/keyboardpaninteraction.js
@@ -25,7 +25,7 @@ ol.interaction.KEYBOARD_PAN_DURATION = 100;
  * Note that, although this interaction is by default included in maps,
  * the keys can only be used when browser focus is on the element to which
  * the keyboard events are attached. By default, this is the map div,
- * though you can change this with the `keyboardTargetElement` in
+ * though you can change this with the `keyboardEventTarget` in
  * {@link ol.Map}. `document` never loses focus but, for any other element,
  * focus will have to be on, and returned to, this element if the keys are to
  * function.

--- a/src/ol/interaction/keyboardzoominteraction.js
+++ b/src/ol/interaction/keyboardzoominteraction.js
@@ -15,7 +15,7 @@ goog.require('ol.interaction.Interaction');
  * Note that, although this interaction is by default included in maps,
  * the keys can only be used when browser focus is on the element to which
  * the keyboard events are attached. By default, this is the map div,
- * though you can change this with the `keyboardTargetElement` in
+ * though you can change this with the `keyboardEventTarget` in
  * {@link ol.Map}. `document` never loses focus but, for any other element,
  * focus will have to be on, and returned to, this element if the keys are to
  * function.


### PR DESCRIPTION
The two relevant interactions were listing `keyboardTargetElement` and not `keyboardEventTarget`.

Please review.
