### PR TITLE
Compute anchor value only once

### DIFF
--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -54,6 +54,12 @@ ol.style.Icon = function(opt_options) {
 
   /**
    * @private
+   * @type {Array.<number>}
+   */
+  this.normalizedAnchor_ = null;
+
+  /**
+   * @private
    * @type {ol.style.IconAnchorOrigin}
    */
   this.anchorOrigin_ = goog.isDef(options.anchorOrigin) ?
@@ -128,6 +134,9 @@ goog.inherits(ol.style.Icon, ol.style.Image);
  * @inheritDoc
  */
 ol.style.Icon.prototype.getAnchor = function() {
+  if (!goog.isNull(this.normalizedAnchor_)) {
+    return this.normalizedAnchor_;
+  }
   var anchor = this.anchor_;
   var size = this.getSize();
   if (this.anchorXUnits_ == ol.style.IconAnchorUnits.FRACTION ||
@@ -160,7 +169,8 @@ ol.style.Icon.prototype.getAnchor = function() {
       anchor[1] = -anchor[1] + size[1];
     }
   }
-  return anchor;
+  this.normalizedAnchor_ = anchor;
+  return this.normalizedAnchor_;
 };
 
 


### PR DESCRIPTION
Because the styles are not mutable the anchor can be cached in `ol.style.Icon`. Otherwise the value is re-computed for every icon and for every frame.
