### PR TITLE
Stop 'mouseweel' events in ol-overlaycontainer-stopevent div

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -265,7 +265,8 @@ ol.Map = function(options) {
     goog.events.EventType.MOUSEDOWN,
     goog.events.EventType.TOUCHSTART,
     goog.events.EventType.MSPOINTERDOWN,
-    ol.MapBrowserEvent.EventType.POINTERDOWN
+    ol.MapBrowserEvent.EventType.POINTERDOWN,
+    goog.events.MouseWheelHandler.EventType.MOUSEWHEEL
   ], goog.events.Event.stopPropagation);
   goog.dom.appendChild(this.viewport_, this.overlayContainerStopEvent_);
 


### PR DESCRIPTION
See https://groups.google.com/d/msg/ol3-dev/L2m8HI5FiU8/30X-Oa9CyQUJ

`mousewheel` events should be stopped by the div to be able to scroll the popup content
