### PR TITLE
Stop draw order from preventing batch reuse

### DIFF
--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -15,6 +15,16 @@ goog.require('ol.style.Style');
 
 
 /**
+ * @param {ol.Feature} feature1 Feature 1.
+ * @param {ol.Feature} feature2 Feature 2.
+ * @return {number} Order.
+ */
+ol.renderer.vector.defaultOrder = function(feature1, feature2) {
+  return goog.getUid(feature1) - goog.getUid(feature2);
+};
+
+
+/**
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -183,15 +183,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
   var vectorLayerRevision = vectorLayer.getRevision();
   var vectorLayerRenderOrder = vectorLayer.getRenderOrder();
   if (!goog.isDef(vectorLayerRenderOrder)) {
-    vectorLayerRenderOrder =
-        /**
-         * @param {ol.Feature} feature1 Feature 1.
-         * @param {ol.Feature} feature2 Feature 2.
-         * @return {number} Order.
-         */
-        function(feature1, feature2) {
-      return goog.getUid(feature1) - goog.getUid(feature2);
-    };
+    vectorLayerRenderOrder = ol.renderer.vector.defaultOrder;
   }
 
   if (!this.dirty_ &&


### PR DESCRIPTION
This fixes a bug [reported by](https://github.com/openlayers/ol3/pull/1888#commitcomment-5865234) @fredj, where a faulty test was always false, preventing batch re-use.
