### PR TITLE
Handle skipped features when setting the map

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -179,8 +179,20 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
  * @inheritDoc
  */
 ol.interaction.Select.prototype.setMap = function(map) {
+  var currentMap = this.getMap();
+  var selectedFeatures = this.featureOverlay_.getFeatures();
+  if (!goog.isNull(currentMap)) {
+    selectedFeatures.forEach(function(feature) {
+      currentMap.getSkippedFeatures().remove(feature);
+    });
+  }
   goog.base(this, 'setMap', map);
   this.featureOverlay_.setMap(map);
+  if (!goog.isNull(map)) {
+    selectedFeatures.forEach(function(feature) {
+      map.getSkippedFeatures().push(feature);
+    });
+  }
 };
 
 


### PR DESCRIPTION
When a Select interaction is removed from the map, it should
remove its selected features from the map's skippedFeatures
collection. When it is added to a map, it should add them.
