### PR TITLE
Export ol.source.TileImage

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2601,6 +2601,96 @@ olx.source.GPXOptions.prototype.urls;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *            crossOrigin: (null|string|undefined),
+ *            extent: (ol.Extent|undefined),
+ *            logo: (string|undefined),
+ *            opaque: (boolean|undefined),
+ *            projection: ol.proj.ProjectionLike,
+ *            tileClass: (function(new: ol.ImageTile, ol.TileCoord,
+ *                                 ol.TileState, string, ?string,
+ *                                 ol.TileLoadFunctionType)|undefined),
+ *            tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *            tileUrlFunction: (ol.TileUrlFunctionType|undefined)}}
+ * @todo stability experimental
+ */
+olx.source.TileImageOptions;
+
+
+/**
+ * Attributions.
+ * @type {Array.<ol.Attribution>|undefined}
+ */
+olx.source.TileImageOptions.prototype.attributions;
+
+
+/**
+ * crossOrigin setting for image requests. Default is `null`.
+ * @type {null|string|undefined}
+ */
+olx.source.TileImageOptions.prototype.crossOrigin;
+
+
+/**
+ * Extent.
+ * @type {ol.Extent|undefined}
+ */
+olx.source.TileImageOptions.prototype.extent;
+
+
+/**
+ * Logo.
+ * @type {string|undefined}
+ */
+olx.source.TileImageOptions.prototype.logo;
+
+
+/**
+ * Whether the layer is opaque.
+ * @type {boolean|undefined}
+ */
+olx.source.TileImageOptions.prototype.opaque;
+
+
+/**
+ * Projection.
+ * @type {ol.proj.ProjectionLike}
+ */
+olx.source.TileImageOptions.prototype.projection;
+
+
+/**
+ * tile class
+ * @type {function(new: ol.ImageTile, ol.TileCoord,
+ *                 ol.TileState, string, ?string,
+ *                 ol.TileLoadFunctionType)|undefined}
+ */
+olx.source.TileImageOptions.prototype.tileClass;
+
+
+/**
+ * Tile grid.
+ * @type {ol.tilegrid.TileGrid|undefined}
+ */
+olx.source.TileImageOptions.prototype.tileGrid;
+
+
+/**
+ * Optional function to load a tile given a URL.
+ * @type {ol.TileLoadFunctionType|undefined}
+ */
+olx.source.TileImageOptions.prototype.tileLoadFunction;
+
+
+/**
+ * Optional function to get tile URL given a tile coordinate and the projection.
+ * @type {ol.TileUrlFunctionType|undefined}
+ */
+olx.source.TileImageOptions.prototype.tileUrlFunction;
+
+
+/**
+ * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
  *     defaultProjection: ol.proj.ProjectionLike,
  *     extent: (ol.Extent|undefined),
  *     logo: (string|undefined),

--- a/src/ol/source/tileimagesource.exports
+++ b/src/ol/source/tileimagesource.exports
@@ -1,0 +1,1 @@
+@exportSymbol ol.source.TileImage

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -1,8 +1,6 @@
 goog.provide('ol.source.TileImage');
 
 goog.require('goog.asserts');
-goog.require('ol.Attribution');
-goog.require('ol.Extent');
 goog.require('ol.ImageTile');
 goog.require('ol.Tile');
 goog.require('ol.TileCache');
@@ -12,32 +10,13 @@ goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.TileUrlFunctionType');
 goog.require('ol.source.Tile');
-goog.require('ol.tilegrid.TileGrid');
-
-
-/**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *            crossOrigin: (null|string|undefined),
- *            extent: (ol.Extent|undefined),
- *            logo: (string|undefined),
- *            opaque: (boolean|undefined),
- *            projection: ol.proj.ProjectionLike,
- *            tileClass: (function(new: ol.ImageTile, ol.TileCoord,
- *                                 ol.TileState, string, ?string,
- *                                 ol.TileLoadFunctionType)|undefined),
- *            tileGrid: (ol.tilegrid.TileGrid|undefined),
- *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *            tileUrlFunction: (ol.TileUrlFunctionType|undefined)}}
- * @todo stability experimental
- */
-ol.source.TileImageOptions;
 
 
 
 /**
  * @constructor
  * @extends {ol.source.Tile}
- * @param {ol.source.TileImageOptions} options Image tile options.
+ * @param {olx.source.TileImageOptions} options Image tile options.
  * @todo stability experimental
  */
 ol.source.TileImage = function(options) {


### PR DESCRIPTION
This PR suggests exporting `ol.source.TileImage` as [requested](https://groups.google.com/d/msg/ol3-dev/2aQKgT4cqzA/UHREkUcf42MJ) on the mailing list.
