### PR TITLE
Added an event to get the feature during a Draw Interaction

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -43,7 +43,7 @@ ol.DrawEventType = {
    * @event ol.DrawEvent#drawchange
    * @todo stability experimental
    */
-  DRAWCHANGE: 'drawchange'  
+  DRAWCHANGE: 'drawchange'
 };
 
 


### PR DESCRIPTION
The Draw Interaction only presents the drawn feature after the interaction was finished. If one wants to react to the shape of the figure during drawing this is so fat impossible.
With the added event, users can react to every change of the feature.
