### PR TITLE
Define ol.pointer.PointerEvent.createMouseEvent before using it

### DIFF
--- a/src/ol/pointer/pointerevent.js
+++ b/src/ol/pointer/pointerevent.js
@@ -258,6 +258,19 @@ ol.pointer.PointerEvent.prototype.getPressure_ = function(eventDict, buttons) {
 
 
 /**
+ * Warning is suppressed because Closure thinks the MouseEvent
+ * constructor takes no arguments.
+ * @param {string} inType The type of the event to create.
+ * @param {Object} inDict An dictionary of initial event properties.
+ * @return {MouseEvent}
+ * @suppress {checkTypes}
+ */
+ol.pointer.PointerEvent.createMouseEvent = function(inType, inDict) {
+  return new MouseEvent(inType, inDict);
+};
+
+
+/**
  * Is the `buttons` property supported?
  * @type {boolean}
  */
@@ -274,16 +287,3 @@ ol.pointer.PointerEvent.HAS_BUTTONS = false;
   } catch (e) {
   }
 })();
-
-
-/**
- * Warning is suppressed because Closure thinks the MouseEvent
- * constructor takes no arguments.
- * @param {string} inType The type of the event to create.
- * @param {Object} inDict An dictionary of initial event properties.
- * @return {MouseEvent}
- * @suppress {checkTypes}
- */
-ol.pointer.PointerEvent.createMouseEvent = function(inType, inDict) {
-  return new MouseEvent(inType, inDict);
-};


### PR DESCRIPTION
Fixes #1961
