### PR TITLE
Upgrade to jsdoc 3.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 before_install:
   - "sudo pip install -r requirements.txt"
-  - "git clone --depth=50 https://github.com/jsdoc3/jsdoc build/jsdoc"
-  - "cd build/jsdoc"
-  - "git fetch origin refs/tags/v3.2.2:refs/tags/v3.2.2"
-  - "git checkout tags/v3.2.2"
-  - "cd ../.."
   - "npm install"
 
 before_script:
@@ -13,4 +8,4 @@ before_script:
   - "rm src/ol/renderer/webgl/*shader.js"
   - "sleep 3"
 
-script: "./build.py JSDOC=build/jsdoc/jsdoc integration-test"
+script: "./build.py integration-test"

--- a/apidoc/conf.json
+++ b/apidoc/conf.json
@@ -17,7 +17,7 @@
         ]
     },
     "plugins": [
-        "plugins/markdown",
+        "node_modules/jsdoc/plugins/markdown",
         "apidoc/plugins/inheritdoc",
         "apidoc/plugins/exports",
         "apidoc/plugins/todo",

--- a/apidoc/plugins/inheritdoc.js
+++ b/apidoc/plugins/inheritdoc.js
@@ -5,7 +5,7 @@
  * TODO: Remove this hack when https://github.com/jsdoc3/jsdoc/issues/53
  * is addressed.
  */
-exports.nodeVisitor = {
+exports.astNodeVisitor = {
 
   visitNode: function(node, e, parser, currentSourceName) {
     if (/@(inheritDoc)(\n|\r)/.test(e.comment)) {

--- a/build.py
+++ b/build.py
@@ -20,7 +20,7 @@ if sys.platform == 'win32':
         'GJSLINT': 'gjslint.exe',
         'JAVA': 'java.exe',
         'JAR': 'jar.exe',
-        'JSDOC': 'jsdoc.cmd',
+        'JSDOC': './node_modules/.bin/jsdoc',
         'JSHINT': './node_modules/.bin/jshint',
         'PYTHON': 'python.exe',
         'PHANTOMJS': 'phantomjs.cmd'
@@ -75,7 +75,7 @@ else:
     variables.JSHINT = './node_modules/.bin/jshint'
     variables.JAVA = 'java'
     variables.JAR = 'jar'
-    variables.JSDOC = 'jsdoc'
+    variables.JSDOC = './node_modules/.bin/jsdoc'
     variables.PYTHON = 'python'
     variables.PHANTOMJS = 'phantomjs'
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "closure-util": "~0.9.0",
     "async": "~0.2.10",
     "htmlparser2": "~3.7.1",
-    "jshint": "~2.4.4"
+    "jshint": "~2.4.4",
+    "jsdoc": "^3.3.0-alpha5"
   }
 }


### PR DESCRIPTION
This PR adds jsdoc 3.3 as an npm-installable dependency and modifies build.py to run it from the node_modules folder.  There are minor changes to the jsdoc conf file and template to accommodate the change from Rhino to Node.  The resulting API appear to be identical.  This PR is a precursor to updating the documentation template.
