### PR TITLE
Define wmts layer extent to avoid unnecessary 404 requests

### DIFF
--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -25,6 +25,7 @@ var attribution = new ol.Attribution({
       'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>'
 });
 
+var wmtsExtent = [-19840230.4, 2144435.3, -7452840.5, 11536810.7];
 
 var map = new ol.Map({
   layers: [
@@ -47,7 +48,7 @@ var map = new ol.Map({
           resolutions: resolutions,
           matrixIds: matrixIds
         }),
-        extent: projectionExtent,
+        extent: wmtsExtent,
         style: 'default'
       })
     })


### PR DESCRIPTION
As we are still not using wmts capabilities parser to add wmts layer, it makes sense to manually define layer extents and avoid unnecessary 404 requests outside of layer limits
