### PR TITLE
Automatically skip features on select’s collection changes

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -1,7 +1,10 @@
 goog.provide('ol.interaction.Select');
 
 goog.require('goog.array');
+goog.require('goog.asserts');
+goog.require('goog.events');
 goog.require('goog.functions');
+goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
 goog.require('ol.FeatureOverlay');
 goog.require('ol.events.condition');
@@ -93,6 +96,12 @@ ol.interaction.Select = function(opt_options) {
         ol.interaction.Select.getDefaultStyleFunction()
   });
 
+  var features = this.featureOverlay_.getFeatures();
+  goog.events.listen(features, ol.CollectionEventType.ADD,
+      this.addFeature_, false, this);
+  goog.events.listen(features, ol.CollectionEventType.REMOVE,
+      this.removeFeature_, false, this);
+
 };
 goog.inherits(ol.interaction.Select, ol.interaction.Interaction);
 
@@ -120,7 +129,6 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
   var set = !add && !remove && !toggle;
   var map = mapBrowserEvent.map;
   var features = this.featureOverlay_.getFeatures();
-  var skippedFeatures = map.getSkippedFeatures();
   if (set) {
     // Replace the currently selected feature(s) with the feature at the pixel,
     // or clear the selected feature(s) if there is no feature at the pixel.
@@ -139,14 +147,10 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
       // No change
     } else {
       if (features.getLength() !== 0) {
-        features.forEach(function(feature) {
-          skippedFeatures.remove(feature);
-        });
         features.clear();
       }
       if (goog.isDef(feature)) {
         features.push(feature);
-        skippedFeatures.push(feature);
       }
     }
   } else {
@@ -161,12 +165,10 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
           if (index == -1) {
             if (add || toggle) {
               features.push(feature);
-              skippedFeatures.push(feature);
             }
           } else {
             if (remove || toggle) {
               features.removeAt(index);
-              skippedFeatures.remove(feature);
             }
           }
         }, undefined, this.layerFilter_);
@@ -209,4 +211,32 @@ ol.interaction.Select.getDefaultStyleFunction = function() {
   return function(feature, resolution) {
     return styles[feature.getGeometry().getType()];
   };
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ol.interaction.Select.prototype.addFeature_ = function(evt) {
+  var feature = evt.element;
+  var map = this.getMap();
+  goog.asserts.assertInstanceof(feature, ol.Feature);
+  if (!goog.isNull(map)) {
+    map.getSkippedFeatures().push(feature);
+  }
+};
+
+
+/**
+ * @param {ol.CollectionEvent} evt Event.
+ * @private
+ */
+ol.interaction.Select.prototype.removeFeature_ = function(evt) {
+  var feature = evt.element;
+  var map = this.getMap();
+  goog.asserts.assertInstanceof(feature, ol.Feature);
+  if (!goog.isNull(map)) {
+    map.getSkippedFeatures().remove(feature);
+  }
 };


### PR DESCRIPTION
Replaces #1973, to make programmatic selection works as intended.
