### PR TITLE
Required return from event handler

### DIFF
--- a/src/ol/interaction/modifyinteraction.js
+++ b/src/ol/interaction/modifyinteraction.js
@@ -481,6 +481,7 @@ ol.interaction.Modify.prototype.handlePointerUp = function(evt) {
     this.rBush_.update(ol.extent.boundingExtent(segmentData.segment),
         segmentData);
   }
+  return false;
 };
 
 


### PR DESCRIPTION
This avoids the following compiler warning:

```
../src/ol/interaction/modifyinteraction.js:477: WARNING - Missing return statement. Function expected to return boolean.
ol.interaction.Modify.prototype.handlePointerUp = function(evt) {
                                                  ^
```

It will be nice when these warnings aren't so buried.
