### PR TITLE
Add an olx.js related comment to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -293,6 +293,11 @@ def build_examples_all_js(t):
 @rule(r'\Abuild/examples/(?P<id>.*).json\Z')
 def examples_star_json(name, match):
     def action(t):
+        # It would make more sense to use olx.js as an input file here. We use
+        # it as an externs file instead to prevent "Cannot read property '*' of
+        # undefined" error when running examples in "raw" or "whitespace" mode.
+        # Note that we use the proper way in buildcfg/examples-all.json, which
+        # is only used to check the examples code using the compiler.
         content = json.dumps({
             'id': match.group('id'),
             'inherits': '../../buildcfg/base.json',


### PR DESCRIPTION
This PR just adds a comment to (somehow) explain why we use olx.js as externs file rather than as an input file for the examples' Plovr configuration files.
