### PR TITLE
Make handling of skipped features faster

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -368,9 +368,10 @@ ol.Map = function(options) {
    * @private
    */
   this.skippedFeatures_ = new ol.Collection();
-  goog.events.listen(this.skippedFeatures_,
-      [ol.CollectionEventType.ADD, ol.CollectionEventType.REMOVE],
-      this.handleSkippedFeaturesChange_, false, this);
+  goog.events.listen(this.skippedFeatures_, ol.CollectionEventType.ADD,
+      this.handleSkippedFeaturesAdd_, false, this);
+  goog.events.listen(this.skippedFeatures_, ol.CollectionEventType.REMOVE,
+      this.handleSkippedFeaturesRemove_, false, this);
   this.registerDisposable(this.skippedFeatures_);
 
   /**
@@ -931,17 +932,24 @@ ol.Map.prototype.handleSizeChanged_ = function() {
 
 /**
  * @private
+ * @param {ol.CollectionEvent} event Collection "add" event.
  */
-ol.Map.prototype.handleSkippedFeaturesChange_ = function() {
-  this.skippedFeatureUids_ = {};
-  this.skippedFeatures_.forEach(
-      /**
-       * @param {ol.Feature} feature Feature.
-       * @this {ol.Map}
-       */
-      function(feature) {
-        this.skippedFeatureUids_[goog.getUid(feature).toString()] = true;
-      }, this);
+ol.Map.prototype.handleSkippedFeaturesAdd_ = function(event) {
+  var feature = /** @type {ol.Feature} */ (event.element);
+  var featureUid = goog.getUid(feature).toString();
+  this.skippedFeatureUids_[featureUid] = true;
+  this.render();
+};
+
+
+/**
+ * @private
+ * @param {ol.CollectionEvent} event Collection "remove" event.
+ */
+ol.Map.prototype.handleSkippedFeaturesRemove_ = function(event) {
+  var feature = /** @type {ol.Feature} */ (event.element);
+  var featureUid = goog.getUid(feature).toString();
+  delete this.skippedFeatureUids_[featureUid];
   this.render();
 };
 


### PR DESCRIPTION
Aaron Solberg [reported](https://groups.google.com/d/msg/ol3-dev/LjHVWy3AHO0/tGjEcDsmlPgJ) serious performance problems occuring when adding features to the map's skippedFeatures collection.

The issue can be reproduced on the synthetic-points example:
- open http://ol3js.org/en/master/examples/synthetic-points.html?mode=raw
- in the console do
  
  ``` js
  features = vectorSource.getFeatures();
  for (i = 0; i < 10000; ++i) { map.getSkippedFeatures().push(features[i]); }
  ```
  
  The code will take a long time to execute… (and the map to be refreshed)

The issue has nothing to do with the rendering code. It's related to the way we handle "add" (and "remove") events in ol.Map when features are added to the skipped features collection. Currently, each time a feature is added we clear the skippedFeatureUids_ object and re-populate with a loop over the features in the skipped features collection. So the complexity of adding N features to a skipped features collection of length M is O(M \* N).

With this PR we no longer repopulate the skippedFeatureUids_ object from scratch. The complexity of adding N features to a skipped features collection is O(N). Can be tested here: http://erilem.net/ol3/skipped-features-performance/examples/synthetic-points.html?mode=raw.
