### PR TITLE
Fix zoomcontrol, set type button in button, not span

### DIFF
--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -66,12 +66,12 @@ ol.control.Zoom = function(opt_options) {
   }, false);
 
   var tTipsZoomOut = goog.dom.createDom(goog.dom.TagName.SPAN, {
-    'role' : 'tooltip',
-    'type' : 'button'
+    'role' : 'tooltip'
   }, zoomOutTipLabel);
   var outElement = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': className + '-out  ol-has-tooltip',
-    'name' : 'ZoomOut'
+    'name' : 'ZoomOut',
+    'type' : 'button'
   }, tTipsZoomOut, zoomOutLabel);
 
   var outElementHandler = new ol.pointer.PointerEventHandler(outElement);


### PR DESCRIPTION
This PR fixes a somewhat trivial issue where the type="button" of the zoom out control was placed in the span tag instead of the button one.  In my app, clicking on the zoom out button could trigger unwanted behaviours because of that.

Ready for review.
