### PR TITLE
ol.format.WFS has no readProjection method

### DIFF
--- a/examples/vector-wfs.html
+++ b/examples/vector-wfs.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>WFS example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>          
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span4">
+          <h4 id="title">WFS example</h4>
+          <p id="shortdesc">Example of using WFS with a BBOX strategy.</p>
+          <div id="docs">
+            <p>See the <a href="vector-wfs.js" target="_blank">vector-wfs.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">vector, WFS, bbox, loading, server</div>
+        </div>
+        <div class="span4 offset4">
+          <div id="info" class="alert alert-success">
+            &nbsp;
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=vector-wfs" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -1,0 +1,60 @@
+goog.require('ol.Map');
+goog.require('ol.View2D');
+goog.require('ol.format.GeoJSON');
+goog.require('ol.layer.Tile');
+goog.require('ol.layer.Vector');
+goog.require('ol.loadingstrategy');
+goog.require('ol.source.BingMaps');
+goog.require('ol.source.ServerVector');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+goog.require('ol.tilegrid.XYZ');
+
+var loadFeatures = function(response) {
+  vectorSource.addFeatures(vectorSource.readFeatures(response));
+};
+
+var vectorSource = new ol.source.ServerVector({
+  format: new ol.format.GeoJSON(),
+  loader: function(extent, resolution, projection) {
+    var url = 'http://demo.opengeo.org/geoserver/wfs?service=WFS&' +
+        'version=1.1.0&request=GetFeature&typename=osm:water_areas&' +
+        'outputFormat=text/javascript&format_options=callback:loadFeatures' +
+        '&srsname=EPSG:3857&bbox=' + extent.join(',');
+    $.ajax({
+      url: url,
+      dataType: 'jsonp'
+    });
+  },
+  strategy: ol.loadingstrategy.createTile(new ol.tilegrid.XYZ({
+    maxZoom: 19
+  })),
+  projection: 'EPSG:3857'
+});
+
+var vector = new ol.layer.Vector({
+  source: vectorSource,
+  style: new ol.style.Style({
+    stroke: new ol.style.Stroke({
+      color: 'rgba(0, 0, 255, 1.0)',
+      width: 2
+    })
+  })
+});
+
+var raster = new ol.layer.Tile({
+  source: new ol.source.BingMaps({
+    imagerySet: 'Aerial',
+    key: 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3'
+  })
+});
+
+var map = new ol.Map({
+  layers: [raster, vector],
+  target: document.getElementById('map'),
+  view: new ol.View2D({
+    center: [-8908887.277395891, 5381918.072437216],
+    maxZoom: 19,
+    zoom: 12
+  })
+});

--- a/src/ol/proj/epsg3857projection.js
+++ b/src/ol/proj/epsg3857projection.js
@@ -59,7 +59,8 @@ ol.proj.EPSG3857.CODES = [
   'EPSG:102100',
   'EPSG:102113',
   'EPSG:900913',
-  'urn:ogc:def:crs:EPSG:6.18:3:3857'
+  'urn:ogc:def:crs:EPSG:6.18:3:3857',
+  'http://www.opengis.net/gml/srs/epsg.xml#3857'
 ];
 
 

--- a/src/ol/source/formatvectorsource.js
+++ b/src/ol/source/formatvectorsource.js
@@ -118,7 +118,7 @@ ol.source.FormatVector.prototype.readFeatures = function(source) {
   var features = format.readFeatures(source);
   var featureProjection = format.readProjection(source);
   var projection = this.getProjection();
-  if (!goog.isNull(projection)) {
+  if (!goog.isNull(projection) && !goog.isNull(featureProjection)) {
     if (!ol.proj.equivalent(featureProjection, projection)) {
       var transform = ol.proj.getTransform(featureProjection, projection);
       var i, ii;


### PR DESCRIPTION
Currently ol.format.WFS cannot be used with an ol.source.FormatVector (and ol.source.StaticVector) because it does not have a readProjection method.

https://github.com/openlayers/ol3/blob/master/src/ol/source/formatvectorsource.js#L119
