### PR TITLE
Remove name attributes from the zoom buttons

### DIFF
--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -48,7 +48,6 @@ ol.control.Zoom = function(opt_options) {
   }, zoomInTipLabel);
   var inElement = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': className + '-in ol-has-tooltip',
-    'name' : 'ZoomIn',
     'type' : 'button'
   }, tTipZoomIn, zoomInLabel);
 
@@ -70,7 +69,6 @@ ol.control.Zoom = function(opt_options) {
   }, zoomOutTipLabel);
   var outElement = goog.dom.createDom(goog.dom.TagName.BUTTON, {
     'class': className + '-out  ol-has-tooltip',
-    'name' : 'ZoomOut',
     'type' : 'button'
   }, tTipsZoomOut, zoomOutLabel);
 


### PR DESCRIPTION
I don't think that this attribute is useful. Maybe for the accessibility? 
