### PR TITLE
export getKeys on ol.Object

### DIFF
--- a/src/ol/object.exports
+++ b/src/ol/object.exports
@@ -1,6 +1,7 @@
 @exportSymbol ol.Object
 @exportProperty ol.Object.prototype.bindTo
 @exportProperty ol.Object.prototype.get
+@exportProperty ol.Object.prototype.getKeys
 @exportProperty ol.Object.prototype.getProperties
 @exportProperty ol.Object.prototype.notify
 @exportProperty ol.Object.prototype.set


### PR DESCRIPTION
is there a reason not to export getKeys on ol.Object?

For the table header of a feature it would be practical. Although the job can also be done with getProperties ofcourse.

Thoughts?
