### PR TITLE
Add fifth value for BBOX to be conforming to the WFS 1.1 spec

### DIFF
--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -20,7 +20,7 @@ var vectorSource = new ol.source.ServerVector({
     var url = 'http://demo.opengeo.org/geoserver/wfs?service=WFS&' +
         'version=1.1.0&request=GetFeature&typename=osm:water_areas&' +
         'outputFormat=text/javascript&format_options=callback:loadFeatures' +
-        '&srsname=EPSG:3857&bbox=' + extent.join(',');
+        '&srsname=EPSG:3857&bbox=' + extent.join(',') + ',EPSG:3857';
     $.ajax({
       url: url,
       dataType: 'jsonp'


### PR DESCRIPTION
14.3.3 Bounding box

The bounding box parameter, BBOX, is included in this specification for convenience as a shorthand representation of the very common a bounding box filter which would be expressed in much longer form using XML and the filter encoding described in [3]. A BBOX applies to all feature types listed in the request.

The KVP encoding for a bounding box is defined in subclause 10.2.3 of normative reference [15]. The general form of the parameter is:

BBOX=lcc1,lcc2,...,lccN,ucc1,ucc2,...uccN[,crsuri]

where lcc means Lower Corner Coordinate, ucc means Upper Corner Coordinate and crsuri means the URI reference to the coordinate system being used. This encoding allows N coordinates for each corner listed in the order of the optional crsuri. If the crsuri is not specified then the 2-D coordinates shall be specified using decimal degrees and WGS84 as described in [15].
