### PR TITLE
Remove duplicate record field "duration" in olx.js

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -889,8 +889,7 @@ olx.control.ScaleLineOptions.prototype.units;
  *     label: (string|undefined),
  *     tipLabel: (string|undefined),
  *     target: (Element|undefined),
- *     autoHide: (boolean|undefined),
- *     duration: (number|undefined)}}
+ *     autoHide: (boolean|undefined)}}
  * @todo stability experimental
  */
 olx.control.RotateOptions;


### PR DESCRIPTION
This patch remove the following warning that we have at compile time:

```
/home/elemoine/src/ol3/buildcfg/../externs/olx.js:887: WARNING - Parse error. Duplicate record field duration
 * @typedef {{duration: (number|undefined),
```

Please review.
