### PR TITLE
Fix anchor offsets for line numbers

### DIFF
--- a/apidoc/template/static/styles/jaguar.css
+++ b/apidoc/template/static/styles/jaguar.css
@@ -13,10 +13,9 @@
 body {
   padding-top: 50px;
 }
-.nameContainer .name {
+.nameContainer .name, .prettyprint.source .pln {
   padding-top: 50px;
   margin-top: -50px;
-  display: inline-block; /* required for webkit browsers */
 }
 .navigation li {
   color: #888;


### PR DESCRIPTION
When following a line number link in the API docs, the anchor is 50 pixels off because of the header. This pull request adds an offset, just like the one used for members/methods.
