### PR TITLE
apidoc: display the event name in lower case

### DIFF
--- a/apidoc/plugins/observable.js
+++ b/apidoc/plugins/observable.js
@@ -44,7 +44,7 @@ exports.handlers = {
         if (!cls.fires) {
           cls.fires = [];
         }
-        var event = 'ol.ObjectEvent#event:change:' + name;
+        var event = 'ol.ObjectEvent#event:change:' + name.toLowerCase();
         if (cls.fires.indexOf(event) == -1) {
           cls.fires.push(event);
         }


### PR DESCRIPTION
The event type are always in lower case: `change:accuracygeometry` not `change:accuracyGeometry`
