### PR TITLE
Fix icon rendering on hidpi devices

### DIFF
--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -283,7 +283,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         // Remaining arguments in DRAW_IMAGE are in alphabetical order
         var anchorX = /** @type {number} */ (instruction[4]) * pixelRatio;
         var anchorY = /** @type {number} */ (instruction[5]) * pixelRatio;
-        var height = /** @type {number} */ (instruction[6]) * pixelRatio;
+        var height = /** @type {number} */ (instruction[6]);
         var opacity = /** @type {number} */ (instruction[7]);
         var originX = /** @type {number} */ (instruction[8]);
         var originY = /** @type {number} */ (instruction[9]);
@@ -291,7 +291,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         var rotation = /** @type {number} */ (instruction[11]);
         var scale = /** @type {number} */ (instruction[12]);
         var snapToPixel = /** @type {boolean} */ (instruction[13]);
-        var width = /** @type {number} */ (instruction[14]) * pixelRatio;
+        var width = /** @type {number} */ (instruction[14]);
         if (rotateWithView) {
           rotation += viewRotation;
         }
@@ -322,7 +322,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
           }
 
           context.drawImage(image, originX, originY, width, height,
-              x, y, width, height);
+              x, y, width * pixelRatio, height * pixelRatio);
 
           if (opacity != 1) {
             context.globalAlpha = alpha;


### PR DESCRIPTION
This PR fixes a major regression introduced with https://github.com/openlayers/ol3/pull/2040 (icon sprite support) where icons (and circle symbols) are either not rendered with the expected size or not rendered at all on retina devices. This was reported on the [mailing list](https://groups.google.com/d/msg/ol3-dev/vtT-3IRCAjc/iGcHfaSTTQIJ) and in an old GitHub [issue](https://github.com/openlayers/ol3/issues/1918#issuecomment-42630958).

The fix involves using the icon/symbol image's width and height as the width and height of the source image in the `drawImage` call. Previously, values multiplied by pixelRatio were passed, which was wrong.

Please review.
