### PR TITLE
Export readFeatures on FormatVectorSource

### DIFF
--- a/src/ol/source/formatvectorsource.js
+++ b/src/ol/source/formatvectorsource.js
@@ -111,6 +111,7 @@ ol.source.FormatVector.prototype.loadFeaturesFromURL =
 /**
  * @param {ArrayBuffer|Document|Node|Object|string} source Source.
  * @return {Array.<ol.Feature>} Features.
+ * @todo api
  */
 ol.source.FormatVector.prototype.readFeatures = function(source) {
   var format = this.format;


### PR DESCRIPTION
To add consistency with ol.source.ServerVector where the method is already exported.
