### PR TITLE
Fire moveend only once after view settles

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -213,6 +213,13 @@ ol.Map = function(options) {
   this.frameState_ = null;
 
   /**
+   * The extent at the previous 'moveend' event.
+   * @private
+   * @type {ol.Extent}
+   */
+  this.previousExtent_ = null;
+
+  /**
    * @private
    * @type {goog.events.Key}
    */
@@ -1235,12 +1242,15 @@ ol.Map.prototype.renderFrame_ = function(time) {
         this.postRenderFunctions_, frameState.postRenderFunctions);
 
     var idle = this.preRenderFunctions_.length === 0 &&
-        !frameState.animate &&
         !frameState.viewHints[ol.ViewHint.ANIMATING] &&
-        !frameState.viewHints[ol.ViewHint.INTERACTING];
+        !frameState.viewHints[ol.ViewHint.INTERACTING] &&
+        (!this.previousExtent_ ||
+            !ol.extent.equals(frameState.extent, this.previousExtent_));
 
     if (idle) {
-      this.dispatchEvent(new ol.MapEvent(ol.MapEventType.MOVEEND, this));
+      this.dispatchEvent(
+          new ol.MapEvent(ol.MapEventType.MOVEEND, this, frameState));
+      this.previousExtent_ = ol.extent.clone(frameState.extent);
     }
   }
 

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -48,6 +48,60 @@ describe('ol.Map', function() {
     });
   });
 
+  describe('moveend event', function() {
+
+    var target, view, map;
+
+    beforeEach(function() {
+      target = document.createElement('div');
+
+      var style = target.style;
+      style.position = 'absolute';
+      style.left = '-1000px';
+      style.top = '-1000px';
+      style.width = '360px';
+      style.height = '180px';
+      document.body.appendChild(target);
+
+      view = new ol.View2D({
+        projection: 'EPSG:4326'
+      });
+      map = new ol.Map({
+        target: target,
+        view: view,
+        layers: [
+          new ol.layer.Tile({
+            source: new ol.source.XYZ({
+              url: '#{x}/{y}/{z}'
+            })
+          })
+        ]
+      });
+    });
+
+    afterEach(function() {
+      goog.dispose(map);
+      document.body.removeChild(target);
+    });
+
+    it('is fired only once after view changes', function(done) {
+      var center = [10, 20];
+      var zoom = 3;
+      var calls = 0;
+      map.on('moveend', function() {
+        ++calls;
+        expect(calls).to.be(1);
+        expect(view.getCenter()).to.eql(center);
+        expect(view.getZoom()).to.be(zoom);
+        window.setTimeout(done, 1000);
+      });
+
+      view.setCenter(center);
+      view.setZoom(zoom);
+    });
+
+  });
+
   describe('#render()', function() {
 
     var target, map;
@@ -197,3 +251,5 @@ goog.require('ol.interaction');
 goog.require('ol.interaction.Interaction');
 goog.require('ol.interaction.DoubleClickZoom');
 goog.require('ol.interaction.MouseWheelZoom');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.XYZ');


### PR DESCRIPTION
Currently, the `moveend` event is fired multiple times after the view "settles."  This can be seen by logging events in any of the examples:

``` js
var ends = 0;
map.on('moveend', function() {
  ++ends;
  console.log('end', ends);
});
```

The Canvas and WebGL renderers behave differently with regard to the excessive events, but the event is consistently fired too often.  Instead, `moveend` should be fired under these conditions:
- the user is not interacting with the map in a way that modifies the view
- the view is not animating between states
- the view changed (with regard to visible extent) since the last time the event was fired

Note that `moveend` **will** be fired even if there are tiles still loading.  Rendering new tiles does result in a changed view (from the user's perspective), but rendering tiles does not "move" the view (and `moveend` should not wait until all tiles are rendered).  If it is desirable to know when all tiles have finished loading and are rendered, that should be handled by a different event (without "move" in the name).

Fixes #1823.
