### PR TITLE
Restore setTimeout after it is mocked

### DIFF
--- a/test/spec/ol/pointer/mousesource.test.js
+++ b/test/spec/ol/pointer/mousesource.test.js
@@ -20,6 +20,7 @@ describe('ol.pointer.MouseSource', function() {
   });
 
   afterEach(function() {
+    clock.restore();
     handler.dispose();
   });
 


### PR DESCRIPTION
Without restoring this mock, later tests that rely on `setTimeout` can fail (see #2063). 
