### PR TITLE
Properly reset the click count in ol.pointer.TouchSource

### DIFF
--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -149,7 +149,8 @@ ol.pointer.TouchSource.prototype.removePrimaryPointer_ = function(inPointer) {
  * @private
  */
 ol.pointer.TouchSource.prototype.resetClickCount_ = function() {
-  this.resetId_ = goog.global.setTimeout(this.resetClickCountHandler_,
+  this.resetId_ = goog.global.setTimeout(
+      goog.bind(this.resetClickCountHandler_, this),
       ol.pointer.TouchSource.CLICK_COUNT_TIMEOUT);
 };
 


### PR DESCRIPTION
Without this change, `resetClickCount_` was not actually resetting the click count (instead,  `clickCount_` and `resetId_` were being set on the global object).

Reading through the code, it looks like this would cause issues like erroneous event `detail` values.
