### PR TITLE
Only document arguments of exported constructors

### DIFF
--- a/apidoc/template/tmpl/method.tmpl
+++ b/apidoc/template/tmpl/method.tmpl
@@ -4,7 +4,7 @@ var self = this;
 ?>
 <dt>
     <div class="nameContainer<?js if (data.inherited) { ?> inherited<?js } ?>">
-        <?js if (data.stability) { ?>
+        <?js if (data.stability || kind !== 'class') { ?>
         <h4 class="name" id="<?js= id ?>"><?js= this.partial('stability.tmpl', data) ?>
             <?js if (data.inherited || data.inherits) { ?>
                 <span class="inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>
@@ -46,8 +46,10 @@ var self = this;
         <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
     <?js } ?>
     
+    <?js if (data.stability || kind !== 'class') { ?>
     <?js if (data.params && params.length) { ?>
         <?js= this.partial('params.tmpl', params) ?>
+    <?js } ?>
     <?js } ?>
     
     <?js= this.partial('details.tmpl', data) ?>


### PR DESCRIPTION
This fixes one of the improvement suggestions listed in #2054 and an issue reported in https://github.com/openlayers/ol3/pull/2063#issuecomment-43047629. It prevents constructor arguments of unexported constructors from being documented.
