### PR TITLE
Restore map interaction on touch devices

### DIFF
--- a/src/ol/pointer/touchsource.js
+++ b/src/ol/pointer/touchsource.js
@@ -218,7 +218,8 @@ ol.pointer.TouchSource.prototype.touchToPointer_ =
  */
 ol.pointer.TouchSource.prototype.processTouches_ =
     function(inEvent, inFunction) {
-  var touches = inEvent.getBrowserEvent().changedTouches.slice();
+  var touches = Array.prototype.slice.call(
+      inEvent.getBrowserEvent().changedTouches);
   var count = touches.length;
   function preventDefault() {
     inEvent.preventDefault();


### PR DESCRIPTION
This fixes an issue introduced with: https://github.com/openlayers/ol3/pull/2067

inEvent.getBrowserEvent().changedTouches is a TouchList.
