### PR TITLE
Document event stability even when there is no description

### DIFF
--- a/apidoc/template/tmpl/method.tmpl
+++ b/apidoc/template/tmpl/method.tmpl
@@ -75,8 +75,8 @@ var self = this;
                 (<?js= self.linkto(eventClass.longname) ?>)
               <?js } ?>
             <?js } ?>
-            <?js if (description) { ?> -
             <?js= self.partial('stability.tmpl', eventDoclet || (data.stability ? data : {stability: 'experimental'})) ?>
+            <?js if (description) { ?> -
             <?js= description ?>
             <?js } ?>
         </li>


### PR DESCRIPTION
This is a minor follow-up on #2075, which makes sure that event stability is also listed for event types that do not have a description (yet).
