### PR TITLE
Create valid XML in ol.format.WFS and ability to specify srsName

### DIFF
--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -48,6 +48,13 @@ goog.inherits(ol.format.WFS, ol.format.XMLFeature);
 
 
 /**
+ * @const
+ * @type {string}
+ */
+ol.format.WFS.featurePrefix = 'feature';
+
+
+/**
  * @typedef {{numberOfFeatures: number,
  *            bounds: ol.Extent}}
  */
@@ -355,7 +362,11 @@ ol.format.WFS.writeDelete_ = function(node, feature, objectStack) {
   goog.asserts.assert(goog.isObject(context));
   var featureType = goog.object.get(context, 'featureType');
   var featurePrefix = goog.object.get(context, 'featurePrefix');
+  featurePrefix = goog.isDef(featurePrefix) ? featurePrefix :
+      ol.format.WFS.featurePrefix;
+  var featureNS = goog.object.get(context, 'featureNS');
   node.setAttribute('typeName', featurePrefix + ':' + featureType);
+  node.setAttribute('xmlns:' + featurePrefix, featureNS);
   var fid = feature.getId();
   if (goog.isDef(fid)) {
     ol.format.WFS.writeOgcFidFilter_(node, fid, objectStack);
@@ -374,7 +385,11 @@ ol.format.WFS.writeUpdate_ = function(node, feature, objectStack) {
   goog.asserts.assert(goog.isObject(context));
   var featureType = goog.object.get(context, 'featureType');
   var featurePrefix = goog.object.get(context, 'featurePrefix');
+  featurePrefix = goog.isDef(featurePrefix) ? featurePrefix :
+      ol.format.WFS.featurePrefix;
+  var featureNS = goog.object.get(context, 'featureNS');
   node.setAttribute('typeName', featurePrefix + ':' + featureType);
+  node.setAttribute('xmlns:' + featurePrefix, featureNS);
   var fid = feature.getId();
   if (goog.isDef(fid)) {
     var keys = feature.getKeys();
@@ -385,10 +400,11 @@ ol.format.WFS.writeUpdate_ = function(node, feature, objectStack) {
         values.push({name: keys[i], value: value});
       }
     }
-    ol.xml.pushSerializeAndPop({node: node},
-        ol.format.WFS.TRANSACTION_SERIALIZERS_,
-        ol.xml.makeSimpleNodeFactory('Property'), values,
-        objectStack);
+    ol.xml.pushSerializeAndPop({node: node, srsName:
+          goog.object.get(context, 'srsName')},
+    ol.format.WFS.TRANSACTION_SERIALIZERS_,
+    ol.xml.makeSimpleNodeFactory('Property'), values,
+    objectStack);
     ol.format.WFS.writeOgcFidFilter_(node, fid, objectStack);
   }
 };

--- a/test/spec/ol/format/wfs/TransactionUpdate.xml
+++ b/test/spec/ol/format/wfs/TransactionUpdate.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" version="1.1.0"
+    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Update typeName="foo:FAULTS" xmlns:foo="http://foo">
+        <Property>
+            <Name>the_geom</Name>
+            <Value><MultiLineString xmlns="http://www.opengis.net/gml" srsName="EPSG:900913">
+                    <lineStringMember>
+                        <LineString srsName="EPSG:900913">
+                            <posList>-12279454.47665902 6741885.67968707 -12064207.805007964
+                                6732101.740066567 -11941908.559751684 6595126.585379533
+                                -12240318.718177011 6507071.128795006 -12416429.631346056
+                                6604910.52500003</posList>
+                        </LineString>
+                    </lineStringMember>
+                </MultiLineString></Value>
+        </Property>
+        <Filter xmlns="http://www.opengis.net/ogc">
+            <FeatureId fid="FAULTS.4455"/>
+        </Filter>
+    </Update>
+</Transaction>

--- a/test/spec/ol/format/wfsformat.test.js
+++ b/test/spec/ol/format/wfsformat.test.js
@@ -225,6 +225,37 @@ describe('ol.format.WFS', function() {
   describe('when writing out a Transaction request', function() {
     var text;
     before(function(done) {
+      afterLoadText('spec/ol/format/wfs/TransactionUpdate.xml', function(xml) {
+        text = xml;
+        done();
+      });
+    });
+
+    it('creates the correct update', function() {
+      var format = new ol.format.WFS();
+      var updateFeature = new ol.Feature();
+      updateFeature.setGeometryName('the_geom');
+      updateFeature.setGeometry(new ol.geom.MultiLineString([[
+        [-12279454.47665902, 6741885.67968707],
+        [-12064207.805007964, 6732101.740066567],
+        [-11941908.559751684, 6595126.585379533],
+        [-12240318.718177011, 6507071.128795006],
+        [-12416429.631346056, 6604910.52500003]
+      ]]));
+      updateFeature.setId('FAULTS.4455');
+      var serialized = format.writeTransaction(null, [updateFeature], null, {
+        featureNS: 'http://foo',
+        featureType: 'FAULTS',
+        featurePrefix: 'foo',
+        gmlOptions: {srsName: 'EPSG:900913'}
+      });
+      expect(serialized).to.xmleql(ol.xml.load(text));
+    });
+  });
+
+  describe('when writing out a Transaction request', function() {
+    var text;
+    before(function(done) {
       afterLoadText('spec/ol/format/wfs/TransactionMulti.xml', function(xml) {
         text = xml;
         done();


### PR DESCRIPTION
Make sure we create xmlns for the featurePrefix on both Update and Delete.
Ability to specify an srsName on the geometry contained by the Update.
