### PR TITLE
opt_dest should be assigned to not pushed

### DIFF
--- a/src/ol/geom/flat/interpolateflatgeom.js
+++ b/src/ol/geom/flat/interpolateflatgeom.js
@@ -61,7 +61,8 @@ ol.geom.flat.interpolate.lineString =
     }
   }
   if (goog.isDefAndNotNull(opt_dest)) {
-    opt_dest.push(pointX, pointY);
+    opt_dest[0] = pointX;
+    opt_dest[1] = pointY;
     return opt_dest;
   } else {
     return [pointX, pointY];

--- a/test/spec/ol/geom/flat/interpolateflatgeom.test.js
+++ b/test/spec/ol/geom/flat/interpolateflatgeom.test.js
@@ -42,6 +42,14 @@ describe('ol.geom.flat.interpolate', function() {
           expect(point).to.eql([3, 4]);
         });
 
+    it('returns the expected value when using opt_dest',
+        function() {
+          var flatCoordinates = [0, 1, 2, 3, 6, 7];
+          var point = ol.geom.flat.interpolate.lineString(
+              flatCoordinates, 0, 6, 2, 0.5, [0, 0]);
+          expect(point).to.eql([3, 4]);
+        });
+
   });
 
 });


### PR DESCRIPTION
ol.geom.flat.interpolate.lineString will push result into opt_dest which only works if supplied array is empty. Because of this ol.geom.LineString.prototype.getFlatMidpoint will produce invalid results on geometries when they are modified. This pull request resolves the problem using a fix from @tschaub. I've also supplied a test case that requires the fix to pass.
