### PR TITLE
Ability to specify geometryName on ol.format.GeoJSON

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1104,7 +1104,8 @@ olx.control.ZoomToExtentOptions.prototype.extent;
 
 
 /**
- * @typedef {{defaultProjection: ol.proj.ProjectionLike}}
+ * @typedef {{defaultProjection: ol.proj.ProjectionLike,
+ *     geometryName: (string|undefined)}}
  * @todo api
  */
 olx.format.GeoJSONOptions;
@@ -1115,6 +1116,13 @@ olx.format.GeoJSONOptions;
  * @type {ol.proj.ProjectionLike}
  */
 olx.format.GeoJSONOptions.prototype.defaultProjection;
+
+
+/**
+ * Geometry name to use when creating features.
+ * @type {string|undefined}
+ */
+olx.format.GeoJSONOptions.prototype.geometryName;
 
 
 /**

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -41,6 +41,14 @@ ol.format.GeoJSON = function(opt_options) {
   this.defaultProjection_ = ol.proj.get(options.defaultProjection ?
       options.defaultProjection : 'EPSG:4326');
 
+
+  /**
+   * Name of the geometry attribute for features.
+   * @type {string|undefined}
+   * @private
+   */
+  this.geometryName_ = options.geometryName;
+
 };
 goog.inherits(ol.format.GeoJSON, ol.format.JSONFeature);
 
@@ -346,7 +354,11 @@ ol.format.GeoJSON.prototype.readFeatureFromObject = function(object) {
   var geoJSONFeature = /** @type {GeoJSONFeature} */ (object);
   goog.asserts.assert(geoJSONFeature.type == 'Feature');
   var geometry = ol.format.GeoJSON.readGeometry_(geoJSONFeature.geometry);
-  var feature = new ol.Feature(geometry);
+  var feature = new ol.Feature();
+  if (goog.isDef(this.geometryName_)) {
+    feature.setGeometryName(this.geometryName_);
+  }
+  feature.setGeometry(geometry);
   if (goog.isDef(geoJSONFeature.id)) {
     feature.setId(geoJSONFeature.id);
   }

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -174,6 +174,13 @@ describe('ol.format.GeoJSON', function() {
       expect(features[2].getGeometry()).to.be.an(ol.geom.Polygon);
     });
 
+    it('can create a feature with a specific geometryName', function() {
+      var feature = new ol.format.GeoJSON({geometryName: 'the_geom'}).
+          readFeature(pointGeoJSON);
+      expect(feature.getGeometryName()).to.be('the_geom');
+      expect(feature.getGeometry()).to.be.an(ol.geom.Point);
+    });
+
   });
 
   describe('#readFeatures', function() {


### PR DESCRIPTION
GeoJSON by default uses 'geometry' for the geometry name. However, when used in combination with WFS, the geometry attribute might be named differently on the server. This new config option allows people to have the GeoJSON format create features with the same structure as on the server.
