### PR TITLE
Do not set geometry by default

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -63,8 +63,9 @@ ol.Feature = function(opt_geometryOrValues) {
       this, ol.Object.getChangeEventType(this.geometryName_),
       this.handleGeometryChanged_, false, this);
 
-  if (goog.isDefAndNotNull(opt_geometryOrValues)) {
-    if (opt_geometryOrValues instanceof ol.geom.Geometry) {
+  if (goog.isDef(opt_geometryOrValues)) {
+    if (opt_geometryOrValues instanceof ol.geom.Geometry ||
+        goog.isNull(opt_geometryOrValues)) {
       var geometry = /** @type {ol.geom.Geometry} */ (opt_geometryOrValues);
       this.setGeometry(geometry);
     } else {
@@ -72,8 +73,6 @@ ol.Feature = function(opt_geometryOrValues) {
       var values = /** @type {Object.<string, *>} */ (opt_geometryOrValues);
       this.setValues(values);
     }
-  } else {
-    this.setGeometry(null);
   }
 };
 goog.inherits(ol.Feature, ol.Object);

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -58,7 +58,7 @@ describe('ol.Feature', function() {
 
   });
 
-  describe('#getAttributes()', function() {
+  describe('#getProperties()', function() {
 
     it('returns an object with all attributes', function() {
       var point = new ol.geom.Point([15, 30]);
@@ -78,6 +78,12 @@ describe('ol.Feature', function() {
       expect(attributes.ten).to.be(10);
     });
 
+    it('is empty by default', function() {
+      var feature = new ol.Feature();
+      var properties = feature.getProperties();
+      expect(goog.object.isEmpty(properties)).to.be(true);
+    });
+
   });
 
 
@@ -85,8 +91,19 @@ describe('ol.Feature', function() {
 
     var point = new ol.geom.Point([15, 30]);
 
-    it('returns null for no geometry', function() {
+    it('returns undefined for unset geometry', function() {
       var feature = new ol.Feature();
+      expect(feature.getGeometry()).to.be(undefined);
+    });
+
+    it('returns null for null geometry (constructor)', function() {
+      var feature = new ol.Feature(null);
+      expect(feature.getGeometry()).to.be(null);
+    });
+
+    it('returns null for null geometry (setGeometry())', function() {
+      var feature = new ol.Feature();
+      feature.setGeometry(null);
       expect(feature.getGeometry()).to.be(null);
     });
 


### PR DESCRIPTION
A feature can have a geometry whose value is an `ol.geom.Geometry` instance or `null`.  A feature can also have no geometry property.  By default, a feature has no geometry property.  To set a geometry, one can be passed to the constructor (including `null`) or passed to `setGeometry()`.

See #2059.
