### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
-    "closure-util": "~0.11.0",
-    "jshint": "~2.4.4",
+    "closure-util": "~0.12.0",
+    "jshint": "~2.5.1",
     "jsdoc": "~3.3.0-alpha5",
-    "walk": "~2.3.1",
+    "walk": "~2.3.3",
     "fs-extra": "~0.8.1",
     "nomnom": "~1.6.2",
     "temp": "~0.7.0",


### PR DESCRIPTION
This updates the following packages:
- `closure-util@0.12.0` - force inclusion of deps.js files when compiling
- `jshint@2.5.1` - various enhancements and fixes (https://github.com/jshint/jshint/compare/2.4.4...2.5.1)
- `walk@2.3.3` - directory exclusion fix

I added [documentation](https://github.com/openlayers/closure-util/blob/master/readme.md#publishing) on publishing new versions of the `closure-util` package.  Let me know if anybody is interested in trying it out (even for just a quick doc fix).  It will be good to have multiple maintainers.
