### PR TITLE
Make the scale factor of ol.format.Polyline configurable

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1129,6 +1129,21 @@ olx.format.GeoJSONOptions.prototype.geometryName;
 
 
 /**
+ * @typedef {{factor: (number|undefined)}}
+ * @todo stability experimental
+ */
+olx.format.PolylineOptions;
+
+
+/**
+ * The factor by which the coordinates values will be scaled.
+ * Default is `1e5`.
+ */
+olx.format.PolylineOptions.prototype.factor;
+
+
+
+/**
  * @typedef {{defaultProjection: ol.proj.ProjectionLike}}
  * @todo api
  */

--- a/test/spec/ol/format/polylineformat.test.js
+++ b/test/spec/ol/format/polylineformat.test.js
@@ -34,27 +34,6 @@ describe('ol.format.Polyline', function() {
   beforeEach(resetTestingData);
 
 
-
-  describe('encodeFlatCoordinates', function() {
-    it('returns expected value', function() {
-      var encodeFlatCoordinates = ol.format.Polyline.encodeFlatCoordinates;
-
-      // from the "Encoded Polyline Algorithm Format" page at Google
-      expect(encodeFlatCoordinates(flatPoints)).to.eql(encodedFlatPoints);
-    });
-  });
-
-  describe('decodeFlatCoordinates', function() {
-    it('returns expected value', function() {
-      var decodeFlatCoordinates = ol.format.Polyline.decodeFlatCoordinates;
-
-      // from the "Encoded Polyline Algorithm Format" page at Google
-      expect(decodeFlatCoordinates(encodedFlatPoints)).to.eql(flatPoints);
-    });
-  });
-
-
-
   describe('encodeDeltas', function() {
     it('returns expected value', function() {
       var encodeDeltas = ol.format.Polyline.encodeDeltas;


### PR DESCRIPTION
The default scale factor is `1e5` (see [Google algorithm](https://developers.google.com/maps/documentation/utilities/polylinealgorithm))

OSRM returns a polyline scale with a `1e6` factor.

Ping @Turbo87
