### PR TITLE
Account for null or undefined geometry

### DIFF
--- a/src/ol/interaction/draganddropinteraction.js
+++ b/src/ol/interaction/draganddropinteraction.js
@@ -115,7 +115,7 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, result) {
       for (j = 0, jj = readFeatures.length; j < jj; ++j) {
         var feature = readFeatures[j];
         var geometry = feature.getGeometry();
-        if (!goog.isNull(geometry)) {
+        if (goog.isDefAndNotNull(geometry)) {
           geometry.applyTransform(transform);
         }
         features.push(feature);

--- a/src/ol/render/box.js
+++ b/src/ol/render/box.js
@@ -96,7 +96,7 @@ ol.render.Box.prototype.disposeInternal = function() {
  */
 ol.render.Box.prototype.handleMapPostCompose_ = function(event) {
   var geometry = this.geometry_;
-  goog.asserts.assert(!goog.isNull(geometry));
+  goog.asserts.assert(goog.isDefAndNotNull(geometry));
   var style = this.style_;
   goog.asserts.assert(!goog.isNull(style));
   // use drawAsync(Infinity) to draw above everything

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -462,7 +462,7 @@ ol.render.canvas.Immediate.prototype.drawCircleGeometry =
  */
 ol.render.canvas.Immediate.prototype.drawFeature = function(feature, style) {
   var geometry = feature.getGeometry();
-  if (goog.isNull(geometry) ||
+  if (!goog.isDefAndNotNull(geometry) ||
       !ol.extent.intersects(this.extent_, geometry.getExtent())) {
     return;
   }

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -105,7 +105,7 @@ ol.renderer.vector.renderFeature = function(
 ol.renderer.vector.renderFeature_ = function(
     replayGroup, feature, style, squaredTolerance, data) {
   var geometry = feature.getGeometry();
-  if (goog.isNull(geometry)) {
+  if (!goog.isDefAndNotNull(geometry)) {
     return;
   }
   var simplifiedGeometry = geometry.getSimplifiedGeometry(squaredTolerance);

--- a/src/ol/source/formatvectorsource.js
+++ b/src/ol/source/formatvectorsource.js
@@ -125,7 +125,7 @@ ol.source.FormatVector.prototype.readFeatures = function(source) {
       for (i = 0, ii = features.length; i < ii; ++i) {
         var feature = features[i];
         var geometry = feature.getGeometry();
-        if (!goog.isNull(geometry)) {
+        if (goog.isDefAndNotNull(geometry)) {
           geometry.applyTransform(transform);
         }
       }

--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -110,11 +110,11 @@ ol.source.Vector.prototype.addFeatureInternal = function(feature) {
         this.handleFeatureChange_, false, this)
   ];
   var geometry = feature.getGeometry();
-  if (goog.isNull(geometry)) {
-    this.nullGeometryFeatures_[goog.getUid(feature).toString()] = feature;
-  } else {
+  if (goog.isDefAndNotNull(geometry)) {
     var extent = geometry.getExtent();
     this.rBush_.insert(extent, feature);
+  } else {
+    this.nullGeometryFeatures_[goog.getUid(feature).toString()] = feature;
   }
   this.dispatchEvent(
       new ol.source.VectorEvent(ol.source.VectorEventType.ADDFEATURE, feature));
@@ -183,7 +183,7 @@ ol.source.Vector.prototype.forEachFeatureAtCoordinate =
   var extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
   return this.forEachFeatureInExtent(extent, function(feature) {
     var geometry = feature.getGeometry();
-    goog.asserts.assert(!goog.isNull(geometry));
+    goog.asserts.assert(goog.isDefAndNotNull(geometry));
     if (geometry.containsCoordinate(coordinate)) {
       return f.call(opt_this, feature);
     } else {
@@ -284,7 +284,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate =
        */
       function(feature) {
         var geometry = feature.getGeometry();
-        goog.asserts.assert(!goog.isNull(geometry));
+        goog.asserts.assert(goog.isDefAndNotNull(geometry));
         var previousMinSquaredDistance = minSquaredDistance;
         minSquaredDistance = geometry.closestPointXY(
             x, y, closestPoint, minSquaredDistance);
@@ -322,7 +322,7 @@ ol.source.Vector.prototype.handleFeatureChange_ = function(event) {
   var feature = /** @type {ol.Feature} */ (event.target);
   var featureKey = goog.getUid(feature).toString();
   var geometry = feature.getGeometry();
-  if (goog.isNull(geometry)) {
+  if (!goog.isDefAndNotNull(geometry)) {
     if (!(featureKey in this.nullGeometryFeatures_)) {
       this.rBush_.remove(feature);
       this.nullGeometryFeatures_[featureKey] = feature;


### PR DESCRIPTION
The change in #2098 made it so a feature's geometry could be `undefined`.  This is consistent with the return type for the [`getGeometry`](https://github.com/openlayers/ol3/blob/0e7f86ea17e3698a4e560fa5f06f509cb7e3427c/src/ol/feature.js#L81-L85) method.  Where calling code needs to ensure that it has a geometry instance, it can use `instanceof`, `goog.isDefAndNotNull()`, or test for a truthy value.

One alternative would be to have `getGeometry` return `{ol.geom.Geometry}` (allowing `null` but not `undefined`).  However, this would mean that `feature.get(feature.getGeometryName()) === feature.getGeometry()` was not always true.
