### PR TITLE
Hit detection respects min and maxResolution

### DIFF
--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -38,6 +38,20 @@ goog.inherits(ol.layer.Layer, ol.layer.Base);
 
 
 /**
+ * Return `true` if the layer is visible, and if the passed resolution is
+ * between the layer's minResolution and maxResolution. The comparison is
+ * inclusive for `minResolution` and exclusive for `maxResolution`.
+ * @param {ol.layer.LayerState} layerState Layer state.
+ * @param {number} resolution Resolution.
+ * @return {boolean} The layer is visible at the given resolution.
+ */
+ol.layer.Layer.visibleAtResolution = function(layerState, resolution) {
+  return layerState.visible && resolution >= layerState.minResolution &&
+      resolution < layerState.maxResolution;
+};
+
+
+/**
  * @inheritDoc
  */
 ol.layer.Layer.prototype.getLayersArray = function(opt_array) {

--- a/src/ol/renderer/canvas/canvasmaprenderer.js
+++ b/src/ol/renderer/canvas/canvasmaprenderer.js
@@ -10,6 +10,7 @@ goog.require('ol');
 goog.require('ol.css');
 goog.require('ol.dom');
 goog.require('ol.layer.Image');
+goog.require('ol.layer.Layer');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
 goog.require('ol.render.Event');
@@ -160,10 +161,8 @@ ol.renderer.canvas.Map.prototype.renderFrame = function(frameState) {
     layer = layerState.layer;
     layerRenderer = this.getLayerRenderer(layer);
     goog.asserts.assertInstanceof(layerRenderer, ol.renderer.canvas.Layer);
-    if (!layerState.visible ||
-        layerState.sourceState != ol.source.State.READY ||
-        viewResolution >= layerState.maxResolution ||
-        viewResolution < layerState.minResolution) {
+    if (!ol.layer.Layer.visibleAtResolution(layerState, viewResolution) ||
+        layerState.sourceState != ol.source.State.READY) {
       continue;
     }
     layerRenderer.prepareFrame(frameState, layerState);

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -99,11 +99,13 @@ ol.renderer.Map.prototype.forEachFeatureAtPixel =
         layerFilter, thisArg2) {
   var layerStates = this.map_.getLayerGroup().getLayerStatesArray();
   var numLayers = layerStates.length;
+  var viewResolution = frameState.view2DState.resolution;
   var i;
   for (i = numLayers - 1; i >= 0; --i) {
     var layerState = layerStates[i];
     var layer = layerState.layer;
-    if (layerState.visible && layerFilter.call(thisArg2, layer)) {
+    if (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
+        layerFilter.call(thisArg2, layer)) {
       var layerRenderer = this.getLayerRenderer(layer);
       var result = layerRenderer.forEachFeatureAtPixel(
           coordinate, frameState, callback, thisArg);

--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -17,6 +17,7 @@ goog.require('ol.Tile');
 goog.require('ol.css');
 goog.require('ol.dom');
 goog.require('ol.layer.Image');
+goog.require('ol.layer.Layer');
 goog.require('ol.layer.Tile');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');
@@ -442,10 +443,8 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
   var i, ii, layerState;
   for (i = 0, ii = layerStatesArray.length; i < ii; ++i) {
     layerState = layerStatesArray[i];
-    if (layerState.visible &&
-        layerState.sourceState == ol.source.State.READY &&
-        viewResolution < layerState.maxResolution &&
-        viewResolution >= layerState.minResolution) {
+    if (ol.layer.Layer.visibleAtResolution(layerState, viewResolution) &&
+        layerState.sourceState == ol.source.State.READY) {
       layerStatesToDraw.push(layerState);
     }
   }

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -108,6 +108,55 @@ describe('ol.layer.Layer', function() {
 
   });
 
+  describe('visibleAtResolution', function() {
+    var layer;
+
+    beforeEach(function() {
+      layer = new ol.layer.Layer({
+        source: new ol.source.Source({
+          projection: ol.proj.get('EPSG:4326')
+        })
+      });
+    });
+
+    afterEach(function() {
+      goog.dispose(layer);
+    });
+
+    it('returns false if layer is not visible', function() {
+      layer.setVisible(false);
+      layer.setMinResolution(3);
+      layer.setMaxResolution(5);
+      var layerState = layer.getLayerState();
+      expect(ol.layer.Layer.visibleAtResolution(layerState, 4)).to.be(false);
+    });
+
+    it('returns false if resolution lower than minResolution', function() {
+      layer.setVisible(true);
+      layer.setMinResolution(3);
+      layer.setMaxResolution(5);
+      var layerState = layer.getLayerState();
+      expect(ol.layer.Layer.visibleAtResolution(layerState, 2)).to.be(false);
+    });
+
+    it('returns false if resolution greater than maxResolution', function() {
+      layer.setVisible(true);
+      layer.setMinResolution(3);
+      layer.setMaxResolution(5);
+      var layerState = layer.getLayerState();
+      expect(ol.layer.Layer.visibleAtResolution(layerState, 6)).to.be(false);
+    });
+
+    it('returns true otherwise', function() {
+      layer.setVisible(true);
+      layer.setMinResolution(3);
+      layer.setMaxResolution(5);
+      var layerState = layer.getLayerState();
+      expect(ol.layer.Layer.visibleAtResolution(layerState, 4)).to.be(true);
+    });
+
+  });
+
   describe('#getLayerState', function() {
 
     var layer;


### PR DESCRIPTION
This fixes the bug reported in #2106, where the hit detection code detects features that are not actually rendered because the current resolution is outside the resolution range defined on the vector layer.

Please review.

closes #2106.
