### PR TITLE
Do not make ol.style.Image exportable

### DIFF
--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -28,7 +28,6 @@ ol.style.ImageOptions;
 /**
  * @constructor
  * @param {ol.style.ImageOptions} options Options.
- * @todo api
  */
 ol.style.Image = function(options) {
 


### PR DESCRIPTION
Application developers should use its subclasses.
