### PR TITLE
Add getters and setters for TileUrlFunction and TileLoadFunction properties

### DIFF
--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -120,8 +120,17 @@ ol.source.TileImage.prototype.getTile =
 
 
 /**
+ * @return {ol.TileLoadFunctionType} TileLoadFunction
+ * @todo api
+ */
+ol.source.TileImage.prototype.getTileLoadFunction = function() {
+  return this.tileLoadFunction;
+};
+
+
+/**
  * @return {ol.TileUrlFunctionType} TileUrlFunction
- * @todo stability experimental
+ * @todo api
  */
 ol.source.TileImage.prototype.getTileUrlFunction = function() {
   return this.tileUrlFunction;
@@ -129,7 +138,19 @@ ol.source.TileImage.prototype.getTileUrlFunction = function() {
 
 
 /**
+ * @param {ol.TileLoadFunctionType} tileLoadFunction Tile load function.
+ * @todo api
+ */
+ol.source.TileImage.prototype.setTileLoadFunction = function(tileLoadFunction) {
+  this.tileCache.clear();
+  this.tileLoadFunction = tileLoadFunction;
+  this.dispatchChangeEvent();
+};
+
+
+/**
  * @param {ol.TileUrlFunctionType} tileUrlFunction Tile URL function.
+ * @todo api
  */
 ol.source.TileImage.prototype.setTileUrlFunction = function(tileUrlFunction) {
   // FIXME It should be possible to be more intelligent and avoid clearing the


### PR DESCRIPTION
This PR add getters and setters for `TileUrlFunction` and `TileLoadFunction` properties in `ol.source.TileImage`.

These functions are needed  to use tiles in offline mode, see https://github.com/oterral/ol3/commit/87399ef85a206a92e752723732ca2bd339762289 for an example of use.
