### PR TITLE
Fix bug in ol.FeatureOverlay

### DIFF
--- a/src/ol/featureoverlay.js
+++ b/src/ol/featureoverlay.js
@@ -118,6 +118,8 @@ ol.FeatureOverlay.prototype.drawFeature_ = function(vectorContext, feature,
       goog.asserts.assert(imageState == ol.style.ImageState.LOADING);
       imageStyle.listenImageChange(this.handleImageChange_, this);
     }
+  } else {
+    vectorContext.drawFeature(feature, style);
   }
 };
 


### PR DESCRIPTION
This fixes a major regression introduced by db5b443 (#2028), where the FeatureOverlay won't draw features that do not have an image style.

closes #2126
