### PR TITLE
Fix GoogleMaps example view max zoom levels

### DIFF
--- a/examples/google-map.js
+++ b/examples/google-map.js
@@ -21,7 +21,10 @@ var gmap = new google.maps.Map(document.getElementById('gmap'), {
   streetViewControl: false
 });
 
-var view = new ol.View2D();
+var view = new ol.View2D({
+  // make sure the view doesn't go beyond the 22 zoom levels of Google Maps
+  maxZoom: 21
+});
 view.on('change:center', function() {
   var center = ol.proj.transform(view.getCenter(), 'EPSG:3857', 'EPSG:4326');
   gmap.setCenter(new google.maps.LatLng(center[1], center[0]));


### PR DESCRIPTION
This fixes the number of zoom levels available in the GoogleMaps example to fit the actual number of available zoom levels in a GoogleMaps map.
