### PR TITLE
Add the jsdoc ol.extent namespace

### DIFF
--- a/src/ol/extent.jsdoc
+++ b/src/ol/extent.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace ol.extent
+ */


### PR DESCRIPTION
make the `ol.extent` functions appear in doc.
