### PR TITLE
Suggested improvements to Object/Collection docs

### DIFF
--- a/build.py
+++ b/build.py
@@ -342,7 +342,7 @@ virtual('lint', 'build/lint-timestamp', 'build/lint-libtess.js-timestamp',
 def build_lint_src_timestamp(t):
     t.run('%(GJSLINT)s',
           '--jslint_error=all',
-          '--custom_jsdoc_tags=event,fires,todo,function',
+          '--custom_jsdoc_tags=event,fires,todo,function,classdesc',
           '--strict',
           t.newer(t.dependencies))
     t.touch()

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -65,7 +65,12 @@ ol.CollectionProperty = {
 
 
 /**
- * A mutable MVC Array.
+ * @classdesc
+ * Adds methods to standard Array; changes (add/remove) to the Collection
+ * trigger events. Because a Collection is itself an {@link ol.Object}, it
+ * can be bound to any other Object or Collection such that a change in one
+ * will automatically be reflected in the other.
+ *
  * @constructor
  * @extends {ol.Object}
  * @fires ol.CollectionEvent

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -103,7 +103,17 @@ ol.ObjectAccessor.prototype.transform = function(from, to) {
 
 
 /**
- * Base class implementing KVO (Key Value Observing).
+ * @classdesc
+ * This is the base class from which all non-trivial classes inherit.
+ *
+ * It provides standardised get/set methods, and implements a form of
+ * Key Value Observing. Setting a value triggers a change event, and 2 objects
+ * can be bound together such that a change in one will automatically be
+ * reflected in the other.
+ *
+ * See {@link ol.dom.Input} for specific case of binding an object with an
+ * HTML element.
+ *
  * @constructor
  * @extends {ol.Observable}
  * @param {Object.<string, *>=} opt_values Values.


### PR DESCRIPTION
Having comments at the top of the file means they don't appear in the api docs, so I've moved them down to the constructor so they appear at the top of the appropriate docs page.
