### PR TITLE
Add ol.easing to api docs

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -530,7 +530,8 @@ olx.animation.BounceOptions.prototype.duration;
 
 
 /**
- * The easing function to use. Default is `ol.easing.upAndDown`
+ * The easing function to use. Can be an {@link ol.easing} or a custom function.
+ * Default is {@link ol.easing.upAndDown}.
  * @type {function(number):number|undefined}
  */
 olx.animation.BounceOptions.prototype.easing;
@@ -568,7 +569,8 @@ olx.animation.PanOptions.prototype.duration;
 
 
 /**
- * The easing function to use. Default is `ol.easing.inAndOut`
+ * The easing function to use. Can be an {@link ol.easing} or a custom function.
+ * Default is {@link ol.easing.inAndOut}.
  * @type {function(number):number|undefined}
  */
 olx.animation.PanOptions.prototype.easing;
@@ -616,7 +618,8 @@ olx.animation.RotateOptions.prototype.duration;
 
 
 /**
- * The easing function to use. Default is `ol.easing.inAndOut`
+ * The easing function to use. Can be an {@link ol.easing} or a custom function.
+ * Default is {@link ol.easing.inAndOut}.
  * @type {function(number):number|undefined}
  */
 olx.animation.RotateOptions.prototype.easing;
@@ -655,7 +658,8 @@ olx.animation.ZoomOptions.prototype.duration;
 
 
 /**
- * Easing function.
+ * The easing function to use. Can be an {@link ol.easing} or a custom function.
+ * Default is {@link ol.easing.inAndOut}.
  * @type {function(number):number|undefined}
  */
 olx.animation.ZoomOptions.prototype.easing;

--- a/src/ol/animation.jsdoc
+++ b/src/ol/animation.jsdoc
@@ -1,5 +1,6 @@
 /**
- * The {ol.animation} static methods are designed to be used with the {@link ol.Map#beforeRender} method.  For example:
+ * The animation static methods are designed to be used with the
+ * {@link ol.Map#beforeRender} method.  For example:
  *
  *     var map = new ol.Map({ ... });
  *     var zoom = ol.animation.zoom({

--- a/src/ol/easing.js
+++ b/src/ol/easing.js
@@ -4,7 +4,7 @@ goog.require('goog.fx.easing');
 
 
 /**
- * from https://raw.github.com/DmitryBaranovskiy/raphael/master/raphael.js
+ * from https://github.com/DmitryBaranovskiy/raphael
  * @param {number} t Input between 0 and 1.
  * @return {number} Output between 0 and 1.
  * @todo api
@@ -48,7 +48,7 @@ ol.easing.easeOut = goog.fx.easing.easeOut;
 
 
 /**
- * from https://raw.github.com/DmitryBaranovskiy/raphael/master/raphael.js
+ * from https://github.com/DmitryBaranovskiy/raphael
  * @param {number} t Input between 0 and 1.
  * @return {number} Output between 0 and 1.
  * @todo api

--- a/src/ol/easing.jsdoc
+++ b/src/ol/easing.jsdoc
@@ -1,0 +1,4 @@
+/**
+ * Easing functions for {@link ol.animation}.
+ * @namespace ol.easing
+ */


### PR DESCRIPTION
Similar to #2125.

I think the individual functions should be documented, even if only to say they are a reference to the goog function. This is not an area I know much about; would someone like to give me a one-line description for each one and I'll add?

I think github prefer not to have raw links, so I changed the Raphael links to the repo.

PS I regenerated the apidocs and AFAICS the links all seem to be correct.
