### PR TITLE
Restore control’s keyboard navigation

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -51,7 +51,7 @@ ol.control.FullScreen = function(opt_options) {
   var buttonHandler = new ol.pointer.PointerEventHandler(button);
   this.registerDisposable(buttonHandler);
   goog.events.listen(buttonHandler,
-      ol.pointer.EventType.POINTERUP, this.handleClick_, false, this);
+      ol.pointer.EventType.POINTERUP, this.handlePointerUp_, false, this);
   goog.events.listen(button, goog.events.EventType.CLICK,
       this.handleClick_, false, this);
 
@@ -87,16 +87,32 @@ goog.inherits(ol.control.FullScreen, ol.control.Control);
 
 
 /**
- * @param {ol.pointer.PointerEvent} pointerEvent Pointer event.
+ * @param {goog.events.BrowserEvent} event The event to handle
  * @private
  */
-ol.control.FullScreen.prototype.handleClick_ = function(pointerEvent) {
-  if (!googx.dom.fullscreen.isSupported()) {
+ol.control.FullScreen.prototype.handleClick_ = function(event) {
+  if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
-  if (goog.isDef(pointerEvent.browserEvent)) {
-    pointerEvent.browserEvent.preventDefault();
-  } else if (pointerEvent.screenX !== 0 && pointerEvent.screenY !== 0) {
+  this.handleFullScreen_();
+};
+
+
+/**
+ * @param {ol.pointer.PointerEvent} pointerEvent The event to handle
+ * @private
+ */
+ol.control.FullScreen.prototype.handlePointerUp_ = function(pointerEvent) {
+  pointerEvent.browserEvent.preventDefault();
+  this.handleFullScreen_();
+};
+
+
+/**
+ * @private
+ */
+ol.control.FullScreen.prototype.handleFullScreen_ = function() {
+  if (!googx.dom.fullscreen.isSupported()) {
     return;
   }
   var map = this.getMap();

--- a/src/ol/control/rotatecontrol.js
+++ b/src/ol/control/rotatecontrol.js
@@ -51,9 +51,9 @@ ol.control.Rotate = function(opt_options) {
   var handler = new ol.pointer.PointerEventHandler(button);
   this.registerDisposable(handler);
   goog.events.listen(handler, ol.pointer.EventType.POINTERUP,
-      ol.control.Rotate.prototype.resetNorth_, false, this);
+      ol.control.Rotate.prototype.handlePointerUp_, false, this);
   goog.events.listen(button, goog.events.EventType.CLICK,
-      ol.control.Rotate.prototype.resetNorth_, false, this);
+      ol.control.Rotate.prototype.handleClick_, false, this);
 
   goog.events.listen(button, [
     goog.events.EventType.MOUSEOUT,
@@ -90,16 +90,31 @@ goog.inherits(ol.control.Rotate, ol.control.Control);
 
 
 /**
- * @param {ol.pointer.PointerEvent} pointerEvent The pointer event to handle.
+ * @param {goog.events.BrowserEvent} event The event to handle
  * @private
  */
-ol.control.Rotate.prototype.resetNorth_ = function(pointerEvent) {
-  if (goog.isDef(pointerEvent.browserEvent)) {
-    pointerEvent.browserEvent.preventDefault();
-  } else if (pointerEvent.screenX !== 0 && pointerEvent.screenY !== 0) {
+ol.control.Rotate.prototype.handleClick_ = function(event) {
+  if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
-  // prevent the anchor from getting appended to the url
+  this.resetNorth_();
+};
+
+
+/**
+ * @param {ol.pointer.PointerEvent} pointerEvent The event to handle
+ * @private
+ */
+ol.control.Rotate.prototype.handlePointerUp_ = function(pointerEvent) {
+  pointerEvent.browserEvent.preventDefault();
+  this.resetNorth_();
+};
+
+
+/**
+ * @private
+ */
+ol.control.Rotate.prototype.resetNorth_ = function() {
   var map = this.getMap();
   // FIXME works for View2D only
   var view = map.getView();

--- a/src/ol/control/zoomcontrol.js
+++ b/src/ol/control/zoomcontrol.js
@@ -55,10 +55,10 @@ ol.control.Zoom = function(opt_options) {
   this.registerDisposable(inElementHandler);
   goog.events.listen(inElementHandler,
       ol.pointer.EventType.POINTERUP, goog.partial(
-          ol.control.Zoom.prototype.zoomByDelta_, delta), false, this);
+          ol.control.Zoom.prototype.handlePointerUp_, delta), false, this);
   goog.events.listen(inElement,
       goog.events.EventType.CLICK, goog.partial(
-          ol.control.Zoom.prototype.zoomByDelta_, delta), false, this);
+          ol.control.Zoom.prototype.handleClick_, delta), false, this);
 
   goog.events.listen(inElement, [
     goog.events.EventType.MOUSEOUT,
@@ -79,10 +79,10 @@ ol.control.Zoom = function(opt_options) {
   this.registerDisposable(outElementHandler);
   goog.events.listen(outElementHandler,
       ol.pointer.EventType.POINTERUP, goog.partial(
-          ol.control.Zoom.prototype.zoomByDelta_, -delta), false, this);
+          ol.control.Zoom.prototype.handlePointerUp_, -delta), false, this);
   goog.events.listen(outElement,
       goog.events.EventType.CLICK, goog.partial(
-          ol.control.Zoom.prototype.zoomByDelta_, -delta), false, this);
+          ol.control.Zoom.prototype.handleClick_, -delta), false, this);
 
   goog.events.listen(outElement, [
     goog.events.EventType.MOUSEOUT,
@@ -113,16 +113,33 @@ goog.inherits(ol.control.Zoom, ol.control.Control);
 
 /**
  * @param {number} delta Zoom delta.
- * @param {ol.pointer.PointerEvent} pointerEvent The pointer event to handle.
+ * @param {goog.events.BrowserEvent} event The event to handle
  * @private
  */
-ol.control.Zoom.prototype.zoomByDelta_ = function(delta, pointerEvent) {
-  if (goog.isDef(pointerEvent.browserEvent)) {
-    pointerEvent.browserEvent.preventDefault();
-  } else if (pointerEvent.screenX !== 0 && pointerEvent.screenY !== 0) {
+ol.control.Zoom.prototype.handleClick_ = function(delta, event) {
+  if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
-  // prevent the anchor from getting appended to the url
+  this.zoomByDelta_(delta);
+};
+
+
+/**
+ * @param {number} delta Zoom delta.
+ * @param {ol.pointer.PointerEvent} pointerEvent The event to handle
+ * @private
+ */
+ol.control.Zoom.prototype.handlePointerUp_ = function(delta, pointerEvent) {
+  pointerEvent.browserEvent.preventDefault();
+  this.zoomByDelta_(delta);
+};
+
+
+/**
+ * @param {number} delta Zoom delta.
+ * @private
+ */
+ol.control.Zoom.prototype.zoomByDelta_ = function(delta) {
   var map = this.getMap();
   // FIXME works for View2D only
   var view = map.getView();

--- a/src/ol/control/zoomtoextentcontrol.js
+++ b/src/ol/control/zoomtoextentcontrol.js
@@ -47,9 +47,9 @@ ol.control.ZoomToExtent = function(opt_options) {
   var buttonHandler = new ol.pointer.PointerEventHandler(button);
   this.registerDisposable(buttonHandler);
   goog.events.listen(buttonHandler, ol.pointer.EventType.POINTERUP,
-      this.handleZoomToExtent_, false, this);
+      this.handlePointerUp_, false, this);
   goog.events.listen(button, goog.events.EventType.CLICK,
-      this.handleZoomToExtent_, false, this);
+      this.handleClick_, false, this);
 
   goog.events.listen(button, [
     goog.events.EventType.MOUSEOUT,
@@ -71,16 +71,31 @@ goog.inherits(ol.control.ZoomToExtent, ol.control.Control);
 
 
 /**
- * @param {ol.pointer.PointerEvent} pointerEvent Pointer event.
+ * @param {goog.events.BrowserEvent} event The event to handle
  * @private
  */
-ol.control.ZoomToExtent.prototype.handleZoomToExtent_ = function(pointerEvent) {
-  if (goog.isDef(pointerEvent.browserEvent)) {
-    pointerEvent.browserEvent.preventDefault();
-  } else if (pointerEvent.screenX !== 0 && pointerEvent.screenY !== 0) {
+ol.control.ZoomToExtent.prototype.handleClick_ = function(event) {
+  if (event.screenX !== 0 && event.screenY !== 0) {
     return;
   }
-  // prevent #zoomExtent anchor from getting appended to the url
+  this.handleZoomToExtent_();
+};
+
+
+/**
+ * @param {ol.pointer.PointerEvent} pointerEvent The event to handle
+ * @private
+ */
+ol.control.ZoomToExtent.prototype.handlePointerUp_ = function(pointerEvent) {
+  pointerEvent.browserEvent.preventDefault();
+  this.handleZoomToExtent_();
+};
+
+
+/**
+ * @private
+ */
+ol.control.ZoomToExtent.prototype.handleZoomToExtent_ = function() {
   var map = this.getMap();
   var view = map.getView();
   goog.asserts.assert(goog.isDef(view));


### PR DESCRIPTION
By listening to `click` event too, but ignore it unless `evt.screenX` or `evt.screenY` equals 0. That _should_ only happen when button are activated with the keyboard. 

IE is supposed to accept Enter or Space to activate links, but IE9 returns ~~completely crazy~~ incoherent `screenX/screenY` when activated with Enter, so only space works here (IE9 only).

Feedback welcome (-:
