### PR TITLE
Remove olx and interfaces from docs sidebar

### DIFF
--- a/apidoc/template/publish.js
+++ b/apidoc/template/publish.js
@@ -201,6 +201,8 @@ function buildNav(members) {
 
     if (members.namespaces.length) {
         _.each(members.namespaces, function (v) {
+          // exclude 'olx' from sidebar
+          if (v.longname.indexOf('olx') !== 0) {
             nav.push({
                 type: 'namespace',
                 longname: v.longname,
@@ -222,11 +224,14 @@ function buildNav(members) {
                     memberof: v.longname
                 })
             });
+          }
         });
     }
 
     if (members.classes.length) {
         _.each(members.classes, function (v) {
+          // ignore interfaces
+          if (v.interface !== true) {
             nav.push({
                 type: 'class',
                 longname: v.longname,
@@ -249,6 +254,7 @@ function buildNav(members) {
                     memberof: v.longname
                 })
             });
+          }
         });
     }
 


### PR DESCRIPTION
First stage in making the api docs sidebar more manageable.
As developers don't ever need to use these in their code, there's no real need to have them in the sidebar.

I would stress that they are not removed from the docs; the appropriate pages are still generated and all the links still work. They simply no longer appear in the sidebar.

I can provide a url to docs after this change if anyone wants.
