### PR TITLE
Change sourceDir to src/ in generate-info.js

### DIFF
--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -6,7 +6,7 @@ var async = require('async');
 var fse = require('fs-extra');
 var walk = require('walk').walk;
 
-var sourceDir = path.join(__dirname, '..', 'src', 'ol');
+var sourceDir = path.join(__dirname, '..', 'src');
 var infoPath = path.join(__dirname, '..', 'build', 'info.json');
 var jsdoc = path.join(__dirname, '..', 'node_modules', '.bin', 'jsdoc');
 var jsdocConfig = path.join(


### PR DESCRIPTION
This is to accomodate the case where other directories than "ol" include "api" annotations. For example, the Swisstopo geoadmin folks extend OpenLayers 3 in an ol3 fork, and they have their own "ga" namespace/directory under "src". See https://github.com/geoadmin/ol3/tree/master/src.

Discussed in https://github.com/openlayers/ol3/commit/f9157a61231a230df07ed09792cecaa39f57164f#commitcomment-6582726.

CC @gjn.
