### PR TITLE
Remove getSimplifiedGeometry from ol.geom.Circle

### DIFF
--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -133,15 +133,6 @@ ol.geom.Circle.prototype.getRadiusSquared_ = function() {
  * @inheritDoc
  * @todo api
  */
-ol.geom.Circle.prototype.getSimplifiedGeometry = function(squaredTolerance) {
-  return this;
-};
-
-
-/**
- * @inheritDoc
- * @todo api
- */
 ol.geom.Circle.prototype.getType = function() {
   return ol.geom.GeometryType.CIRCLE;
 };


### PR DESCRIPTION
The `getSimplifiedGeometry` method is unnecessary as `ol.geom.SimpleGeometry`'s default implementation is to do the same thing (return `this`).
