### PR TITLE
Restore synchronized map panning in google-map example

### DIFF
--- a/examples/google-map.js
+++ b/examples/google-map.js
@@ -54,9 +54,9 @@ var map = new ol.Map({
   layers: [vector],
   interactions: ol.interaction.defaults({
     altShiftDragRotate: false,
-    pan: false,
+    dragPan: false,
     rotate: false
-  }).extend([new ol.interaction.DragPan({kinetic: false})]),
+  }).extend([new ol.interaction.DragPan({kinetic: null})]),
   target: olMapDiv,
   view: view
 });


### PR DESCRIPTION
This broke as a collateral damage when the pointer-events effort was merged.
