### PR TITLE
ol.source.ImageVector doesn't skip features

### DIFF
--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -52,7 +52,9 @@ ol.renderer.canvas.ImageLayer.prototype.forEachFeatureAtPixel =
   var extent = frameState.extent;
   var resolution = frameState.view2DState.resolution;
   var rotation = frameState.view2DState.rotation;
-  return source.forEachFeatureAtPixel(extent, resolution, rotation, coordinate,
+  var skippedFeatureUids = frameState.skippedFeatureUids_;
+  return source.forEachFeatureAtPixel(
+      extent, resolution, rotation, coordinate, skippedFeatureUids,
       /**
        * @param {ol.Feature} feature Feature.
        * @return {?} Callback result.

--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -57,7 +57,9 @@ ol.renderer.dom.ImageLayer.prototype.forEachFeatureAtPixel =
   var extent = frameState.extent;
   var resolution = frameState.view2DState.resolution;
   var rotation = frameState.view2DState.rotation;
-  return source.forEachFeatureAtPixel(extent, resolution, rotation, coordinate,
+  var skippedFeatureUids = frameState.skippedFeatureUids_;
+  return source.forEachFeatureAtPixel(
+      extent, resolution, rotation, coordinate, skippedFeatureUids,
       /**
        * @param {ol.Feature} feature Feature.
        * @return {?} Callback result.

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -83,7 +83,10 @@ ol.renderer.webgl.ImageLayer.prototype.forEachFeatureAtPixel =
   var extent = frameState.extent;
   var resolution = frameState.view2DState.resolution;
   var rotation = frameState.view2DState.rotation;
-  return source.forEachFeatureAtPixel(extent, resolution, rotation, coordinate,
+  var skippedFeatureUids = frameState.skippedFeatureUids_;
+  return source.forEachFeatureAtPixel(
+      extent, resolution, rotation, coordinate, skippedFeatureUids,
+
       /**
        * @param {ol.Feature} feature Feature.
        * @return {?} Callback result.

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -144,13 +144,13 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
 /**
  * @inheritDoc
  */
-ol.source.ImageVector.prototype.forEachFeatureAtPixel =
-    function(extent, resolution, rotation, coordinate, callback) {
+ol.source.ImageVector.prototype.forEachFeatureAtPixel = function(
+    extent, resolution, rotation, coordinate, skippedFeatureUids, callback) {
   if (goog.isNull(this.replayGroup_)) {
     return undefined;
   } else {
     return this.replayGroup_.forEachGeometryAtPixel(
-        extent, resolution, 0, coordinate, {},
+        extent, resolution, 0, coordinate, skippedFeatureUids,
         /**
          * @param {ol.geom.Geometry} geometry Geometry.
          * @param {Object} data Data.

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -88,6 +88,7 @@ goog.inherits(ol.source.Source, ol.Observable);
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
  * @param {ol.Coordinate} coordinate Coordinate.
+ * @param {Object.<string, boolean>} skippedFeatureUids Skipped feature uids.
  * @param {function(ol.Feature): T} callback Feature callback.
  * @return {T|undefined} Callback result.
  * @template T


### PR DESCRIPTION
This fixes a bug [reported](https://groups.google.com/d/msgid/ol3-dev/7a208c83-d724-4e2f-ae2c-06e02423528a%40googlegroups.com?utm_medium=email&utm_source=footer) on the mailing list where multi-selection doesn't work when an image vector layer is used instead of a pure vector layer. The bug is that ol.source.ImageVector doesn't pass the skippedFeatureUids object to the replay group, preventing the select interaction to work properly.

Please review.
