### PR TITLE
Rename ol.structs.RBush#forEach to ol.structs.RBush#some

### DIFF
--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -177,7 +177,7 @@ ol.source.Vector.prototype.addFeaturesInternal = function(features) {
  * Clear the source
  */
 ol.source.Vector.prototype.clear = function() {
-  this.rBush_.forEach(this.removeFeatureInternal, this);
+  this.rBush_.some(this.removeFeatureInternal, this);
   this.rBush_.clear();
   goog.object.forEach(
       this.nullGeometryFeatures_, this.removeFeatureInternal, this);
@@ -195,7 +195,7 @@ ol.source.Vector.prototype.clear = function() {
  * @todo api
  */
 ol.source.Vector.prototype.forEachFeature = function(f, opt_this) {
-  return this.rBush_.forEach(f, opt_this);
+  return this.rBush_.some(f, opt_this);
 };
 
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -402,16 +402,16 @@ ol.structs.RBush.prototype.condense_ = function(path) {
  * @return {*} Callback return value.
  * @template S
  */
-ol.structs.RBush.prototype.forEach = function(callback, opt_this) {
+ol.structs.RBush.prototype.some = function(callback, opt_this) {
   if (goog.DEBUG) {
     ++this.readers_;
     try {
-      return this.forEach_(this.root_, callback, opt_this);
+      return this.some_(this.root_, callback, opt_this);
     } finally {
       --this.readers_;
     }
   } else {
-    return this.forEach_(this.root_, callback, opt_this);
+    return this.some_(this.root_, callback, opt_this);
   }
 };
 
@@ -424,7 +424,7 @@ ol.structs.RBush.prototype.forEach = function(callback, opt_this) {
  * @return {*} Callback return value.
  * @template S
  */
-ol.structs.RBush.prototype.forEach_ = function(node, callback, opt_this) {
+ol.structs.RBush.prototype.some_ = function(node, callback, opt_this) {
   goog.asserts.assert(!node.isLeaf());
   /** @type {Array.<ol.structs.RBushNode.<T>>} */
   var toVisit = [node];
@@ -492,7 +492,7 @@ ol.structs.RBush.prototype.forEachInExtent_ =
           return result;
         }
       } else if (ol.extent.containsExtent(extent, node.extent)) {
-        result = this.forEach_(node, callback, opt_this);
+        result = this.some_(node, callback, opt_this);
         if (result) {
           return result;
         }
@@ -533,7 +533,7 @@ ol.structs.RBush.prototype.forEachNode = function(callback, opt_this) {
  */
 ol.structs.RBush.prototype.getAll = function() {
   var values = [];
-  this.forEach(
+  this.some(
       /**
        * @param {T} value Value.
        */

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -64,11 +64,11 @@ describe('ol.structs.RBush', function() {
       rBush.insert([-3, -3, -2, -2], objs[10]);
     });
 
-    describe('#forEach', function() {
+    describe('#some', function() {
 
       it('called for all the objects', function() {
         var i = 0;
-        rBush.forEach(function() {
+        rBush.some(function() {
           ++i;
         });
         expect(i).to.be(objs.length);
@@ -76,7 +76,7 @@ describe('ol.structs.RBush', function() {
 
       it('stops when the function returns true', function() {
         var i = 0;
-        var result = rBush.forEach(function() {
+        var result = rBush.some(function() {
           return ++i >= 4;
         });
         expect(i).to.be(4);
@@ -112,7 +112,7 @@ describe('ol.structs.RBush', function() {
       it('throws an exception if called while iterating over all values',
           function() {
             expect(function() {
-              rBush.forEach(function(value) {
+              rBush.some(function(value) {
                 rBush.insert([0, 0, 1, 1], {});
               });
             }).to.throwException();
@@ -150,7 +150,7 @@ describe('ol.structs.RBush', function() {
       it('throws an exception if called while iterating over all values',
           function() {
             expect(function() {
-              rBush.forEach(function(value) {
+              rBush.some(function(value) {
                 rBush.remove(value);
               });
             }).to.throwException();
@@ -172,7 +172,7 @@ describe('ol.structs.RBush', function() {
       it('throws an exception if called while iterating over all values',
           function() {
             expect(function() {
-              rBush.forEach(function(value) {
+              rBush.some(function(value) {
                 rBush.update([0, 0, 1, 1], objs[1]);
               });
             }).to.throwException();


### PR DESCRIPTION
See comments in #2186

But I'm not very happy with it: 
`forEachInExtent` should be renamed to `someInExtent` as well as `ol.source.Vector#forEachFeature`, `ol.source.Vector#forEachFeatureAtCoordinate`, `ol.source.Vector#forEachFeatureInExtent` ...

In the meantime I played with the [goog.iter](http://docs.closure-library.googlecode.com/git/namespace_goog_iter.html) package (see https://github.com/fredj/ol3/compare/iterator): this could provide a far flexible and simple system to iterate over the tree.
