### PR TITLE
Mark abstract method as function for JSDoc to pick it up

### DIFF
--- a/src/ol/tile.js
+++ b/src/ol/tile.js
@@ -56,6 +56,7 @@ ol.Tile.prototype.dispatchChangeEvent = function() {
 
 
 /**
+ * @function
  * @param {Object=} opt_context Object.
  * @return {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement} Image.
  */


### PR DESCRIPTION
This leaves aside the question whether getImage needs to be
defined as abstract method in a base class that does not know
about images, but at least it makes the documentation appear
correctly in ol.tile.Image.
