### PR TITLE
Update closure-util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
   - "sudo pip install -r requirements.txt"
-  - "npm install"
+  - "npm install -g npm && npm install"
 
 before_script:
   - "./build.py plovr"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "htmlparser2": "~3.7.1"
   },
   "devDependencies": {
-    "closure-util": "~0.12.0",
+    "closure-util": "~0.14.0",
     "jshint": "~2.5.1",
     "jsdoc": "~3.3.0-alpha7",
     "taffydb": "~2.7.0",


### PR DESCRIPTION
The `closure-util` package works on Node 0.8, 0.10, and 0.11 (as of this writing), but it requires an updated version of `npm` to install on Node 0.8.  For the build to pass on Travis, we update `npm` before installing other dependencies.  For others who are installing the `openlayers` package, nothing special is required for Node 0.10 and above.  For users on Node 0.8, the `openlayers` package will only install with an updated version of `npm`.  This can be installed with `npm` itself.

```
# this is only needed on Node 0.8
npm install -g npm
```

I'll add more complete instructions for using ol3 with Node after the Windows installation issues are addressed.
