### PR TITLE
Add standard docs text to abstract base classes

### DIFF
--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -10,7 +10,8 @@ goog.require('ol.Object');
 
 /**
  * @classdesc
- * Abstract parent class for controls.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  * A control is a visible widget with a DOM element in a fixed position on the
  * screen. They can involve user input (buttons), or be informational only;
  * the position is determined using CSS. By default these are part of the map

--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -6,7 +6,9 @@ goog.require('goog.functions');
 
 /**
  * @classdesc
- * Abstract base class for feature formats.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for feature formats.
  * {ol.format.Feature} subclasses provide the ability to decode and encode
  * {@link ol.Feature} objects from a variety of commonly used geospatial
  * file formats.  See the documentation for each format for more details.

--- a/src/ol/format/jsonfeatureformat.js
+++ b/src/ol/format/jsonfeatureformat.js
@@ -10,7 +10,9 @@ goog.require('ol.format.FormatType');
 
 /**
  * @classdesc
- * Abstract base class for JSON feature formats.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for JSON feature formats.
  *
  * @constructor
  * @extends {ol.format.Feature}

--- a/src/ol/format/textfeatureformat.js
+++ b/src/ol/format/textfeatureformat.js
@@ -8,7 +8,9 @@ goog.require('ol.format.FormatType');
 
 /**
  * @classdesc
- * Abstract base class for text feature formats.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for text feature formats.
  *
  * @constructor
  * @extends {ol.format.Feature}

--- a/src/ol/format/xmlfeatureformat.js
+++ b/src/ol/format/xmlfeatureformat.js
@@ -11,7 +11,9 @@ goog.require('ol.xml');
 
 /**
  * @classdesc
- * Abstract base class for XML feature formats.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for XML feature formats.
  *
  * @constructor
  * @extends {ol.format.Feature}

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -45,7 +45,9 @@ ol.geom.GeometryLayout = {
 
 /**
  * @classdesc
- * Abstract base class for vector geometries.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for vector geometries.
  *
  * @constructor
  * @extends {ol.Observable}

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -11,7 +11,8 @@ goog.require('ol.geom.flat.transform');
 
 /**
  * @classdesc
- * Abstract base class for geometry objects
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  *
  * @constructor
  * @extends {ol.geom.Geometry}

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -13,6 +13,8 @@ goog.require('ol.easing');
 
 /**
  * @classdesc
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  * User actions that change the state of the map. Some are similar to controls,
  * but are not associated with a DOM element.
  * For example, {@link ol.interaction.KeyboardZoom} is functionally the same as

--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -13,7 +13,8 @@ goog.require('ol.interaction.Interaction');
 
 /**
  * @classdesc
- * Abstract base class for pointer interactions.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  *
  * @constructor
  * @extends {ol.interaction.Interaction}

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -11,7 +11,9 @@ goog.require('ol.source.Source');
 
 /**
  * @classdesc
- * Abstract base class. A visual representation of raster or vector map data.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * A visual representation of raster or vector map data.
  * Layers group together those properties that pertain to how the data is to be
  * displayed, irrespective of the source of that data.
  *

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -42,7 +42,8 @@ ol.layer.LayerState;
 
 /**
  * @classdesc
- * Abstract base class for all layers.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  *
  * @constructor
  * @extends {ol.Object}

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -105,7 +105,9 @@ ol.ObjectAccessor.prototype.transform = function(from, to) {
 
 /**
  * @classdesc
- * Abstract base class from which all non-trivial classes inherit.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * All non-trivial classes inherit from this.
  *
  * It provides standardised get/set methods, and implements a form of
  * Key Value Observing. Setting a value triggers a change event, and 2 objects

--- a/src/ol/observable.js
+++ b/src/ol/observable.js
@@ -8,7 +8,8 @@ goog.require('goog.events.EventType');
 
 /**
  * @classdesc
- * Abstract base class.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  * An event target providing convenient methods for listener registration
  * and unregistration. A generic `change` event is always available through
  * {@link ol.Observable#dispatchChangeEvent}.

--- a/src/ol/source/imagesource.js
+++ b/src/ol/source/imagesource.js
@@ -23,7 +23,9 @@ ol.source.ImageOptions;
 
 /**
  * @classdesc
- * Abstract base class for sources providing a single image.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for sources providing a single image.
  *
  * @constructor
  * @extends {ol.source.Source}

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -34,7 +34,9 @@ ol.source.SourceOptions;
 
 /**
  * @classdesc
- * Abstract base class for {@link ol.layer.Layer} sources.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for {@link ol.layer.Layer} sources.
  *
  * @constructor
  * @extends {ol.Observable}

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -25,7 +25,9 @@ ol.source.TileOptions;
 
 /**
  * @classdesc
- * Abstract base class for sources providing images divided into a tile grid.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
+ * Base class for sources providing images divided into a tile grid.
  *
  * @constructor
  * @extends {ol.source.Source}

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -19,7 +19,8 @@ ol.ViewHint = {
 
 /**
  * @classdesc
- * Abstract base class for views.
+ * Abstract base class; normally only used for creating subclasses and not
+ * instantiated in apps.
  * Maps can be viewed from different perspectives: 2D or 3D, or at different
  * angles. To enable this, properties determining projection, position, angle or
  * rotation cannot be part of the map itself, but of the particular view of that


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/ol3-dev/GILyoFGDzwI
I accept @ahocevar's point that it's not worth making changes to docs tags just for this relatively small number of classes.

Docs only; no logic change
