### PR TITLE
Document defaultProjection in JSON sources/formats

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1115,14 +1115,15 @@ olx.format.GeoJSONOptions;
 
 
 /**
- * Default projection.
+ * Default projection. The projection to be used if none is defined in the
+ * source. Default is EPSG:4326.
  * @type {ol.proj.ProjectionLike}
  */
 olx.format.GeoJSONOptions.prototype.defaultProjection;
 
 
 /**
- * Geometry name to use when creating features.
+ * Geometry name to use when creating features. Default is 'geometry'.
  * @type {string|undefined}
  */
 olx.format.GeoJSONOptions.prototype.geometryName;
@@ -1136,7 +1137,8 @@ olx.format.TopoJSONOptions;
 
 
 /**
- * Default projection.
+ * Default projection. The projection to be used if none is defined in the
+ * source. Default is EPSG:4326.
  * @type {ol.proj.ProjectionLike}
  */
 olx.format.TopoJSONOptions.prototype.defaultProjection;
@@ -2589,7 +2591,8 @@ olx.source.GeoJSONOptions.prototype.attributions;
 
 
 /**
- * Default projection.
+ * Default projection. The projection to be used by {@link ol.format.GeoJSON}
+ * if none is defined in the source. Default is EPSG:4326.
  * @type {ol.proj.ProjectionLike}
  */
 olx.source.GeoJSONOptions.prototype.defaultProjection;
@@ -2816,10 +2819,8 @@ olx.source.TileImageOptions.prototype.tileUrlFunction;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
- *     defaultProjection: ol.proj.ProjectionLike,
  *     extent: (ol.Extent|undefined),
  *     logo: (string|undefined),
- *     object: (GeoJSONObject|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     tileGrid: ol.tilegrid.TileGrid,
  *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
@@ -2838,13 +2839,6 @@ olx.source.TileVectorOptions.prototype.attributions;
 
 
 /**
- * Default projection.
- * @type {ol.proj.ProjectionLike}
- */
-olx.source.TileVectorOptions.prototype.defaultProjection;
-
-
-/**
  * Extent.
  * @type {ol.Extent|undefined}
  */
@@ -2856,13 +2850,6 @@ olx.source.TileVectorOptions.prototype.extent;
  * @type {string|undefined}
  */
 olx.source.TileVectorOptions.prototype.logo;
-
-
-/**
- * Object.
- * @type {GeoJSONObject|undefined}
- */
-olx.source.TileVectorOptions.prototype.object;
 
 
 /**
@@ -2924,7 +2911,8 @@ olx.source.TopoJSONOptions.prototype.attributions;
 
 
 /**
- * Default projection.
+ * Default projection. The projection to be used by {@link ol.format.TopoJSON}
+ * if none is defined in the source. Default is EPSG:4326.
  * @type {ol.proj.ProjectionLike}
  */
 olx.source.TopoJSONOptions.prototype.defaultProjection;


### PR DESCRIPTION
I'm documenting what the code currently does, but I have to say it doesn't seem very consistent to me. Why define this in both source and format? As it only applies to JSON formats, wouldn't it be better in format.JSONFeature, the parent of both GeoJSON and TopoJSON?

The TileVector example sets the defaultProjection in the format (though as 4326 is the default, I'm not sure this is necessary). defaultProjection is currently also defined as an option for TileVector source, as is 'object', but AFAICS these are never used, so I've removed them.
