### PR TITLE
Remove static button in docs sidebar if none

### DIFF
--- a/apidoc/template/tmpl/navigation.tmpl
+++ b/apidoc/template/tmpl/navigation.tmpl
@@ -12,7 +12,9 @@ var self = this;
         <li class="item" data-name="<?js= item.longname ?>">
             <span class="title">
                 <?js= self.linkto(item.longname, item.longname) ?>
-                <?js if (item.type === 'namespace') { ?>
+                <?js if (item.type === 'namespace' &&
+                        (item.members.length + item.typedefs.length + item.methods.length +
+                         item.events.length > 0)) { ?>
                 <span class="static">static</span>
                 <?js } ?>
             </span>


### PR DESCRIPTION
a minor improvement to the api docs sidebar. At present, a 'static' 'button' (in fact, just a piece of text, but it looks like a button) is printed next to the namespace whether there are any or not. If there are none, clicking on it appears to have no effect, which may look like a bug. This small change suppresses the button if there are no 'statics'.
