### PR TITLE
Get rid of unused info div in vector-wfs example

### DIFF
--- a/examples/vector-wfs.html
+++ b/examples/vector-wfs.html
@@ -30,7 +30,7 @@
 
       <div class="row-fluid">
 
-        <div class="span4">
+        <div class="span12">
           <h4 id="title">WFS example</h4>
           <p id="shortdesc">Example of using WFS with a BBOX strategy.</p>
           <div id="docs">
@@ -38,12 +38,6 @@
           </div>
           <div id="tags">vector, WFS, bbox, loading, server</div>
         </div>
-        <div class="span4 offset4">
-          <div id="info" class="alert alert-success">
-            &nbsp;
-          </div>
-        </div>
-
       </div>
 
     </div>


### PR DESCRIPTION
Get rid of unused info div in vector-wfs example
