### PR TITLE
Add "None" to draw-features example's select

### DIFF
--- a/examples/draw-features.html
+++ b/examples/draw-features.html
@@ -36,6 +36,7 @@
           <form class="form-inline">
             <label>Geometry type &nbsp;</label>
               <select id="type">
+                <option value="None">None</option>
                 <option value="Point">Point</option>
                 <option value="LineString">LineString</option>
                 <option value="Polygon">Polygon</option>

--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -49,11 +49,14 @@ var typeSelect = document.getElementById('type');
 
 var draw; // global so we can remove it later
 function addInteraction() {
-  draw = new ol.interaction.Draw({
-    source: source,
-    type: /** @type {ol.geom.GeometryType} */ (typeSelect.value)
-  });
-  map.addInteraction(draw);
+  var value = typeSelect.value;
+  if (value !== 'None') {
+    draw = new ol.interaction.Draw({
+      source: source,
+      type: /** @type {ol.geom.GeometryType} */ (value)
+    });
+    map.addInteraction(draw);
+  }
 }
 
 


### PR DESCRIPTION
This allows to deactivate drawing entirely in the example.
