### PR TITLE
Stop exporting getTransformFromProjections and transformWithProjections

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -579,7 +579,6 @@ ol.proj.getTransform = function(source, destination) {
  * @param {ol.proj.Projection} sourceProjection Source projection.
  * @param {ol.proj.Projection} destinationProjection Destination projection.
  * @return {ol.TransformFunction} Transform.
- * @todo api
  */
 ol.proj.getTransformFromProjections =
     function(sourceProjection, destinationProjection) {
@@ -714,7 +713,6 @@ ol.proj.transform = function(point, source, destination) {
  * @param {ol.proj.Projection} sourceProjection Source projection.
  * @param {ol.proj.Projection} destinationProjection Destination projection.
  * @return {ol.Coordinate} Point.
- * @todo api
  */
 ol.proj.transformWithProjections =
     function(point, sourceProjection, destinationProjection) {


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/ol3-dev/-JoO_B3cPWY

This is all that's needed to stop functions being exported, right? They are not currently used in any examples.
