### PR TITLE
Don't export View2D.getView2D

### DIFF
--- a/examples/custom-controls.js
+++ b/examples/custom-controls.js
@@ -37,7 +37,7 @@ app.RotateNorthControl = function(opt_options) {
   var handleRotateNorth = function(e) {
     // prevent #rotate-north anchor from getting appended to the url
     e.preventDefault();
-    this_.getMap().getView().getView2D().setRotation(0);
+    this_.getMap().getView().setRotation(0);
   };
 
   anchor.addEventListener('click', handleRotateNorth, false);

--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -123,7 +123,7 @@ dragAndDropInteraction.on('addfeatures', function(event) {
       style: styleFunction
     })
   }));
-  var view2D = map.getView().getView2D();
+  var view2D = map.getView();
   view2D.fitExtent(vectorSource.getExtent(), map.getSize());
 });
 

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -119,7 +119,7 @@ dragAndDropInteraction.on('addfeatures', function(event) {
     source: vectorSource,
     style: styleFunction
   }));
-  var view2D = map.getView().getView2D();
+  var view2D = map.getView();
   view2D.fitExtent(vectorSource.getExtent(), map.getSize());
 });
 

--- a/src/ol/view2d.js
+++ b/src/ol/view2d.js
@@ -367,7 +367,6 @@ ol.View2D.prototype.getValueForResolutionFunction = function(opt_power) {
 
 /**
  * @inheritDoc
- * @todo api
  */
 ol.View2D.prototype.getView2D = function() {
   return this;


### PR DESCRIPTION
Small tidy-up. See https://groups.google.com/forum/#!topic/ol3-dev/wdyZgN2GuY4

Not sure whether the function is needed at all, but it is currently used in several places in the lib, so it can keep for the moment.
