### PR TITLE
Cleanup vector-labels example

### DIFF
--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -63,7 +63,7 @@ var myDom = {
 var getText = function(feature, resolution, dom) {
   var type = dom.text.value;
   var maxResolution = dom.maxreso.value;
-  var text = feature.getProperties().name;
+  var text = feature.get('name');
 
   if (resolution > maxResolution) {
     text = '';


### PR DESCRIPTION
Only get the `name` value, not all the properties.
