### PR TITLE
Add ol.Feature#clone

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -85,6 +85,27 @@ goog.inherits(ol.Feature, ol.Object);
 
 
 /**
+ * Clone this feature. If the original feature has a geometry it
+ * is also cloned. The feature id is not set in the clone.
+ * @return {ol.Feature} The clone.
+ * @todo api
+ */
+ol.Feature.prototype.clone = function() {
+  var clone = new ol.Feature(this.getProperties());
+  clone.setGeometryName(this.getGeometryName());
+  var geometry = this.getGeometry();
+  if (goog.isDefAndNotNull(geometry)) {
+    clone.setGeometry(geometry.clone());
+  }
+  var style = this.getStyle();
+  if (!goog.isNull(style)) {
+    clone.setStyle(style);
+  }
+  return clone;
+};
+
+
+/**
  * @return {ol.geom.Geometry|undefined} Geometry.
  * @todo api
  */

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -371,6 +371,43 @@ describe('ol.Feature', function() {
 
   });
 
+  describe('#clone', function() {
+
+    it('correctly clones features', function() {
+      var feature = new ol.Feature();
+      feature.setValues({'fookey': 'fooval'});
+      feature.setId(1);
+      feature.setGeometryName('geom');
+      var geometry = new ol.geom.Point([1, 2]);
+      feature.setGeometry(geometry);
+      var style = new ol.style.Style({});
+      feature.setStyle(style);
+      feature.set('barkey', 'barval');
+
+      var clone = feature.clone();
+      expect(clone.get('fookey')).to.be('fooval');
+      expect(clone.getId()).to.be(undefined);
+      expect(clone.getGeometryName()).to.be('geom');
+      var geometryClone = clone.getGeometry();
+      expect(geometryClone).not.to.be(geometry);
+      var coordinates = geometryClone.getFlatCoordinates();
+      expect(coordinates[0]).to.be(1);
+      expect(coordinates[1]).to.be(2);
+      expect(clone.getStyle()).to.be(style);
+      expect(clone.get('barkey')).to.be('barval');
+    });
+
+    it('correctly clones features with no geometry and no style', function() {
+      var feature = new ol.Feature();
+      feature.set('fookey', 'fooval');
+
+      var clone = feature.clone();
+      expect(clone.get('fookey')).to.be('fooval');
+      expect(clone.getGeometry()).to.be(undefined);
+      expect(clone.getStyle()).to.be(null);
+    });
+  });
+
 
 });
 


### PR DESCRIPTION
This PR suggests adding a clone method to ol.Feature. Please review.

My use-case: I need to serialize features in a different projection. Without a clone method it looks like this:

``` js
var features = [];
vectorSource.forEachFeature(function(feature) {
  var clone = new ol.Feature();
  clone.setId(feature.getId());
  clone.setValues(feature.getProperties());
  clone.setGeometryName(feature.getGeometryName());
  var geometryClone = feature.getGeometry().clone();
  clone.setGeometry(geometryClone);
  var style = feature.getStyle();
  if (style) {
    clone.setStyle(style);
  }
  features.push(clone);
});
var serialized = format.writeFeatures(features);
```

With a clone method it looks like this:

``` js
var feature = [];
vectorSource.forEachFeature(function(feature) {
  var clone = feature.clone();
  clone.setId(feature.getId());  // clone does not set the id
  features.push(clone);
});
var serialized = format.writeFeatures(features);
```
