### PR TITLE
Add symbol kind to info

### DIFF
--- a/buildcfg/jsdoc/info/publish.js
+++ b/buildcfg/jsdoc/info/publish.js
@@ -46,6 +46,7 @@ exports.publish = function(data, opts) {
     } else {
       symbols.push({
         name: doc.longname,
+        kind: doc.kind,
         description: doc.description,
         extends: doc.augments,
         path: path.join(doc.meta.path, doc.meta.filename)


### PR DESCRIPTION
The hosted build tool will group symbols for easier bulk exports.  Initially,  the `kind` property will be used to group symbols for classes.
