### PR TITLE
Use string values for ol.source.State enum

### DIFF
--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -9,15 +9,14 @@ goog.require('ol.proj');
 
 
 /**
- * State of the source. `0` means 'loading', `1` means 'ready', and `2` means
- * 'error'.
- * @enum {number}
+ * State of the source, one of 'loading', 'ready' or 'error'.
+ * @enum {string}
  * @todo api
  */
 ol.source.State = {
-  LOADING: 0,
-  READY: 1,
-  ERROR: 2
+  LOADING: 'loading',
+  READY: 'ready',
+  ERROR: 'error'
 };
 
 


### PR DESCRIPTION
Many user-facing enums are string values and we document use of the string values rather than more confusing enum reference or the numeric values.
