### PR TITLE
Change setValues to setProperties

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -25,11 +25,11 @@ goog.require('ol.style.Style');
  * @constructor
  * @extends {ol.Object}
  * @fires change Triggered when the geometry or style of the feature changes.
- * @param {ol.geom.Geometry|Object.<string, *>=} opt_geometryOrValues
- *     Values or geometry.
+ * @param {ol.geom.Geometry|Object.<string, *>=} opt_geometryOrProperties
+ *     Geometry or properties.
  * @todo api
  */
-ol.Feature = function(opt_geometryOrValues) {
+ol.Feature = function(opt_geometryOrProperties) {
 
   goog.base(this);
 
@@ -69,15 +69,16 @@ ol.Feature = function(opt_geometryOrValues) {
       this, ol.Object.getChangeEventType(this.geometryName_),
       this.handleGeometryChanged_, false, this);
 
-  if (goog.isDef(opt_geometryOrValues)) {
-    if (opt_geometryOrValues instanceof ol.geom.Geometry ||
-        goog.isNull(opt_geometryOrValues)) {
-      var geometry = /** @type {ol.geom.Geometry} */ (opt_geometryOrValues);
+  if (goog.isDef(opt_geometryOrProperties)) {
+    if (opt_geometryOrProperties instanceof ol.geom.Geometry ||
+        goog.isNull(opt_geometryOrProperties)) {
+      var geometry = /** @type {ol.geom.Geometry} */ (opt_geometryOrProperties);
       this.setGeometry(geometry);
     } else {
-      goog.asserts.assert(goog.isObject(opt_geometryOrValues));
-      var values = /** @type {Object.<string, *>} */ (opt_geometryOrValues);
-      this.setValues(values);
+      goog.asserts.assert(goog.isObject(opt_geometryOrProperties));
+      var properties = /** @type {Object.<string, *>} */
+          (opt_geometryOrProperties);
+      this.setProperties(properties);
     }
   }
 };

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -364,7 +364,7 @@ ol.format.GeoJSON.prototype.readFeatureFromObject = function(object) {
     feature.setId(geoJSONFeature.id);
   }
   if (goog.isDef(geoJSONFeature.properties)) {
-    feature.setValues(geoJSONFeature.properties);
+    feature.setProperties(geoJSONFeature.properties);
   }
   return feature;
 };

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -165,7 +165,7 @@ ol.format.GPX.readRte_ = function(node, objectStack) {
   var geometry = new ol.geom.LineString(null);
   geometry.setFlatCoordinates(ol.geom.GeometryLayout.XYZM, flatCoordinates);
   var feature = new ol.Feature(geometry);
-  feature.setValues(values);
+  feature.setProperties(values);
   return feature;
 };
 
@@ -195,7 +195,7 @@ ol.format.GPX.readTrk_ = function(node, objectStack) {
   geometry.setFlatCoordinates(
       ol.geom.GeometryLayout.XYZM, flatCoordinates, ends);
   var feature = new ol.Feature(geometry);
-  feature.setValues(values);
+  feature.setProperties(values);
   return feature;
 };
 
@@ -218,7 +218,7 @@ ol.format.GPX.readWpt_ = function(node, objectStack) {
   var geometry = new ol.geom.Point(
       coordinates, ol.geom.GeometryLayout.XYZM);
   var feature = new ol.Feature(geometry);
-  feature.setValues(values);
+  feature.setProperties(values);
   return feature;
 };
 

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -168,7 +168,7 @@ ol.format.IGC.prototype.readFeatureFromText = function(text) {
       ol.geom.GeometryLayout.XYM : ol.geom.GeometryLayout.XYZM;
   lineString.setFlatCoordinates(layout, flatCoordinates);
   var feature = new ol.Feature(lineString);
-  feature.setValues(properties);
+  feature.setProperties(properties);
   return feature;
 };
 

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -1426,7 +1426,7 @@ ol.format.KML.prototype.readPlacemark_ = function(node, objectStack) {
   if (!goog.isNull(id)) {
     feature.setId(id);
   }
-  feature.setValues(object);
+  feature.setProperties(object);
   feature.setStyle(this.featureStyleFunction_);
   return feature;
 };

--- a/src/ol/format/osmxmlformat.js
+++ b/src/ol/format/osmxmlformat.js
@@ -68,7 +68,7 @@ ol.format.OSMXML.readNode_ = function(node, objectStack) {
     var geometry = new ol.geom.Point(coordinates);
     var feature = new ol.Feature(geometry);
     feature.setId(id);
-    feature.setValues(values.tags);
+    feature.setProperties(values.tags);
     state.features.push(feature);
   }
 };
@@ -105,7 +105,7 @@ ol.format.OSMXML.readWay_ = function(node, objectStack) {
   }
   var feature = new ol.Feature(geometry);
   feature.setId(id);
-  feature.setValues(values.tags);
+  feature.setProperties(values.tags);
   state.features.push(feature);
 };
 

--- a/src/ol/format/topojsonformat.js
+++ b/src/ol/format/topojsonformat.js
@@ -261,7 +261,7 @@ ol.format.TopoJSON.readFeatureFromGeometry_ = function(object, arcs,
     feature.setId(object.id);
   }
   if (goog.isDef(object.properties)) {
-    feature.setValues(object.properties);
+    feature.setProperties(object.properties);
   }
   return feature;
 };

--- a/src/ol/layer/layerbase.js
+++ b/src/ol/layer/layerbase.js
@@ -53,28 +53,32 @@ ol.layer.Base = function(options) {
 
   goog.base(this);
 
-  var values = goog.object.clone(options);
+  var properties = goog.object.clone(options);
 
   /** @type {number} */
-  values.brightness = goog.isDef(values.brightness) ? values.brightness : 0;
+  properties.brightness = goog.isDef(properties.brightness) ?
+      properties.brightness : 0;
   /** @type {number} */
-  values.contrast = goog.isDef(values.contrast) ? values.contrast : 1;
+  properties.contrast = goog.isDef(properties.contrast) ?
+      properties.contrast : 1;
   /** @type {number} */
-  values.hue = goog.isDef(values.hue) ? values.hue : 0;
+  properties.hue = goog.isDef(properties.hue) ? properties.hue : 0;
   /** @type {number} */
-  values.opacity = goog.isDef(values.opacity) ? values.opacity : 1;
+  properties.opacity = goog.isDef(properties.opacity) ? properties.opacity : 1;
   /** @type {number} */
-  values.saturation = goog.isDef(values.saturation) ? values.saturation : 1;
+  properties.saturation = goog.isDef(properties.saturation) ?
+      properties.saturation : 1;
   /** @type {boolean} */
-  values.visible = goog.isDef(values.visible) ? values.visible : true;
+  properties.visible = goog.isDef(properties.visible) ?
+      properties.visible : true;
   /** @type {number} */
-  values.maxResolution = goog.isDef(values.maxResolution) ?
-      values.maxResolution : Infinity;
+  properties.maxResolution = goog.isDef(properties.maxResolution) ?
+      properties.maxResolution : Infinity;
   /** @type {number} */
-  values.minResolution = goog.isDef(values.minResolution) ?
-      values.minResolution : 0;
+  properties.minResolution = goog.isDef(properties.minResolution) ?
+      properties.minResolution : 0;
 
-  this.setValues(values);
+  this.setProperties(properties);
 };
 goog.inherits(ol.layer.Base, ol.Object);
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -369,9 +369,9 @@ ol.Map = function(options) {
   goog.events.listen(this, ol.Object.getChangeEventType(ol.MapProperty.TARGET),
       this.handleTargetChanged_, false, this);
 
-  // setValues will trigger the rendering of the map if the map
+  // setProperties will trigger the rendering of the map if the map
   // is "defined" already.
-  this.setValues(optionsInternal.values);
+  this.setProperties(optionsInternal.values);
 
   this.controls_.forEach(
       /**

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -158,7 +158,7 @@ ol.Object = function(opt_values) {
   this.listeners_ = {};
 
   if (goog.isDef(opt_values)) {
-    this.setValues(opt_values);
+    this.setProperties(opt_values);
   }
 };
 goog.inherits(ol.Object, ol.Observable);
@@ -453,7 +453,7 @@ ol.Object.prototype.set = function(key, value) {
  * @param {Object.<string, *>} values Values.
  * @todo api
  */
-ol.Object.prototype.setValues = function(values) {
+ol.Object.prototype.setProperties = function(values) {
   var key;
   for (key in values) {
     this.set(key, values[key]);

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -104,10 +104,10 @@ ol.View = function(opt_options) {
   /**
    * @type {Object.<string, *>}
    */
-  var values = {};
-  values[ol.ViewProperty.CENTER] = goog.isDef(options.center) ?
+  var properties = {};
+  properties[ol.ViewProperty.CENTER] = goog.isDef(options.center) ?
       options.center : null;
-  values[ol.ViewProperty.PROJECTION] = ol.proj.createProjection(
+  properties[ol.ViewProperty.PROJECTION] = ol.proj.createProjection(
       options.projection, 'EPSG:3857');
 
   var resolutionConstraintInfo = ol.View.createResolutionConstraint_(
@@ -143,14 +143,14 @@ ol.View = function(opt_options) {
       centerConstraint, resolutionConstraint, rotationConstraint);
 
   if (goog.isDef(options.resolution)) {
-    values[ol.ViewProperty.RESOLUTION] = options.resolution;
+    properties[ol.ViewProperty.RESOLUTION] = options.resolution;
   } else if (goog.isDef(options.zoom)) {
-    values[ol.ViewProperty.RESOLUTION] = this.constrainResolution(
+    properties[ol.ViewProperty.RESOLUTION] = this.constrainResolution(
         this.maxResolution_, options.zoom - this.minZoom_);
   }
-  values[ol.ViewProperty.ROTATION] =
+  properties[ol.ViewProperty.ROTATION] =
       goog.isDef(options.rotation) ? options.rotation : 0;
-  this.setValues(values);
+  this.setProperties(properties);
 };
 goog.inherits(ol.View, ol.Object);
 

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -9,7 +9,7 @@ describe('ol.Feature', function() {
       expect(feature).to.be.a(ol.Feature);
     });
 
-    it('takes attribute values', function() {
+    it('takes properties', function() {
       var feature = new ol.Feature({
         foo: 'bar'
       });
@@ -375,7 +375,7 @@ describe('ol.Feature', function() {
 
     it('correctly clones features', function() {
       var feature = new ol.Feature();
-      feature.setValues({'fookey': 'fooval'});
+      feature.setProperties({'fookey': 'fooval'});
       feature.setId(1);
       feature.setGeometryName('geom');
       var geometry = new ol.geom.Point([1, 2]);

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -82,10 +82,10 @@ describe('ol.Object', function() {
 
   });
 
-  describe('setValues', function() {
+  describe('setProperties', function() {
 
     it('sets multiple values at once', function() {
-      o.setValues({
+      o.setProperties({
         k1: 1,
         k2: 2
       });


### PR DESCRIPTION
This changes `ol.Object#setValues` to `ol.Object#setProperties`, as discussed in https://github.com/openlayers/ol3/issues/2240.

Please review.

fixes #2240
