### PR TITLE
Docs: fix missing space on type signature

### DIFF
--- a/apidoc/template/publish.js
+++ b/apidoc/template/publish.js
@@ -76,14 +76,14 @@ function addSignatureReturns(f) {
 function addSignatureTypes(f) {
     var types = helper.getSignatureTypes(f);
     
-    f.signature = (f.signature || '') + '<span class="type-signature">'+(types.length? ' :'+types.join('|') : '')+'</span>';
+    f.signature = (f.signature || '') + '<span class="type-signature">'+(types.length? ' :'+types.join('|') : '')+' </span>';
 }
 
 function addAttribs(f) {
     var attribs = helper.getAttribs(f);
 
     if (attribs.length) {
-        f.attribs = '<span class="type-signature ' + (attribs[0] === 'static' ? 'static' : '') + '">' + htmlsafe(attribs.length ? attribs.join(',') : '') + '</span>';
+        f.attribs = '<span class="type-signature ' + (attribs[0] === 'static' ? 'static' : '') + '">' + htmlsafe(attribs.length ? attribs.join(',') : '') + ' </span>';
     }    
 }
 


### PR DESCRIPTION
A small change to improve, for example, 'nullable' and 'constant' on http://ol3js.org/en/master/apidoc/ol.MapBrowserEvent.html
