### PR TITLE
Treat classdesc as description

### DIFF
--- a/buildcfg/jsdoc/info/publish.js
+++ b/buildcfg/jsdoc/info/publish.js
@@ -47,7 +47,7 @@ exports.publish = function(data, opts) {
       symbols.push({
         name: doc.longname,
         kind: doc.kind,
-        description: doc.description,
+        description: doc.classdesc || doc.description,
         extends: doc.augments,
         path: path.join(doc.meta.path, doc.meta.filename)
       });


### PR DESCRIPTION
With #2178, the build tool (in progress) lost descriptions for our constructors.  With this change, the `@classdesc` is used as description if present.
