### PR TITLE
Use goog.dom.classlist functions

### DIFF
--- a/src/ol/control/fullscreencontrol.js
+++ b/src/ol/control/fullscreencontrol.js
@@ -3,7 +3,7 @@ goog.provide('ol.control.FullScreen');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
-goog.require('goog.dom.classes');
+goog.require('goog.dom.classlist');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('googx.dom.fullscreen');
@@ -145,9 +145,9 @@ ol.control.FullScreen.prototype.handleFullScreenChange_ = function() {
   var anchor = goog.dom.getFirstElementChild(this.element);
   var map = this.getMap();
   if (googx.dom.fullscreen.isFullScreen()) {
-    goog.dom.classes.swap(anchor, closed, opened);
+    goog.dom.classlist.swap(anchor, closed, opened);
   } else {
-    goog.dom.classes.swap(anchor, opened, closed);
+    goog.dom.classlist.swap(anchor, opened, closed);
   }
   if (!goog.isNull(map)) {
     map.updateSize();

--- a/test/spec/ol/control/zoomslidercontrol.test.js
+++ b/test/spec/ol/control/zoomslidercontrol.test.js
@@ -36,7 +36,7 @@ describe('ol.control.ZoomSlider', function() {
       zoomSliderContainer = zoomSliderContainers[0];
       expect(zoomSliderContainer instanceof HTMLDivElement).to.be(true);
 
-      hasUnselectableCls = goog.dom.classes.has(zoomSliderContainer,
+      hasUnselectableCls = goog.dom.classlist.contains(zoomSliderContainer,
           'ol-unselectable');
       expect(hasUnselectableCls).to.be(true);
 
@@ -47,7 +47,7 @@ describe('ol.control.ZoomSlider', function() {
       zoomSliderThumb = zoomSliderThumbs[0];
       expect(zoomSliderThumb instanceof HTMLDivElement).to.be(true);
 
-      hasUnselectableCls = goog.dom.classes.has(zoomSliderThumb,
+      hasUnselectableCls = goog.dom.classlist.contains(zoomSliderThumb,
           'ol-unselectable');
       expect(hasUnselectableCls).to.be(true);
     });
@@ -93,7 +93,7 @@ describe('ol.control.ZoomSlider', function() {
 
 goog.require('goog.dispose');
 goog.require('goog.dom');
-goog.require('goog.dom.classes');
+goog.require('goog.dom.classlist');
 goog.require('goog.fx.Dragger');
 goog.require('goog.math.Rect');
 goog.require('ol.Map');


### PR DESCRIPTION
The goog.dom.classes functions have now been deprecated.  See https://github.com/google/closure-library/commit/97e8a0c0fc7238a56cc4dacd4a96fd4c0735b992
