### PR TITLE
Mark the color argument to ol.color.transform non-nullable

### DIFF
--- a/src/ol/color/color.js
+++ b/src/ol/color/color.js
@@ -315,9 +315,9 @@ ol.color.toString = function(color) {
 
 
 /**
- * @param {ol.Color} color Color.
+ * @param {!ol.Color} color Color.
  * @param {goog.vec.Mat4.Number} transform Transform.
- * @param {ol.Color=} opt_color Color.
+ * @param {!ol.Color=} opt_color Color.
  * @return {ol.Color} Transformed color.
  */
 ol.color.transform = function(color, transform, opt_color) {


### PR DESCRIPTION
Inside this function `goog.vec.Mat4.multVec3` is called and and its arguments must not be null (with recent version of the google closure library).

This PR and #2284 make the code base compatible with the latest version of the google closure library.
