### PR TITLE
Minor change to vector-wfs example

### DIFF
--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -10,10 +10,6 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.tilegrid.XYZ');
 
-var loadFeatures = function(response) {
-  vectorSource.addFeatures(vectorSource.readFeatures(response));
-};
-
 var vectorSource = new ol.source.ServerVector({
   format: new ol.format.GeoJSON(),
   loader: function(extent, resolution, projection) {
@@ -31,6 +27,10 @@ var vectorSource = new ol.source.ServerVector({
   })),
   projection: 'EPSG:3857'
 });
+
+var loadFeatures = function(response) {
+  vectorSource.addFeatures(vectorSource.readFeatures(response));
+};
 
 var vector = new ol.layer.Vector({
   source: vectorSource,


### PR DESCRIPTION
My linter complains that vectorSource is used before it is defined. This PR fixes it.

Non-functional change.
