### PR TITLE
GeoJSON format needs to implement readProjectionFromObject

### DIFF
--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -416,13 +416,20 @@ ol.format.GeoJSON.prototype.readGeometryFromObject = function(object) {
 
 
 /**
- * Read the projection from the GeoJSON source file.
+ * Read the projection from a GeoJSON source.
  *
- * @param {ArrayBuffer|Document|Node|Object|string} object Source.
+ * @function
+ * @param {ArrayBuffer|Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
  * @todo api
  */
-ol.format.GeoJSON.prototype.readProjection = function(object) {
+ol.format.GeoJSON.prototype.readProjection;
+
+
+/**
+ * @inheritDoc
+ */
+ol.format.GeoJSON.prototype.readProjectionFromObject = function(object) {
   var geoJSONObject = /** @type {GeoJSONObject} */ (object);
   var crs = geoJSONObject.crs;
   if (goog.isDefAndNotNull(crs)) {


### PR DESCRIPTION
Currently ol.format.GeoJSON implements readProjection, and that method expects an object as its first argument. Instead it should implement readProjectionFromObject.

fixes #2299 
