### PR TITLE
Add TileWMS setUrl(s)

### DIFF
--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -331,6 +331,29 @@ ol.source.TileWMS.prototype.resetCoordKeyPrefix_ = function() {
 
 
 /**
+ * @param {string|undefined} url URL.
+ * @api
+ */
+ol.source.TileWMS.prototype.setUrl = function(url) {
+  if (goog.isDef(url)) {
+    this.setUrls(ol.TileUrlFunction.expandUrl(url));
+  }
+};
+
+
+/**
+ * @param {Array.<string>|undefined} urls URLs.
+ * @api
+ */
+ol.source.TileWMS.prototype.setUrls = function(urls) {
+  if (urls != this.urls_) {
+    this.urls_ = urls;
+    this.dispatchChangeEvent();
+  }
+};
+
+
+/**
  * @param {ol.TileCoord} tileCoord Tile coordinate.
  * @param {number} pixelRatio Pixel ratio.
  * @param {ol.proj.Projection} projection Projection.


### PR DESCRIPTION
Fixes #1217.

There's an example at http://probins.github.io/cz.html which accesses the WMS of the Czech mapping agency. This has the different scale map rasters, and orthophotos, as different 'services', so, to have these in the same layer, as you zoom in, the service part of the url has to be changed as well as the layers param for the different resolutions.
The urls in this example are all on the same server, but you could use the same technique to load tiles from different servers in the same layer, as long as the other parameters, such as projection and tilesize, are the same. It's quite common for example for orthophotos to be on a different server from other map layers.

I ran into a tilegrid issue when creating this. I'll raise a topic on the list for this.
