### PR TITLE
Make transform exportable

### DIFF
--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -105,6 +105,7 @@ ol.ObjectAccessor = function(source, target, sourceKey, targetKey) {
  *     before it is set to the target.
  * @param {function(?): ?} to A function that transforms the target value
  *     before it is set to the source.
+ * @api
  */
 ol.ObjectAccessor.prototype.transform = function(from, to) {
   this.from = from;


### PR DESCRIPTION
`ol.ObjectAccessor#transform()` is used in the bind-input example. Why the
example works without this export is a mystery to me. Either way, we
will want this in the docs.
