### PR TITLE
Make sure that projection is an ol.proj.Projection instance

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -699,8 +699,8 @@ ol.View.createResolutionConstraint_ = function(options) {
         resolutions);
   } else {
     // calculate the default min and max resolution
-    var projection = options.projection;
-    var extent = ol.proj.createProjection(projection, 'EPSG:3857').getExtent();
+    var projection = ol.proj.createProjection(options.projection, 'EPSG:3857');
+    var extent = projection.getExtent();
     var size = goog.isNull(extent) ?
         // use an extent that can fit the whole world if need be
         360 * ol.proj.METERS_PER_UNIT[ol.proj.Units.DEGREES] /


### PR DESCRIPTION
When a projection has no extent configured, the current code will fail because projection is a string. This pull request fixed that.
