### PR TITLE
ServerVector addFeaturesInternal fails when features lack an id

### DIFF
--- a/src/ol/source/servervectorsource.js
+++ b/src/ol/source/servervectorsource.js
@@ -69,7 +69,9 @@ ol.source.ServerVector.prototype.addFeaturesInternal = function(features) {
   for (i = 0, ii = features.length; i < ii; ++i) {
     var feature = features[i];
     var featureId = feature.getId();
-    if (!(featureId in this.loadedFeatures_)) {
+    if (!goog.isDef(featureId)) {
+      notLoadedFeatures.push(feature);
+    } else if (!(featureId in this.loadedFeatures_)) {
       notLoadedFeatures.push(feature);
       this.loadedFeatures_[featureId] = true;
     }

--- a/test/spec/ol/source/servervectorsource.test.js
+++ b/test/spec/ol/source/servervectorsource.test.js
@@ -1,0 +1,68 @@
+goog.provide('ol.test.source.ServerVector');
+
+
+describe('ol.source.ServerVector', function() {
+
+  describe('when empty', function() {
+
+    var vectorSource;
+    beforeEach(function() {
+      vectorSource = new ol.source.ServerVector({});
+    });
+
+    describe('#addFeatures', function() {
+
+      it('adds features with the same id only once', function() {
+        var addfeatureSpy = sinon.spy();
+        vectorSource.on('addfeature', addfeatureSpy);
+        features = [];
+        var i;
+        var feature;
+        for (i = 0; i < 5; i++) {
+          feature = new ol.Feature();
+          feature.setId(0);
+          features.push(feature);
+        }
+        vectorSource.addFeatures(features);
+        expect(vectorSource.getFeatures().length).to.be(1);
+        expect(addfeatureSpy.callCount).to.be(1);
+      });
+
+      it('adds features all features with distinct ids', function() {
+        var addfeatureSpy = sinon.spy();
+        vectorSource.on('addfeature', addfeatureSpy);
+        features = [];
+        var i;
+        var feature;
+        for (i = 0; i < 5; i++) {
+          feature = new ol.Feature();
+          feature.setId(i);
+          features.push(feature);
+        }
+        vectorSource.addFeatures(features);
+        expect(vectorSource.getFeatures().length).to.be(5);
+        expect(addfeatureSpy.callCount).to.be(5);
+      });
+
+      it('adds features without ids', function() {
+        var addfeatureSpy = sinon.spy();
+        vectorSource.on('addfeature', addfeatureSpy);
+        features = [];
+        var i;
+        for (i = 0; i < 10; i++) {
+          features.push(new ol.Feature());
+        }
+        vectorSource.addFeatures(features);
+        expect(vectorSource.getFeatures().length).to.be(10);
+        expect(addfeatureSpy.callCount).to.be(10);
+      });
+
+    });
+
+  });
+
+});
+
+
+goog.require('ol.Feature');
+goog.require('ol.source.ServerVector');


### PR DESCRIPTION
`ol.source.ServerVector::addFeatures` will only add the first of an array of features if the features lack an `id` property because `addFeaturesInternal` tries to track them by id to avoid loading the same feature twice.  But if the features return nothing for `getId()` then only the first feature will be loaded.
