### PR TITLE
Pass tolerance to ReplayGroup

### DIFF
--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -103,7 +103,7 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
     function(extent, resolution, pixelRatio, size, projection) {
 
   var replayGroup = new ol.render.canvas.ReplayGroup(
-      ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio), extent,
+      ol.renderer.vector.getTolerance(resolution, pixelRatio), extent,
       resolution);
 
   var loading = false;


### PR DESCRIPTION
The tolerance instead of the squared tolerance must be passed to the ReplayGroup constructor.

Fixes #2324.
