### PR TITLE
Remove Projection subclasses from API

### DIFF
--- a/src/ol/proj/chprojection.js
+++ b/src/ol/proj/chprojection.js
@@ -17,7 +17,6 @@ goog.require('ol.proj.Units');
  * @constructor
  * @extends {ol.proj.Projection}
  * @param {{code: string, extent: ol.Extent}} options Options.
- * @api
  */
 ol.proj.CH = function(options) {
   goog.base(this, {
@@ -396,7 +395,6 @@ ol.proj.CH.prototype.getPointResolution = function(resolution, point) {
  * The EPSG:2056 projection, also known as LV95 (CH1903+).
  * @constructor
  * @extends {ol.proj.CH}
- * @api
  */
 ol.proj.EPSG2056 = function() {
   goog.base(this, {
@@ -435,7 +433,6 @@ ol.proj.EPSG2056.add = function() {
  * The EPSG:21781 projection, also known as LV03 (CH1903).
  * @constructor
  * @extends {ol.proj.CH}
- * @api
  */
 ol.proj.EPSG21781 = function() {
   goog.base(this, {

--- a/src/ol/proj/epsg3857projection.js
+++ b/src/ol/proj/epsg3857projection.js
@@ -16,7 +16,6 @@ goog.require('ol.proj.Units');
  * @constructor
  * @extends {ol.proj.Projection}
  * @param {string} code Code.
- * @api
  */
 ol.proj.EPSG3857 = function(code) {
   goog.base(this, {

--- a/src/ol/proj/epsg4326projection.js
+++ b/src/ol/proj/epsg4326projection.js
@@ -18,7 +18,6 @@ goog.require('ol.proj.Units');
  * @extends {ol.proj.Projection}
  * @param {string} code Code.
  * @param {string=} opt_axisOrientation Axis orientation.
- * @api
  */
 ol.proj.EPSG4326 = function(code, opt_axisOrientation) {
   goog.base(this, {


### PR DESCRIPTION
As mentioned in https://github.com/openlayers/ol3/pull/1228#issuecomment-48446611 I don't see the use case for these in applications. When would I need to instantiate one of these? If they're not needed, it would be better if they're not in the API, where they're just likely to confuse people.
