### PR TITLE
Also accept empty array for ol.geom.MultiPolygon

### DIFF
--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -330,9 +330,13 @@ ol.geom.MultiPolygon.prototype.setCoordinates =
     }
     var endss = ol.geom.flat.deflate.coordinatesss(
         this.flatCoordinates, 0, coordinates, this.stride, this.endss_);
-    var lastEnds = endss[endss.length - 1];
-    this.flatCoordinates.length = lastEnds.length === 0 ?
-        0 : lastEnds[lastEnds.length - 1];
+    if (endss.length === 0) {
+      this.flatCoordinates.length = 0;
+    } else {
+      var lastEnds = endss[endss.length - 1];
+      this.flatCoordinates.length = lastEnds.length === 0 ?
+          0 : lastEnds[lastEnds.length - 1];
+    }
     this.dispatchChangeEvent();
   }
 };

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -10,7 +10,7 @@ describe('ol.geom.MultiPolygon', function() {
     }).not.to.throwException();
   });
 
-  describe('with an empty MultiPolygon', function() {
+  describe('with a null MultiPolygon', function() {
 
     var multiPolygon;
     beforeEach(function() {
@@ -28,6 +28,30 @@ describe('ol.geom.MultiPolygon', function() {
         [[[0, 0], [0, 2], [1, 1], [2, 0]]],
         [[[3, 0], [4, 1], [5, 2], [5, 0]]]
       ]);
+      expect(multiPolygon.getPolygons().length).to.eql(2);
+    });
+
+  });
+
+  describe('with an empty MultiPolygon', function() {
+
+    var multiPolygon;
+    beforeEach(function() {
+      multiPolygon = new ol.geom.MultiPolygon([]);
+    });
+
+    it('can append polygons', function() {
+      multiPolygon.appendPolygon(
+          new ol.geom.Polygon([[[0, 0], [0, 2], [1, 1], [2, 0]]]));
+      expect(multiPolygon.getCoordinates()).to.eql(
+          [[[[0, 0], [0, 2], [1, 1], [2, 0]]]]);
+      multiPolygon.appendPolygon(
+          new ol.geom.Polygon([[[3, 0], [4, 1], [5, 2], [5, 0]]]));
+      expect(multiPolygon.getCoordinates()).to.eql([
+        [[[0, 0], [0, 2], [1, 1], [2, 0]]],
+        [[[3, 0], [4, 1], [5, 2], [5, 0]]]
+      ]);
+      expect(multiPolygon.getPolygons().length).to.eql(2);
     });
 
   });


### PR DESCRIPTION
The constructors of `MultiLineString` and `MultiPoint` both accept an empty array as default parameter, but the constructor of `MultiPolygon` throws an exception.
