### PR TITLE
Safeguard against cases where no projection and no proj4 is available

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -468,7 +468,7 @@ ol.proj.get = function(projectionLike) {
     var projections = ol.proj.projections_;
     projection = projections[code];
     if (ol.ENABLE_PROJ4JS && !goog.isDef(projection) &&
-        goog.isFunction(proj4)) {
+        goog.isFunction(goog.global.proj4)) {
       var def = proj4.defs(code);
       if (goog.isDef(def)) {
         var units = def.units;


### PR DESCRIPTION
This fixes a regression introduced with #1228.
