### PR TITLE
Check for proj4 in a way that also works in module environments

### DIFF
--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -468,7 +468,7 @@ ol.proj.get = function(projectionLike) {
     var projections = ol.proj.projections_;
     projection = projections[code];
     if (ol.ENABLE_PROJ4JS && !goog.isDef(projection) &&
-        goog.isFunction(goog.global.proj4)) {
+        typeof proj4 == 'function') {
       var def = proj4.defs(code);
       if (goog.isDef(def)) {
         var units = def.units;


### PR DESCRIPTION
This is better than #2330, and it should also address @probins's [concern](https://github.com/openlayers/ol3/pull/2330#issuecomment-48630893).
