### PR TITLE
Add tilePixelRatio option to ol.source.XYZ

### DIFF
--- a/examples/xyz-retina.html
+++ b/examples/xyz-retina.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>XYZ Retina tiles example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">XYZ with Retina tiles example</h4>
+          <p id="shortdesc">Example of Retina / HiDPI mercator tiles (512x512px) available as XYZ.</p>
+          <div id="docs">
+              <p>The ol.source.XYZ must contain <code>tilePixelRatio</code> parameter. The tiles were prepared from a GeoTIFF file with <a href="http://www.maptiler.com/">MapTiler</a>.</p>
+            <p>See the <a href="xyz-retina.js" target="_blank">xyz-retina.js source</a> for details on how this is done.</p>
+          </div>
+          <div id="tags">retina, hidpi, xyz, maptiler, @2x, devicePixelRatio</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=xyz-retina" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/xyz-retina.js
+++ b/examples/xyz-retina.js
@@ -1,0 +1,41 @@
+goog.require('ol.Attribution');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.OSM');
+goog.require('ol.source.XYZ');
+
+
+var attribution = new ol.Attribution({
+  html: 'Tiles rendered with <a href="http://www.maptiler.com/"> &copy; USGS'
+});
+
+var mapMinZoom = 1;
+var mapMaxZoom = 15;
+var mapExtent = [-112.261791, 35.983744, -112.113981, 36.132062];
+
+var map = new ol.Map({
+  target: 'map',
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    }),
+    new ol.layer.Tile({
+      source: new ol.source.XYZ({
+        url: 'http://tileserver.maptiler.com/grandcanyon@2x/{z}/{x}/{y}.png',
+        tilePixelRatio: 2, // THIS IS IMPORTANT
+        maxExtent: ol.proj.transformExtent(
+            mapExtent, 'EPSG:4326', 'EPSG:3857'),
+        minZoom: mapMinZoom,
+        maxZoom: mapMaxZoom
+      })
+    })
+  ],
+  view: new ol.View({
+    projection: 'EPSG:3857',
+    center: ol.proj.transform([-112.18688965, 36.057944835],
+        'EPSG:4326', 'EPSG:3857'),
+    zoom: 12
+  })
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4357,6 +4357,7 @@ olx.source.WMTSOptions.prototype.urls;
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     tilePixelRatio: (number|undefined),
  *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
  *     url: (string|undefined),
  *     urls: (Array.<string>|undefined),
@@ -4420,6 +4421,16 @@ olx.source.XYZOptions.prototype.minZoom;
  * @type {ol.TileLoadFunctionType|undefined}
  */
 olx.source.XYZOptions.prototype.tileLoadFunction;
+
+
+/**
+ * The pixel ratio used by the tile service. For example, if the tile
+ * service advertizes 256px by 256px tiles but actually sends 512px
+ * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
+ * should be set to `2`. Default is `1`.
+ * @type {number|undefined}
+ */
+olx.source.XYZOptions.prototype.tilePixelRatio;
 
 
 /**

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -35,6 +35,7 @@ ol.source.XYZ = function(options) {
     projection: projection,
     tileGrid: tileGrid,
     tileLoadFunction: options.tileLoadFunction,
+    tilePixelRatio: options.tilePixelRatio,
     tileUrlFunction: ol.TileUrlFunction.nullTileUrlFunction
   });
 


### PR DESCRIPTION
This PR supersedes #2308. It squashes @klokan's commits into a single commit, and uses the `ol.proj.transformExtent` as suggested in a comment in #2308.

I'll merge this before gamma.2.

Fixes #2308.
Fixes #1905.
