### PR TITLE
Add maxZoom to ol.View.fitGeometry() options

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5070,6 +5070,14 @@ olx.View.fitGeometryOptions.prototype.nearest;
 olx.View.fitGeometryOptions.prototype.minResolution;
 
 
+/**
+ * Maximum zoom level that we zoom to. If `minResolution` is given,
+ * this property is ignored.
+ * @type {number|undefined}
+ */
+olx.View.fitGeometryOptions.prototype.maxZoom;
+
+
 /* typedefs for object literals exposed by the library */
 
 

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -462,8 +462,15 @@ ol.View.prototype.fitGeometry = function(geometry, size, opt_options) {
   var constrainResolution = goog.isDef(options.constrainResolution) ?
       options.constrainResolution : true;
   var nearest = goog.isDef(options.nearest) ? options.nearest : false;
-  var minResolution = goog.isDef(options.minResolution) ?
-      options.minResolution : 0;
+  var minResolution;
+  if (goog.isDef(options.minResolution)) {
+    minResolution = options.minResolution;
+  } else if (goog.isDef(options.maxZoom)) {
+    minResolution = this.constrainResolution(
+        this.maxResolution_, options.maxZoom - this.minZoom_, 0);
+  } else {
+    minResolution = 0;
+  }
   var coords = geometry.getFlatCoordinates();
 
   // calculate rotated extent

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -401,6 +401,19 @@ describe('ol.View', function() {
       expect(view.getCenter()[0]).to.be(5900);
       expect(view.getCenter()[1]).to.be(46100);
 
+      view.fitGeometry(
+          new ol.geom.Point([6000, 46000]),
+          [200, 200],
+          {
+            padding: [100, 0, 0, 100],
+            maxZoom: 6
+          }
+      );
+      expect(view.getResolution()).to.be(2);
+      expect(view.getZoom()).to.be(6);
+      expect(view.getCenter()[0]).to.be(5900);
+      expect(view.getCenter()[1]).to.be(46100);
+
       view.setRotation(Math.PI / 4);
       view.fitGeometry(
           new ol.geom.LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),


### PR DESCRIPTION
For convenience, allow to specify `maxZoom` as alternative to `minResolution` in the options of `ol.View.fitGeometry()`.
