### PR TITLE
Make internal proj constructors private

### DIFF
--- a/apidoc/index.md
+++ b/apidoc/index.md
@@ -30,7 +30,7 @@ Interactions for [vector features](ol.Feature.html)
 <br>[Formats](ol.format.Feature.html) for reading/writing vector data
 <br>[ol.format.WMSCapabilities](ol.format.WMSCapabilities.html)</td></tr>
 <tr><th>Projections</th><th>2-way bindings</th><th>Other components</th></tr>
-<tr><td><p>All coordinates and extents need to be provided in view projection (default: [EPSG:3857](ol.proj.EPSG3857.html)). To transform, use [ol.proj.transform()](ol.proj.html#transform) and [ol.extent.applyTransform()](ol.extent.html#applyTransform).</p>
+<tr><td><p>All coordinates and extents need to be provided in view projection (default: EPSG:3857). To transform, use [ol.proj.transform()](ol.proj.html#transform) and [ol.extent.applyTransform()](ol.extent.html#applyTransform).</p>
 [ol.proj](ol.proj.html)</td>
 <td><p>[Objects](ol.Object.html) can be kept in sync using the [bindTo()](ol.Object.html#bindTo) method.</p>
 <p>A [DOM Input](ol.dom.Input.html) class is available to bind Object properties to HTML Input elements.</p></td>

--- a/src/ol/proj/epsg3857projection.js
+++ b/src/ol/proj/epsg3857projection.js
@@ -16,9 +16,9 @@ goog.require('ol.proj.Units');
  * @constructor
  * @extends {ol.proj.Projection}
  * @param {string} code Code.
- * @api
+ * @private
  */
-ol.proj.EPSG3857 = function(code) {
+ol.proj.EPSG3857_ = function(code) {
   goog.base(this, {
     code: code,
     units: ol.proj.Units.METERS,
@@ -26,7 +26,15 @@ ol.proj.EPSG3857 = function(code) {
     global: true
   });
 };
-goog.inherits(ol.proj.EPSG3857, ol.proj.Projection);
+goog.inherits(ol.proj.EPSG3857_, ol.proj.Projection);
+
+
+/**
+ * @inheritDoc
+ */
+ol.proj.EPSG3857_.prototype.getPointResolution = function(resolution, point) {
+  return resolution / ol.math.cosh(point[1] / ol.proj.EPSG3857.RADIUS);
+};
 
 
 /**
@@ -77,7 +85,7 @@ ol.proj.EPSG3857.CODES = [
 ol.proj.EPSG3857.PROJECTIONS = goog.array.map(
     ol.proj.EPSG3857.CODES,
     function(code) {
-      return new ol.proj.EPSG3857(code);
+      return new ol.proj.EPSG3857_(code);
     });
 
 
@@ -138,12 +146,4 @@ ol.proj.EPSG3857.toEPSG4326 = function(input, opt_output, opt_dimension) {
         Math.exp(input[i + 1] / ol.proj.EPSG3857.RADIUS)) / Math.PI - 90;
   }
   return output;
-};
-
-
-/**
- * @inheritDoc
- */
-ol.proj.EPSG3857.prototype.getPointResolution = function(resolution, point) {
-  return resolution / ol.math.cosh(point[1] / ol.proj.EPSG3857.RADIUS);
 };

--- a/src/ol/proj/epsg4326projection.js
+++ b/src/ol/proj/epsg4326projection.js
@@ -18,9 +18,9 @@ goog.require('ol.proj.Units');
  * @extends {ol.proj.Projection}
  * @param {string} code Code.
  * @param {string=} opt_axisOrientation Axis orientation.
- * @api
+ * @private
  */
-ol.proj.EPSG4326 = function(code, opt_axisOrientation) {
+ol.proj.EPSG4326_ = function(code, opt_axisOrientation) {
   goog.base(this, {
     code: code,
     units: ol.proj.Units.DEGREES,
@@ -29,7 +29,15 @@ ol.proj.EPSG4326 = function(code, opt_axisOrientation) {
     global: true
   });
 };
-goog.inherits(ol.proj.EPSG4326, ol.proj.Projection);
+goog.inherits(ol.proj.EPSG4326_, ol.proj.Projection);
+
+
+/**
+ * @inheritDoc
+ */
+ol.proj.EPSG4326_.prototype.getPointResolution = function(resolution, point) {
+  return resolution;
+};
 
 
 /**
@@ -48,19 +56,11 @@ ol.proj.EPSG4326.EXTENT = [-180, -90, 180, 90];
  * @type {Array.<ol.proj.Projection>}
  */
 ol.proj.EPSG4326.PROJECTIONS = [
-  new ol.proj.EPSG4326('CRS:84'),
-  new ol.proj.EPSG4326('EPSG:4326', 'neu'),
-  new ol.proj.EPSG4326('urn:ogc:def:crs:EPSG:6.6:4326', 'neu'),
-  new ol.proj.EPSG4326('urn:ogc:def:crs:OGC:1.3:CRS84'),
-  new ol.proj.EPSG4326('urn:ogc:def:crs:OGC:2:84'),
-  new ol.proj.EPSG4326('http://www.opengis.net/gml/srs/epsg.xml#4326', 'neu'),
-  new ol.proj.EPSG4326('urn:x-ogc:def:crs:EPSG:4326', 'neu')
+  new ol.proj.EPSG4326_('CRS:84'),
+  new ol.proj.EPSG4326_('EPSG:4326', 'neu'),
+  new ol.proj.EPSG4326_('urn:ogc:def:crs:EPSG:6.6:4326', 'neu'),
+  new ol.proj.EPSG4326_('urn:ogc:def:crs:OGC:1.3:CRS84'),
+  new ol.proj.EPSG4326_('urn:ogc:def:crs:OGC:2:84'),
+  new ol.proj.EPSG4326_('http://www.opengis.net/gml/srs/epsg.xml#4326', 'neu'),
+  new ol.proj.EPSG4326_('urn:x-ogc:def:crs:EPSG:4326', 'neu')
 ];
-
-
-/**
- * @inheritDoc
- */
-ol.proj.EPSG4326.prototype.getPointResolution = function(resolution, point) {
-  return resolution;
-};


### PR DESCRIPTION
The `ol.proj.EPSG3857` and `ol.proj.EPSG4326` constructors were not used outside the modules where they are defined.  The change here renames these constructors to make them private.  Since we do use other constants in the `ol.proj.EPSG3857` and `ol.proj.EPSG4326` namespaces, those are still provided.

We are left with the `ol.proj.CH` projection subclass, which is not used in the library and is a potential candidate for removal.  I could add a commit that removes [`chprojection.js`](https://github.com/tschaub/ol3/blob/521cbfb1b0c4cebe6affda350cefae8e27160209/src/ol/proj/chprojection.js), but will wait to hear comments from anyone else who might see utility in it (@fredj?).

This is an alternative to #2328.
