### PR TITLE
Build cleanups

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,6 @@ if sys.platform == 'win32':
         'CLEANCSS': './node_modules/.bin/cleancss',
         'GIT': 'git.exe',
         'GJSLINT': 'gjslint.exe',
-        'JAVA': 'java.exe',
         'JSDOC': './node_modules/.bin/jsdoc',
         'JSHINT': './node_modules/.bin/jshint',
         'PYTHON': 'python.exe',
@@ -28,22 +27,6 @@ if sys.platform == 'win32':
 
     sys_dir = os.environ.get('SYSTEMDRIVE')
     program_files = os.environ.get('PROGRAMFILES')
-    java_home = os.environ.get('JAVA_HOME')
-
-    if not java_home:
-        # Following lines choose sensible defaults to guess JAVA_HOME in
-        # 32/64bit Program Files folder opting for the most current version.
-        search_term = os.path.join(sys_dir, os.sep, 'Program Files*', 'Java', 'jdk*')
-        found_jdks = sorted(glob.glob(search_term), key=lambda x: x[-8:])
-        if found_jdks:
-            java_home = found_jdks[-1]
-
-    if java_home:
-        if not which(win['JAVA']):
-            win['JAVA'] = os.path.join(java_home, 'bin', 'java.exe')
-    elif not which(win['JAVA']):
-        win['JAVA'] = os.path.join(program_files,
-                                   'Java', 'jre7', 'bin', 'java.exe')
 
     if not which(win['GIT']):
         win['GIT'] = os.path.join(program_files, 'Git', 'cmd', 'git.exe')
@@ -72,7 +55,6 @@ else:
     variables.GIT = 'git'
     variables.GJSLINT = 'gjslint'
     variables.JSHINT = './node_modules/.bin/jshint'
-    variables.JAVA = 'java'
     variables.JSDOC = './node_modules/.bin/jsdoc'
     variables.PYTHON = 'python'
     variables.PHANTOMJS = './node_modules/.bin/phantomjs'
@@ -81,8 +63,8 @@ variables.BRANCH = output(
     '%(GIT)s', 'rev-parse', '--abbrev-ref', 'HEAD').strip()
 
 EXECUTABLES = [variables.CLEANCSS, variables.GIT, variables.GJSLINT,
-               variables.JAVA, variables.JSDOC, variables.JSHINT,
-               variables.PYTHON, variables.PHANTOMJS]
+               variables.JSDOC, variables.JSHINT, variables.PYTHON,
+               variables.PHANTOMJS]
 
 EXAMPLES = [path
             for path in ifind('examples')


### PR DESCRIPTION
The `build.py` script doesn't need to run `generate-exports.js` directly.  In addition, `build.py` doesn't run `java` or `jar` directly.

Fixes #2337.
