### PR TITLE
Fix the export map example

### DIFF
--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -31,7 +31,7 @@ if ('download' in exportPNGElement) {
       var canvas = event.context.canvas;
       exportPNGElement.href = canvas.toDataURL('image/png');
     });
-    map.render();
+    map.renderSync();
   }, false);
 } else {
   var info = document.getElementById('no-download');


### PR DESCRIPTION
As @barbalex discovered, the map needs to be rendered synchronously for the export map example to work.

While it is nice to have a justification for synchronous map rendering, I'll point out that it really shouldn't be necessary to re-render the map in this example.  Ideally, a click would just grab the pixels that are already rendered.  So I don't think that this is a solid justification for synchronous map rendering.  But this would involve exposing the map canvas in a different way (not just in a render event).  If we didn't have a `renderSync` method and didn't want to expose another method for getting the map canvas, we still could make this example work by rendering asynchronously, creating a new (hidden) anchor element on the first `postcompose`, setting its `href` to the rendered data, and invoking its `click` method.  But this would make for some pretty ugly example code.

Anyway, nice fix @barbalex (can you tell there is some history here?).

Fixes #2341.
