### PR TITLE
Enable ProjectionLike on getGetFeatureInfoUrl

### DIFF
--- a/examples/getfeatureinfo.js
+++ b/examples/getfeatureinfo.js
@@ -18,8 +18,6 @@ var view = new ol.View({
   zoom: 1
 });
 
-var viewProjection = view.getProjection();
-
 var map = new ol.Map({
   layers: [wmsLayer],
   target: 'map',
@@ -30,7 +28,7 @@ map.on('singleclick', function(evt) {
   document.getElementById('info').innerHTML = '';
   var viewResolution = /** @type {number} */ (view.getResolution());
   var url = wmsSource.getGetFeatureInfoUrl(
-      evt.coordinate, viewResolution, viewProjection,
+      evt.coordinate, viewResolution, 'EPSG:3857',
       {'INFO_FORMAT': 'text/html'});
   if (url) {
     document.getElementById('info').innerHTML =

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -14,6 +14,7 @@ goog.require('ol');
 goog.require('ol.TileCoord');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.extent');
+goog.require('ol.proj');
 goog.require('ol.source.TileImage');
 goog.require('ol.source.wms');
 goog.require('ol.source.wms.ServerType');
@@ -121,7 +122,7 @@ goog.inherits(ol.source.TileWMS, ol.source.TileImage);
  * constructed.
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
- * @param {ol.proj.Projection} projection Projection.
+ * @param {ol.proj.ProjectionLike} projection Projection.
  * @param {!Object} params GetFeatureInfo params. `INFO_FORMAT` at least should
  *     be provided. If `QUERY_LAYERS` is not provided then the layers specified
  *     in the `LAYERS` parameter will be used. `VERSION` should not be
@@ -139,9 +140,11 @@ ol.source.TileWMS.prototype.getGetFeatureInfoUrl =
     return undefined;
   }
 
+  var projectionObj = ol.proj.get(projection);
+
   var tileGrid = this.getTileGrid();
   if (goog.isNull(tileGrid)) {
-    tileGrid = this.getTileGridForProjection(projection);
+    tileGrid = this.getTileGridForProjection(projectionObj);
   }
 
   var tileCoord = tileGrid.getTileCoordForCoordAndResolution(
@@ -185,7 +188,7 @@ ol.source.TileWMS.prototype.getGetFeatureInfoUrl =
   goog.object.set(baseParams, this.v13_ ? 'J' : 'Y', y);
 
   return this.getRequestUrl_(tileCoord, tileSize, tileExtent,
-      pixelRatio, projection, baseParams);
+      pixelRatio, projectionObj, baseParams);
 };
 
 


### PR DESCRIPTION
I think as a general rule all projection api params/options should be ProjectionLike and not require that apps create a Projection object. TileWMS.getGetFeatureInfoUrl (what an ugly name!) is one that isn't, so this PR changes that.

This means that examples/getfeatureinfo can be simplified (remove a type cast).

If there are other params/options that require a Projection object, I think they should also be changed.
