### PR TITLE
Document build.js issue with deleted symbols

### DIFF
--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -84,6 +84,8 @@ To export the `ol` symbol to somewhere other than the global namespace, a `names
 
 The `defines` section of `build.json` above lists common settings for the Closure library in production code. The OL3 library also defines constants that can be set in this section at compile time. These are all defined in the `ol.js` source file; see the comments in this file to see what effect setting these would have. Some of them can reduce the size of the build in advanced mode.
 
+__Note__: if this script fails with undefined symbol/property errors, try deleting `build/info.json` (see below) and re-running.
+
 ## `generate-exports.js`
 
 Called internally to generate a `build/exports.js` file optionally with a limited set of exports.


### PR DESCRIPTION
I reported this issue in https://groups.google.com/d/msg/ol3-dev/bMEyHJAY0Is/JzK5OqJDiQUJ and it has just come up again after #2159 which removed control.Logo. It only occurs when symbols are removed from the api, which won't happen very often. There is an easy work-around, so I'm not sure it makes sense working on a  software fix; on the other hand, the problem is likely to baffle those running build.js, so I'd suggest adding a comment to the readme.
