### PR TITLE
Always regenerate info using all sources if any have changed

### DIFF
--- a/buildcfg/jsdoc/info/publish.js
+++ b/buildcfg/jsdoc/info/publish.js
@@ -48,7 +48,6 @@ exports.publish = function(data, opts) {
         name: doc.longname,
         kind: doc.kind,
         description: doc.classdesc || doc.description,
-        extends: doc.augments,
         path: path.join(doc.meta.path, doc.meta.filename)
       });
     }


### PR DESCRIPTION
Because we don't know if a new or modified file includes changes to the class hierarchy, we regenerate info for all sources any time any one has changed.  An alternative would be to generate info first for the new or modified file and then (potentially) regenerate info for more source files in the class hierarchy, but this makes the `generate-info.js` task far more complicated.

Fixes #2352.
