### PR TITLE
Tag always exported methods as api/observable

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -111,6 +111,7 @@ ol.Feature.prototype.clone = function() {
 /**
  * @return {ol.geom.Geometry|undefined} Geometry.
  * @api
+ * @observable
  */
 ol.Feature.prototype.getGeometry = function() {
   return /** @type {ol.geom.Geometry|undefined} */ (
@@ -187,6 +188,7 @@ ol.Feature.prototype.handleGeometryChanged_ = function() {
 /**
  * @param {ol.geom.Geometry|undefined} geometry Geometry.
  * @api
+ * @observable
  */
 ol.Feature.prototype.setGeometry = function(geometry) {
   this.set(this.geometryName_, geometry);

--- a/src/ol/layer/heatmaplayer.js
+++ b/src/ol/layer/heatmaplayer.js
@@ -157,6 +157,8 @@ ol.layer.Heatmap.createCircle_ = function(radius, blur, shadow) {
 
 /**
  * @return {Array.<string>} Colors.
+ * @api
+ * @observable
  */
 ol.layer.Heatmap.prototype.getGradient = function() {
   return /** @type {Array.<string>} */ (
@@ -201,6 +203,8 @@ ol.layer.Heatmap.prototype.handleRender_ = function(event) {
 
 /**
  * @param {Array.<string>} colors Gradient.
+ * @api
+ * @observable
  */
 ol.layer.Heatmap.prototype.setGradient = function(colors) {
   this.set(ol.layer.HeatmapLayerProperty.GRADIENT, colors);


### PR DESCRIPTION
Fixes #2145. As discussed there, I'm assuming that these are currently in error, and that all always exported methods should be both api and observable.
