### PR TITLE
Add color to api docs

### DIFF
--- a/src/ol/color/color.js
+++ b/src/ol/color/color.js
@@ -18,6 +18,7 @@ goog.require('ol');
  * red, green, and blue should be integers in the range 0..255 inclusive.
  * alpha should be a float in the range 0..1 inclusive.
  * @typedef {Array.<number>}
+ * @api
  */
 ol.Color;
 

--- a/src/ol/color/color.jsdoc
+++ b/src/ol/color/color.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace ol.color
+ */


### PR DESCRIPTION
`ol.color` is currently being exported, but does not appear in api docs. `ol.Color` is a type used by styles but is not currently exported. This PR fixes both of these
