### PR TITLE
Fix jshint issues in apidoc/plugins

### DIFF
--- a/apidoc/plugins/api.js
+++ b/apidoc/plugins/api.js
@@ -72,7 +72,6 @@ function includeAugments(doclet) {
 }
 
 var api = [];
-var augments = {};
 var classes = {};
 
 exports.handlers = {

--- a/apidoc/plugins/events.js
+++ b/apidoc/plugins/events.js
@@ -19,7 +19,7 @@ exports.handlers = {
 
   parseComplete: function(e) {
     var doclets = e.doclets;
-    var eventClass, doclet, i, ii, j, jj, event, fires;
+    var doclet, i, ii, j, jj, event, fires;
     for (i = 0, ii = doclets.length - 1; i < ii; ++i) {
       doclet = doclets[i];
       if (doclet.fires) {

--- a/apidoc/plugins/inheritdoc.js
+++ b/apidoc/plugins/inheritdoc.js
@@ -87,7 +87,7 @@ exports.handlers = {
               for (l = candidates.length - 1; l >= 0; --l) {
                 candidate = candidates[l];
                 if (candidate && !candidate.inheritdoc) {
-                  stability = candidate.stability || incompleteDoclet.stability
+                  stability = candidate.stability || incompleteDoclet.stability;
                   if (stability) {
                     incompleteDoclet.stability = stability;
                     for (key in candidate) {

--- a/apidoc/plugins/interface.js
+++ b/apidoc/plugins/interface.js
@@ -1,4 +1,3 @@
-var util = require('util');
 exports.defineTags = function(dictionary) {
 
   var classTag = dictionary.lookUp('class');

--- a/apidoc/plugins/observable.js
+++ b/apidoc/plugins/observable.js
@@ -44,7 +44,7 @@ exports.handlers = {
         if (!cls.fires) {
           cls.fires = [];
         }
-        var event = 'ol.ObjectEvent#event:change:' + name.toLowerCase();
+        event = 'ol.ObjectEvent#event:change:' + name.toLowerCase();
         if (cls.fires.indexOf(event) == -1) {
           cls.fires.push(event);
         }


### PR DESCRIPTION
Whilst I was looking into the events issue in the docs, my editor informed me of some unused variables and other issues in the plugins. I ran jshint and corrected these issues.

It might be a good idea for the jshint build target to include these.
