### PR TITLE
ol.format.GPX writeFeatures is not working

### DIFF
--- a/examples/gpx.html
+++ b/examples/gpx.html
@@ -25,6 +25,12 @@
       <div class="row-fluid">
         <div class="span12">
           <div id="map" class="map"></div>
+          <div id="no-download" class="alert alert-error" style="display: none">
+            The "Export GPX" functionality requires a browser that supports the
+            <a href="http://caniuse.com/#feat=download">link download</a> attribute.
+          </div>
+          <a id="export-gpx" class="btn" download="map.gpx"><i class="icon-download"></i>Export GPX</a>
+        </div>
         </div>
       </div>
 

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -1,13 +1,17 @@
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.format.GPX');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
+goog.require('ol.proj');
 goog.require('ol.source.BingMaps');
 goog.require('ol.source.GPX');
 goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
+
+var projection = ol.proj.get('EPSG:3857');
 
 var raster = new ol.layer.Tile({
   source: new ol.source.BingMaps({
@@ -45,7 +49,7 @@ var style = {
 
 var vector = new ol.layer.Vector({
   source: new ol.source.GPX({
-    projection: 'EPSG:3857',
+    projection: projection,
     url: 'data/gpx/fells_loop.gpx'
   }),
   style: function(feature, resolution) {
@@ -89,3 +93,30 @@ $(map.getViewport()).on('mousemove', function(evt) {
 map.on('click', function(evt) {
   displayFeatureInfo(evt.pixel);
 });
+
+var exportGPXElement = document.getElementById('export-gpx');
+if ('download' in exportGPXElement) {
+  var vectorSource = /** @type {ol.source.Vector} */ (vector.getSource());
+  exportGPXElement.addEventListener('click', function(e) {
+    if (!exportGPXElement.href) {
+      var features = [];
+      vectorSource.forEachFeature(function(feature) {
+        var clone = feature.clone();
+        clone.getGeometry().transform(projection, 'EPSG:4326');
+        features.push(clone);
+      });
+      var node = new ol.format.GPX().writeFeatures(features);
+      var string = new XMLSerializer().serializeToString(
+          /** @type {Node} */ (node));
+      var base64 = exampleNS.strToBase64(string);
+      exportGPXElement.href =
+          'data:gpx+xml;base64,' + base64;
+    }
+  }, false);
+} else {
+  var info = document.getElementById('no-download');
+  /**
+   * display error message
+   */
+  info.style.display = '';
+}

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -1,5 +1,4 @@
 goog.provide('ol.format.GPX');
-goog.provide('ol.format.GPX.V1_1');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
@@ -794,17 +793,6 @@ ol.format.GPX.GPX_SERIALIZERS_ = ol.xml.makeStructureNS(
     });
 
 
-
-/**
- * @constructor
- * @extends {ol.format.GPX}
- */
-ol.format.GPX.V1_1 = function() {
-  goog.base(this);
-};
-goog.inherits(ol.format.GPX.V1_1, ol.format.GPX);
-
-
 /**
  * Encode an array of features in the GPX format.
  *
@@ -819,7 +807,7 @@ ol.format.GPX.prototype.writeFeatures;
 /**
  * @inheritDoc
  */
-ol.format.GPX.V1_1.prototype.writeFeaturesNode = function(features) {
+ol.format.GPX.prototype.writeFeaturesNode = function(features) {
   //FIXME Serialize metadata
   var gpx = ol.xml.createElementNS('http://www.topografix.com/GPX/1/1', 'gpx');
   ol.xml.pushSerializeAndPop(/** @type {ol.xml.NodeStackItem} */

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -5,7 +5,7 @@ describe('ol.format.GPX', function() {
 
   var format;
   beforeEach(function() {
-    format = new ol.format.GPX.V1_1();
+    format = new ol.format.GPX();
   });
 
   describe('readFeatures', function() {
@@ -401,7 +401,6 @@ describe('ol.format.GPX', function() {
 
 goog.require('ol.Feature');
 goog.require('ol.format.GPX');
-goog.require('ol.format.GPX.V1_1');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.MultiLineString');
 goog.require('ol.geom.Point');


### PR DESCRIPTION
I have tried to export layers to these formats: 
- GeoJSON
- KML
- GPX

using 

```
new ol.format
```

then

```
writeFeatures(features)
```

This only works for me when I use GeoJSON.

With KML and GPX 'writeFeatures(features)' returns

```
TypeError: undefined is not a function
```

See the demo: http://codepen.io/barbalex/pen/IDwrj (try setting the 'Data type' to 'KML')
