### PR TITLE
Remove ol.pointer.PointerEvent.createMouseEvent

### DIFF
--- a/src/ol/pointer/pointerevent.js
+++ b/src/ol/pointer/pointerevent.js
@@ -258,19 +258,6 @@ ol.pointer.PointerEvent.prototype.getPressure_ = function(eventDict, buttons) {
 
 
 /**
- * Warning is suppressed because Closure thinks the MouseEvent
- * constructor takes no arguments.
- * @param {string} inType The type of the event to create.
- * @param {Object} inDict An dictionary of initial event properties.
- * @return {MouseEvent}
- * @suppress {checkTypes}
- */
-ol.pointer.PointerEvent.createMouseEvent = function(inType, inDict) {
-  return new MouseEvent(inType, inDict);
-};
-
-
-/**
  * Is the `buttons` property supported?
  * @type {boolean}
  */
@@ -282,7 +269,7 @@ ol.pointer.PointerEvent.HAS_BUTTONS = false;
  */
 (function() {
   try {
-    var ev = ol.pointer.PointerEvent.createMouseEvent('click', {buttons: 1});
+    var ev = new MouseEvent('click', {buttons: 1});
     ol.pointer.PointerEvent.HAS_BUTTONS = ev.buttons === 1;
   } catch (e) {
   }


### PR DESCRIPTION
The externs declarations for MouseEvent are now fixed upstream
