### PR TITLE
Build css if source is newer

### DIFF
--- a/build.py
+++ b/build.py
@@ -136,7 +136,7 @@ virtual('check', 'lint', 'jshint', 'test')
 virtual('todo', 'fixme')
 
 
-@target('build/ol.css')
+@target('build/ol.css', 'css/ol.css')
 def build_ol_css(t):
     t.output('%(CLEANCSS)s', 'css/ol.css')
 


### PR DESCRIPTION
Previously, build/ol.css wasn't getting rebuilt on updates to css/ol.css.
