### PR TITLE
Reuse event pixel to compute the coordinate

### DIFF
--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -46,16 +46,16 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_frameState) {
   this.originalEvent = browserEvent.getBrowserEvent();
 
   /**
-   * @type {ol.Coordinate}
-   * @api
-   */
-  this.coordinate = map.getEventCoordinate(this.originalEvent);
-
-  /**
    * @type {ol.Pixel}
    * @api
    */
   this.pixel = map.getEventPixel(this.originalEvent);
+
+  /**
+   * @type {ol.Coordinate}
+   * @api
+   */
+  this.coordinate = map.getCoordinateFromPixel(this.pixel);
 
 };
 goog.inherits(ol.MapBrowserEvent, ol.MapEvent);


### PR DESCRIPTION
Avoid to call `ol.Map#getEventPixel` twice by reusing the pixel value.

Non functional change.
