### PR TITLE
Write library version in build files

### DIFF
--- a/buildcfg/ol.json
+++ b/buildcfg/ol.json
@@ -58,7 +58,7 @@
       "es5Strict"
     ],
     "compilation_level": "ADVANCED",
-    "output_wrapper": "// OpenLayers 3. See http://ol3.js.org/\n(function(){%output%})();",
+    "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true,
     "manage_closure_dependencies": true
   }


### PR DESCRIPTION
This PR adds the most recent Git tag (`git describe --tags`) to the build files.

The `ol.js` now looks like this:

```
// OpenLayers 3. See http://ol3.js.org/
// Version: v3.0.0-gamma.3
(function(){var ...
```

And `ol-debug.js`:

```
// OpenLayers 3. See http://ol3.js.org/
// Version: v3.0.0-gamma.3
var CLOSURE_NO_DEPS = true;
...
```

If there are further commits after the tag, you will also see the last commit. For example, after I made this commit, the version changed to `v3.0.0-gamma.3-1-g076f53c`.

Note that you'll have to run `git fetch upstream --tags` to get all remote tags.

closes #1792
