### PR TITLE
Add Closure lib/compiler version to build fileHeader

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -218,10 +218,13 @@ function addFileHeader(compiledSource, callback) {
     }
     var fileHeader = 
           '// OpenLayers 3. See http://ol3.js.org/\n' +
-          '// Version: ' + version;
+          '// Version: ' + version +
+          '// Compiled with Closure library ' +
+          path.basename(closure.getLibraryPath()) + '\n' +
+          '// and compiler ' + path.basename(closure.getCompilerPath()) + '\n';
     callback(null, fileHeader + compiledSource);
   });
-};
+}
 
 
 /**


### PR DESCRIPTION
adds slightly to build size, but gives a bit more information on build status.

While I was at it, my editor complained about a surplus ';', so I removed that too.

Fixes #1192
