### PR TITLE
Add ol.version

### DIFF
--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -4,6 +4,23 @@ goog.provide('ol');
 
 
 /**
+ * The version number of the library.
+ *
+ * @type {string}
+ * @const
+ * @api
+ */
+ol.version = (function() {
+  var major = 3,
+      minor = 0,
+      patch = 0,
+      label = 'gamma.4.dev';
+  return 'v' + major + '.' + minor + '.' + patch + (label ? '-' + label : '');
+})();
+
+
+
+/**
  * Constants defined with the define tag cannot be changed in application
  * code, but can be set at compile time.
  * Some reduce the size of the build in advanced compile mode.

--- a/test/spec/ol/ol.test.js
+++ b/test/spec/ol/ol.test.js
@@ -1,0 +1,25 @@
+goog.provide('ol.test.ol');
+
+describe('ol', function() {
+
+  describe('lives in ol namespace', function() {
+    expect(ol).not.to.be(undefined);
+    expect(ol).to.be.a(Object);
+  });
+
+  describe('is versioned', function() {
+
+    it('has version-attribute', function() {
+      expect(ol.version).not.to.be(undefined);
+    });
+
+    it('has a version starting with "v3"', function() {
+      expect(/^v3/.test(ol.version)).to.be(true);
+    });
+
+  });
+
+});
+
+
+goog.require('ol');


### PR DESCRIPTION
This PR suggests adding a property `ol.version` which will hold the version number of the library. I think it makes a lot of sense to have such version information available not only in the file header, but also as a property of the library itself.

This property must be set manually before releasing.

Please share your thoughts on this.
