### PR TITLE
Add workaround for mousewheel event name

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -263,7 +263,8 @@ ol.Map = function(options) {
     goog.events.EventType.TOUCHSTART,
     goog.events.EventType.MSPOINTERDOWN,
     ol.MapBrowserEvent.EventType.POINTERDOWN,
-    goog.events.MouseWheelHandler.EventType.MOUSEWHEEL
+    // see https://github.com/google/closure-library/pull/308
+    goog.userAgent.GECKO ? 'DOMMouseScroll' : 'mousewheel'
   ], goog.events.Event.stopPropagation);
   goog.dom.appendChild(this.viewport_, this.overlayContainerStopEvent_);
 


### PR DESCRIPTION
'DOMMouseScroll' for Gecko and 'mousewheel' otherwise.

See https://github.com/google/closure-library/pull/308

Fixes #2460
