### PR TITLE
Rename olx.FrameState#skippedFeatureUids_ skippedFeatureUids

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5131,7 +5131,7 @@ olx.View.fitGeometryOptions.prototype.maxZoom;
  *     pixelToCoordinateMatrix: goog.vec.Mat4.Number,
  *     postRenderFunctions: Array.<ol.PostRenderFunction>,
  *     size: ol.Size,
- *     skippedFeatureUids_: Object.<string, boolean>,
+ *     skippedFeatureUids: Object.<string, boolean>,
  *     tileQueue: ol.TileQueue,
  *     time: number,
  *     usedTiles: Object.<string, Object.<string, ol.TileRange>>,

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1216,7 +1216,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
       pixelToCoordinateMatrix: this.pixelToCoordinateMatrix_,
       postRenderFunctions: [],
       size: size,
-      skippedFeatureUids_: this.skippedFeatureUids_,
+      skippedFeatureUids: this.skippedFeatureUids_,
       tileQueue: this.tileQueue_,
       time: time,
       usedTiles: {},

--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -53,7 +53,7 @@ ol.renderer.canvas.ImageLayer.prototype.forEachFeatureAtPixel =
   var extent = frameState.extent;
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
-  var skippedFeatureUids = frameState.skippedFeatureUids_;
+  var skippedFeatureUids = frameState.skippedFeatureUids;
   return source.forEachFeatureAtPixel(
       extent, resolution, rotation, coordinate, skippedFeatureUids,
       /**

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -96,7 +96,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame =
     replayContext.globalAlpha = layerState.opacity;
     replayGroup.replay(
         replayContext, frameState.extent, frameState.pixelRatio, transform,
-        frameState.viewState.rotation, frameState.skippedFeatureUids_);
+        frameState.viewState.rotation, frameState.skippedFeatureUids);
 
     if (replayContext != context) {
       this.dispatchRenderEvent(replayContext, frameState, transform);
@@ -122,7 +122,7 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtPixel =
     var rotation = frameState.viewState.rotation;
     var layer = this.getLayer();
     return this.replayGroup_.forEachGeometryAtPixel(extent, resolution,
-        rotation, coordinate, frameState.skippedFeatureUids_,
+        rotation, coordinate, frameState.skippedFeatureUids,
         /**
          * @param {ol.geom.Geometry} geometry Geometry.
          * @param {Object} data Data.

--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -58,7 +58,7 @@ ol.renderer.dom.ImageLayer.prototype.forEachFeatureAtPixel =
   var extent = frameState.extent;
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
-  var skippedFeatureUids = frameState.skippedFeatureUids_;
+  var skippedFeatureUids = frameState.skippedFeatureUids;
   return source.forEachFeatureAtPixel(
       extent, resolution, rotation, coordinate, skippedFeatureUids,
       /**

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -84,7 +84,7 @@ ol.renderer.webgl.ImageLayer.prototype.forEachFeatureAtPixel =
   var extent = frameState.extent;
   var resolution = frameState.viewState.resolution;
   var rotation = frameState.viewState.rotation;
-  var skippedFeatureUids = frameState.skippedFeatureUids_;
+  var skippedFeatureUids = frameState.skippedFeatureUids;
   return source.forEachFeatureAtPixel(
       extent, resolution, rotation, coordinate, skippedFeatureUids,
 


### PR DESCRIPTION
To let the ol.Map#skippedFeatureUids_ property to be renamed by the compiler.

fixes #2472
