### PR TITLE
Opacity of last layer is used in postcompose drawing

### DIFF
--- a/src/ol/renderer/canvas/canvaslayerrenderer.js
+++ b/src/ol/renderer/canvas/canvaslayerrenderer.js
@@ -45,6 +45,10 @@ ol.renderer.canvas.Layer.prototype.composeFrame =
   var image = this.getImage();
   if (!goog.isNull(image)) {
     var imageTransform = this.getImageTransform();
+    // for performance reasons, context.save / context.restore is not used
+    // to save and restore the transformation matrix and the opacity.
+    // see http://jsperf.com/context-save-restore-versus-variable
+    var alpha = context.globalAlpha;
     context.globalAlpha = layerState.opacity;
 
     // for performance reasons, context.setTransform is only used
@@ -67,6 +71,7 @@ ol.renderer.canvas.Layer.prototype.composeFrame =
       context.drawImage(image, 0, 0);
       context.setTransform(1, 0, 0, 1, 0, 0);
     }
+    context.globalAlpha = alpha;
   }
 
   this.dispatchPostComposeEvent(context, frameState);


### PR DESCRIPTION
Reported on the [mailing list](https://groups.google.com/forum/#!topic/ol3-dev/ksBhk80_aqE).

It seems that `context.globalAlpha` set in [ol.renderer.canvas.Layer.prototype.composeFrame](https://github.com/openlayers/ol3/blob/master/src/ol/renderer/canvas/canvaslayerrenderer.js#L48) is not restored after drawing…
