### PR TITLE
Unprecise transormation used in example

### DIFF
--- a/examples/wms-image-custom-proj.html
+++ b/examples/wms-image-custom-proj.html
@@ -46,7 +46,7 @@
 
     <script src="jquery.min.js" type="text/javascript"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/proj4js/2.2.1/proj4.js" type="text/javascript"></script>
-    <script src="http://epsg.io/21781.js" type="text/javascript"></script>
+    <script src="http://epsg.io/21781-1753.js" type="text/javascript"></script>
     <script src="../resources/example-behaviour.js" type="text/javascript"></script>
     <script src="loader.js?id=wms-image-custom-proj" type="text/javascript"></script>
 


### PR DESCRIPTION
In the image custom projection example [1], the projection used is coming from epsg.io [2], but this definition is currently wrong. The `towgs84` parameter lacks precision. Please compare with the old definition. Now, this certainly is an epsg.io problem, but I think you should be aware of that.

[1] https://github.com/openlayers/ol3/blob/master/examples/wms-image-custom-proj.html#L49
[2] http://epsg.io/21781.js
[3] http://cdnjs.cloudflare.com/ajax/libs/proj4js/1.1.0/defs/EPSG21781.js
