### PR TITLE
TileUrlFunction only replaces first instance of placeholder variables

### DIFF
--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -31,6 +31,10 @@ ol.TileCoordTransformType;
  * @return {ol.TileUrlFunctionType} Tile URL function.
  */
 ol.TileUrlFunction.createFromTemplate = function(template) {
+  var zRegEx = /\{z\}/g;
+  var xRegEx = /\{x\}/g;
+  var yRegEx = /\{y\}/g;
+  var dashYRegEx = /\{-y\}/g;
   return (
       /**
        * @param {ol.TileCoord} tileCoord Tile Coordinate.
@@ -42,10 +46,10 @@ ol.TileUrlFunction.createFromTemplate = function(template) {
         if (goog.isNull(tileCoord)) {
           return undefined;
         } else {
-          return template.replace('{z}', tileCoord.z.toString())
-                         .replace('{x}', tileCoord.x.toString())
-                         .replace('{y}', tileCoord.y.toString())
-                         .replace('{-y}', function() {
+          return template.replace(zRegEx, tileCoord.z.toString())
+                         .replace(xRegEx, tileCoord.x.toString())
+                         .replace(yRegEx, tileCoord.y.toString())
+                         .replace(dashYRegEx, function() {
                            var y = (1 << tileCoord.z) - tileCoord.y - 1;
                            return y.toString();
                          });


### PR DESCRIPTION
I'm using a local copy of OSM data which is stored on my site in a /{z}/{z}_{x}_{y}.png fashion.
The TileUrlFunction to do the replacement of the placeholder vars is only doing a simple replace, which gets the first search only. Please change to regex /g option to replace all instances, thanks!
I would offer patch, but I'm on Windows and have not been able to get dev env setup yet. This should be an easy fix:

``` js
ol.TileUrlFunction.createFromTemplate = function(template) {
  return (
      /**
       * @param {ol.TileCoord} tileCoord Tile Coordinate.
       * @param {number} pixelRatio Pixel ratio.
       * @param {ol.proj.Projection} projection Projection.
       * @return {string|undefined} Tile URL.
       */
      function(tileCoord, pixelRatio, projection) {
        if (goog.isNull(tileCoord)) {
          return undefined;
        } else {
          return template.replace(/\{z\}/g, tileCoord.z.toString())
                         .replace(/\{x\}/g, tileCoord.x.toString())
                         .replace(/\{y\}/g, tileCoord.y.toString())
                         .replace(/\{-y\}/g, function() {
                           var y = (1 << tileCoord.z) - tileCoord.y - 1;
                           return y.toString();
                         });
        }
      });
};
```
