### PR TITLE
bug fix to play nice with sencha touch 2.3

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -604,7 +604,7 @@ ol.Map.prototype.getEventPixel = function(event) {
   // So we ourselves compute the position of touch events.
   // See https://github.com/google/closure-library/pull/323
   if (goog.isDef(event.changedTouches)) {
-    var touch = event.changedTouches.item(0);
+    var touch = event.changedTouches[0];
     var viewportPosition = goog.style.getClientPosition(this.viewport_);
     return [
       touch.clientX - viewportPosition.x,


### PR DESCRIPTION
We have included ol3 map in a sencha touch 2.3 mobile application. Within the mobile app, the map crash as soon as we click on it. We have been able to pin point the problem (and do a dummy fix) with the ol-whitespace.js file.

OL3 version: 3.0.0-beta.5 
File: ol-whitespace.js

Line: 25856
var touch = event.changedTouches.item(0);
replaced by
var touch = event.changedTouches[0];

No more crash, the click event is now propagated successfully to the sencha app handlers.
