### PR TITLE
EPSG:4326 example broken

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -9,11 +9,9 @@ goog.require('ol.source.TileWMS');
 var layers = [
   new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
+      url: 'http://demo.opengeo.org/geoserver/wms',
       params: {
-        'VERSION': '1.1.1',
-        'LAYERS': 'basic',
-        'FORMAT': 'image/jpeg'
+        'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
       }
     })
   })

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -14,11 +14,9 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://vmap0.tiles.osgeo.org/wms/vmap0',
+        url: 'http://demo.opengeo.org/geoserver/wms',
         params: {
-          'VERSION': '1.1.1',
-          'LAYERS': 'basic',
-          'FORMAT': 'image/jpeg'
+          'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
         }
       })
     }),


### PR DESCRIPTION
The [EPSG:4326 example](http://ol3js.org/en/master/examples/epsg-4326.html) is currently not working.  Requests for [tiles like this](http://vmap0.tiles.osgeo.org/wms/vmap0?SERVICE=WMS&VERSION=1.1.1&REQUEST=Ge%E2%80%A6=basic&WIDTH=256&HEIGHT=256&SRS=EPSG%3A4326&STYLES=&BBOX=-90%2C-90%2C0%2C0) result in:

```
loadSymbolSet(): Unable to access file. (/mapdata/vmap.sym)
```

Rather than fix this, it would be nice to show something prettier than vmap0.  @bartvde @ahocevar should we commit to this layer being available?

``` js
  new ol.layer.Tile({
    source: new ol.source.TileWMS({
      url: 'http://demo.opengeo.org/geoserver/wms',
      params: {'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'}
    })
  })
```
