### PR TITLE
Fix missing API docs

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -23,13 +23,6 @@ olx.AttributionOptions.prototype.html;
 
 
 /**
- * Tile ranges (FOR INTERNAL USE ONLY).
- * @type {Object.<string, Array.<ol.TileRange>>|undefined}
- */
-olx.AttributionOptions.prototype.tileRanges;
-
-
-/**
  * @typedef {{loadTilesWhileAnimating: (boolean|undefined),
  *     loadTilesWhileInteracting: (boolean|undefined)}}
  * @api

--- a/src/ol/format.jsdoc
+++ b/src/ol/format.jsdoc
@@ -1,0 +1,3 @@
+/**
+ * @namespace ol.format
+ */

--- a/src/ol/format/igcformat.js
+++ b/src/ol/format/igcformat.js
@@ -11,7 +11,9 @@ goog.require('ol.proj');
 
 
 /**
+ * IGC altitude/z. One of 'barometric', 'gps', 'none'.
  * @enum {string}
+ * @api
  */
 ol.format.IGCZ = {
   BAROMETRIC: 'barometric',

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -65,17 +65,21 @@ ol.format.WFS.xmlns = 'http://www.w3.org/2000/xmlns/';
 
 
 /**
+ * Number of features; bounds/extent.
  * @typedef {{numberOfFeatures: number,
  *            bounds: ol.Extent}}
+ * @api
  */
 ol.format.WFS.FeatureCollectionMetadata;
 
 
 /**
+ * Total deleted; total inserted; total updated; array of insert ids.
  * @typedef {{totalDeleted: number,
  *            totalInserted: number,
-              totalUpdated: number,
-              insertIds: Array.<string>}}
+ *            totalUpdated: number,
+ *            insertIds: Array.<string>}}
+ * @api
  */
 ol.format.WFS.TransactionResponse;
 

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -16,7 +16,9 @@ goog.require('ol.tilegrid.WMTS');
 
 
 /**
+ * Request encoding. One of 'KVP', 'REST'.
  * @enum {string}
+ * @api
  */
 ol.source.WMTSRequestEncoding = {
   KVP: 'KVP',  // see spec §8

--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -14,7 +14,9 @@ goog.require('ol.style.ImageState');
 
 
 /**
+ * Icon anchor units. One of 'fraction', 'pixels'.
  * @enum {string}
+ * @api
  */
 ol.style.IconAnchorUnits = {
   FRACTION: 'fraction',
@@ -23,7 +25,9 @@ ol.style.IconAnchorUnits = {
 
 
 /**
+ * Icon origin. One of 'bottom-left', 'bottom-right', 'top-left', 'top-right'.
  * @enum {string}
+ * @api
  */
 ol.style.IconOrigin = {
   BOTTOM_LEFT: 'bottom-left',


### PR DESCRIPTION
See https://github.com/openlayers/ol3/pull/2479#issuecomment-51438681.

Removes attribution#tileRanges as suggested, and adds `@api` for others. Two are not addressed here: `ol.format.Feature` and `ol.render.IVectorContext`. These are parent classes, already in the api docs, and AFAICS are only referred to as types in private methods. I'm not sure what needs to be done here - should they be template types (`T`)?
