### PR TITLE
Make the check target build ol.js

### DIFF
--- a/build.py
+++ b/build.py
@@ -130,7 +130,7 @@ virtual('ci', 'lint', 'jshint', 'build', 'test',
 virtual('build', 'build/ol.css', 'build/ol.js', 'build/ol-debug.js')
 
 
-virtual('check', 'lint', 'jshint', 'test')
+virtual('check', 'lint', 'build/ol.js', 'jshint', 'test')
 
 
 virtual('todo', 'fixme')


### PR DESCRIPTION
With a [commit](https://github.com/openlayers/ol3/commit/e9c6e58663772699712ba922f22ae31a922c901a) that was recently merged the `check` target just runs the linters and the tests but doesn't compile the ol3 code anymore. The `check` target is the target we [tell](https://github.com/openlayers/ol3/blob/master/CONTRIBUTING.md#running-the-check-target) people to use before submitting PRs, so I think that target should check that the ol3 code compiles.
