### PR TITLE
Return rather than fail if resolution is not defined

### DIFF
--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -89,9 +89,11 @@ ol.source.Cluster.prototype.onSourceChange_ = function() {
  * @private
  */
 ol.source.Cluster.prototype.cluster_ = function() {
+  if (!goog.isDef(this.resolution_)) {
+    return;
+  }
   goog.array.clear(this.features_);
   var extent = ol.extent.createEmpty();
-  goog.asserts.assert(goog.isDef(this.resolution_));
   var mapDistance = this.distance_ * this.resolution_;
   var features = this.source_.getFeatures();
 


### PR DESCRIPTION
When using a source which has to parse data, it is possible for the source to `change` before the map has called `loadFeatures`, triggering the assertion in debug mode and failing entirely otherwise.  This proposes to remove the assertion and simply return if `resolution_` is not defined.

An alternate approach I considered was to delay registering for the `change` event on the origin source until the first time loadFeatures is called, but this seemed simpler and safer.
