### PR TITLE
Rename BrowserFeature to browserfeature

### DIFF
--- a/examples/bind-input.js
+++ b/examples/bind-input.js
@@ -1,6 +1,6 @@
-goog.require('ol.BrowserFeature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.browserfeature');
 goog.require('ol.control');
 goog.require('ol.dom.Input');
 goog.require('ol.layer.Tile');
@@ -9,9 +9,9 @@ goog.require('ol.source.OSM');
 
 function checkWebGL(evt) {
   document.getElementById('no-webgl').style.display =
-      ol.BrowserFeature.HAS_WEBGL ? 'none' : '';
+      ol.browserfeature.HAS_WEBGL ? 'none' : '';
   document.getElementById('has-webgl').style.display =
-      ol.BrowserFeature.HAS_WEBGL && !evt.glContext ? '' : 'none';
+      ol.browserfeature.HAS_WEBGL && !evt.glContext ? '' : 'none';
   document.getElementById('webgl').style.display =
       evt.glContext ? '' : 'none';
 }

--- a/examples/brightness-contrast.js
+++ b/examples/brightness-contrast.js
@@ -1,6 +1,6 @@
-goog.require('ol.BrowserFeature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.browserfeature');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.MapQuest');
 
@@ -14,7 +14,7 @@ function setResetContrastButtonHTML() {
   resetContrast.innerHTML = 'Contrast (' + layer.getContrast().toFixed(3) + ')';
 }
 
-if (!ol.BrowserFeature.HAS_WEBGL) {
+if (!ol.browserfeature.HAS_WEBGL) {
   var info = document.getElementById('no-webgl');
   /**
    * display error message

--- a/examples/hue-saturation.js
+++ b/examples/hue-saturation.js
@@ -1,6 +1,6 @@
-goog.require('ol.BrowserFeature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.browserfeature');
 goog.require('ol.layer.Tile');
 goog.require('ol.proj');
 goog.require('ol.source.BingMaps');
@@ -15,7 +15,7 @@ function setResetSaturationButtonHTML() {
       layer.getSaturation().toFixed(2) + ')';
 }
 
-if (!ol.BrowserFeature.HAS_WEBGL) {
+if (!ol.browserfeature.HAS_WEBGL) {
   var info = document.getElementById('no-webgl');
   /**
    * display error message

--- a/examples/layer-clipping-webgl.js
+++ b/examples/layer-clipping-webgl.js
@@ -1,11 +1,11 @@
-goog.require('ol.BrowserFeature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.browserfeature');
 goog.require('ol.control');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
 
-if (!ol.BrowserFeature.HAS_WEBGL) {
+if (!ol.browserfeature.HAS_WEBGL) {
   var info = document.getElementById('no-webgl');
   /**
    * display error message

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -1,6 +1,6 @@
-goog.require('ol.BrowserFeature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.browserfeature');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.MapQuest');
 
@@ -19,7 +19,7 @@ var domMap = new ol.Map({
   })
 });
 
-if (ol.BrowserFeature.HAS_WEBGL) {
+if (ol.browserfeature.HAS_WEBGL) {
   var webglMap = new ol.Map({
     renderer: 'webgl',
     target: 'webglMap'

--- a/examples/wmts-hidpi.js
+++ b/examples/wmts-hidpi.js
@@ -1,6 +1,6 @@
-goog.require('ol.BrowserFeature');
 goog.require('ol.Map');
 goog.require('ol.View');
+goog.require('ol.browserfeature');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.WMTS');
 goog.require('ol.tilegrid.WMTS');
@@ -20,7 +20,7 @@ var urls = [
 // HiDPI support:
 // * Use 'bmaphidpi' layer (pixel ratio 2) for device pixel ratio > 1
 // * Use 'geolandbasemap' layer (pixel ratio 1) for device pixel ratio == 1
-var hiDPI = ol.BrowserFeature.DEVICE_PIXEL_RATIO > 1;
+var hiDPI = ol.browserfeature.DEVICE_PIXEL_RATIO > 1;
 
 var source = new ol.source.WMTS({
   projection: 'EPSG:3857',

--- a/src/ol/binary.js
+++ b/src/ol/binary.js
@@ -5,7 +5,7 @@ goog.provide('ol.binary.IReader');
 
 goog.require('goog.asserts');
 goog.require('goog.userAgent');
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 
 
 
@@ -29,7 +29,7 @@ ol.binary.Buffer = function(data) {
  */
 ol.binary.Buffer.prototype.getReader = function() {
   var data = this.data_;
-  if (ol.BrowserFeature.HAS_ARRAY_BUFFER) {
+  if (ol.browserfeature.HAS_ARRAY_BUFFER) {
     var arrayBuffer;
     if (data instanceof ArrayBuffer) {
       arrayBuffer = data;

--- a/src/ol/browserfeature.js
+++ b/src/ol/browserfeature.js
@@ -1,4 +1,4 @@
-goog.provide('ol.BrowserFeature');
+goog.provide('ol.browserfeature');
 
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
@@ -14,7 +14,7 @@ goog.require('ol.webgl');
  * @type {number}
  * @api
  */
-ol.BrowserFeature.DEVICE_PIXEL_RATIO = goog.global.devicePixelRatio || 1;
+ol.browserfeature.DEVICE_PIXEL_RATIO = goog.global.devicePixelRatio || 1;
 
 
 /**
@@ -22,14 +22,14 @@ ol.BrowserFeature.DEVICE_PIXEL_RATIO = goog.global.devicePixelRatio || 1;
  * @const
  * @type {boolean}
  */
-ol.BrowserFeature.HAS_ARRAY_BUFFER = 'ArrayBuffer' in goog.global;
+ol.browserfeature.HAS_ARRAY_BUFFER = 'ArrayBuffer' in goog.global;
 
 
 /**
  * True if the browser's Canvas implementation implements {get,set}LineDash.
  * @type {boolean}
  */
-ol.BrowserFeature.HAS_CANVAS_LINE_DASH = false;
+ol.browserfeature.HAS_CANVAS_LINE_DASH = false;
 
 
 /**
@@ -38,7 +38,7 @@ ol.BrowserFeature.HAS_CANVAS_LINE_DASH = false;
  * @type {boolean}
  * @api
  */
-ol.BrowserFeature.HAS_CANVAS = ol.ENABLE_CANVAS && (
+ol.browserfeature.HAS_CANVAS = ol.ENABLE_CANVAS && (
     /**
      * @return {boolean} Canvas supported.
      */
@@ -52,7 +52,7 @@ ol.BrowserFeature.HAS_CANVAS = ol.ENABLE_CANVAS && (
           return false;
         } else {
           if (goog.isDef(context.setLineDash)) {
-            ol.BrowserFeature.HAS_CANVAS_LINE_DASH = true;
+            ol.browserfeature.HAS_CANVAS_LINE_DASH = true;
           }
           return true;
         }
@@ -68,7 +68,7 @@ ol.BrowserFeature.HAS_CANVAS = ol.ENABLE_CANVAS && (
  * @type {boolean}
  * @api
  */
-ol.BrowserFeature.HAS_DEVICE_ORIENTATION =
+ol.browserfeature.HAS_DEVICE_ORIENTATION =
     'DeviceOrientationEvent' in goog.global;
 
 
@@ -77,7 +77,7 @@ ol.BrowserFeature.HAS_DEVICE_ORIENTATION =
  * @const
  * @type {boolean}
  */
-ol.BrowserFeature.HAS_DOM = ol.ENABLE_DOM;
+ol.browserfeature.HAS_DOM = ol.ENABLE_DOM;
 
 
 /**
@@ -86,7 +86,7 @@ ol.BrowserFeature.HAS_DOM = ol.ENABLE_DOM;
  * @type {boolean}
  * @api
  */
-ol.BrowserFeature.HAS_GEOLOCATION = 'geolocation' in goog.global.navigator;
+ol.browserfeature.HAS_GEOLOCATION = 'geolocation' in goog.global.navigator;
 
 
 /**
@@ -95,7 +95,7 @@ ol.BrowserFeature.HAS_GEOLOCATION = 'geolocation' in goog.global.navigator;
  * @type {boolean}
  * @api
  */
-ol.BrowserFeature.HAS_TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in goog.global;
+ol.browserfeature.HAS_TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in goog.global;
 
 
 /**
@@ -103,7 +103,7 @@ ol.BrowserFeature.HAS_TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in goog.global;
  * @const
  * @type {boolean}
  */
-ol.BrowserFeature.HAS_POINTER = 'PointerEvent' in goog.global;
+ol.browserfeature.HAS_POINTER = 'PointerEvent' in goog.global;
 
 
 /**
@@ -111,7 +111,7 @@ ol.BrowserFeature.HAS_POINTER = 'PointerEvent' in goog.global;
  * @const
  * @type {boolean}
  */
-ol.BrowserFeature.HAS_MSPOINTER =
+ol.browserfeature.HAS_MSPOINTER =
     !!(goog.global.navigator.msPointerEnabled);
 
 
@@ -121,7 +121,7 @@ ol.BrowserFeature.HAS_MSPOINTER =
  * @type {boolean}
  * @api
  */
-ol.BrowserFeature.HAS_WEBGL = ol.ENABLE_WEBGL && (
+ol.browserfeature.HAS_WEBGL = ol.ENABLE_WEBGL && (
     /**
      * @return {boolean} WebGL supported.
      */

--- a/src/ol/browserfeature.jsdoc
+++ b/src/ol/browserfeature.jsdoc
@@ -1,3 +1,3 @@
 /**
- * @namespace ol.BrowserFeature
+ * @namespace ol.browserfeature
  */

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -3,8 +3,8 @@ goog.provide('ol.DeviceOrientationProperty');
 
 goog.require('goog.events');
 goog.require('goog.math');
-goog.require('ol.BrowserFeature');
 goog.require('ol.Object');
+goog.require('ol.browserfeature');
 
 
 /**
@@ -221,7 +221,7 @@ goog.exportProperty(
  * @private
  */
 ol.DeviceOrientation.prototype.handleTrackingChanged_ = function() {
-  if (ol.BrowserFeature.HAS_DEVICE_ORIENTATION) {
+  if (ol.browserfeature.HAS_DEVICE_ORIENTATION) {
     var tracking = this.getTracking();
     if (tracking && goog.isNull(this.listenerKey_)) {
       this.listenerKey_ = goog.events.listen(goog.global, 'deviceorientation',

--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -1,7 +1,7 @@
 // FIXME add tests for browser features (Modernizr?)
 
 goog.provide('ol.dom');
-goog.provide('ol.dom.BrowserFeature');
+goog.provide('ol.dom.browserfeature');
 
 goog.require('goog.asserts');
 goog.require('goog.dom');
@@ -33,7 +33,7 @@ ol.dom.createCanvasContext2D = function(opt_width, opt_height) {
 /**
  * @enum {boolean}
  */
-ol.dom.BrowserFeature = {
+ol.dom.browserfeature = {
   USE_MS_MATRIX_TRANSFORM: ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE,
   USE_MS_ALPHA_FILTER: ol.LEGACY_IE_SUPPORT && ol.IS_LEGACY_IE
 };
@@ -148,7 +148,7 @@ ol.dom.setTransform = function(element, value) {
  * @param {number} value Opacity, [0..1]
  */
 ol.dom.setOpacity = function(element, value) {
-  if (ol.dom.BrowserFeature.USE_MS_ALPHA_FILTER) {
+  if (ol.dom.browserfeature.USE_MS_ALPHA_FILTER) {
     /** @type {string} */
     var filter = element.currentStyle.filter;
 
@@ -256,7 +256,7 @@ ol.dom.transformElement2D =
       value2D = transform2D.join(',');
     }
     ol.dom.setTransform(element, 'matrix(' + value2D + ')');
-  } else if (ol.dom.BrowserFeature.USE_MS_MATRIX_TRANSFORM) {
+  } else if (ol.dom.browserfeature.USE_MS_MATRIX_TRANSFORM) {
     var m11 = goog.vec.Mat4.getElement(transform, 0, 0),
         m12 = goog.vec.Mat4.getElement(transform, 0, 1),
         m21 = goog.vec.Mat4.getElement(transform, 1, 0),

--- a/src/ol/format/binaryfeatureformat.js
+++ b/src/ol/format/binaryfeatureformat.js
@@ -1,8 +1,8 @@
 goog.provide('ol.format.BinaryFeature');
 
 goog.require('goog.asserts');
-goog.require('ol.BrowserFeature');
 goog.require('ol.binary.Buffer');
+goog.require('ol.browserfeature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.FormatType');
 goog.require('ol.proj');
@@ -25,7 +25,7 @@ goog.inherits(ol.format.BinaryFeature, ol.format.Feature);
  * @return {ol.binary.Buffer} Buffer.
  */
 ol.format.BinaryFeature.getBuffer_ = function(source) {
-  if (ol.BrowserFeature.HAS_ARRAY_BUFFER && source instanceof ArrayBuffer) {
+  if (ol.browserfeature.HAS_ARRAY_BUFFER && source instanceof ArrayBuffer) {
     return new ol.binary.Buffer(source);
   } else if (goog.isString(source)) {
     return new ol.binary.Buffer(source);

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -6,9 +6,9 @@ goog.provide('ol.GeolocationProperty');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
 goog.require('goog.math');
-goog.require('ol.BrowserFeature');
 goog.require('ol.Coordinate');
 goog.require('ol.Object');
+goog.require('ol.browserfeature');
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.Polygon');
 goog.require('ol.proj');
@@ -130,7 +130,7 @@ ol.Geolocation.prototype.handleProjectionChanged_ = function() {
  * @private
  */
 ol.Geolocation.prototype.handleTrackingChanged_ = function() {
-  if (ol.BrowserFeature.HAS_GEOLOCATION) {
+  if (ol.browserfeature.HAS_GEOLOCATION) {
     var tracking = this.getTracking();
     if (tracking && !goog.isDef(this.watchId_)) {
       this.watchId_ = goog.global.navigator.geolocation.watchPosition(

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -27,7 +27,6 @@ goog.require('goog.log.Level');
 goog.require('goog.object');
 goog.require('goog.style');
 goog.require('goog.vec.Mat4');
-goog.require('ol.BrowserFeature');
 goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.MapBrowserEvent');
@@ -46,6 +45,7 @@ goog.require('ol.Size');
 goog.require('ol.TileQueue');
 goog.require('ol.View');
 goog.require('ol.ViewHint');
+goog.require('ol.browserfeature');
 goog.require('ol.control');
 goog.require('ol.extent');
 goog.require('ol.interaction');
@@ -168,7 +168,7 @@ ol.Map = function(options) {
    * @type {number}
    */
   this.pixelRatio_ = goog.isDef(options.pixelRatio) ?
-      options.pixelRatio : ol.BrowserFeature.DEVICE_PIXEL_RATIO;
+      options.pixelRatio : ol.browserfeature.DEVICE_PIXEL_RATIO;
 
   /**
    * @private
@@ -238,7 +238,7 @@ ol.Map = function(options) {
   this.viewport_.style.height = '100%';
   // prevent page zoom on IE >= 10 browsers
   this.viewport_.style.msTouchAction = 'none';
-  if (ol.BrowserFeature.HAS_TOUCH) {
+  if (ol.browserfeature.HAS_TOUCH) {
     this.viewport_.className = 'ol-touch';
   }
 
@@ -1463,17 +1463,17 @@ ol.Map.createOptionsInternal = function(options) {
     /** @type {ol.RendererType} */
     var rendererType = rendererTypes[i];
     if (ol.ENABLE_CANVAS && rendererType == ol.RendererType.CANVAS) {
-      if (ol.BrowserFeature.HAS_CANVAS) {
+      if (ol.browserfeature.HAS_CANVAS) {
         rendererConstructor = ol.renderer.canvas.Map;
         break;
       }
     } else if (ol.ENABLE_DOM && rendererType == ol.RendererType.DOM) {
-      if (ol.BrowserFeature.HAS_DOM) {
+      if (ol.browserfeature.HAS_DOM) {
         rendererConstructor = ol.renderer.dom.Map;
         break;
       }
     } else if (ol.ENABLE_WEBGL && rendererType == ol.RendererType.WEBGL) {
-      if (ol.BrowserFeature.HAS_WEBGL) {
+      if (ol.browserfeature.HAS_WEBGL) {
         rendererConstructor = ol.renderer.webgl.Map;
         break;
       }

--- a/src/ol/pointer/pointereventhandler.js
+++ b/src/ol/pointer/pointereventhandler.js
@@ -36,7 +36,7 @@ goog.require('goog.events.BrowserEvent');
 goog.require('goog.events.Event');
 goog.require('goog.events.EventTarget');
 
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 goog.require('ol.pointer.MouseSource');
 goog.require('ol.pointer.MsSource');
 goog.require('ol.pointer.NativeSource');
@@ -88,15 +88,15 @@ goog.inherits(ol.pointer.PointerEventHandler, goog.events.EventTarget);
  * that generate pointer events.
  */
 ol.pointer.PointerEventHandler.prototype.registerSources = function() {
-  if (ol.BrowserFeature.HAS_POINTER) {
+  if (ol.browserfeature.HAS_POINTER) {
     this.registerSource('native', new ol.pointer.NativeSource(this));
-  } else if (ol.BrowserFeature.HAS_MSPOINTER) {
+  } else if (ol.browserfeature.HAS_MSPOINTER) {
     this.registerSource('ms', new ol.pointer.MsSource(this));
   } else {
     var mouseSource = new ol.pointer.MouseSource(this);
     this.registerSource('mouse', mouseSource);
 
-    if (ol.BrowserFeature.HAS_TOUCH) {
+    if (ol.browserfeature.HAS_TOUCH) {
       this.registerSource('touch',
           new ol.pointer.TouchSource(this, mouseSource));
     }

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -8,7 +8,7 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.object');
 goog.require('goog.vec.Mat4');
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 goog.require('ol.color');
 goog.require('ol.extent');
 goog.require('ol.geom.flat.transform');
@@ -764,7 +764,7 @@ ol.render.canvas.Immediate.prototype.setContextStrokeState_ =
   var contextStrokeState = this.contextStrokeState_;
   if (goog.isNull(contextStrokeState)) {
     context.lineCap = strokeState.lineCap;
-    if (ol.BrowserFeature.HAS_CANVAS_LINE_DASH) {
+    if (ol.browserfeature.HAS_CANVAS_LINE_DASH) {
       context.setLineDash(strokeState.lineDash);
     }
     context.lineJoin = strokeState.lineJoin;
@@ -783,7 +783,7 @@ ol.render.canvas.Immediate.prototype.setContextStrokeState_ =
     if (contextStrokeState.lineCap != strokeState.lineCap) {
       contextStrokeState.lineCap = context.lineCap = strokeState.lineCap;
     }
-    if (ol.BrowserFeature.HAS_CANVAS_LINE_DASH) {
+    if (ol.browserfeature.HAS_CANVAS_LINE_DASH) {
       if (!goog.array.equals(
           contextStrokeState.lineDash, strokeState.lineDash)) {
         context.setLineDash(contextStrokeState.lineDash = strokeState.lineDash);

--- a/src/ol/render/canvas/canvasreplay.js
+++ b/src/ol/render/canvas/canvasreplay.js
@@ -8,8 +8,8 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.object');
 goog.require('goog.vec.Mat4');
-goog.require('ol.BrowserFeature');
 goog.require('ol.array');
+goog.require('ol.browserfeature');
 goog.require('ol.color');
 goog.require('ol.dom');
 goog.require('ol.extent');
@@ -425,7 +425,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
         context.lineCap = /** @type {string} */ (instruction[3]);
         context.lineJoin = /** @type {string} */ (instruction[4]);
         context.miterLimit = /** @type {number} */ (instruction[5]);
-        if (ol.BrowserFeature.HAS_CANVAS_LINE_DASH) {
+        if (ol.browserfeature.HAS_CANVAS_LINE_DASH) {
           context.setLineDash(/** @type {Array.<number>} */ (instruction[6]));
         }
         ++i;

--- a/src/ol/renderer/dom/domtilelayerrenderer.js
+++ b/src/ol/renderer/dom/domtilelayerrenderer.js
@@ -17,7 +17,7 @@ goog.require('ol.TileRange');
 goog.require('ol.TileState');
 goog.require('ol.ViewHint');
 goog.require('ol.dom');
-goog.require('ol.dom.BrowserFeature');
+goog.require('ol.dom.browserfeature');
 goog.require('ol.extent');
 goog.require('ol.layer.Tile');
 goog.require('ol.renderer.dom.Layer');
@@ -39,7 +39,7 @@ ol.renderer.dom.TileLayer = function(mapRenderer, tileLayer) {
   target.style.position = 'absolute';
 
   // Needed for IE7-8 to render a transformed element correctly
-  if (ol.dom.BrowserFeature.USE_MS_MATRIX_TRANSFORM) {
+  if (ol.dom.browserfeature.USE_MS_MATRIX_TRANSFORM) {
     target.style.width = '100%';
     target.style.height = '100%';
   }

--- a/src/ol/source/formatvectorsource.js
+++ b/src/ol/source/formatvectorsource.js
@@ -10,7 +10,7 @@ goog.require('goog.net.EventType');
 goog.require('goog.net.XhrIo');
 goog.require('goog.net.XhrIo.ResponseType');
 goog.require('goog.userAgent');
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 goog.require('ol.format.FormatType');
 goog.require('ol.proj');
 goog.require('ol.source.State');
@@ -60,7 +60,7 @@ ol.source.FormatVector.prototype.loadFeaturesFromURL =
   var responseType;
   // FIXME maybe use ResponseType.DOCUMENT?
   if (type == ol.format.FormatType.BINARY &&
-      ol.BrowserFeature.HAS_ARRAY_BUFFER) {
+      ol.browserfeature.HAS_ARRAY_BUFFER) {
     responseType = goog.net.XhrIo.ResponseType.ARRAY_BUFFER;
   } else {
     responseType = goog.net.XhrIo.ResponseType.TEXT;
@@ -80,7 +80,7 @@ ol.source.FormatVector.prototype.loadFeaturesFromURL =
           /** @type {ArrayBuffer|Document|Node|Object|string|undefined} */
           var source;
           if (type == ol.format.FormatType.BINARY &&
-              ol.BrowserFeature.HAS_ARRAY_BUFFER) {
+              ol.browserfeature.HAS_ARRAY_BUFFER) {
             source = xhrIo.getResponse();
             goog.asserts.assertInstanceof(source, ArrayBuffer);
           } else if (type == ol.format.FormatType.JSON) {

--- a/test/spec/ol/pointer/mousesource.test.js
+++ b/test/spec/ol/pointer/mousesource.test.js
@@ -11,9 +11,9 @@ describe('ol.pointer.MouseSource', function() {
     target = goog.dom.createElement(goog.dom.TagName.DIV);
 
     // make sure that a mouse and touch event source is used
-    ol.BrowserFeature.HAS_POINTER = false;
-    ol.BrowserFeature.HAS_MSPOINTER = false;
-    ol.BrowserFeature.HAS_TOUCH = true;
+    ol.browserfeature.HAS_POINTER = false;
+    ol.browserfeature.HAS_MSPOINTER = false;
+    ol.browserfeature.HAS_TOUCH = true;
 
     handler = new ol.pointer.PointerEventHandler(target);
     eventSpy = sinon.spy();
@@ -95,7 +95,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 goog.require('ol.pointer.MouseSource');
 goog.require('ol.pointer.PointerEvent');
 goog.require('ol.pointer.PointerEventHandler');

--- a/test/spec/ol/pointer/pointereventhandler.test.js
+++ b/test/spec/ol/pointer/pointereventhandler.test.js
@@ -9,8 +9,8 @@ describe('ol.pointer.PointerEventHandler', function() {
     target = goog.dom.createElement(goog.dom.TagName.DIV);
 
     // make sure that a mouse event source is used
-    ol.BrowserFeature.HAS_POINTER = false;
-    ol.BrowserFeature.HAS_MSPOINTER = false;
+    ol.browserfeature.HAS_POINTER = false;
+    ol.browserfeature.HAS_MSPOINTER = false;
 
     handler = new ol.pointer.PointerEventHandler(target);
     eventSpy = sinon.spy();
@@ -164,7 +164,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 goog.require('ol.pointer.MouseSource');
 goog.require('ol.pointer.PointerEvent');
 goog.require('ol.pointer.PointerEventHandler');

--- a/test/spec/ol/pointer/touchsource.test.js
+++ b/test/spec/ol/pointer/touchsource.test.js
@@ -11,9 +11,9 @@ describe('ol.pointer.TouchSource', function() {
     target = goog.dom.createElement(goog.dom.TagName.DIV);
 
     // make sure that a mouse and touch event source is used
-    ol.BrowserFeature.HAS_POINTER = false;
-    ol.BrowserFeature.HAS_MSPOINTER = false;
-    ol.BrowserFeature.HAS_TOUCH = true;
+    ol.browserfeature.HAS_POINTER = false;
+    ol.browserfeature.HAS_MSPOINTER = false;
+    ol.browserfeature.HAS_TOUCH = true;
 
     handler = new ol.pointer.PointerEventHandler(target);
     eventSpy = sinon.spy();
@@ -133,7 +133,7 @@ goog.require('goog.dom');
 goog.require('goog.dom.TagName');
 goog.require('goog.events');
 goog.require('goog.events.BrowserEvent');
-goog.require('ol.BrowserFeature');
+goog.require('ol.browserfeature');
 goog.require('ol.pointer.PointerEvent');
 goog.require('ol.pointer.PointerEventHandler');
 goog.require('ol.pointer.TouchSource');


### PR DESCRIPTION
Fixes #2453.

For consistency, also renames (not exported) `ol.dom.BrowserFeature`
