### PR TITLE
Change ol.TileCoord to Array.<number>

### DIFF
--- a/src/ol/loadingstrategy.js
+++ b/src/ol/loadingstrategy.js
@@ -46,11 +46,12 @@ ol.loadingstrategy.createTile = function(tileGrid) {
         var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
         /** @type {Array.<ol.Extent>} */
         var extents = [];
-        var tileCoord = new ol.TileCoord(z, 0, 0);
-        for (tileCoord.x = tileRange.minX; tileCoord.x <= tileRange.maxX;
-             ++tileCoord.x) {
-          for (tileCoord.y = tileRange.minY; tileCoord.y <= tileRange.maxY;
-               ++tileCoord.y) {
+        /** @type {ol.TileCoord} */
+        var tileCoord = [z, 0, 0];
+        for (tileCoord[1] = tileRange.minX; tileCoord[1] <= tileRange.maxX;
+             ++tileCoord[1]) {
+          for (tileCoord[2] = tileRange.minY; tileCoord[2] <= tileRange.maxY;
+               ++tileCoord[2]) {
             extents.push(tileGrid.getTileCoordExtent(tileCoord));
           }
         }

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -58,6 +58,7 @@ goog.require('ol.renderer.canvas.Map');
 goog.require('ol.renderer.dom.Map');
 goog.require('ol.renderer.webgl.Map');
 goog.require('ol.structs.PriorityQueue');
+goog.require('ol.tilecoord');
 goog.require('ol.vec.Mat4');
 
 
@@ -816,7 +817,7 @@ ol.Map.prototype.getTilePriority =
   if (goog.isNull(frameState) || !(tileSourceKey in frameState.wantedTiles)) {
     return ol.structs.PriorityQueue.DROP;
   }
-  var coordKey = tile.tileCoord.toString();
+  var coordKey = ol.tilecoord.toString(tile.tileCoord);
   if (!frameState.wantedTiles[tileSourceKey][coordKey]) {
     return ol.structs.PriorityQueue.DROP;
   }

--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -8,7 +8,6 @@ goog.require('goog.asserts');
 goog.require('goog.object');
 goog.require('goog.vec.Mat4');
 goog.require('ol.Size');
-goog.require('ol.TileCoord');
 goog.require('ol.TileRange');
 goog.require('ol.TileState');
 goog.require('ol.dom');
@@ -17,6 +16,7 @@ goog.require('ol.layer.Tile');
 goog.require('ol.renderer.Map');
 goog.require('ol.renderer.canvas.Layer');
 goog.require('ol.source.Tile');
+goog.require('ol.tilecoord');
 goog.require('ol.vec.Mat4');
 
 
@@ -299,7 +299,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
       if (tileState == ol.TileState.LOADED ||
           tileState == ol.TileState.EMPTY ||
           (tileState == ol.TileState.ERROR && !useInterimTilesOnError)) {
-        tilesToDrawByZ[z][tile.tileCoord.toString()] = tile;
+        tilesToDrawByZ[z][ol.tilecoord.toString(tile.tileCoord)] = tile;
         continue;
       }
 
@@ -322,8 +322,8 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   var i, ii;
   for (i = 0, ii = tilesToClear.length; i < ii; ++i) {
     tile = tilesToClear[i];
-    x = tilePixelSize * (tile.tileCoord.x - canvasTileRange.minX);
-    y = tilePixelSize * (canvasTileRange.maxY - tile.tileCoord.y);
+    x = tilePixelSize * (tile.tileCoord[1] - canvasTileRange.minX);
+    y = tilePixelSize * (canvasTileRange.maxY - tile.tileCoord[2]);
     context.clearRect(x, y, tilePixelSize, tilePixelSize);
   }
 
@@ -332,7 +332,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
   goog.array.sort(zs);
   var opaque = tileSource.getOpaque();
   var origin = ol.extent.getTopLeft(tileGrid.getTileCoordExtent(
-      new ol.TileCoord(z, canvasTileRange.minX, canvasTileRange.maxY),
+      [z, canvasTileRange.minX, canvasTileRange.maxY],
       tmpExtent));
   var currentZ, index, scale, tileCoordKey, tileExtent, tilesToDraw;
   var ix, iy, interimTileExtent, interimTileRange, maxX, maxY;
@@ -346,11 +346,11 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame =
       for (tileCoordKey in tilesToDraw) {
         tile = tilesToDraw[tileCoordKey];
         index =
-            (tile.tileCoord.y - canvasTileRange.minY) * canvasTileRangeWidth +
-            (tile.tileCoord.x - canvasTileRange.minX);
+            (tile.tileCoord[2] - canvasTileRange.minY) * canvasTileRangeWidth +
+            (tile.tileCoord[1] - canvasTileRange.minX);
         if (this.renderedTiles_[index] != tile) {
-          x = tilePixelSize * (tile.tileCoord.x - canvasTileRange.minX);
-          y = tilePixelSize * (canvasTileRange.maxY - tile.tileCoord.y);
+          x = tilePixelSize * (tile.tileCoord[1] - canvasTileRange.minX);
+          y = tilePixelSize * (canvasTileRange.maxY - tile.tileCoord[2]);
           tileState = tile.getState();
           if (tileState == ol.TileState.EMPTY ||
               (tileState == ol.TileState.ERROR && !useInterimTilesOnError) ||

--- a/src/ol/renderer/layerrenderer.js
+++ b/src/ol/renderer/layerrenderer.js
@@ -10,6 +10,7 @@ goog.require('ol.layer.LayerState');
 goog.require('ol.source.Source');
 goog.require('ol.source.State');
 goog.require('ol.source.Tile');
+goog.require('ol.tilecoord');
 
 
 
@@ -282,7 +283,7 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
         if (currentZ - z <= preload) {
           tile = tileSource.getTile(z, x, y, pixelRatio, projection);
           if (tile.getState() == ol.TileState.IDLE) {
-            wantedTiles[tile.tileCoord.toString()] = true;
+            wantedTiles[ol.tilecoord.toString(tile.tileCoord)] = true;
             if (!tileQueue.isKeyQueued(tile.getKey())) {
               tileQueue.enqueue([tile, tileSourceKey,
                 tileGrid.getTileCoordCenter(tile.tileCoord), tileResolution]);

--- a/src/ol/renderer/webgl/webgltilelayerrenderer.js
+++ b/src/ol/renderer/webgl/webgltilelayerrenderer.js
@@ -18,6 +18,7 @@ goog.require('ol.renderer.webgl.Layer');
 goog.require('ol.renderer.webgl.tilelayer.shader');
 goog.require('ol.source.Tile');
 goog.require('ol.structs.Buffer');
+goog.require('ol.tilecoord');
 
 
 
@@ -222,7 +223,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
         tileState = tile.getState();
         if (tileState == ol.TileState.LOADED) {
           if (mapRenderer.isTileTextureLoaded(tile)) {
-            tilesToDrawByZ[z][tile.tileCoord.toString()] = tile;
+            tilesToDrawByZ[z][ol.tilecoord.toString(tile.tileCoord)] = tile;
             continue;
           }
         } else if (tileState == ol.TileState.EMPTY ||
@@ -300,7 +301,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame =
           tileTextureQueue.enqueue([
             tile,
             tileGrid.getTileCoordCenter(tile.tileCoord),
-            tileGrid.getResolution(tile.tileCoord.z),
+            tileGrid.getResolution(tile.tileCoord[0]),
             tilePixelSize, tileGutter * pixelRatio
           ]);
         }

--- a/src/ol/source/bingmapssource.js
+++ b/src/ol/source/bingmapssource.js
@@ -12,6 +12,7 @@ goog.require('ol.extent');
 goog.require('ol.proj');
 goog.require('ol.source.State');
 goog.require('ol.source.TileImage');
+goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.XYZ');
 
 
@@ -120,7 +121,7 @@ ol.source.BingMaps.prototype.handleImageryMetadataResponse =
                         return undefined;
                       } else {
                         return imageUrl.replace(
-                            '{quadkey}', tileCoord.quadKey());
+                            '{quadkey}', ol.tilecoord.quadKey(tileCoord));
                       }
                     });
               })));

--- a/src/ol/source/tiledebugsource.js
+++ b/src/ol/source/tiledebugsource.js
@@ -6,6 +6,7 @@ goog.require('ol.TileCoord');
 goog.require('ol.TileState');
 goog.require('ol.dom');
 goog.require('ol.source.Tile');
+goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');
 
 
@@ -25,7 +26,7 @@ ol.DebugTile_ = function(tileCoord, tileGrid) {
    * @private
    * @type {number}
    */
-  this.tileSize_ = tileGrid.getTileSize(tileCoord.z);
+  this.tileSize_ = tileGrid.getTileSize(tileCoord[0]);
 
   /**
    * @private
@@ -56,7 +57,8 @@ ol.DebugTile_.prototype.getImage = function(opt_context) {
     context.textAlign = 'center';
     context.textBaseline = 'middle';
     context.font = '24px sans-serif';
-    context.fillText(this.tileCoord.toString(), tileSize / 2, tileSize / 2);
+    context.fillText(ol.tilecoord.toString(this.tileCoord),
+        tileSize / 2, tileSize / 2);
 
     this.canvasByContext_[key] = context.canvas;
     return context.canvas;
@@ -121,7 +123,7 @@ ol.source.TileDebug.prototype.getTile = function(z, x, y) {
   if (this.tileCache_.containsKey(tileCoordKey)) {
     return /** @type {!ol.DebugTile_} */ (this.tileCache_.get(tileCoordKey));
   } else {
-    var tile = new ol.DebugTile_(new ol.TileCoord(z, x, y), this.tileGrid);
+    var tile = new ol.DebugTile_([z, x, y], this.tileGrid);
     this.tileCache_.set(tileCoordKey, tile);
     return tile;
   }

--- a/src/ol/source/tileimagesource.js
+++ b/src/ol/source/tileimagesource.js
@@ -110,7 +110,7 @@ ol.source.TileImage.prototype.getTile =
     return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {
     goog.asserts.assert(projection);
-    var tileCoord = new ol.TileCoord(z, x, y);
+    var tileCoord = [z, x, y];
     var tileUrl = this.tileUrlFunction(tileCoord, pixelRatio, projection);
     var tile = new this.tileClass(
         tileCoord,

--- a/src/ol/source/tilesource.js
+++ b/src/ol/source/tilesource.js
@@ -4,9 +4,9 @@ goog.provide('ol.source.TileOptions');
 goog.require('goog.functions');
 goog.require('ol.Attribution');
 goog.require('ol.Extent');
-goog.require('ol.TileCoord');
 goog.require('ol.TileRange');
 goog.require('ol.source.Source');
+goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');
 
 
@@ -133,7 +133,7 @@ ol.source.Tile.prototype.getGutter = function() {
  * @return {string} Key.
  * @protected
  */
-ol.source.Tile.prototype.getKeyZXY = ol.TileCoord.getKeyZXY;
+ol.source.Tile.prototype.getKeyZXY = ol.tilecoord.getKeyZXY;
 
 
 /**

--- a/src/ol/source/tilevectorsource.js
+++ b/src/ol/source/tilevectorsource.js
@@ -184,15 +184,15 @@ ol.source.TileVector.prototype.loadFeatures =
   var tiles = this.tiles_;
   var z = tileGrid.getZForResolution(resolution);
   var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
-  var tileCoord = new ol.TileCoord(z, 0, 0);
+  var tileCoord = [z, 0, 0];
   var x, y;
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
       var tileKey = this.getTileKeyZXY_(z, x, y);
       if (!(tileKey in tiles)) {
-        tileCoord.z = z;
-        tileCoord.x = x;
-        tileCoord.y = y;
+        tileCoord[0] = z;
+        tileCoord[1] = x;
+        tileCoord[2] = y;
         tileCoordTransform(tileCoord, projection, tileCoord);
         var url = tileUrlFunction(tileCoord, 1, projection);
         if (goog.isDef(url)) {

--- a/src/ol/source/tilewmssource.js
+++ b/src/ol/source/tilewmssource.js
@@ -18,6 +18,7 @@ goog.require('ol.proj');
 goog.require('ol.source.TileImage');
 goog.require('ol.source.wms');
 goog.require('ol.source.wms.ServerType');
+goog.require('ol.tilecoord');
 
 
 
@@ -150,14 +151,14 @@ ol.source.TileWMS.prototype.getGetFeatureInfoUrl =
   var tileCoord = tileGrid.getTileCoordForCoordAndResolution(
       coordinate, resolution);
 
-  if (tileGrid.getResolutions().length <= tileCoord.z) {
+  if (tileGrid.getResolutions().length <= tileCoord[0]) {
     return undefined;
   }
 
-  var tileResolution = tileGrid.getResolution(tileCoord.z);
+  var tileResolution = tileGrid.getResolution(tileCoord[0]);
   var tileExtent = tileGrid.getTileCoordExtent(
       tileCoord, this.tmpExtent_);
-  var tileSize = tileGrid.getTileSize(tileCoord.z);
+  var tileSize = tileGrid.getTileSize(tileCoord[0]);
 
   var gutter = this.gutter_;
   if (gutter !== 0) {
@@ -285,7 +286,7 @@ ol.source.TileWMS.prototype.getRequestUrl_ =
   if (urls.length == 1) {
     url = urls[0];
   } else {
-    var index = goog.math.modulo(tileCoord.hash(), urls.length);
+    var index = goog.math.modulo(ol.tilecoord.hash(tileCoord), urls.length);
     url = urls[index];
   }
   return goog.uri.utils.appendParamsFromMap(url, params);
@@ -376,7 +377,7 @@ ol.source.TileWMS.prototype.tileUrlFunction_ =
     tileGrid = this.getTileGridForProjection(projection);
   }
 
-  if (tileGrid.getResolutions().length <= tileCoord.z) {
+  if (tileGrid.getResolutions().length <= tileCoord[0]) {
     return undefined;
   }
 
@@ -384,10 +385,10 @@ ol.source.TileWMS.prototype.tileUrlFunction_ =
     pixelRatio = 1;
   }
 
-  var tileResolution = tileGrid.getResolution(tileCoord.z);
+  var tileResolution = tileGrid.getResolution(tileCoord[0]);
   var tileExtent = tileGrid.getTileCoordExtent(
       tileCoord, this.tmpExtent_);
-  var tileSize = tileGrid.getTileSize(tileCoord.z);
+  var tileSize = tileGrid.getTileSize(tileCoord[0]);
 
   var gutter = this.gutter_;
   if (gutter !== 0) {

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -109,9 +109,9 @@ ol.source.WMTS = function(options) {
             return undefined;
           } else {
             var localContext = {
-              'TileMatrix': tileGrid.getMatrixId(tileCoord.z),
-              'TileCol': tileCoord.x,
-              'TileRow': tileCoord.y
+              'TileMatrix': tileGrid.getMatrixId(tileCoord[0]),
+              'TileCol': tileCoord[1],
+              'TileRow': tileCoord[2]
             };
             goog.object.extend(localContext, dimensions);
             var url = template;
@@ -138,7 +138,7 @@ ol.source.WMTS = function(options) {
   }
 
   var tmpExtent = ol.extent.createEmpty();
-  var tmpTileCoord = new ol.TileCoord(0, 0, 0);
+  var tmpTileCoord = [0, 0, 0];
   tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
       /**
        * @param {ol.TileCoord} tileCoord Tile coordinate.
@@ -148,11 +148,11 @@ ol.source.WMTS = function(options) {
        */
       function(tileCoord, projection, opt_tileCoord) {
         goog.asserts.assert(!goog.isNull(tileGrid));
-        if (tileGrid.getResolutions().length <= tileCoord.z) {
+        if (tileGrid.getResolutions().length <= tileCoord[0]) {
           return null;
         }
-        var x = tileCoord.x;
-        var y = -tileCoord.y - 1;
+        var x = tileCoord[1];
+        var y = -tileCoord[2] - 1;
         var tileExtent = tileGrid.getTileCoordExtent(tileCoord);
         var extent = projection.getExtent();
 
@@ -161,16 +161,16 @@ ol.source.WMTS = function(options) {
               ol.extent.getWidth(extent) /
               ol.extent.getWidth(tileExtent));
           x = goog.math.modulo(x, numCols);
-          tmpTileCoord.z = tileCoord.z;
-          tmpTileCoord.x = x;
-          tmpTileCoord.y = tileCoord.y;
+          tmpTileCoord[0] = tileCoord[0];
+          tmpTileCoord[1] = x;
+          tmpTileCoord[2] = tileCoord[2];
           tileExtent = tileGrid.getTileCoordExtent(tmpTileCoord, tmpExtent);
         }
         if (!ol.extent.intersects(tileExtent, extent) ||
             ol.extent.touches(tileExtent, extent)) {
           return null;
         }
-        return new ol.TileCoord(tileCoord.z, x, y);
+        return [tileCoord[0], x, y];
       },
       tileUrlFunction);
 

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -105,12 +105,16 @@ ol.source.Zoomify = function(opt_options) {
         if (goog.isNull(tileCoord)) {
           return undefined;
         } else {
-          var tileIndex = tileCoord.x +
-              tileCoord.y * tierSizeInTiles[tileCoord.z][0] +
-              tileCountUpToTier[tileCoord.z];
+          var tileCoordZ = tileCoord[0];
+          var tileCoordX = tileCoord[1];
+          var tileCoordY = tileCoord[2];
+          var tileIndex =
+              tileCoordX +
+              tileCoordY * tierSizeInTiles[tileCoordZ][0] +
+              tileCountUpToTier[tileCoordZ];
           var tileGroup = (tileIndex / ol.DEFAULT_TILE_SIZE) | 0;
           return url + 'TileGroup' + tileGroup + '/' +
-              tileCoord.z + '-' + tileCoord.x + '-' + tileCoord.y + '.jpg';
+              tileCoordZ + '-' + tileCoordX + '-' + tileCoordY + '.jpg';
         }
       });
 

--- a/src/ol/tilecache.js
+++ b/src/ol/tilecache.js
@@ -2,9 +2,9 @@ goog.provide('ol.TileCache');
 
 goog.require('goog.asserts');
 goog.require('ol');
-goog.require('ol.TileCoord');
 goog.require('ol.TileRange');
 goog.require('ol.structs.LRUCache');
+goog.require('ol.tilecoord');
 
 
 
@@ -44,7 +44,7 @@ ol.TileCache.prototype.expireCache = function(usedTiles) {
   var tile, zKey;
   while (this.canExpireCache()) {
     tile = /** @type {ol.Tile} */ (this.peekLast());
-    zKey = tile.tileCoord.z.toString();
+    zKey = tile.tileCoord[0].toString();
     if (zKey in usedTiles && usedTiles[zKey].contains(tile.tileCoord)) {
       break;
     } else {
@@ -63,7 +63,7 @@ ol.TileCache.prototype.pruneTileRange = function(tileRange) {
       key;
   while (i--) {
     key = this.peekLastKey();
-    if (tileRange.contains(ol.TileCoord.createFromString(key))) {
+    if (tileRange.contains(ol.tilecoord.createFromString(key))) {
       this.pop().dispose();
     } else {
       this.get(key);

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -1,7 +1,17 @@
 goog.provide('ol.TileCoord');
+goog.provide('ol.tilecoord');
 
 goog.require('goog.array');
 goog.require('goog.asserts');
+
+
+/**
+ * An array of three numbers representing the location of a tile in a tile
+ * grid. The order is `z`, `x`, and `y`. `z` is the zoom level.
+ * @typedef {Array.<number>} ol.TileCoord
+ * @api
+ */
+ol.TileCoord;
 
 
 /**
@@ -15,43 +25,11 @@ ol.QuadKeyCharCode = {
 };
 
 
-
-/**
- * @classdesc
- * Represents the location of a tile in a tile grid.
- *
- * @constructor
- * @param {number} z Zoom level.
- * @param {number} x X.
- * @param {number} y Y.
- * @struct
- */
-ol.TileCoord = function(z, x, y) {
-
-  /**
-   * Zoom level.
-   * @type {number}
-   */
-  this.z = z;
-
-  /**
-   * @type {number}
-   */
-  this.x = x;
-
-  /**
-   * @type {number}
-   */
-  this.y = y;
-
-};
-
-
 /**
  * @param {string} quadKey Quad key.
  * @return {ol.TileCoord} Tile coordinate.
  */
-ol.TileCoord.createFromQuadKey = function(quadKey) {
+ol.tilecoord.createFromQuadKey = function(quadKey) {
   var z = quadKey.length, x = 0, y = 0;
   var mask = 1 << (z - 1);
   var i;
@@ -70,7 +48,7 @@ ol.TileCoord.createFromQuadKey = function(quadKey) {
     }
     mask >>= 1;
   }
-  return new ol.TileCoord(z, x, y);
+  return [z, x, y];
 };
 
 
@@ -79,12 +57,13 @@ ol.TileCoord.createFromQuadKey = function(quadKey) {
  *   numbers.
  * @return {ol.TileCoord} Tile coord.
  */
-ol.TileCoord.createFromString = function(str) {
+ol.tilecoord.createFromString = function(str) {
   var v = str.split('/');
+  goog.asserts.assert(v.length === 3);
   v = goog.array.map(v, function(e, i, a) {
     return parseInt(e, 10);
   });
-  return new ol.TileCoord(v[0], v[1], v[2]);
+  return v;
 };
 
 
@@ -95,14 +74,14 @@ ol.TileCoord.createFromString = function(str) {
  * @param {ol.TileCoord|undefined} tileCoord Tile coordinate.
  * @return {ol.TileCoord} Tile coordinate.
  */
-ol.TileCoord.createOrUpdate = function(z, x, y, tileCoord) {
+ol.tilecoord.createOrUpdate = function(z, x, y, tileCoord) {
   if (goog.isDef(tileCoord)) {
-    tileCoord.z = z;
-    tileCoord.x = x;
-    tileCoord.y = y;
+    tileCoord[0] = z;
+    tileCoord[1] = x;
+    tileCoord[2] = y;
     return tileCoord;
   } else {
-    return new ol.TileCoord(z, x, y);
+    return [z, x, y];
   }
 };
 
@@ -113,50 +92,35 @@ ol.TileCoord.createOrUpdate = function(z, x, y, tileCoord) {
  * @param {number} y Y.
  * @return {string} Key.
  */
-ol.TileCoord.getKeyZXY = function(z, x, y) {
+ol.tilecoord.getKeyZXY = function(z, x, y) {
   return z + '/' + x + '/' + y;
 };
 
 
 /**
- * @param {Array.<number>=} opt_result Optional array to reuse.
- * @return {Array.<number>} Array of z, x, y.
- * @api
- */
-ol.TileCoord.prototype.getZXY = function(opt_result) {
-  if (goog.isDef(opt_result)) {
-    goog.asserts.assert(opt_result.length == 3);
-    opt_result[0] = this.z;
-    opt_result[1] = this.x;
-    opt_result[2] = this.y;
-    return opt_result;
-  } else {
-    return [this.z, this.x, this.y];
-  }
-};
-
-
-/**
+ * @param {ol.TileCoord} tileCoord Tile coord.
  * @return {number} Hash.
  */
-ol.TileCoord.prototype.hash = function() {
-  return (this.x << this.z) + this.y;
+ol.tilecoord.hash = function(tileCoord) {
+  return (tileCoord[1] << tileCoord[0]) + tileCoord[2];
 };
 
 
 /**
+ * @param {ol.TileCoord} tileCoord Tile coord.
  * @return {string} Quad key.
  */
-ol.TileCoord.prototype.quadKey = function() {
-  var digits = new Array(this.z);
-  var mask = 1 << (this.z - 1);
+ol.tilecoord.quadKey = function(tileCoord) {
+  var z = tileCoord[0];
+  var digits = new Array(z);
+  var mask = 1 << (z - 1);
   var i, charCode;
-  for (i = 0; i < this.z; ++i) {
+  for (i = 0; i < z; ++i) {
     charCode = ol.QuadKeyCharCode.ZERO;
-    if (this.x & mask) {
+    if (tileCoord[1] & mask) {
       charCode += 1;
     }
-    if (this.y & mask) {
+    if (tileCoord[2] & mask) {
       charCode += 2;
     }
     digits[i] = String.fromCharCode(charCode);
@@ -167,8 +131,9 @@ ol.TileCoord.prototype.quadKey = function() {
 
 
 /**
+ * @param {ol.TileCoord} tileCoord Tile coord.
  * @return {string} String.
  */
-ol.TileCoord.prototype.toString = function() {
-  return ol.TileCoord.getKeyZXY(this.z, this.x, this.y);
+ol.tilecoord.toString = function(tileCoord) {
+  return ol.tilecoord.getKeyZXY(tileCoord[0], tileCoord[1], tileCoord[2]);
 };

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -11,6 +11,7 @@ goog.require('ol.extent');
 goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Projection');
 goog.require('ol.proj.Units');
+goog.require('ol.tilecoord');
 
 
 
@@ -94,7 +95,7 @@ ol.tilegrid.TileGrid = function(options) {
  * @private
  * @type {ol.TileCoord}
  */
-ol.tilegrid.TileGrid.tmpTileCoord_ = new ol.TileCoord(0, 0, 0);
+ol.tilegrid.TileGrid.tmpTileCoord_ = [0, 0, 0];
 
 
 /**
@@ -118,7 +119,7 @@ ol.tilegrid.TileGrid.prototype.createTileCoordTransform = goog.abstractMethod;
 ol.tilegrid.TileGrid.prototype.forEachTileCoordParentTileRange =
     function(tileCoord, callback, opt_this, opt_tileRange, opt_extent) {
   var tileCoordExtent = this.getTileCoordExtent(tileCoord, opt_extent);
-  var z = tileCoord.z - 1;
+  var z = tileCoord[0] - 1;
   while (z >= this.minZoom) {
     if (callback.call(opt_this, z,
         this.getTileRangeForExtentAndZ(tileCoordExtent, z, opt_tileRange))) {
@@ -191,10 +192,10 @@ ol.tilegrid.TileGrid.prototype.getResolutions = function() {
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordChildTileRange =
     function(tileCoord, opt_tileRange, opt_extent) {
-  if (tileCoord.z < this.maxZoom) {
+  if (tileCoord[0] < this.maxZoom) {
     var tileCoordExtent = this.getTileCoordExtent(tileCoord, opt_extent);
     return this.getTileRangeForExtentAndZ(
-        tileCoordExtent, tileCoord.z + 1, opt_tileRange);
+        tileCoordExtent, tileCoord[0] + 1, opt_tileRange);
   } else {
     return null;
   }
@@ -231,12 +232,12 @@ ol.tilegrid.TileGrid.prototype.getTileRangeForExtentAndResolution =
   var tileCoord = ol.tilegrid.TileGrid.tmpTileCoord_;
   this.getTileCoordForXYAndResolution_(
       extent[0], extent[1], resolution, false, tileCoord);
-  var minX = tileCoord.x;
-  var minY = tileCoord.y;
+  var minX = tileCoord[1];
+  var minY = tileCoord[2];
   this.getTileCoordForXYAndResolution_(
       extent[2], extent[3], resolution, true, tileCoord);
   return ol.TileRange.createOrUpdate(
-      minX, tileCoord.x, minY, tileCoord.y, opt_tileRange);
+      minX, tileCoord[1], minY, tileCoord[2], opt_tileRange);
 };
 
 
@@ -259,12 +260,12 @@ ol.tilegrid.TileGrid.prototype.getTileRangeForExtentAndZ =
  * @return {ol.Coordinate} Tile center.
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordCenter = function(tileCoord) {
-  var origin = this.getOrigin(tileCoord.z);
-  var resolution = this.getResolution(tileCoord.z);
-  var tileSize = this.getTileSize(tileCoord.z);
+  var origin = this.getOrigin(tileCoord[0]);
+  var resolution = this.getResolution(tileCoord[0]);
+  var tileSize = this.getTileSize(tileCoord[0]);
   return [
-    origin[0] + (tileCoord.x + 0.5) * tileSize * resolution,
-    origin[1] + (tileCoord.y + 0.5) * tileSize * resolution
+    origin[0] + (tileCoord[1] + 0.5) * tileSize * resolution,
+    origin[1] + (tileCoord[2] + 0.5) * tileSize * resolution
   ];
 };
 
@@ -276,11 +277,11 @@ ol.tilegrid.TileGrid.prototype.getTileCoordCenter = function(tileCoord) {
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordExtent =
     function(tileCoord, opt_extent) {
-  var origin = this.getOrigin(tileCoord.z);
-  var resolution = this.getResolution(tileCoord.z);
-  var tileSize = this.getTileSize(tileCoord.z);
-  var minX = origin[0] + tileCoord.x * tileSize * resolution;
-  var minY = origin[1] + tileCoord.y * tileSize * resolution;
+  var origin = this.getOrigin(tileCoord[0]);
+  var resolution = this.getResolution(tileCoord[0]);
+  var tileSize = this.getTileSize(tileCoord[0]);
+  var minX = origin[0] + tileCoord[1] * tileSize * resolution;
+  var minY = origin[1] + tileCoord[2] * tileSize * resolution;
   var maxX = minX + tileSize * resolution;
   var maxY = minY + tileSize * resolution;
   return ol.extent.createOrUpdate(minX, minY, maxX, maxY, opt_extent);
@@ -333,7 +334,7 @@ ol.tilegrid.TileGrid.prototype.getTileCoordForXYAndResolution_ = function(
     tileCoordY = Math.floor(tileCoordY);
   }
 
-  return ol.TileCoord.createOrUpdate(z, tileCoordX, tileCoordY, opt_tileCoord);
+  return ol.tilecoord.createOrUpdate(z, tileCoordX, tileCoordY, opt_tileCoord);
 };
 
 
@@ -357,8 +358,8 @@ ol.tilegrid.TileGrid.prototype.getTileCoordForCoordAndZ =
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordResolution = function(tileCoord) {
   goog.asserts.assert(
-      this.minZoom <= tileCoord.z && tileCoord.z <= this.maxZoom);
-  return this.resolutions_[tileCoord.z];
+      this.minZoom <= tileCoord[0] && tileCoord[0] <= this.maxZoom);
+  return this.resolutions_[tileCoord[0]];
 };
 
 

--- a/src/ol/tilegrid/xyztilegrid.js
+++ b/src/ol/tilegrid/xyztilegrid.js
@@ -6,6 +6,7 @@ goog.require('ol.TileCoord');
 goog.require('ol.TileRange');
 goog.require('ol.proj');
 goog.require('ol.proj.EPSG3857');
+goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');
 
 
@@ -69,18 +70,18 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
        * @return {ol.TileCoord} Tile coordinate.
        */
       function(tileCoord, projection, opt_tileCoord) {
-        var z = tileCoord.z;
+        var z = tileCoord[0];
         if (z < minZ || maxZ < z) {
           return null;
         }
         var n = Math.pow(2, z);
-        var x = tileCoord.x;
+        var x = tileCoord[1];
         if (wrapX) {
           x = goog.math.modulo(x, n);
         } else if (x < 0 || n <= x) {
           return null;
         }
-        var y = tileCoord.y;
+        var y = tileCoord[2];
         if (y < -n || -1 < y) {
           return null;
         }
@@ -89,7 +90,7 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
             return null;
           }
         }
-        return ol.TileCoord.createOrUpdate(z, x, -y - 1, opt_tileCoord);
+        return ol.tilecoord.createOrUpdate(z, x, -y - 1, opt_tileCoord);
       });
 };
 
@@ -99,10 +100,10 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
  */
 ol.tilegrid.XYZ.prototype.getTileCoordChildTileRange =
     function(tileCoord, opt_tileRange) {
-  if (tileCoord.z < this.maxZoom) {
+  if (tileCoord[0] < this.maxZoom) {
     return ol.TileRange.createOrUpdate(
-        2 * tileCoord.x, 2 * (tileCoord.x + 1),
-        2 * tileCoord.y, 2 * (tileCoord.y + 1),
+        2 * tileCoord[1], 2 * (tileCoord[1] + 1),
+        2 * tileCoord[2], 2 * (tileCoord[2] + 1),
         opt_tileRange);
   } else {
     return null;
@@ -116,9 +117,9 @@ ol.tilegrid.XYZ.prototype.getTileCoordChildTileRange =
 ol.tilegrid.XYZ.prototype.forEachTileCoordParentTileRange =
     function(tileCoord, callback, opt_this, opt_tileRange) {
   var tileRange = ol.TileRange.createOrUpdate(
-      0, tileCoord.x, 0, tileCoord.y, opt_tileRange);
+      0, tileCoord[1], 0, tileCoord[2], opt_tileRange);
   var z;
-  for (z = tileCoord.z - 1; z >= this.minZoom; --z) {
+  for (z = tileCoord[0] - 1; z >= this.minZoom; --z) {
     tileRange.minX = tileRange.maxX >>= 1;
     tileRange.minY = tileRange.maxY >>= 1;
     if (callback.call(opt_this, z, tileRange)) {

--- a/src/ol/tilegrid/zoomifytilegrid.js
+++ b/src/ol/tilegrid/zoomifytilegrid.js
@@ -3,6 +3,7 @@ goog.provide('ol.tilegrid.Zoomify');
 goog.require('goog.math');
 goog.require('ol.TileCoord');
 goog.require('ol.proj');
+goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');
 
 
@@ -55,16 +56,16 @@ ol.tilegrid.Zoomify.prototype.createTileCoordTransform = function(opt_options) {
        * @return {ol.TileCoord} Tile coordinate.
        */
       function(tileCoord, projection, opt_tileCoord) {
-        var z = tileCoord.z;
+        var z = tileCoord[0];
         if (z < minZ || maxZ < z) {
           return null;
         }
         var n = Math.pow(2, z);
-        var x = tileCoord.x;
+        var x = tileCoord[1];
         if (x < 0 || n <= x) {
           return null;
         }
-        var y = tileCoord.y;
+        var y = tileCoord[2];
         if (y < -n || -1 < y) {
           return null;
         }
@@ -73,6 +74,6 @@ ol.tilegrid.Zoomify.prototype.createTileCoordTransform = function(opt_options) {
             return null;
           }
         }
-        return ol.TileCoord.createOrUpdate(z, x, -y - 1, opt_tileCoord);
+        return ol.tilecoord.createOrUpdate(z, x, -y - 1, opt_tileCoord);
       });
 };

--- a/src/ol/tilerange.js
+++ b/src/ol/tilerange.js
@@ -48,16 +48,22 @@ ol.TileRange = function(minX, maxX, minY, maxY) {
  */
 ol.TileRange.boundingTileRange = function(var_args) {
   var tileCoord0 = /** @type {ol.TileCoord} */ (arguments[0]);
-  var tileRange = new ol.TileRange(tileCoord0.x, tileCoord0.x,
-                                   tileCoord0.y, tileCoord0.y);
-  var i, ii, tileCoord;
+  var tileCoord0Z = tileCoord0[0];
+  var tileCoord0X = tileCoord0[1];
+  var tileCoord0Y = tileCoord0[2];
+  var tileRange = new ol.TileRange(tileCoord0X, tileCoord0X,
+                                   tileCoord0Y, tileCoord0Y);
+  var i, ii, tileCoord, tileCoordX, tileCoordY, tileCoordZ;
   for (i = 1, ii = arguments.length; i < ii; ++i) {
     tileCoord = /** @type {ol.TileCoord} */ (arguments[i]);
-    goog.asserts.assert(tileCoord.z == tileCoord0.z);
-    tileRange.minX = Math.min(tileRange.minX, tileCoord.x);
-    tileRange.maxX = Math.max(tileRange.maxX, tileCoord.x);
-    tileRange.minY = Math.min(tileRange.minY, tileCoord.y);
-    tileRange.maxY = Math.max(tileRange.maxY, tileCoord.y);
+    tileCoordZ = tileCoord[0];
+    tileCoordX = tileCoord[1];
+    tileCoordY = tileCoord[2];
+    goog.asserts.assert(tileCoordZ == tileCoord0Z);
+    tileRange.minX = Math.min(tileRange.minX, tileCoordX);
+    tileRange.maxX = Math.max(tileRange.maxX, tileCoordX);
+    tileRange.minY = Math.min(tileRange.minY, tileCoordY);
+    tileRange.maxY = Math.max(tileRange.maxY, tileCoordY);
   }
   return tileRange;
 };
@@ -89,7 +95,7 @@ ol.TileRange.createOrUpdate = function(minX, maxX, minY, maxY, tileRange) {
  * @return {boolean} Contains tile coordinate.
  */
 ol.TileRange.prototype.contains = function(tileCoord) {
-  return this.containsXY(tileCoord.x, tileCoord.y);
+  return this.containsXY(tileCoord[1], tileCoord[2]);
 };
 
 

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -4,6 +4,7 @@ goog.provide('ol.TileUrlFunctionType');
 goog.require('goog.array');
 goog.require('goog.math');
 goog.require('ol.TileCoord');
+goog.require('ol.tilecoord');
 
 
 /**
@@ -46,11 +47,11 @@ ol.TileUrlFunction.createFromTemplate = function(template) {
         if (goog.isNull(tileCoord)) {
           return undefined;
         } else {
-          return template.replace(zRegEx, tileCoord.z.toString())
-                         .replace(xRegEx, tileCoord.x.toString())
-                         .replace(yRegEx, tileCoord.y.toString())
+          return template.replace(zRegEx, tileCoord[0].toString())
+                         .replace(xRegEx, tileCoord[1].toString())
+                         .replace(yRegEx, tileCoord[2].toString())
                          .replace(dashYRegEx, function() {
-                           var y = (1 << tileCoord.z) - tileCoord.y - 1;
+                           var y = (1 << tileCoord[0]) - tileCoord[2] - 1;
                            return y.toString();
                          });
         }
@@ -87,8 +88,8 @@ ol.TileUrlFunction.createFromTileUrlFunctions = function(tileUrlFunctions) {
         if (goog.isNull(tileCoord)) {
           return undefined;
         } else {
-          var index =
-              goog.math.modulo(tileCoord.hash(), tileUrlFunctions.length);
+          var h = ol.tilecoord.hash(tileCoord);
+          var index = goog.math.modulo(h, tileUrlFunctions.length);
           return tileUrlFunctions[index](tileCoord, pixelRatio, projection);
         }
       });
@@ -114,7 +115,7 @@ ol.TileUrlFunction.nullTileUrlFunction =
  */
 ol.TileUrlFunction.withTileCoordTransform =
     function(transformFn, tileUrlFunction) {
-  var tmpTileCoord = new ol.TileCoord(0, 0, 0);
+  var tmpTileCoord = [0, 0, 0];
   return (
       /**
        * @param {ol.TileCoord} tileCoord Tile Coordinate.

--- a/test/spec/ol/source/tilesource.test.js
+++ b/test/spec/ol/source/tilesource.test.js
@@ -224,9 +224,9 @@ goog.inherits(ol.test.source.TileMock, ol.source.Tile);
  * @inheritDoc
  */
 ol.test.source.TileMock.prototype.getTile = function(z, x, y) {
-  var key = ol.TileCoord.getKeyZXY(z, x, y);
+  var key = ol.tilecoord.getKeyZXY(z, x, y);
   var tileState = this.loaded_[key] ? ol.TileState.LOADED : ol.TileState.IDLE;
-  return new ol.Tile(new ol.TileCoord(z, x, y), tileState);
+  return new ol.Tile([z, x, y], tileState);
 };
 
 
@@ -270,9 +270,9 @@ describe('ol.test.source.TileMock', function() {
 
 goog.require('goog.object');
 goog.require('ol.Tile');
-goog.require('ol.TileCoord');
 goog.require('ol.TileState');
 goog.require('ol.proj');
 goog.require('ol.source.Source');
 goog.require('ol.source.Tile');
+goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');

--- a/test/spec/ol/source/tilewmssource.test.js
+++ b/test/spec/ol/source/tilewmssource.test.js
@@ -109,7 +109,7 @@ describe('ol.source.TileWMS', function() {
     it('returns a tile if it is contained within layers extent', function() {
       options.extent = [-80, -40, -50, -10];
       var source = new ol.source.TileWMS(options);
-      var tileCoord = new ol.TileCoord(3, 2, 1);
+      var tileCoord = [3, 2, 1];
       var url = source.tileUrlFunction(tileCoord, 1, ol.proj.get('EPSG:4326'));
       var uri = new goog.Uri(url);
       var queryData = uri.getQueryData();
@@ -119,7 +119,7 @@ describe('ol.source.TileWMS', function() {
     it('returns a tile if it intersects layers extent', function() {
       options.extent = [-80, -40, -40, -10];
       var source = new ol.source.TileWMS(options);
-      var tileCoord = new ol.TileCoord(3, 3, 1);
+      var tileCoord = [3, 3, 1];
       var url = source.tileUrlFunction(tileCoord, 1, ol.proj.get('EPSG:4326'));
       var uri = new goog.Uri(url);
       var queryData = uri.getQueryData();
@@ -201,5 +201,4 @@ describe('ol.source.TileWMS', function() {
 goog.require('goog.Uri');
 goog.require('ol.ImageTile');
 goog.require('ol.source.TileWMS');
-goog.require('ol.TileCoord');
 goog.require('ol.proj');

--- a/test/spec/ol/source/xyzsource.test.js
+++ b/test/spec/ol/source/xyzsource.test.js
@@ -54,13 +54,13 @@ describe('ol.source.XYZ', function() {
 
       it('returns the expected URL', function() {
         var tileUrl = xyzTileSource.tileUrlFunction(
-            new ol.TileCoord(6, -31, -23));
+            [6, -31, -23]);
         expect(tileUrl).to.eql('6/33/22');
 
-        tileUrl = xyzTileSource.tileUrlFunction(new ol.TileCoord(6, 33, -23));
+        tileUrl = xyzTileSource.tileUrlFunction([6, 33, -23]);
         expect(tileUrl).to.eql('6/33/22');
 
-        tileUrl = xyzTileSource.tileUrlFunction(new ol.TileCoord(6, 97, -23));
+        tileUrl = xyzTileSource.tileUrlFunction([6, 97, -23]);
         expect(tileUrl).to.eql('6/33/22');
       });
 
@@ -70,13 +70,13 @@ describe('ol.source.XYZ', function() {
 
       it('returns the expected URL', function() {
         var tileUrl = xyzTileSource.tileUrlFunction(
-            new ol.TileCoord(6, 33, -87));
+            [6, 33, -87]);
         expect(tileUrl).to.be(undefined);
 
-        tileUrl = xyzTileSource.tileUrlFunction(new ol.TileCoord(6, 33, -23));
+        tileUrl = xyzTileSource.tileUrlFunction([6, 33, -23]);
         expect(tileUrl).to.eql('6/33/22');
 
-        tileUrl = xyzTileSource.tileUrlFunction(new ol.TileCoord(6, 33, 41));
+        tileUrl = xyzTileSource.tileUrlFunction([6, 33, 41]);
         expect(tileUrl).to.be(undefined);
       });
 

--- a/test/spec/ol/tilecoord.test.js
+++ b/test/spec/ol/tilecoord.test.js
@@ -4,47 +4,49 @@ describe('ol.TileCoord', function() {
 
   describe('create', function() {
     it('sets x y z properties as expected', function() {
-      var tc = new ol.TileCoord(1, 2, 3);
-      expect(tc.z).to.eql(1);
-      expect(tc.x).to.eql(2);
-      expect(tc.y).to.eql(3);
+      var tileCoord = [1, 2, 3];
+      expect(tileCoord[0]).to.eql(1);
+      expect(tileCoord[1]).to.eql(2);
+      expect(tileCoord[2]).to.eql(3);
     });
   });
 
   describe('create from quad key', function() {
     it('sets x y z properties as expected', function() {
-      var tc = ol.TileCoord.createFromQuadKey('213');
-      expect(tc.z).to.eql(3);
-      expect(tc.x).to.eql(3);
-      expect(tc.y).to.eql(5);
+      var tileCoord = ol.tilecoord.createFromQuadKey('213');
+      expect(tileCoord[0]).to.eql(3);
+      expect(tileCoord[1]).to.eql(3);
+      expect(tileCoord[2]).to.eql(5);
     });
   });
 
   describe('create from string', function() {
     it('sets x y z properties as expected', function() {
       var str = '1/2/3';
-      var tc = ol.TileCoord.createFromString(str);
-      expect(tc.z).to.eql(1);
-      expect(tc.x).to.eql(2);
-      expect(tc.y).to.eql(3);
+      var tileCoord = ol.tilecoord.createFromString(str);
+      expect(tileCoord[0]).to.eql(1);
+      expect(tileCoord[1]).to.eql(2);
+      expect(tileCoord[2]).to.eql(3);
     });
   });
 
   describe('call quadKey', function() {
     it('returns expected string', function() {
-      var tc = new ol.TileCoord(3, 3, 5);
-      var s = tc.quadKey();
+      var tileCoord = [3, 3, 5];
+      var s = ol.tilecoord.quadKey(tileCoord);
       expect(s).to.eql('213');
     });
   });
 
   describe('hash', function() {
     it('produces different hashes for different tile coords', function() {
-      var tc1 = new ol.TileCoord(3, 2, 1);
-      var tc2 = new ol.TileCoord(3, 1, 1);
-      expect(tc1.hash()).not.to.eql(tc2.hash());
+      var tileCoord1 = [3, 2, 1];
+      var tileCoord2 = [3, 1, 1];
+      expect(ol.tilecoord.hash(tileCoord1)).not.to.eql(
+          ol.tilecoord.hash(tileCoord2));
     });
   });
 });
 
 goog.require('ol.TileCoord');
+goog.require('ol.tilecoord');

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -238,24 +238,24 @@ describe('ol.tilegrid.TileGrid', function() {
         var tileCoord;
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 0], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(0);
-        expect(tileCoord.y).to.eql(0);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(0);
+        expect(tileCoord[2]).to.eql(0);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 100000], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(0);
-        expect(tileCoord.y).to.eql(10);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(0);
+        expect(tileCoord[2]).to.eql(10);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 0], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(10);
-        expect(tileCoord.y).to.eql(0);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(10);
+        expect(tileCoord[2]).to.eql(0);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 100000], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(10);
-        expect(tileCoord.y).to.eql(10);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(10);
+        expect(tileCoord[2]).to.eql(10);
       });
     });
 
@@ -271,24 +271,24 @@ describe('ol.tilegrid.TileGrid', function() {
         var tileCoord;
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 0], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(0);
-        expect(tileCoord.y).to.eql(-10);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(0);
+        expect(tileCoord[2]).to.eql(-10);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 100000], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(0);
-        expect(tileCoord.y).to.eql(0);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(0);
+        expect(tileCoord[2]).to.eql(0);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 0], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(10);
-        expect(tileCoord.y).to.eql(-10);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(10);
+        expect(tileCoord[2]).to.eql(-10);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 100000], 3);
-        expect(tileCoord.z).to.eql(3);
-        expect(tileCoord.x).to.eql(10);
-        expect(tileCoord.y).to.eql(0);
+        expect(tileCoord[0]).to.eql(3);
+        expect(tileCoord[1]).to.eql(10);
+        expect(tileCoord[2]).to.eql(0);
       });
     });
   });
@@ -309,65 +309,65 @@ describe('ol.tilegrid.TileGrid', function() {
       // gets the first tile at the origin
       coordinate = [0, 0];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(0);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(0);
 
       // gets one tile northwest of the origin
       coordinate = [-1280, 1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(-1);
-      expect(tileCoord.y).to.eql(0);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(0);
 
       // gets one tile northeast of the origin
       coordinate = [1280, 1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(0);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(0);
 
       // gets one tile southeast of the origin
       coordinate = [1280, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(-1);
 
       // gets one tile southwest of the origin
       coordinate = [-1280, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(-1);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(-1);
 
       // gets the tile to the east when on the edge
       coordinate = [2560, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(1);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(1);
+      expect(tileCoord[2]).to.eql(-1);
 
       // gets the tile to the north when on the edge
       coordinate = [1280, -2560];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(-1);
 
       // pixels are top aligned to the origin
       coordinate = [1280, -2559.999];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(-1);
 
       // pixels are left aligned to the origin
       coordinate = [2559.999, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
-      expect(tileCoord.z).to.eql(0);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(0);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(-1);
     });
   });
 
@@ -386,16 +386,16 @@ describe('ol.tilegrid.TileGrid', function() {
       // gets higher tile for edge intersection
       tileCoord = tileGrid.getTileCoordForXYAndResolution_(
           0, 0, 100, false);
-      expect(tileCoord.z).to.eql(3);
-      expect(tileCoord.x).to.eql(0);
-      expect(tileCoord.y).to.eql(0);
+      expect(tileCoord[0]).to.eql(3);
+      expect(tileCoord[1]).to.eql(0);
+      expect(tileCoord[2]).to.eql(0);
 
       // gets higher tile for edge intersection
       tileCoord = tileGrid.getTileCoordForXYAndResolution_(
           100000, 100000, 100, false);
-      expect(tileCoord.z).to.eql(3);
-      expect(tileCoord.x).to.eql(10);
-      expect(tileCoord.y).to.eql(10);
+      expect(tileCoord[0]).to.eql(3);
+      expect(tileCoord[1]).to.eql(10);
+      expect(tileCoord[2]).to.eql(10);
 
     });
 
@@ -412,16 +412,16 @@ describe('ol.tilegrid.TileGrid', function() {
       // can get lower tile for edge intersection
       tileCoord = tileGrid.getTileCoordForXYAndResolution_(
           0, 0, 100, true);
-      expect(tileCoord.z).to.eql(3);
-      expect(tileCoord.x).to.eql(-1);
-      expect(tileCoord.y).to.eql(-1);
+      expect(tileCoord[0]).to.eql(3);
+      expect(tileCoord[1]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(-1);
 
       // gets higher tile for edge intersection
       tileCoord = tileGrid.getTileCoordForXYAndResolution_(
           100000, 100000, 100, true);
-      expect(tileCoord.z).to.eql(3);
-      expect(tileCoord.x).to.eql(9);
-      expect(tileCoord.y).to.eql(9);
+      expect(tileCoord[0]).to.eql(3);
+      expect(tileCoord[1]).to.eql(9);
+      expect(tileCoord[2]).to.eql(9);
 
     });
 
@@ -437,15 +437,15 @@ describe('ol.tilegrid.TileGrid', function() {
       });
       var center;
 
-      center = tileGrid.getTileCoordCenter(new ol.TileCoord(0, 0, 0));
+      center = tileGrid.getTileCoordCenter([0, 0, 0]);
       expect(center[0]).to.eql(50000);
       expect(center[1]).to.eql(50000);
 
-      center = tileGrid.getTileCoordCenter(new ol.TileCoord(3, 0, 0));
+      center = tileGrid.getTileCoordCenter([3, 0, 0]);
       expect(center[0]).to.eql(5000);
       expect(center[1]).to.eql(5000);
 
-      center = tileGrid.getTileCoordCenter(new ol.TileCoord(3, 9, 9));
+      center = tileGrid.getTileCoordCenter([3, 9, 9]);
       expect(center[0]).to.eql(95000);
       expect(center[1]).to.eql(95000);
     });
@@ -461,19 +461,19 @@ describe('ol.tilegrid.TileGrid', function() {
       });
       var tileCoordExtent;
 
-      tileCoordExtent = tileGrid.getTileCoordExtent(new ol.TileCoord(0, 0, 0));
+      tileCoordExtent = tileGrid.getTileCoordExtent([0, 0, 0]);
       expect(tileCoordExtent[0]).to.eql(0);
       expect(tileCoordExtent[1]).to.eql(0);
       expect(tileCoordExtent[2]).to.eql(100000);
       expect(tileCoordExtent[3]).to.eql(100000);
 
-      tileCoordExtent = tileGrid.getTileCoordExtent(new ol.TileCoord(3, 9, 0));
+      tileCoordExtent = tileGrid.getTileCoordExtent([3, 9, 0]);
       expect(tileCoordExtent[0]).to.eql(90000);
       expect(tileCoordExtent[1]).to.eql(0);
       expect(tileCoordExtent[2]).to.eql(100000);
       expect(tileCoordExtent[3]).to.eql(10000);
 
-      tileCoordExtent = tileGrid.getTileCoordExtent(new ol.TileCoord(3, 0, 9));
+      tileCoordExtent = tileGrid.getTileCoordExtent([3, 0, 9]);
       expect(tileCoordExtent[0]).to.eql(0);
       expect(tileCoordExtent[1]).to.eql(90000);
       expect(tileCoordExtent[2]).to.eql(10000);
@@ -569,7 +569,7 @@ describe('ol.tilegrid.TileGrid', function() {
       var zs = [], tileRanges = [];
 
       tileGrid.forEachTileCoordParentTileRange(
-          new ol.TileCoord(3, 7, 3),
+          [3, 7, 3],
           function(z, tileRange) {
             zs.push(z);
             tileRanges.push(tileRange);
@@ -643,7 +643,6 @@ describe('ol.tilegrid.TileGrid', function() {
 });
 
 goog.require('ol.Coordinate');
-goog.require('ol.TileCoord');
 goog.require('ol.proj');
 goog.require('ol.proj.METERS_PER_UNIT');
 goog.require('ol.proj.Projection');

--- a/test/spec/ol/tilegrid/xyztilegrid.test.js
+++ b/test/spec/ol/tilegrid/xyztilegrid.test.js
@@ -14,7 +14,7 @@ describe('ol.tilegrid.XYZ', function() {
 
     it('iterates as expected', function() {
 
-      var tileCoord = new ol.TileCoord(5, 11, 21);
+      var tileCoord = [5, 11, 21];
       var zs = [], tileRanges = [];
       xyzTileGrid.forEachTileCoordParentTileRange(
           tileCoord,

--- a/test/spec/ol/tilerange.test.js
+++ b/test/spec/ol/tilerange.test.js
@@ -19,39 +19,38 @@ describe('ol.TileRange', function() {
   describe('contains', function() {
     it('returns the expected value', function() {
       var tileRange = new ol.TileRange(1, 3, 1, 3);
-      expect(tileRange.contains(new ol.TileCoord(0, 0, 0))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 0, 1))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 0, 2))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 0, 3))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 0, 4))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 1, 0))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 1, 1))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 1, 2))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 1, 3))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 1, 4))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 2, 0))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 2, 1))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 2, 2))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 2, 3))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 2, 4))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 3, 0))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 3, 1))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 3, 2))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 3, 3))).to.be.ok();
-      expect(tileRange.contains(new ol.TileCoord(0, 3, 4))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 4, 0))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 4, 1))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 4, 2))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 4, 3))).to.not.be();
-      expect(tileRange.contains(new ol.TileCoord(0, 4, 4))).to.not.be();
+      expect(tileRange.contains([0, 0, 0])).to.not.be();
+      expect(tileRange.contains([0, 0, 1])).to.not.be();
+      expect(tileRange.contains([0, 0, 2])).to.not.be();
+      expect(tileRange.contains([0, 0, 3])).to.not.be();
+      expect(tileRange.contains([0, 0, 4])).to.not.be();
+      expect(tileRange.contains([0, 1, 0])).to.not.be();
+      expect(tileRange.contains([0, 1, 1])).to.be.ok();
+      expect(tileRange.contains([0, 1, 2])).to.be.ok();
+      expect(tileRange.contains([0, 1, 3])).to.be.ok();
+      expect(tileRange.contains([0, 1, 4])).to.not.be();
+      expect(tileRange.contains([0, 2, 0])).to.not.be();
+      expect(tileRange.contains([0, 2, 1])).to.be.ok();
+      expect(tileRange.contains([0, 2, 2])).to.be.ok();
+      expect(tileRange.contains([0, 2, 3])).to.be.ok();
+      expect(tileRange.contains([0, 2, 4])).to.not.be();
+      expect(tileRange.contains([0, 3, 0])).to.not.be();
+      expect(tileRange.contains([0, 3, 1])).to.be.ok();
+      expect(tileRange.contains([0, 3, 2])).to.be.ok();
+      expect(tileRange.contains([0, 3, 3])).to.be.ok();
+      expect(tileRange.contains([0, 3, 4])).to.not.be();
+      expect(tileRange.contains([0, 4, 0])).to.not.be();
+      expect(tileRange.contains([0, 4, 1])).to.not.be();
+      expect(tileRange.contains([0, 4, 2])).to.not.be();
+      expect(tileRange.contains([0, 4, 3])).to.not.be();
+      expect(tileRange.contains([0, 4, 4])).to.not.be();
     });
   });
 
   describe('boundingTileRange', function() {
     it('returns the expected TileRange', function() {
       var tileRange = new ol.TileRange.boundingTileRange(
-          new ol.TileCoord(3, 1, 3),
-          new ol.TileCoord(3, 2, 0));
+          [3, 1, 3], [3, 2, 0]);
       expect(tileRange.minX).to.eql(1);
       expect(tileRange.maxX).to.eql(2);
       expect(tileRange.minY).to.eql(0);
@@ -61,8 +60,7 @@ describe('ol.TileRange', function() {
     describe('with mixed z', function() {
       expect(function() {
         var tileRange = new ol.TileRange.boundingTileRange(
-            new ol.TileCoord(3, 1, 3),
-            new ol.TileCoord(4, 2, 0));
+            [3, 1, 3], [4, 2, 0]);
         tileRange = tileRange; // suppress gjslint warning about unused variable
       }).to.throwException();
     });

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -30,16 +30,16 @@ describe('ol.TileUrlFunction', function() {
   describe('createFromTemplate', function() {
     it('creates expected URL', function() {
       var tileUrl = ol.TileUrlFunction.createFromTemplate('{z}/{x}/{y}');
-      expect(tileUrl(new ol.TileCoord(3, 2, 1))).to.eql('3/2/1');
+      expect(tileUrl([3, 2, 1])).to.eql('3/2/1');
       expect(tileUrl(null)).to.be(undefined);
     });
     it('accepts {-y} placeholder', function() {
       var tileUrl = ol.TileUrlFunction.createFromTemplate('{z}/{x}/{-y}');
-      expect(tileUrl(new ol.TileCoord(3, 2, 2))).to.eql('3/2/5');
+      expect(tileUrl([3, 2, 2])).to.eql('3/2/5');
     });
     it('replaces multiple placeholder occurrences', function() {
       var tileUrl = ol.TileUrlFunction.createFromTemplate('{z}/{z}{x}{y}');
-      expect(tileUrl(new ol.TileCoord(3, 2, 1))).to.eql('3/321');
+      expect(tileUrl([3, 2, 1])).to.eql('3/321');
     });
   });
 
@@ -51,13 +51,19 @@ describe('ol.TileUrlFunction', function() {
         'http://tile-3/{z}/{x}/{y}'
       ];
       var tileUrlFunction = ol.TileUrlFunction.createFromTemplates(templates);
-      var tileCoord = new ol.TileCoord(3, 2, 1);
-      tileCoord.hash = function() { return 3; };
+      var tileCoord = [3, 2, 1];
+
+      sinon.stub(ol.tilecoord, 'hash', function() { return 3; });
       expect(tileUrlFunction(tileCoord)).to.eql('http://tile-1/3/2/1');
-      tileCoord.hash = function() { return 2; };
+      ol.tilecoord.hash.restore();
+
+      sinon.stub(ol.tilecoord, 'hash', function() { return 2; });
       expect(tileUrlFunction(tileCoord)).to.eql('http://tile-3/3/2/1');
-      tileCoord.hash = function() { return 1; };
+      ol.tilecoord.hash.restore();
+
+      sinon.stub(ol.tilecoord, 'hash', function() { return 1; });
       expect(tileUrlFunction(tileCoord)).to.eql('http://tile-2/3/2/1');
+      ol.tilecoord.hash.restore();
     });
   });
 
@@ -65,10 +71,10 @@ describe('ol.TileUrlFunction', function() {
     it('creates expected URL', function() {
       var tileUrl = ol.TileUrlFunction.withTileCoordTransform(
           function(tileCoord) {
-            return new ol.TileCoord(tileCoord.z, tileCoord.x, -tileCoord.y);
+            return [tileCoord[0], tileCoord[1], -tileCoord[2]];
           },
           ol.TileUrlFunction.createFromTemplate('{z}/{x}/{y}'));
-      expect(tileUrl(new ol.TileCoord(3, 2, -1))).to.eql('3/2/1');
+      expect(tileUrl([3, 2, -1])).to.eql('3/2/1');
       expect(tileUrl(null)).to.be(undefined);
     });
   });
@@ -79,8 +85,8 @@ describe('ol.TileUrlFunction', function() {
         ol.TileUrlFunction.createFromTemplate('a'),
         ol.TileUrlFunction.createFromTemplate('b')
       ]);
-      var tileUrl1 = tileUrl(new ol.TileCoord(1, 0, 0));
-      var tileUrl2 = tileUrl(new ol.TileCoord(1, 0, 1));
+      var tileUrl1 = tileUrl([1, 0, 0]);
+      var tileUrl2 = tileUrl([1, 0, 1]);
       expect(tileUrl1).not.to.be(tileUrl2);
       expect(tileUrl(null)).to.be(undefined);
     });


### PR DESCRIPTION
This PR changes the `ol.TileCoord` type to an array of three numbers: `[z, x, y]`. This is as discussed in #2514.

I did not test every example. I would be good that someone else could also test some of the examples. Thanks.

Closes #2514.
