### PR TITLE
Rename ol.source.MapGuide to ol.source.ImageMapGuide

### DIFF
--- a/examples/mapguide-untiled.js
+++ b/examples/mapguide-untiled.js
@@ -1,7 +1,7 @@
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Image');
-goog.require('ol.source.MapGuide');
+goog.require('ol.source.ImageMapGuide');
 
 var mdf = 'Library://Samples/Sheboygan/Maps/Sheboygan.MapDefinition';
 var agentUrl =
@@ -16,7 +16,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Image({
       extent: bounds,
-      source: new ol.source.MapGuide({
+      source: new ol.source.ImageMapGuide({
         projection: 'EPSG:4326',
         url: agentUrl,
         useOverlay: false,

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3269,28 +3269,28 @@ olx.source.IGCOptions.prototype.urls;
  *     params: (Object|undefined)}}
  * @api
  */
-olx.source.MapGuideOptions;
+olx.source.ImageMapGuideOptions;
 
 
 /**
  * The mapagent url.
  * @type {string|undefined}
  */
-olx.source.MapGuideOptions.prototype.url;
+olx.source.ImageMapGuideOptions.prototype.url;
 
 
 /**
  * The display resolution. Default is `96`.
  * @type {number|undefined}
  */
-olx.source.MapGuideOptions.prototype.displayDpi;
+olx.source.ImageMapGuideOptions.prototype.displayDpi;
 
 
 /**
  * The meters-per-unit value. Default is `1`.
  * @type {number|undefined}
  */
-olx.source.MapGuideOptions.prototype.metersPerUnit;
+olx.source.ImageMapGuideOptions.prototype.metersPerUnit;
 
 
 /**
@@ -3298,21 +3298,21 @@ olx.source.MapGuideOptions.prototype.metersPerUnit;
  * server. Default is `true`.
  * @type {boolean|undefined}
  */
-olx.source.MapGuideOptions.prototype.hidpi;
+olx.source.ImageMapGuideOptions.prototype.hidpi;
 
 
 /**
  * If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
  * @type {boolean|undefined}
  */
-olx.source.MapGuideOptions.prototype.useOverlay;
+olx.source.ImageMapGuideOptions.prototype.useOverlay;
 
 
 /**
  * Projection.
  * @type {ol.proj.ProjectionLike}
  */
-olx.source.MapGuideOptions.prototype.projection;
+olx.source.ImageMapGuideOptions.prototype.projection;
 
 
 /**
@@ -3320,21 +3320,21 @@ olx.source.MapGuideOptions.prototype.projection;
  * twice the size of the map viewport, and so on. Default is `1`.
  * @type {number|undefined}
  */
-olx.source.MapGuideOptions.prototype.ratio;
+olx.source.ImageMapGuideOptions.prototype.ratio;
 
 
 /**
  * Resolutions. If specified, requests will be made for these resolutions only.
  * @type {Array.<number>|undefined}
  */
-olx.source.MapGuideOptions.prototype.resolutions;
+olx.source.ImageMapGuideOptions.prototype.resolutions;
 
 
 /**
  * Additional parameters.
  * @type {Object|undefined}
  */
-olx.source.MapGuideOptions.prototype.params;
+olx.source.ImageMapGuideOptions.prototype.params;
 
 
 /**

--- a/src/ol/source/imagemapguidesource.js
+++ b/src/ol/source/imagemapguidesource.js
@@ -1,4 +1,4 @@
-goog.provide('ol.source.MapGuide');
+goog.provide('ol.source.ImageMapGuide');
 
 goog.require('goog.object');
 goog.require('goog.uri.utils');
@@ -15,10 +15,10 @@ goog.require('ol.source.Image');
  *
  * @constructor
  * @extends {ol.source.Image}
- * @param {olx.source.MapGuideOptions} options Options.
+ * @param {olx.source.ImageMapGuideOptions} options Options.
  * @api
  */
-ol.source.MapGuide = function(options) {
+ol.source.ImageMapGuide = function(options) {
 
   goog.base(this, {
     projection: options.projection,
@@ -98,7 +98,7 @@ ol.source.MapGuide = function(options) {
   this.renderedRevision_ = 0;
 
 };
-goog.inherits(ol.source.MapGuide, ol.source.Image);
+goog.inherits(ol.source.ImageMapGuide, ol.source.Image);
 
 
 /**
@@ -107,7 +107,7 @@ goog.inherits(ol.source.MapGuide, ol.source.Image);
  * @return {Object} Params.
  * @api
  */
-ol.source.MapGuide.prototype.getParams = function() {
+ol.source.ImageMapGuide.prototype.getParams = function() {
   return this.params_;
 };
 
@@ -115,7 +115,7 @@ ol.source.MapGuide.prototype.getParams = function() {
 /**
  * @inheritDoc
  */
-ol.source.MapGuide.prototype.getImage =
+ol.source.ImageMapGuide.prototype.getImage =
     function(extent, resolution, pixelRatio, projection) {
   resolution = this.findNearestResolution(resolution);
   pixelRatio = this.hidpi_ ? pixelRatio : 1;
@@ -158,7 +158,7 @@ ol.source.MapGuide.prototype.getImage =
  * @param {number} dpi The display resolution.
  * @return {number} The computed map scale.
  */
-ol.source.MapGuide.getScale = function(extent, size, metersPerUnit, dpi) {
+ol.source.ImageMapGuide.getScale = function(extent, size, metersPerUnit, dpi) {
   var mcsW = ol.extent.getWidth(extent);
   var mcsH = ol.extent.getHeight(extent);
   var devW = size[0];
@@ -177,7 +177,7 @@ ol.source.MapGuide.getScale = function(extent, size, metersPerUnit, dpi) {
  * @param {Object} params Params.
  * @api
  */
-ol.source.MapGuide.prototype.updateParams = function(params) {
+ol.source.ImageMapGuide.prototype.updateParams = function(params) {
   goog.object.extend(this.params_, params);
   this.dispatchChangeEvent();
 };
@@ -191,16 +191,16 @@ ol.source.MapGuide.prototype.updateParams = function(params) {
  * @param {ol.proj.Projection} projection Projection.
  * @return {string} The mapagent map image request URL.
  */
-ol.source.MapGuide.prototype.getUrl =
+ol.source.ImageMapGuide.prototype.getUrl =
     function(baseUrl, params, extent, size, projection) {
-  var scale = ol.source.MapGuide.getScale(extent, size,
+  var scale = ol.source.ImageMapGuide.getScale(extent, size,
       this.metersPerUnit_, this.displayDpi_);
   var center = ol.extent.getCenter(extent);
   var baseParams = {
     'OPERATION': this.useOverlay_ ? 'GETDYNAMICMAPOVERLAYIMAGE' : 'GETMAPIMAGE',
     'VERSION': '2.0.0',
     'LOCALE': 'en',
-    'CLIENTAGENT': 'ol.source.MapGuide source',
+    'CLIENTAGENT': 'ol.source.ImageMapGuide source',
     'CLIP': '1',
     'SETDISPLAYDPI': this.displayDpi_,
     'SETDISPLAYWIDTH': Math.round(size[0]),


### PR DESCRIPTION
For consistency with `ol.source.ImageWMS`. This also leaves room for `ol.source.TileMapGuide`.

Closes #2553.
