### PR TITLE
Making ol.Overlay accept offset values for positioning -right or bottom-

### DIFF
--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -405,8 +405,8 @@ ol.Overlay.prototype.updatePixelPosition_ = function() {
   var positioning = this.getPositioning();
   goog.asserts.assert(goog.isDef(positioning));
 
-  var offsetX = -offset[0];
-  var offsetY = -offset[1];
+  var offsetX = offset[0];
+  var offsetY = offset[1];
   if (positioning == ol.OverlayPositioning.BOTTOM_RIGHT ||
       positioning == ol.OverlayPositioning.CENTER_RIGHT ||
       positioning == ol.OverlayPositioning.TOP_RIGHT) {
@@ -424,9 +424,9 @@ ol.Overlay.prototype.updatePixelPosition_ = function() {
     if (positioning == ol.OverlayPositioning.BOTTOM_CENTER ||
         positioning == ol.OverlayPositioning.CENTER_CENTER ||
         positioning == ol.OverlayPositioning.TOP_CENTER) {
-      offsetX += goog.style.getSize(this.element_).width / 2;
+      offsetX -= goog.style.getSize(this.element_).width / 2;
     }
-    var left = Math.round(pixel[0] - offsetX) + 'px';
+    var left = Math.round(pixel[0] + offsetX) + 'px';
     if (this.rendered_.left_ != left) {
       this.rendered_.left_ = style.left = left;
     }
@@ -448,9 +448,9 @@ ol.Overlay.prototype.updatePixelPosition_ = function() {
     if (positioning == ol.OverlayPositioning.CENTER_LEFT ||
         positioning == ol.OverlayPositioning.CENTER_CENTER ||
         positioning == ol.OverlayPositioning.CENTER_RIGHT) {
-      offsetY += goog.style.getSize(this.element_).height / 2;
+      offsetY -= goog.style.getSize(this.element_).height / 2;
     }
-    var top = Math.round(pixel[1] - offsetY) + 'px';
+    var top = Math.round(pixel[1] + offsetY) + 'px';
     if (this.rendered_.top_ != top) {
       this.rendered_.top_ = style.top = top;
     }


### PR DESCRIPTION
i made 2 fiddles showing the bahaviour before and after.
the divs are named after their positioning (anchor point)! not the actual position!
before: http://jsfiddle.net/simon_seyock/ob7ggtx6/
as you can see, on div named "bottom-right" no offset at all is applied. on "bottom-center" it is only applied horizontally and on "center-right" only vertically.
after: http://jsfiddle.net/simon_seyock/sL2f3nL9/2/
all offsets are applied correctly, you could draw a straight line through the anchor points of every div.
