### PR TITLE
Write out stability info for symbols

### DIFF
--- a/buildcfg/jsdoc/info/publish.js
+++ b/buildcfg/jsdoc/info/publish.js
@@ -83,6 +83,7 @@ exports.publish = function(data, opts) {
         name: doc.longname,
         kind: doc.kind,
         description: doc.classdesc || doc.description,
+        stability: doc.api,
         path: path.join(doc.meta.path, doc.meta.filename)
       };
       if (doc.type) {


### PR DESCRIPTION
The hosted build tool will let users pick only "stable" symbols (for example).  And no, I don't think the `build.js` task should be enhanced to parse stability level from a build config.
