### PR TITLE
Mark map.beforeRender as unstable

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -517,7 +517,7 @@ ol.Map.prototype.addOverlay = function(overlay) {
  * animations before updating the map's view.  The {@link ol.animation}
  * namespace provides several static methods for creating prerender functions.
  * @param {...ol.PreRenderFunction} var_args Any number of pre-render functions.
- * @api stable
+ * @api
  */
 ol.Map.prototype.beforeRender = function(var_args) {
   this.render();


### PR DESCRIPTION
I'm planning on reworking how animation is done.  Instead of setting the final view state and then adding functions that tween the frame state, the view will be animated.  This will make synchronized maps work as expected during animated transitions.

Instead of a `beforeRender` function on the map, the view may have an `animate` method.
