### PR TITLE
Add @api stable annotations for olx.control.DefaultsOptions

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -873,8 +873,9 @@ olx.control.ControlOptions.prototype.target;
 /**
  * @typedef {{attribution: (boolean|undefined),
  *     attributionOptions: (olx.control.AttributionOptions|undefined),
- *     zoom: (boolean|undefined),
+ *     rotate: (boolean|undefined),
  *     rotateOptions: (olx.control.RotateOptions|undefined),
+ *     zoom: (boolean|undefined),
  *     zoomOptions: (olx.control.ZoomOptions|undefined)}}
  * @api
  */


### PR DESCRIPTION
This follows up on #2564.

`olx.control.DefaultsOptions` currently includes the following options:
- `attribution`
- `attributionOptions`
- `rotate`
- `rotateOptions`
- `zoom`
- `zoomOptions`

Based on https://github.com/openlayers/ol3/issues/2236 I've marked `attribution`, `rotate` and `zoom` as stable, and left the corresponding `*Options` options experimental. In this way we can implement what's described in #2236 without breaking the API.

Please review.
