### PR TITLE
Add @api stable annotation to ol.Size

### DIFF
--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -5,7 +5,7 @@ goog.provide('ol.size');
 /**
  * An array of numbers representing a size: `[width, height]`.
  * @typedef {Array.<number>}
- * @api
+ * @api stable
  */
 ol.Size;
 


### PR DESCRIPTION
We have a lot of constructors that accept a `size` option (of type `ol.Size`)  so it makes sense to me to mark `ol.Size` as stable in the API docs.

Please review.
