### PR TITLE
Add @api stable annotation to ol.Pixel

### DIFF
--- a/src/ol/pixel.js
+++ b/src/ol/pixel.js
@@ -5,6 +5,6 @@ goog.provide('ol.Pixel');
  * An array with two elements, representing a pixel. The first element is the
  * x-coordinate, the second the y-coordinate of the pixel.
  * @typedef {Array.<number>}
- * @api
+ * @api stable
  */
 ol.Pixel;


### PR DESCRIPTION
The `ol.Map#forEachFeatureAtPixel`, which is marked as "stable", takes an `ol.Pixel` as its first argument. So it makes sense to mark the `ol.Pixel` type as "stable" as well.

Please review.
