### PR TITLE
Indicates that ol.geom.Geometry#clone never return null

### DIFF
--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -95,7 +95,7 @@ goog.inherits(ol.geom.Geometry, ol.Observable);
 /**
  * Make a complete copy of the geometry.
  * @function
- * @return {ol.geom.Geometry} Clone.
+ * @return {!ol.geom.Geometry} Clone.
  * @api stable
  */
 ol.geom.Geometry.prototype.clone = goog.abstractMethod;


### PR DESCRIPTION
cc @gberaudo
