### PR TITLE
Set default ol.source.OSM maxZoom to 19

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3905,7 +3905,7 @@ olx.source.OSMOptions.prototype.crossOrigin;
 
 
 /**
- * Max zoom.
+ * Max zoom. Default is `19`.
  * @type {number|undefined}
  * @api
  */

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -37,7 +37,7 @@ ol.source.OSM = function(opt_options) {
     attributions: attributions,
     crossOrigin: crossOrigin,
     opaque: true,
-    maxZoom: options.maxZoom,
+    maxZoom: goog.isDef(options.maxZoom) ? options.maxZoom : 19,
     tileLoadFunction: options.tileLoadFunction,
     url: url
   });


### PR DESCRIPTION
The current default is undefined; tile beyond 19 are loaded.
See http://wiki.openstreetmap.org/wiki/Zoom_levels
