### PR TITLE
Process typedefs last when generating externs

### DIFF
--- a/tasks/generate-externs.js
+++ b/tasks/generate-externs.js
@@ -126,6 +126,8 @@ function generateExterns(typedefs, symbols, externs) {
 
   externs.forEach(processSymbol);
 
+  symbols.forEach(processSymbol);
+
   typedefs.forEach(function(typedef) {
     addNamespaces(typedef.name);
     lines.push('/**');
@@ -135,8 +137,6 @@ function generateExterns(typedefs, symbols, externs) {
     lines.push('\n');
   });
 
-  symbols.forEach(processSymbol);
-  
   return lines.join('\n');
 }
 


### PR DESCRIPTION
Becasue typedefs sometimes use namespaces that are actually
constructors, we need to process typedefs after symbols to avoid
duplicate entries for such namespace types.

Partially fixes #2615.
