### PR TITLE
Map and LayerGroup layer collection as a reference.

### DIFF
--- a/src/ol/layer/layergroup.js
+++ b/src/ol/layer/layergroup.js
@@ -67,7 +67,7 @@ ol.layer.Group = function(opt_options) {
     layers = new ol.Collection();
   }
 
-  this.setLayers(layers);
+  this.set(ol.layer.GroupProperty.LAYERS, layers);
 
 };
 goog.inherits(ol.layer.Group, ol.layer.Base);
@@ -145,34 +145,19 @@ ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
 
 
 /**
- * @return {ol.Collection.<ol.layer.Base>|undefined} Collection of
+ * @return {!ol.Collection.<ol.layer.Base>} Collection of
  * {@link ol.layer.Layer layers} that are part of this group.
  * @observable
  * @api stable
  */
 ol.layer.Group.prototype.getLayers = function() {
-  return /** @type {ol.Collection.<ol.layer.Base>|undefined} */ (this.get(
+  return /** @type {!ol.Collection.<ol.layer.Base>} */ (this.get(
       ol.layer.GroupProperty.LAYERS));
 };
 goog.exportProperty(
     ol.layer.Group.prototype,
     'getLayers',
     ol.layer.Group.prototype.getLayers);
-
-
-/**
- * @param {ol.Collection.<ol.layer.Base>|undefined} layers Collection of
- * {@link ol.layer.Layer layers} that are part of this group.
- * @observable
- * @api stable
- */
-ol.layer.Group.prototype.setLayers = function(layers) {
-  this.set(ol.layer.GroupProperty.LAYERS, layers);
-};
-goog.exportProperty(
-    ol.layer.Group.prototype,
-    'setLayers',
-    ol.layer.Group.prototype.setLayers);
 
 
 /**

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -495,7 +495,6 @@ ol.Map.prototype.addInteraction = function(interaction) {
  */
 ol.Map.prototype.addLayer = function(layer) {
   var layers = this.getLayerGroup().getLayers();
-  goog.asserts.assert(goog.isDef(layers));
   layers.push(layer);
 };
 
@@ -703,16 +702,11 @@ goog.exportProperty(
 
 /**
  * Get the collection of layers associated with this map.
- * @return {ol.Collection.<ol.layer.Base>|undefined} Layers.
+ * @return {!ol.Collection.<ol.layer.Base>} Layers.
  * @api stable
  */
 ol.Map.prototype.getLayers = function() {
-  var layerGroup = this.getLayerGroup();
-  if (goog.isDef(layerGroup)) {
-    return layerGroup.getLayers();
-  } else {
-    return undefined;
-  }
+  return this.getLayerGroup().getLayers();
 };
 
 
@@ -1147,7 +1141,6 @@ ol.Map.prototype.removeInteraction = function(interaction) {
  */
 ol.Map.prototype.removeLayer = function(layer) {
   var layers = this.getLayerGroup().getLayers();
-  goog.asserts.assert(goog.isDef(layers));
   return layers.remove(layer);
 };
 
@@ -1272,22 +1265,6 @@ ol.Map.prototype.renderFrame_ = function(time) {
   goog.async.nextTick(this.handlePostRender, this);
 
 };
-
-
-/**
- * Sets the layergroup of this map.
- * @param {ol.layer.Group} layerGroup A layer group containing the layers in
- *     this map.
- * @observable
- * @api stable
- */
-ol.Map.prototype.setLayerGroup = function(layerGroup) {
-  this.set(ol.MapProperty.LAYERGROUP, layerGroup);
-};
-goog.exportProperty(
-    ol.Map.prototype,
-    'setLayerGroup',
-    ol.Map.prototype.setLayerGroup);
 
 
 /**

--- a/test/spec/ol/layer/layergroup.test.js
+++ b/test/spec/ol/layer/layergroup.test.js
@@ -326,32 +326,6 @@ describe('ol.layer.Group', function() {
 
   });
 
-
-  describe('#setLayers', function() {
-
-    it('sets layers property', function() {
-      var layer = new ol.layer.Layer({
-        source: new ol.source.Source({
-          projection: 'EPSG:4326'
-        })
-      });
-      var layers = new ol.Collection([layer]);
-      var layerGroup = new ol.layer.Group();
-
-      layerGroup.setLayers(layers);
-      expect(layerGroup.getLayers()).to.be(layers);
-
-      layerGroup.setLayers(null);
-      expect(layerGroup.getLayers()).to.be(null);
-
-      goog.dispose(layerGroup);
-      goog.dispose(layer);
-      goog.dispose(layers);
-    });
-
-  });
-
-
   describe('#getLayerStatesArray', function() {
 
     it('returns an empty array if no layer', function() {


### PR DESCRIPTION
Ensures:
- getLayers() always returns defined and non-null result;
- getLayers() always returns the same object.

Solves:
- cumbersome undefined / null checks in caller code;
- unhandled cases like in Map.addLayer();
- using an obsolete layer collection reference after a setLayers(myNewLayers)
  Ex:
  - bindto(someLayers, map.getLayers()) having no more effects;
  - var sync = new Synchronizer(map.getLayers(), ...); sync.syncLayers().
