### PR TITLE
Set inherited values when parsing a GetCapabilities

### DIFF
--- a/src/ol/format/wmscapabilitiesformat.js
+++ b/src/ol/format/wmscapabilitiesformat.js
@@ -327,6 +327,7 @@ ol.format.WMSCapabilities.readLayer_ = function(node, objectStack) {
     if (goog.isDef(parentValue)) {
       var childValue = goog.object.setIfUndefined(layerObject, key, []);
       childValue = childValue.concat(parentValue);
+      goog.object.set(layerObject, key, childValue);
     }
   });
 

--- a/test/spec/ol/format/wmscapabilities.test.js
+++ b/test/spec/ol/format/wmscapabilities.test.js
@@ -97,7 +97,7 @@ describe('ol.format.WMSCapabilities', function() {
       expect(layer.Layer.length).to.eql(4);
       expect(layer.Layer[0].Name).to.eql('ROADS_RIVERS');
       expect(layer.Layer[0].Title).to.eql('Roads and Rivers');
-      expect(layer.Layer[0].CRS).to.eql(['EPSG:26986']);
+      expect(layer.Layer[0].CRS).to.eql(['EPSG:26986', 'CRS:84']);
       expect(layer.Layer[0].Identifier).to.eql(['123456']);
       expect(layer.Layer[0].BoundingBox).to.eql([{
         crs: 'CRS:84',


### PR DESCRIPTION
During the parsing of WMS GetCapabilities, inherited values from parent layer was never set to the child.
