### PR TITLE
New domain in the build header

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -195,7 +195,7 @@ function build(config, paths, callback) {
  */
 function addHeader(compiledSource, callback) {
   exec('git describe --tags', function(error, stdout, stderr) {
-    var header = '// OpenLayers 3. See http://ol3.js.org/\n';
+    var header = '// OpenLayers 3. See http://openlayers.org/\n';
     header += '// License: https://raw.githubusercontent.com/openlayers/' +
         'ol3/master/LICENSE.md\n';
     if (stdout !== '') {


### PR DESCRIPTION
This one was missed because of a typo in the original domain name. So the URL to the OpenLayers 3 web site is not correct in the hosted build. See http://openlayers.org/en/v3.0.0/build/ol.js. I think that's ok.

Please review.
