### PR TITLE
Set tracking property to false on geolocation error

### DIFF
--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -183,6 +183,7 @@ ol.Geolocation.prototype.positionChange_ = function(position) {
  */
 ol.Geolocation.prototype.positionError_ = function(error) {
   error.type = goog.events.EventType.ERROR;
+  this.setTracking(false);
   this.dispatchEvent(error);
 };
 


### PR DESCRIPTION
Set the  tracking property to false if the `Geolocation.watchPosition()` returns an error.
