### PR TITLE
Make tileSize a config option for ol.source.XYZ

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5053,6 +5053,7 @@ olx.source.WMTSOptions.prototype.urls;
  *     minZoom: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     tilePixelRatio: (number|undefined),
+ *     tileSize: (number|undefined),
  *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
  *     url: (string|undefined),
  *     urls: (Array.<string>|undefined),
@@ -5127,6 +5128,14 @@ olx.source.XYZOptions.prototype.tileLoadFunction;
  * @api
  */
 olx.source.XYZOptions.prototype.tilePixelRatio;
+
+
+/**
+ * The tile size used by the tile service. Default is `256` pixels.
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.XYZOptions.prototype.tileSize;
 
 
 /**

--- a/src/ol/source/xyzsource.js
+++ b/src/ol/source/xyzsource.js
@@ -22,7 +22,8 @@ ol.source.XYZ = function(options) {
 
   var tileGrid = new ol.tilegrid.XYZ({
     extent: ol.tilegrid.extentFromProjection(projection),
-    maxZoom: options.maxZoom
+    maxZoom: options.maxZoom,
+    tileSize: options.tileSize
   });
 
   goog.base(this, {

--- a/test/spec/ol/source/xyzsource.test.js
+++ b/test/spec/ol/source/xyzsource.test.js
@@ -3,6 +3,17 @@ goog.provide('ol.test.source.XYZ');
 
 describe('ol.source.XYZ', function() {
 
+  describe('constructor', function() {
+
+    it('can be constructed with a custom tile size', function() {
+      var tileSource = new ol.source.XYZ({
+        tileSize: 512
+      });
+      expect(tileSource.getTileGrid().getTileSize(0)).to.be(512);
+    });
+
+  });
+
   describe('tileUrlFunction', function() {
 
     var xyzTileSource, tileGrid;


### PR DESCRIPTION
As discussed in today's hangout, it would be convenient to be able to configure an XYZ source with a different tile size than the default by just passing the tileSize as a constructor option.
