### PR TITLE
Unset z-index in overlay example

### DIFF
--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -24,9 +24,6 @@
         font-weight: bold;
         text-shadow: black 0.1em 0.1em 0.2em;
       }
-      .popover {
-        z-index: auto;
-      }
       .popover-content {
         min-width: 180px;
       }


### PR DESCRIPTION
otherwise the "Vienna" link is above the popup (popover) div.
(see http://openlayers.org/en/v3.0.0/examples/overlay.html)
