### PR TITLE
Consistent circle transform.

### DIFF
--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -5,6 +5,7 @@ goog.require('ol.extent');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.geom.SimpleGeometry');
 goog.require('ol.geom.flat.deflate');
+goog.require('ol.proj');
 
 
 
@@ -199,6 +200,7 @@ ol.geom.Circle.prototype.setFlatCoordinates =
 
 
 /**
+ * The radius is in the units of the projection.
  * @param {number} radius Radius.
  * @api
  */
@@ -210,6 +212,25 @@ ol.geom.Circle.prototype.setRadius = function(radius) {
 
 
 /**
- * @inheritDoc
+ * Transform each coordinate of the circle from one coordinate reference system
+ * to another. The geometry is modified in place.
+ * If you do not want the geometry modified in place, first clone() it and
+ * then use this function on the clone.
+ *
+ * Internally a circle is currently represented by two points: the center of
+ * the circle `[cx, cy]`, and the point to the right of the circle
+ * `[cx + r, cy]`. This `transform` function just transforms these two points.
+ * So the resulting geometry is also a circle, and that circle does not
+ * correspond to the shape that would be obtained by transforming every point
+ * of the original circle.
+ *
+ * @param {ol.proj.ProjectionLike} source The current projection.  Can be a
+ *     string identifier or a {@link ol.proj.Projection} object.
+ * @param {ol.proj.ProjectionLike} destination The desired projection.  Can be a
+ *     string identifier or a {@link ol.proj.Projection} object.
+ * @return {ol.geom.Circle} This geometry.  Note that original geometry is
+ *     modified in place.
+ * @function
+ * @api stable
  */
-ol.geom.Circle.prototype.applyTransform = goog.abstractMethod;
+ol.geom.Circle.prototype.transform;

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -173,7 +173,8 @@ ol.geom.Geometry.prototype.getType = goog.abstractMethod;
 
 
 /**
- * Apply a transform function to the geometry.  Modifies the geometry in place.
+ * Apply a transform function to each coordinate of the geometry.
+ * The geometry is modified in place.
  * If you do not want the geometry modified in place, first clone() it and
  * then use this function on the clone.
  * @function
@@ -184,8 +185,9 @@ ol.geom.Geometry.prototype.applyTransform = goog.abstractMethod;
 
 
 /**
- * Transform a geometry from one coordinate reference system to another.
- * Modifies the geometry in place.
+ * Transform each coordinate of the geometry from one coordinate reference
+ * system to another. The geometry is modified in place.
+ * For example, a line will be transformed to a line and a circle to a circle.
  * If you do not want the geometry modified in place, first clone() it and
  * then use this function on the clone.
  *

--- a/test/spec/ol/geom/circle.test.js
+++ b/test/spec/ol/geom/circle.test.js
@@ -203,16 +203,6 @@ describe('ol.geom.Circle', function() {
 
     });
 
-    describe('#transform', function() {
-
-      it('throws an exception', function() {
-        expect(function() {
-          circle.applyTransform(ol.proj.identityTransform);
-        }).to.throwException();
-      });
-
-    });
-
   });
 
 });
@@ -220,4 +210,3 @@ describe('ol.geom.Circle', function() {
 
 goog.require('ol.geom.Circle');
 goog.require('ol.geom.GeometryType');
-goog.require('ol.proj');


### PR DESCRIPTION
Depending on compilation flags, applying a transform used to either:
- work;
- fail throwing an abstract method not implemented message;
- fail silently.

Now it should consistently work, like the other geometries.

Fix #2680 
