### PR TITLE
StaticVector is not an abstract base class

### DIFF
--- a/src/ol/source/staticvectorsource.js
+++ b/src/ol/source/staticvectorsource.js
@@ -7,10 +7,8 @@ goog.require('ol.source.State');
 
 /**
  * @classdesc
- * Abstract base class; normally only used for creating subclasses and not
- * instantiated in apps.
- * Base class for vector sources in one of the supported formats, where the data
- * is read from a file or other static source.
+ * A vector source that uses one of the supported formats to read the data from
+ * a file or other static source.
  *
  * @constructor
  * @extends {ol.source.FormatVector}


### PR DESCRIPTION
It is perfectly fine to create an ol.Source.StaticVector and e.g. configure it with an ol.format.GML and a url.
