### PR TITLE
Add style image state and listener functions to API.

### DIFF
--- a/src/ol/style/iconstyle.js
+++ b/src/ol/style/iconstyle.js
@@ -247,6 +247,7 @@ ol.style.Icon.prototype.getImageSize = function() {
 
 /**
  * @inheritDoc
+ * @api
  */
 ol.style.Icon.prototype.getImageState = function() {
   return this.iconImage_.getImageState();
@@ -312,6 +313,7 @@ ol.style.Icon.prototype.getSize = function() {
 
 /**
  * @inheritDoc
+ * @api
  */
 ol.style.Icon.prototype.listenImageChange = function(listener, thisArg) {
   return goog.events.listen(this.iconImage_, goog.events.EventType.CHANGE,
@@ -329,6 +331,7 @@ ol.style.Icon.prototype.load = function() {
 
 /**
  * @inheritDoc
+ * @api
  */
 ol.style.Icon.prototype.unlistenImageChange = function(listener, thisArg) {
   goog.events.unlisten(this.iconImage_, goog.events.EventType.CHANGE,

--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -4,6 +4,7 @@ goog.provide('ol.style.ImageState');
 
 /**
  * @enum {number}
+ * @api
  */
 ol.style.ImageState = {
   IDLE: 0,
@@ -124,7 +125,9 @@ ol.style.Image.prototype.getImage = goog.abstractMethod;
 
 
 /**
+ * @function
  * @return {ol.style.ImageState} Image state.
+ * @api
  */
 ol.style.Image.prototype.getImageState = goog.abstractMethod;
 
@@ -151,10 +154,12 @@ ol.style.Image.prototype.getSize = goog.abstractMethod;
 
 
 /**
+ * @function
  * @param {function(this: T, goog.events.Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {goog.events.Key|undefined} Listener key.
  * @template T
+ * @api
  */
 ol.style.Image.prototype.listenImageChange = goog.abstractMethod;
 
@@ -166,8 +171,10 @@ ol.style.Image.prototype.load = goog.abstractMethod;
 
 
 /**
+ * @function
  * @param {function(this: T, goog.events.Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @template T
+ * @api
  */
 ol.style.Image.prototype.unlistenImageChange = goog.abstractMethod;


### PR DESCRIPTION
Allows application code to be notified when the image is loaded.

Unfortunately, the enum will no be exported, see https://github.com/openlayers/ol3/issues/954
