### PR TITLE
Use goog.array.ASSUME_NATIVE_FUNCTIONS define

### DIFF
--- a/build.py
+++ b/build.py
@@ -239,6 +239,7 @@ def examples_star_json(name, match):
               "externs/vbarray.js"
             ],
             "define": [
+              "goog.array.ASSUME_NATIVE_FUNCTIONS=true",
               "goog.dom.ASSUME_STANDARDS_MODE=true",
               "goog.json.USE_NATIVE_JSON=true",
               "goog.DEBUG=false"

--- a/config/examples-all.json
+++ b/config/examples-all.json
@@ -17,6 +17,7 @@
       "externs/vbarray.js"
     ],
     "define": [
+      "goog.array.ASSUME_NATIVE_FUNCTIONS=true",
       "goog.dom.ASSUME_STANDARDS_MODE=true",
       "goog.json.USE_NATIVE_JSON=true",
       "goog.DEBUG=false"

--- a/config/ol.json
+++ b/config/ol.json
@@ -13,6 +13,7 @@
       "externs/vbarray.js"
     ],
     "define": [
+      "goog.array.ASSUME_NATIVE_FUNCTIONS=true",
       "goog.dom.ASSUME_STANDARDS_MODE=true",
       "goog.json.USE_NATIVE_JSON=true",
       "goog.DEBUG=false"

--- a/src/ol/ol.js
+++ b/src/ol/ol.js
@@ -146,6 +146,8 @@ ol.ENABLE_WEBGL = true;
 
 /**
  * @define {boolean} Support legacy IE (7-8).  Default is `false`.
+ *     If set to `true`, `goog.array.ASSUME_NATIVE_FUNCTIONS` must be set
+ *     to `false` because legacy IE do not support ECMAScript 5 array functions.
  */
 ol.LEGACY_IE_SUPPORT = false;
 


### PR DESCRIPTION
If set to `true`, the native implementation of array functions are used and the pure js implementation is removed from the build.
But because we (conditionally) support IE 7-8 (`ol.LEGACY_IE_SUPPORT`) we cannot add this define in `buildcfg/ol.json`
