### PR TITLE
Set the opacity directly to element.style.opacity

### DIFF
--- a/src/ol/dom/dom.js
+++ b/src/ol/dom/dom.js
@@ -6,7 +6,6 @@ goog.provide('ol.dom.BrowserFeature');
 goog.require('goog.asserts');
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
-goog.require('goog.style');
 goog.require('goog.userAgent');
 goog.require('goog.vec.Mat4');
 goog.require('ol');
@@ -180,7 +179,7 @@ ol.dom.setOpacity = function(element, value) {
       element.style.zIndex = 0;
     }
   } else {
-    goog.style.setOpacity(element, value);
+    element.style.opacity = value;
   }
 };
 


### PR DESCRIPTION
`goog.style.setOpacity` handles the IE8 case (but we are doing the same
above in the same function) and Firefox prior to version 3.5 (latest
stable release in April 2011).

We can directly use `element.style.opacity`

See https://developer.mozilla.org/en-US/docs/Web/CSS/opacity
