### PR TITLE
Error when compiling individual example

### DIFF
--- a/build.py
+++ b/build.py
@@ -310,10 +310,12 @@ def examples_star_json(name, match):
               "tweakValidation",
               "undefinedNames",
               "undefinedVars",
-              "unknownDefines",
               "uselessCode",
               "violatedModuleDep",
               "visibility"
+            ],
+            "jscomp_off": [
+              "unknownDefines"
             ],
             "extra_annotation_name": [
               "api", "observable"


### PR DESCRIPTION
When compiling individual example with:

```
$ ./build.py build/examples/simple.combined.js
info ol Parsing dependencies
info ol Compiling 331 sources
ERR! compile ERROR - unknown @define variable goog.json.USE_NATIVE_JSON
ERR! compile 
ERR! compile 1 error(s), 0 warning(s), 98.0% typed
ERR! compile 
ERR! Process exited with non-zero status, see log for more detail: 1 
2014-09-17 15:58:18,346 build/examples/simple.combined.js: clean
2014-09-17 15:58:18,347 pake: build/examples/simple.combined.js: Command '['node', 'tasks/build.js', 'build/examples/simple.json', 'build/examples/simple.combined.js']' returned non-zero exit status 1
```

found by @elemoine 
