### PR TITLE
Do not call toLowerCase when forming a change:property event

### DIFF
--- a/config/jsdoc/api/plugins/observable.js
+++ b/config/jsdoc/api/plugins/observable.js
@@ -47,7 +47,7 @@ exports.handlers = {
         if (!cls.fires) {
           cls.fires = [];
         }
-        event = 'ol.ObjectEvent#event:change:' + name.toLowerCase();
+        event = 'ol.ObjectEvent#event:change:' + name;
         if (cls.fires.indexOf(event) == -1) {
           cls.fires.push(event);
         }

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -242,7 +242,7 @@ ol.Object.capitalize = function(str) {
 ol.Object.getChangeEventType = function(key) {
   return ol.Object.changeEventTypeCache_.hasOwnProperty(key) ?
       ol.Object.changeEventTypeCache_[key] :
-      (ol.Object.changeEventTypeCache_[key] = 'change:' + key.toLowerCase());
+      (ol.Object.changeEventTypeCache_[key] = 'change:' + key);
 };
 
 

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -614,8 +614,8 @@ describe('ol.Object', function() {
 
     it('dispatches the expected event', function() {
       o.set('K', 1);
-      expect(listener1).to.be.called();
-      expect(listener2).to.not.be.called();
+      expect(listener1).to.not.be.called();
+      expect(listener2).to.be.called();
 
       expect(o.getKeys()).to.eql(['K']);
     });


### PR DESCRIPTION
Fixes #2729.
