### PR TITLE
Add maxZoom option to BingMaps

### DIFF
--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -42,6 +42,7 @@
           <h4 id="title">Bing Maps example</h4>
           <p id="shortdesc">Example of a Bing Maps layer.</p>
           <div id="docs">
+            <p>When the Bing Maps tile service doesn't have tiles for a given resolution and region it returns "placeholder" tiles indicating that. Zoom the map beyond level 19 to see the "placeholder" tiles. If you want OpenLayers to display stretched tiles in place of "placeholder" tiles beyond zoom level 19 then set <code>maxZoom</code> to <code>19</code> in the options passed to <code>ol.source.BingMaps</code>.</p>
             <p>See the <a href="bing-maps.js" target="_blank">bing-maps.js source</a> to see how this is done.</p>
           </div>
           <div id="tags">bing, bing-maps</div>

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -20,6 +20,9 @@ for (i = 0, ii = styles.length; i < ii; ++i) {
     source: new ol.source.BingMaps({
       key: 'Ak-dzM4wZjSqTlzveKz5u0d4IQ4bRzVI309GxmkgSVr1ewS6iPSrOvOKhA-CJlm3',
       imagerySet: styles[i]
+      // use maxZoom 19 to see stretched tiles instead of the BingMaps
+      // "no photos at this zoom level" tiles
+      // maxZoom: 19
     })
   }));
 }

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3101,6 +3101,7 @@ olx.FeatureOverlayOptions.prototype.style;
  * @typedef {{culture: (string|undefined),
  *     key: string,
  *     imagerySet: string,
+ *     maxZoom: (number|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined)}}
  * @api
  */
@@ -3129,6 +3130,15 @@ olx.source.BingMapsOptions.prototype.key;
  * @api stable
  */
 olx.source.BingMapsOptions.prototype.imagerySet;
+
+
+/**
+ * Max zoom. Default is what's advertized by the BingMaps service (`21`
+ * currently).
+ * @type {number|undefined}
+ * @api
+ */
+olx.source.BingMapsOptions.prototype.maxZoom;
 
 
 /**


### PR DESCRIPTION
This is to support the use-case where stretched tiles are displayed instead of BingMaps "no photos at this zoom level" tiles beyond zoom level 19.

See this [request](https://groups.google.com/d/msg/ol3-dev/WXIFvf_w1-4/BZ7qX-Xcx1YJ) on the mailing list for example.
