### PR TITLE
issue with reading scientific notation coordinates in ol.format.GML

### DIFF
--- a/src/ol/format/gmlformat.js
+++ b/src/ol/format/gmlformat.js
@@ -699,7 +699,7 @@ ol.format.GML.readFlatCoordinatesFromNode_ = function(node, objectStack) {
  */
 ol.format.GML.readFlatPos_ = function(node, objectStack) {
   var s = ol.xml.getAllTextContent(node, false);
-  var re = /^\s*([+\-]?\d*\.?\d+(?:e[+\-]?\d+)?)\s*/;
+  var re = /^\s*([+\-]?\d*\.?\d+(?:[eE][+\-]?\d+)?)\s*/;
   /** @type {Array.<number>} */
   var flatCoordinates = [];
   var m;

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -34,6 +34,25 @@ describe('ol.format.GML', function() {
         expect(serialized.firstElementChild).to.xmleql(ol.xml.load(text));
       });
 
+      it('can read a point geometry with scientific notation', function() {
+        var text =
+            '<gml:Point xmlns:gml="http://www.opengis.net/gml" ' +
+            '    srsName="CRS:84">' +
+            '  <gml:pos>1E7 2</gml:pos>' +
+            '</gml:Point>';
+        var g = readGeometry(format, text);
+        expect(g).to.be.an(ol.geom.Point);
+        expect(g.getCoordinates()).to.eql([10000000, 2, 0]);
+        text =
+            '<gml:Point xmlns:gml="http://www.opengis.net/gml" ' +
+            '    srsName="CRS:84">' +
+            '  <gml:pos>1e7 2</gml:pos>' +
+            '</gml:Point>';
+        g = readGeometry(format, text);
+        expect(g).to.be.an(ol.geom.Point);
+        expect(g.getCoordinates()).to.eql([10000000, 2, 0]);
+      });
+
       it('can read, transform and write a point geometry', function() {
         var config = {
           featureProjection: 'EPSG:3857'


### PR DESCRIPTION
For example:

```
<gml:Point srsDimension="2" srsName="http://www.opengis.net/gml/srs/epsg.xml#3857">
  <gml:pos>-1.153568815095287E7 5539267.516059847</gml:pos>
</gml:Point>
```
