### PR TITLE
DragBoxInteraction: getGeometry return type can be ol.geom.Polygon ?

### DIFF
--- a/src/ol/interaction/dragboxinteraction.js
+++ b/src/ol/interaction/dragboxinteraction.js
@@ -133,7 +133,7 @@ ol.interaction.DragBox.prototype.handlePointerDrag = function(mapBrowserEvent) {
 
 /**
  * Returns geometry of last drawn box.
- * @return {ol.geom.Geometry} Geometry.
+ * @return {ol.geom.Polygon} Geometry.
  * @api stable
  */
 ol.interaction.DragBox.prototype.getGeometry = function() {


### PR DESCRIPTION
since this.box_ is `ol.render.Box` which has `ol.geom.Polygon`, getGeometry on the DragBoxInteraction can be more specific, so `ol.geom.Polygon` instead of `ol.geom.Geometry`

This will also make it easier for people doing a custom build to export the right things.
