### PR TITLE
Call loadFeatures from ol.source.ImageVector

### DIFF
--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -105,6 +105,8 @@ ol.source.ImageVector.prototype.canvasFunctionInternal_ =
       ol.renderer.vector.getTolerance(resolution, pixelRatio), extent,
       resolution);
 
+  this.source_.loadFeatures(extent, resolution, projection);
+
   var loading = false;
   this.source_.forEachFeatureInExtentAtResolution(extent, resolution,
       /**


### PR DESCRIPTION
This PR fixes a bug [reported](https://groups.google.com/d/msg/ol3-dev/sScaKKx2744/8qSFCC2VZY8J) on the mailing list that makes it impossible to use an `ol.source.TileVector` in an `ol.source.ImageVector`.

The fix involves calling `loadFeatures` from `ol.source.ImageVector#.canvasFunctionInternal_`, as done by the canvas vector layer renderer.

Please review.
