### PR TITLE
Add an example for using an Esri 512x512 tile server in EPSG:4326

### DIFF
--- a/examples/xyz-esri-4326-512.html
+++ b/examples/xyz-esri-4326-512.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>XYZ Esri EPSG:4326 tileSize 512 example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">XYZ Esri EPSG:4326 tileSize 512 example</h4>
+          <p id="shortdesc">Example of a XYZ source in EPSG:4326 using Esri 512x512 tiles.</p>
+          <div id="docs">
+            <p>See the <a href="xyz-esri-4326-512.js" target="_blank">xyz-esri-4326-512.js source</a> for details on how this is done.</p>
+          </div>
+          <div id="tags">xyz, esri, tilesize, custom projection</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=xyz-esri-4326-512" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -1,0 +1,53 @@
+goog.require('ol.Attribution');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.extent');
+goog.require('ol.layer.Tile');
+goog.require('ol.proj');
+goog.require('ol.source.TileImage');
+goog.require('ol.tilegrid.TileGrid');
+
+var attribution = new ol.Attribution({
+  html: 'Copyright:&copy; 2013 ESRI, i-cubed, GeoEye'
+});
+
+var projection = ol.proj.get('EPSG:4326');
+var projectionExtent = projection.getExtent();
+
+var size = ol.extent.getWidth(projectionExtent) / 256;
+var resolutions = new Array(16);
+for (var z = 2; z < 18; ++z) {
+  resolutions[z - 2] = size / Math.pow(2, z);
+}
+
+var url = 'http://services.arcgisonline.com/arcgis/rest/services/' +
+    'ESRI_Imagery_World_2D/MapServer/tile/';
+
+var map = new ol.Map({
+  target: 'map',
+  layers: [
+    new ol.layer.Tile({
+      extent: projectionExtent,
+      /* ol.source.XYZ and ol.tilegrid.XYZ have nu resolutions config */
+      source: new ol.source.TileImage({
+        attributions: [attribution],
+        tileUrlFunction: function(tileCoord, pixelRatio, projection) {
+          return url + tileCoord[0] + '/' + (-tileCoord[2] - 1) + '/' +
+              tileCoord[1];
+        },
+        projection: projection,
+        tileGrid: new ol.tilegrid.TileGrid({
+          origin: ol.extent.getTopLeft(projectionExtent),
+          resolutions: resolutions,
+          tileSize: 512
+        })
+      })
+    })
+  ],
+  view: new ol.View({
+    center: [0, 0],
+    projection: projection,
+    zoom: 2,
+    minZoom: 2
+  })
+});


### PR DESCRIPTION
This shows how to use http://services.arcgisonline.com/arcgis/rest/services/esri_imagery_world_2d/mapserver in ol3.

So currently XYZ sources can only be used with 256x256 right?
