### PR TITLE
Clear the canvas on layer extent changes

### DIFF
--- a/src/ol/renderer/canvas/canvastilelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvastilelayerrenderer.js
@@ -81,11 +81,30 @@ ol.renderer.canvas.TileLayer = function(mapRenderer, tileLayer) {
    */
   this.renderedTiles_ = null;
 
-  goog.events.listen(
-      tileLayer, ol.Object.getChangeEventType(ol.layer.LayerProperty.EXTENT),
-      this.handleLayerExtentChanged_, false, this);
+  /**
+   * @private
+   * @type {Array.<goog.events.Key>}
+   */
+  this.eventKeys_ = [
+    goog.events.listen(
+        tileLayer, ol.Object.getChangeEventType(ol.layer.LayerProperty.EXTENT),
+        this.handleLayerExtentChanged_, false, this)
+  ];
+
 };
 goog.inherits(ol.renderer.canvas.TileLayer, ol.renderer.canvas.Layer);
+
+
+/**
+ * @inheritDoc
+ */
+ol.renderer.canvas.TileLayer.prototype.disposeInternal = function() {
+  for (var i = 0, ii = this.eventKeys_.length; i < ii; ++i) {
+    goog.events.unlistenByKey(this.eventKeys_[i]);
+  }
+  this.eventKeys_.length = 0;
+  goog.base(this, 'disposeInternal');
+};
 
 
 /**


### PR DESCRIPTION
Things I like about this solution:
- The layer renderer listens for changes on the layer.  This is far more direct than having the map listen for layer group changes and then call `map.render()`, as by the time we get to preparing the frame in the layer renderer, we know nothing about what changed.  And we have to store extra state on the layer renderer in order to figure out what work we need to do.

Things I don't like about this solution:
- Clearing the canvas and unsetting `rendereredCanvasZ_` is a bit awkward.  It would be nice to have a `forgetEverythingAndStartOver` method.  But I'm not sure where else this would get used yet.
- The WebGL renderer doesn't really work well with layers with limited extents.  This doesn't help there.
- Both the Canvas and the DOM renderer will render tiles from a higher zoom level while zooming out.  So, when zooming from 2 to 1, tiles from 2 will be rendered when we get to 1 if tiles from 1 are not loaded.  The result is that when you change the layer extent and zoom out, you can occasionally see tiles from the previously rendered zoom level that are outside the new extent.  I feel like there is a bug lurking here.

Input welcome.

Fixes #2731.
