### PR TITLE
Correctly generate child tile ranges for XYZ tiles

### DIFF
--- a/src/ol/tilegrid/xyztilegrid.js
+++ b/src/ol/tilegrid/xyztilegrid.js
@@ -100,9 +100,11 @@ ol.tilegrid.XYZ.prototype.createTileCoordTransform = function(opt_options) {
 ol.tilegrid.XYZ.prototype.getTileCoordChildTileRange =
     function(tileCoord, opt_tileRange) {
   if (tileCoord[0] < this.maxZoom) {
+    var doubleX = 2 * tileCoord[1];
+    var doubleY = 2 * tileCoord[2];
     return ol.TileRange.createOrUpdate(
-        2 * tileCoord[1], 2 * (tileCoord[1] + 1),
-        2 * tileCoord[2], 2 * (tileCoord[2] + 1),
+        doubleX, doubleX + 1,
+        doubleY, doubleY + 1,
         opt_tileRange);
   } else {
     return null;

--- a/test/spec/ol/tilegrid/xyztilegrid.test.js
+++ b/test/spec/ol/tilegrid/xyztilegrid.test.js
@@ -10,6 +10,74 @@ describe('ol.tilegrid.XYZ', function() {
     });
   });
 
+  describe('#getTileCoordChildTileRange()', function() {
+
+    it('returns the tile range for one zoom level deeper', function() {
+      var range;
+
+      range = xyzTileGrid.getTileCoordChildTileRange([0, 0, 0]);
+      expect(range.minX).to.be(0);
+      expect(range.maxX).to.be(1);
+      expect(range.minY).to.be(0);
+      expect(range.maxY).to.be(1);
+
+      range = xyzTileGrid.getTileCoordChildTileRange([0, 1, 0]);
+      expect(range.minX).to.be(2);
+      expect(range.maxX).to.be(3);
+      expect(range.minY).to.be(0);
+      expect(range.maxY).to.be(1);
+
+      range = xyzTileGrid.getTileCoordChildTileRange([0, 0, 1]);
+      expect(range.minX).to.be(0);
+      expect(range.maxX).to.be(1);
+      expect(range.minY).to.be(2);
+      expect(range.maxY).to.be(3);
+
+      range = xyzTileGrid.getTileCoordChildTileRange([0, -1, 0]);
+      expect(range.minX).to.be(-2);
+      expect(range.maxX).to.be(-1);
+      expect(range.minY).to.be(0);
+      expect(range.maxY).to.be(1);
+
+      range = xyzTileGrid.getTileCoordChildTileRange([0, 0, -1]);
+      expect(range.minX).to.be(0);
+      expect(range.maxX).to.be(1);
+      expect(range.minY).to.be(-2);
+      expect(range.maxY).to.be(-1);
+    });
+
+    it('returns null for z > maxZoom', function() {
+      var max = xyzTileGrid.maxZoom;
+      var range = xyzTileGrid.getTileCoordChildTileRange([max + 1, 0, 0]);
+      expect(range).to.be(null);
+    });
+
+    it('is like ol.tilegrid.TileGrid#getTileCoordChildTileRange()', function() {
+      var superMethod = ol.tilegrid.TileGrid.prototype
+          .getTileCoordChildTileRange.bind(xyzTileGrid);
+
+      var coord, selfRange, superRange;
+
+      coord = [0, 0, 0];
+      selfRange = xyzTileGrid.getTileCoordChildTileRange(coord);
+      superRange = superMethod(coord);
+      expect(selfRange.minX).to.be(superRange.minX);
+      expect(selfRange.maxX).to.be(superRange.maxX);
+      expect(selfRange.minY).to.be(superRange.minY);
+      expect(selfRange.maxY).to.be(superRange.maxY);
+
+      coord = [1, 2, 3];
+      selfRange = xyzTileGrid.getTileCoordChildTileRange(coord);
+      superRange = superMethod(coord);
+      expect(selfRange.minX).to.be(superRange.minX);
+      expect(selfRange.maxX).to.be(superRange.maxX);
+      expect(selfRange.minY).to.be(superRange.minY);
+      expect(selfRange.maxY).to.be(superRange.maxY);
+
+    });
+
+  });
+
   describe('forEachTileCoordParentTileRange', function() {
 
     it('iterates as expected', function() {
@@ -96,4 +164,5 @@ describe('ol.tilegrid.XYZ', function() {
 
 goog.require('ol.TileCoord');
 goog.require('ol.TileRange');
+goog.require('ol.tilegrid.TileGrid');
 goog.require('ol.tilegrid.XYZ');


### PR DESCRIPTION
Instead of incrementing and then doubling, calculate the child tile range by doubling and then incrementing.

With this change, tile coord [0, 0, 0] has the four following children:

```
[1, 0, 0]    [1, 1, 0]

[1, 0, 1]    [1, 1, 1]
```

Without this change, tile coord [0, 0, 0] had the nine following children:

```
[1, 0, 0]    [1, 1, 0]    [1, 2, 0]

[1, 0, 1]    [1, 1, 1]    [1, 2, 1]

[1, 0, 2]    [1, 1, 2]    [1, 2, 2]
```

The `ol.tilegrid.XYZ#getTileCoordChildTileRange()` override was added as an optimization in 66f0e0d8e8bd8983897d214ccd91a806c39d8612 (as part of #509).  This when the issue was introduced, and it [survived refactoring](https://github.com/openlayers/ol3/commit/6976fd96e37faf0c8dc8e08b19a1f440066cc7c8#diff-7ae0ead3ce7223df8936f91fba8da0deL47) in #671 and #2539.
