### PR TITLE
Report test failures to the console

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -46,7 +46,22 @@
     if (window.mochaPhantomJS) {
       mochaPhantomJS.run();
     } else {
-      mocha.run();
+      var runner = mocha.run();
+      if (window.console && console.log) {
+        // write stacks to the console for failed tests
+        runner.on('fail', function(test, err) {
+          if (test.duration > test._timeout) {
+            var titles = [];
+            for (var p = test; p; p = p.parent) {
+              if (p.title) {
+                titles.unshift(p.title);
+              }
+            }
+            console.log('Test timed out:', titles.join(' > '));
+          }
+          console.error(test.err.stack);
+        });
+      }
     }
   </script>
   <!--


### PR DESCRIPTION
This gives us nice clickable stack traces in the console (in addition to the often truncated traces in the HTML reporter).

![stacks](https://cloud.githubusercontent.com/assets/41094/4437261/418a9a30-4791-11e4-8e18-24ca184dea8d.png)
