### PR TITLE
Treat unknown opt types as Object in ol externs

### DIFF
--- a/tasks/generate-externs.js
+++ b/tasks/generate-externs.js
@@ -39,6 +39,7 @@ function generateExterns(typedefs, symbols, externs, base) {
   var lines = [];
   var processedSymbols = {};
   var constructors = {};
+  var constructorOptionsTypes = {};
 
   function addNamespaces(name) {
     var parts = name.split('.');
@@ -74,6 +75,16 @@ function generateExterns(typedefs, symbols, externs, base) {
     return typesWithoutGoog;
   }
 
+  // Store in "constructorOptionsTypes" type names that start
+  // with "ol." and end with "Options".
+  function findConstructorOptionsTypes(types) {
+    types.forEach(function(type) {
+      if (type.match(/^ol\..*Options$/)) {
+        constructorOptionsTypes[type] = true;
+      }
+    });
+  }
+
   function processSymbol(symbol) {
     addNamespaces(symbol.name.split('#')[0]);
 
@@ -105,6 +116,7 @@ function generateExterns(typedefs, symbols, externs, base) {
     var args = [];
     if (symbol.params) {
       symbol.params.forEach(function(param) {
+        findConstructorOptionsTypes(param.types);
         args.push(param.name);
         lines.push(' * @param {' +
             (param.variable ? '...' : '') +
@@ -137,11 +149,34 @@ function generateExterns(typedefs, symbols, externs, base) {
   symbols.forEach(processSymbol);
 
   typedefs.forEach(function(typedef) {
+    // we're about to add a @typedef for "typedef.name" so remove that
+    // type from constructorOptionsTypes
+    delete constructorOptionsTypes[typedef.name];
+
     addNamespaces(typedef.name);
     lines.push('/**');
     lines.push(' * @typedef {' + noGoogTypes(typedef.types).join('|') + '}');
     lines.push(' */');
     lines.push(nameToJS(typedef.name) + ';');
+    lines.push('\n');
+  });
+
+
+  // At this point constructorOptionsTypes includes options types for which we
+  // did not have a @typedef yet. For those we add @typedef {Object}.
+  //
+  // This is used for abstract base classes. Abstract base classes should be
+  // defined as types in the ol externs file. But the corresponding @typedef's
+  // are not marked with an @api annotation because abstract base classes are
+  // not instantiated by applications. Yet, we need to have a type defined
+  // in the ol externs file for these options types. So we just use
+  // @typedef {Object}.
+  Object.keys(constructorOptionsTypes).forEach(function(key) {
+    lines.push('/**');
+    lines.push(' * No `@api` annotation for `' + key + '`, use `Object`.');
+    lines.push(' * @typedef {Object}');
+    lines.push(' */');
+    lines.push(nameToJS(key) + ';');
     lines.push('\n');
   });
 


### PR DESCRIPTION
As discussed previously we want to export base classes. This is to be able to do, for example, `source instanceof ol.style.Image` in applications. Exporting base classes means marking them with the `@api` annotation.

The problem is that, currently, if we just add the `@api` annotation to the base class we get an unknown type for that class' options type in the ol externs file:

``` js
/**
 * @constructor
 * @param {ol.style.ImageOptions} options
 */
ol.style.Image = function(options) {};
```

where `ol.style.ImageOptions` is not declared in the ol externs file.

One option involves adding `@api` to the options `@typedef` as well. This indeed fixes the problem in the ol externs file. But this creates a broken link in the API doc. In any way, it does not make sense to add `@api` to the options `@typedef`, because abstract base classes are not meant to be instantiated by applications.

This PR fixes the problem by making the `generate-externs.js` script use `@typedef {Object}` in the generated externs file for options types that are referenced in "exported" constructors but not marked with an `@api` annotation.

I have to admit that the code added to `generate-externs.js` is not of the prettiest, but I haven't been able to come up with a prettier solution.

Thanks for any review.
