### PR TITLE
Make interaction "active" an ol.Object property

### DIFF
--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -1,12 +1,21 @@
 // FIXME factor out key precondition (shift et. al)
 
 goog.provide('ol.interaction.Interaction');
+goog.provide('ol.interaction.InteractionProperty');
 
 goog.require('goog.asserts');
 goog.require('ol.MapBrowserEvent');
-goog.require('ol.Observable');
+goog.require('ol.Object');
 goog.require('ol.animation');
 goog.require('ol.easing');
+
+
+/**
+ * @enum {string}
+ */
+ol.interaction.InteractionProperty = {
+  ACTIVE: 'active'
+};
 
 
 
@@ -23,9 +32,10 @@ goog.require('ol.easing');
  * vectors and so are visible on the screen.
  *
  * @constructor
- * @extends {ol.Observable}
+ * @extends {ol.Object}
  */
 ol.interaction.Interaction = function() {
+
   goog.base(this);
 
   /**
@@ -34,23 +44,25 @@ ol.interaction.Interaction = function() {
    */
   this.map_ = null;
 
-  /**
-   * @private
-   * @type {boolean}
-   */
-  this.active_ = true;
+  this.setActive(true);
 
 };
-goog.inherits(ol.interaction.Interaction, ol.Observable);
+goog.inherits(ol.interaction.Interaction, ol.Object);
 
 
 /**
  * @return {boolean} `true` if the interaction is active, `false` otherwise.
+ * @observable
  * @api
  */
 ol.interaction.Interaction.prototype.getActive = function() {
-  return this.active_;
+  return /** @type {boolean} */ (
+      this.get(ol.interaction.InteractionProperty.ACTIVE));
 };
+goog.exportProperty(
+    ol.interaction.Interaction.prototype,
+    'getActive',
+    ol.interaction.Interaction.prototype.getActive);
 
 
 /**
@@ -75,11 +87,16 @@ ol.interaction.Interaction.prototype.handleMapBrowserEvent =
 /**
  * Activate or deactivate the interaction.
  * @param {boolean} active Active.
+ * @observable
  * @api
  */
 ol.interaction.Interaction.prototype.setActive = function(active) {
-  this.active_ = active;
+  this.set(ol.interaction.InteractionProperty.ACTIVE, active);
 };
+goog.exportProperty(
+    ol.interaction.Interaction.prototype,
+    'setActive',
+    ol.interaction.Interaction.prototype.setActive);
 
 
 /**

--- a/test/spec/ol/interaction/interaction.test.js
+++ b/test/spec/ol/interaction/interaction.test.js
@@ -3,11 +3,19 @@ goog.provide('ol.test.interaction.Interaction');
 describe('ol.interaction.Interaction', function() {
 
   describe('constructor', function() {
+    var interaction;
+
+    beforeEach(function() {
+      interaction = new ol.interaction.Interaction();
+    });
 
     it('creates a new interaction', function() {
-      var interaction = new ol.interaction.Interaction();
       expect(interaction).to.be.a(ol.interaction.Interaction);
       expect(interaction).to.be.a(goog.events.EventTarget);
+    });
+
+    it('creates an active interaction', function() {
+      expect(interaction.getActive()).to.be(true);
     });
 
   });


### PR DESCRIPTION
This PR makes `ol.interaction.Interaction` inherit from `ol.Object` and makes `'active'` an `ol.Object` property. With this `change:active` and `propertychange` events are emitted when `setActive` is called on an interaction.
