### PR TITLE
write the function name correctly in the doc

### DIFF
--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -43,7 +43,7 @@ ol.GeolocationProperty = {
  *
  *     var geolocation = new ol.Geolocation({
  *       // take the projection to use from the map's view
- *       projection: view.getprojection()
+ *       projection: view.getProjection()
  *     });
  *     // listen to changes in position
  *     geolocation.on('change', function(evt) {


### PR DESCRIPTION
You wrote getprojection() instead of getProjection().
Just a little error that may confuse some people.
