### PR TITLE
Allow package to be published in npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "openlayers",
-  "version": "3.0.0-beta",
+  "name": "ol",
+  "version": "3.1.0-pre.1",
   "description": "Mapping library",
   "scripts": {
     "install": "node tasks/parse-examples.js",


### PR DESCRIPTION
I've contacted the maintainer of the https://www.npmjs.org/package/openlayers package (in addition to the npm folks) to see if we can take over ownership.  Until then, we can publish packages under the name 'ol'.

Once the process is ironed out, I'll document package publishing as part of the release process.  I'd like to publish (frequent) pre-releases under the `next` tag.  That will allow anyone using `npm` to install the latest pre-release with `npm install ol@next`.

A manual set of publishing steps will look something like this:

```
# increment the version in package.json to something like 3.1.0-pre.5
npm publish --tag next
```

We can create git tags for pre-releases if we want to as well (though not required).  This should not interfere with the normal release process, it is only intended as a way to let people use ol3 with the npm registry.
