### PR TITLE
Hide the rotate control when the rotation is 0

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -57,6 +57,7 @@
 }
 .ol-rotate.ol-hidden {
   opacity: 0;
+  display: none;
 }
 .ol-zoom-extent {
   top: 4.643em;


### PR DESCRIPTION
To prevent the cursor to be displayed as a pointer (only happens with bootstrap)
