### PR TITLE
Add 'tooltip'-tag to KML example.

### DIFF
--- a/examples/kml-earthquakes.html
+++ b/examples/kml-earthquakes.html
@@ -60,7 +60,7 @@
             </p>
             <p>See the <a href="kml-earthquakes.js" target="_blank">kml-earthquakes.js source</a> to see how this is done.</p>
           </div>
-          <div id="tags">KML, vector, style</div>
+          <div id="tags">KML, vector, style, tooltip</div>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #2708.
