### PR TITLE
Use goog.* types in externs

### DIFF
--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -22,14 +22,6 @@ exports.publish = function(data, opts) {
     return types;
   }
 
-  function replaceUnknownTypes(item) {
-    item.types.forEach(function(type, index) {
-      if (!(type in names)) {
-        item.types[index] = '*';
-      }
-    });
-  }
-
   // get all doclets with the "api" property or define (excluding events) or
   // with olx namespace
   var classes = {};
@@ -168,16 +160,7 @@ exports.publish = function(data, opts) {
   });
 
   base = base.filter(function(symbol) {
-    var pass = symbol.name in augments || symbol.virtual;
-    if (pass) {
-      if (symbol.params) {
-        symbol.params.forEach(replaceUnknownTypes);
-      }
-      if (symbol.returns) {
-        symbol.returns.forEach(replaceUnknownTypes);
-      }
-    }
-    return pass;
+    return (symbol.name in augments || symbol.virtual);
   });
 
   process.stdout.write(

--- a/tasks/generate-externs.js
+++ b/tasks/generate-externs.js
@@ -67,14 +67,6 @@ function generateExterns(typedefs, symbols, externs, base) {
     return name;
   }
 
-  function noGoogTypes(typesWithGoog) {
-    var typesWithoutGoog = [];
-    typesWithGoog.forEach(function(type) {
-      typesWithoutGoog.push(type.replace(googRegEx, '*'));
-    });
-    return typesWithoutGoog;
-  }
-
   // Store in "constructorOptionsTypes" type names that start
   // with "ol." and end with "Options".
   function findConstructorOptionsTypes(types) {
@@ -111,7 +103,7 @@ function generateExterns(typedefs, symbols, externs, base) {
       }
     }
     if (symbol.types) {
-      lines.push(' * @type {' + noGoogTypes(symbol.types).join('|') + '}');
+      lines.push(' * @type {' + symbol.types.join('|') + '}');
     }
     var args = [];
     if (symbol.params) {
@@ -120,7 +112,7 @@ function generateExterns(typedefs, symbols, externs, base) {
         args.push(param.name);
         lines.push(' * @param {' +
             (param.variable ? '...' : '') +
-            noGoogTypes(param.types).join('|') +
+            param.types.join('|') +
             (param.optional ? '=' : '') + (param.nullable ? '!' : '') +
             '} ' + param.name);
       });
@@ -128,7 +120,7 @@ function generateExterns(typedefs, symbols, externs, base) {
     if (symbol.returns) {
       lines.push(' * @return {' +
           (symbol.returns.nullable ? '!' : '') +
-          noGoogTypes(symbol.returns.types).join('|') + '}');
+          symbol.returns.types.join('|') + '}');
     }
     if (symbol.template) {
       lines.push(' * @template ' + symbol.template);
@@ -155,7 +147,7 @@ function generateExterns(typedefs, symbols, externs, base) {
 
     addNamespaces(typedef.name);
     lines.push('/**');
-    lines.push(' * @typedef {' + noGoogTypes(typedef.types).join('|') + '}');
+    lines.push(' * @typedef {' + typedef.types.join('|') + '}');
     lines.push(' */');
     lines.push(nameToJS(typedef.name) + ';');
     lines.push('\n');


### PR DESCRIPTION
To have an externs file as accurate as possible, we also need to use
types that are provided by the Closure library.
