### PR TITLE
Cluster get source features

### DIFF
--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -67,7 +67,7 @@ ol.source.Cluster.prototype.loadFeatures = function(extent, resolution) {
   if (resolution !== this.resolution_) {
     this.clear();
     this.resolution_ = resolution;
-    this.source_.loadFeatures(extent,resolution); 
+    this.source_.loadFeatures(extent, resolution);
     this.cluster_();
     this.addFeatures(this.features_);
   }


### PR DESCRIPTION
Using clustersource with a servervectorsource is not triggering feature loading from the server.  The proposed change adds this.source_.loadFeatures(extent, resolution) to the ol.source.Cluster.prototype.loadFeatures function to force loading.
