### PR TITLE
Use valid mediatype for GPX export.

### DIFF
--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -110,7 +110,7 @@ if ('download' in exportGPXElement) {
           /** @type {Node} */ (node));
       var base64 = exampleNS.strToBase64(string);
       exportGPXElement.href =
-          'data:gpx+xml;base64,' + base64;
+          'data:text/gpx+xml;base64,' + base64;
     }
   }, false);
 } else {


### PR DESCRIPTION
This pull request fixes an issue in the GPX example using Chrome 37 where the button "export GPX" doesn't do anything.

Cause: in Chrome 37 a grammar check on the mediatype part in a data URI was introduced.
https://chromium.googlesource.com/chromium/src/+/5a665643fafcb4f102c4fb26f64e586496f46600
