### PR TITLE
Add ol.Observable.unByKey

### DIFF
--- a/src/ol/observable.js
+++ b/src/ol/observable.js
@@ -35,6 +35,16 @@ goog.inherits(ol.Observable, goog.events.EventTarget);
 
 
 /**
+ * Removes an event listener using the key returned by `on()` or `once()`.
+ * @param {goog.events.Key} key The key returned by `on()` or `once()`.
+ * @api stable
+ */
+ol.Observable.unByKey = function(key) {
+  goog.events.unlistenByKey(key);
+};
+
+
+/**
  * Increases the revision counter and disptches a 'change' event.
  * @fires change
  * @api
@@ -95,9 +105,10 @@ ol.Observable.prototype.un = function(type, listener, opt_this) {
 
 /**
  * Removes an event listener using the key returned by `on()` or `once()`.
- * @param {goog.events.Key} key Key.
+ * Note that using the {@link ol.Observable.unByKey} static function is to
+ * be preferred.
+ * @param {goog.events.Key} key The key returned by `on()` or `once()`.
+ * @function
  * @api stable
  */
-ol.Observable.prototype.unByKey = function(key) {
-  goog.events.unlistenByKey(key);
-};
+ol.Observable.prototype.unByKey = ol.Observable.unByKey;

--- a/test/spec/ol/observable.test.js
+++ b/test/spec/ol/observable.test.js
@@ -144,7 +144,7 @@ describe('ol.Observable', function() {
 
   });
 
-  describe('#unByKey()', function() {
+  describe('ol.Observable.unByKey()', function() {
     var observable, listener;
     beforeEach(function() {
       observable = new ol.Observable();
@@ -157,7 +157,7 @@ describe('ol.Observable', function() {
       observable.dispatchEvent('foo');
       expect(listener.calledOnce).to.be(true);
 
-      observable.unByKey(key);
+      ol.Observable.unByKey(key);
       observable.dispatchEvent('foo');
       expect(listener.callCount).to.be(1);
     });


### PR DESCRIPTION
Today we have `ol.Observable.prototype.unByKey`:

``` js

/**
* Removes an event listener using the key returned by `on()` or `once()`.
* @param {goog.events.Key} key Key.
* @api stable
*/
ol.Observable.prototype.unByKey = function(key) {
  goog.events.unlistenByKey(key);
};
```

So it is a method wrapping a static function. That means it could instead be static:

``` js

/**
* Removes an event listener using the key returned by `on()` or `once()`.
* @param {goog.events.Key} key Key.
* @api stable
*/
ol.Observable.unByKey = function(key) {
  goog.events.unlistenByKey(key);
};
```

Having a static function (`ol.Observable.unByKey`) would be more convenient. Because when it is the time to unregister your listeners you may not have a reference to the object you registered your listeners on. You may even have an array of listener ids for listeners on multiple observables.

Please review.

We could also consider `@deprecate`'ing `ol.Observable.prototype.unByKey`.
