### PR TITLE
Using clustersource with a servervectorsource is not triggering feature ...

### DIFF
--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -59,14 +59,13 @@ ol.source.Cluster = function(options) {
 goog.inherits(ol.source.Cluster, ol.source.Vector);
 
 
-/**
- * @param {ol.Extent} extent
- * @param {number} resolution
- */
-ol.source.Cluster.prototype.loadFeatures = function(extent, resolution) {
+/** @inheritDoc */
+ol.source.Cluster.prototype.loadFeatures = function(extent, resolution,
+    projection) {
   if (resolution !== this.resolution_) {
     this.clear();
     this.resolution_ = resolution;
+    this.source_.loadFeatures(extent, resolution, projection);
     this.cluster_();
     this.addFeatures(this.features_);
   }


### PR DESCRIPTION
...loading from the server. The proposed change adds this.source_.loadFeatures(extent, resolution) to the ol.source.Cluster.prototype.loadFeatures function to force loading.
