### PR TITLE
Add parsing of LabelStyle in KML format

### DIFF
--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -1267,7 +1267,7 @@ describe('ol.format.KML', function() {
         expect(imageStyle.getOrigin()).to.be(null);
         expect(imageStyle.getRotation()).to.eql(0);
         expect(imageStyle.getSize()).to.be(null);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1310,7 +1310,42 @@ describe('ol.format.KML', function() {
         expect(imageStyle.getAnchor()).to.eql([24, 36]);
         expect(imageStyle.getOrigin()).to.eql([24, 108]);
         expect(imageStyle.getRotation()).to.eql(0);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
+        expect(style.getZIndex()).to.be(undefined);
+      });
+
+      it('can read a feature\'s LabelStyle', function() {
+        var text =
+            '<kml xmlns="http://earth.google.com/kml/2.2">' +
+            '  <Placemark>' +
+            '    <Style>' +
+            '      <LabelStyle>' +
+            '        <color>12345678</color>' +
+            '        <scale>0.25</scale>' +
+            '      </LabelStyle>' +
+            '    </Style>' +
+            '  </Placemark>' +
+            '</kml>';
+        var fs = format.readFeatures(text);
+        expect(fs).to.have.length(1);
+        var f = fs[0];
+        expect(f).to.be.an(ol.Feature);
+        var styleFunction = f.getStyleFunction();
+        expect(styleFunction).not.to.be(undefined);
+        var styleArray = styleFunction.call(f, 0);
+        expect(styleArray).to.be.an(Array);
+        expect(styleArray).to.have.length(1);
+        var style = styleArray[0];
+        expect(style).to.be.an(ol.style.Style);
+        expect(style.getFill()).to.be(ol.format.KML.DEFAULT_FILL_STYLE_);
+        expect(style.getImage()).to.be(ol.format.KML.DEFAULT_IMAGE_STYLE_);
+        expect(style.getStroke()).to.be(ol.format.KML.DEFAULT_STROKE_STYLE_);
+        var textStyle = style.getText();
+        expect(textStyle).to.be.an(ol.style.Text);
+        expect(textStyle.getScale()).to.be(0.5);
+        var textFillStyle = textStyle.getFill();
+        expect(textFillStyle).to.be.an(ol.style.Fill);
+        expect(textFillStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1343,7 +1378,7 @@ describe('ol.format.KML', function() {
         expect(strokeStyle).to.be.an(ol.style.Stroke);
         expect(strokeStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
         expect(strokeStyle.getWidth()).to.be(9);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1374,7 +1409,7 @@ describe('ol.format.KML', function() {
         expect(fillStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
         expect(style.getImage()).to.be(ol.format.KML.DEFAULT_IMAGE_STYLE_);
         expect(style.getStroke()).to.be(ol.format.KML.DEFAULT_STROKE_STYLE_);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1415,7 +1450,7 @@ describe('ol.format.KML', function() {
         expect(strokeStyle).to.be.an(ol.style.Stroke);
         expect(strokeStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
         expect(strokeStyle.getWidth()).to.be(9);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1452,7 +1487,7 @@ describe('ol.format.KML', function() {
         expect(strokeStyle).to.be.an(ol.style.Stroke);
         expect(strokeStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
         expect(strokeStyle.getWidth()).to.be(9);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1488,7 +1523,7 @@ describe('ol.format.KML', function() {
         expect(fillStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
         expect(style.getImage()).to.be(ol.format.KML.DEFAULT_IMAGE_STYLE_);
         expect(style.getStroke()).to.be(null);
-        expect(style.getText()).to.be(null);
+        expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
         expect(style.getZIndex()).to.be(undefined);
       });
 
@@ -1524,7 +1559,7 @@ describe('ol.format.KML', function() {
             expect(style.getFill()).to.be(null);
             expect(style.getImage()).to.be(ol.format.KML.DEFAULT_IMAGE_STYLE_);
             expect(style.getStroke()).to.be(null);
-            expect(style.getText()).to.be(null);
+            expect(style.getText()).to.be(ol.format.KML.DEFAULT_TEXT_STYLE_);
             expect(style.getZIndex()).to.be(undefined);
           });
 


### PR DESCRIPTION
Parse the LabelStyle tags of a KML file. 

That adds a basic ol.style.Text with a color and scale.
