### PR TITLE
Make Stamen layer work with SSL

### DIFF
--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -97,9 +97,10 @@ ol.source.Stamen = function(options) {
   goog.asserts.assert(options.layer in ol.source.StamenLayerConfig);
   var layerConfig = ol.source.StamenLayerConfig[options.layer];
 
-  var protocol = ol.IS_HTTPS ? 'https:' : 'http:';
+  var root = ol.IS_HTTPS ? 'https://stamen-tiles-{a-d}.a.ssl.fastly.net/' :
+      'http://{a-d}.tile.stamen.com/';
   var url = goog.isDef(options.url) ? options.url :
-      protocol + '//{a-d}.tile.stamen.com/' + options.layer + '/{z}/{x}/{y}.' +
+      root + options.layer + '/{z}/{x}/{y}.' +
       layerConfig.extension;
 
   goog.base(this, {


### PR DESCRIPTION
StamenLayer fails with mismatch hostname under HTTPS. Use HTTP instead.
