### PR TITLE
Dependency updates and new package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
   "name": "openlayers",
   "version": "3.1.0-pre.2",
-  "description": "Mapping library",
+  "description": "Build tools and sources for developing OpenLayers based mapping applications",
+  "keywords": [
+    "map",
+    "mapping",
+    "ol3"
+  ],
+  "homepage": "http://openlayers.org/",
   "scripts": {
     "install": "node tasks/parse-examples.js",
     "postinstall": "closure-util update",


### PR DESCRIPTION
We now have access to the [`openlayers`](https://www.npmjs.org/package/openlayers) package name in the npm registry.  I'd like to start publishing pre-releases there.  Over time, we'll work out exactly what gets published.  For now, it's the whole repo.
