### PR TITLE
Constrain center in zoomify example

### DIFF
--- a/examples/zoomify.js
+++ b/examples/zoomify.js
@@ -45,6 +45,9 @@ var map = new ol.Map({
   view: new ol.View({
     projection: proj,
     center: imgCenter,
-    zoom: 0
+    zoom: 0,
+    // constrain the center: center cannot be set outside
+    // this extent
+    extent: [0, -imgHeight, imgWidth, 0]
   })
 });


### PR DESCRIPTION
This is in response to a [question](https://groups.google.com/d/msg/ol3-dev/DuL6RlfpzoA/XqUriBhntLYJ) on the mailing list, and because it makes sense to constrain the center to an extent in that example.
