### PR TITLE
Update the OSM attribution

### DIFF
--- a/examples/igc.js
+++ b/examples/igc.js
@@ -73,7 +73,7 @@ var map = new ol.Map({
             html: 'All maps &copy; ' +
                 '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
           }),
-          ol.source.OSM.DATA_ATTRIBUTION
+          ol.source.OSM.ATTRIBUTION
         ],
         url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
       })

--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -16,7 +16,7 @@ var openCycleMapLayer = new ol.layer.Tile({
         html: 'All maps &copy; ' +
             '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
       }),
-      ol.source.OSM.DATA_ATTRIBUTION
+      ol.source.OSM.ATTRIBUTION
     ],
     url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
   })
@@ -29,7 +29,7 @@ var openSeaMapLayer = new ol.layer.Tile({
         html: 'All maps &copy; ' +
             '<a href="http://www.openseamap.org/">OpenSeaMap</a>'
       }),
-      ol.source.OSM.DATA_ATTRIBUTION
+      ol.source.OSM.ATTRIBUTION
     ],
     crossOrigin: null,
     url: 'http://tiles.openseamap.org/seamark/{z}/{x}/{y}.png'

--- a/examples/xyz.js
+++ b/examples/xyz.js
@@ -27,7 +27,7 @@ var map = new ol.Map({
             html: 'Tiles &copy; <a href="http://www.opencyclemap.org/">' +
                 'OpenCycleMap</a>'
           }),
-          ol.source.OSM.DATA_ATTRIBUTION
+          ol.source.OSM.ATTRIBUTION
         ],
         url: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png'
       })

--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -16,7 +16,7 @@ goog.require('ol.TileRange');
  *           html: 'All maps &copy; ' +
  *               '<a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
  *         }),
- *         ol.source.OSM.DATA_ATTRIBUTION
+ *         ol.source.OSM.ATTRIBUTION
  *       ],
  *     ..
  *

--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -59,7 +59,7 @@ ol.source.MapQuestConfig = {
     maxZoom: 28,
     attributions: [
       ol.source.MapQuest.TILE_ATTRIBUTION,
-      ol.source.OSM.DATA_ATTRIBUTION
+      ol.source.OSM.ATTRIBUTION
     ]
   },
   'sat': {
@@ -76,7 +76,7 @@ ol.source.MapQuestConfig = {
     maxZoom: 18,
     attributions: [
       ol.source.MapQuest.TILE_ATTRIBUTION,
-      ol.source.OSM.DATA_ATTRIBUTION
+      ol.source.OSM.ATTRIBUTION
     ]
   }
 };

--- a/src/ol/source/osmsource.js
+++ b/src/ol/source/osmsource.js
@@ -23,7 +23,7 @@ ol.source.OSM = function(opt_options) {
   if (goog.isDef(options.attributions)) {
     attributions = options.attributions;
   } else {
-    attributions = ol.source.OSM.ATTRIBUTIONS;
+    attributions = [ol.source.OSM.ATTRIBUTION];
   }
 
   var crossOrigin = goog.isDef(options.crossOrigin) ?
@@ -51,29 +51,8 @@ goog.inherits(ol.source.OSM, ol.source.XYZ);
  * @type {ol.Attribution}
  * @api
  */
-ol.source.OSM.DATA_ATTRIBUTION = new ol.Attribution({
+ol.source.OSM.ATTRIBUTION = new ol.Attribution({
   html: '&copy; ' +
       '<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
       'contributors.'
 });
-
-
-/**
- * @const
- * @type {ol.Attribution}
- * @api
- */
-ol.source.OSM.TILE_ATTRIBUTION = new ol.Attribution({
-  html: '&copy; ' +
-      '<a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-      'contributors.'
-});
-
-
-/**
- * @const
- * @type {Array.<ol.Attribution>}
- */
-ol.source.OSM.ATTRIBUTIONS = [
-  ol.source.OSM.TILE_ATTRIBUTION
-];

--- a/src/ol/source/stamensource.js
+++ b/src/ol/source/stamensource.js
@@ -128,5 +128,5 @@ ol.source.Stamen.ATTRIBUTIONS = [
         'under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY' +
         ' 3.0</a>.'
   }),
-  ol.source.OSM.DATA_ATTRIBUTION
+  ol.source.OSM.ATTRIBUTION
 ];


### PR DESCRIPTION
This combines the `ol.source.OSM.TILE_ATTRIBUTION` and `ol.source.OSM.DATA_ATTRIBUTION` into a single `ol.source.OSM.ATTRIBUTION`.

Fixes #2802.
