### PR TITLE
Avoid shrinking logos

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -217,6 +217,7 @@ button.ol-full-screen-true:after {
 }
 .ol-attribution img {
   max-height: 2em;
+  max-width: inherit;
 }
 .ol-attribution ul, .ol-attribution button {
   display: inline-block;


### PR DESCRIPTION
Bootstrap sets both the max-width and max-height of all image elements to 100%.  When attributions are removed from their containing element, this causes logos to shrink.

This can be reproduced by opening the [vector layer example](http://openlayers.org/en/master/examples/vector-layer.html) and running the following:

``` js
map.getLayers().removeAt(0)
```

![tiny](https://cloud.githubusercontent.com/assets/41094/4782019/8d411416-5cd3-11e4-950b-6f0597646941.png)
