### PR TITLE
Avoid modifying map.logos_ with each frame

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -1209,7 +1209,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
       index: this.frameIndex_++,
       layerStates: layerStates,
       layerStatesArray: layerStatesArray,
-      logos: this.logos_,
+      logos: goog.object.clone(this.logos_),
       pixelRatio: this.pixelRatio_,
       pixelToCoordinateMatrix: this.pixelToCoordinateMatrix_,
       postRenderFunctions: [],


### PR DESCRIPTION
Currently, the `map.logos_` object is assigned to the frame state.  Layer renderers then modify this (adding logos) when [`renderer.updateLogos()`](https://github.com/openlayers/ol3/blob/773ac433ced854c1b48e2b4f5adc8ea22dfeb745/src/ol/renderer/layerrenderer.js#L158-L174) is called.  This means logos are "append only" - if you remove a layer, its source's logo will not be removed.

This can be reproduced by opening the [MapQuest example](http://openlayers.org/en/master/examples/mapquest.html) and running the following:

``` js
map.getLayers().removeAt(0)
```

Though it is hard to see (because the logos also [become tiny](https://github.com/openlayers/ol3/pull/2874)), the logo is still in the DOM.

![orphan](https://cloud.githubusercontent.com/assets/41094/4782035/9a0e18fe-5cd5-11e4-86d2-8f3bfc2508a6.png)
