### PR TITLE
Allow olx.source.WMTSOptions#requestEncoding to be a string

### DIFF
--- a/examples/wmts-hidpi.js
+++ b/examples/wmts-hidpi.js
@@ -29,7 +29,7 @@ var source = new ol.source.WMTS({
   style: 'normal',
   matrixSet: 'google3857',
   urls: urls,
-  requestEncoding: /** @type {ol.source.WMTSRequestEncoding} */ ('REST'),
+  requestEncoding: 'REST',
   tileGrid: new ol.tilegrid.WMTS({
     origin: [-20037508.3428, 20037508.3428],
     resolutions: [

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4987,7 +4987,7 @@ olx.source.StaticVectorOptions.prototype.urls;
  *     logo: (string|olx.LogoOptions|undefined),
  *     tileGrid: ol.tilegrid.WMTS,
  *     projection: ol.proj.ProjectionLike,
- *     requestEncoding: (ol.source.WMTSRequestEncoding|undefined),
+ *     requestEncoding: (ol.source.WMTSRequestEncoding|string|undefined),
  *     layer: string,
  *     style: string,
  *     tilePixelRatio: (number|undefined),
@@ -5049,7 +5049,7 @@ olx.source.WMTSOptions.prototype.projection;
 
 /**
  * Request encoding. Default is `KVP`.
- * @type {ol.source.WMTSRequestEncoding|undefined}
+ * @type {ol.source.WMTSRequestEncoding|string|undefined}
  * @api
  */
 olx.source.WMTSOptions.prototype.requestEncoding;

--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -59,7 +59,8 @@ ol.source.WMTS = function(options) {
   // FIXME: should we guess this requestEncoding from options.url(s)
   //        structure? that would mean KVP only if a template is not provided.
   var requestEncoding = goog.isDef(options.requestEncoding) ?
-      options.requestEncoding : ol.source.WMTSRequestEncoding.KVP;
+      /** @type {ol.source.WMTSRequestEncoding} */ (options.requestEncoding) :
+      ol.source.WMTSRequestEncoding.KVP;
 
   // FIXME: should we create a default tileGrid?
   // we could issue a getCapabilities xhr to retrieve missing configuration


### PR DESCRIPTION
Just like `olx.MapOptions#renderer`, `olx.OverlayOptions#positioning`, ...
