### PR TITLE
Add wrapX option to TileJSON source

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -4656,7 +4656,8 @@ olx.source.ServerVectorOptions.prototype.projection;
 /**
  * @typedef {{crossOrigin: (null|string|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: string}}
+ *     url: string,
+ *     wrapX: (boolean|undefined)}}
  * @api
  */
 olx.source.TileJSONOptions;
@@ -4684,6 +4685,14 @@ olx.source.TileJSONOptions.prototype.tileLoadFunction;
  * @api stable
  */
 olx.source.TileJSONOptions.prototype.url;
+
+
+/**
+ * Whether to wrap the world horizontally. Default is `true`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.source.TileJSONOptions.prototype.wrapX;
 
 
 /**

--- a/src/ol/source/tilejsonsource.js
+++ b/src/ol/source/tilejsonsource.js
@@ -39,6 +39,12 @@ ol.source.TileJSON = function(options) {
     tileLoadFunction: options.tileLoadFunction
   });
 
+  /**
+   * @type {boolean|undefined}
+   * @private
+   */
+  this.wrapX_ = options.wrapX;
+
   var request = new goog.net.Jsonp(options.url);
   request.send(undefined, goog.bind(this.handleTileJSONResponse, this));
 
@@ -76,7 +82,8 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
 
   this.tileUrlFunction = ol.TileUrlFunction.withTileCoordTransform(
       tileGrid.createTileCoordTransform({
-        extent: extent
+        extent: extent,
+        wrapX: this.wrapX_
       }),
       ol.TileUrlFunction.createFromTemplates(tileJSON.tiles));
 


### PR DESCRIPTION
This PR adds a `wrapX` option to `ol.source.TileJSON` in response to a [feature request](https://groups.google.com/d/msg/ol3-dev/RQpvwp_Gs5M/WJ-yflyHqHMJ) on the mailing list. This option allows disabling the wrapping of the world for TileJSON sources.
