### PR TITLE
Move font-family customization to layout.css

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -99,7 +99,6 @@
 }
 .ol-compass {
   display: block;
-  font-family: Arial;
   font-weight: normal;
   font-size: 1.2em;
 }
@@ -220,12 +219,6 @@ button.ol-full-screen-true:after {
 }
 .ol-touch .ol-zoomslider-thumb {
   width: 1.8em;
-}
-
-.ol-control button,
-.ol-attribution,
-.ol-scale-line-inner {
-  font-family: 'Lucida Grande',Verdana,Geneva,Lucida,Arial,Helvetica,sans-serif;
 }
 
 .ol-overviewmap {

--- a/resources/layout.css
+++ b/resources/layout.css
@@ -11,6 +11,10 @@ body {
 .ol-attribution {
   max-width: calc(100% - 3em);
 }
+.ol-control button, .ol-attribution, .ol-scale-line-inner {
+  font-family: 'Lucida Grande',Verdana,Geneva,Lucida,Arial,Helvetica,sans-serif;
+}
+
 #tags {
   display: none;
 }


### PR DESCRIPTION
Don't force a font-family at the library level, move it to `resources/layout.css` (used by the examples)
