### PR TITLE
Remove duplicated style parameter

### DIFF
--- a/src/ol/source/wmtssource.js
+++ b/src/ol/source/wmtssource.js
@@ -68,7 +68,6 @@ ol.source.WMTS = function(options) {
 
   var context = {
     'Layer': options.layer,
-    'style': options.style,
     'Style': options.style,
     'TileMatrixSet': options.matrixSet
   };


### PR DESCRIPTION
- "duplicated" style parameter is not supported by Intergraph GeoMedia
- Uppercase Parameter is needed by ARCGis 
- are there other constraints?
