### PR TITLE
Correct URL in output wrapper

### DIFF
--- a/build.py
+++ b/build.py
@@ -346,7 +346,7 @@ def examples_star_json(name, match):
             ],
             "compilation_level": "ADVANCED",
             "warning_level": "VERBOSE",
-            "output_wrapper": "// OpenLayers 3. See http://ol3.js.org/\n(function(){%output%})();",
+            "output_wrapper": "// OpenLayers 3. See http://openlayers.org/\n(function(){%output%})();",
             "use_types_for_optimization": True,
             "manage_closure_dependencies": True
           }

--- a/config/examples-all.json
+++ b/config/examples-all.json
@@ -69,7 +69,7 @@
     ],
     "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
-    "output_wrapper": "// OpenLayers 3. See http://ol3js.org/\n(function(){%output%})();",
+    "output_wrapper": "// OpenLayers 3. See http://openlayers.org/\n(function(){%output%})();",
     "use_types_for_optimization": true,
     "manage_closure_dependencies": true
 


### PR DESCRIPTION
Where we include the URL in build output, it should be openlayers.org.

Fixes #2898.
