### PR TITLE
Allow build.js task to add header

### DIFF
--- a/build.py
+++ b/build.py
@@ -346,7 +346,7 @@ def examples_star_json(name, match):
             ],
             "compilation_level": "ADVANCED",
             "warning_level": "VERBOSE",
-            "output_wrapper": "// OpenLayers 3. See http://ol3.js.org/\n(function(){%output%})();",
+            "output_wrapper": "(function(){%output%})();",
             "use_types_for_optimization": True,
             "manage_closure_dependencies": True
           }

--- a/config/examples-all.json
+++ b/config/examples-all.json
@@ -69,7 +69,7 @@
     ],
     "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
-    "output_wrapper": "// OpenLayers 3. See http://ol3js.org/\n(function(){%output%})();",
+    "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true,
     "manage_closure_dependencies": true
 


### PR DESCRIPTION
The `build.js` task [adds a comment header](https://github.com/openlayers/ol3/blob/127818f9b722cd2a11324f1fdb8f80f4bd84667d/tasks/build.js#L196-L206) to build output.  So we don't need to include the comment in the wrapper in these build configs.

Fixes #2898.
