### PR TITLE
Make it possible to programmatically finish drawing

### DIFF
--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -286,7 +286,7 @@ ol.interaction.Draw.prototype.handlePointerUp = function(event) {
       this.startDrawing_(event);
     } else if (this.mode_ === ol.interaction.DrawMode.POINT ||
         this.atFinish_(event)) {
-      this.finishDrawing_();
+      this.finishDrawing();
     } else {
       this.addToDrawing_(event);
     }
@@ -481,9 +481,9 @@ ol.interaction.Draw.prototype.addToDrawing_ = function(event) {
 
 /**
  * Stop drawing and add the sketch feature to the target layer.
- * @private
+ * @api
  */
-ol.interaction.Draw.prototype.finishDrawing_ = function() {
+ol.interaction.Draw.prototype.finishDrawing = function() {
   var sketchFeature = this.abortDrawing_();
   goog.asserts.assert(!goog.isNull(sketchFeature));
   var coordinates;


### PR DESCRIPTION
This PR changes `ol.interaction.Draw#finishDrawing_` to a public function and adds that function to the API (with the `@api` annotation).

With this change one can listen to `change` event on the feature being drawn and finish the drawing when some (user-specific) condition is met.

For example, to automatically finish the drawing of a linestring when the number of vertices is 2:

``` js
var listenerKey;
drawInteraction.on('drawstart', function(e) {
  var feature = e.feature;
  var lineString = feature.getGeometry();
  // finish the drawing when the linestring has 2 vertices
  listenerKey = lineString.on('change', function(e) {
    var lineString = e.target;
    var vertices = lineString.getCoordinates();
    if (vertices.length == 3) {
      drawInteraction.finishDrawing();
    }
  });
 });
drawInteraction.on('drawend', function(e) {
  ol.Observable.unByKey(listenerKey);
});
```
