### PR TITLE
Do not rename handleMapBrowserEvent internally

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -138,7 +138,7 @@ oli.interaction.Interaction = function() {};
 /**
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} Whether the map browser event should continue
- *     through the chain of interactions. false means stop, true
+ *     through the chain of interactions. `false` means stop, `true`
  *     means continue.
  */
 oli.interaction.Interaction.prototype.handleMapBrowserEvent = function(e) {};

--- a/src/ol/interaction/interaction.js
+++ b/src/ol/interaction/interaction.js
@@ -77,10 +77,15 @@ ol.interaction.Interaction.prototype.getMap = function() {
 
 
 /**
+ * Method called by the map to notify the interaction that a browser
+ * event was dispatched on the map. If the interaction wants to handle
+ * that event it can return `false` to prevent the propagation of the
+ * event to other interactions in the map's interactions chain.
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} Whether the map browser event should continue
- *     through the chain of interactions. false means stop, true
+ *     through the chain of interactions. `false` means stop, `true`
  *     means continue.
+ * @function
  * @api
  */
 ol.interaction.Interaction.prototype.handleMapBrowserEvent =


### PR DESCRIPTION
This supersedes #2806. It includes @sweco-sebhar's commit plus an additional doc-related commit.

Closes #2806.
