### PR TITLE
Fix compile warning

### DIFF
--- a/externs/oli.js
+++ b/externs/oli.js
@@ -149,7 +149,8 @@ oli.interaction.Interaction = function() {};
  *     through the chain of interactions. `false` means stop, `true`
  *     means continue.
  */
-oli.interaction.Interaction.prototype.handleMapBrowserEvent = function(e) {};
+oli.interaction.Interaction.prototype.handleMapBrowserEvent =
+    function(mapBrowserEvent) {};
 
 
 /**


### PR DESCRIPTION
This PR fixes a compilation warning that was introduced by https://github.com/openlayers/ol3/commit/c4d6e04e4beab5f6cabdba265f233a012402fba1. 

The warning is:

```
ERR! compile externs/oli.js:152: WARNING - parameter mapBrowserEvent does not appear in oli.interaction.Interaction.prototype.handleMapBrowserEvent's parameter list
```
