### PR TITLE
Deselect ovelapping features is broken

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -169,7 +169,7 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
             }
           } else {
             if (remove || toggle) {
-              deselected.push(index);
+              deselected.push(feature);
             }
           }
         }, undefined, this.layerFilter_);


### PR DESCRIPTION
With Select in a toggle mode, clicking a point where there’s overlapping selected features, results in “Uncaught TypeError: Cannot read property 'closure_uid_xxxxxxx’ of undefined” from goog.getUid.

There appears to be a bug in Select.handleMapBrowserEvent: Deselected array containing matching feature indexes is iterated in reverse order and features are removed by this index. It assumes that deselected indexes are in ascending order as to remove them starting from the end of features collection, but as it happens, the indexes are actually in descending order and it starts to remove them from the start of the collection and runs into undefined halfway through when all features overlap.
