### PR TITLE
Make stability checkbox sticky

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -54,11 +54,25 @@ $(function () {
     _onResize();
 
     // show/hide unstable items
+    var links = $('a[href^="ol."');
     var unstable = $('.unstable');
     var stabilityToggle = $('#stability-toggle');
     stabilityToggle.change(function() {
         unstable.toggleClass('hidden', this.checked);
+        var search = this.checked ? '' : '?unstable=true';
+        links.each(function(i, el) {
+            this.href = this.pathname + search + this.hash;
+        });
+        if (history.replaceState) {
+            var url = window.location.pathname + search + window.location.hash;
+            history.replaceState({}, '', url);
+        }
         return false;
     });
+    var search = window.location.search;
+    links.each(function(i, el) {
+        this.href = this.pathname + search + this.hash;
+    });
+    stabilityToggle.prop('checked', search !== '?unstable=true');
     unstable.toggleClass('hidden', stabilityToggle[0].checked);
 });


### PR DESCRIPTION
When the "stable only" checkbox is unchecked, this rewrites all link `href` to include the `?unstable=true` query string.  In browsers that support it, the current location is also updated with the same.  When the checkbox is checked the query string is removed.

Fixes #2694.
