### PR TITLE
Revert "Remove mousewheel event name workaround"

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -265,7 +265,7 @@ ol.Map = function(options) {
     goog.events.EventType.TOUCHSTART,
     goog.events.EventType.MSPOINTERDOWN,
     ol.MapBrowserEvent.EventType.POINTERDOWN,
-    goog.events.EventType.MOUSEWHEEL
+    goog.userAgent.GECKO ? 'DOMMouseScroll' : 'mousewheel'
   ], goog.events.Event.stopPropagation);
   goog.dom.appendChild(this.viewport_, this.overlayContainerStopEvent_);
 


### PR DESCRIPTION
This reverts commit 20ce6640688ade1398f15f1ebca299859d497c8b.

Reverted upstream: https://github.com/google/closure-library/commit/4ee0daca0ec1bea486ab670310a6e9bdbaaad720

fixes #2955 
