### PR TITLE
Fix typo in selector

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -54,7 +54,7 @@ $(function () {
     _onResize();
 
     // show/hide unstable items
-    var links = $('a[href^="ol."');
+    var links = $('a[href^="ol."]');
     var unstable = $('.unstable');
     var stabilityToggle = $('#stability-toggle');
     stabilityToggle.change(function() {


### PR DESCRIPTION
This change fixes the api docs so the stable checkbox works again.
