### PR TITLE
Making GetTileCoordFor methods public avaible

### DIFF
--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -300,7 +300,7 @@ ol.tilegrid.TileGrid.prototype.getTileCoordExtent =
  * @param {number} resolution Resolution.
  * @param {ol.TileCoord=} opt_tileCoord Destination ol.TileCoord object.
  * @return {ol.TileCoord} Tile coordinate.
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordForCoordAndResolution = function(
     coordinate, resolution, opt_tileCoord) {
@@ -347,7 +347,7 @@ ol.tilegrid.TileGrid.prototype.getTileCoordForXYAndResolution_ = function(
  * @param {number} z Z.
  * @param {ol.TileCoord=} opt_tileCoord Destination ol.TileCoord object.
  * @return {ol.TileCoord} Tile coordinate.
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordForCoordAndZ =
     function(coordinate, z, opt_tileCoord) {


### PR DESCRIPTION
I am using tilegrid to request elevation data tiles side by side of a raster layer. It would be nice if these two method was public avaible such I could use the tilegrid to convert mouse coordinates to tile coordinates to request backend tiles. 

The elevation tiles are not shown as a layer directly but rather used to compute and show information in relationship to mouse curser or map view.

This would save me the time of adding another tilegrid implementation in my application specific context.
