### PR TITLE
Add an example to show off ol.style.RegularShape

### DIFF
--- a/examples/regularshape.html
+++ b/examples/regularshape.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="../resources/layout.css" type="text/css">
+    <link rel="stylesheet" href="../resources/bootstrap/css/bootstrap-responsive.min.css" type="text/css">
+    <title>Regular Shape example</title>
+  </head>
+  <body>
+
+    <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="navbar-inner">
+        <div class="container">
+          <a class="brand" href="./"><img src="../resources/logo.png"> OpenLayers 3 Examples</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="row-fluid">
+        <div class="span12">
+          <div id="map" class="map"></div>
+        </div>
+      </div>
+
+      <div class="row-fluid">
+
+        <div class="span12">
+          <h4 id="title">Regular Shape example</h4>
+          <p id="shortdesc">Example of some Regular Shape styles.</p>
+          <div id="docs">
+            <p>See the <a href="regularshape.js" target="_blank">regularshape.js source</a> to see how this is done.</p>
+          </div>
+          <div id="tags">vector, symbol, regularshape, style, square, cross, star, triangle, x</div>
+        </div>
+
+      </div>
+
+    </div>
+
+    <script src="../resources/jquery.min.js" type="text/javascript"></script>
+    <script src="../resources/example-behaviour.js" type="text/javascript"></script>
+    <script src="loader.js?id=regularshape" type="text/javascript"></script>
+
+  </body>
+</html>

--- a/examples/regularshape.js
+++ b/examples/regularshape.js
@@ -1,0 +1,100 @@
+goog.require('ol.Feature');
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.geom.Point');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
+goog.require('ol.style.Fill');
+goog.require('ol.style.RegularShape');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
+
+
+var stroke = new ol.style.Stroke({color: 'black', width: 2});
+var fill = new ol.style.Fill({color: 'red'});
+
+var styles = {
+  'square': [new ol.style.Style({
+    image: new ol.style.RegularShape(
+        /** @type {olx.style.RegularShapeOptions} */({
+          fill: fill,
+          stroke: stroke,
+          points: 4,
+          radius: 10,
+          angle: Math.PI / 4
+        }))
+  })],
+  'triangle': [new ol.style.Style({
+    image: new ol.style.RegularShape(
+        /** @type {olx.style.RegularShapeOptions} */({
+          fill: fill,
+          stroke: stroke,
+          points: 3,
+          radius: 10,
+          angle: 0
+        }))
+  })],
+  'star': [new ol.style.Style({
+    image: new ol.style.RegularShape(
+        /** @type {olx.style.RegularShapeOptions} */({
+          fill: fill,
+          stroke: stroke,
+          points: 5,
+          radius: 10,
+          radius2: 4,
+          angle: 0
+        }))
+  })],
+  'cross': [new ol.style.Style({
+    image: new ol.style.RegularShape(
+        /** @type {olx.style.RegularShapeOptions} */({
+          fill: fill,
+          stroke: stroke,
+          points: 4,
+          radius: 10,
+          radius2: 0,
+          angle: 0
+        }))
+  })],
+  'x': [new ol.style.Style({
+    image: new ol.style.RegularShape(
+        /** @type {olx.style.RegularShapeOptions} */({
+          fill: fill,
+          stroke: stroke,
+          points: 4,
+          radius: 10,
+          radius2: 0,
+          angle: Math.PI / 4
+        }))
+  })]
+};
+
+
+var styleKeys = ['x', 'cross', 'star', 'triangle', 'square'];
+var count = 250;
+var features = new Array(count);
+var e = 4500000;
+for (var i = 0; i < count; ++i) {
+  var coordinates = [2 * e * Math.random() - e, 2 * e * Math.random() - e];
+  features[i] = new ol.Feature(new ol.geom.Point(coordinates));
+  features[i].setStyle(styles[styleKeys[Math.floor(Math.random() * 5)]]);
+}
+
+var source = new ol.source.Vector({
+  features: features
+});
+
+var vectorLayer = new ol.layer.Vector({
+  source: source
+});
+
+var map = new ol.Map({
+  layers: [
+    vectorLayer
+  ],
+  target: 'map',
+  view: new ol.View({
+    center: [0, 0],
+    zoom: 2
+  })
+});


### PR DESCRIPTION
`ol.style.RegularShape` was added with #2706 but doesn't come with an example (except for a jsfiddle in that respective ticket that draws symbols on the canvas, not related to ol3)
