### PR TITLE
Fix zoom levels for the MapQuest Street layer

### DIFF
--- a/src/ol/source/mapquestsource.js
+++ b/src/ol/source/mapquestsource.js
@@ -56,7 +56,7 @@ ol.source.MapQuest.TILE_ATTRIBUTION = new ol.Attribution({
  */
 ol.source.MapQuestConfig = {
   'osm': {
-    maxZoom: 28,
+    maxZoom: 19,
     attributions: [
       ol.source.MapQuest.TILE_ATTRIBUTION,
       ol.source.OSM.ATTRIBUTION


### PR DESCRIPTION
A typo in 65b8e0f91576e521606d906ecdfa9dffd2159dcb introduced this bug.
Before that, 18 zoom levels were used. Now we're using 19, which appears
to be available with full world coverage.
