### PR TITLE
Support OGC srs urns without an EPSG database version

### DIFF
--- a/src/ol/proj/epsg3857projection.js
+++ b/src/ol/proj/epsg3857projection.js
@@ -80,6 +80,7 @@ ol.proj.EPSG3857.CODES = [
   'EPSG:102113',
   'EPSG:900913',
   'urn:ogc:def:crs:EPSG:6.18:3:3857',
+  'urn:ogc:def:crs:EPSG::3857',
   'http://www.opengis.net/gml/srs/epsg.xml#3857'
 ];
 

--- a/src/ol/proj/epsg4326projection.js
+++ b/src/ol/proj/epsg4326projection.js
@@ -59,6 +59,7 @@ ol.proj.EPSG4326.EXTENT = [-180, -90, 180, 90];
 ol.proj.EPSG4326.PROJECTIONS = [
   new ol.proj.EPSG4326_('CRS:84'),
   new ol.proj.EPSG4326_('EPSG:4326', 'neu'),
+  new ol.proj.EPSG4326_('urn:ogc:def:crs:EPSG::4326', 'neu'),
   new ol.proj.EPSG4326_('urn:ogc:def:crs:EPSG:6.6:4326', 'neu'),
   new ol.proj.EPSG4326_('urn:ogc:def:crs:OGC:1.3:CRS84'),
   new ol.proj.EPSG4326_('urn:ogc:def:crs:OGC:2:84'),


### PR DESCRIPTION
Since these are quite common, it makes sense to support them out of the box IMHO
