### PR TITLE
Allow radius1 as an alias for radius in ol.style.RegularShape

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5653,9 +5653,11 @@ olx.style.IconOptions.prototype.src;
 
 
 /**
+ * Specify radius for regular polygons, or radius1 and radius2 for stars.
  * @typedef {{fill: (ol.style.Fill|undefined),
  *     points: number,
  *     radius: number,
+ *     radius1: number,
  *     radius2: number,
  *     angle: number,
  *     snapToPixel: (boolean|undefined),
@@ -5683,7 +5685,7 @@ olx.style.RegularShapeOptions.prototype.points;
 
 
 /**
- * Shape radius.
+ * Radius of a regular polygon.
  * @type {number}
  * @api
  */
@@ -5691,9 +5693,15 @@ olx.style.RegularShapeOptions.prototype.radius;
 
 
 /**
- * Shape secondary radius for drawing stars. If radius 2 is equal to radius,
- * the regular shape will be a regular polygon instead of a star.
- * Default value is equal to radius.
+* Inner radius of a star.
+* @type {number}
+* @api
+*/
+olx.style.RegularShapeOptions.prototype.radius1;
+
+
+/**
+ * Outer radius of a star.
  * @type {number}
  * @api
  */
@@ -6120,7 +6128,6 @@ olx.tilegrid.XYZOptions.prototype.tileSize;
 
 /**
  * @typedef {{resolutions: !Array.<number>}}
- * @api
  * @api
  */
 olx.tilegrid.ZoomifyOptions;

--- a/src/ol/style/regularshapestyle.js
+++ b/src/ol/style/regularshapestyle.js
@@ -13,7 +13,9 @@ goog.require('ol.style.Stroke');
 
 /**
  * @classdesc
- * Set regular shape style for vector features.
+ * Set regular shape style for vector features. The resulting shape will be
+ * a regular polygon when `radius` is provided, or a star when `radius1` and
+ * `radius2` are provided.
  *
  * @constructor
  * @param {olx.style.RegularShapeOptions=} opt_options Options.
@@ -59,14 +61,14 @@ ol.style.RegularShape = function(opt_options) {
    * @private
    * @type {number}
    */
-  this.radius_ = options.radius;
+  this.radius_ = goog.isDef(options.radius) ? options.radius : options.radius1;
 
   /**
    * @private
    * @type {number}
    */
   this.radius2_ =
-      goog.isDef(options.radius2) ? options.radius2 : options.radius;
+      goog.isDef(options.radius2) ? options.radius2 : this.radius_;
 
   /**
    * @private
@@ -170,6 +172,15 @@ ol.style.RegularShape.prototype.getOrigin = function() {
  */
 ol.style.RegularShape.prototype.getRadius = function() {
   return this.radius_;
+};
+
+
+/**
+ * @return {number} Radius2.
+ * @api
+ */
+ol.style.RegularShape.prototype.getRadius2 = function() {
+  return this.radius2_;
 };
 
 

--- a/test/spec/ol/style/regularshapestyle.test.js
+++ b/test/spec/ol/style/regularshapestyle.test.js
@@ -1,0 +1,36 @@
+goog.provide('ol.test.style.RegularShape');
+
+describe('ol.style.RegularShape', function() {
+  it('can use radius', function() {
+    var style = new ol.style.RegularShape({
+      radius: 5,
+      radius2: 10
+    });
+    expect(style.getRadius()).to.eql(5);
+    expect(style.getRadius2()).to.eql(10);
+  });
+  it('can use radius1 as an alias for radius', function() {
+    var style = new ol.style.RegularShape({
+      radius1: 5,
+      radius2: 10
+    });
+    expect(style.getRadius()).to.eql(5);
+    expect(style.getRadius2()).to.eql(10);
+  });
+  it('will use radius for radius2 if radius2 not defined', function() {
+    var style = new ol.style.RegularShape({
+      radius: 5
+    });
+    expect(style.getRadius()).to.eql(5);
+    expect(style.getRadius2()).to.eql(5);
+  });
+  it('will use radius1 for radius2 if radius2 not defined', function() {
+    var style = new ol.style.RegularShape({
+      radius1: 5
+    });
+    expect(style.getRadius()).to.eql(5);
+    expect(style.getRadius2()).to.eql(5);
+  });
+});
+
+goog.require('ol.style.RegularShape');


### PR DESCRIPTION
When creating star symbols having radius1 and radius2 makes more sense as config options, hence the proposal to have radius1 be an alias for radius in `ol.style.RegularShape`
