### PR TITLE
Image layer renderers use source projection if given and equivalent

### DIFF
--- a/src/ol/renderer/canvas/canvasimagelayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasimagelayerrenderer.js
@@ -111,7 +111,7 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame =
       !ol.extent.isEmpty(renderedExtent)) {
     var projection = viewState.projection;
     var sourceProjection = imageSource.getProjection();
-    if (goog.isDefAndNotNull(sourceProjection)) {
+    if (!goog.isNull(sourceProjection)) {
       goog.asserts.assert(ol.proj.equivalent(projection, sourceProjection));
       projection = sourceProjection;
     }

--- a/src/ol/renderer/dom/domimagelayerrenderer.js
+++ b/src/ol/renderer/dom/domimagelayerrenderer.js
@@ -107,7 +107,7 @@ ol.renderer.dom.ImageLayer.prototype.prepareFrame =
       !ol.extent.isEmpty(renderedExtent)) {
     var projection = viewState.projection;
     var sourceProjection = imageSource.getProjection();
-    if (goog.isDefAndNotNull(sourceProjection)) {
+    if (!goog.isNull(sourceProjection)) {
       goog.asserts.assert(ol.proj.equivalent(projection, sourceProjection));
       projection = sourceProjection;
     }

--- a/src/ol/renderer/webgl/webglimagelayerrenderer.js
+++ b/src/ol/renderer/webgl/webglimagelayerrenderer.js
@@ -127,7 +127,7 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame =
       !ol.extent.isEmpty(renderedExtent)) {
     var projection = viewState.projection;
     var sourceProjection = imageSource.getProjection();
-    if (goog.isDefAndNotNull(sourceProjection)) {
+    if (!goog.isNull(sourceProjection)) {
       goog.asserts.assert(ol.proj.equivalent(projection, sourceProjection));
       projection = sourceProjection;
     }


### PR DESCRIPTION
Again to solve #2966 - I tested the Canvas renderer and edited the duplicated code in DOM and WebGL untested.
If any of these renderers can handle different projections (or learns to), the equivalency assertion may be removed. 
