### PR TITLE
support gml/3.2 namespace, nested elements in metadata

### DIFF
--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -78,7 +78,6 @@ ol.format.GML3 = function(opt_options) {
 goog.inherits(ol.format.GML3, ol.format.GMLBase);
 
 
-
 /**
  * @const
  * @type {string}
@@ -87,6 +86,8 @@ goog.inherits(ol.format.GML3, ol.format.GMLBase);
 ol.format.GML3.schemaLocation_ = ol.format.GMLBase.GMLNS +
     ' http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/' +
     '1.0.0/gmlsf.xsd';
+
+
 /**
  * @const
  * @type {Array.<string>}
@@ -100,6 +101,7 @@ for (var i in ol.format.GML3.prototype) {
     ol.format.GMLBase.prototype[i]['http://www.opengis.net/gml/3.2'] = ol.format.GML3.prototype[i]['http://www.opengis.net/gml']; // because of references in ol.format.WFS
   }
 }
+
 
 /**
  * @param {Node} node Node.
@@ -445,11 +447,11 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
-      'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
+    'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
+  };
 });
 
 
@@ -459,11 +461,11 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'interior': ol.format.GML3.prototype.interiorParser_,
-      'exterior': ol.format.GML3.prototype.exteriorParser_
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'interior': ol.format.GML3.prototype.interiorParser_,
+    'exterior': ol.format.GML3.prototype.exteriorParser_
+  };
 });
 
 
@@ -473,28 +475,28 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
-      'MultiPoint': ol.xml.makeReplacer(
-          ol.format.GMLBase.prototype.readMultiPoint),
-      'LineString': ol.xml.makeReplacer(
-          ol.format.GMLBase.prototype.readLineString),
-      'MultiLineString': ol.xml.makeReplacer(
-          ol.format.GMLBase.prototype.readMultiLineString),
-      'LinearRing' : ol.xml.makeReplacer(
-          ol.format.GMLBase.prototype.readLinearRing),
-      'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
-      'MultiPolygon': ol.xml.makeReplacer(
-          ol.format.GMLBase.prototype.readMultiPolygon),
-      'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
-      'MultiSurface': ol.xml.makeReplacer(
-          ol.format.GML3.prototype.readMultiSurface_),
-      'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
-      'MultiCurve': ol.xml.makeReplacer(
-          ol.format.GML3.prototype.readMultiCurve_),
-      'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
+    'MultiPoint': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readMultiPoint),
+    'LineString': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readLineString),
+    'MultiLineString': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readMultiLineString),
+    'LinearRing' : ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readLinearRing),
+    'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
+    'MultiPolygon': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readMultiPolygon),
+    'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
+    'MultiSurface': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readMultiSurface_),
+    'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
+    'MultiCurve': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readMultiCurve_),
+    'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
+  };
 });
 
 
@@ -504,13 +506,13 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'curveMember': ol.xml.makeArrayPusher(
-          ol.format.GML3.prototype.curveMemberParser_),
-      'curveMembers': ol.xml.makeArrayPusher(
-          ol.format.GML3.prototype.curveMemberParser_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'curveMember': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.curveMemberParser_),
+    'curveMembers': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.curveMemberParser_)
+  };
 });
 
 
@@ -520,13 +522,13 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'surfaceMember': ol.xml.makeArrayPusher(
-          ol.format.GML3.prototype.surfaceMemberParser_),
-      'surfaceMembers': ol.xml.makeArrayPusher(
-          ol.format.GML3.prototype.surfaceMemberParser_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'surfaceMember': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.surfaceMemberParser_),
+    'surfaceMembers': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.surfaceMemberParser_)
+  };
 });
 
 
@@ -536,12 +538,12 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'LineString': ol.xml.makeArrayPusher(
-          ol.format.GMLBase.prototype.readLineString),
-      'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'LineString': ol.xml.makeArrayPusher(
+        ol.format.GMLBase.prototype.readLineString),
+    'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
+  };
 });
 
 
@@ -551,11 +553,11 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
-      'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
+    'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
+  };
 });
 
 
@@ -565,10 +567,10 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SURFACE_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
+  };
 });
 
 
@@ -578,10 +580,10 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.CURVE_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
+  };
 });
 
 
@@ -591,13 +593,13 @@ ol.format.GML3.prototype.CURVE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'lowerCorner': ol.xml.makeArrayPusher(
-          ol.format.GML3.prototype.readFlatPosList_),
-      'upperCorner': ol.xml.makeArrayPusher(
-          ol.format.GML3.prototype.readFlatPosList_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'lowerCorner': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.readFlatPosList_),
+    'upperCorner': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.readFlatPosList_)
+  };
 });
 
 
@@ -607,11 +609,11 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.PATCHES_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'PolygonPatch': ol.xml.makeReplacer(
-          ol.format.GML3.prototype.readPolygonPatch_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'PolygonPatch': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readPolygonPatch_)
+  };
 });
 
 
@@ -621,11 +623,11 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SEGMENTS_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'LineStringSegment': ol.xml.makeReplacer(
-          ol.format.GML3.prototype.readLineStringSegment_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'LineStringSegment': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readLineStringSegment_)
+  };
 });
 
 
@@ -719,11 +721,11 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @private
  */
 ol.format.GML3.ENVELOPE_SERIALIZERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
-      'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
+    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
+  };
 });
 
 
@@ -1122,13 +1124,13 @@ ol.format.GML3.prototype.writeFeatureMembers_ =
  * @private
  */
 ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'surfaceMember': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
-      'polygonMember': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'surfaceMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
+    'polygonMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
+  };
 });
 
 
@@ -1137,11 +1139,11 @@ ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'pointMember': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writePointMember_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'pointMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writePointMember_)
+  };
 });
 
 
@@ -1150,13 +1152,13 @@ ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'lineStringMember': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeLineStringOrCurveMember_),
-      'curveMember': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'lineStringMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeLineStringOrCurveMember_),
+    'curveMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeLineStringOrCurveMember_)
+  };
 });
 
 
@@ -1165,11 +1167,11 @@ ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.RING_SERIALIZERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
-      'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
+    'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
+  };
 });
 
 
@@ -1178,32 +1180,32 @@ ol.format.GML3.RING_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.GEOMETRY_SERIALIZERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-    return {
-      'Curve': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeCurveOrLineString_),
-      'MultiCurve': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-      'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
-      'MultiPoint': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeMultiPoint_),
-      'LineString': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeCurveOrLineString_),
-      'MultiLineString': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-      'LinearRing': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeLinearRing_),
-      'Polygon': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-      'MultiPolygon': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-      'Surface': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-      'MultiSurface': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-      'Envelope': ol.xml.makeChildAppender(
-          ol.format.GML3.prototype.writeEnvelope)
-    };
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
+  return {
+    'Curve': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeCurveOrLineString_),
+    'MultiCurve': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+    'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
+    'MultiPoint': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiPoint_),
+    'LineString': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeCurveOrLineString_),
+    'MultiLineString': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+    'LinearRing': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeLinearRing_),
+    'Polygon': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+    'MultiPolygon': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+    'Surface': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+    'MultiSurface': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+    'Envelope': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeEnvelope)
+  };
 });
 
 

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -78,6 +78,7 @@ ol.format.GML3 = function(opt_options) {
 goog.inherits(ol.format.GML3, ol.format.GMLBase);
 
 
+
 /**
  * @const
  * @type {string}
@@ -86,7 +87,19 @@ goog.inherits(ol.format.GML3, ol.format.GMLBase);
 ol.format.GML3.schemaLocation_ = ol.format.GMLBase.GMLNS +
     ' http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/' +
     '1.0.0/gmlsf.xsd';
+/**
+ * @const
+ * @type {Array.<string>}
+ * @private
+ */
+ol.format.GML3.NAMESPACES_ = ['http://www.opengis.net/gml', 'http://www.opengis.net/gml/3.2'];
 
+for (var i in ol.format.GML3.prototype) {
+  if (goog.isDef(ol.format.GML3.prototype[i]['http://www.opengis.net/gml'])) {
+    ol.format.GML3.prototype[i]['http://www.opengis.net/gml/3.2'] = ol.format.GML3.prototype[i]['http://www.opengis.net/gml'];
+    ol.format.GMLBase.prototype[i]['http://www.opengis.net/gml/3.2'] = ol.format.GML3.prototype[i]['http://www.opengis.net/gml']; // because of references in ol.format.WFS
+  }
+}
 
 /**
  * @param {Node} node Node.
@@ -431,11 +444,12 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
-    'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
-  }
+ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
+      'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
+    };
 });
 
 
@@ -444,11 +458,12 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'interior': ol.format.GML3.prototype.interiorParser_,
-    'exterior': ol.format.GML3.prototype.exteriorParser_
-  }
+ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'interior': ol.format.GML3.prototype.interiorParser_,
+      'exterior': ol.format.GML3.prototype.exteriorParser_
+    }
 });
 
 
@@ -457,28 +472,29 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
-    'MultiPoint': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPoint),
-    'LineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLineString),
-    'MultiLineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiLineString),
-    'LinearRing' : ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLinearRing),
-    'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
-    'MultiPolygon': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPolygon),
-    'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
-    'MultiSurface': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiSurface_),
-    'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
-    'MultiCurve': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiCurve_),
-    'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-  }
+ol.format.GML3.prototype.GEOMETRY_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
+      'MultiPoint': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readMultiPoint),
+      'LineString': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readLineString),
+      'MultiLineString': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readMultiLineString),
+      'LinearRing' : ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readLinearRing),
+      'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
+      'MultiPolygon': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readMultiPolygon),
+      'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
+      'MultiSurface': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readMultiSurface_),
+      'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
+      'MultiCurve': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readMultiCurve_),
+      'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
+    }
 });
 
 
@@ -487,13 +503,14 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTICURVE_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'curveMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_),
-    'curveMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_)
-  }
+ol.format.GML3.prototype.MULTICURVE_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'curveMember': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.curveMemberParser_),
+      'curveMembers': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.curveMemberParser_)
+    }
 });
 
 
@@ -502,13 +519,14 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'surfaceMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_),
-    'surfaceMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_)
-  }
+ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'surfaceMember': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.surfaceMemberParser_),
+      'surfaceMembers': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.surfaceMemberParser_)
+    }
 });
 
 
@@ -517,12 +535,13 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'LineString': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readLineString),
-    'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-  }
+ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'LineString': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.readLineString),
+      'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
+    }
 });
 
 
@@ -531,11 +550,12 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
-    'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-  }
+ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
+      'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
+    }
 });
 
 
@@ -544,10 +564,11 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACE_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-  }
+ol.format.GML3.prototype.SURFACE_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
+    }
 });
 
 
@@ -556,10 +577,11 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVE_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-  }
+ol.format.GML3.prototype.CURVE_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
+    }
 });
 
 
@@ -568,13 +590,14 @@ ol.format.GML3.prototype.CURVE_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.ENVELOPE_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'lowerCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_),
-    'upperCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_)
-  }
+ol.format.GML3.prototype.ENVELOPE_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'lowerCorner': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.readFlatPosList_),
+      'upperCorner': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.readFlatPosList_)
+    }
 });
 
 
@@ -583,11 +606,12 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.PATCHES_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'PolygonPatch': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readPolygonPatch_)
-  }
+ol.format.GML3.prototype.PATCHES_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'PolygonPatch': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readPolygonPatch_)
+    }
 });
 
 
@@ -596,11 +620,12 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ = Object({
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.SEGMENTS_PARSERS_ = Object({
-  'http://www.opengis.net/gml' : {
-    'LineStringSegment': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readLineStringSegment_)
-  }
+ol.format.GML3.prototype.SEGMENTS_PARSERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'LineStringSegment': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readLineStringSegment_)
+    }
 });
 
 
@@ -693,12 +718,13 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.ENVELOPE_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
-    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
-    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-  }
-};
+ol.format.GML3.ENVELOPE_SERIALIZERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
+      'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
+    }
+});
 
 
 /**
@@ -1095,85 +1121,90 @@ ol.format.GML3.prototype.writeFeatureMembers_ =
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
-    'surfaceMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
-    'polygonMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-  }
-};
+ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'surfaceMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
+      'polygonMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
+    }
+});
 
 
 /**
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.POINTMEMBER_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
-    'pointMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writePointMember_)
-  }
-};
+ol.format.GML3.POINTMEMBER_SERIALIZERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'pointMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writePointMember_)
+    }
+});
 
 
 /**
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
-    'lineStringMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_),
-    'curveMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-  }
-};
+ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'lineStringMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeLineStringOrCurveMember_),
+      'curveMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeLineStringOrCurveMember_)
+    }
+});
 
 
 /**
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.RING_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
-    'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
-    'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-  }
-};
+ol.format.GML3.RING_SERIALIZERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
+      'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
+    }
+});
 
 
 /**
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.GEOMETRY_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
-    'Curve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiCurve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
-    'MultiPoint': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiPoint_),
-    'LineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiLineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'LinearRing': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLinearRing_),
-    'Polygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiPolygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Surface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiSurface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Envelope': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeEnvelope)
-  }
-};
+ol.format.GML3.GEOMETRY_SERIALIZERS_ = 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+    return {
+      'Curve': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeCurveOrLineString_),
+      'MultiCurve': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+      'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
+      'MultiPoint': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiPoint_),
+      'LineString': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeCurveOrLineString_),
+      'MultiLineString': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+      'LinearRing': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeLinearRing_),
+      'Polygon': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+      'MultiPolygon': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+      'Surface': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+      'MultiSurface': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+      'Envelope': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeEnvelope)
+    }
+});
 
 
 /**

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -93,12 +93,18 @@ ol.format.GML3.schemaLocation_ = ol.format.GMLBase.GMLNS +
  * @type {Array.<string>}
  * @private
  */
-ol.format.GML3.NAMESPACES_ = ['http://www.opengis.net/gml', 'http://www.opengis.net/gml/3.2'];
+ol.format.GML3.NAMESPACES_ = [
+  'http://www.opengis.net/gml',
+  'http://www.opengis.net/gml/3.2'
+];
 
 for (var i in ol.format.GML3.prototype) {
   if (goog.isDef(ol.format.GML3.prototype[i]['http://www.opengis.net/gml'])) {
-    ol.format.GML3.prototype[i]['http://www.opengis.net/gml/3.2'] = ol.format.GML3.prototype[i]['http://www.opengis.net/gml'];
-    ol.format.GMLBase.prototype[i]['http://www.opengis.net/gml/3.2'] = ol.format.GML3.prototype[i]['http://www.opengis.net/gml']; // because of references in ol.format.WFS
+    ol.format.GML3.prototype[i]['http://www.opengis.net/gml/3.2'] =
+        ol.format.GML3.prototype[i]['http://www.opengis.net/gml'];
+    // and, because of references in ol.format.WFS:
+    ol.format.GMLBase.prototype[i]['http://www.opengis.net/gml/3.2'] =
+        ol.format.GML3.prototype[i]['http://www.opengis.net/gml'];
   }
 }
 
@@ -447,12 +453,14 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
-    'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
+        'posList':
+            ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
+      };
+    });
 
 
 /**
@@ -461,12 +469,13 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'interior': ol.format.GML3.prototype.interiorParser_,
-    'exterior': ol.format.GML3.prototype.exteriorParser_
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'interior': ol.format.GML3.prototype.interiorParser_,
+        'exterior': ol.format.GML3.prototype.exteriorParser_
+      };
+    });
 
 
 /**
@@ -475,29 +484,30 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
-    'MultiPoint': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPoint),
-    'LineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLineString),
-    'MultiLineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiLineString),
-    'LinearRing' : ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLinearRing),
-    'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
-    'MultiPolygon': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPolygon),
-    'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
-    'MultiSurface': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiSurface_),
-    'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
-    'MultiCurve': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiCurve_),
-    'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
+        'MultiPoint': ol.xml.makeReplacer(
+            ol.format.GMLBase.prototype.readMultiPoint),
+        'LineString': ol.xml.makeReplacer(
+            ol.format.GMLBase.prototype.readLineString),
+        'MultiLineString': ol.xml.makeReplacer(
+            ol.format.GMLBase.prototype.readMultiLineString),
+        'LinearRing' : ol.xml.makeReplacer(
+            ol.format.GMLBase.prototype.readLinearRing),
+        'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
+        'MultiPolygon': ol.xml.makeReplacer(
+            ol.format.GMLBase.prototype.readMultiPolygon),
+        'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
+        'MultiSurface': ol.xml.makeReplacer(
+            ol.format.GML3.prototype.readMultiSurface_),
+        'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
+        'MultiCurve': ol.xml.makeReplacer(
+            ol.format.GML3.prototype.readMultiCurve_),
+        'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
+      };
+    });
 
 
 /**
@@ -506,14 +516,15 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'curveMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_),
-    'curveMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'curveMember': ol.xml.makeArrayPusher(
+            ol.format.GML3.prototype.curveMemberParser_),
+        'curveMembers': ol.xml.makeArrayPusher(
+            ol.format.GML3.prototype.curveMemberParser_)
+      };
+    });
 
 
 /**
@@ -522,14 +533,15 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'surfaceMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_),
-    'surfaceMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'surfaceMember': ol.xml.makeArrayPusher(
+            ol.format.GML3.prototype.surfaceMemberParser_),
+        'surfaceMembers': ol.xml.makeArrayPusher(
+            ol.format.GML3.prototype.surfaceMemberParser_)
+      };
+    });
 
 
 /**
@@ -538,13 +550,14 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'LineString': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readLineString),
-    'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'LineString': ol.xml.makeArrayPusher(
+            ol.format.GMLBase.prototype.readLineString),
+        'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
+      };
+    });
 
 
 /**
@@ -553,12 +566,14 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
-    'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'Polygon':
+            ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
+        'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
+      };
+    });
 
 
 /**
@@ -567,11 +582,12 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SURFACE_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
+      };
+    });
 
 
 /**
@@ -580,11 +596,12 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.CURVE_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
+      };
+    });
 
 
 /**
@@ -593,14 +610,15 @@ ol.format.GML3.prototype.CURVE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'lowerCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_),
-    'upperCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'lowerCorner': ol.xml.makeArrayPusher(
+            ol.format.GML3.prototype.readFlatPosList_),
+        'upperCorner': ol.xml.makeArrayPusher(
+            ol.format.GML3.prototype.readFlatPosList_)
+      };
+    });
 
 
 /**
@@ -609,12 +627,13 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.PATCHES_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'PolygonPatch': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readPolygonPatch_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'PolygonPatch': ol.xml.makeReplacer(
+            ol.format.GML3.prototype.readPolygonPatch_)
+      };
+    });
 
 
 /**
@@ -623,12 +642,13 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SEGMENTS_PARSERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'LineStringSegment': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readLineStringSegment_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'LineStringSegment': ol.xml.makeReplacer(
+            ol.format.GML3.prototype.readLineStringSegment_)
+      };
+    });
 
 
 /**
@@ -721,12 +741,15 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @private
  */
 ol.format.GML3.ENVELOPE_SERIALIZERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
-    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'lowerCorner':
+            ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
+        'upperCorner':
+            ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
+      };
+    });
 
 
 /**
@@ -1124,14 +1147,15 @@ ol.format.GML3.prototype.writeFeatureMembers_ =
  * @private
  */
 ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'surfaceMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
-    'polygonMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'surfaceMember': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
+        'polygonMember': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
+      };
+    });
 
 
 /**
@@ -1139,12 +1163,13 @@ ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'pointMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writePointMember_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'pointMember': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writePointMember_)
+      };
+    });
 
 
 /**
@@ -1152,14 +1177,15 @@ ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'lineStringMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_),
-    'curveMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'lineStringMember': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeLineStringOrCurveMember_),
+        'curveMember': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeLineStringOrCurveMember_)
+      };
+    });
 
 
 /**
@@ -1167,12 +1193,15 @@ ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.RING_SERIALIZERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
-    'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'exterior':
+            ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
+        'interior':
+            ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
+      };
+    });
 
 
 /**
@@ -1180,33 +1209,34 @@ ol.format.GML3.RING_SERIALIZERS_ =
  * @private
  */
 ol.format.GML3.GEOMETRY_SERIALIZERS_ =
-    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
-  return {
-    'Curve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiCurve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
-    'MultiPoint': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiPoint_),
-    'LineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiLineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'LinearRing': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLinearRing_),
-    'Polygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiPolygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Surface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiSurface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Envelope': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeEnvelope)
-  };
-});
+    goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_),
+    function() {
+      return {
+        'Curve': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeCurveOrLineString_),
+        'MultiCurve': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+        'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
+        'MultiPoint': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeMultiPoint_),
+        'LineString': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeCurveOrLineString_),
+        'MultiLineString': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+        'LinearRing': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeLinearRing_),
+        'Polygon': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+        'MultiPolygon': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+        'Surface': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+        'MultiSurface': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+        'Envelope': ol.xml.makeChildAppender(
+            ol.format.GML3.prototype.writeEnvelope)
+      };
+    });
 
 
 /**

--- a/src/ol/format/gml/gml3format.js
+++ b/src/ol/format/gml/gml3format.js
@@ -445,7 +445,7 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
       'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
@@ -458,12 +458,12 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'interior': ol.format.GML3.prototype.interiorParser_,
       'exterior': ol.format.GML3.prototype.exteriorParser_
-    }
+    };
 });
 
 
@@ -472,8 +472,8 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
       'MultiPoint': ol.xml.makeReplacer(
@@ -494,7 +494,7 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
       'MultiCurve': ol.xml.makeReplacer(
           ol.format.GML3.prototype.readMultiCurve_),
       'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-    }
+    };
 });
 
 
@@ -503,14 +503,14 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTICURVE_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'curveMember': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.curveMemberParser_),
       'curveMembers': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.curveMemberParser_)
-    }
+    };
 });
 
 
@@ -519,14 +519,14 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'surfaceMember': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.surfaceMemberParser_),
       'surfaceMembers': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.surfaceMemberParser_)
-    }
+    };
 });
 
 
@@ -535,13 +535,13 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'LineString': ol.xml.makeArrayPusher(
           ol.format.GMLBase.prototype.readLineString),
       'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-    }
+    };
 });
 
 
@@ -551,11 +551,11 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
  * @private
  */
 ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
       'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-    }
+    };
 });
 
 
@@ -564,11 +564,11 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACE_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.SURFACE_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-    }
+    };
 });
 
 
@@ -577,11 +577,11 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVE_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.CURVE_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-    }
+    };
 });
 
 
@@ -590,14 +590,14 @@ ol.format.GML3.prototype.CURVE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.ENVELOPE_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'lowerCorner': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.readFlatPosList_),
       'upperCorner': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.readFlatPosList_)
-    }
+    };
 });
 
 
@@ -606,12 +606,12 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.PATCHES_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.PATCHES_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'PolygonPatch': ol.xml.makeReplacer(
           ol.format.GML3.prototype.readPolygonPatch_)
-    }
+    };
 });
 
 
@@ -620,12 +620,12 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Parser>>}
  * @private
  */
-ol.format.GML3.prototype.SEGMENTS_PARSERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.prototype.SEGMENTS_PARSERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'LineStringSegment': ol.xml.makeReplacer(
           ol.format.GML3.prototype.readLineStringSegment_)
-    }
+    };
 });
 
 
@@ -718,12 +718,12 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.ENVELOPE_SERIALIZERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.ENVELOPE_SERIALIZERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
       'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-    }
+    };
 });
 
 
@@ -1121,14 +1121,14 @@ ol.format.GML3.prototype.writeFeatureMembers_ =
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'surfaceMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
       'polygonMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-    }
+    };
 });
 
 
@@ -1136,12 +1136,12 @@ ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.POINTMEMBER_SERIALIZERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'pointMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writePointMember_)
-    }
+    };
 });
 
 
@@ -1149,14 +1149,14 @@ ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'lineStringMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeLineStringOrCurveMember_),
       'curveMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-    }
+    };
 });
 
 
@@ -1164,12 +1164,12 @@ ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.RING_SERIALIZERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.RING_SERIALIZERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
       'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-    }
+    };
 });
 
 
@@ -1177,8 +1177,8 @@ ol.format.GML3.RING_SERIALIZERS_ =
  * @type {Object.<string, Object.<string, ol.xml.Serializer>>}
  * @private
  */
-ol.format.GML3.GEOMETRY_SERIALIZERS_ = 
-  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() { 
+ol.format.GML3.GEOMETRY_SERIALIZERS_ =
+  goog.object.map(goog.object.transpose(ol.format.GML3.NAMESPACES_), function() {
     return {
       'Curve': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeCurveOrLineString_),
@@ -1203,7 +1203,7 @@ ol.format.GML3.GEOMETRY_SERIALIZERS_ =
           ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
       'Envelope': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeEnvelope)
-    }
+    };
 });
 
 

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -149,30 +149,48 @@ ol.format.GMLBase.prototype.readGeometryElement = function(node, objectStack) {
 
 
 /**
+ * @type {Object.<string, Object.<string, Object>>}
+ */
+ol.format.GMLBase.prototype.FEATURE_COLLECTION_PARSERS = Object({
+  'http://www.opengis.net/gml': {
+    'featureMember': ol.xml.makeArrayPusher(
+        ol.format.GMLBase.prototype.readFeatures_),
+    'featureMembers': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readFeatures_),
+    'boundedBy': ol.xml.makeObjectPropertySetter(
+        ol.format.GMLBase.prototype.readGeometryElement, 'bounds')
+  }
+});
+
+
+/**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @return {ol.Feature} Feature.
  */
 ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
-  var n;
+  var n, i, hasGeometry;
+  var knownGeometries = goog.object.getKeys(this.GEOMETRY_PARSERS_['http://www.opengis.net/gml']);
   var fid = node.getAttribute('fid') ||
       ol.xml.getAttributeNS(node, ol.format.GMLBase.GMLNS, 'id');
   var values = {}, geometryName;
   for (n = node.firstElementChild; !goog.isNull(n);
       n = n.nextElementSibling) {
+    // Assume there is only one geometry node, and that is has a know geometry as child node:
+    hasGeometry = false;
+    for (i=0;i<n.childNodes.length;i++) {
+      hasGeometry = hasGeometry | (knownGeometries.indexOf(n.childNodes[i].localName) > -1);
+    }
     var localName = ol.xml.getLocalName(n);
-    // Assume attribute elements have one child node and that the child
-    // is a text node.  Otherwise assume it is a geometry node.
-    if (n.childNodes.length === 0 ||
-        (n.childNodes.length === 1 &&
-        n.firstChild.nodeType === 3)) {
-      var value = ol.xml.getAllTextContent(n, false);
-      if (goog.string.isEmpty(value)) {
-        value = undefined;
+    if (!hasGeometry) {
+      var data = ol.xml.getStructuredTextContent(n, false);
+      if (goog.object.isEmpty(data)) {
+        data = undefined;
+      } else if (goog.array.equals(goog.object.getKeys(data), ['text_'])) {
+        data = data['text_'];
       }
-      values[localName] = value;
+      values[localName] = data;
     } else {
-      // boundedBy is an extent and must not be considered as a geometry
       if (localName !== 'boundedBy') {
         geometryName = localName;
       }

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -170,16 +170,20 @@ ol.format.GMLBase.prototype.FEATURE_COLLECTION_PARSERS = Object({
  */
 ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
   var n, i, hasGeometry;
-  var knownGeometries = goog.object.getKeys(this.GEOMETRY_PARSERS_['http://www.opengis.net/gml']);
+  var knownGeometries = goog.object.getKeys(
+      this.GEOMETRY_PARSERS_['http://www.opengis.net/gml']
+      );
   var fid = node.getAttribute('fid') ||
       ol.xml.getAttributeNS(node, ol.format.GMLBase.GMLNS, 'id');
   var values = {}, geometryName;
   for (n = node.firstElementChild; !goog.isNull(n);
       n = n.nextElementSibling) {
-    // Assume there is only one geometry node, and that is has a know geometry as child node:
+    // Assume there is only one geometry node,
+    // and that is has a know geometry as child node:
     hasGeometry = false;
     for (i = 0; i < n.childNodes.length; i++) {
-      hasGeometry = hasGeometry | (knownGeometries.indexOf(n.childNodes[i].localName) > -1);
+      hasGeometry = hasGeometry |
+          (knownGeometries.indexOf(n.childNodes[i].localName) > -1);
     }
     var localName = ol.xml.getLocalName(n);
     if (!hasGeometry) {

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -7,7 +7,6 @@ goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
 goog.require('goog.object');
-goog.require('goog.string');
 goog.require('ol.Feature');
 goog.require('ol.format.Feature');
 goog.require('ol.format.XMLFeature');
@@ -191,7 +190,7 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
       if (goog.object.isEmpty(data)) {
         data = undefined;
       } else if (goog.array.equals(goog.object.getKeys(data), ['text_'])) {
-        data = data['text_'];
+        data = data.text_;
       }
       values[localName] = data;
     } else {

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -74,7 +74,9 @@ ol.format.GMLBase = function(opt_options) {
     'featureMember': ol.xml.makeReplacer(
         ol.format.GMLBase.prototype.readFeaturesInternal),
     'featureMembers': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readFeaturesInternal)
+        ol.format.GMLBase.prototype.readFeaturesInternal),
+    'boundedBy': ol.xml.makeObjectPropertySetter(
+        ol.format.GMLBase.prototype.readGeometryElement, 'bounds')
   };
 
   goog.base(this);
@@ -145,21 +147,6 @@ ol.format.GMLBase.prototype.readGeometryElement = function(node, objectStack) {
     return undefined;
   }
 };
-
-
-/**
- * @type {Object.<string, Object.<string, Object>>}
- */
-ol.format.GMLBase.prototype.FEATURE_COLLECTION_PARSERS = Object({
-  'http://www.opengis.net/gml': {
-    'featureMember': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readFeatures_),
-    'featureMembers': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readFeatures_),
-    'boundedBy': ol.xml.makeObjectPropertySetter(
-        ol.format.GMLBase.prototype.readGeometryElement, 'bounds')
-  }
-});
 
 
 /**

--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -178,7 +178,7 @@ ol.format.GMLBase.prototype.readFeatureElement = function(node, objectStack) {
       n = n.nextElementSibling) {
     // Assume there is only one geometry node, and that is has a know geometry as child node:
     hasGeometry = false;
-    for (i=0;i<n.childNodes.length;i++) {
+    for (i = 0; i < n.childNodes.length; i++) {
       hasGeometry = hasGeometry | (knownGeometries.indexOf(n.childNodes[i].localName) > -1);
     }
     var localName = ol.xml.getLocalName(n);

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -210,7 +210,7 @@ ol.format.WFS.FEATURE_COLLECTION_PARSERS_ = {
         ol.format.GMLBase.prototype.readGeometryElement, 'bounds')
   }
 };
-
+ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml/3.2'] = ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml']
 
 /**
  * @param {Node} node Node.

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -210,7 +210,8 @@ ol.format.WFS.FEATURE_COLLECTION_PARSERS_ = {
         ol.format.GMLBase.prototype.readGeometryElement, 'bounds')
   }
 };
-ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml/3.2'] = ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml']
+ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml/3.2'] =
+  ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml'];
 
 /**
  * @param {Node} node Node.

--- a/src/ol/format/wfsformat.js
+++ b/src/ol/format/wfsformat.js
@@ -211,7 +211,8 @@ ol.format.WFS.FEATURE_COLLECTION_PARSERS_ = {
   }
 };
 ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml/3.2'] =
-  ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml'];
+    ol.format.WFS.FEATURE_COLLECTION_PARSERS_['http://www.opengis.net/gml'];
+
 
 /**
  * @param {Node} node Node.

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -128,12 +128,17 @@ ol.xml.getStructuredTextContent = function(node, normalizeWhitespace) {
   var accumulator = {};
   if (node.nodeType == goog.dom.NodeType.CDATA_SECTION ||
       node.nodeType == goog.dom.NodeType.TEXT) {
-    accumulator["text_"] =  normalizeWhitespace ? String(node.nodeValue).replace(/(\r\n|\r|\n)/g, '') : node.nodeValue;
+    accumulator['text_'] = normalizeWhitespace ?
+      String(node.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
+      node.nodeValue;
   } else {
     var n;
     for (n = node.firstChild; !goog.isNull(n); n = n.nextSibling) {
       if (n.nodeType == goog.dom.NodeType.TEXT) {
-        accumulator["text_"] = (accumulator["text_"] || "") + (normalizeWhitespace ? String(n.nodeValue).replace(/(\r\n|\r|\n)/g, '') : n.nodeValue);
+        accumulator['text_'] = (accumulator['text_'] || '') +
+          (normalizeWhitespace ?
+            String(n.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
+            n.nodeValue);
       } else {
         accumulator[n.localName] = ol.xml.getStructuredTextContent(n, normalizeWhitespace);
       }

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -95,7 +95,7 @@ ol.xml.getAllTextContent = function(node, normalizeWhitespace) {
  * breaks.
  * @param {Array.<String|string>} accumulator Accumulator.
  * @private
- * @return {Array.<String|string>} Accumulator.
+ * @return {Array.<String>} Accumulator.
  */
 ol.xml.getAllTextContent_ = function(node, normalizeWhitespace, accumulator) {
   if (node.nodeType == goog.dom.NodeType.CDATA_SECTION ||
@@ -114,6 +114,34 @@ ol.xml.getAllTextContent_ = function(node, normalizeWhitespace, accumulator) {
   }
   return accumulator;
 };
+
+/**
+ * Recursively grab content of child nodes into a nested object.
+ * @param {Node} node Node.
+ * @param {boolean} normalizeWhitespace Normalize whitespace: remove all line
+ * breaks from text nodes.
+ * @return {Object.<*>} Content.
+ * @api
+ */
+
+ol.xml.getStructuredTextContent = function(node, normalizeWhitespace) {
+  var accumulator = {};
+  if (node.nodeType == goog.dom.NodeType.CDATA_SECTION ||
+      node.nodeType == goog.dom.NodeType.TEXT) {
+    accumulator["text_"] =  normalizeWhitespace ? String(node.nodeValue).replace(/(\r\n|\r|\n)/g, '') : node.nodeValue;
+  } else {
+    var n;
+    for (n = node.firstChild; !goog.isNull(n); n = n.nextSibling) {
+      if (n.nodeType == goog.dom.NodeType.TEXT) {
+        accumulator["text_"] = (accumulator["text_"] || "") + (normalizeWhitespace ? String(n.nodeValue).replace(/(\r\n|\r|\n)/g, '') : n.nodeValue);
+      } else {
+        accumulator[n.localName] = ol.xml.getStructuredTextContent(n, normalizeWhitespace);
+      }
+    }
+  }
+  return accumulator;
+};
+
 
 
 /**

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -128,14 +128,14 @@ ol.xml.getStructuredTextContent = function(node, normalizeWhitespace) {
   var accumulator = {};
   if (node.nodeType == goog.dom.NodeType.CDATA_SECTION ||
       node.nodeType == goog.dom.NodeType.TEXT) {
-    accumulator['text_'] = normalizeWhitespace ?
+    accumulator.text_ = normalizeWhitespace ?
         String(node.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
         node.nodeValue;
   } else {
     var n;
     for (n = node.firstChild; !goog.isNull(n); n = n.nextSibling) {
       if (n.nodeType == goog.dom.NodeType.TEXT) {
-        accumulator['text_'] = (accumulator['text_'] || '') +
+        accumulator.text_ = (accumulator.text_ || '') +
             (normalizeWhitespace ?
             String(n.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
             n.nodeValue);

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -140,7 +140,8 @@ ol.xml.getStructuredTextContent = function(node, normalizeWhitespace) {
             String(n.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
             n.nodeValue);
       } else {
-        accumulator[n.localName] = ol.xml.getStructuredTextContent(n, normalizeWhitespace);
+        accumulator[n.localName] =
+            ol.xml.getStructuredTextContent(n, normalizeWhitespace);
       }
     }
   }

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -129,14 +129,14 @@ ol.xml.getStructuredTextContent = function(node, normalizeWhitespace) {
   if (node.nodeType == goog.dom.NodeType.CDATA_SECTION ||
       node.nodeType == goog.dom.NodeType.TEXT) {
     accumulator['text_'] = normalizeWhitespace ?
-      String(node.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
-      node.nodeValue;
+        String(node.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
+        node.nodeValue;
   } else {
     var n;
     for (n = node.firstChild; !goog.isNull(n); n = n.nextSibling) {
       if (n.nodeType == goog.dom.NodeType.TEXT) {
         accumulator['text_'] = (accumulator['text_'] || '') +
-          (normalizeWhitespace ?
+            (normalizeWhitespace ?
             String(n.nodeValue).replace(/(\r\n|\r|\n)/g, '') :
             n.nodeValue);
       } else {
@@ -146,7 +146,6 @@ ol.xml.getStructuredTextContent = function(node, normalizeWhitespace) {
   }
   return accumulator;
 };
-
 
 
 /**


### PR DESCRIPTION
Solve #2977 - addresses several issues with the service mentioned:
- Namespace http://www.opengis.net/gml/3.2 as alternative to http://www.opengis.net/gml supported in all GML3 and relevant base classes.
- Detect GML geometry element by confirming that its child elements actually are known geometries
- support boundedBy on FeatureCollections
- parse nested metadata into an object structure, return flat text if the structure is not nested to maintain backwards compatibility.
