### PR TITLE
Use new demo GeoServer location

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -9,7 +9,7 @@ goog.require('ol.source.TileWMS');
 var layers = [
   new ol.layer.Tile({
     source: new ol.source.TileWMS({
-      url: 'http://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {
         'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
       }

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -5,7 +5,7 @@ goog.require('ol.source.ImageWMS');
 
 
 var wmsSource = new ol.source.ImageWMS({
-  url: 'http://demo.opengeo.org/geoserver/wms',
+  url: 'http://demo.boundlessgeo.com/geoserver/wms',
   params: {'LAYERS': 'ne:ne'},
   serverType: 'geoserver'
 });

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -5,7 +5,7 @@ goog.require('ol.source.TileWMS');
 
 
 var wmsSource = new ol.source.TileWMS({
-  url: 'http://demo.opengeo.org/geoserver/wms',
+  url: 'http://demo.boundlessgeo.com/geoserver/wms',
   params: {'LAYERS': 'ne:ne'},
   serverType: 'geoserver'
 });

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -20,7 +20,7 @@ var map4326 = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
+        url: 'http://demo.boundlessgeo.com/geoserver/wms',
         params: {
           'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
         }
@@ -41,7 +41,7 @@ var map3857 = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.TileWMS({
-        url: 'http://demo.opengeo.org/geoserver/wms',
+        url: 'http://demo.boundlessgeo.com/geoserver/wms',
         params: {
           'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
         }

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -13,7 +13,7 @@ goog.require('ol.tilegrid.XYZ');
 var vectorSource = new ol.source.ServerVector({
   format: new ol.format.GeoJSON(),
   loader: function(extent, resolution, projection) {
-    var url = 'http://demo.opengeo.org/geoserver/wfs?service=WFS&' +
+    var url = 'http://demo.boundlessgeo.com/geoserver/wfs?service=WFS&' +
         'version=1.1.0&request=GetFeature&typename=osm:water_areas&' +
         'outputFormat=text/javascript&format_options=callback:loadFeatures' +
         '&srsname=EPSG:3857&bbox=' + extent.join(',') + ',EPSG:3857';

--- a/examples/wms-image.js
+++ b/examples/wms-image.js
@@ -13,7 +13,7 @@ var layers = [
   new ol.layer.Image({
     extent: [-13884991, 2870341, -7455066, 6338219],
     source: new ol.source.ImageWMS({
-      url: 'http://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {'LAYERS': 'topp:states'},
       serverType: 'geoserver'
     })

--- a/examples/wms-tiled.js
+++ b/examples/wms-tiled.js
@@ -12,7 +12,7 @@ var layers = [
   new ol.layer.Tile({
     extent: [-13884991, 2870341, -7455066, 6338219],
     source: new ol.source.TileWMS(/** @type {olx.source.TileWMSOptions} */ ({
-      url: 'http://demo.opengeo.org/geoserver/wms',
+      url: 'http://demo.boundlessgeo.com/geoserver/wms',
       params: {'LAYERS': 'topp:states', 'TILED': true},
       serverType: 'geoserver'
     }))


### PR DESCRIPTION
demo.opengeo.org currently redirects to demo.boundlessgeo.com, so this
change makes it so the new location is used directly.
