### PR TITLE
Writing GeoJSON does not respect the feature's geometryName

### DIFF
--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -508,7 +508,7 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
         ol.format.GeoJSON.writeGeometry_(geometry, opt_options));
   }
   var properties = feature.getProperties();
-  goog.object.remove(properties, 'geometry');
+  goog.object.remove(properties, feature.getGeometryName());
   if (!goog.object.isEmpty(properties)) {
     goog.object.set(object, 'properties', properties);
   }

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -498,6 +498,15 @@ describe('ol.format.GeoJSON', function() {
       }
     });
 
+    it('writes out a feature with a different geometryName correctly',
+        function() {
+          var feature = new ol.Feature({'foo': 'bar'});
+          feature.setGeometryName('mygeom');
+          feature.setGeometry(new ol.geom.Point([5, 10]));
+          var geojson = format.writeFeatures([feature]);
+          expect(geojson.features[0].properties.mygeom).to.eql(undefined);
+        });
+
   });
 
   describe('#writeGeometry', function() {


### PR DESCRIPTION
When serializing GeoJSON from features that have a geometryName other than the default, the format tries to serialize geometries as property rather than a geometry.

<bountysource-plugin>

---

Want to back this issue? **[Place a bounty on it!](https://www.bountysource.com/issues/4293490-writing-geojson-does-not-respect-the-feature-s-geometryname?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github)** We accept bounties via [Bountysource](https://www.bountysource.com/?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github).
</bountysource-plugin>
