### PR TITLE
The writeFeatures method should always return a string

### DIFF
--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -105,7 +105,7 @@ if ('download' in exportGPXElement) {
         clone.getGeometry().transform(projection, 'EPSG:4326');
         features.push(clone);
       });
-      var node = new ol.format.GPX().writeFeatures(features);
+      var node = new ol.format.GPX().writeFeaturesNode(features);
       var string = new XMLSerializer().serializeToString(
           /** @type {Node} */ (node));
       var base64 = exampleNS.strToBase64(string);

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -73,7 +73,7 @@ if ('download' in exportKMLElement) {
         clone.getGeometry().transform(projection, 'EPSG:4326');
         features.push(clone);
       });
-      var node = new ol.format.KML().writeFeatures(features);
+      var node = new ol.format.KML().writeFeaturesNode(features);
       var string = new XMLSerializer().serializeToString(
           /** @type {Node} */ (node));
       var base64 = exampleNS.strToBase64(string);

--- a/src/ol/format/featureformat.js
+++ b/src/ol/format/featureformat.js
@@ -128,7 +128,7 @@ ol.format.Feature.prototype.readProjection = goog.abstractMethod;
  *
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @return {ArrayBuffer|Node|Object|string} Result.
+ * @return {string} Result.
  */
 ol.format.Feature.prototype.writeFeature = goog.abstractMethod;
 
@@ -138,7 +138,7 @@ ol.format.Feature.prototype.writeFeature = goog.abstractMethod;
  *
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @return {ArrayBuffer|Node|Object|string} Result.
+ * @return {string} Result.
  */
 ol.format.Feature.prototype.writeFeatures = goog.abstractMethod;
 
@@ -148,7 +148,7 @@ ol.format.Feature.prototype.writeFeatures = goog.abstractMethod;
  *
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @return {ArrayBuffer|Node|Object|string} Node.
+ * @return {string} Result.
  */
 ol.format.Feature.prototype.writeGeometry = goog.abstractMethod;
 

--- a/src/ol/format/geojsonformat.js
+++ b/src/ol/format/geojsonformat.js
@@ -478,22 +478,28 @@ ol.format.GeoJSON.prototype.readProjectionFromObject = function(object) {
 
 
 /**
- * Encode a feature as a GeoJSON Feature object.
+ * Encode a feature as a GeoJSON Feature string.
  *
  * @function
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions} options Write options.
- * @return {GeoJSONFeature} GeoJSON.
+ * @return {string} GeoJSON.
  * @api stable
  */
 ol.format.GeoJSON.prototype.writeFeature;
 
 
 /**
- * @inheritDoc
+ * Encode a feature as a GeoJSON Feature object.
+ *
+ * @param {ol.Feature} feature Feature.
+ * @param {olx.format.WriteOptions=} opt_options Write options.
+ * @api
+ * @return {Object} Object.
  */
 ol.format.GeoJSON.prototype.writeFeatureObject = function(
     feature, opt_options) {
+  opt_options = this.adaptOptions(opt_options);
   var object = {
     'type': 'Feature'
   };
@@ -522,17 +528,23 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(
  * @function
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions} options Write options.
- * @return {GeoJSONObject} GeoJSON.
+ * @return {string} GeoJSON.
  * @api stable
  */
 ol.format.GeoJSON.prototype.writeFeatures;
 
 
 /**
- * @inheritDoc
+ * Encode an array of features as a GeoJSON object.
+ *
+ * @param {Array.<ol.Feature>} features Features.
+ * @param {olx.format.WriteOptions=} opt_options Write options.
+ * @return {Object} GeoJSON Object.
+ * @api
  */
 ol.format.GeoJSON.prototype.writeFeaturesObject =
     function(features, opt_options) {
+  opt_options = this.adaptOptions(opt_options);
   var objects = [];
   var i, ii;
   for (i = 0, ii = features.length; i < ii; ++i) {
@@ -546,19 +558,27 @@ ol.format.GeoJSON.prototype.writeFeaturesObject =
 
 
 /**
- * Encode a geometry as GeoJSON.
+ * Encode a geometry as a GeoJSON string.
  *
  * @function
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions} options Write options.
- * @return {GeoJSONGeometry|GeoJSONGeometryCollection} GeoJSON.
+ * @return {string} GeoJSON.
  * @api stable
  */
 ol.format.GeoJSON.prototype.writeGeometry;
 
 
 /**
- * @inheritDoc
+ * Encode a geometry as a GeoJSON object.
+ *
+ * @param {ol.geom.Geometry} geometry Geometry.
+ * @param {olx.format.WriteOptions=} opt_options Write options.
+ * @return {GeoJSONGeometry|GeoJSONGeometryCollection} Object.
+ * @api
  */
-ol.format.GeoJSON.prototype.writeGeometryObject =
-    ol.format.GeoJSON.writeGeometry_;
+ol.format.GeoJSON.prototype.writeGeometryObject = function(geometry,
+    opt_options) {
+  return ol.format.GeoJSON.writeGeometry_(geometry,
+      this.adaptOptions(opt_options));
+};

--- a/src/ol/format/gml/gml3.js
+++ b/src/ol/format/gml/gml3.js
@@ -1247,9 +1247,15 @@ ol.format.GML3.prototype.GEOMETRY_NODE_FACTORY_ =
 
 
 /**
- * @inheritDoc
+ * Encode a geometry in GML 3.1.1 Simple Features.
+ *
+ * @param {ol.geom.Geometry} geometry Geometry.
+ * @param {olx.format.WriteOptions=} opt_options Options.
+ * @return {Node} Node.
+ * @api
  */
 ol.format.GML3.prototype.writeGeometryNode = function(geometry, opt_options) {
+  opt_options = this.adaptOptions(opt_options);
   var geom = ol.xml.createElementNS('http://www.opengis.net/gml', 'geom');
   var context = {node: geom, srsName: this.srsName,
     curve: this.curve_, surface: this.surface_,
@@ -1268,16 +1274,22 @@ ol.format.GML3.prototype.writeGeometryNode = function(geometry, opt_options) {
  * @function
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
- * @return {Node} Result.
+ * @return {string} Result.
  * @api stable
  */
 ol.format.GML3.prototype.writeFeatures;
 
 
 /**
- * @inheritDoc
+ * Encode an array of features in the GML 3.1.1 format as an XML node.
+ *
+ * @param {Array.<ol.Feature>} features Features.
+ * @param {olx.format.WriteOptions=} opt_options Options.
+ * @return {Node} Node.
+ * @api
  */
 ol.format.GML3.prototype.writeFeaturesNode = function(features, opt_options) {
+  opt_options = this.adaptOptions(opt_options);
   var node = ol.xml.createElementNS('http://www.opengis.net/gml',
       'featureMembers');
   ol.xml.setAttributeNS(node, 'http://www.w3.org/2001/XMLSchema-instance',
@@ -1321,7 +1333,19 @@ ol.format.GML = ol.format.GML3;
  * @function
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
- * @return {Node} Result.
+ * @return {string} Result.
  * @api stable
  */
 ol.format.GML.prototype.writeFeatures;
+
+
+/**
+ * Encode an array of features in the GML 3.1.1 format as an XML node.
+ *
+ * @function
+ * @param {ol.Feature} feature Feature.
+ * @param {olx.format.WriteOptions=} opt_options Options.
+ * @return {Node} Node.
+ * @api
+ */
+ol.format.GML.prototype.writeFeaturesNode;

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -876,9 +876,15 @@ ol.format.GPX.prototype.writeFeatures;
 
 
 /**
- * @inheritDoc
+ * Encode an array of features in the GPX format as an XML node.
+ *
+ * @param {Array.<ol.Feature>} features Features.
+ * @param {olx.format.WriteOptions=} opt_options Options.
+ * @return {Node} Node.
+ * @api
  */
 ol.format.GPX.prototype.writeFeaturesNode = function(features, opt_options) {
+  opt_options = this.adaptOptions(opt_options);
   //FIXME Serialize metadata
   var gpx = ol.xml.createElementNS('http://www.topografix.com/GPX/1/1', 'gpx');
 

--- a/src/ol/format/jsonfeatureformat.js
+++ b/src/ol/format/jsonfeatureformat.js
@@ -122,14 +122,13 @@ ol.format.JSONFeature.prototype.readProjectionFromObject = goog.abstractMethod;
  * @inheritDoc
  */
 ol.format.JSONFeature.prototype.writeFeature = function(feature, opt_options) {
-  return this.writeFeatureObject(feature, this.adaptOptions(opt_options));
+  return goog.json.serialize(this.writeFeatureObject(feature, opt_options));
 };
 
 
 /**
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @protected
  * @return {Object} Object.
  */
 ol.format.JSONFeature.prototype.writeFeatureObject = goog.abstractMethod;
@@ -140,14 +139,13 @@ ol.format.JSONFeature.prototype.writeFeatureObject = goog.abstractMethod;
  */
 ol.format.JSONFeature.prototype.writeFeatures = function(
     features, opt_options) {
-  return this.writeFeaturesObject(features, this.adaptOptions(opt_options));
+  return goog.json.serialize(this.writeFeaturesObject(features, opt_options));
 };
 
 
 /**
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @protected
  * @return {Object} Object.
  */
 ol.format.JSONFeature.prototype.writeFeaturesObject = goog.abstractMethod;
@@ -158,14 +156,13 @@ ol.format.JSONFeature.prototype.writeFeaturesObject = goog.abstractMethod;
  */
 ol.format.JSONFeature.prototype.writeGeometry = function(
     geometry, opt_options) {
-  return this.writeGeometryObject(geometry, this.adaptOptions(opt_options));
+  return goog.json.serialize(this.writeGeometryObject(geometry, opt_options));
 };
 
 
 /**
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @protected
  * @return {Object} Object.
  */
 ol.format.JSONFeature.prototype.writeGeometryObject = goog.abstractMethod;

--- a/src/ol/format/kmlformat.js
+++ b/src/ol/format/kmlformat.js
@@ -2581,16 +2581,22 @@ ol.format.KML.OUTER_BOUNDARY_NODE_FACTORY_ =
  * @function
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
- * @return {Node} Result.
+ * @return {string} Result.
  * @api stable
  */
 ol.format.KML.prototype.writeFeatures;
 
 
 /**
- * @inheritDoc
+ * Encode an array of features in the KML format as an XML node.
+ *
+ * @param {Array.<ol.Feature>} features Features.
+ * @param {olx.format.WriteOptions=} opt_options Options.
+ * @return {Node} Node.
+ * @api
  */
 ol.format.KML.prototype.writeFeaturesNode = function(features, opt_options) {
+  opt_options = this.adaptOptions(opt_options);
   var kml = ol.xml.createElementNS(ol.format.KML.NAMESPACE_URIS_[4], 'kml');
   var xmlnsUri = 'http://www.w3.org/2000/xmlns/';
   var xmlSchemaInstanceUri = 'http://www.w3.org/2001/XMLSchema-instance';

--- a/src/ol/format/xmlfeatureformat.js
+++ b/src/ol/format/xmlfeatureformat.js
@@ -3,6 +3,7 @@ goog.provide('ol.format.XMLFeature');
 goog.require('goog.array');
 goog.require('goog.asserts');
 goog.require('goog.dom.NodeType');
+goog.require('goog.dom.xml');
 goog.require('ol.format.Feature');
 goog.require('ol.format.FormatType');
 goog.require('ol.proj');
@@ -199,7 +200,9 @@ ol.format.XMLFeature.prototype.readProjectionFromNode = goog.abstractMethod;
  * @inheritDoc
  */
 ol.format.XMLFeature.prototype.writeFeature = function(feature, opt_options) {
-  return this.writeFeatureNode(feature, this.adaptOptions(opt_options));
+  var node = this.writeFeatureNode(feature, opt_options);
+  goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
+  return goog.dom.xml.serialize(/** @type {Element} */(node));
 };
 
 
@@ -216,14 +219,15 @@ ol.format.XMLFeature.prototype.writeFeatureNode = goog.abstractMethod;
  * @inheritDoc
  */
 ol.format.XMLFeature.prototype.writeFeatures = function(features, opt_options) {
-  return this.writeFeaturesNode(features, this.adaptOptions(opt_options));
+  var node = this.writeFeaturesNode(features, opt_options);
+  goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
+  return goog.dom.xml.serialize(/** @type {Element} */(node));
 };
 
 
 /**
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
- * @protected
  * @return {Node} Node.
  */
 ol.format.XMLFeature.prototype.writeFeaturesNode = goog.abstractMethod;
@@ -233,14 +237,15 @@ ol.format.XMLFeature.prototype.writeFeaturesNode = goog.abstractMethod;
  * @inheritDoc
  */
 ol.format.XMLFeature.prototype.writeGeometry = function(geometry, opt_options) {
-  return this.writeGeometryNode(geometry, this.adaptOptions(opt_options));
+  var node = this.writeGeometryNode(geometry, opt_options);
+  goog.asserts.assert(node.nodeType == goog.dom.NodeType.ELEMENT);
+  return goog.dom.xml.serialize(/** @type {Element} */(node));
 };
 
 
 /**
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Options.
- * @protected
  * @return {Node} Node.
  */
 ol.format.XMLFeature.prototype.writeGeometryNode = goog.abstractMethod;

--- a/test/spec/ol/format/geojsonformat.test.js
+++ b/test/spec/ol/format/geojsonformat.test.js
@@ -465,7 +465,7 @@ describe('ol.format.GeoJSON', function() {
     it('encodes feature collection', function() {
       var str = JSON.stringify(data),
           array = format.readFeatures(str);
-      var geojson = format.writeFeatures(array);
+      var geojson = format.writeFeaturesObject(array);
       var result = format.readFeatures(geojson);
       expect(array.length).to.equal(result.length);
       var got, exp, gotProp, expProp;
@@ -503,7 +503,7 @@ describe('ol.format.GeoJSON', function() {
           var feature = new ol.Feature({'foo': 'bar'});
           feature.setGeometryName('mygeom');
           feature.setGeometry(new ol.geom.Point([5, 10]));
-          var geojson = format.writeFeatures([feature]);
+          var geojson = format.writeFeaturesObject([feature]);
           expect(geojson.features[0].properties.mygeom).to.eql(undefined);
         });
 
@@ -555,7 +555,7 @@ describe('ol.format.GeoJSON', function() {
 
     it('encodes a circle as an empty geometry collection', function() {
       var circle = new ol.geom.Circle([0, 0], 1);
-      var geojson = format.writeGeometry(circle);
+      var geojson = format.writeGeometryObject(circle);
       expect(geojson).to.eql({
         'type': 'GeometryCollection',
         'geometries': []

--- a/test/spec/ol/format/gmlformat.test.js
+++ b/test/spec/ol/format/gmlformat.test.js
@@ -130,7 +130,7 @@ describe('ol.format.GML3', function() {
         var g = readGeometry(format, text);
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([1, 2, 0]);
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -168,7 +168,7 @@ describe('ol.format.GML3', function() {
         expect(coordinates.splice(0, 2)).to.eql(
             ol.proj.transform([1, 2], 'CRS:84', 'EPSG:3857'));
         config.dataProjection = 'CRS:84';
-        var serialized = format.writeGeometry(g, config);
+        var serialized = format.writeGeometryNode(g, config);
         var pos = serialized.firstElementChild.firstElementChild.textContent;
         var coordinate = pos.split(' ');
         expect(coordinate[0]).to.roughlyEqual(1, 1e-9);
@@ -200,7 +200,7 @@ describe('ol.format.GML3', function() {
         var g = readGeometry(formatWGS84, text);
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([1, 2, 0]);
-        var serialized = formatWGS84.writeGeometry(g);
+        var serialized = formatWGS84.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -217,7 +217,7 @@ describe('ol.format.GML3', function() {
         var g = readGeometry(format, text);
         expect(g).to.be.an(ol.geom.LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [3, 4, 0]]);
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -238,7 +238,7 @@ describe('ol.format.GML3', function() {
             ol.proj.transform([1, 2], 'CRS:84', 'EPSG:3857'));
         expect(coordinates[1].slice(0, 2)).to.eql(
             ol.proj.transform([3, 4], 'CRS:84', 'EPSG:3857'));
-        var serialized = format.writeGeometry(g, config);
+        var serialized = format.writeGeometryNode(g, config);
         var poss = serialized.firstElementChild.firstElementChild.textContent;
         var coordinate = poss.split(' ');
         expect(coordinate[0]).to.roughlyEqual(1, 1e-9);
@@ -256,7 +256,7 @@ describe('ol.format.GML3', function() {
         var g = readGeometry(formatWGS84, text);
         expect(g).to.be.an(ol.geom.LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [3, 4, 0]]);
-        var serialized = formatWGS84.writeGeometry(g);
+        var serialized = formatWGS84.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -274,7 +274,7 @@ describe('ol.format.GML3', function() {
             var g = readGeometry(format, text);
             expect(g).to.be.an(ol.geom.LineString);
             expect(g.getCoordinates()).to.eql([[-180, -90, 0], [180, 90, 0]]);
-            var serialized = formatWGS84.writeGeometry(g);
+            var serialized = formatWGS84.writeGeometryNode(g);
             expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
           });
 
@@ -288,7 +288,7 @@ describe('ol.format.GML3', function() {
             var g = readGeometry(format, text);
             expect(g).to.be.an(ol.geom.Point);
             expect(g.getCoordinates()).to.eql([-180, -90, 0]);
-            var serialized = formatWGS84.writeGeometry(g);
+            var serialized = formatWGS84.writeGeometryNode(g);
             expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
           });
 
@@ -319,7 +319,7 @@ describe('ol.format.GML3', function() {
             format = new ol.format.GML({
               srsName: 'urn:x-ogc:def:crs:EPSG:4326',
               surface: false});
-            var serialized = format.writeGeometry(g);
+            var serialized = format.writeGeometryNode(g);
             expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
           });
 
@@ -352,7 +352,7 @@ describe('ol.format.GML3', function() {
         expect(g).to.be.an(ol.geom.LinearRing);
         expect(g.getCoordinates()).to.eql(
             [[1, 2, 0], [3, 4, 0], [5, 6, 0], [1, 2, 0]]);
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -385,7 +385,7 @@ describe('ol.format.GML3', function() {
         expect(g.getCoordinates()).to.eql([[[1, 2, 0], [3, 2, 0], [3, 4, 0],
                 [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
               [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]]);
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -423,7 +423,7 @@ describe('ol.format.GML3', function() {
                 [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
               [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]]);
         format = new ol.format.GML({srsName: 'CRS:84', surface: true});
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -445,7 +445,7 @@ describe('ol.format.GML3', function() {
         expect(g).to.be.an(ol.geom.LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [3, 4, 0]]);
         format = new ol.format.GML({srsName: 'CRS:84', curve: true});
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -491,7 +491,7 @@ describe('ol.format.GML3', function() {
         var g = readGeometry(format, text);
         expect(g).to.be.an(ol.geom.MultiPoint);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [2, 3, 0], [3, 4, 0]]);
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -540,7 +540,7 @@ describe('ol.format.GML3', function() {
         expect(g.getCoordinates()).to.eql(
             [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
         format = new ol.format.GML({srsName: 'CRS:84', multiCurve: false});
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -608,7 +608,7 @@ describe('ol.format.GML3', function() {
             [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]],
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0], [1, 2, 0]]]]);
         format = new ol.format.GML({srsName: 'CRS:84', multiSurface: false});
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -676,7 +676,7 @@ describe('ol.format.GML3', function() {
             expect(g).to.be.an(ol.geom.MultiLineString);
             expect(g.getCoordinates()).to.eql(
                 [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
-            var serialized = format.writeGeometry(g);
+            var serialized = format.writeGeometryNode(g);
             expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
           });
 
@@ -708,7 +708,7 @@ describe('ol.format.GML3', function() {
         expect(g.getCoordinates()).to.eql(
             [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
         format = new ol.format.GML({srsName: 'CRS:84', curve: true});
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -756,7 +756,7 @@ describe('ol.format.GML3', function() {
             [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
             [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]],
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0], [1, 2, 0]]]]);
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -851,7 +851,7 @@ describe('ol.format.GML3', function() {
             [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]],
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0], [1, 2, 0]]]]);
         format = new ol.format.GML({srsName: 'CRS:84', surface: true});
-        var serialized = format.writeGeometry(g);
+        var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(ol.xml.parse(text));
       });
 
@@ -978,7 +978,7 @@ describe('ol.format.GML3', function() {
 
     it('writes back features as GML', function() {
       this.timeout(4000);
-      var serialized = gmlFormat.writeFeatures(features);
+      var serialized = gmlFormat.writeFeaturesNode(features);
       expect(serialized).to.xmleql(ol.xml.parse(text));
     });
 

--- a/test/spec/ol/format/gpxformat.test.js
+++ b/test/spec/ol/format/gpxformat.test.js
@@ -55,7 +55,7 @@ describe('ol.format.GPX', function() {
         expect(f.get('linkType')).to.be('Link type');
         expect(f.get('number')).to.be(1);
         expect(f.get('type')).to.be('Type');
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -75,7 +75,7 @@ describe('ol.format.GPX', function() {
         expect(g).to.be.an(ol.geom.LineString);
         expect(g.getCoordinates()).to.eql([[2, 1, 0, 0], [4, 3, 0, 0]]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -101,7 +101,7 @@ describe('ol.format.GPX', function() {
         p2.push(0, 0);
         expect(g.getCoordinates()).to.eql([p1, p2]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs, {
+        var serialized = format.writeFeaturesNode(fs, {
           featureProjection: 'EPSG:3857'
         });
         expect(serialized).to.xmleql(ol.xml.parse(text));
@@ -155,7 +155,7 @@ describe('ol.format.GPX', function() {
         expect(f.get('linkType')).to.be('Link type');
         expect(f.get('number')).to.be(1);
         expect(f.get('type')).to.be('Type');
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -174,7 +174,7 @@ describe('ol.format.GPX', function() {
         expect(g).to.be.an(ol.geom.MultiLineString);
         expect(g.getCoordinates()).to.eql([[]]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -204,7 +204,7 @@ describe('ol.format.GPX', function() {
           [[2, 1, 3, 1263115752], [6, 5, 7, 1263115812]]
         ]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -238,7 +238,7 @@ describe('ol.format.GPX', function() {
         p2.push(7, 1263115812);
         expect(g.getCoordinates()).to.eql([[p1, p2]]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs, {
+        var serialized = format.writeFeaturesNode(fs, {
           featureProjection: 'EPSG:3857'
         });
         expect(serialized).to.xmleql(ol.xml.parse(text));
@@ -281,7 +281,7 @@ describe('ol.format.GPX', function() {
           [[9, 8, 10, 1263115872], [12, 11, 13, 1263115932]]
         ]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -302,7 +302,7 @@ describe('ol.format.GPX', function() {
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([2, 1, 0, 0]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -323,7 +323,7 @@ describe('ol.format.GPX', function() {
         expectedPoint.push(0, 0);
         expect(g.getCoordinates()).to.eql(expectedPoint);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs, {
+        var serialized = format.writeFeaturesNode(fs, {
           featureProjection: 'EPSG:3857'
         });
         expect(serialized).to.xmleql(ol.xml.parse(text));
@@ -344,7 +344,7 @@ describe('ol.format.GPX', function() {
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([2, 1, 3, 0]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -363,7 +363,7 @@ describe('ol.format.GPX', function() {
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([2, 1, 0, 1263115752]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -383,7 +383,7 @@ describe('ol.format.GPX', function() {
         expect(g).to.be.an(ol.geom.Point);
         expect(g.getCoordinates()).to.eql([2, 1, 3, 1263115752]);
         expect(g.getLayout()).to.be(ol.geom.GeometryLayout.XYZM);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 
@@ -433,7 +433,7 @@ describe('ol.format.GPX', function() {
         expect(f.get('pdop')).to.be(8);
         expect(f.get('ageofdgpsdata')).to.be(9);
         expect(f.get('dgpsid')).to.be(10);
-        var serialized = format.writeFeatures(fs);
+        var serialized = format.writeFeaturesNode(fs);
         expect(serialized).to.xmleql(ol.xml.parse(text));
       });
 

--- a/test/spec/ol/format/kmlformat.test.js
+++ b/test/spec/ol/format/kmlformat.test.js
@@ -38,7 +38,7 @@ describe('ol.format.KML', function() {
 
       it('can write a Feature', function() {
         var features = [new ol.Feature()];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -50,11 +50,25 @@ describe('ol.format.KML', function() {
         expect(node).to.xmleql(ol.xml.parse(text));
       });
 
+      it('can write a Feature as string', function() {
+        var features = [new ol.Feature()];
+        var node = format.writeFeatures(features);
+        var text =
+            '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+            ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+            ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+            ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+            '  <Placemark/>' +
+            '</kml>';
+        expect(ol.xml.parse(node)).to.xmleql(ol.xml.parse(text));
+      });
+
       it('can write a Feature\'s id', function() {
         var feature = new ol.Feature();
         feature.setId('foo');
         var features = [feature];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -85,7 +99,7 @@ describe('ol.format.KML', function() {
 
       it('can write feature with null geometries', function() {
         var features = [new ol.Feature(null)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -193,7 +207,7 @@ describe('ol.format.KML', function() {
         var layout = ol.geom.GeometryLayout.XY;
         var point = new ol.geom.Point([1, 2], layout);
         var features = [new ol.Feature(point)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -213,7 +227,7 @@ describe('ol.format.KML', function() {
         var layout = ol.geom.GeometryLayout.XYZ;
         var point = new ol.geom.Point([1, 2, 3], layout);
         var features = [new ol.Feature(point)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -243,7 +257,7 @@ describe('ol.format.KML', function() {
         var point = new ol.geom.Point([1, 2, 3], layout).transform(
             'EPSG:4326', 'double');
         var features = [new ol.Feature(point)];
-        var node = format.writeFeatures(features, {
+        var node = format.writeFeaturesNode(features, {
           featureProjection: 'double'
         });
         var text =
@@ -270,7 +284,7 @@ describe('ol.format.KML', function() {
         var layout = ol.geom.GeometryLayout.XYM;
         var point = new ol.geom.Point([1, 2, 100], layout);
         var features = [new ol.Feature(point)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -290,7 +304,7 @@ describe('ol.format.KML', function() {
         var layout = ol.geom.GeometryLayout.XYZM;
         var point = new ol.geom.Point([1, 2, 3, 100], layout);
         var features = [new ol.Feature(point)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -328,7 +342,7 @@ describe('ol.format.KML', function() {
         var layout = ol.geom.GeometryLayout.XY;
         var lineString = new ol.geom.LineString([[1, 2], [3, 4]], layout);
         var features = [new ol.Feature(lineString)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -349,7 +363,7 @@ describe('ol.format.KML', function() {
         var lineString = new ol.geom.LineString(
             [[1, 2, 3], [4, 5, 6]], layout);
         var features = [new ol.Feature(lineString)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -370,7 +384,7 @@ describe('ol.format.KML', function() {
         var lineString = new ol.geom.LineString(
             [[1, 2, 100], [3, 4, 200]], layout);
         var features = [new ol.Feature(lineString)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -391,7 +405,7 @@ describe('ol.format.KML', function() {
         var lineString = new ol.geom.LineString(
             [[1, 2, 3, 100], [4, 5, 6, 200]], layout);
         var features = [new ol.Feature(lineString)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -430,7 +444,7 @@ describe('ol.format.KML', function() {
         var linearRing = new ol.geom.LinearRing(
             [[1, 2], [3, 4], [1, 2]], layout);
         var features = [new ol.Feature(linearRing)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -451,7 +465,7 @@ describe('ol.format.KML', function() {
         var linearRing = new ol.geom.LinearRing(
             [[1, 2, 3], [4, 5, 6], [1, 2, 3]], layout);
         var features = [new ol.Feature(linearRing)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -472,7 +486,7 @@ describe('ol.format.KML', function() {
         var linearRing = new ol.geom.LinearRing(
             [[1, 2, 100], [3, 4, 200], [1, 2, 100]], layout);
         var features = [new ol.Feature(linearRing)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -493,7 +507,7 @@ describe('ol.format.KML', function() {
         var linearRing = new ol.geom.LinearRing(
             [[1, 2, 3, 100], [4, 5, 6, 200], [1, 2, 3, 100]], layout);
         var features = [new ol.Feature(linearRing)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -537,7 +551,7 @@ describe('ol.format.KML', function() {
         var polygon = new ol.geom.Polygon(
             [[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]], layout);
         var features = [new ol.Feature(polygon)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -562,7 +576,7 @@ describe('ol.format.KML', function() {
         var polygon = new ol.geom.Polygon(
             [[[0, 0, 1], [0, 2, 2], [2, 2, 3], [2, 0, 4], [0, 0, 5]]], layout);
         var features = [new ol.Feature(polygon)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -589,7 +603,7 @@ describe('ol.format.KML', function() {
         var polygon = new ol.geom.Polygon(
             [[[0, 0, 1], [0, 2, 1], [2, 2, 1], [2, 0, 1], [0, 0, 1]]], layout);
         var features = [new ol.Feature(polygon)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -617,7 +631,7 @@ describe('ol.format.KML', function() {
             [[[0, 0, 1, 1], [0, 2, 2, 1], [2, 2, 3, 1],
               [2, 0, 4, 1], [0, 0, 5, 1]]], layout);
         var features = [new ol.Feature(polygon)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -679,7 +693,7 @@ describe('ol.format.KML', function() {
              [[1, 1, 0], [1, 2, 0], [2, 2, 0], [2, 1, 0]],
              [[3, 3, 0], [3, 4, 0], [4, 4, 0], [4, 3, 0]]], layout);
         var features = [new ol.Feature(polygon)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -737,7 +751,7 @@ describe('ol.format.KML', function() {
         var multiPoint = new ol.geom.MultiPoint(
             [[1, 2, 3], [4, 5, 6]], layout);
         var features = [new ol.Feature(multiPoint)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -787,7 +801,7 @@ describe('ol.format.KML', function() {
         var multiLineString = new ol.geom.MultiLineString(
             [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], layout);
         var features = [new ol.Feature(multiLineString)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -847,7 +861,7 @@ describe('ol.format.KML', function() {
             [[[[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]],
              [[[3, 0, 0], [3, 1, 0], [4, 1, 0], [4, 0, 0]]]], layout);
         var features = [new ol.Feature(multiPolygon)];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -1126,7 +1140,7 @@ describe('ol.format.KML', function() {
         feature.set('name', 'My name');
         feature.set('phoneNumber', 'My phone number');
         var features = [feature];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -1148,7 +1162,7 @@ describe('ol.format.KML', function() {
         feature.set('open', true);
         feature.set('visibility', false);
         var features = [feature];
-        var node = format.writeFeatures(features);
+        var node = format.writeFeaturesNode(features);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -1583,7 +1597,7 @@ describe('ol.format.KML', function() {
         imageStyle.iconImage_.size_ = [192, 144]; // sprite de 12 images(4*3)
         var feature = new ol.Feature();
         feature.setStyle([style]);
-        var node = format.writeFeatures([feature]);
+        var node = format.writeFeaturesNode([feature]);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -1623,7 +1637,7 @@ describe('ol.format.KML', function() {
         });
         var feature = new ol.Feature();
         feature.setStyle([style]);
-        var node = format.writeFeatures([feature]);
+        var node = format.writeFeaturesNode([feature]);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -1652,7 +1666,7 @@ describe('ol.format.KML', function() {
         });
         var feature = new ol.Feature();
         feature.setStyle([style]);
-        var node = format.writeFeatures([feature]);
+        var node = format.writeFeaturesNode([feature]);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -1679,7 +1693,7 @@ describe('ol.format.KML', function() {
         });
         var feature = new ol.Feature();
         feature.setStyle([style]);
-        var node = format.writeFeatures([feature]);
+        var node = format.writeFeaturesNode([feature]);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
@@ -2196,7 +2210,7 @@ describe('ol.format.KML', function() {
         feature1.setId('1');
         var feature2 = new ol.Feature();
         feature2.setId('2');
-        var node = format.writeFeatures([feature1, feature2]);
+        var node = format.writeFeaturesNode([feature1, feature2]);
         var text =
             '<kml xmlns="http://www.opengis.net/kml/2.2"' +
             ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +


### PR DESCRIPTION
This PR fixes  #2102

All writeFeatures, writeFeature and writeGeometry methods now return a string. The respective methods such as writeFeaturesObject (JSON) and writeFeaturesNode (XML) have been marked api but not stable as yet.
