### PR TITLE
opt_options may not be defined, use options

### DIFF
--- a/src/ol/interaction/dragpaninteraction.js
+++ b/src/ol/interaction/dragpaninteraction.js
@@ -47,8 +47,8 @@ ol.interaction.DragPan = function(opt_options) {
    * @private
    * @type {ol.events.ConditionType}
    */
-  this.condition_ = goog.isDef(opt_options.condition) ?
-      opt_options.condition : ol.events.condition.noModifierKeys;
+  this.condition_ = goog.isDef(options.condition) ?
+      options.condition : ol.events.condition.noModifierKeys;
 
   /**
    * @private


### PR DESCRIPTION
Constructing an instance of `ol.interaction.DragPan` with no options should be possible, the reference to `opt_options` makes this throw an error when no options are passed.
