### PR TITLE
Simplify hit detection code

### DIFF
--- a/src/ol/featureoverlay.js
+++ b/src/ol/featureoverlay.js
@@ -191,7 +191,7 @@ ol.FeatureOverlay.prototype.handleMapPostCompose_ = function(event) {
     ii = styles.length;
     for (i = 0; i < ii; ++i) {
       ol.renderer.vector.renderFeature(replayGroup, feature, styles[i],
-          squaredTolerance, feature, this.handleImageChange_, this);
+          squaredTolerance, this.handleImageChange_, this);
     }
   }, this);
 };

--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -428,11 +428,11 @@ ol.render.canvas.Immediate.prototype.drawAsync = function(zIndex, callback) {
  * the current fill and stroke styles.
  *
  * @param {ol.geom.Circle} circleGeometry Circle geometry.
- * @param {Object} data Opaque data object,
+ * @param {ol.Feature} feature Feature,
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawCircleGeometry =
-    function(circleGeometry, data) {
+    function(circleGeometry, feature) {
   if (!ol.extent.intersects(this.extent_, circleGeometry.getExtent())) {
     return;
   }
@@ -504,10 +504,10 @@ ol.render.canvas.Immediate.prototype.drawFeature = function(feature, style) {
  *
  * @param {ol.geom.GeometryCollection} geometryCollectionGeometry Geometry
  *     collection.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.canvas.Immediate.prototype.drawGeometryCollectionGeometry =
-    function(geometryCollectionGeometry, data) {
+    function(geometryCollectionGeometry, feature) {
   var geometries = geometryCollectionGeometry.getGeometriesArray();
   var i, ii;
   for (i = 0, ii = geometries.length; i < ii; ++i) {
@@ -515,7 +515,7 @@ ol.render.canvas.Immediate.prototype.drawGeometryCollectionGeometry =
     var geometryRenderer =
         ol.render.canvas.Immediate.GEOMETRY_RENDERERS_[geometry.getType()];
     goog.asserts.assert(goog.isDef(geometryRenderer));
-    geometryRenderer.call(this, geometry, data);
+    geometryRenderer.call(this, geometry, feature);
   }
 };
 
@@ -525,11 +525,11 @@ ol.render.canvas.Immediate.prototype.drawGeometryCollectionGeometry =
  * the current style.
  *
  * @param {ol.geom.Point} pointGeometry Point geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawPointGeometry =
-    function(pointGeometry, data) {
+    function(pointGeometry, feature) {
   var flatCoordinates = pointGeometry.getFlatCoordinates();
   var stride = pointGeometry.getStride();
   if (!goog.isNull(this.image_)) {
@@ -546,11 +546,11 @@ ol.render.canvas.Immediate.prototype.drawPointGeometry =
  * uses the current style.
  *
  * @param {ol.geom.MultiPoint} multiPointGeometry MultiPoint geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawMultiPointGeometry =
-    function(multiPointGeometry, data) {
+    function(multiPointGeometry, feature) {
   var flatCoordinates = multiPointGeometry.getFlatCoordinates();
   var stride = multiPointGeometry.getStride();
   if (!goog.isNull(this.image_)) {
@@ -567,11 +567,11 @@ ol.render.canvas.Immediate.prototype.drawMultiPointGeometry =
  * the current style.
  *
  * @param {ol.geom.LineString} lineStringGeometry Line string geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawLineStringGeometry =
-    function(lineStringGeometry, data) {
+    function(lineStringGeometry, feature) {
   if (!ol.extent.intersects(this.extent_, lineStringGeometry.getExtent())) {
     return;
   }
@@ -597,11 +597,11 @@ ol.render.canvas.Immediate.prototype.drawLineStringGeometry =
  *
  * @param {ol.geom.MultiLineString} multiLineStringGeometry
  *     MultiLineString geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawMultiLineStringGeometry =
-    function(multiLineStringGeometry, data) {
+    function(multiLineStringGeometry, feature) {
   var geometryExtent = multiLineStringGeometry.getExtent();
   if (!ol.extent.intersects(this.extent_, geometryExtent)) {
     return;
@@ -633,11 +633,11 @@ ol.render.canvas.Immediate.prototype.drawMultiLineStringGeometry =
  * the current style.
  *
  * @param {ol.geom.Polygon} polygonGeometry Polygon geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawPolygonGeometry =
-    function(polygonGeometry, data) {
+    function(polygonGeometry, feature) {
   if (!ol.extent.intersects(this.extent_, polygonGeometry.getExtent())) {
     return;
   }
@@ -670,11 +670,11 @@ ol.render.canvas.Immediate.prototype.drawPolygonGeometry =
  * Render MultiPolygon geometry into the canvas.  Rendering is immediate and
  * uses the current style.
  * @param {ol.geom.MultiPolygon} multiPolygonGeometry MultiPolygon geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawMultiPolygonGeometry =
-    function(multiPolygonGeometry, data) {
+    function(multiPolygonGeometry, feature) {
   if (!ol.extent.intersects(this.extent_, multiPolygonGeometry.getExtent())) {
     return;
   }

--- a/src/ol/render/ivectorcontext.js
+++ b/src/ol/render/ivectorcontext.js
@@ -23,10 +23,10 @@ ol.render.IVectorContext.prototype.drawAsync = function(zIndex, callback) {
 
 /**
  * @param {ol.geom.Circle} circleGeometry Circle geometry.
- * @param {Object} data Opaque data object,
+ * @param {ol.Feature} feature Feature,
  */
 ol.render.IVectorContext.prototype.drawCircleGeometry =
-    function(circleGeometry, data) {
+    function(circleGeometry, feature) {
 };
 
 
@@ -41,65 +41,65 @@ ol.render.IVectorContext.prototype.drawFeature = function(feature, style) {
 /**
  * @param {ol.geom.GeometryCollection} geometryCollectionGeometry Geometry
  *     collection.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawGeometryCollectionGeometry =
-    function(geometryCollectionGeometry, data) {
+    function(geometryCollectionGeometry, feature) {
 };
 
 
 /**
  * @param {ol.geom.Point} pointGeometry Point geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawPointGeometry =
-    function(pointGeometry, data) {
+    function(pointGeometry, feature) {
 };
 
 
 /**
  * @param {ol.geom.LineString} lineStringGeometry Line string geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawLineStringGeometry =
-    function(lineStringGeometry, data) {
+    function(lineStringGeometry, feature) {
 };
 
 
 /**
  * @param {ol.geom.MultiLineString} multiLineStringGeometry
  *     MultiLineString geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawMultiLineStringGeometry =
-    function(multiLineStringGeometry, data) {
+    function(multiLineStringGeometry, feature) {
 };
 
 
 /**
  * @param {ol.geom.MultiPoint} multiPointGeometry MultiPoint geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawMultiPointGeometry =
-    function(multiPointGeometry, data) {
+    function(multiPointGeometry, feature) {
 };
 
 
 /**
  * @param {ol.geom.MultiPolygon} multiPolygonGeometry MultiPolygon geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawMultiPolygonGeometry =
-    function(multiPolygonGeometry, data) {
+    function(multiPolygonGeometry, feature) {
 };
 
 
 /**
  * @param {ol.geom.Polygon} polygonGeometry Polygon geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawPolygonGeometry =
-    function(polygonGeometry, data) {
+    function(polygonGeometry, feature) {
 };
 
 
@@ -109,10 +109,10 @@ ol.render.IVectorContext.prototype.drawPolygonGeometry =
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {ol.geom.Geometry} geometry Geometry.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  */
 ol.render.IVectorContext.prototype.drawText =
-    function(flatCoordinates, offset, end, stride, geometry, data) {
+    function(flatCoordinates, offset, end, stride, geometry, feature) {
 };
 
 

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -49,11 +49,11 @@ ol.renderer.vector.getTolerance = function(resolution, pixelRatio) {
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderCircleGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.Circle);
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
@@ -61,14 +61,14 @@ ol.renderer.vector.renderCircleGeometry_ =
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);
-    polygonReplay.drawCircleGeometry(geometry, data);
+    polygonReplay.drawCircleGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
-    textReplay.drawText(geometry.getCenter(), 0, 2, 2, geometry, data);
+    textReplay.drawText(geometry.getCenter(), 0, 2, 2, geometry, feature);
   }
 };
 
@@ -78,20 +78,19 @@ ol.renderer.vector.renderCircleGeometry_ =
  * @param {ol.Feature} feature Feature.
  * @param {ol.style.Style} style Style.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {Object} data Opaque data object.
  * @param {function(this: T, goog.events.Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {boolean} `true` if style is loading.
  * @template T
  */
 ol.renderer.vector.renderFeature = function(
-    replayGroup, feature, style, squaredTolerance, data, listener, thisArg) {
+    replayGroup, feature, style, squaredTolerance, listener, thisArg) {
   var loading = false;
   var imageStyle, imageState;
   imageStyle = style.getImage();
   if (goog.isNull(imageStyle)) {
     ol.renderer.vector.renderFeature_(
-        replayGroup, feature, style, squaredTolerance, data);
+        replayGroup, feature, style, squaredTolerance);
   } else {
     imageState = imageStyle.getImageState();
     if (imageState == ol.style.ImageState.LOADED ||
@@ -99,7 +98,7 @@ ol.renderer.vector.renderFeature = function(
       imageStyle.unlistenImageChange(listener, thisArg);
       if (imageState == ol.style.ImageState.LOADED) {
         ol.renderer.vector.renderFeature_(
-            replayGroup, feature, style, squaredTolerance, data);
+            replayGroup, feature, style, squaredTolerance);
       }
     } else {
       if (imageState == ol.style.ImageState.IDLE) {
@@ -120,11 +119,10 @@ ol.renderer.vector.renderFeature = function(
  * @param {ol.Feature} feature Feature.
  * @param {ol.style.Style} style Style.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {Object} data Opaque data object.
  * @private
  */
 ol.renderer.vector.renderFeature_ = function(
-    replayGroup, feature, style, squaredTolerance, data) {
+    replayGroup, feature, style, squaredTolerance) {
   var geometry = feature.getGeometry();
   if (!goog.isDefAndNotNull(geometry)) {
     return;
@@ -133,7 +131,7 @@ ol.renderer.vector.renderFeature_ = function(
   var geometryRenderer =
       ol.renderer.vector.GEOMETRY_RENDERERS_[simplifiedGeometry.getType()];
   goog.asserts.assert(goog.isDef(geometryRenderer));
-  geometryRenderer(replayGroup, simplifiedGeometry, style, data);
+  geometryRenderer(replayGroup, simplifiedGeometry, style, feature);
 };
 
 
@@ -141,11 +139,11 @@ ol.renderer.vector.renderFeature_ = function(
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderGeometryCollectionGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.GeometryCollection);
   var geometries = geometry.getGeometriesArray();
   var i, ii;
@@ -153,7 +151,7 @@ ol.renderer.vector.renderGeometryCollectionGeometry_ =
     var geometryRenderer =
         ol.renderer.vector.GEOMETRY_RENDERERS_[geometries[i].getType()];
     goog.asserts.assert(goog.isDef(geometryRenderer));
-    geometryRenderer(replayGroup, geometries[i], style, data);
+    geometryRenderer(replayGroup, geometries[i], style, feature);
   }
 };
 
@@ -162,25 +160,25 @@ ol.renderer.vector.renderGeometryCollectionGeometry_ =
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderLineStringGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.LineString);
   var strokeStyle = style.getStroke();
   if (!goog.isNull(strokeStyle)) {
     var lineStringReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.LINE_STRING);
     lineStringReplay.setFillStrokeStyle(null, strokeStyle);
-    lineStringReplay.drawLineStringGeometry(geometry, data);
+    lineStringReplay.drawLineStringGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
-    textReplay.drawText(geometry.getFlatMidpoint(), 0, 2, 2, geometry, data);
+    textReplay.drawText(geometry.getFlatMidpoint(), 0, 2, 2, geometry, feature);
   }
 };
 
@@ -189,18 +187,18 @@ ol.renderer.vector.renderLineStringGeometry_ =
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderMultiLineStringGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiLineString);
   var strokeStyle = style.getStroke();
   if (!goog.isNull(strokeStyle)) {
     var lineStringReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.LINE_STRING);
     lineStringReplay.setFillStrokeStyle(null, strokeStyle);
-    lineStringReplay.drawMultiLineStringGeometry(geometry, data);
+    lineStringReplay.drawMultiLineStringGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
@@ -209,7 +207,7 @@ ol.renderer.vector.renderMultiLineStringGeometry_ =
     textReplay.setTextStyle(textStyle);
     var flatMidpointCoordinates = geometry.getFlatMidpoints();
     textReplay.drawText(flatMidpointCoordinates, 0,
-        flatMidpointCoordinates.length, 2, geometry, data);
+        flatMidpointCoordinates.length, 2, geometry, feature);
   }
 };
 
@@ -218,11 +216,11 @@ ol.renderer.vector.renderMultiLineStringGeometry_ =
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderMultiPolygonGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPolygon);
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
@@ -230,7 +228,7 @@ ol.renderer.vector.renderMultiPolygonGeometry_ =
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);
-    polygonReplay.drawMultiPolygonGeometry(geometry, data);
+    polygonReplay.drawMultiPolygonGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
@@ -239,7 +237,7 @@ ol.renderer.vector.renderMultiPolygonGeometry_ =
     textReplay.setTextStyle(textStyle);
     var flatInteriorPointCoordinates = geometry.getFlatInteriorPoints();
     textReplay.drawText(flatInteriorPointCoordinates, 0,
-        flatInteriorPointCoordinates.length, 2, geometry, data);
+        flatInteriorPointCoordinates.length, 2, geometry, feature);
   }
 };
 
@@ -248,25 +246,25 @@ ol.renderer.vector.renderMultiPolygonGeometry_ =
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderPointGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.Point);
   var imageStyle = style.getImage();
   if (!goog.isNull(imageStyle)) {
     var imageReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.IMAGE);
     imageReplay.setImageStyle(imageStyle);
-    imageReplay.drawPointGeometry(geometry, data);
+    imageReplay.drawPointGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
     var textReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
-    textReplay.drawText(geometry.getCoordinates(), 0, 2, 2, geometry, data);
+    textReplay.drawText(geometry.getCoordinates(), 0, 2, 2, geometry, feature);
   }
 };
 
@@ -275,18 +273,18 @@ ol.renderer.vector.renderPointGeometry_ =
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderMultiPointGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.MultiPoint);
   var imageStyle = style.getImage();
   if (!goog.isNull(imageStyle)) {
     var imageReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.IMAGE);
     imageReplay.setImageStyle(imageStyle);
-    imageReplay.drawMultiPointGeometry(geometry, data);
+    imageReplay.drawMultiPointGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
@@ -295,7 +293,7 @@ ol.renderer.vector.renderMultiPointGeometry_ =
     textReplay.setTextStyle(textStyle);
     var flatCoordinates = geometry.getFlatCoordinates();
     textReplay.drawText(flatCoordinates, 0, flatCoordinates.length,
-        geometry.getStride(), geometry, data);
+        geometry.getStride(), geometry, feature);
   }
 };
 
@@ -304,11 +302,11 @@ ol.renderer.vector.renderMultiPointGeometry_ =
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
- * @param {Object} data Opaque data object.
+ * @param {ol.Feature} feature Feature.
  * @private
  */
 ol.renderer.vector.renderPolygonGeometry_ =
-    function(replayGroup, geometry, style, data) {
+    function(replayGroup, geometry, style, feature) {
   goog.asserts.assertInstanceof(geometry, ol.geom.Polygon);
   var fillStyle = style.getFill();
   var strokeStyle = style.getStroke();
@@ -316,7 +314,7 @@ ol.renderer.vector.renderPolygonGeometry_ =
     var polygonReplay = replayGroup.getReplay(
         style.getZIndex(), ol.render.ReplayType.POLYGON);
     polygonReplay.setFillStrokeStyle(fillStyle, strokeStyle);
-    polygonReplay.drawPolygonGeometry(geometry, data);
+    polygonReplay.drawPolygonGeometry(geometry, feature);
   }
   var textStyle = style.getText();
   if (!goog.isNull(textStyle)) {
@@ -324,7 +322,7 @@ ol.renderer.vector.renderPolygonGeometry_ =
         style.getZIndex(), ol.render.ReplayType.TEXT);
     textReplay.setTextStyle(textStyle);
     textReplay.drawText(
-        geometry.getFlatInteriorPoint(), 0, 2, 2, geometry, data);
+        geometry.getFlatInteriorPoint(), 0, 2, 2, geometry, feature);
   }
 };
 

--- a/src/ol/render/webgl/webglreplay.js
+++ b/src/ol/render/webgl/webglreplay.js
@@ -382,7 +382,7 @@ ol.render.webgl.ImageReplay.prototype.drawMultiLineStringGeometry =
  * @inheritDoc
  */
 ol.render.webgl.ImageReplay.prototype.drawMultiPointGeometry =
-    function(multiPointGeometry, data) {
+    function(multiPointGeometry, feature) {
   ol.extent.extend(this.extent_, multiPointGeometry.getExtent());
   var flatCoordinates = multiPointGeometry.getFlatCoordinates();
   var stride = multiPointGeometry.getStride();
@@ -402,7 +402,7 @@ ol.render.webgl.ImageReplay.prototype.drawMultiPolygonGeometry =
  * @inheritDoc
  */
 ol.render.webgl.ImageReplay.prototype.drawPointGeometry =
-    function(pointGeometry, data) {
+    function(pointGeometry, feature) {
   ol.extent.extend(this.extent_, pointGeometry.getExtent());
   var flatCoordinates = pointGeometry.getFlatCoordinates();
   var stride = pointGeometry.getStride();

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -130,12 +130,10 @@ ol.renderer.canvas.VectorLayer.prototype.forEachFeatureAtPixel =
     return this.replayGroup_.forEachGeometryAtPixel(extent, resolution,
         rotation, coordinate, frameState.skippedFeatureUids,
         /**
-         * @param {ol.geom.Geometry} geometry Geometry.
-         * @param {Object} data Data.
+         * @param {ol.Feature} feature Feature.
          * @return {?} Callback result.
          */
-        function(geometry, data) {
-          var feature = /** @type {ol.Feature} */ (data);
+        function(feature) {
           goog.asserts.assert(goog.isDef(feature));
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
@@ -278,7 +276,7 @@ ol.renderer.canvas.VectorLayer.prototype.renderFeature =
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles[i],
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        feature, this.handleImageChange_, this) || loading;
+        this.handleImageChange_, this) || loading;
   }
   return loading;
 };

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -171,12 +171,10 @@ ol.renderer.dom.VectorLayer.prototype.forEachFeatureAtPixel =
     return this.replayGroup_.forEachGeometryAtPixel(extent, resolution,
         rotation, coordinate, frameState.skippedFeatureUids,
         /**
-         * @param {ol.geom.Geometry} geometry Geometry.
-         * @param {Object} data Data.
+         * @param {ol.Feature} feature Feature.
          * @return {?} Callback result.
          */
-        function(geometry, data) {
-          var feature = /** @type {ol.Feature} */ (data);
+        function(feature) {
           goog.asserts.assert(goog.isDef(feature));
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
@@ -319,7 +317,7 @@ ol.renderer.dom.VectorLayer.prototype.renderFeature =
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles[i],
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        feature, this.handleImageChange_, this) || loading;
+        this.handleImageChange_, this) || loading;
   }
   return loading;
 };

--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -135,12 +135,10 @@ ol.renderer.Map.prototype.forEachFeatureAtPixel =
     result = this.replayGroup.forEachGeometryAtPixel(extent, viewResolution,
         viewRotation, coordinate, {},
         /**
-         * @param {ol.geom.Geometry} geometry Geometry.
-         * @param {Object} data Data.
+         * @param {ol.Feature} feature Feature.
          * @return {?} Callback result.
          */
-        function(geometry, data) {
-          var feature = /** @type {ol.Feature} */ (data);
+        function(feature) {
           goog.asserts.assert(goog.isDef(feature));
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -234,7 +234,7 @@ ol.renderer.webgl.VectorLayer.prototype.renderFeature =
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles[i],
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        feature, this.handleImageChange_, this) || loading;
+        this.handleImageChange_, this) || loading;
   }
   return loading;
 };

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -163,12 +163,10 @@ ol.source.ImageVector.prototype.forEachFeatureAtPixel = function(
     return this.replayGroup_.forEachGeometryAtPixel(
         extent, resolution, 0, coordinate, skippedFeatureUids,
         /**
-         * @param {ol.geom.Geometry} geometry Geometry.
-         * @param {Object} data Data.
+         * @param {ol.Feature} feature Feature.
          * @return {?} Callback result.
          */
-        function(geometry, data) {
-          var feature = /** @type {ol.Feature} */ (data);
+        function(feature) {
           goog.asserts.assert(goog.isDef(feature));
           var key = goog.getUid(feature).toString();
           if (!(key in features)) {
@@ -274,7 +272,7 @@ ol.source.ImageVector.prototype.renderFeature_ =
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles[i],
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        feature, this.handleImageChange_, this) || loading;
+        this.handleImageChange_, this) || loading;
   }
   return loading;
 };

--- a/test/spec/ol/render/vector.test.js
+++ b/test/spec/ol/render/vector.test.js
@@ -33,7 +33,7 @@ describe('ol.renderer.vector', function() {
 
         // call #1
         ol.renderer.vector.renderFeature(replayGroup, feature,
-            style, 1, feature, listener, listenerThis);
+            style, 1, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = goog.events.getListeners(
@@ -42,7 +42,7 @@ describe('ol.renderer.vector', function() {
 
         // call #2
         ol.renderer.vector.renderFeature(replayGroup, feature,
-            style, 1, feature, listener, listenerThis);
+            style, 1, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = goog.events.getListeners(


### PR DESCRIPTION
This PR is a major refactoring of the replay hit detection code, to simplify the code.

Previously the replay objects did not know about features, and they manipulated opaque `data` objects instead. This was true until we introduced the `skippedFeatureHash`.

This PR clarifies the situation by removing the opaque `data` object. The replay objects now know about features, which simplifies and clarifies the code.
