### PR TITLE
Use writeFeatures instead of writeFeaturesNode in GPX and KML example

### DIFF
--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -105,9 +105,7 @@ if ('download' in exportGPXElement) {
         clone.getGeometry().transform(projection, 'EPSG:4326');
         features.push(clone);
       });
-      var node = new ol.format.GPX().writeFeaturesNode(features);
-      var string = new XMLSerializer().serializeToString(
-          /** @type {Node} */ (node));
+      var string = new ol.format.GPX().writeFeatures(features);
       var base64 = exampleNS.strToBase64(string);
       exportGPXElement.href =
           'data:text/gpx+xml;base64,' + base64;

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -73,9 +73,7 @@ if ('download' in exportKMLElement) {
         clone.getGeometry().transform(projection, 'EPSG:4326');
         features.push(clone);
       });
-      var node = new ol.format.KML().writeFeaturesNode(features);
-      var string = new XMLSerializer().serializeToString(
-          /** @type {Node} */ (node));
+      var string = new ol.format.KML().writeFeatures(features);
       var base64 = exampleNS.strToBase64(string);
       exportKMLElement.href =
           'data:application/vnd.google-earth.kml+xml;base64,' + base64;

--- a/src/ol/format/gpxformat.js
+++ b/src/ol/format/gpxformat.js
@@ -869,7 +869,7 @@ ol.format.GPX.GPX_SERIALIZERS_ = ol.xml.makeStructureNS(
  * @function
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
- * @return {Node} Result.
+ * @return {string} Result.
  * @api stable
  */
 ol.format.GPX.prototype.writeFeatures;


### PR DESCRIPTION
This was pointed out by @tschaub in https://github.com/openlayers/ol3/pull/3003#discussion_r21418437 and https://github.com/openlayers/ol3/pull/3003#discussion_r21418435
