### PR TITLE
[WIP] Introduce geometryFunction for rendering

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3067,6 +3067,7 @@ olx.layer.TileOptions.prototype.useInterimTilesOnError;
 /**
  * @typedef {{brightness: (number|undefined),
  *     contrast: (number|undefined),
+ *     geometryFunction: (undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry),
  *     renderOrder: (function(ol.Feature, ol.Feature):number|null|undefined),
  *     hue: (number|undefined),
  *     minResolution: (number|undefined),
@@ -3095,6 +3096,16 @@ olx.layer.VectorOptions.prototype.brightness;
  * @api
  */
 olx.layer.VectorOptions.prototype.contrast;
+
+
+/**
+ * Function that receives a feature, a resolution and a style as argument, and
+ * is expected to return the geometry that will be rendered for the given
+ * feature, resolution and style.
+ * @type {undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry}
+ * @api
+ */
+olx.layer.VectorOptions.prototype.geometryFunction;
 
 
 /**
@@ -3183,6 +3194,7 @@ olx.layer.VectorOptions.prototype.visible;
 
 /**
  * @typedef {{features: (Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined),
+ *     geometryFunction: (undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry),
  *     map: (ol.Map|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined)}}
  * @api
@@ -3196,6 +3208,16 @@ olx.FeatureOverlayOptions;
  * @api
  */
 olx.FeatureOverlayOptions.prototype.features;
+
+
+/**
+ * Function that receives a feature, a resolution and a style as argument, and
+ * is expected to return the geometry that will be rendered for the given
+ * feature, resolution and style.
+ * @type {undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry}
+ * @api
+ */
+olx.FeatureOverlayOptions.prototype.geometryFunction;
 
 
 /**
@@ -4320,6 +4342,7 @@ olx.source.ImageCanvasOptions.prototype.state;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     geometryFunction: (undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry),
  *     logo: (string|olx.LogoOptions|undefined),
  *     projection: ol.proj.ProjectionLike,
  *     ratio: (number|undefined),
@@ -4337,6 +4360,16 @@ olx.source.ImageVectorOptions;
  * @api
  */
 olx.source.ImageVectorOptions.prototype.attributions;
+
+
+/**
+ * Function that receives a feature, a resolution and a style as argument, and
+ * is expected to return the geometry that will be rendered for the given
+ * feature, resolution and style.
+ * @type {undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry}
+ * @api
+ */
+olx.source.ImageVectorOptions.prototype.geometryFunction;
 
 
 /**

--- a/src/ol/layer/vectorlayer.js
+++ b/src/ol/layer/vectorlayer.js
@@ -38,6 +38,13 @@ ol.layer.Vector = function(opt_options) {
   goog.base(this, /** @type {olx.layer.LayerOptions} */ (baseOptions));
 
   /**
+   * Function to calculate a geometry from a feature, a resolution, and a style.
+   * @type {undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry}
+   * @private
+   */
+  this.geometryFunction_ = options.geometryFunction;
+
+  /**
    * User provided style.
    * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
    * @private
@@ -55,6 +62,17 @@ ol.layer.Vector = function(opt_options) {
 
 };
 goog.inherits(ol.layer.Vector, ol.layer.Layer);
+
+
+/**
+ * Get the geometry function.
+ * @return {undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry}
+ *     Layer style function.
+ * @api
+ */
+ol.layer.Vector.prototype.getGeometryFunction = function() {
+  return this.geometryFunction_;
+};
 
 
 /**

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -76,6 +76,7 @@ ol.renderer.vector.renderCircleGeometry_ =
 /**
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.Feature} feature Feature.
+ * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
  * @param {number} squaredTolerance Squared tolerance.
  * @param {function(this: T, goog.events.Event)} listener Listener function.
@@ -83,14 +84,14 @@ ol.renderer.vector.renderCircleGeometry_ =
  * @return {boolean} `true` if style is loading.
  * @template T
  */
-ol.renderer.vector.renderFeature = function(
-    replayGroup, feature, style, squaredTolerance, listener, thisArg) {
+ol.renderer.vector.renderFeature = function(replayGroup, feature, geometry,
+    style, squaredTolerance, listener, thisArg) {
   var loading = false;
   var imageStyle, imageState;
   imageStyle = style.getImage();
   if (goog.isNull(imageStyle)) {
     ol.renderer.vector.renderFeature_(
-        replayGroup, feature, style, squaredTolerance);
+        replayGroup, feature, geometry, style, squaredTolerance);
   } else {
     imageState = imageStyle.getImageState();
     if (imageState == ol.style.ImageState.LOADED ||
@@ -98,7 +99,7 @@ ol.renderer.vector.renderFeature = function(
       imageStyle.unlistenImageChange(listener, thisArg);
       if (imageState == ol.style.ImageState.LOADED) {
         ol.renderer.vector.renderFeature_(
-            replayGroup, feature, style, squaredTolerance);
+            replayGroup, feature, geometry, style, squaredTolerance);
       }
     } else {
       if (imageState == ol.style.ImageState.IDLE) {
@@ -117,16 +118,13 @@ ol.renderer.vector.renderFeature = function(
 /**
  * @param {ol.render.IReplayGroup} replayGroup Replay group.
  * @param {ol.Feature} feature Feature.
+ * @param {ol.geom.Geometry} geometry Geometry.
  * @param {ol.style.Style} style Style.
  * @param {number} squaredTolerance Squared tolerance.
  * @private
  */
 ol.renderer.vector.renderFeature_ = function(
-    replayGroup, feature, style, squaredTolerance) {
-  var geometry = feature.getGeometry();
-  if (!goog.isDefAndNotNull(geometry)) {
-    return;
-  }
+    replayGroup, feature, geometry, style, squaredTolerance) {
   var simplifiedGeometry = geometry.getSimplifiedGeometry(squaredTolerance);
   var geometryRenderer =
       ol.renderer.vector.GEOMETRY_RENDERERS_[simplifiedGeometry.getType()];

--- a/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
+++ b/src/ol/renderer/canvas/canvasvectorlayerrenderer.js
@@ -226,8 +226,8 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
       styles = vectorLayer.getStyleFunction()(feature, resolution);
     }
     if (goog.isDefAndNotNull(styles)) {
-      var dirty = this.renderFeature(
-          feature, resolution, pixelRatio, styles, replayGroup);
+      var dirty = this.renderFeature(feature, resolution,
+          pixelRatio, styles, replayGroup, vectorLayer.getGeometryFunction());
       this.dirty_ = this.dirty_ || dirty;
     }
   };
@@ -264,19 +264,28 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame =
  * @param {number} pixelRatio Pixel ratio.
  * @param {Array.<ol.style.Style>} styles Array of styles
  * @param {ol.render.canvas.ReplayGroup} replayGroup Replay group.
+ * @param {(function(ol.Feature, number, ol.style.Style): ol.geom.Geometry)=} opt_geometryFunction
+ *     Geometry function.
  * @return {boolean} `true` if an image is loading.
  */
-ol.renderer.canvas.VectorLayer.prototype.renderFeature =
-    function(feature, resolution, pixelRatio, styles, replayGroup) {
+ol.renderer.canvas.VectorLayer.prototype.renderFeature = function(feature,
+    resolution, pixelRatio, styles, replayGroup, opt_geometryFunction) {
   if (!goog.isDefAndNotNull(styles)) {
     return false;
   }
-  var i, ii, loading = false;
+  var geometry, i, ii, style;
+  var loading = false;
   for (i = 0, ii = styles.length; i < ii; ++i) {
-    loading = ol.renderer.vector.renderFeature(
-        replayGroup, feature, styles[i],
-        ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleImageChange_, this) || loading;
+    style = styles[i];
+    geometry = goog.isDef(opt_geometryFunction) ?
+        opt_geometryFunction(feature, resolution, style) :
+        feature.getGeometry();
+    if (goog.isDefAndNotNull(geometry)) {
+      loading = ol.renderer.vector.renderFeature(
+          replayGroup, feature, geometry, style,
+          ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
+          this.handleImageChange_, this) || loading;
+    }
   }
   return loading;
 };

--- a/src/ol/renderer/dom/domvectorlayerrenderer.js
+++ b/src/ol/renderer/dom/domvectorlayerrenderer.js
@@ -267,8 +267,8 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
       styles = vectorLayer.getStyleFunction()(feature, resolution);
     }
     if (goog.isDefAndNotNull(styles)) {
-      var dirty = this.renderFeature(
-          feature, resolution, pixelRatio, styles, replayGroup);
+      var dirty = this.renderFeature(feature, resolution,
+          pixelRatio, styles, replayGroup, vectorLayer.getGeometryFunction());
       this.dirty_ = this.dirty_ || dirty;
     }
   };
@@ -305,19 +305,28 @@ ol.renderer.dom.VectorLayer.prototype.prepareFrame =
  * @param {number} pixelRatio Pixel ratio.
  * @param {Array.<ol.style.Style>} styles Array of styles
  * @param {ol.render.canvas.ReplayGroup} replayGroup Replay group.
+ * @param {(function(ol.Feature, number, ol.style.Style): ol.geom.Geometry)=} opt_geometryFunction
+ *     Geometry function.
  * @return {boolean} `true` if an image is loading.
  */
-ol.renderer.dom.VectorLayer.prototype.renderFeature =
-    function(feature, resolution, pixelRatio, styles, replayGroup) {
+ol.renderer.dom.VectorLayer.prototype.renderFeature = function(feature,
+    resolution, pixelRatio, styles, replayGroup, opt_geometryFunction) {
   if (!goog.isDefAndNotNull(styles)) {
     return false;
   }
-  var i, ii, loading = false;
+  var geometry, i, ii, style;
+  var loading = false;
   for (i = 0, ii = styles.length; i < ii; ++i) {
-    loading = ol.renderer.vector.renderFeature(
-        replayGroup, feature, styles[i],
-        ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleImageChange_, this) || loading;
+    style = styles[i];
+    geometry = goog.isDef(opt_geometryFunction) ?
+        opt_geometryFunction(feature, resolution, style) :
+        feature.getGeometry();
+    if (goog.isDefAndNotNull(geometry)) {
+      loading = ol.renderer.vector.renderFeature(
+          replayGroup, feature, geometry, style,
+          ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
+          this.handleImageChange_, this) || loading;
+    }
   }
   return loading;
 };

--- a/src/ol/renderer/webgl/webglvectorlayerrenderer.js
+++ b/src/ol/renderer/webgl/webglvectorlayerrenderer.js
@@ -222,19 +222,28 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame =
  * @param {number} pixelRatio Pixel ratio.
  * @param {Array.<ol.style.Style>} styles Array of styles
  * @param {ol.render.webgl.ReplayGroup} replayGroup Replay group.
+ * @param {(function(ol.Feature, number, ol.style.Style): ol.geom.Geometry)=} opt_geometryFunction
+ *     Geometry function.
  * @return {boolean} `true` if an image is loading.
  */
-ol.renderer.webgl.VectorLayer.prototype.renderFeature =
-    function(feature, resolution, pixelRatio, styles, replayGroup) {
+ol.renderer.webgl.VectorLayer.prototype.renderFeature = function(feature,
+    resolution, pixelRatio, styles, replayGroup, opt_geometryFunction) {
   if (!goog.isDefAndNotNull(styles)) {
     return false;
   }
-  var i, ii, loading = false;
+  var geometry, i, ii, style;
+  var loading = false;
   for (i = 0, ii = styles.length; i < ii; ++i) {
-    loading = ol.renderer.vector.renderFeature(
-        replayGroup, feature, styles[i],
-        ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleImageChange_, this) || loading;
+    style = styles[i];
+    geometry = goog.isDef(opt_geometryFunction) ?
+        opt_geometryFunction(feature, resolution, style) :
+        feature.getGeometry();
+    if (goog.isDefAndNotNull(geometry)) {
+      loading = ol.renderer.vector.renderFeature(
+          replayGroup, feature, geometry, style,
+          ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
+          this.handleImageChange_, this) || loading;
+    }
   }
   return loading;
 };

--- a/src/ol/source/imagevectorsource.js
+++ b/src/ol/source/imagevectorsource.js
@@ -75,6 +75,13 @@ ol.source.ImageVector = function(options) {
   });
 
   /**
+   * Function to calculate a geometry from a feature, a resolution, and a style.
+   * @type {undefined|function(ol.Feature, number, ol.style.Style): ol.geom.Geometry}
+   * @private
+   */
+  this.geometryFunction_ = options.geometryFunction;
+
+  /**
    * User provided style.
    * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
    * @private
@@ -267,12 +274,19 @@ ol.source.ImageVector.prototype.renderFeature_ =
   if (!goog.isDefAndNotNull(styles)) {
     return false;
   }
-  var i, ii, loading = false;
+  var geometry, i, ii, style;
+  var loading = false;
   for (i = 0, ii = styles.length; i < ii; ++i) {
-    loading = ol.renderer.vector.renderFeature(
-        replayGroup, feature, styles[i],
-        ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleImageChange_, this) || loading;
+    style = styles[i];
+    geometry = goog.isDef(this.geometryFunction_) ?
+        this.geometryFunction_(feature, resolution, style) :
+        feature.getGeometry();
+    if (goog.isDefAndNotNull(geometry)) {
+      loading = ol.renderer.vector.renderFeature(
+          replayGroup, feature, geometry, style,
+          ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
+          this.handleImageChange_, this) || loading;
+    }
   }
   return loading;
 };

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -33,7 +33,7 @@ describe('ol.renderer.vector', function() {
 
         // call #1
         ol.renderer.vector.renderFeature(replayGroup, feature,
-            style, 1, listener, listenerThis);
+            feature.getGeometry(), style, 1, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = goog.events.getListeners(
@@ -42,7 +42,7 @@ describe('ol.renderer.vector', function() {
 
         // call #2
         ol.renderer.vector.renderFeature(replayGroup, feature,
-            style, 1, listener, listenerThis);
+            feature.getGeometry(), style, 1, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = goog.events.getListeners(


### PR DESCRIPTION
This is an alternative to #3010.

`ol.layer.Vector`, `ol.FeatureOverlay` and `ol.source.ImageVector` now support a new geometryFunction option. This function, called with the feature, the resolution and a style, allows application developers to return a geometry different from the original feature geometry.

I'm going to add an example and also add a `geometryFunction` option to the interactions that create a feature overlay, but before I spend more time on it I would like to hear from @tschaub and @elemoine if this approach is better than #3010.

Oh, and @tsauerwein, if this is used to draw an arrow on a linestring, you can use `setRotation()` on the arrow style that is passed to the `geometryFunction` to set the rotation that you calculate from the line segment's gradient.
