### PR TITLE
Change loader function return type

### DIFF
--- a/src/ol/source/servervectorsource.js
+++ b/src/ol/source/servervectorsource.js
@@ -38,7 +38,7 @@ ol.source.ServerVector = function(options) {
   /**
    * @private
    * @type {function(this: ol.source.ServerVector, ol.Extent, number,
-   *                 ol.proj.Projection): string}
+   *                 ol.proj.Projection)}
    */
   this.loader_ = options.loader;
 


### PR DESCRIPTION
Changing from `string` to `?`: the return value from the function is not used.
