### PR TITLE
Allow custom mousemove conditions for Select interaction

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -179,7 +179,7 @@ ol.interaction.Select.prototype.handleMapBrowserEvent =
     }
     features.extend(selected);
   }
-  return this.condition_ == ol.events.condition.mouseMove;
+  return ol.events.condition.mouseMove(mapBrowserEvent);
 };
 
 


### PR DESCRIPTION
When configuring a Select interaction with a custom condition that includes mousemove, panning the map will not work any more. This is because the return value of handleMapBrowserEvent is determined by checking for a default condition function. By checking for the underlying event type instead, we gain flexibility with custom condition functions.

This change makes Select interaction configurations like the following work:

``` js
new ol.interaction.Select({
  condition: function(evt) {
    return evt.originalEvent.type == 'mousemove' ||
        evt.type == 'singleclick';
  }
});
```

This configuration is useful for hover selection with a click fallback on mobile devices that do not have hover.
