### PR TITLE
Print example name in check-examples exception

### DIFF
--- a/build.py
+++ b/build.py
@@ -32,7 +32,11 @@ class ThreadPool:
                 try:
                     function(*args, **kargs)
                 except:
+                    print("ERROR")
+                    for count, thing in enumerate(args):
+                        print '{0}. {1}'.format(count, thing)
                     print(sys.exc_info()[0])
+                    print("ERROR")
                     self.tasks.errors = True
                 self.tasks.task_done()
 


### PR DESCRIPTION
Will allow spotting failures even when the original exception message is not informative enough.

Example output:

```
ERROR
0. %(PHANTOMJS)s
1. bin/check-example.js
2. build/hosted/%(BRANCH)s/examples/vector-wfs.html?mode=advanced
<class 'pake.BuildError'>
ERROR
```
