### PR TITLE
Use // NOCOMPILE for vector-wfs

### DIFF
--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -1,3 +1,4 @@
+// NOCOMPILE
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.format.GeoJSON');


### PR DESCRIPTION
This is temporary solution until the demo.boundless.com WFS works again.

Fixes #3041.
