### PR TITLE
Mark Image style constructor properties `@api`

### DIFF
--- a/src/ol/style/imagestyle.js
+++ b/src/ol/style/imagestyle.js
@@ -70,6 +70,7 @@ ol.style.Image = function(options) {
 
 /**
  * @return {number} Opacity.
+ * @api
  */
 ol.style.Image.prototype.getOpacity = function() {
   return this.opacity_;
@@ -78,6 +79,7 @@ ol.style.Image.prototype.getOpacity = function() {
 
 /**
  * @return {boolean} Rotate with map.
+ * @api
  */
 ol.style.Image.prototype.getRotateWithView = function() {
   return this.rotateWithView_;
@@ -104,6 +106,7 @@ ol.style.Image.prototype.getScale = function() {
 
 /**
  * @return {boolean} Snap to pixel?
+ * @api
  */
 ol.style.Image.prototype.getSnapToPixel = function() {
   return this.snapToPixel_;


### PR DESCRIPTION
It is necessary so that the developer or ol3-cesium is able to read back the values.
