### PR TITLE
Need exportable constructor for constructor options in olx

### DIFF
--- a/src/ol/interaction/pointerinteraction.js
+++ b/src/ol/interaction/pointerinteraction.js
@@ -19,6 +19,7 @@ goog.require('ol.interaction.Interaction');
  * @constructor
  * @param {olx.interaction.PointerOptions=} opt_options Options.
  * @extends {ol.interaction.Interaction}
+ * @api
  */
 ol.interaction.Pointer = function(opt_options) {
 


### PR DESCRIPTION
When a constructor options object is created in the olx namespace,
the constructor that uses it must be exportable as well.

Fixes #3045.
