### PR TITLE
No need for featureNS and featureType to be quoted

### DIFF
--- a/src/ol/format/gml/gmlbaseformat.js
+++ b/src/ol/format/gml/gmlbaseformat.js
@@ -544,8 +544,8 @@ ol.format.GMLBase.prototype.readFeatures;
 ol.format.GMLBase.prototype.readFeaturesFromNode =
     function(node, opt_options) {
   var options = {
-    'featureType': this.featureType,
-    'featureNS': this.featureNS
+    featureType: this.featureType,
+    featureNS: this.featureNS
   };
   if (goog.isDef(opt_options)) {
     goog.object.extend(options, this.getReadOptions(node, opt_options));


### PR DESCRIPTION
In the GML format, [`featureNS` and `featureType`](https://github.com/openlayers/ol3/blob/ad1f255211aeadc522ebb9edbfcf27dfc4a89015/src/ol/format/gmlformat.js#L1068-L1071) should not be quoted.  We would only need to quote these if they were element names or if we were passing the context object to users.

<bountysource-plugin>

---

Want to back this issue? **[Place a bounty on it!](https://www.bountysource.com/issues/4292720-no-need-for-featurens-and-featuretype-to-be-quoted?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github)** We accept bounties via [Bountysource](https://www.bountysource.com/?utm_campaign=plugin&utm_content=tracker%2F79013&utm_medium=issues&utm_source=github).
</bountysource-plugin>
