### PR TITLE
Use an API function to extend the extent

### DIFF
--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -65,8 +65,7 @@ function calculateClusterInfo(resolution) {
     var originalFeatures = feature.get('features');
     var extent = ol.extent.createEmpty();
     for (var j = 0, jj = originalFeatures.length; j < jj; ++j) {
-      ol.extent.extendCoordinate(extent,
-          originalFeatures[j].getGeometry().getCoordinates());
+      ol.extent.extend(extent, originalFeatures[j].getGeometry().getExtent());
     }
     maxFeatureCount = Math.max(maxFeatureCount, jj);
     radius = 0.25 * (ol.extent.getWidth(extent) + ol.extent.getHeight(extent)) /


### PR DESCRIPTION
This is a follow-up on #3010. The `earthquake-clusters.html` example does not work in compiled mode because it uses the `ol.extent.extendCoordinate` function which is not part of the API. This change makes it so `ol.extent.extend` is used instead.
