### PR TITLE
Define goog and assign to global when generating UMD debug builds

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -175,11 +175,14 @@ function concatenate(paths, callback) {
       var msg = 'Trouble concatenating sources.  ' + err.message;
       callback(new Error(msg));
     } else {
-      var preamble = 'var CLOSURE_NO_DEPS = true;\n';
       var parts = umdWrapper.split('%output%');
-      var postamble = 'OPENLAYERS.ol = ol;\n';
-      callback(null,
-          preamble + parts[0] + results.join('\n') + postamble + parts[1]);
+      var src = 'var CLOSURE_NO_DEPS = true;\n' +
+          parts[0] +
+          'var goog = this.goog = {};\n' +
+          results.join('\n') +
+          'OPENLAYERS.ol = ol;\n' +
+          parts[1];
+      callback(null, src);
     }
   });
 }


### PR DESCRIPTION
When concatenating the Closure Library, `base.js` creates a new `goog` object if there is not already one in scope.  Later, `goog.global` is assigned the value of `this`.  Calls to `goog.provide` create "namespace" objects by assigning to `goog.global`.  To ensure that `goog` is the same as `goog.global.goog`, we need to create a new `goog` object in the scope of base.js and assign it to `this.goog`.
