### PR TITLE
Remove misplaced function annotation

### DIFF
--- a/src/ol/renderer/webgl/webglmaprenderer.js
+++ b/src/ol/renderer/webgl/webglmaprenderer.js
@@ -126,10 +126,6 @@ ol.renderer.webgl.Map = function(container, map) {
    * @type {ol.structs.PriorityQueue.<Array>}
    */
   this.tileTextureQueue_ = new ol.structs.PriorityQueue(
-      /**
-       * @param {Array.<*>} element Element.
-       * @return {number} Priority.
-       */
       goog.bind(
           /**
            * @param {Array.<*>} element Element.


### PR DESCRIPTION
Found while testing the new [closure-compiler](https://github.com/google/closure-compiler/wiki/Releases#december-15-2014-v20141215)
