### PR TITLE
Correct arguments for forEachGeometryAtPixel

### DIFF
--- a/src/ol/renderer/maprenderer.js
+++ b/src/ol/renderer/maprenderer.js
@@ -125,14 +125,13 @@ ol.renderer.Map.prototype.forEachFeatureAtPixel =
     function(coordinate, frameState, callback, thisArg,
         layerFilter, thisArg2) {
   var result;
-  var extent = frameState.extent;
   var viewState = frameState.viewState;
   var viewResolution = viewState.resolution;
   var viewRotation = viewState.rotation;
   if (!goog.isNull(this.replayGroup)) {
     /** @type {Object.<string, boolean>} */
     var features = {};
-    result = this.replayGroup.forEachGeometryAtPixel(extent, viewResolution,
+    result = this.replayGroup.forEachGeometryAtPixel(viewResolution,
         viewRotation, coordinate, {},
         /**
          * @param {ol.Feature} feature Feature.


### PR DESCRIPTION
The signature for `replayGroup.forEachGeometryAtPixel()` changed with ddc51ee267e66b6ec87098436bb55193d66e64d4, but the map renderer was still [calling it with the old signature](https://github.com/elemoine/ol3/blob/ddc51ee267e66b6ec87098436bb55193d66e64d4/src/ol/renderer/maprenderer.js#L135-L136).  This fixes that.

Fixes #3081.
