### PR TITLE
Fixed URL link for test README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ To run the tests on the console (headless testing with PhantomJS) use the `test`
 
     $ ./build.py test
 
-See also the test-specific [README](../blob/master/test/README.md).
+See also the test-specific [README](../master/test/README.md).
 
 ## Running the integration tests
 


### PR DESCRIPTION
In CONTRIBUTING.md, under the "Running Tests" heading, the link to the specific README gives a 404 error. Removed the extra blob from the path. 
