### PR TITLE
Avoid "Window.getComputedStyle does not implement interface Element" exception in Firefox

### DIFF
--- a/lib/OpenLayers/Handler/MouseWheel.js
+++ b/lib/OpenLayers/Handler/MouseWheel.js
@@ -111,7 +111,7 @@ OpenLayers.Handler.MouseWheel = OpenLayers.Class(OpenLayers.Handler, {
         var overMapDiv = false;
         
         var elem = OpenLayers.Event.element(e);
-        while((elem != null) && !overMapDiv && !overScrollableDiv) {
+        while(elem && (elem.nodeType == 1) && !overMapDiv && !overScrollableDiv) {
 
             if (!overScrollableDiv) {
                 try {


### PR DESCRIPTION
In Firefox an exception "Window.getComputedStyle does not implement interface Element" was being raised when the MouseWheel event was outside the map, due to the traverse up the tree winding up at the document object (which naturally doesn't implement the Element interface!).

This error was swallowed in the try-catch block and so did not bubble up to the user, but trying to use Firebug and stop on all errors then it becomes noticeable.

No changes required in the test-suite (which passes!).