### PR TITLE
Fix (MS)Pointer-based touch events for IE11+

### DIFF
--- a/lib/OpenLayers/Events.js
+++ b/lib/OpenLayers/Events.js
@@ -125,6 +125,23 @@ OpenLayers.Event = {
     },
 
     /**
+     * Method: isTouchEvent
+     * Determine whether the event was triggered by a touch
+     * 
+     * Parameters:
+     * evt - {Event}
+     * 
+     * Returns:
+     * {Boolean}
+     */
+    isTouchEvent: function(evt) {
+        return ("" + evt.type).indexOf("touch") === 0 || (
+                "pointerType" in evt && (
+                     evt.pointerType === evt.MSPOINTER_TYPE_MOUSE /*IE10 pointer*/ ||
+                     evt.pointerType === "touch" /*W3C pointer*/));
+    },
+
+    /**
      * Method: isLeftClick
      * Determine whether event was caused by a left click. 
      *
@@ -407,6 +424,24 @@ OpenLayers.Events = OpenLayers.Class({
         "touchstart", "touchmove", "touchend",
         "keydown"
     ],
+    
+    /**
+     * Constant: standard pointer model
+     * {string}
+     */
+    TOUCH_MODEL_POINTER: "pointer",
+
+    /**
+     * Constant: prefixed pointer model (IE10)
+     * {string}
+     */
+    TOUCH_MODEL_MSPOINTER: "MSPointer",
+
+    /**
+     * Constant: legacy touch model
+     * {string}
+     */
+    TOUCH_MODEL_TOUCH: "touch",
 
     /** 
      * Property: listeners 
@@ -566,7 +601,7 @@ OpenLayers.Events = OpenLayers.Class({
         this.listeners  = {};
         this.extensions = {};
         this.extensionCount = {};
-        this._msTouches = [];
+        this._pointerTouches = [];
         
         // if a dom element is specified, add a listeners list 
         // for browser events on the element and register them
@@ -633,15 +668,17 @@ OpenLayers.Events = OpenLayers.Class({
             );
         }
         this.element = element;
-        var msTouch = !!window.navigator.msMaxTouchPoints;
+        var touchModel = this.getTouchModel();
         var type;
         for (var i = 0, len = this.BROWSER_EVENTS.length; i < len; i++) {
             type = this.BROWSER_EVENTS[i];
             // register the event cross-browser
             OpenLayers.Event.observe(element, type, this.eventHandler
             );
-            if (msTouch && type.indexOf('touch') === 0) {
-                this.addMsTouchListener(element, type, this.eventHandler);
+            if ((touchModel === this.TOUCH_MODEL_POINTER ||
+                    touchModel === this.TOUCH_MODEL_MSPOINTER) &&
+                    type.indexOf('touch') === 0) {
+                this.addPointerTouchListener(element, type, this.eventHandler);
             }
         }
         // disable dragstart in IE so that mousedown/move/up works normally
@@ -1021,18 +1058,38 @@ OpenLayers.Events = OpenLayers.Class({
     },
 
     /**
-     * Method: addMsTouchListener
+     * Method: getTouchModel
+     * Get the touch model currently in use.
+     * 
+     * This is cached on OpenLayers.Events as _TOUCH_MODEL 
+     * 
+     * Returns:
+     * {string} The current touch model (TOUCH_MODEL_xxx), null if none
+     */
+    getTouchModel: function() {
+        if (!("_TOUCH_MODEL" in OpenLayers.Events)) {
+            OpenLayers.Events._TOUCH_MODEL =
+                    (window.PointerEvent && "pointer") ||
+                    (window.MSPointerEvent && "MSPointer") ||
+                    (("ontouchdown" in document) && "touch") ||
+                    null;
+        }
+        return OpenLayers.Events._TOUCH_MODEL;
+    },
+
+    /**
+     * Method: addPointerTouchListener
      *
      * Parameters:
      * element - {DOMElement} The DOM element to register the listener on
      * type - {String} The event type
      * handler - {Function} the handler
      */
-    addMsTouchListener: function (element, type, handler) {
+    addPointerTouchListener: function (element, type, handler) {
         var eventHandler = this.eventHandler;
-        var touches = this._msTouches;
+        var touches = this._pointerTouches;
 
-        function msHandler(evt) {
+        function pointerHandler(evt) {
             handler(OpenLayers.Util.applyDefaults({
                 stopPropagation: function() {
                     for (var i=touches.length-1; i>=0; --i) {
@@ -1050,28 +1107,33 @@ OpenLayers.Events = OpenLayers.Class({
 
         switch (type) {
             case 'touchstart':
-                return this.addMsTouchListenerStart(element, type, msHandler);
+                return this.addPointerTouchListenerStart(element, type, pointerHandler);
             case 'touchend':
-                return this.addMsTouchListenerEnd(element, type, msHandler);
+                return this.addPointerTouchListenerEnd(element, type, pointerHandler);
             case 'touchmove':
-                return this.addMsTouchListenerMove(element, type, msHandler);
+                return this.addPointerTouchListenerMove(element, type, pointerHandler);
             default:
                 throw 'Unknown touch event type';
         }
     },
 
     /**
-     * Method: addMsTouchListenerStart
+     * Method: addPointerTouchListenerStart
      *
      * Parameters:
      * element - {DOMElement} The DOM element to register the listener on
      * type - {String} The event type
      * handler - {Function} the handler
      */
-    addMsTouchListenerStart: function(element, type, handler) {
-        var touches = this._msTouches;
+    addPointerTouchListenerStart: function(element, type, handler) {
+        var touches = this._pointerTouches;
 
         var cb = function(e) {
+
+            // pointer could be mouse or pen
+            if (!OpenLayers.Event.isTouchEvent(e)) {
+                return;
+            }
 
             var alreadyInArray = false;
             for (var i=0, ii=touches.length; i<ii; ++i) {
@@ -1088,11 +1150,20 @@ OpenLayers.Events = OpenLayers.Class({
             handler(e);
         };
 
-        OpenLayers.Event.observe(element, 'MSPointerDown', cb);
+        OpenLayers.Event.observe(element,
+                this.getTouchModel() === this.TOUCH_MODEL_MSPOINTER ?
+                        'MSPointerDown' : 'pointerdown',
+                cb);
         
-        // the pointerId only needs to be removed from the _msTouches array
+        // the pointerId only needs to be removed from the _pointerTouches array
         // when the pointer has left its element
         var internalCb = function (e) {
+
+            // pointer could be mouse or pen
+            if (!OpenLayers.Event.isTouchEvent(e)) {
+            	return;
+            }
+
             var up = false;
             for (var i = 0, ii = touches.length; i < ii; ++i) {
                 if (touches[i].pointerId == e.pointerId) {
@@ -1105,23 +1176,26 @@ OpenLayers.Events = OpenLayers.Class({
                 }
             }
         };
-        OpenLayers.Event.observe(element, 'MSPointerOut', internalCb);
+        OpenLayers.Event.observe(element,
+                this.getTouchModel() === this.TOUCH_MODEL_MSPOINTER ?
+                        'MSPointerOut' : 'pointerout',
+                internalCb);
     },
 
     /**
-     * Method: addMsTouchListenerMove
+     * Method: addPointerTouchListenerMove
      *
      * Parameters:
      * element - {DOMElement} The DOM element to register the listener on
      * type - {String} The event type
      * handler - {Function} the handler
      */
-    addMsTouchListenerMove: function (element, type, handler) {
-        var touches = this._msTouches;
+    addPointerTouchListenerMove: function (element, type, handler) {
+        var touches = this._pointerTouches;
         var cb = function(e) {
 
-            //Don't fire touch moves when mouse isn't down
-            if (e.pointerType == e.MSPOINTER_TYPE_MOUSE && e.buttons == 0) {
+            // pointer could be mouse or pen
+            if (!OpenLayers.Event.isTouchEvent(e)) {
                 return;
             }
 
@@ -1141,21 +1215,29 @@ OpenLayers.Events = OpenLayers.Class({
             handler(e);
         };
 
-        OpenLayers.Event.observe(element, 'MSPointerMove', cb);
+        OpenLayers.Event.observe(element,
+                this.getTouchModel() === this.TOUCH_MODEL_MSPOINTER ?
+                        'MSPointerMove' : 'pointermove',
+                cb);
     },
 
     /**
-     * Method: addMsTouchListenerEnd
+     * Method: addPointerTouchListenerEnd
      *
      * Parameters:
      * element - {DOMElement} The DOM element to register the listener on
      * type - {String} The event type
      * handler - {Function} the handler
      */
-    addMsTouchListenerEnd: function (element, type, handler) {
-        var touches = this._msTouches;
+    addPointerTouchListenerEnd: function (element, type, handler) {
+        var touches = this._pointerTouches;
 
         var cb = function(e) {
+
+            // pointer could be mouse or pen
+            if (!OpenLayers.Event.isTouchEvent(e)) {
+            	return;
+            }
 
             for (var i=0, ii=touches.length; i<ii; ++i) {
                 if (touches[i].pointerId == e.pointerId) {
@@ -1168,7 +1250,10 @@ OpenLayers.Events = OpenLayers.Class({
             handler(e);
         };
 
-        OpenLayers.Event.observe(element, 'MSPointerUp', cb);
+        OpenLayers.Event.observe(element,
+                this.getTouchModel() === this.TOUCH_MODEL_MSPOINTER ?
+                        'MSPointerUp' : 'pointerup',
+                cb);
     },
 
     CLASS_NAME: "OpenLayers.Events"

--- a/lib/OpenLayers/Handler/Drag.js
+++ b/lib/OpenLayers/Handler/Drag.js
@@ -154,6 +154,7 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
         var propagate = true;
         this.dragging = false;
         if (this.checkModifiers(evt) &&
+               this._pointerId == evt.pointerId &&
                (OpenLayers.Event.isLeftClick(evt) ||
                 OpenLayers.Event.isSingleTouch(evt))) {
             this.started = true;
@@ -176,6 +177,7 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
 
             propagate = !this.stopDown;
         } else {
+            delete this._pointerId;
             this.started = false;
             this.start = null;
             this.last = null;
@@ -195,8 +197,9 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
      */
     dragmove: function (evt) {
         this.lastMoveEvt = evt;
-        if (this.started && !this.timeoutId && (evt.xy.x != this.last.x ||
-                                                evt.xy.y != this.last.y)) {
+        if (this.started && this._pointerId == evt.pointerId &&
+            !this.timeoutId && (evt.xy.x != this.last.x ||
+                                evt.xy.y != this.last.y)) {
             if(this.documentDrag === true && this.documentEvents) {
                 if(evt.element === document) {
                     this.adjustXY(evt);
@@ -236,7 +239,7 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
      * {Boolean} Let the event propagate.
      */
     dragend: function (evt) {
-        if (this.started) {
+        if (this.started && this._pointerId == evt.pointerId) {
             if(this.documentDrag === true && this.documentEvents) {
                 this.adjustXY(evt);
                 this.removeDocumentEvents();
@@ -244,6 +247,7 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
             var dragged = (this.start != this.last);
             this.started = false;
             this.dragging = false;
+            delete this._pointerId;
             OpenLayers.Element.removeClass(
                 this.map.viewPortDiv, "olDragDown"
             );
@@ -339,6 +343,11 @@ OpenLayers.Handler.Drag = OpenLayers.Class(OpenLayers.Handler, {
      */
     touchstart: function(evt) {
         this.startTouch();
+        // only allow the first pointer event to be monitored by noting its pointerId
+        // which is unique in the pointer model (and undefined in the touch model)
+        if (!("_pointerId" in this)) {
+            this._pointerId = evt.pointerId;
+        }
         return this.dragstart(evt);
     },
 

--- a/tests/Events.html
+++ b/tests/Events.html
@@ -381,11 +381,13 @@
         var div   = OpenLayers.Util.getElement('test');
         var obj   = {};
         var events = new OpenLayers.Events(obj, div);
-
+        var touchModel = events.getTouchModel();
+        // +5 because of additional binding to pointer events (down, up, move, out)
         // +1 because of blocking dragstart in attachToElement()
+        var eventsOffset = ((touchModel === events.TOUCH_MODEL_MSPOINTER) ||
+                (touchModel === events.TOUCH_MODEL_POINTER)) ? 5 : 1;
         t.eq(OpenLayers.Event.observers[div._eventCacheID].length,
-             OpenLayers.Events.prototype.BROWSER_EVENTS.length + 1,
-             "construction creates new arrayin hash, registers appropriate events");
+             OpenLayers.Events.prototype.BROWSER_EVENTS.length + eventsOffset);
              
         events.destroy();
         events = null;


### PR DESCRIPTION
This PR contains three commits, each dealing with a sub-problem of the current handling of (MS)Pointer-based touch events:

1. one test in Events fails as in browsers with pointer events we listen to an additional 4 pointer events
   * changes in tests/Events.html
2. IE11 drops the MS prefixes for pointer events: MSPointerDown -> pointerdown, etc. Furthermore the pointerType property of pointer event objects is no longer a numeric constant on the event object (e.g. e.MSPOINTER_TYPE_MOUSE) but now a string (e.g. "touch"). Additionally, not all devices set e.buttons to 0 for pointermove events (Surface 1 with WinRT 8.1 seems to, Lumia WP8.1 not)
   * changes in lib/OpenLayers/Events.js
3. handling of multitouch events in the drag handler was a bit wonky, as in the pointer model multiple events are fired rather than a single event. An attempt was being made to polyfill this by adding a touches array to the event, but the very first event didn't have this as there is no way of knowing that this will be part of a multitouch event. This led to e.g. pinch-zooming being a little dicey as some bits of the multitouch were being interpreted differently and the map tended to spring a bit. By tracking the pointerId of the events in the drag handler we can reliably tell whether it is really a single-finger drag or a multitouch gesture.
   * changes in lib/OpenLayers/Handler/Drag.js

Although these are three separate fixes for three distinct problems, they are all parts of the general problem that pointer event handling (particularly pinch zoom) is unsatisfactory in IE11 on touch devices, hence I've rolled them all into one PR. If preferred I can split into 3 separate PRs.