### PR TITLE
Prevent the map from zooming out further than minZoomLevel

### DIFF
--- a/lib/OpenLayers/Map.js
+++ b/lib/OpenLayers/Map.js
@@ -2462,7 +2462,13 @@ OpenLayers.Map = OpenLayers.Class({
         if (this.zoomTween) {
             this.zoomTween.stop();
         }
-        this.zoomTo(this.getZoom() - 1);
+        if (this.baseLayer.minZoomLevel !== undefined) {
+            if (this.getZoom() > this.baseLayer.minZoomLevel) {
+                this.zoomTo(this.getZoom() - 1);
+            }
+        } else {
+            this.zoomTo(this.getZoom() - 1);
+        }
     },
 
     /**


### PR DESCRIPTION
if it is defined on the base layer