### PR TITLE
Only redraw layer when singleTile changes if it's visible

### DIFF
--- a/lib/OpenLayers/Layer/Grid.js
+++ b/lib/OpenLayers/Layer/Grid.js
@@ -396,7 +396,9 @@ OpenLayers.Layer.Grid = OpenLayers.Class(OpenLayers.Layer.HTTPRequest, {
             this.clearGrid();
             this.tileSize = this.options.tileSize;
             this.setTileSize();
-            this.moveTo(null, true);
+            if (this.visibility) {
+                this.moveTo(null, true);
+            }
         }
     },
     


### PR DESCRIPTION
Otherwise tiles will be fetched even if the layer is not visible.