### PR TITLE
SelectFeature should toggle features with box select

### DIFF
--- a/lib/OpenLayers/Control/SelectFeature.js
+++ b/lib/OpenLayers/Control/SelectFeature.js
@@ -592,6 +592,9 @@ OpenLayers.Control.SelectFeature = OpenLayers.Class(OpenLayers.Control, {
                             if (OpenLayers.Util.indexOf(layer.selectedFeatures, feature) == -1) {
                                 this.select(feature);
                             }
+                            else if (this.toggleSelect()) {
+                                this.unselect(feature);
+                            }
                         }
                     }
                 }

--- a/tests/Control/SelectFeature.html
+++ b/tests/Control/SelectFeature.html
@@ -214,6 +214,29 @@
         t.ok(firesBoxselectionend,"selectBox fires boxselectionend event");
         t.eq(afterSelectingNumberOfFeatures,1,"boxselectionend fires after feature selected");
     }
+    function test_selectBox_toggle(t) {
+		 t.plan(2);
+		 var map = new OpenLayers.Map("map");
+		 var layer1 = new OpenLayers.Layer.Vector();
+		 map.addLayer(layer1);
+		 map.setBaseLayer(layer1);
+		 var layer2 = new OpenLayers.Layer.Vector();
+		 map.addLayer(layer2);
+		 map.setCenter(new OpenLayers.LonLat(1,1));
+		 var feature = new OpenLayers.Feature.Vector(new OpenLayers.Geometry.Point(1,1));
+		 layer1.addFeatures([feature]);
+		 var control = new OpenLayers.Control.SelectFeature(layer1, {toggle: true, multiple: true});
+		 control.setMap(map);
+		 map.getLonLatFromPixel = function(arg) {
+			 return new OpenLayers.LonLat(arg.x, arg.y);
+		 };
+		 control.activate();
+		 var bounds = new OpenLayers.Bounds(-1,-1,2,2);
+		 control.selectBox(bounds);
+		 t.eq(layer1.selectedFeatures.length, 1, "selectBox toggles the selected item.");
+		 control.selectBox(bounds);
+		 t.eq(layer1.selectedFeatures.length, 0, "selectBox toggles the selected item.");
+	 }
     function test_Control_SelectFeature_activate(t) {
         t.plan(4);
         var map = new OpenLayers.Map("map");


### PR DESCRIPTION
I recently ran into an issue with the SelectFeature control where features I had selected would toggle properly on click, but would not toggle at all under box select. I have added a condition for unselecting selected features in the selectBox method to implement this behavior if the toggle setting is enabled, and a simple unit test to verify that it works.