### PR TITLE
Useful linestring getLength method added to ol.proj

### DIFF
--- a/examples/measure.html
+++ b/examples/measure.html
@@ -1,10 +1,12 @@
 ---
 template: example.html
 title: Measure example
-shortdesc: Example of using the ol.interaction.Draw interaction for creating simple measuring application.
+shortdesc: Example of using the ol.interaction.Draw interaction for creating a simple measuring application.
 docs: >
-  <p><i>NOTE: If use geodesic measures is not checked, measure is done in simple way on projected plane. Earth curvature is not taken into account</i></p>
-tags: "draw, edit, measure, vector"
+  The Linestring coordinates and the view projection are passed to ol.proj.getLength to get a distance in metres.
+  The length calculation method is Haversine on a sphere with the WGS84 equatorial radius.
+  Area computation is also done on a sphere with the WGS84 equatorial radius.
+tags: "draw, edit, measure, vector, length, area"
 ---
 <div class="row-fluid">
   <div class="span12">
@@ -17,5 +19,4 @@ tags: "draw, edit, measure, vector"
       <option value="length">Length</option>
       <option value="area">Area</option>
     </select>
-    <label class="checkbox"><input type="checkbox" id="geodesic"/>use geodesic measures</label>
 </form>

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -139,7 +139,6 @@ var map = new ol.Map({
 map.on('pointermove', pointerMoveHandler);
 
 var typeSelect = document.getElementById('type');
-var geodesicCheckbox = document.getElementById('geodesic');
 
 var draw; // global so we can remove it later
 function addInteraction() {
@@ -244,18 +243,12 @@ typeSelect.onchange = function(e) {
  */
 var formatLength = function(line) {
   var length;
-  if (geodesicCheckbox.checked) {
-    var coordinates = line.getCoordinates();
-    length = 0;
-    var sourceProj = map.getView().getProjection();
-    for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-      var c1 = ol.proj.transform(coordinates[i], sourceProj, 'EPSG:4326');
-      var c2 = ol.proj.transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
-      length += wgs84Sphere.haversineDistance(c1, c2);
-    }
-  } else {
-    length = Math.round(line.getLength() * 100) / 100;
-  }
+
+  var sourceProj = map.getView().getProjection();
+
+  length = Math.round(
+      ol.proj.getLength(line.getCoordinates(), sourceProj) * 100) / 100;
+
   var output;
   if (length > 100) {
     output = (Math.round(length / 1000 * 100) / 100) +
@@ -269,21 +262,19 @@ var formatLength = function(line) {
 
 
 /**
- * format length output
+ * format area output
  * @param {ol.geom.Polygon} polygon
  * @return {string}
  */
 var formatArea = function(polygon) {
   var area;
-  if (geodesicCheckbox.checked) {
-    var sourceProj = map.getView().getProjection();
-    var geom = /** @type {ol.geom.Polygon} */(polygon.clone().transform(
-        sourceProj, 'EPSG:4326'));
-    var coordinates = geom.getLinearRing(0).getCoordinates();
-    area = Math.abs(wgs84Sphere.geodesicArea(coordinates));
-  } else {
-    area = polygon.getArea();
-  }
+
+  var sourceProj = map.getView().getProjection();
+  var geom = /** @type {ol.geom.Polygon} */(polygon.clone().transform(
+      sourceProj, 'EPSG:4326'));
+  var coordinates = geom.getLinearRing(0).getCoordinates();
+  area = Math.abs(wgs84Sphere.geodesicArea(coordinates));
+
   var output;
   if (area > 10000) {
     output = (Math.round(area / 1000000 * 100) / 100) +

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -167,8 +167,12 @@ ol.geom.LineString.prototype.getCoordinates = function() {
 
 
 /**
- * Return the length of the linestring on projected plane.
- * @return {number} Length (on projected plane).
+ * Return the linestring length using cartesian maths.
+ * This method will not give useful results for geometries with
+ * EPSG:3857 or EPSG:4326 coordinates. To obtain line string lengths
+ * in metres, for these projections, use the getLength method of ol.proj
+ * instead.
+ * @return {number} Length, assuming cartesian coordinates.
  * @api stable
  */
 ol.geom.LineString.prototype.getLength = function() {

--- a/src/ol/sphere/normal.js
+++ b/src/ol/sphere/normal.js
@@ -4,7 +4,10 @@ goog.require('ol.Sphere');
 
 
 /**
- * The normal sphere.
+ * The "normal" sphere.
+ * Radius of a sphere of equal area or 'Authalic' to
+ * the NAD27 / Clarke 1866 ellipsoid.
+ * NAD27 is commonly used in the USA.
  * @const
  * @type {ol.Sphere}
  */

--- a/src/ol/sphere/wgs84sphere.js
+++ b/src/ol/sphere/wgs84sphere.js
@@ -5,6 +5,7 @@ goog.require('ol.Sphere');
 
 /**
  * A sphere with radius equal to the semi-major axis of the WGS84 ellipsoid.
+ * This is the same radius as used for the EPSG:3857 projection.
  * @const
  * @type {ol.Sphere}
  */

--- a/test/spec/ol/proj/proj.test.js
+++ b/test/spec/ol/proj/proj.test.js
@@ -512,6 +512,126 @@ describe('ol.proj', function() {
 
   });
 
+
+  describe('ol.proj.getLength with a 3 segment linestring', function() {
+
+    var lineString = [[0, 0], [100, 0], [100, 100], [0, 0]];
+
+    var expectL = 100.0 + 100.0 + (100.0 * Math.sqrt(2.0));
+
+    var lineString4326 = [[0, 0], [20, 0], [20, 20], [0, 0]];
+
+    describe('EPSG:3857, CARTESIAN', function() {
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, 'EPSG:3857',
+            ol.proj.LengthMethod.CARTESIAN)
+        ).to.roughlyEqual(expectL, 1e-6);
+      });
+    });
+
+    describe('EPSG:3857, HAVERSINE', function() {
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, 'EPSG:3857',
+            ol.proj.LengthMethod.HAVERSINE)
+        ).to.roughlyEqual(expectL, 1);
+      });
+    });
+
+    describe('EPSG:3857, RHUMB', function() {
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, 'EPSG:3857',
+            ol.proj.LengthMethod.RHUMB)
+        ).to.roughlyEqual(expectL, 1);
+      });
+    });
+
+    describe('EPSG:3857, default method', function() {
+
+      it('returns the expected result', function() {
+        var hl = ol.proj.getLength(lineString, 'EPSG:3857',
+            ol.proj.LengthMethod.HAVERSINE);
+        expect(ol.proj.getLength(lineString, 'EPSG:3857')).to.be(hl);
+      });
+    });
+
+    describe('EPSG:4326, CARTESIAN', function() {
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, 'EPSG:4326',
+            ol.proj.LengthMethod.CARTESIAN)
+        ).to.roughlyEqual(expectL, 1e-6);
+      });
+    });
+
+    describe('EPSG:4326, HAVERSINE', function() {
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString4326, 'EPSG:4326',
+            ol.proj.LengthMethod.HAVERSINE)
+        ).to.roughlyEqual(7568711, 1);
+      });
+    });
+
+    describe('EPSG:4326, RHUMB', function() {
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString4326, 'EPSG:4326',
+            ol.proj.LengthMethod.RHUMB)
+        ).to.roughlyEqual(7569234, 1);
+      });
+    });
+
+    describe('Default non-global method is CARTESIAN', function() {
+
+      var localProj = new ol.proj.Projection(
+          { units: ol.proj.Units.METERS, code: 'local', global: false });
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, localProj)
+        ).to.roughlyEqual(expectL, 1e-6);
+      });
+    });
+
+    describe('Uses Meters Per Unit', function() {
+
+      var localProj = new ol.proj.Projection(
+          { units: ol.proj.Units.FEET, code: 'local', global: false });
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, localProj)
+        ).to.roughlyEqual(expectL / 0.3048, 1e-6);
+      });
+    });
+
+    describe('Pixels projection ignores HAVERSINE method', function() {
+
+      var pxProj = new ol.proj.Projection(
+          { units: ol.proj.Units.PIXELS, code: 'px' });
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, pxProj,
+            ol.proj.LengthMethod.HAVERSINE)
+        ).to.roughlyEqual(expectL, 1e-6);
+      });
+    });
+
+    describe('Pixels projection ignores RHUMB method', function() {
+
+      var pxProj = new ol.proj.Projection(
+          { units: ol.proj.Units.PIXELS, code: 'px' });
+
+      it('returns the expected result', function() {
+        expect(ol.proj.getLength(lineString, pxProj,
+            ol.proj.LengthMethod.RHUMB)
+        ).to.roughlyEqual(expectL, 1e-6);
+      });
+    });
+
+  });
+
 });
 
 

--- a/test/spec/ol/sphere/sphere.test.js
+++ b/test/spec/ol/sphere/sphere.test.js
@@ -17,6 +17,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 0,
       finalBearing: 180,
       haversineDistance: 0,
+      rhumbDistance: 0,
       initialBearing: 0,
       midpoint: [0, 0]
     },
@@ -27,6 +28,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 6812.398372654371,
       finalBearing: 54.735610317245346,
       haversineDistance: 6671.695598673525,
+      rhumbDistance: 6702.199948935220,
       initialBearing: 35.264389682754654,
       midpoint: [18.434948822922006, 24.0948425521107]
     },
@@ -37,6 +39,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 6812.398372654371,
       finalBearing: 305.26438968275465,
       haversineDistance: 6671.695598673525,
+      rhumbDistance: 6702.199948935221,
       initialBearing: -35.264389682754654,
       midpoint: [-18.434948822922006, 24.0948425521107]
     },
@@ -47,6 +50,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 6812.398372654371,
       finalBearing: 234.73561031724535,
       haversineDistance: 6671.695598673525,
+      rhumbDistance: 6702.199948935222,
       initialBearing: -144.73561031724535,
       midpoint: [-18.434948822922006, -24.0948425521107]
     },
@@ -57,6 +61,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 6812.398372654371,
       finalBearing: 125.26438968275465,
       haversineDistance: 6671.695598673525,
+      rhumbDistance: 6702.199948935223,
       initialBearing: 144.73561031724535,
       midpoint: [18.434948822922006, -24.0948425521107]
     },
@@ -67,6 +72,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 0,
       finalBearing: 180,
       haversineDistance: 0,
+      rhumbDistance: 0,
       initialBearing: 0,
       midpoint: [45.00000000000005, 45]
     },
@@ -77,6 +83,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 7076.401799751738,
       finalBearing: 234.73561031724535,
       haversineDistance: 6671.695598673525,
+      rhumbDistance: 7076.401799751738,
       initialBearing: -54.73561031724535,
       midpoint: [0, 54.735610317245346]
     },
@@ -87,6 +94,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 14152.803599503475,
       finalBearing: 234.73561031724535,
       haversineDistance: 13343.391197347048,
+      rhumbDistance: 13404.399897870455,
       initialBearing: -125.26438968275465,
       midpoint: [0, 0]
     },
@@ -97,6 +105,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 10007.543398010286,
       finalBearing: 180,
       haversineDistance: 10007.543398010286,
+      rhumbDistance: 10007.543398010286,
       initialBearing: 180,
       midpoint: [45.00000000000005, 0]
     },
@@ -107,6 +116,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 0,
       finalBearing: 180,
       haversineDistance: 0,
+      rhumbDistance: 0,
       initialBearing: 0,
       midpoint: [-45.00000000000005, 45]
     },
@@ -117,6 +127,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 10007.543398010286,
       finalBearing: 180,
       haversineDistance: 10007.543398010286,
+      rhumbDistance: 10007.543398010286,
       initialBearing: 180,
       midpoint: [-45.00000000000005, 0]
     },
@@ -127,6 +138,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 14152.803599503475,
       finalBearing: 125.26438968275465,
       haversineDistance: 13343.391197347048,
+      rhumbDistance: 13404.399897870455,
       initialBearing: 125.26438968275465,
       midpoint: [0, 0]
     },
@@ -137,6 +149,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 0,
       finalBearing: 180,
       haversineDistance: 0,
+      rhumbDistance: 0,
       initialBearing: 0,
       midpoint: [-45.00000000000005, -45]
     },
@@ -147,6 +160,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 7076.401799751738,
       finalBearing: 54.735610317245346,
       haversineDistance: 6671.695598673525,
+      rhumbDistance: 7076.401799751738,
       initialBearing: 125.26438968275465,
       midpoint: [0, -54.735610317245346]
     },
@@ -157,6 +171,7 @@ describe('ol.Sphere', function() {
       equirectangularDistance: 0,
       finalBearing: 180,
       haversineDistance: 0,
+      rhumbDistance: 0,
       initialBearing: 0,
       midpoint: [45.00000000000005, -45]
     }
@@ -209,6 +224,19 @@ describe('ol.Sphere', function() {
         e = expected[i];
         expect(sphere.haversineDistance(e.c1, e.c2)).to.roughlyEqual(
             e.haversineDistance, 1e-9);
+      }
+    });
+
+  });
+
+  describe('rhumbDistance', function() {
+
+    it('results match Chris Veness\'s reference implementation', function() {
+      var e, i;
+      for (i = 0; i < expected.length; ++i) {
+        e = expected[i];
+        expect(sphere.rhumbLineDistance(e.c1, e.c2)).to.roughlyEqual(
+            e.rhumbDistance, 1e-9);
       }
     });
 


### PR DESCRIPTION
New method parameters enable the generation of useful LineString length results from
geometries in any projection. Calculation method can be specified, with
a suitable default being selected. Projection must always be specified (a breaking change).
New tests have been added for ol.Sphere (RhumbLineDistance) and ol.geom.LineString (getLength method). The Measure example is corrected.

I anticipate a new PR for fixing the getArea method of ol.geom.LinearRing and ol.geom.Polygon. This method also needs a mandatory projection parameter and should have an optional calculation method - Cartesian or Spherical.

When there is API access to the GreatCircle generator in ol.geom.flat.geodesic then a new example plotting the Rhumb Line and Great Circle between New York and Tokyo and showing their lengths, would make sense.
