### PR TITLE
Remove extent to the list of loaded extent in case of server error/restriction

### DIFF
--- a/src/ol/source/vectorsource.js
+++ b/src/ol/source/vectorsource.js
@@ -793,6 +793,27 @@ ol.source.Vector.prototype.loadFeatures = function(
 
 
 /**
+ * Remove the current extent from the list of loaded extent.
+ * @param {ol.Extent} extent Extent.
+ * @api
+ */
+ol.source.Vector.prototype.removeFromLoadedExtent = function(
+    extent) {
+  var loadedExtentsRtree = this.loadedExtentsRtree_;
+  var obj;
+  loadedExtentsRtree.forEachInExtent(extent, function(object) {
+    if (ol.extent.equals(object.extent, extent)) {
+      obj = object;
+      return true;
+    }
+  });
+  if (obj) {
+    loadedExtentsRtree.remove(obj);
+  }
+};
+
+
+/**
  * Remove a single feature from the source.  If you want to remove all features
  * at once, use the {@link ol.source.Vector#clear source.clear()} method
  * instead.


### PR DESCRIPTION
This method offers the possibility of removing the current extent of the list of already loaded extent . In this way, the current extent ( or smaller extents ) can be (re)loaded on server error.

The creation of this code has been motivated by the impossibility to load "children" tiles when a lower zoom tile was marked as treated , even if the server returned an error (especially due to the async. of http method in JS). In my case, the data are too dense to be displayed at certain zoom levels, but may be drawn on a higher zoom level. I could probably use the notion of minZoom , but in my case, the threshold zoom level can not be determined beforehand.

I'm not satisfied with the method name. Maybe can you have a better proposal ?

Usage (example with http helper from AngularJS) :

```
            var vectorSource = new ol.source.Vector({
              loader: function(extent, resolution, projection) {
                var _url = options.featuresUrl.replace("{id}", annotation.id) +
                  "?format=json&bbox=" + extent.join(',');

                $http.get(_url).success(function(data, status, headers, config) {
                  var features = jsonFormat.readFeatures(data);
                  vectorSource.addFeatures(features);
                }).error(function(data, status, headers, config) {
                  if (status === 500 && data.cause == "Too many results")
                    vectorSource.removeFromLoadedExtent(extent);
                });
              },
              strategy: ol.loadingstrategy.tile(ol.tilegrid.createXYZ({})),
              projection: 'EPSG:3857'
            });

```

Can also be a solution for :
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/ol3-dev/vu9eyrGLIrY/reV2RXkR5Q0J
