### PR TITLE
Remove the mouse only limitation for ol.interaction.DragBox

### DIFF
--- a/src/ol/interaction/dragbox.js
+++ b/src/ol/interaction/dragbox.js
@@ -26,8 +26,6 @@ ol.DRAG_BOX_HYSTERESIS_PIXELS_SQUARED =
  * (see {@link ol.interaction.DragZoom} and
  * {@link ol.interaction.DragRotateAndZoom}).
  *
- * This interaction is only supported for mouse devices.
- *
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @fires ol.interaction.DragBox.Event
@@ -97,10 +95,6 @@ ol.interaction.DragBox.defaultBoxEndCondition = function(mapBrowserEvent,
  * @private
  */
 ol.interaction.DragBox.handleDragEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return;
-  }
-
   this.box_.setPixels(this.startPixel_, mapBrowserEvent.pixel);
 
   this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType.BOXDRAG,
@@ -134,10 +128,6 @@ ol.interaction.DragBox.prototype.onBoxEnd = ol.nullFunction;
  * @private
  */
 ol.interaction.DragBox.handleUpEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return true;
-  }
-
   this.box_.setMap(null);
 
   if (this.boxEndCondition_(mapBrowserEvent,
@@ -157,12 +147,7 @@ ol.interaction.DragBox.handleUpEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.DragBox.handleDownEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return false;
-  }
-
-  if (ol.events.condition.mouseActionButton(mapBrowserEvent) &&
-      this.condition_(mapBrowserEvent)) {
+  if (ol.events.condition.primaryAction(mapBrowserEvent) && this.condition_(mapBrowserEvent)) {
     this.startPixel_ = mapBrowserEvent.pixel;
     this.box_.setMap(mapBrowserEvent.map);
     this.box_.setPixels(this.startPixel_, this.startPixel_);

--- a/src/ol/interaction/dragrotate.js
+++ b/src/ol/interaction/dragrotate.js
@@ -14,8 +14,6 @@ goog.require('ol.interaction.Pointer');
  * normally combined with an {@link ol.events.condition} that limits
  * it to when the alt and shift keys are held down.
  *
- * This interaction is only supported for mouse devices.
- *
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.DragRotateOptions=} opt_options Options.
@@ -59,10 +57,6 @@ ol.inherits(ol.interaction.DragRotate, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.DragRotate.handleDragEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return;
-  }
-
   var map = mapBrowserEvent.map;
   var size = map.getSize();
   var offset = mapBrowserEvent.pixel;
@@ -86,10 +80,6 @@ ol.interaction.DragRotate.handleDragEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.DragRotate.handleUpEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return true;
-  }
-
   var map = mapBrowserEvent.map;
   var view = map.getView();
   view.setHint(ol.View.Hint.INTERACTING, -1);
@@ -107,12 +97,7 @@ ol.interaction.DragRotate.handleUpEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.DragRotate.handleDownEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return false;
-  }
-
-  if (ol.events.condition.mouseActionButton(mapBrowserEvent) &&
-      this.condition_(mapBrowserEvent)) {
+  if (ol.events.condition.primaryAction(mapBrowserEvent) && this.condition_(mapBrowserEvent)) {
     var map = mapBrowserEvent.map;
     map.getView().setHint(ol.View.Hint.INTERACTING, 1);
     this.lastAngle_ = undefined;

--- a/src/ol/interaction/dragrotateandzoom.js
+++ b/src/ol/interaction/dragrotateandzoom.js
@@ -13,9 +13,7 @@ goog.require('ol.interaction.Pointer');
  * on the map.  By default, this interaction is limited to when the shift
  * key is held down.
  *
- * This interaction is only supported for mouse devices.
- *
- * And this interaction is not included in the default interactions.
+ * This interaction is not included in the default interactions.
  *
  * @constructor
  * @extends {ol.interaction.Pointer}
@@ -73,10 +71,6 @@ ol.inherits(ol.interaction.DragRotateAndZoom, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.DragRotateAndZoom.handleDragEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return;
-  }
-
   var map = mapBrowserEvent.map;
   var size = map.getSize();
   var offset = mapBrowserEvent.pixel;
@@ -109,10 +103,6 @@ ol.interaction.DragRotateAndZoom.handleDragEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.DragRotateAndZoom.handleUpEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return true;
-  }
-
   var map = mapBrowserEvent.map;
   var view = map.getView();
   view.setHint(ol.View.Hint.INTERACTING, -1);
@@ -132,10 +122,6 @@ ol.interaction.DragRotateAndZoom.handleUpEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.DragRotateAndZoom.handleDownEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return false;
-  }
-
   if (this.condition_(mapBrowserEvent)) {
     mapBrowserEvent.map.getView().setHint(ol.View.Hint.INTERACTING, 1);
     this.lastAngle_ = undefined;


### PR DESCRIPTION
If possible, remove the hard coded mouse only limitation for `ol.interaction.DragBox`, `ol.interaction.DragRotateAndZoom` and `ol.interaction.DragRotate`.

See https://groups.google.com/d/msg/ol3-dev/9ojeuOXXREQ/iceX5ODQC4oJ
