### PR TITLE
Interaction zindex

### DIFF
--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -196,7 +196,8 @@ ol.interaction.Select = function(opt_options) {
     style: options.style ? options.style :
         ol.interaction.Select.getDefaultStyleFunction(),
     updateWhileAnimating: true,
-    updateWhileInteracting: true
+    updateWhileInteracting: true,
+    zIndex: goog.isDef(options.zIndex) ? options.zIndex : Infinity
   });
 
   var features = this.featureOverlay_.getSource().getFeaturesCollection();

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -171,8 +171,9 @@ ol.layer.Layer.prototype.setMap = function(map) {
     this.mapPrecomposeKey_ = goog.events.listen(
         map, ol.render.EventType.PRECOMPOSE, function(evt) {
           var layerState = this.getLayerState();
+          var zIndex = this.getZIndex();
           layerState.managed = false;
-          layerState.zIndex = Infinity;
+          layerState.zIndex = goog.isDef(zIndex) ? zIndex : Infinity;
           evt.frameState.layerStatesArray.push(layerState);
           evt.frameState.layerStates[goog.getUid(this)] = layerState;
         }, false, this);

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -173,7 +173,7 @@ ol.layer.Layer.prototype.setMap = function(map) {
           var layerState = this.getLayerState();
           var zIndex = this.getZIndex();
           layerState.managed = false;
-          layerState.zIndex = goog.isDef(zIndex) ? zIndex : Infinity;
+          layerState.zIndex = (goog.isDef(zIndex) && zIndex != 0) ? zIndex : Infinity;
           evt.frameState.layerStatesArray.push(layerState);
           evt.frameState.layerStates[goog.getUid(this)] = layerState;
         }, false, this);


### PR DESCRIPTION
I've to display the select overlay and one feature what frame vertex. The problem is this feature render under the select overlay.
The idea is to be able to set zIndex for interaction overlay (not necessary the select interaction), like that :

```
this.selectInteraction = new ol.interaction.Select({
    layers: [myLayer],
    zIndex: 10
});
```

Then we can create a layer with an higher zIndex to render it over. Of course this layer will be rendered over all layers added with addLayer map method.

Before :

![image](https://cloud.githubusercontent.com/assets/7794435/10607625/18e95c44-773b-11e5-9a49-a0c1b4cf0a3d.png)

Now :

![image](https://cloud.githubusercontent.com/assets/7794435/10607669/5efb4b7a-773b-11e5-93bb-5f0acee1de09.png)

Thanks
