### PR TITLE
Update CQL.js

### DIFF
--- a/lib/OpenLayers/Format/CQL.js
+++ b/lib/OpenLayers/Format/CQL.js
@@ -31,7 +31,7 @@ OpenLayers.Format.CQL = (function() {
         IS_NULL: /^IS NULL/i,
         COMMA: /^,/,
         LOGICAL: /^(AND|OR)/i,
-        VALUE: /^('([^']|'')*'|\d+(\.\d*)?|\.\d+)/,
+        VALUE: /^('([^']|'')*'|^-?\d*(\.\d+)?)/,
         LPAREN: /^\(/,
         RPAREN: /^\)/,
         SPATIAL: /^(BBOX|INTERSECTS|DWITHIN|WITHIN|CONTAINS)/i,


### PR DESCRIPTION
The ReEx for CQL's BBOX VALUE didn't account for positive and negative coordinates.  For example:

BBOX( the_geom, 1, 2, 3, 4 ) worked but BBOX( the_geom, -180, -90, 180, 90 ) does not.   

Replaced it with one that does.