### PR TITLE
Useful getLength and getArea methods

### DIFF
--- a/examples/measure.html
+++ b/examples/measure.html
@@ -1,10 +1,12 @@
 ---
 layout: example.html
 title: Measure example
-shortdesc: Example of using the ol.interaction.Draw interaction for creating simple measuring application.
+shortdesc: Example of using the ol.interaction.Draw interaction for creating a simple measuring application.
 docs: >
-  <p><i>NOTE: If use geodesic measures is not checked, measure is done in simple way on projected plane. Earth curvature is not taken into account</i></p>
-tags: "draw, edit, measure, vector"
+  <p><i>NOTE: Area and length calculations are done using ol.proj getLength and ol.proj getArea to get answers in meters or square meters at any latitude.
+  The ol.geom.Linestring getLength method does not give a length in meters for EPSG:3857 or EPSG:4326 linestrings.
+  The ol.geom.Polygon getArea method does not give an area in square meters for EPSG:3857 or EPSG:4326 polygons.</i></p>
+tags: "draw, edit, measure, vector, length, area"
 ---
 <div class="row-fluid">
   <div class="span12">
@@ -17,5 +19,5 @@ tags: "draw, edit, measure, vector"
       <option value="length">Length</option>
       <option value="area">Area</option>
     </select>
-    <label class="checkbox"><input type="checkbox" id="geodesic"/>use geodesic measures</label>
+
 </form>

--- a/examples/measure.html
+++ b/examples/measure.html
@@ -4,8 +4,8 @@ title: Measure example
 shortdesc: Example of using the ol.interaction.Draw interaction for creating a simple measuring application.
 docs: >
   <p><i>NOTE: Area and length calculations are done using ol.proj getLength and ol.proj getArea to get answers in meters or square meters at any latitude.
-  The ol.geom.Linestring getLength method does not give a length in meters for EPSG:3857 or EPSG:4326 linestrings.
-  The ol.geom.Polygon getArea method does not give an area in square meters for EPSG:3857 or EPSG:4326 polygons.</i></p>
+  The ol.geom.Linestring getLength method does not give a true length in meters for EPSG:3857 or EPSG:4326 linestrings.
+  The ol.geom.Polygon getArea method does not give a true area in square meters for EPSG:3857 or EPSG:4326 polygons.</i></p>
 tags: "draw, edit, measure, vector, length, area"
 ---
 <div class="row-fluid">

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -1,8 +1,9 @@
 goog.require('ol.Map');
 goog.require('ol.Observable');
 goog.require('ol.Overlay');
-goog.require('ol.Sphere');
 goog.require('ol.View');
+goog.require('ol.control');
+goog.require('ol.control.ScaleLine');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Polygon');
 goog.require('ol.interaction.Draw');
@@ -15,9 +16,6 @@ goog.require('ol.style.Circle');
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
-
-
-var wgs84Sphere = new ol.Sphere(6378137);
 
 var raster = new ol.layer.Tile({
   source: new ol.source.MapQuest({layer: 'sat'})
@@ -120,6 +118,7 @@ var pointerMoveHandler = function(evt) {
   $(helpTooltipElement).removeClass('hidden');
 };
 
+var scaleLineControl = new ol.control.ScaleLine();
 
 var map = new ol.Map({
   layers: [raster, vector],
@@ -127,7 +126,8 @@ var map = new ol.Map({
   view: new ol.View({
     center: [-11000000, 4600000],
     zoom: 15
-  })
+  }),
+  controls: ol.control.defaults({}).extend([scaleLineControl])
 });
 
 map.on('pointermove', pointerMoveHandler);
@@ -260,19 +260,11 @@ typeSelect.onchange = function(e) {
  * @return {string}
  */
 var formatLength = function(line) {
-  var length;
-  if (geodesicCheckbox.checked) {
-    var coordinates = line.getCoordinates();
-    length = 0;
-    var sourceProj = map.getView().getProjection();
-    for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-      var c1 = ol.proj.transform(coordinates[i], sourceProj, 'EPSG:4326');
-      var c2 = ol.proj.transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
-      length += wgs84Sphere.haversineDistance(c1, c2);
-    }
-  } else {
-    length = Math.round(line.getLength() * 100) / 100;
-  }
+
+  var coordinates = line.getCoordinates();
+  var proj = map.getView().getProjection();
+  var length = ol.proj.getLength(coordinates, proj);
+
   var output;
   if (length > 100) {
     output = (Math.round(length / 1000 * 100) / 100) +
@@ -286,21 +278,16 @@ var formatLength = function(line) {
 
 
 /**
- * format length output
+ * format area output
  * @param {ol.geom.Polygon} polygon
  * @return {string}
  */
 var formatArea = function(polygon) {
-  var area;
-  if (geodesicCheckbox.checked) {
-    var sourceProj = map.getView().getProjection();
-    var geom = /** @type {ol.geom.Polygon} */(polygon.clone().transform(
-        sourceProj, 'EPSG:4326'));
-    var coordinates = geom.getLinearRing(0).getCoordinates();
-    area = Math.abs(wgs84Sphere.geodesicArea(coordinates));
-  } else {
-    area = polygon.getArea();
-  }
+
+  var coordinates = polygon.getCoordinates();
+  var proj = map.getView().getProjection();
+  var area = ol.proj.getArea(coordinates, proj);
+
   var output;
   if (area > 10000) {
     output = (Math.round(area / 1000000 * 100) / 100) +

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -137,7 +137,6 @@ $(map.getViewport()).on('mouseout', function() {
 });
 
 var typeSelect = document.getElementById('type');
-var geodesicCheckbox = document.getElementById('geodesic');
 
 var draw; // global so we can remove it later
 function addInteraction() {

--- a/src/ol/geom/geom.jsdoc
+++ b/src/ol/geom/geom.jsdoc
@@ -1,3 +1,33 @@
 /**
+ *
+ * The ol.geom namespace contains classes representing geometries.
+ * The coordinates used to define geometries can be of any {@link ol.proj.Projection}.
+ *
+ * For calculating length, {@link ol.geom.LineString#getLength} is provided.
+ * For calculating area, {@link ol.geom.Polygon#getArea} is provided. These
+ * planar methods need to be used with care. Neither will give answers in
+ * meters for EPSG:3857 or EPSG:4326 projection coordinates. These projections
+ * both have a scale, in meters, that varies with latitude.
+ * For these and similar projections, use the {@link ol.proj.getLength} and
+ * {@link ol.proj.getArea} methods instead. These perform calculations on the
+ * sphere. They can be passed coordinates obtained using
+ * {@link ol.geom.LineString#getCoordinates} or
+ * {@link ol.geom.Polygon#getCoordinates}.
+ *
+ * Some projections, such as UTM and BNG (EPSG:27700), have near constant scale
+ * (meters per pixel) across their extent. Such projections are normally
+ * used for large scale topographic maps. These types of maps are often printed
+ * with a grid and enable good measurements to be made with a ruler or
+ * protractor. The {@link ol.geom.LineString#getLength} and
+ * {@link ol.geom.Polygon#getArea} methods can be used with
+ * this class of projection and will produce more accurate results than the
+ * {@link ol.proj.getLength} or {@link ol.proj.getArea} methods.
+ *
+ * The {@link ol.geom.LineString#getLength} or
+ * {@link ol.geom.Polygon#getArea} methods should always be used for
+ * geometries with coordinates using a projection with units of `pixels`.
+ * An attempt to use the {@link ol.proj.getLength} and {@link ol.proj.getArea}
+ * methods for these will cause an exception.
+ *
  * @namespace ol.geom
  */

--- a/src/ol/geom/geom.jsdoc
+++ b/src/ol/geom/geom.jsdoc
@@ -5,20 +5,21 @@
  *
  * For calculating length, {@link ol.geom.LineString#getLength} is provided.
  * For calculating area, {@link ol.geom.Polygon#getArea} is provided. These
- * planar methods need to be used with care. Neither will give answers in
- * meters for EPSG:3857 or EPSG:4326 projection coordinates. These projections
- * both have a scale, in meters, that varies with latitude.
- * For these and similar projections, use the {@link ol.proj.getLength} and
- * {@link ol.proj.getArea} methods instead. These perform calculations on the
- * sphere. They can be passed coordinates obtained using
+ * methods operate on the projected plane and need to be used with care.
+ * Neither will give answers in surface meters for EPSG:3857 or EPSG:4326
+ * projection coordinates. These projections both have a scale, in meters,
+ * that varies with latitude. For these and similar projections,
+ * use the {@link ol.proj.getLength} and {@link ol.proj.getArea} methods
+ * to obtain surface lengths and areas. These perform calculations on
+ * the sphere. They can be passed coordinates obtained using
  * {@link ol.geom.LineString#getCoordinates} or
  * {@link ol.geom.Polygon#getCoordinates}.
  *
  * Some projections, such as UTM and BNG (EPSG:27700), have near constant scale
  * (meters per pixel) across their extent. Such projections are normally
  * used for large scale topographic maps. These types of maps are often printed
- * with a grid and enable good measurements to be made with a ruler or
- * protractor. The {@link ol.geom.LineString#getLength} and
+ * with a grid and enable good measurements to be made with a ruler.
+ * The {@link ol.geom.LineString#getLength} and
  * {@link ol.geom.Polygon#getArea} methods can be used with
  * this class of projection and will produce more accurate results than the
  * {@link ol.proj.getLength} or {@link ol.proj.getArea} methods.

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -168,6 +168,8 @@ ol.geom.LineString.prototype.getCoordinates = function() {
 
 /**
  * Return the length of the linestring on projected plane.
+ * To get a length in meters, use {@link ol.proj.getLength} instead.
+ * See {@link ol.geom} for more details.
  * @return {number} Length (on projected plane).
  * @api stable
  */

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -167,8 +167,8 @@ ol.geom.LineString.prototype.getCoordinates = function() {
 
 
 /**
- * Return the length of the linestring on projected plane.
- * To get a length in meters, use {@link ol.proj.getLength} instead.
+ * Return the length of the linestring on the projected plane.
+ * To get a surface length in meters, use {@link ol.proj.getLength} instead.
  * See {@link ol.geom} for more details.
  * @return {number} Length (on projected plane).
  * @api stable

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -159,6 +159,8 @@ ol.geom.MultiPolygon.prototype.containsXY = function(x, y) {
 
 /**
  * Return the area of the multipolygon on projected plane.
+ * To get an area in square meters, use {@link ol.proj.getArea} instead.
+ * See {@link ol.geom} for more details.
  * @return {number} Area (on projected plane).
  * @api stable
  */

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -158,8 +158,8 @@ ol.geom.MultiPolygon.prototype.containsXY = function(x, y) {
 
 
 /**
- * Return the area of the multipolygon on projected plane.
- * To get an area in square meters, use {@link ol.proj.getArea} instead.
+ * Return the area of the multipolygon on the projected plane.
+ * To get a surface area in square meters, use {@link ol.proj.getArea} instead.
  * See {@link ol.geom} for more details.
  * @return {number} Area (on projected plane).
  * @api stable

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -146,6 +146,8 @@ ol.geom.Polygon.prototype.containsXY = function(x, y) {
 
 /**
  * Return the area of the polygon on projected plane.
+ * To get an area in square meters, use {@link ol.proj.getArea} instead.
+ * See {@link ol.geom} for more details.
  * @return {number} Area (on projected plane).
  * @api stable
  */

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -145,8 +145,8 @@ ol.geom.Polygon.prototype.containsXY = function(x, y) {
 
 
 /**
- * Return the area of the polygon on projected plane.
- * To get an area in square meters, use {@link ol.proj.getArea} instead.
+ * Return the area of the polygon on the projected plane.
+ * To get a surface area in square meters, use {@link ol.proj.getArea} instead.
  * See {@link ol.geom} for more details.
  * @return {number} Area (on projected plane).
  * @api stable

--- a/src/ol/proj/proj.js
+++ b/src/ol/proj/proj.js
@@ -489,11 +489,10 @@ ol.proj.getArea = function(coordinates, projection, opt_sphere) {
   var totalArea = 0;
   var proj = ol.proj.get(projection);
   var units = proj.getUnits();
-
   var sphere = (opt_sphere !== undefined) ? opt_sphere : ol.sphere.NORMAL;
-  var i;
-
+  var ring;
   var coordss = [];
+  var aAsLen;
 
   goog.asserts.assert((units != ol.proj.Units.PIXELS) &&
       (units != ol.proj.Units.TILE_PIXELS),
@@ -505,25 +504,28 @@ ol.proj.getArea = function(coordinates, projection, opt_sphere) {
   else {
     coordss = coordinates;
   }
+  aAsLen = coordss.length;
 
-  coordss.forEach(function(coords, index, array) {
+  for (ring = 0; ring < aAsLen; ring++) {
 
+    var coords = coordss[ring];
     var aLen = coords.length;
     var area = 0;
+    var i;
 
     if (units == ol.proj.Units.DEGREES) {
       area = sphere.geodesicArea(coords);
     }
     else {
-      var transformedCoords = [];
+      var transformedCoords = coords.slice();
       for (i = 0; i < aLen; i++) {
-        transformedCoords[i] = ol.proj.toLonLat(coords[i], proj);
+        transformedCoords[i] = ol.proj.toLonLat(transformedCoords[i], proj);
       }
       area = sphere.geodesicArea(transformedCoords);
     }
 
     totalArea += area;
-  });
+  }
   return Math.abs(totalArea);
 };
 

--- a/src/ol/proj/proj.jsdoc
+++ b/src/ol/proj/proj.jsdoc
@@ -38,7 +38,7 @@
  * object has been created with `setExtent`, for example,
  * `ol.proj.get('EPSG:1234').setExtent(extent)`.
  *
- * To calculate lengths in meters and areas in square meters the
+ * To calculate surface lengths in meters and areas in square meters the
  * spherical {@link ol.proj.getLength} and {@link ol.proj.getArea} methods
  * should normally be used. See {@link ol.geom} for more details.
  *

--- a/src/ol/proj/proj.jsdoc
+++ b/src/ol/proj/proj.jsdoc
@@ -38,6 +38,10 @@
  * object has been created with `setExtent`, for example,
  * `ol.proj.get('EPSG:1234').setExtent(extent)`.
  *
+ * To calculate lengths in meters and areas in square meters the
+ * spherical {@link ol.proj.getLength} and {@link ol.proj.getArea} methods
+ * should normally be used. See {@link ol.geom} for more details.
+ *
  * In addition to Proj4js support, any transform functions can be added with
  * {@link ol.proj.addCoordinateTransforms}. To use this, you must first create
  * a {@link ol.proj.Projection} object for the new projection and add it with


### PR DESCRIPTION
This is a new attempt at providing useful methods in ol.proj that give a LineString's length in metres and a Polygon's area in square metres.

The measure example is updated to use them. A scale bar is added to it.

Notes are added about when to use ol.proj.getArea, ol.proj.getLength, ol.geom.LineString.getLength and ol.geom.Polygon.getLength.
