### PR TITLE
Do not stop event propagation and ignore clicks except on direct viewport children

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -286,15 +286,6 @@ ol.Map = function(options) {
    */
   this.overlayContainerStopEvent_ = goog.dom.createDom('DIV',
       'ol-overlaycontainer-stopevent');
-  goog.events.listen(this.overlayContainerStopEvent_, [
-    goog.events.EventType.CLICK,
-    goog.events.EventType.DBLCLICK,
-    goog.events.EventType.MOUSEDOWN,
-    goog.events.EventType.TOUCHSTART,
-    goog.events.EventType.MSPOINTERDOWN,
-    ol.MapBrowserEvent.EventType.POINTERDOWN,
-    goog.userAgent.GECKO ? 'DOMMouseScroll' : 'mousewheel'
-  ], goog.events.Event.stopPropagation);
   this.viewport_.appendChild(this.overlayContainerStopEvent_);
 
   var mapBrowserEventHandler = new ol.MapBrowserEventHandler(this);

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -318,6 +318,10 @@ ol.MapBrowserEventHandler.prototype.isMouseActionButton_ =
  */
 ol.MapBrowserEventHandler.prototype.handlePointerDown_ =
     function(pointerEvent) {
+  if (pointerEvent.browserEvent.target
+    .parentElement.className !== 'ol-viewport') {
+    return;
+  }
   this.updateActivePointers_(pointerEvent);
   var newEvent = new ol.MapBrowserPointerEvent(
       ol.MapBrowserEvent.EventType.POINTERDOWN, this.map_, pointerEvent);


### PR DESCRIPTION
This PR proposes to avoid stopping event propagation for reasons described in #4400. It's prototype code not ready for formal review but is rather up for discussion.
