### PR TITLE
Fix WFS GetFeature when featureNS is null for v1_0_0 and v2_0_0

### DIFF
--- a/lib/OpenLayers/Format/WFST/v1_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v1_0_0.js
@@ -139,7 +139,7 @@ OpenLayers.Format.WFST.v1_0_0 = OpenLayers.Class(
                 var prefix = options.featurePrefix;
                 var node = this.createElementNSPlus("wfs:Query", {
                     attributes: {
-                        typeName: (prefix ? prefix + ":" : "") +
+                        typeName: (options.featureNS ? prefix + ":" : "") +
                             options.featureType
                     }
                 });

--- a/lib/OpenLayers/Format/WFST/v2_0_0.js
+++ b/lib/OpenLayers/Format/WFST/v2_0_0.js
@@ -170,7 +170,7 @@ OpenLayers.Format.WFST.v2_0_0 = OpenLayers.Class(
                 var prefix = options.featurePrefix;
                 var node = this.createElementNSPlus("wfs:Query", {
                     attributes: {
-                        typeNames: (prefix ? prefix + ":" : "") +
+                        typeNames: (options.featureNS ? prefix + ":" : "") +
                             options.featureType,
                         srsName: options.srsName
                     }

--- a/tests/Format/WFST/v1_0_0.html
+++ b/tests/Format/WFST/v1_0_0.html
@@ -75,7 +75,7 @@
             featureType: "states",
             featurePrefix: "topp"
         });
-        var exp = "topp:states";
+        var exp = "states";
         var got = format.writeNode("wfs:Query").getAttribute("typeName");
         t.eq(got, exp, "Query without featureNS but with featurePrefix queries for the correct featureType");
     }

--- a/tests/Format/WFST/v2_0_0.html
+++ b/tests/Format/WFST/v2_0_0.html
@@ -278,7 +278,7 @@
             featureType: "states",
             featurePrefix: "topp"
         });
-        var exp = "topp:states";
+        var exp = "states";
         var got = format.writeNode("wfs:Query").getAttribute("typeNames");
         t.eq(got, exp, "Query without featureNS but with featurePrefix queries for the correct featureType");
     }


### PR DESCRIPTION
Commit https://github.com/openlayers/openlayers/commit/ff28cf458a31ab5341e9aa20e713b5213822293f fixed problem partially - only for WFST/v1_1_0.js. This PR makes the same for WFS 1.0.0 and 2.0.0.

I'm already in ICLA [list](https://github.com/openlayers/cla/blob/master/signed-agreements.md) as `Rykov, Denis Rykov (@dr)`.