### PR TITLE
Make it clear that the examples are for OpenLayers 2

### DIFF
--- a/examples/example-list.html
+++ b/examples/example-list.html
@@ -10,7 +10,7 @@
         "This Frame -> View source" when right clicking on the example. If not,
         choose to open the example in a new window (via the context menu
         click on the link), and view source from there. -->
-        <title>OpenLayers Examples</title>
+        <title>OpenLayers 2 Examples</title>
         <link rel="alternate" href="example-list.xml" type="application/atom+xml" />
         <link rel="stylesheet" href="style.css" type="text/css">
         <style type="text/css">
@@ -266,7 +266,7 @@
                 <div id="logo">
                 <img src="http://openlayers.org/two/images/OpenLayers.trac.png"
                  />
-                 OpenLayers
+                 OpenLayers 2
              </div>
                 <p>
                     <input autofocus placeholder="filter by keywords..." type="text" id="keywords" />


### PR DESCRIPTION
This adds " 2" to "OpenLayers" in the example index title and heading.