### PR TITLE
Addition of updateSketchCondition on Ol.interaction.draw as a way to fix #3907

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2603,6 +2603,16 @@ olx.interaction.DrawOptions.prototype.geometryName;
  */
 olx.interaction.DrawOptions.prototype.condition;
 
+/**
+ * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether the current sketch being drawn should be updated. This
+ * can be used to either limit the scope of the feature being drawn, or to
+ * skip events caused panning/zooming on a touch device. By default
+ * {@link ol.events.condition.always}, i.e. it is always updated.
+ * @type {ol.events.ConditionType|undefined}
+ * @api
+ */
+olx.interaction.DrawOptions.prototype.updateSketchCondition;
 
 /**
  * Condition that activates freehand drawing for lines and polygons. This

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -297,6 +297,13 @@ ol.interaction.Draw = function(options) {
    * @private
    * @type {ol.events.ConditionType}
    */
+  this.updateSketchCondition_ = options.updateSketchCondition ?
+      options.updateSketchCondition : ol.events.condition.always;
+
+  /**
+   * @private
+   * @type {ol.events.ConditionType}
+   */
   this.freehandCondition_ = options.freehandCondition ?
       options.freehandCondition : ol.events.condition.shiftKeyOnly;
 
@@ -528,6 +535,9 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
  * @private
  */
 ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
+  if (!this.updateSketchCondition_(event)) {
+    return;
+  }
   var coordinate = event.coordinate;
   var geometry = this.sketchFeature_.getGeometry();
   goog.asserts.assertInstanceof(geometry, ol.geom.SimpleGeometry,


### PR DESCRIPTION
By adding a updateSketchCondition we can fix issue #3907.

``` javascript
        var draw = new ol.interaction.Draw({
          features: featureCollection,
          type: 'Polygon',
          updateSketchCondition: function(event) {
            return event.originalEvent.type !== 'touchmove';
          }
        });
```

The concept of limiting the modifyDrawing_ function might also be used by other use cases like creating a boundingbox available to draw the features.
