### PR TITLE
Allow ol.source.Cluster to cluster by a physical distance

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3912,6 +3912,7 @@ olx.source.BingMapsOptions.prototype.wrapX;
 
 /**
  * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ *     clusterUnits: (ol.source.ClusterUnits|undefined),
  *     distance: (number|undefined),
  *     extent: (ol.Extent|undefined),
  *     format: (ol.format.Feature|undefined),

--- a/src/ol/source/clustersource.js
+++ b/src/ol/source/clustersource.js
@@ -13,6 +13,17 @@ goog.require('ol.geom.Point');
 goog.require('ol.source.Vector');
 
 
+/**
+ * Cluster source clustering units. One of 'pixels', 'meters'.
+ * @enum {string}
+ * @api
+ */
+ol.source.ClusterUnits = {
+  PIXELS: 'pixels',
+  METERS: 'meters'
+};
+
+
 
 /**
  * @classdesc
@@ -43,6 +54,12 @@ ol.source.Cluster = function(options) {
    * @private
    */
   this.distance_ = options.distance !== undefined ? options.distance : 20;
+
+  /**
+   * @type {ol.source.ClusterUnits}
+   * @private
+   */
+  this.clusterUnits_ = options.clusterUnits || ol.source.ClusterUnits.PIXELS;
 
   /**
    * @type {Array.<ol.Feature>}
@@ -109,6 +126,10 @@ ol.source.Cluster.prototype.cluster_ = function() {
   this.features_.length = 0;
   var extent = ol.extent.createEmpty();
   var mapDistance = this.distance_ * this.resolution_;
+  if (this.clusterUnits_ === ol.source.ClusterUnits.METERS) {
+    mapDistance = this.distance_;
+  }
+
   var features = this.source_.getFeatures();
 
   /**


### PR DESCRIPTION
Previously, ol.source.Cluster only created clusters using a distance in pixels on the screen. This is useful for decluttering features as a user changes zoom level.

This change adds a `ClusterUnits` option to ol.source.Cluster to allow clustering by a physical distance as well. This is useful when you want the clusters to be independent of zoom level. For example, consider a situation where you want to automatically pan/zoom between clusters of geographical features.

This new option defaults to the old behavior if it is undefined.
