### PR TITLE
Added updateSketchCondition as a Draw Interaction option

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2658,6 +2658,16 @@ olx.interaction.DrawOptions.prototype.geometryName;
  */
 olx.interaction.DrawOptions.prototype.condition;
 
+/**
+ * A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether the current sketch being drawn should be updated. This
+ * can be used to either limit the scope of the feature being drawn, or to
+ * skip events caused by panning/zooming on a touch device. By default
+ * {@link ol.events.condition.always}, i.e. it is always updated.
+ * @type {ol.events.ConditionType|undefined}
+ * @api
+ */
+olx.interaction.DrawOptions.prototype.updateSketchCondition;
 
 /**
  * Condition that activates freehand drawing for lines and polygons. This

--- a/src/ol/interaction/drawinteraction.js
+++ b/src/ol/interaction/drawinteraction.js
@@ -297,6 +297,13 @@ ol.interaction.Draw = function(options) {
    * @private
    * @type {ol.events.ConditionType}
    */
+  this.updateSketchCondition_ = options.updateSketchCondition ?
+      options.updateSketchCondition : ol.events.condition.always;
+
+  /**
+   * @private
+   * @type {ol.events.ConditionType}
+   */
   this.freehandCondition_ = options.freehandCondition ?
       options.freehandCondition : ol.events.condition.shiftKeyOnly;
 
@@ -528,6 +535,9 @@ ol.interaction.Draw.prototype.startDrawing_ = function(event) {
  * @private
  */
 ol.interaction.Draw.prototype.modifyDrawing_ = function(event) {
+  if (!this.updateSketchCondition_(event)) {
+    return;
+  }
   var coordinate = event.coordinate;
   var geometry = this.sketchFeature_.getGeometry();
   goog.asserts.assertInstanceof(geometry, ol.geom.SimpleGeometry,


### PR DESCRIPTION
Enables the developer to specify on which browser event the sketch is updated.

This is a squashed and rebased version of #4556 which is a proposed fix for #3907.

One could debate if the current default behavior for the mobile case should be changed, but at least this makes it possible to change it.
