### PR TITLE
Overlay: No touch scrolling in ol.Overlay

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -282,6 +282,7 @@ ol.Map = function(options) {
     ol.events.EventType.DBLCLICK,
     ol.events.EventType.MOUSEDOWN,
     ol.events.EventType.TOUCHSTART,
+    ol.events.EventType.TOUCHMOVE,
     ol.events.EventType.MSPOINTERDOWN,
     ol.MapBrowserEvent.EventType.POINTERDOWN,
     ol.events.EventType.MOUSEWHEEL,

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -295,7 +295,7 @@ ol.Map = function(options) {
     ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE,ol.events.Event.stopPropagation);
   }, this);
   ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHEND, function(e) {
-    ol.events.unlisten(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE);
+    ol.events.unlisten(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE, ol.events.Event.stopPropagation, this);
   },this);
   this.viewport_.appendChild(this.overlayContainerStopEvent_);
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -292,10 +292,10 @@ ol.Map = function(options) {
         ol.events.Event.stopPropagation);
   }
   ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHSTART, function(e) {
-		ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE,ol.events.Event.stopPropagation);
+    ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE,ol.events.Event.stopPropagation);
   }, this);
   ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHEND, function(e) {
-		ol.events.unlisten(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE);
+    ol.events.unlisten(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE);
   },this);
   this.viewport_.appendChild(this.overlayContainerStopEvent_);
 

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -282,7 +282,6 @@ ol.Map = function(options) {
     ol.events.EventType.DBLCLICK,
     ol.events.EventType.MOUSEDOWN,
     ol.events.EventType.TOUCHSTART,
-    ol.events.EventType.TOUCHMOVE,
     ol.events.EventType.MSPOINTERDOWN,
     ol.MapBrowserEvent.EventType.POINTERDOWN,
     ol.events.EventType.MOUSEWHEEL,
@@ -292,6 +291,12 @@ ol.Map = function(options) {
     ol.events.listen(this.overlayContainerStopEvent_, overlayEvents[i],
         ol.events.Event.stopPropagation);
   }
+  ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHSTART, function(e) {
+		ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE,ol.events.Event.stopPropagation);
+  }, this);
+  ol.events.listen(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHEND, function(e) {
+		ol.events.unlisten(this.overlayContainerStopEvent_, ol.events.EventType.TOUCHMOVE);
+  },this);
   this.viewport_.appendChild(this.overlayContainerStopEvent_);
 
   /**


### PR DESCRIPTION
Touch scrolling in an overlay is prevented by ol.pointer.TouchSource.prototype.touchmove. If the overlay has set the style properties max-height and overflow: auto, the overlay is not scrollable on touch devices (iOS, Android, Chrome Dev Tools)

Fiddle: http://jsfiddle.net/ttgo4wr0/1/

The workaround in issue #3253 doesn't apply because the position of the overlay should get moved with the map.

A fix for this issue would be to add ol.events.EventType.TOUCHMOVE in the overlayContainerStopEvents array in map.js: c5384a4
