### PR TITLE
Using a collection for ol.interaction.Select instead of an unmanaged layer

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3010,8 +3010,7 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  * @typedef {{addCondition: (ol.events.ConditionType|undefined),
  *     condition: (ol.events.ConditionType|undefined),
  *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
- *     dontStyle: (boolean|undefined)
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null|undefined),
  *     removeCondition: (ol.events.ConditionType|undefined),
  *     toggleCondition: (ol.events.ConditionType|undefined),
  *     multi: (boolean|undefined),
@@ -3063,7 +3062,8 @@ olx.interaction.SelectOptions.prototype.layers;
 
 /**
  * Style for the selected features. By default the default edit style is used
- * (see {@link ol.style}).
+ * (see {@link ol.style}). If set to null the selected features won't be styled
+ * by the interaction.
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined}
  * @api
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3011,6 +3011,7 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  *     condition: (ol.events.ConditionType|undefined),
  *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|undefined),
+ *     dontStyle: (boolean|undefined)
  *     removeCondition: (ol.events.ConditionType|undefined),
  *     toggleCondition: (ol.events.ConditionType|undefined),
  *     multi: (boolean|undefined),

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -149,12 +149,23 @@ ol.interaction.Select = function(opt_options) {
   this.filter_ = options.filter ? options.filter :
       ol.functions.TRUE;
 
+  var style = options.style;
+
+  if (style !== undefined) {
+    if (goog.isFunction(style)) {
+      style = function(resolution) {
+        return /** @type {ol.style.StyleFunction} */ (style)(this, resolution);
+      };
+    }
+  } else {
+    style = ol.interaction.Select.getDefaultStyleFunction();
+  }
+
   /**
    * @private
-   * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null}
+   * @type {ol.style.Style|Array.<ol.style.Style>|ol.FeatureStyleFunction|null}
    */
-  this.style_ = (options.style !== undefined) ? options.style :
-      ol.interaction.Select.getDefaultStyleFunction();
+  this.style_ = style;
 
   /**
    * An association between selected feature (key)
@@ -277,15 +288,7 @@ ol.interaction.Select.prototype.getLayer = function(feature) {
 ol.interaction.Select.prototype.giveSelectedStyle_ = function(feature) {
   var key = goog.getUid(feature);
   this.featureStyleAssociation_[key] = feature.getStyle();
-  if (goog.isFunction(this.style_)) {
-    /** @type {ol.style.StyleFunction} */
-    var style = this.style_;
-    feature.setStyle(function(resolution) {
-      return style(this, resolution);
-    });
-  } else {
-    feature.setStyle(this.style_);
-  }
+  feature.setStyle(this.style_);
 };
 
 
@@ -418,7 +421,7 @@ ol.interaction.Select.prototype.setMap = function(map) {
 
 
 /**
- * @return {ol.style.StyleFunction} Styles.
+ * @return {ol.FeatureStyleFunction} Styles.
  */
 ol.interaction.Select.getDefaultStyleFunction = function() {
   var styles = ol.style.createDefaultEditingStyles();
@@ -427,8 +430,8 @@ ol.interaction.Select.getDefaultStyleFunction = function() {
   ol.array.extend(styles[ol.geom.GeometryType.GEOMETRY_COLLECTION],
       styles[ol.geom.GeometryType.LINE_STRING]);
 
-  return function(feature, resolution) {
-    return styles[feature.getGeometry().getType()];
+  return function(resolution) {
+    return styles[this.getGeometry().getType()];
   };
 };
 

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -13,9 +13,8 @@ goog.require('ol.events.Event');
 goog.require('ol.events.condition');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.interaction.Interaction');
-goog.require('ol.layer.Vector');
+goog.require('ol.Collection');
 goog.require('ol.object');
-goog.require('ol.source.Vector');
 
 
 /**
@@ -152,7 +151,7 @@ ol.interaction.Select = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.style.Style|null}
+   * @type {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction|null}
    */
   this.style_ = (options.style !== undefined) ? options.style :
       ol.interaction.Select.getDefaultStyleFunction();
@@ -161,7 +160,7 @@ ol.interaction.Select = function(opt_options) {
    * An association between selected feature (key)
    * and original style (value)
    * @private
-   * @type {Object.<number, ol.style.Style>}
+   * @type {Object.<number, ol.style.Style|Array.<ol.style.Style>|ol.FeatureStyleFunction>}
    */
   this.featureStyleAssociation_ = {};
 
@@ -272,16 +271,21 @@ ol.interaction.Select.prototype.getLayer = function(feature) {
 
 
 /**
- * @param {ol.Feature} feature
+ * @param {ol.Feature} feature Feature
  * @private
  */
-ol.interaction.Select.prototype.giveSelectedStyle_ = function (feature) {
+ol.interaction.Select.prototype.giveSelectedStyle_ = function(feature) {
   var key = goog.getUid(feature);
   this.featureStyleAssociation_[key] = feature.getStyle();
-  var style = this.style_;
-  feature.setStyle(function (resolution) {
-    return style(this, resolution);
-  });
+  if (goog.isFunction(this.style_)) {
+    /** @type {ol.style.StyleFunction} */
+    var style = this.style_;
+    feature.setStyle(function(resolution) {
+      return style(this, resolution);
+    });
+  } else {
+    feature.setStyle(this.style_);
+  }
 };
 
 
@@ -355,11 +359,11 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
         function(feature, layer) {
           if (this.filter_(feature, layer)) {
             if ((add || toggle) &&
-              !ol.array.includes(features.getArray(), feature)) {
+                !ol.array.includes(features.getArray(), feature)) {
               selected.push(feature);
               this.addFeatureLayerAssociation_(feature, layer);
             } else if ((remove || toggle) &&
-              ol.array.includes(features.getArray(), feature)) {
+                ol.array.includes(features.getArray(), feature)) {
               deselected.push(feature);
               this.removeFeatureLayerAssociation_(feature);
             }
@@ -385,10 +389,10 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
 
 
 /**
- * @param {ol.Feature} feature
+ * @param {ol.Feature} feature Feature
  * @private
  */
-ol.interaction.Select.prototype.removeSelectedStyle_ = function (feature) {
+ol.interaction.Select.prototype.removeSelectedStyle_ = function(feature) {
   var key = goog.getUid(feature);
   feature.setStyle(this.featureStyleAssociation_[key]);
   delete this.featureStyleAssociation_[key];

--- a/src/ol/interaction/selectinteraction.js
+++ b/src/ol/interaction/selectinteraction.js
@@ -114,28 +114,28 @@ ol.interaction.Select = function(opt_options) {
    * @type {ol.events.ConditionType}
    */
   this.condition_ = options.condition ?
-    options.condition : ol.events.condition.singleClick;
+      options.condition : ol.events.condition.singleClick;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
   this.addCondition_ = options.addCondition ?
-    options.addCondition : ol.events.condition.never;
+      options.addCondition : ol.events.condition.never;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
   this.removeCondition_ = options.removeCondition ?
-    options.removeCondition : ol.events.condition.never;
+      options.removeCondition : ol.events.condition.never;
 
   /**
    * @private
    * @type {ol.events.ConditionType}
    */
   this.toggleCondition_ = options.toggleCondition ?
-    options.toggleCondition : ol.events.condition.shiftKeyOnly;
+      options.toggleCondition : ol.events.condition.shiftKeyOnly;
 
   /**
    * @private
@@ -148,20 +148,14 @@ ol.interaction.Select = function(opt_options) {
    * @type {ol.interaction.SelectFilterFunction}
    */
   this.filter_ = options.filter ? options.filter :
-    ol.functions.TRUE;
+      ol.functions.TRUE;
 
   /**
    * @private
-   * @type {ol.style.Style}
+   * @type {ol.style.Style|null}
    */
-  this.style_ = options.style ? options.style :
-    ol.interaction.Select.getDefaultStyleFunction();
-
-  /**
-   * @type {boolean}
-   * @private
-   */
-  this.dontStyle_ = options.dontStyle ? options.dontStyle : false;
+  this.style_ = (options.style !== undefined) ? options.style :
+      ol.interaction.Select.getDefaultStyleFunction();
 
   /**
    * An association between selected feature (key)
@@ -233,7 +227,7 @@ ol.interaction.Select.prototype.addFeature_ = function(evt) {
   var feature = evt.element;
   goog.asserts.assertInstanceof(feature, ol.Feature,
     'feature should be an ol.Feature');
-  if (!this.dontStyle_) {
+  if (this.style_) {
     this.giveSelectedStyle_(feature);
   }
 };
@@ -271,7 +265,7 @@ ol.interaction.Select.prototype.getFeatures = function() {
  */
 ol.interaction.Select.prototype.getLayer = function(feature) {
   goog.asserts.assertInstanceof(feature, ol.Feature,
-    'feature should be an ol.Feature');
+      'feature should be an ol.Feature');
   var key = goog.getUid(feature);
   return /** @type {ol.layer.Vector} */ (this.featureLayerAssociation_[key]);
 };
@@ -317,20 +311,20 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     // pixel, or clear the selected feature(s) if there is no feature at
     // the pixel.
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
-      /**
-       * @param {ol.Feature|ol.render.Feature} feature Feature.
-       * @param {ol.layer.Layer} layer Layer.
-       * @return {boolean|undefined} Continue to iterate over the features.
-       */
-      function(feature, layer) {
-        if (this.filter_(feature, layer)) {
-          selected.push(feature);
-          this.addFeatureLayerAssociation_(feature, layer);
-          return !this.multi_;
-        }
-      }, this, this.layerFilter_);
+        /**
+         * @param {ol.Feature|ol.render.Feature} feature Feature.
+         * @param {ol.layer.Layer} layer Layer.
+         * @return {boolean|undefined} Continue to iterate over the features.
+         */
+        function(feature, layer) {
+          if (this.filter_(feature, layer)) {
+            selected.push(feature);
+            this.addFeatureLayerAssociation_(feature, layer);
+            return !this.multi_;
+          }
+        }, this, this.layerFilter_);
     if (selected.length > 0 && features.getLength() == 1 &&
-      features.item(0) == selected[0]) {
+        features.item(0) == selected[0]) {
       // No change
     } else {
       change = true;
@@ -353,25 +347,25 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
   } else {
     // Modify the currently selected feature(s).
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
-      /**
-       * @param {ol.Feature|ol.render.Feature} feature Feature.
-       * @param {ol.layer.Layer} layer Layer.
-       * @return {boolean|undefined} Continue to iterate over the features.
-       */
-      function(feature, layer) {
-        if (this.filter_(feature, layer)) {
-          if ((add || toggle) &&
-            !ol.array.includes(features.getArray(), feature)) {
-            selected.push(feature);
-            this.addFeatureLayerAssociation_(feature, layer);
-          } else if ((remove || toggle) &&
-            ol.array.includes(features.getArray(), feature)) {
-            deselected.push(feature);
-            this.removeFeatureLayerAssociation_(feature);
+        /**
+         * @param {ol.Feature|ol.render.Feature} feature Feature.
+         * @param {ol.layer.Layer} layer Layer.
+         * @return {boolean|undefined} Continue to iterate over the features.
+         */
+        function(feature, layer) {
+          if (this.filter_(feature, layer)) {
+            if ((add || toggle) &&
+              !ol.array.includes(features.getArray(), feature)) {
+              selected.push(feature);
+              this.addFeatureLayerAssociation_(feature, layer);
+            } else if ((remove || toggle) &&
+              ol.array.includes(features.getArray(), feature)) {
+              deselected.push(feature);
+              this.removeFeatureLayerAssociation_(feature);
+            }
+            return !this.multi_;
           }
-          return !this.multi_;
-        }
-      }, this, this.layerFilter_);
+        }, this, this.layerFilter_);
     var i;
     for (i = deselected.length - 1; i >= 0; --i) {
       features.remove(deselected[i]);
@@ -383,8 +377,8 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
   }
   if (change) {
     this.dispatchEvent(
-      new ol.interaction.SelectEvent(ol.interaction.SelectEventType.SELECT,
-        selected, deselected, mapBrowserEvent));
+        new ol.interaction.SelectEvent(ol.interaction.SelectEventType.SELECT,
+            selected, deselected, mapBrowserEvent));
   }
   return ol.events.condition.pointerMove(mapBrowserEvent);
 };
@@ -409,11 +403,11 @@ ol.interaction.Select.prototype.removeSelectedStyle_ = function (feature) {
  */
 ol.interaction.Select.prototype.setMap = function(map) {
   var currentMap = this.getMap();
-  if (currentMap && !this.dontStyle_) {
+  if (currentMap && this.style_) {
     this.features_.forEach(this.removeSelectedStyle_, this);
   }
   goog.base(this, 'setMap', map);
-  if (map && !this.dontStyle_) {
+  if (map && this.style_) {
     this.features_.forEach(this.giveSelectedStyle_, this);
   }
 };
@@ -425,9 +419,9 @@ ol.interaction.Select.prototype.setMap = function(map) {
 ol.interaction.Select.getDefaultStyleFunction = function() {
   var styles = ol.style.createDefaultEditingStyles();
   ol.array.extend(styles[ol.geom.GeometryType.POLYGON],
-    styles[ol.geom.GeometryType.LINE_STRING]);
+      styles[ol.geom.GeometryType.LINE_STRING]);
   ol.array.extend(styles[ol.geom.GeometryType.GEOMETRY_COLLECTION],
-    styles[ol.geom.GeometryType.LINE_STRING]);
+      styles[ol.geom.GeometryType.LINE_STRING]);
 
   return function(feature, resolution) {
     return styles[feature.getGeometry().getType()];
@@ -442,8 +436,8 @@ ol.interaction.Select.getDefaultStyleFunction = function() {
 ol.interaction.Select.prototype.removeFeature_ = function(evt) {
   var feature = evt.element;
   goog.asserts.assertInstanceof(feature, ol.Feature,
-    'feature should be an ol.Feature');
-  if (!this.dontStyle_) {
+      'feature should be an ol.Feature');
+  if (this.style_) {
     this.removeSelectedStyle_(feature);
   }
 };

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -352,7 +352,7 @@ describe('ol.interaction.Select', function() {
     });
 
   });
-  
+
 });
 
 goog.require('ol.Collection');

--- a/test/spec/ol/interaction/selectinteraction.test.js
+++ b/test/spec/ol/interaction/selectinteraction.test.js
@@ -325,8 +325,6 @@ describe('ol.interaction.Select', function() {
 
       map.addInteraction(interaction);
 
-      expect(interaction.featureOverlay_).not.to.be(null);
-
       simulateEvent(ol.MapBrowserEvent.EventType.SINGLECLICK, 10, -20);
     });
 
@@ -354,41 +352,7 @@ describe('ol.interaction.Select', function() {
     });
 
   });
-
-  describe('#setMap()', function() {
-    var interaction;
-
-    beforeEach(function() {
-      interaction = new ol.interaction.Select();
-      expect(interaction.getActive()).to.be(true);
-    });
-
-    describe('#setMap(null)', function() {
-      beforeEach(function() {
-        map.addInteraction(interaction);
-      });
-      afterEach(function() {
-        map.removeInteraction(interaction);
-      });
-      describe('#setMap(null) when interaction is active', function() {
-        it('unsets the map from the feature overlay', function() {
-          var spy = sinon.spy(interaction.featureOverlay_, 'setMap');
-          interaction.setMap(null);
-          expect(spy.getCall(0).args[0]).to.be(null);
-        });
-      });
-    });
-
-    describe('#setMap(map)', function() {
-      describe('#setMap(map) when interaction is active', function() {
-        it('sets the map into the feature overlay', function() {
-          var spy = sinon.spy(interaction.featureOverlay_, 'setMap');
-          interaction.setMap(map);
-          expect(spy.getCall(0).args[0]).to.be(map);
-        });
-      });
-    });
-  });
+  
 });
 
 goog.require('ol.Collection');


### PR DESCRIPTION
Refering to:
https://groups.google.com/forum/#!topic/ol3-dev/Yh7eMfcUFBI

This is just a first pull request to start a discussion about replacing the unmanaged layer of ol.interaction.Select with an ol.Collection. 

There are some uneccessary whitespace changes i will address later. The obvious tests are failing at the moment, all which have to do with the unmanaged layer.

I am still wondering about the addFeatureLayerAssociation_ and  removeFeatureLayerAssociation_ method calls inside of the handleEvent method. Wouldn't it be easier to call these in the addFeature_ and removeFeature_ method? Or am I missing something?

This would also make it possible to call getLayer for features added programmtically to the collection.
