### PR TITLE
Test individual example compilation

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -42,6 +42,6 @@
     "warning_level": "VERBOSE",
     "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true,
-    "manage_closure_dependencies": true
+    "manage_closure_dependencies": false
   }
 }

--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -13,7 +13,7 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
 
-var symbol = [[0, 0], [4, 2], [6, 0], [10, 5], [6, 3], [4, 5], [0, 0]];
+var symbols = [[0, 0], [4, 2], [6, 0], [10, 5], [6, 3], [4, 5], [0, 0]];
 var scale;
 var scaleFunction = function(coordinate) {
   return [coordinate[0] * scale, coordinate[1] * scale];
@@ -39,7 +39,7 @@ var styleFunction = function(feature) {
       fill: new ol.style.Fill({color: 'rgba(255, 153, 0, 0.4)'}),
       stroke: new ol.style.Stroke({color: 'rgba(255, 204, 0, 0.2)', width: 2})
     }));
-    vectorContext.drawGeometry(new ol.geom.Polygon([symbol.map(scaleFunction)]));
+    vectorContext.drawGeometry(new ol.geom.Polygon([symbols.map(scaleFunction)]));
     style = new ol.style.Style({
       image: new ol.style.Icon({
         img: canvas,

--- a/examples/layer-z-index.js
+++ b/examples/layer-z-index.js
@@ -83,6 +83,7 @@ layer0.setMap(map);
 
 function bindInputs(id, layer) {
   var idxInput = document.getElementById('idx' + id);
+  /** @this {Element} */
   idxInput.onchange = function() {
     layer.setZIndex(parseInt(this.value, 10) || 0);
   };

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -5,11 +5,6 @@ goog.require('ol.format.MVT');
 goog.require('ol.layer.VectorTile');
 goog.require('ol.proj');
 goog.require('ol.source.VectorTile');
-goog.require('ol.style.Fill');
-goog.require('ol.style.Icon');
-goog.require('ol.style.Stroke');
-goog.require('ol.style.Style');
-goog.require('ol.style.Text');
 goog.require('ol.tilegrid.TileGrid');
 
 

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -5,11 +5,6 @@ goog.require('ol.View');
 goog.require('ol.format.MVT');
 goog.require('ol.layer.VectorTile');
 goog.require('ol.source.VectorTile');
-goog.require('ol.style.Fill');
-goog.require('ol.style.Icon');
-goog.require('ol.style.Stroke');
-goog.require('ol.style.Style');
-goog.require('ol.style.Text');
 goog.require('ol.tilegrid');
 
 

--- a/tasks/readme.md
+++ b/tasks/readme.md
@@ -128,3 +128,8 @@ Run a debug server that provides all library sources unminified.  Provides a sta
 ## `test.js`
 
 Run the tests once in a headless browser.  Note that you can also run the tests by running the `serve.js` task and then visiting the root of the test directory in your browser.
+
+
+## `test-compile-each-example.sh`
+
+Compile all examples individually.

--- a/tasks/test-compile-each-example.sh
+++ b/tasks/test-compile-each-example.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This task compiles all examples individually and writes logs in
+# build/compiled-examples/logs.
+
+tmp="`mktemp`"
+logs="build/compiled-examples/logs"
+> $logs
+
+for i in examples/*.html
+do
+  echo Testing example $i | tee -a $logs
+  key="`basename -s .html $i`"
+  grep -q NOCOMPILE examples/$key.js && continue
+
+  make build/compiled-examples/$key.json
+  node tasks/build.js build/compiled-examples/$key.json build/compiled-examples/$key.combined.js 2> >(tee $tmp >&2)
+  echo "$? $key examples/$key.js" >> $logs
+  cat $tmp >> $logs
+done

--- a/tasks/test-compile-each-example.sh
+++ b/tasks/test-compile-each-example.sh
@@ -2,6 +2,7 @@
 # This task compiles all examples individually and writes logs in
 # build/compiled-examples/logs.
 
+mkdir -p build/compiled-examples
 tmp="`mktemp`"
 logs="build/compiled-examples/logs"
 > $logs
@@ -10,6 +11,7 @@ for i in examples/*.html
 do
   echo Testing example $i | tee -a $logs
   key="`basename -s .html $i`"
+  [ -f examples/$key.js ] || continue
   grep -q NOCOMPILE examples/$key.js && continue
 
   make build/compiled-examples/$key.json

--- a/tasks/test-compile-each-example.sh
+++ b/tasks/test-compile-each-example.sh
@@ -7,6 +7,7 @@ tmp="`mktemp`"
 logs="build/compiled-examples/logs"
 > $logs
 
+has_errors=0
 for i in examples/*.html
 do
   echo Testing example $i | tee -a $logs
@@ -16,6 +17,10 @@ do
 
   make build/compiled-examples/$key.json
   node tasks/build.js build/compiled-examples/$key.json build/compiled-examples/$key.combined.js 2> >(tee $tmp >&2)
-  echo "$? $key examples/$key.js" >> $logs
+  status="$?"
+  [ $status -ne 0 ] && has_errors=1
+  echo "$status $key examples/$key.js" >> $logs
   cat $tmp >> $logs
 done
+
+exit $has_errors


### PR DESCRIPTION
Related to https://github.com/openlayers/ol3/issues/5340.

This PR adds a new task `test-compile-each-example.sh` which allows to compile each example individually and thus detect more errors than the fast combined examples we run with `make ci`.

This task is very time consuming so should be run only on occasions, for examples to prepare a release or after a significant commit.

The task returns `1` on error.
