### PR TITLE
Ability to define ol.style.Circle without a fill or stroke color

### DIFF
--- a/src/ol/style/circlestyle.js
+++ b/src/ol/style/circlestyle.js
@@ -238,7 +238,12 @@ ol.style.Circle.prototype.render_ = function(atlasManager) {
   var strokeWidth = 0;
 
   if (this.stroke_) {
-    strokeStyle = ol.color.asString(this.stroke_.getColor());
+    strokeStyle = this.stroke_.getColor();
+    if (strokeStyle === null) {
+      strokeStyle = ol.render.canvas.defaultStrokeStyle;
+    }
+    strokeStyle = ol.color.asString(strokeStyle);
+
     strokeWidth = this.stroke_.getWidth();
     if (strokeWidth === undefined) {
       strokeWidth = ol.render.canvas.defaultLineWidth;
@@ -331,7 +336,11 @@ ol.style.Circle.prototype.draw_ = function(renderOptions, context, x, y) {
       this.radius_, 0, 2 * Math.PI, true);
 
   if (this.fill_) {
-    context.fillStyle = ol.colorlike.asColorLike(this.fill_.getColor());
+    var fillStyle = this.fill_.getColor();
+    if (fillStyle === null) {
+      fillStyle = ol.render.canvas.defaultFillStyle;
+    }
+    context.fillStyle = ol.colorlike.asColorLike(fillStyle);
     context.fill();
   }
   if (this.stroke_) {

--- a/test/spec/ol/style/circlestyle.test.js
+++ b/test/spec/ol/style/circlestyle.test.js
@@ -5,6 +5,27 @@ describe('ol.style.Circle', function() {
 
   describe('#constructor', function() {
 
+    it('can be constructed without a defined fill color', function() {
+      var style = new ol.style.Circle({
+        radius: 10,
+        fill: new ol.style.Fill({
+          color: undefined
+        })
+      });
+      expect(style.getImage()).to.be.an(HTMLCanvasElement);
+    });
+
+    it('can be constructed without a defined stroke color', function() {
+      var style = new ol.style.Circle({
+        radius: 10,
+        stroke: new ol.style.Stroke({
+          color: undefined,
+          width: 2
+        })
+      });
+      expect(style.getImage()).to.be.an(HTMLCanvasElement);
+    });
+
     it('creates a canvas if no atlas is used (no fill-style)', function() {
       var style = new ol.style.Circle({radius: 10});
       expect(style.getImage()).to.be.an(HTMLCanvasElement);


### PR DESCRIPTION
If a stroke style is defined by not the color; use the default `ol.render.canvas.defaultStrokeStyle` value.
Same for the fill style.
