### PR TITLE
Allow definition of an offset for an ol.source.Zoomify

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6485,6 +6485,7 @@ olx.source.CartoDBOptions.prototype.account;
  *     cacheSize: (number|undefined),
  *     crossOrigin: (null|string|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
+ *     offset: (Array.<number>|undefined),
  *     reprojectionErrorThreshold: (number|undefined),
  *     url: !string,
  *     tierSizeCalculation: (string|undefined),
@@ -6529,6 +6530,12 @@ olx.source.ZoomifyOptions.prototype.crossOrigin;
  */
 olx.source.ZoomifyOptions.prototype.logo;
 
+/**
+ * Optional parameter which allows to define an offset for an ol.source.Zoomify. Default is [0, 0].
+ * @type {Array.<number>|undefined}
+ * @api
+ */
+olx.source.ZoomifyOptions.prototype.offset;
 
 /**
  * Maximum allowed reprojection error (in pixels). Default is `0.5`.

--- a/src/ol/source/zoomifysource.js
+++ b/src/ol/source/zoomifysource.js
@@ -85,7 +85,10 @@ ol.source.Zoomify = function(opt_options) {
   }
   resolutions.reverse();
 
-  var extent = [0, -size[1], size[0], 0];
+  var offset = options.offset !== undefined ?
+      options.offset :
+      [0, 0];
+  var extent = [offset[0], offset[1] + -size[1], offset[0] + size[0], offset[1]];
   var tileGrid = new ol.tilegrid.TileGrid({
     extent: extent,
     origin: ol.extent.getTopLeft(extent),


### PR DESCRIPTION
The pull-request just adds an offset parameter to the `options` of the zoomify source. Equal to `imageExtent` for `ol.source.ImageStatic` this option allows to me to display multiple zoomify layers next to each other in one map. 
