### PR TITLE
Optimize no exports generation path

### DIFF
--- a/tasks/generate-exports.js
+++ b/tasks/generate-exports.js
@@ -187,6 +187,11 @@ function generateExports(symbols, namespace) {
  *     error generating it.
  */
 function main(config, callback) {
+  if (config.exports.length === 0) {
+    callback(null, '');
+    return;
+  }
+
   async.waterfall([
     getSymbols.bind(null, config.exports),
     filterSymbols,


### PR DESCRIPTION
Immediately return an empty string if no export must be generated.
