### PR TITLE
add new geometry curve line

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6848,7 +6848,8 @@ olx.style.RegularShapeOptions.prototype.atlasManager;
  *     lineJoin: (string|undefined),
  *     lineDash: (Array.<number>|undefined),
  *     miterLimit: (number|undefined),
- *     width: (number|undefined)}}
+ *     width: (number|undefined),
+ *     cornerRadius: (number|undefined)}}
  */
 olx.style.StrokeOptions;
 

--- a/src/ol/render/canvas/canvas.js
+++ b/src/ol/render/canvas/canvas.js
@@ -72,6 +72,13 @@ ol.render.canvas.defaultLineWidth = 1;
 
 
 /**
+ * @const
+ * @type {number}
+ */
+ol.render.canvas.defaultCornerRadius = 0;
+
+
+/**
  * @param {CanvasRenderingContext2D} context Context.
  * @param {number} rotation Rotation.
  * @param {number} offsetX X offset.

--- a/src/ol/style/strokestyle.js
+++ b/src/ol/style/strokestyle.js
@@ -61,6 +61,12 @@ ol.style.Stroke = function(opt_options) {
    * @type {string|undefined}
    */
   this.checksum_ = undefined;
+
+  /**
+   * @private
+   * @type {number|undefined}
+   */
+  this.cornerRadius_ = options.cornerRadius !== undefined ? options.cornerRadius : undefined;
 };
 
 
@@ -123,6 +129,14 @@ ol.style.Stroke.prototype.getWidth = function() {
   return this.width_;
 };
 
+/**
+ * Get the radius of the corners of the line.
+ * @return {number|undefined} Corner Radius.
+ * @api
+ */
+ol.style.Stroke.prototype.getCornerRadius = function() {
+  return this.cornerRadius_;
+};
 
 /**
  * Set the color.
@@ -201,6 +215,15 @@ ol.style.Stroke.prototype.setWidth = function(width) {
   this.checksum_ = undefined;
 };
 
+/**
+ * Set the radiusCorner.
+ *
+ * @param {number|undefined} cornerRadius Corner Radius.
+ * @api
+ */
+ol.style.Stroke.prototype.setCornerRadius = function(cornerRadius) {
+  this.cornerRadius_ = cornerRadius;
+};
 
 /**
  * @return {string} The checksum.


### PR DESCRIPTION
new geometry "CurveLine"
draw a regular lineString with rounded corner base on radius
example:
{
   "type": "Feature",
   "geometry": {"type": "CurveLine", "coordinates": [[3,3], [5, 15], [7, 15], [10, 8],[15, 5],[13, 2]],"radius":1}
}

notice: I was having errors when I used the function "goog.vec.Mat4.getElement" first parameter documentation to accept null: 
@param {goog.vec.Mat4.AnyType | "null"}  mat

The error occurred in /src/ol/render/canvas/canvasreplay.js line: 485,486.
when I am calculating the new radius with the new transform.

please tell me if you have better way to solve that without changing the goog.vec.Mat4.getElement first parameter.

Fixes #5582.
