### PR TITLE
Add task to test custom builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ check-deps:
 	done ;\
 
 .PHONY: ci
-ci: lint build test test-rendering compile-examples check-examples apidoc
+ci: lint build test test-rendering compile-examples check-examples apidoc test-custom-build
 
 .PHONY: compile-examples
 compile-examples: build/compiled-examples/all.combined.js
@@ -146,6 +146,10 @@ test-rendering: build/timestamps/node-modules-timestamp \
 	@mkdir -p build/slimerjs-profile
 	@cp -r test_rendering/slimerjs-profile/* build/slimerjs-profile/
 	node tasks/test-rendering.js
+
+.PHONY: test-custom-build
+test-custom-build: build/timestamps/node-modules-timestamp
+	node tasks/test-custom-build.js
 
 .PHONY: host-examples
 host-examples: $(BUILD_HOSTED_EXAMPLES) \

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "node tasks/serve.js",
     "pretest": "eslint tasks test test_rendering src examples",
     "test": "node tasks/test.js",
+    "test-custom-build": "node tasks/test-custom-build.js",
     "debug-server": "node tasks/serve-lib.js"
   },
   "main": "dist/ol.js",

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -1,4 +1,5 @@
 goog.provide('ol.control.ScaleLine');
+goog.provide('ol.control.ScaleLine.Units');
 
 goog.require('ol');
 goog.require('ol.Object');

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -1,6 +1,8 @@
 goog.provide('ol.featureloader');
 
 goog.require('ol.Tile');
+// eslint-disable-next-line openlayers-internal/no-unused-requires
+goog.require('ol.VectorTile');
 goog.require('ol.format.FormatType');
 goog.require('ol.xml');
 

--- a/tasks/build-tools.js
+++ b/tasks/build-tools.js
@@ -1,0 +1,31 @@
+var fs = require('fs-extra');
+
+/**
+ * Read the build configuration file.
+ * @param {string} configPath Path to config file.
+ * @param {function(Error, Object)} callback Callback.
+ */
+function readConfig(configPath, callback) {
+  fs.readFile(configPath, function(err, data) {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        err = new Error('Unable to find config file: ' + configPath);
+      }
+      callback(err);
+      return;
+    }
+    var config;
+    try {
+      config = JSON.parse(String(data));
+    } catch (err2) {
+      callback(new Error('Trouble parsing config as JSON: ' + err2.message));
+      return;
+    }
+    callback(null, config);
+  });
+}
+
+
+module.exports = {
+  'readConfig': readConfig
+};

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -11,6 +11,7 @@ var temp = require('temp').track();
 var exec = require('child_process').exec;
 
 var generateExports = require('./generate-exports');
+var buildTools = require('./build-tools');
 
 var log = closure.log;
 var root = path.join(__dirname, '..');
@@ -72,32 +73,6 @@ function assertValidConfig(config, callback) {
       }
     }
     callback(null);
-  });
-}
-
-
-/**
- * Read the build configuration file.
- * @param {string} configPath Path to config file.
- * @param {function(Error, Object)} callback Callback.
- */
-function readConfig(configPath, callback) {
-  fs.readFile(configPath, function(err, data) {
-    if (err) {
-      if (err.code === 'ENOENT') {
-        err = new Error('Unable to find config file: ' + configPath);
-      }
-      callback(err);
-      return;
-    }
-    var config;
-    try {
-      config = JSON.parse(String(data));
-    } catch (err2) {
-      callback(new Error('Trouble parsing config as JSON: ' + err2.message));
-      return;
-    }
-    callback(null, config);
   });
 }
 
@@ -304,7 +279,7 @@ if (require.main === module) {
 
   // read the config, run the main function, and write the output file
   async.waterfall([
-    readConfig.bind(null, options.config),
+    buildTools.readConfig.bind(null, options.config),
     main,
     fs.outputFile.bind(fs, options.output)
   ], function(err) {

--- a/tasks/test-custom-build.js
+++ b/tasks/test-custom-build.js
@@ -1,0 +1,42 @@
+/**
+ * This task compiles all custom build configurations in the folder
+ * `test_custom_builds`.
+ */
+
+var path = require('path');
+var async = require('async');
+var closure = require('closure-util');
+var fs = require('fs-extra');
+
+var build = require('./build');
+var buildTools = require('./build-tools');
+
+var log = closure.log;
+log.level = 'info';
+
+var srcDir = path.join(__dirname, '..', 'test_custom_builds');
+var destDir = path.join(__dirname, '..', 'build', 'test_custom_builds');
+
+function buildConfig(configFile, callback) {
+  log.info('Compiling ' + configFile);
+  var targetFile = configFile.replace('json', 'js');
+
+  async.waterfall([
+    buildTools.readConfig.bind(null, path.join(srcDir, configFile)),
+    build,
+    fs.outputFile.bind(fs, path.join(destDir, targetFile))
+  ], function(err) {
+    if (err) {
+      log.error(err.message);
+      process.exit(1);
+    } else {
+      callback(null);
+    }
+  });
+}
+
+var files = fs.readdirSync(srcDir);
+async.eachSeries(files, buildConfig, function(err) {
+  log.info('All custom build configs compile');
+  process.exit(0);
+});

--- a/test_custom_builds/tutorial.json
+++ b/test_custom_builds/tutorial.json
@@ -1,0 +1,33 @@
+{
+  "exports": [
+    "ol.layer.Heatmap",
+    "ol.source.Vector",
+    "ol.format.KML",
+    "ol.layer.Heatmap#getSource",
+    "ol.source.Vector#on",
+    "ol.source.VectorEvent#feature",
+    "ol.Feature#get",
+    "ol.Feature#set",
+    "ol.layer.Tile",
+    "ol.source.Stamen",
+    "ol.Map",
+    "ol.View",
+    "ol.layer.Heatmap#setRadius",
+    "ol.layer.Heatmap#setBlur"
+  ],
+  "compile": {
+    "externs": [
+      "externs/olx.js",
+      "externs/oli.js"
+    ],
+    "define": [
+      "ol.ENABLE_DOM=false",
+      "ol.ENABLE_WEBGL=false",
+      "ol.ENABLE_PROJ4JS=false",
+      "ol.ENABLE_IMAGE=false",
+      "goog.DEBUG=false"
+    ],
+    "compilation_level": "ADVANCED",
+    "manage_closure_dependencies": true
+  }
+}

--- a/test_custom_builds/workshop.json
+++ b/test_custom_builds/workshop.json
@@ -1,0 +1,51 @@
+ {
+   "exports": [
+       "ol.Map",
+       "ol.View",
+       "ol.format.KML",
+       "ol.layer.Tile",
+       "ol.layer.Vector",
+       "ol.proj.fromLonLat",
+       "ol.source.OSM",
+       "ol.source.Vector",
+       "ol.style.Fill",
+       "ol.style.Stroke",
+       "ol.style.Style",
+       "ol.style.Text"
+   ],
+   "jvm": [],
+   "umd": true,
+   "compile": {
+     "externs": [
+       "externs/bingmaps.js",
+       "externs/closure-compiler.js",
+       "externs/esrijson.js",
+       "externs/geojson.js",
+       "externs/oli.js",
+       "externs/olx.js",
+       "externs/proj4js.js",
+       "externs/tilejson.js",
+       "externs/topojson.js"
+     ],
+     "define": [
+       "ol.ENABLE_DOM=false",
+       "ol.ENABLE_WEBGL=false",
+       "ol.ENABLE_PROJ4JS=false",
+       "ol.ENABLE_IMAGE=false",
+       "goog.DEBUG=false"
+     ],
+     "jscomp_error": [
+       "*"
+     ],
+     "jscomp_off": [
+       "lintChecks"
+     ],
+     "extra_annotation_name": [
+       "api", "observable"
+     ],
+     "compilation_level": "ADVANCED",
+     "warning_level": "VERBOSE",
+     "use_types_for_optimization": true,
+     "manage_closure_dependencies": true
+   }
+ }


### PR DESCRIPTION
Replacement for https://github.com/openlayers/ol3/pull/5738

This PR adds a task that tests custom build configurations provided in the directory `test_custom_builds`.

To make the test pass, I had to add a `goog.require` for a type that is only used in a JSDoc type definition. These were removed in https://github.com/openlayers/ol3/pull/5698, but otherwise the compiler will fail.
