### PR TITLE
Fix closure tutorial, missing typedefs.js to include

### DIFF
--- a/doc/tutorials/closure.md
+++ b/doc/tutorials/closure.md
@@ -173,6 +173,7 @@ The minimum config file looks like this:
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [
+      "node_modules/openlayers/src/ol/typedefs.js",
       "node_modules/openlayers/externs/olx.js",
       "node_modules/openlayers/externs/oli.js"
     ],
@@ -224,6 +225,7 @@ Here is a version of `config.json` with more compilation checks enabled:
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [
+      "node_modules/openlayers/src/ol/typedefs.js",
       "node_modules/openlayers/externs/olx.js",
       "node_modules/openlayers/externs/oli.js"
     ],


### PR DESCRIPTION
This PR fixes the "Closure" tutorial.  With the addition of `typedefs.js` in OpenLayers, the proposed configuration no longer worked.  You need to add `typedefs.js` in the list of JavaScript files to include.  The reason why is that this file doesn't have any `goog.provide`, thus isn't theorically required to do the build but it is.  You need to tell closure that.  In ol3, it's added in the build.js script.  We need to to the same for the tutorial.

Ready for review.
