### PR TITLE
Ensure ol.VectorTile type

### DIFF
--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -143,7 +143,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderTileReplays_ = function(
   var currentZ, i, ii, offsetX, offsetY, origin, pixelSpace, replayState;
   var tile, tileExtent, tilePixelResolution, tileResolution, tileTransform;
   for (i = 0, ii = tilesToDraw.length; i < ii; ++i) {
-    tile = tilesToDraw[i];
+    tile = /** @type {ol.VectorTile} */ (tilesToDraw[i]);
     replayState = tile.getReplayState();
     tileExtent = tileGrid.getTileCoordExtent(
         tile.getTileCoord(), this.tmpExtent);
@@ -290,7 +290,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
   var i, ii, origin, replayGroup;
   var tile, tileCoord, tileExtent, tilePixelRatio, tileResolution;
   for (i = 0, ii = replayables.length; i < ii; ++i) {
-    tile = replayables[i];
+    tile = /** @type {ol.VectorTile} */ (replayables[i]);
     tileCoord = tile.getTileCoord();
     tileExtent = source.getTileGrid().getTileCoordExtent(tileCoord,
         this.tmpExtent);


### PR DESCRIPTION
This PR makes sure that the type of tile object within the `ol.renderer.canvas.VectorTileLayer` are properly cast to `ol.VectorTile`.  OpenLayers' build script works just fine with or without these cast, but when using Closure-util we get errors like:

```
ERR! compile node_modules/openlayers/src/ol/renderer/canvas/vectortilelayer.js:312:
  ERROR - Property getReplayState never defined on ol.Tile
ERR! compile     replayGroup = tile.getReplayState().replayGroup;
```

Ready for review (and if you followed the couple last PRs I just made you'll see that I'm confused as why the OL3 build doesn't complain about those where the build in Closure-util does).
