### PR TITLE
Produce sharp tiles with the WebGL renderer

### DIFF
--- a/src/ol/renderer/webgl/tilelayer.js
+++ b/src/ol/renderer/webgl/tilelayer.js
@@ -333,10 +333,10 @@ if (ol.ENABLE_WEBGL) {
     var texCoordMatrix = this.texCoordMatrix;
     ol.transform.reset(texCoordMatrix);
     ol.transform.translate(texCoordMatrix,
-        (Math.round(center[0] / tileResolution) * tileResolution - framebufferExtent[0]) /
-            (framebufferExtent[2] - framebufferExtent[0]),
-        (Math.round(center[1] / tileResolution) * tileResolution - framebufferExtent[1]) /
-            (framebufferExtent[3] - framebufferExtent[1]));
+        (tileResolution * (Math.round(center[0] / tileResolution) + (frameState.size[0] % 2) / 2) -
+        framebufferExtent[0]) / (framebufferExtent[2] - framebufferExtent[0]),
+        (tileResolution * (Math.round(center[1] / tileResolution) + (frameState.size[1] % 2) / 2) -
+        framebufferExtent[1]) / (framebufferExtent[3] - framebufferExtent[1]));
     if (viewState.rotation !== 0) {
       ol.transform.rotate(texCoordMatrix, viewState.rotation);
     }


### PR DESCRIPTION
Commit 3026fda successfully removes ol.renderer.Layer#snapCenterToPixel and pixel rounds the center in every case. However, as far as I can currently understand, one step is missing from the rounding formula. This commit attempts to fix this, and produce sharp tiles, if the view is not rotated. These are the minimal changes to render sharp tiles by default, and therefore I do not know, if it has any ill-effects in other circumstances.

Before:
![blurry](https://cloud.githubusercontent.com/assets/9150102/19311473/d1621208-908e-11e6-9a6f-f0d0994fc8db.png)

After:
![sharp](https://cloud.githubusercontent.com/assets/9150102/19311482/dcd70cb0-908e-11e6-855b-6c37d059d937.png)
