### PR TITLE
ScaleLine: Allow to assign user defined CSS class in addition to the default

### DIFF
--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -36,7 +36,8 @@ ol.control.ScaleLine = function(opt_options) {
    * @type {Element}
    */
   this.innerElement_ = document.createElement('DIV');
-  this.innerElement_.className = className + '-inner';
+//  this.innerElement_.className = className + '-inner';
+  this.innerElement_.className = className.split(/[\s,]+/).map(function (x) { return (x + "-inner") }).join(" ");
 
   /**
    * @private

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -36,8 +36,11 @@ ol.control.ScaleLine = function(opt_options) {
    * @type {Element}
    */
   this.innerElement_ = document.createElement('DIV');
-//  this.innerElement_.className = className + '-inner';
-  this.innerElement_.className = className.split(/[\s,]+/).map(function (x) { return (x + "-inner") }).join(" ");
+  this.innerElement_.className = className.split(/[\s,]+/).map(
+    function(x) {
+      return (x + '-inner');
+    }
+  ).join(' ');
 
   /**
    * @private


### PR DESCRIPTION
By default, the outer part of ScaleLine is formatted by "ol-scale-line", inner part by "ol-scale-line-inner". 
This PR allows to specify an additional CSS class in the ScaleLine constructor to overwrite individual styles while keeping the default for the rest. E.g.

new ol.control.ScaleLine({className: "ol-scale-line my-scale-style"})

where "my-scale-style" overwrites "ol-scale-line".
