### PR TITLE
ol.style.Circle high DPI support

### DIFF
--- a/src/ol/render/canvas/imagereplay.js
+++ b/src/ol/render/canvas/imagereplay.js
@@ -242,17 +242,18 @@ ol.render.canvas.ImageReplay.prototype.finish = function() {
 /**
  * @inheritDoc
  */
-ol.render.canvas.ImageReplay.prototype.setImageStyle = function(imageStyle) {
+ol.render.canvas.ImageReplay.prototype.setImageStyle = function(imageStyle, pixelRatio) {
   ol.DEBUG && console.assert(imageStyle, 'imageStyle should not be null');
+  // Call getImage to set the correct pixelRatio, before calling getAnchor, getSize etc.
+  var image = imageStyle.getImage(pixelRatio);
+  ol.DEBUG && console.assert(image, 'image should not be null');
   var anchor = imageStyle.getAnchor();
   ol.DEBUG && console.assert(anchor, 'anchor should not be null');
   var size = imageStyle.getSize();
   ol.DEBUG && console.assert(size, 'size should not be null');
-  var hitDetectionImage = imageStyle.getHitDetectionImage(1);
+  var hitDetectionImage = imageStyle.getHitDetectionImage(pixelRatio);
   ol.DEBUG && console.assert(hitDetectionImage,
       'hitDetectionImage should not be null');
-  var image = imageStyle.getImage(1);
-  ol.DEBUG && console.assert(image, 'image should not be null');
   var origin = imageStyle.getOrigin();
   ol.DEBUG && console.assert(origin, 'origin should not be null');
   this.anchorX_ = anchor[0];

--- a/src/ol/render/canvas/immediate.js
+++ b/src/ol/render/canvas/immediate.js
@@ -858,8 +858,7 @@ ol.render.canvas.Immediate.prototype.setImageStyle = function(imageStyle) {
     this.image_ = null;
   } else {
     var imageAnchor = imageStyle.getAnchor();
-    // FIXME pixel ratio
-    var imageImage = imageStyle.getImage(1);
+    var imageImage = imageStyle.getImage(this.pixelRatio_);
     var imageOrigin = imageStyle.getOrigin();
     var imageSize = imageStyle.getSize();
     ol.DEBUG && console.assert(imageImage, 'imageImage must be truthy');

--- a/src/ol/render/vectorcontext.js
+++ b/src/ol/render/vectorcontext.js
@@ -130,8 +130,9 @@ ol.render.VectorContext.prototype.setFillStrokeStyle = function(fillStyle, strok
 /**
  * @abstract
  * @param {ol.style.Image} imageStyle Image style.
+ * @param {number} pixelRatio Pixel ratio.
  */
-ol.render.VectorContext.prototype.setImageStyle = function(imageStyle) {};
+ol.render.VectorContext.prototype.setImageStyle = function(imageStyle, pixelRatio) {};
 
 
 /**

--- a/src/ol/renderer/canvas/vectorlayer.js
+++ b/src/ol/renderer/canvas/vectorlayer.js
@@ -349,13 +349,13 @@ ol.renderer.canvas.VectorLayer.prototype.renderFeature = function(feature, resol
       loading = ol.renderer.vector.renderFeature(
           replayGroup, feature, styles[i],
           ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-          this.handleStyleImageChange_, this) || loading;
+          this.handleStyleImageChange_, pixelRatio, this) || loading;
     }
   } else {
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles,
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleStyleImageChange_, this) || loading;
+        this.handleStyleImageChange_, pixelRatio, this) || loading;
   }
   return loading;
 };

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -246,7 +246,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.createReplayGroup = function(tile,
       if (!Array.isArray(styles)) {
         styles = [styles];
       }
-      var dirty = this.renderFeature(feature, squaredTolerance, styles,
+      var dirty = this.renderFeature(feature, pixelRatio, squaredTolerance, styles,
           replayGroup);
       this.dirty_ = this.dirty_ || dirty;
       replayState.dirty = replayState.dirty || dirty;
@@ -361,13 +361,14 @@ ol.renderer.canvas.VectorTileLayer.prototype.prepareFrame = function(frameState,
 
 /**
  * @param {ol.Feature|ol.render.Feature} feature Feature.
+ * @param {number} pixelRatio Pixel ratio.
  * @param {number} squaredTolerance Squared tolerance.
  * @param {(ol.style.Style|Array.<ol.style.Style>)} styles The style or array of
  *     styles.
  * @param {ol.render.canvas.ReplayGroup} replayGroup Replay group.
  * @return {boolean} `true` if an image is loading.
  */
-ol.renderer.canvas.VectorTileLayer.prototype.renderFeature = function(feature, squaredTolerance, styles, replayGroup) {
+ol.renderer.canvas.VectorTileLayer.prototype.renderFeature = function(feature, pixelRatio, squaredTolerance, styles, replayGroup) {
   if (!styles) {
     return false;
   }
@@ -376,12 +377,12 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderFeature = function(feature, s
     for (var i = 0, ii = styles.length; i < ii; ++i) {
       loading = ol.renderer.vector.renderFeature(
           replayGroup, feature, styles[i], squaredTolerance,
-          this.handleStyleImageChange_, this) || loading;
+          this.handleStyleImageChange_, pixelRatio, this) || loading;
     }
   } else {
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles, squaredTolerance,
-        this.handleStyleImageChange_, this) || loading;
+        this.handleStyleImageChange_, pixelRatio, this) || loading;
   }
   return loading;
 };

--- a/src/ol/renderer/webgl/vectorlayer.js
+++ b/src/ol/renderer/webgl/vectorlayer.js
@@ -303,13 +303,13 @@ ol.renderer.webgl.VectorLayer.prototype.renderFeature = function(feature, resolu
       loading = ol.renderer.vector.renderFeature(
           replayGroup, feature, styles[i],
           ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-          this.handleStyleImageChange_, this) || loading;
+          this.handleStyleImageChange_, pixelRatio, this) || loading;
     }
   } else {
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles,
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleStyleImageChange_, this) || loading;
+        this.handleStyleImageChange_, pixelRatio, this) || loading;
   }
   return loading;
 };

--- a/src/ol/source/imagevector.js
+++ b/src/ol/source/imagevector.js
@@ -277,7 +277,7 @@ ol.source.ImageVector.prototype.renderFeature_ = function(feature, resolution, p
     loading = ol.renderer.vector.renderFeature(
         replayGroup, feature, styles[i],
         ol.renderer.vector.getSquaredTolerance(resolution, pixelRatio),
-        this.handleImageChange_, this) || loading;
+        this.handleImageChange_, pixelRatio, this) || loading;
   }
   return loading;
 };

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -120,8 +120,8 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       var spy = sinon.spy(map.getRenderer().getLayerRenderer(layer),
           'renderFeature');
       map.renderSync();
-      expect(spy.getCall(0).args[2]).to.be(layer.getStyle());
-      expect(spy.getCall(1).args[2]).to.be(feature2.getStyle());
+      expect(spy.getCall(0).args[3]).to.be(layer.getStyle());
+      expect(spy.getCall(1).args[3]).to.be(feature2.getStyle());
     });
 
     it('transforms geometries when tile and view projection are different', function() {

--- a/test/spec/ol/style/regularshape.test.js
+++ b/test/spec/ol/style/regularshape.test.js
@@ -63,6 +63,15 @@ describe('ol.style.RegularShape', function() {
       expect(style.getImage()).to.not.be(style.getHitDetectionImage());
       expect(style.getHitDetectionImage()).to.be.an(HTMLCanvasElement);
       expect(style.getHitDetectionImageSize()).to.eql([21, 21]);
+
+      // with pixelRatio 2
+      var style2 = style.clone();
+      expect(style2.getImage(2)).to.be.an(HTMLCanvasElement);
+      expect(style2.getSize()).to.eql([41, 41]);
+      expect(style2.getImageSize()).to.eql([41, 41]);
+      expect(style2.getOrigin()).to.eql([0, 0]);
+      expect(style2.getAnchor()).to.eql([20.5, 20.5]);
+      expect(style2.getChecksum()).to.not.eql(style.getChecksum());
     });
 
     it('creates a canvas if no atlas is used (fill-style)', function() {
@@ -81,6 +90,15 @@ describe('ol.style.RegularShape', function() {
       expect(style.getImage()).to.be(style.getHitDetectionImage());
       expect(style.getHitDetectionImage()).to.be.an(HTMLCanvasElement);
       expect(style.getHitDetectionImageSize()).to.eql([21, 21]);
+
+      // with pixelRatio 2
+      var style2 = style.clone();
+      expect(style2.getImage(2)).to.be.an(HTMLCanvasElement);
+      expect(style2.getSize()).to.eql([41, 41]);
+      expect(style2.getImageSize()).to.eql([41, 41]);
+      expect(style2.getOrigin()).to.eql([0, 0]);
+      expect(style2.getAnchor()).to.eql([20.5, 20.5]);
+      expect(style2.getChecksum()).to.not.eql(style.getChecksum());
     });
 
     it('adds itself to an atlas manager (no fill-style)', function() {
@@ -96,6 +114,15 @@ describe('ol.style.RegularShape', function() {
       expect(style.getImage()).to.not.be(style.getHitDetectionImage());
       expect(style.getHitDetectionImage()).to.be.an(HTMLCanvasElement);
       expect(style.getHitDetectionImageSize()).to.eql([512, 512]);
+
+      // with pixelRatio 2
+      var style2 = style.clone();
+      expect(style2.getImage(2)).to.be.an(HTMLCanvasElement);
+      expect(style2.getSize()).to.eql([41, 41]);
+      expect(style2.getImageSize()).to.eql([512, 512]);
+      expect(style2.getOrigin()).to.eql([1, 23]);
+      expect(style2.getAnchor()).to.eql([20.5, 20.5]);
+      expect(style2.getChecksum()).to.not.eql(style.getChecksum());
     });
 
     it('adds itself to an atlas manager (fill-style)', function() {
@@ -116,6 +143,15 @@ describe('ol.style.RegularShape', function() {
       expect(style.getImage()).to.be(style.getHitDetectionImage());
       expect(style.getHitDetectionImage()).to.be.an(HTMLCanvasElement);
       expect(style.getHitDetectionImageSize()).to.eql([512, 512]);
+
+      // with pixelRatio 2
+      var style2 = style.clone();
+      expect(style2.getImage(2)).to.be.an(HTMLCanvasElement);
+      expect(style2.getSize()).to.eql([41, 41]);
+      expect(style2.getImageSize()).to.eql([512, 512]);
+      expect(style2.getOrigin()).to.eql([1, 23]);
+      expect(style2.getAnchor()).to.eql([20.5, 20.5]);
+      expect(style2.getChecksum()).to.not.eql(style.getChecksum());
     });
   });
 


### PR DESCRIPTION
Fixes #1574, relates to #6049 and #2192

Adds support to `ol.style.Circle` for high DPI rendering. Most of this PR is plumbing to get the `pixelRatio` into the `ol.style.Circle#getImage()` function calls, then the pixel ratio is applied to the circle radius and stroke.

Tests have been updated/added to check for correct functionality. I'm open to suggestions for more tests if they would be useful.