### PR TITLE
Use the 'openlayers' tag instead of 'openlayers-3'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to OpenLayers.
 
 ## Asking Questions
 
-Please ask questions about using the library on [stackoverflow using the tag 'openlayers-3'](http://stackoverflow.com/questions/tagged/openlayers-3).
+Please ask questions about using the library on [Stack Overflow using the tag 'openlayers'](http://stackoverflow.com/questions/tagged/openlayers).
 
 When you want to get involved and discuss new features or changes, please use [the mailing list](https://groups.google.com/forum/#!forum/openlayers-dev).
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Please see our guide on [contributing](CONTRIBUTING.md) if you're interested in 
 
 ## Community
 
-- Need help? Find it on [stackoverflow using the tag 'openlayers-3'](http://stackoverflow.com/questions/tagged/openlayers-3)
+- Need help? Find it on [Stack Overflow using the tag 'openlayers'](http://stackoverflow.com/questions/tagged/openlayers)
 - Follow [@openlayers](https://twitter.com/openlayers) on Twitter
 - Discuss with openlayers users on IRC in `#openlayers` at `chat.freenode`

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -7,7 +7,7 @@ layout: doc.hbs
 
 Certain questions arise more often than others when users ask for help. This 
 document tries to list some of the common questions that frequently get asked,
-e.g. on [Stack Overflow](http://stackoverflow.com/questions/tagged/openlayers-3).
+e.g. on [Stack Overflow](http://stackoverflow.com/questions/tagged/openlayers).
 
 If you think a question (and naturally its answer) should be added here, feel
 free to ping us or to send a pull request enhancing this document.

--- a/doc/index.hbs
+++ b/doc/index.hbs
@@ -19,4 +19,4 @@ We have put together a document that lists [Frequently Asked Questions (FAQ)](fa
 
 # More questions?
 
-If you cannot find an answer in the documentation or the FAQ, you can ask your question on [stackoverflow using the tag 'openlayers-3'](http://stackoverflow.com/questions/tagged/openlayers-3).
+If you cannot find an answer in the documentation or the FAQ, you can ask your question on [Stack Overflow using the tag 'openlayers'](http://stackoverflow.com/questions/tagged/openlayers).


### PR DESCRIPTION
This pull request is meant to be merged after the tag change has been performed on stackoverflow.com. See http://meta.stackoverflow.com/questions/340754/please-update-openlayers-openlayers-2-and-openlayers-3-tags.

Since many of our users also answer questions on gis.stackexchange, I've made an equivalent request there as well: http://meta.gis.stackexchange.com/questions/4425/updating-openlayers-openlayers-2-and-openlayers-3-tags.