### PR TITLE
ol.geom.polygon documentation update on the coordinates format

### DIFF
--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -26,7 +26,8 @@ goog.require('ol.math');
  *
  * @constructor
  * @extends {ol.geom.SimpleGeometry}
- * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates.
+ * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates of the
+ *     vertices of the polygon where the first coordinate and the last are equivalent.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable
  */

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -26,8 +26,12 @@ goog.require('ol.math');
  *
  * @constructor
  * @extends {ol.geom.SimpleGeometry}
- * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates of the
- *     vertices of the polygon where the first coordinate and the last are equivalent.
+ * @param {Array.<Array.<ol.Coordinate>>} coordinates Array of linear
+ *     rings that define the polygon. The first linear ring of the array
+ *     defines the outer-boundary or surface of the polygon. Each subsequent
+ *     linear ring defines a hole in the surface of the polygon. A linear ring
+ *     is an array of vertices' coordinates where the first coordinate and the
+ *     last are equivalent.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api stable
  */


### PR DESCRIPTION
Should we refer to the GeoJSON specifications (https://tools.ietf.org/html/rfc7946#section-3.1.2) ?
I'm tempted to do so but I'm unsure about some requirements of the specifications, _i.e._:
```
- A linear ring MUST follow the right-hand rule with respect to the
      area it bounds, i.e., exterior rings are counterclockwise, and
      holes are clockwise.
- For Polygons with more than one of these [linear rings], the first MUST be
      the exterior ring, and any others MUST be interior rings.  The
      exterior ring bounds the surface, and the interior rings (if
      present) bound holes within the surface.
```
