### PR TITLE
Ensure view.getZoom() always returns an integer

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -653,7 +653,7 @@ ol.View.prototype.getZoom = function() {
       max = this.maxResolution_;
       zoomFactor = this.zoomFactor_;
     }
-    zoom = offset + Math.log(max / resolution) / Math.log(zoomFactor);
+    zoom = Math.round(offset + Math.log(max / resolution) / Math.log(zoomFactor));
   }
   return zoom;
 };


### PR DESCRIPTION
Hard to reproduce these fp arithmetic issues, but if you go to for example http://openlayers.org/en/master/examples/simple.html and keep zooming in and out, `map.getView().getZoom()` will sooner or later return something like `9.000000000000002`. I'm using zoom level as an array index, which fails when this happens.