### PR TITLE
Remove ol.array.flatten function

### DIFF
--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -125,22 +125,6 @@ ol.array.reverseSubArray = function(arr, begin, end) {
 
 
 /**
- * @param {Array.<*>} arr Array.
- * @return {!Array.<?>} Flattened Array.
- */
-ol.array.flatten = function(arr) {
-  var data = arr.reduce(function(flattened, value) {
-    if (Array.isArray(value)) {
-      return flattened.concat(ol.array.flatten(value));
-    } else {
-      return flattened.concat(value);
-    }
-  }, []);
-  return data;
-};
-
-
-/**
  * @param {Array.<VALUE>} arr The array to modify.
  * @param {Array.<VALUE>|VALUE} data The elements or arrays of elements
  *     to add to arr.

--- a/src/ol/format/esrijson.js
+++ b/src/ol/format/esrijson.js
@@ -2,7 +2,6 @@ goog.provide('ol.format.EsriJSON');
 
 goog.require('ol');
 goog.require('ol.Feature');
-goog.require('ol.array');
 goog.require('ol.asserts');
 goog.require('ol.extent');
 goog.require('ol.format.Feature');
@@ -16,6 +15,7 @@ goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Point');
 goog.require('ol.geom.Polygon');
+goog.require('ol.geom.flat.deflate');
 goog.require('ol.geom.flat.orient');
 goog.require('ol.obj');
 goog.require('ol.proj');
@@ -99,11 +99,13 @@ ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
  * @return {Array.<!Array.<!Array.<number>>>} Transformed rings.
  */
 ol.format.EsriJSON.convertRings_ = function(rings, layout) {
+  var flatRing = [];
   var outerRings = [];
   var holes = [];
   var i, ii;
   for (i = 0, ii = rings.length; i < ii; ++i) {
-    var flatRing = ol.array.flatten(rings[i]);
+    flatRing.length = 0;
+    ol.geom.flat.deflate.coordinates(flatRing, 0, rings[i], layout.length);
     // is this ring an outer ring? is it clockwise?
     var clockwise = ol.geom.flat.orient.linearRingIsClockwise(flatRing, 0,
         flatRing.length, layout.length);

--- a/src/ol/format/esrijson.js
+++ b/src/ol/format/esrijson.js
@@ -96,7 +96,7 @@ ol.format.EsriJSON.readGeometry_ = function(object, opt_options) {
  * @param {Array.<!Array.<!Array.<number>>>} rings Rings.
  * @param {ol.geom.GeometryLayout} layout Geometry layout.
  * @private
- * @return {Array.<!Array.<!Array.<number>>>} Transoformed rings.
+ * @return {Array.<!Array.<!Array.<number>>>} Transformed rings.
  */
 ol.format.EsriJSON.convertRings_ = function(rings, layout) {
   var outerRings = [];

--- a/test/spec/ol/array.test.js
+++ b/test/spec/ol/array.test.js
@@ -427,16 +427,6 @@ describe('ol.array', function() {
     });
   });
 
-  describe('flatten', function() {
-    it('flattens different kinds of nested arrays', function() {
-      expect(ol.array.flatten([1, 2])).to.eql([1, 2]);
-      expect(ol.array.flatten([1, [2, [3, [4, 5]]]])).to.eql([1, 2, 3, 4, 5]);
-      expect(ol.array.flatten([[[[1], 2], 3], 4])).to.eql([1, 2, 3, 4]);
-      expect(ol.array.flatten([[1]])).to.eql([1]);
-      expect(ol.array.flatten([])).to.eql([]);
-    });
-  });
-
   describe('isSorted', function() {
     it('works with just an array as argument', function() {
       expect(ol.array.isSorted([1, 2, 3])).to.be(true);


### PR DESCRIPTION
`ol.array.flatten` was only used in `ol.format.EsriJSON`, the function is replaced by `ol.geom.flat.deflate.coordinates`.