### PR TITLE
Use present in license text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2005-2017 OpenLayers Contributors. All rights reserved.
+Copyright 2005-present OpenLayers Contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
So we don't need to update the license text every year

Facebook does the same in React for instance https://github.com/facebook/react/blob/master/LICENSE