### PR TITLE
Tag deprecated functions with @deprecated

### DIFF
--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -7,11 +7,11 @@ goog.require('ol.easing');
 
 
 /**
- * Deprecated (use {@link ol.View#animate} instead).
  * Generate an animated transition that will "bounce" the resolution as it
  * approaches the final value.
  * @param {olx.animation.BounceOptions} options Bounce options.
  * @return {ol.PreRenderFunction} Pre-render function.
+ * @deprecated Use {@link ol.View#animate} instead.
  * @api
  */
 ol.animation.bounce = function(options) {
@@ -46,10 +46,10 @@ ol.animation.bounce = function(options) {
 
 
 /**
- * Deprecated (use {@link ol.View#animate} instead).
  * Generate an animated transition while updating the view center.
  * @param {olx.animation.PanOptions} options Pan options.
  * @return {ol.PreRenderFunction} Pre-render function.
+ * @deprecated Use {@link ol.View#animate} instead.
  * @api
  */
 ol.animation.pan = function(options) {
@@ -88,10 +88,10 @@ ol.animation.pan = function(options) {
 
 
 /**
- * Deprecated (use {@link ol.View#animate} instead).
  * Generate an animated transition while updating the view rotation.
  * @param {olx.animation.RotateOptions} options Rotate options.
  * @return {ol.PreRenderFunction} Pre-render function.
+ * @deprecated Use {@link ol.View#animate} instead.
  * @api
  */
 ol.animation.rotate = function(options) {
@@ -136,10 +136,10 @@ ol.animation.rotate = function(options) {
 
 
 /**
- * Deprecated (use {@link ol.View#animate} instead).
  * Generate an animated transition while updating the view resolution.
  * @param {olx.animation.ZoomOptions} options Zoom options.
  * @return {ol.PreRenderFunction} Pre-render function.
+ * @deprecated Use {@link ol.View#animate} instead.
  * @api
  */
 ol.animation.zoom = function(options) {

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -521,11 +521,11 @@ ol.Map.prototype.addOverlayInternal_ = function(overlay) {
 
 
 /**
- * Deprecated (use {@link ol.View#animate} instead).
  * Add functions to be called before rendering. This can be used for attaching
  * animations before updating the map's view.  The {@link ol.animation}
  * namespace provides several static methods for creating prerender functions.
  * @param {...ol.PreRenderFunction} var_args Any number of pre-render functions.
+ * @deprecated Use {@link ol.View#animate} instead.
  * @api
  */
 ol.Map.prototype.beforeRender = function(var_args) {


### PR DESCRIPTION
The closure-compiler (and maybe other tools) warns if the functions are used.
The functions are also marked as deprecated in the api doc.