### PR TITLE
Show current year in attribution in "HERE Map Tile API" example

### DIFF
--- a/examples/here-maps.js
+++ b/examples/here-maps.js
@@ -61,7 +61,7 @@ for (i = 0, ii = hereLayers.length; i < ii; ++i) {
     preload: Infinity,
     source: new ol.source.XYZ({
       url: createUrl(urlTpl, layerDesc),
-      attributions: 'Map Tiles &copy; 2016 ' +
+      attributions: 'Map Tiles &copy; ' + new Date().getFullYear() + ' ' +
         '<a href="http://developer.here.com">HERE</a>'
     })
   }));


### PR DESCRIPTION
This ensures that the current year is shown in the layer attribution in the "HERE Map Tile API" example.