### PR TITLE
Be more tolerant of map and position value

### DIFF
--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -271,7 +271,7 @@ ol.Overlay.prototype.handleOffsetChanged = function() {
  */
 ol.Overlay.prototype.handlePositionChanged = function() {
   this.updatePixelPosition();
-  if (this.get(ol.Overlay.Property_.POSITION) !== undefined && this.autoPan) {
+  if (this.get(ol.Overlay.Property_.POSITION) && this.autoPan) {
     this.panIntoView_();
   }
 };
@@ -339,7 +339,7 @@ ol.Overlay.prototype.setPosition = function(position) {
 ol.Overlay.prototype.panIntoView_ = function() {
   var map = this.getMap();
 
-  if (map === undefined || !map.getTargetElement()) {
+  if (!map || !map.getTargetElement()) {
     return;
   }
 
@@ -442,7 +442,7 @@ ol.Overlay.prototype.setVisible = function(visible) {
 ol.Overlay.prototype.updatePixelPosition = function() {
   var map = this.getMap();
   var position = this.getPosition();
-  if (map === undefined || !map.isRendered() || position === undefined) {
+  if (!map || !map.isRendered() || !position) {
     this.setVisible(false);
     return;
   }

--- a/test/spec/ol/overlay.test.js
+++ b/test/spec/ol/overlay.test.js
@@ -75,4 +75,29 @@ describe('ol.Overlay', function() {
 
   });
 
+  describe('#setVisible()', function() {
+    var overlay, target;
+
+    beforeEach(function() {
+      target = document.createElement('div');
+    });
+    afterEach(function() {
+      map.removeOverlay(overlay);
+    });
+
+    it('changes the CSS display value', function() {
+      overlay = new ol.Overlay({
+        element: target,
+        position: [0, 0]
+      });
+      map.addOverlay(overlay);
+      expect(overlay.element_.style.display).to.be('none');
+      overlay.setVisible(true);
+      expect(overlay.element_.style.display).not.to.be('none');
+      overlay.setVisible(false);
+      expect(overlay.element_.style.display).to.be('none');
+    });
+
+  });
+
 });


### PR DESCRIPTION
The `map` property type is `ol.Map|undefined` but `null` is set when
removing the overlay from the map:
https://github.com/openlayers/openlayers/blob/v3.20.1/src/ol/map.js#L453

This raise an exception with:
```js
map.removeOverlay(overlay);
overlay.setPosition(undefined);
```

Because `map === undefined` is used in `ol.Overlay.setPosition`.

This PR suggest to allow both `null` and `undefined`

