### PR TITLE
Gml 3.2 support

### DIFF
--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -120,18 +120,17 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
   }
 };
 
-/**
- * @param {Object} obj An object to add to a map for all known nemspace URIs.
- * @private
- * @return {Object.<string, Object>} A map with known gml namespace URIs as keys.
- */
-ol.format.GML3.makeNamespaceMap_ = function(obj) {
 
-  var ret = {};
-  ret[ol.format.GMLBase.GMLNS] = obj;
-  ret[ol.format.GMLBase.GMLNS_3_2] = obj;
-  return ret;
-};
+/**
+ * @const
+ * @type {Array.<string>}
+ * @private
+ */
+ol.format.GML3.NAMESPACE_URIS_ = [
+  ol.format.GMLBase.GMLNS,
+  ol.format.GMLBase.GMLNS_3_2
+];
+
 
 /**
  * @param {Node} node Node.
@@ -396,11 +395,11 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
-    'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
-  });
+ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
+      'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
+    });
 
 
 /**
@@ -408,11 +407,11 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'interior': ol.format.GML3.prototype.interiorParser_,
-    'exterior': ol.format.GML3.prototype.exteriorParser_
-  });
+ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'interior': ol.format.GML3.prototype.interiorParser_,
+      'exterior': ol.format.GML3.prototype.exteriorParser_
+    });
 
 
 /**
@@ -420,28 +419,28 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
-    'MultiPoint': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPoint),
-    'LineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLineString),
-    'MultiLineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiLineString),
-    'LinearRing': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLinearRing),
-    'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
-    'MultiPolygon': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPolygon),
-    'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
-    'MultiSurface': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiSurface_),
-    'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
-    'MultiCurve': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiCurve_),
-    'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-  });
+ol.format.GML3.prototype.GEOMETRY_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
+      'MultiPoint': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readMultiPoint),
+      'LineString': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readLineString),
+      'MultiLineString': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readMultiLineString),
+      'LinearRing': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readLinearRing),
+      'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
+      'MultiPolygon': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readMultiPolygon),
+      'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
+      'MultiSurface': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readMultiSurface_),
+      'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
+      'MultiCurve': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readMultiCurve_),
+      'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
+    });
 
 
 /**
@@ -449,13 +448,13 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'curveMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_),
-    'curveMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_)
-  });
+ol.format.GML3.prototype.MULTICURVE_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'curveMember': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.curveMemberParser_),
+      'curveMembers': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.curveMemberParser_)
+    });
 
 
 /**
@@ -463,13 +462,13 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'surfaceMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_),
-    'surfaceMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_)
-  });
+ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'surfaceMember': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.surfaceMemberParser_),
+      'surfaceMembers': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.surfaceMemberParser_)
+    });
 
 
 /**
@@ -477,12 +476,12 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'LineString': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readLineString),
-    'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-  });
+ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'LineString': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.readLineString),
+      'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
+    });
 
 
 /**
@@ -490,11 +489,11 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
-    'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-  });
+ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
+      'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
+    });
 
 
 /**
@@ -502,10 +501,10 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACE_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-  });
+ol.format.GML3.prototype.SURFACE_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
+    });
 
 
 /**
@@ -513,10 +512,10 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVE_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-  });
+ol.format.GML3.prototype.CURVE_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
+    });
 
 
 /**
@@ -524,13 +523,13 @@ ol.format.GML3.prototype.CURVE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'lowerCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_),
-    'upperCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_)
-  });
+ol.format.GML3.prototype.ENVELOPE_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'lowerCorner': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.readFlatPosList_),
+      'upperCorner': ol.xml.makeArrayPusher(
+          ol.format.GML3.prototype.readFlatPosList_)
+    });
 
 
 /**
@@ -538,11 +537,11 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.PATCHES_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'PolygonPatch': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readPolygonPatch_)
-  });
+ol.format.GML3.prototype.PATCHES_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'PolygonPatch': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readPolygonPatch_)
+    });
 
 
 /**
@@ -550,11 +549,11 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ =
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.SEGMENTS_PARSERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'LineStringSegment': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readLineStringSegment_)
-  });
+ol.format.GML3.prototype.SEGMENTS_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'LineStringSegment': ol.xml.makeReplacer(
+          ol.format.GML3.prototype.readLineStringSegment_)
+    });
 
 
 /**
@@ -643,11 +642,11 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.ENVELOPE_SERIALIZERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
-    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-  });
+ol.format.GML3.ENVELOPE_SERIALIZERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
+      'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
+    });
 
 
 /**
@@ -1012,80 +1011,80 @@ ol.format.GML3.prototype.writeFeatureMembers_ = function(node, features, objectS
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'surfaceMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
-    'polygonMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-  });
+ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'surfaceMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
+      'polygonMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
+    });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'pointMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writePointMember_)
-  });
+ol.format.GML3.POINTMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'pointMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writePointMember_)
+    });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'lineStringMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_),
-    'curveMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-  });
+ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'lineStringMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeLineStringOrCurveMember_),
+      'curveMember': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeLineStringOrCurveMember_)
+    });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.RING_SERIALIZERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
-    'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-  });
+ol.format.GML3.RING_SERIALIZERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
+      'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
+    });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.GEOMETRY_SERIALIZERS_ =
-  ol.format.GML3.makeNamespaceMap_({
-    'Curve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiCurve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
-    'MultiPoint': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiPoint_),
-    'LineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiLineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'LinearRing': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLinearRing_),
-    'Polygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiPolygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Surface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiSurface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Envelope': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeEnvelope)
-  });
+ol.format.GML3.GEOMETRY_SERIALIZERS_ = ol.xml.makeStructureNS(
+    ol.format.GML3.NAMESPACE_URIS_, {
+      'Curve': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeCurveOrLineString_),
+      'MultiCurve': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+      'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
+      'MultiPoint': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiPoint_),
+      'LineString': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeCurveOrLineString_),
+      'MultiLineString': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+      'LinearRing': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeLinearRing_),
+      'Polygon': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+      'MultiPolygon': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+      'Surface': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+      'MultiSurface': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+      'Envelope': ol.xml.makeChildAppender(
+          ol.format.GML3.prototype.writeEnvelope)
+    });
 
 
 /**

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -123,7 +123,7 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
 /**
  * @param {Object} obj An object to add to a map for all known nemspace URIs.
  * @private
- * @return {Object.<string, Object>} A map with known gml namespace URIs as keys. 
+ * @return {Object.<string, Object>} A map with known gml namespace URIs as keys.
  */
 ol.format.GML3.makeNamespaceMap_ = function(obj) {
 

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -121,8 +121,9 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
 };
 
 /**
- * @param {object} obj An object to add to a map for all known nemspace URIs.
+ * @param {Object} obj An object to add to a map for all known nemspace URIs.
  * @private
+ * @return {Object.<string, Object>} A map with known gml namespace URIs as keys. 
  */
 ol.format.GML3.makeNamespaceMap_ = function(obj) {
 

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -120,6 +120,17 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
   }
 };
 
+/**
+ * @param {object} obj An object to add to a map for all known nemspace URIs.
+ * @private
+ */
+ol.format.GML3.makeNamespaceMap_ = function(obj) {
+
+  var ret = {};
+  ret[ol.format.GMLBase.GMLNS] = obj;
+  ret[ol.format.GMLBase.GMLNS_3_2] = obj;
+  return ret;
+};
 
 /**
  * @param {Node} node Node.
@@ -384,16 +395,11 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
     'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
-    'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
-  }
-};
+  });
 
 
 /**
@@ -401,16 +407,11 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'interior': ol.format.GML3.prototype.interiorParser_,
     'exterior': ol.format.GML3.prototype.exteriorParser_
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'interior': ol.format.GML3.prototype.interiorParser_,
-    'exterior': ol.format.GML3.prototype.exteriorParser_
-  }
-};
+  });
 
 
 /**
@@ -418,8 +419,8 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.GEOMETRY_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.GEOMETRY_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
     'MultiPoint': ol.xml.makeReplacer(
         ol.format.GMLBase.prototype.readMultiPoint),
@@ -439,29 +440,7 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ = {
     'MultiCurve': ol.xml.makeReplacer(
         ol.format.GML3.prototype.readMultiCurve_),
     'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
-    'MultiPoint': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPoint),
-    'LineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLineString),
-    'MultiLineString': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiLineString),
-    'LinearRing': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readLinearRing),
-    'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
-    'MultiPolygon': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readMultiPolygon),
-    'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
-    'MultiSurface': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiSurface_),
-    'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
-    'MultiCurve': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readMultiCurve_),
-    'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
-  }
-};
+  });
 
 
 /**
@@ -469,20 +448,13 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTICURVE_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.MULTICURVE_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'curveMember': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.curveMemberParser_),
     'curveMembers': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.curveMemberParser_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'curveMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_),
-    'curveMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.curveMemberParser_)
-  }
-};
+  });
 
 
 /**
@@ -490,20 +462,13 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.MULTISURFACE_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'surfaceMember': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.surfaceMemberParser_),
     'surfaceMembers': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.surfaceMemberParser_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'surfaceMember': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_),
-    'surfaceMembers': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.surfaceMemberParser_)
-  }
-};
+  });
 
 
 /**
@@ -511,18 +476,12 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'LineString': ol.xml.makeArrayPusher(
         ol.format.GMLBase.prototype.readLineString),
     'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'LineString': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readLineString),
-    'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
-  }
-};
+  });
 
 
 /**
@@ -530,16 +489,11 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
     'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
-    'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
-  }
-};
+  });
 
 
 /**
@@ -547,14 +501,10 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.SURFACE_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.SURFACE_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
-  }
-};
+  });
 
 
 /**
@@ -562,14 +512,10 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.CURVE_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.CURVE_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
-  }
-};
+  });
 
 
 /**
@@ -577,20 +523,13 @@ ol.format.GML3.prototype.CURVE_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.ENVELOPE_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.ENVELOPE_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'lowerCorner': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.readFlatPosList_),
     'upperCorner': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.readFlatPosList_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'lowerCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_),
-    'upperCorner': ol.xml.makeArrayPusher(
-        ol.format.GML3.prototype.readFlatPosList_)
-  }
-};
+  });
 
 
 /**
@@ -598,16 +537,11 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.PATCHES_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.PATCHES_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'PolygonPatch': ol.xml.makeReplacer(
         ol.format.GML3.prototype.readPolygonPatch_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'PolygonPatch': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readPolygonPatch_)
-  }
-};
+  });
 
 
 /**
@@ -615,16 +549,11 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GML3.prototype.SEGMENTS_PARSERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.prototype.SEGMENTS_PARSERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'LineStringSegment': ol.xml.makeReplacer(
         ol.format.GML3.prototype.readLineStringSegment_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'LineStringSegment': ol.xml.makeReplacer(
-        ol.format.GML3.prototype.readLineStringSegment_)
-  }
-};
+  });
 
 
 /**
@@ -713,16 +642,11 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.ENVELOPE_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.ENVELOPE_SERIALIZERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
     'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
-    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
-  }
-};
+  });
 
 
 /**
@@ -1087,80 +1011,56 @@ ol.format.GML3.prototype.writeFeatureMembers_ = function(node, features, objectS
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'surfaceMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
     'polygonMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'surfaceMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
-    'polygonMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
-  }
-};
+  });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.POINTMEMBER_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.POINTMEMBER_SERIALIZERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'pointMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writePointMember_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'pointMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writePointMember_)
-  }
-};
+  });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'lineStringMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeLineStringOrCurveMember_),
     'curveMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'lineStringMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_),
-    'curveMember': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLineStringOrCurveMember_)
-  }
-};
+  });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.RING_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.RING_SERIALIZERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
     'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
-    'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
-  }
-};
+  });
 
 
 /**
  * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
  * @private
  */
-ol.format.GML3.GEOMETRY_SERIALIZERS_ = {
-  'http://www.opengis.net/gml': {
+ol.format.GML3.GEOMETRY_SERIALIZERS_ =
+  ol.format.GML3.makeNamespaceMap_({
     'Curve': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeCurveOrLineString_),
     'MultiCurve': ol.xml.makeChildAppender(
@@ -1184,33 +1084,7 @@ ol.format.GML3.GEOMETRY_SERIALIZERS_ = {
         ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
     'Envelope': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeEnvelope)
-  },
-  'http://www.opengis.net/gml/3.2': {
-    'Curve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiCurve': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
-    'MultiPoint': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiPoint_),
-    'LineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeCurveOrLineString_),
-    'MultiLineString': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
-    'LinearRing': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeLinearRing_),
-    'Polygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiPolygon': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Surface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
-    'MultiSurface': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
-    'Envelope': ol.xml.makeChildAppender(
-        ol.format.GML3.prototype.writeEnvelope)
-  }
-};
+  });
 
 
 /**

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -21,7 +21,8 @@ goog.require('ol.xml');
  * @classdesc
  * Feature format for reading and writing data in the GML format
  * version 3.1.1.
- * Currently only supports GML 3.1.1 Simple Features profile.
+ * Currently only supports GML 3.1.1 Simple Features profile upon writing.
+ * Basic read support for GML 3.2 is also provided.
  *
  * @constructor
  * @param {olx.format.GMLOptions=} opt_options
@@ -119,17 +120,6 @@ ol.format.GML3.prototype.readMultiSurface_ = function(node, objectStack) {
     return undefined;
   }
 };
-
-
-/**
- * @const
- * @type {Array.<string>}
- * @private
- */
-ol.format.GML3.NAMESPACE_URIS_ = [
-  ol.format.GMLBase.GMLNS,
-  ol.format.GMLBase.GMLNS_3_2
-];
 
 
 /**
@@ -396,7 +386,7 @@ ol.format.GML3.prototype.readFlatPosList_ = function(node, objectStack) {
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
       'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
     });
@@ -408,7 +398,7 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = ol.xml.makeStructu
  * @private
  */
 ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'interior': ol.format.GML3.prototype.interiorParser_,
       'exterior': ol.format.GML3.prototype.exteriorParser_
     });
@@ -420,7 +410,7 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.GEOMETRY_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
       'MultiPoint': ol.xml.makeReplacer(
           ol.format.GMLBase.prototype.readMultiPoint),
@@ -449,7 +439,7 @@ ol.format.GML3.prototype.GEOMETRY_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.MULTICURVE_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'curveMember': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.curveMemberParser_),
       'curveMembers': ol.xml.makeArrayPusher(
@@ -463,7 +453,7 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'surfaceMember': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.surfaceMemberParser_),
       'surfaceMembers': ol.xml.makeArrayPusher(
@@ -477,7 +467,7 @@ ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'LineString': ol.xml.makeArrayPusher(
           ol.format.GMLBase.prototype.readLineString),
       'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
@@ -490,7 +480,7 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
       'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
     });
@@ -502,7 +492,7 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.SURFACE_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
     });
 
@@ -513,7 +503,7 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.CURVE_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
     });
 
@@ -524,7 +514,7 @@ ol.format.GML3.prototype.CURVE_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.ENVELOPE_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'lowerCorner': ol.xml.makeArrayPusher(
           ol.format.GML3.prototype.readFlatPosList_),
       'upperCorner': ol.xml.makeArrayPusher(
@@ -538,7 +528,7 @@ ol.format.GML3.prototype.ENVELOPE_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.PATCHES_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'PolygonPatch': ol.xml.makeReplacer(
           ol.format.GML3.prototype.readPolygonPatch_)
     });
@@ -550,7 +540,7 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.prototype.SEGMENTS_PARSERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'LineStringSegment': ol.xml.makeReplacer(
           ol.format.GML3.prototype.readLineStringSegment_)
     });
@@ -643,7 +633,7 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @private
  */
 ol.format.GML3.ENVELOPE_SERIALIZERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
       'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
     });
@@ -1012,7 +1002,7 @@ ol.format.GML3.prototype.writeFeatureMembers_ = function(node, features, objectS
  * @private
  */
 ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'surfaceMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
       'polygonMember': ol.xml.makeChildAppender(
@@ -1025,7 +1015,7 @@ ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.POINTMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'pointMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writePointMember_)
     });
@@ -1036,7 +1026,7 @@ ol.format.GML3.POINTMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'lineStringMember': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeLineStringOrCurveMember_),
       'curveMember': ol.xml.makeChildAppender(
@@ -1049,7 +1039,7 @@ ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.RING_SERIALIZERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
       'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
     });
@@ -1060,7 +1050,7 @@ ol.format.GML3.RING_SERIALIZERS_ = ol.xml.makeStructureNS(
  * @private
  */
 ol.format.GML3.GEOMETRY_SERIALIZERS_ = ol.xml.makeStructureNS(
-    ol.format.GML3.NAMESPACE_URIS_, {
+    ol.format.GMLBase.NAMESPACE_URIS, {
       'Curve': ol.xml.makeChildAppender(
           ol.format.GML3.prototype.writeCurveOrLineString_),
       'MultiCurve': ol.xml.makeChildAppender(

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -388,6 +388,10 @@ ol.format.GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
   'http://www.opengis.net/gml': {
     'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
     'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'pos': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPos_),
+    'posList': ol.xml.makeReplacer(ol.format.GML3.prototype.readFlatPosList_)
   }
 };
 
@@ -401,6 +405,10 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
   'http://www.opengis.net/gml': {
     'interior': ol.format.GML3.prototype.interiorParser_,
     'exterior': ol.format.GML3.prototype.exteriorParser_
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'interior': ol.format.GML3.prototype.interiorParser_,
+    'exterior': ol.format.GML3.prototype.exteriorParser_
   }
 };
 
@@ -412,6 +420,27 @@ ol.format.GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
  */
 ol.format.GML3.prototype.GEOMETRY_PARSERS_ = {
   'http://www.opengis.net/gml': {
+    'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
+    'MultiPoint': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readMultiPoint),
+    'LineString': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readLineString),
+    'MultiLineString': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readMultiLineString),
+    'LinearRing': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readLinearRing),
+    'Polygon': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPolygon),
+    'MultiPolygon': ol.xml.makeReplacer(
+        ol.format.GMLBase.prototype.readMultiPolygon),
+    'Surface': ol.xml.makeReplacer(ol.format.GML3.prototype.readSurface_),
+    'MultiSurface': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readMultiSurface_),
+    'Curve': ol.xml.makeReplacer(ol.format.GML3.prototype.readCurve_),
+    'MultiCurve': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readMultiCurve_),
+    'Envelope': ol.xml.makeReplacer(ol.format.GML3.prototype.readEnvelope_)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'Point': ol.xml.makeReplacer(ol.format.GMLBase.prototype.readPoint),
     'MultiPoint': ol.xml.makeReplacer(
         ol.format.GMLBase.prototype.readMultiPoint),
@@ -446,6 +475,12 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ = {
         ol.format.GML3.prototype.curveMemberParser_),
     'curveMembers': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.curveMemberParser_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'curveMember': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.curveMemberParser_),
+    'curveMembers': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.curveMemberParser_)
   }
 };
 
@@ -457,6 +492,12 @@ ol.format.GML3.prototype.MULTICURVE_PARSERS_ = {
  */
 ol.format.GML3.prototype.MULTISURFACE_PARSERS_ = {
   'http://www.opengis.net/gml': {
+    'surfaceMember': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.surfaceMemberParser_),
+    'surfaceMembers': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.surfaceMemberParser_)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'surfaceMember': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.surfaceMemberParser_),
     'surfaceMembers': ol.xml.makeArrayPusher(
@@ -475,6 +516,11 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = {
     'LineString': ol.xml.makeArrayPusher(
         ol.format.GMLBase.prototype.readLineString),
     'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'LineString': ol.xml.makeArrayPusher(
+        ol.format.GMLBase.prototype.readLineString),
+    'Curve': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readCurve_)
   }
 };
 
@@ -486,6 +532,10 @@ ol.format.GML3.prototype.CURVEMEMBER_PARSERS_ = {
  */
 ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = {
   'http://www.opengis.net/gml': {
+    'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
+    'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'Polygon': ol.xml.makeArrayPusher(ol.format.GMLBase.prototype.readPolygon),
     'Surface': ol.xml.makeArrayPusher(ol.format.GML3.prototype.readSurface_)
   }
@@ -500,6 +550,9 @@ ol.format.GML3.prototype.SURFACEMEMBER_PARSERS_ = {
 ol.format.GML3.prototype.SURFACE_PARSERS_ = {
   'http://www.opengis.net/gml': {
     'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'patches': ol.xml.makeReplacer(ol.format.GML3.prototype.readPatch_)
   }
 };
 
@@ -512,6 +565,9 @@ ol.format.GML3.prototype.SURFACE_PARSERS_ = {
 ol.format.GML3.prototype.CURVE_PARSERS_ = {
   'http://www.opengis.net/gml': {
     'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'segments': ol.xml.makeReplacer(ol.format.GML3.prototype.readSegment_)
   }
 };
 
@@ -523,6 +579,12 @@ ol.format.GML3.prototype.CURVE_PARSERS_ = {
  */
 ol.format.GML3.prototype.ENVELOPE_PARSERS_ = {
   'http://www.opengis.net/gml': {
+    'lowerCorner': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.readFlatPosList_),
+    'upperCorner': ol.xml.makeArrayPusher(
+        ol.format.GML3.prototype.readFlatPosList_)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'lowerCorner': ol.xml.makeArrayPusher(
         ol.format.GML3.prototype.readFlatPosList_),
     'upperCorner': ol.xml.makeArrayPusher(
@@ -540,6 +602,10 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ = {
   'http://www.opengis.net/gml': {
     'PolygonPatch': ol.xml.makeReplacer(
         ol.format.GML3.prototype.readPolygonPatch_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'PolygonPatch': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readPolygonPatch_)
   }
 };
 
@@ -551,6 +617,10 @@ ol.format.GML3.prototype.PATCHES_PARSERS_ = {
  */
 ol.format.GML3.prototype.SEGMENTS_PARSERS_ = {
   'http://www.opengis.net/gml': {
+    'LineStringSegment': ol.xml.makeReplacer(
+        ol.format.GML3.prototype.readLineStringSegment_)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'LineStringSegment': ol.xml.makeReplacer(
         ol.format.GML3.prototype.readLineStringSegment_)
   }
@@ -645,6 +715,10 @@ ol.format.GML3.prototype.writePoint_ = function(node, geometry, objectStack) {
  */
 ol.format.GML3.ENVELOPE_SERIALIZERS_ = {
   'http://www.opengis.net/gml': {
+    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
+    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
     'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
   }
@@ -1019,6 +1093,12 @@ ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
         ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
     'polygonMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'surfaceMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_),
+    'polygonMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygonMember_)
   }
 };
 
@@ -1029,6 +1109,10 @@ ol.format.GML3.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
  */
 ol.format.GML3.POINTMEMBER_SERIALIZERS_ = {
   'http://www.opengis.net/gml': {
+    'pointMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writePointMember_)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'pointMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writePointMember_)
   }
@@ -1045,6 +1129,12 @@ ol.format.GML3.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
         ol.format.GML3.prototype.writeLineStringOrCurveMember_),
     'curveMember': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeLineStringOrCurveMember_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'lineStringMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeLineStringOrCurveMember_),
+    'curveMember': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeLineStringOrCurveMember_)
   }
 };
 
@@ -1057,6 +1147,10 @@ ol.format.GML3.RING_SERIALIZERS_ = {
   'http://www.opengis.net/gml': {
     'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
     'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
+  },
+  'http://www.opengis.net/gml/3.2': {
+    'exterior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_),
+    'interior': ol.xml.makeChildAppender(ol.format.GML3.prototype.writeRing_)
   }
 };
 
@@ -1067,6 +1161,31 @@ ol.format.GML3.RING_SERIALIZERS_ = {
  */
 ol.format.GML3.GEOMETRY_SERIALIZERS_ = {
   'http://www.opengis.net/gml': {
+    'Curve': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeCurveOrLineString_),
+    'MultiCurve': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+    'Point': ol.xml.makeChildAppender(ol.format.GML3.prototype.writePoint_),
+    'MultiPoint': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiPoint_),
+    'LineString': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeCurveOrLineString_),
+    'MultiLineString': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiCurveOrLineString_),
+    'LinearRing': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeLinearRing_),
+    'Polygon': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+    'MultiPolygon': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+    'Surface': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeSurfaceOrPolygon_),
+    'MultiSurface': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeMultiSurfaceOrPolygon_),
+    'Envelope': ol.xml.makeChildAppender(
+        ol.format.GML3.prototype.writeEnvelope)
+  },
+  'http://www.opengis.net/gml/3.2': {
     'Curve': ol.xml.makeChildAppender(
         ol.format.GML3.prototype.writeCurveOrLineString_),
     'MultiCurve': ol.xml.makeChildAppender(

--- a/src/ol/format/gmlbase.js
+++ b/src/ol/format/gmlbase.js
@@ -132,7 +132,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
           objectStack, this);
     }
   } else if (localName == 'featureMembers' || localName == 'featureMember' ||
-			 localName == 'member') {
+             localName == 'member') {
     var context = objectStack[0];
     var featureType = context['featureType'];
     var featureNS = context['featureNS'];
@@ -162,7 +162,7 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
           }
         }
       }
-      if (localName != 'featureMember' && localName != "member") {
+      if (localName != 'featureMember' && localName != 'member') {
         // recheck featureType for each featureMember
         context['featureType'] = featureType;
         context['featureNS'] = featureNS;

--- a/src/ol/format/gmlbase.js
+++ b/src/ol/format/gmlbase.js
@@ -98,6 +98,16 @@ ol.format.GMLBase.GMLNS_3_2 = 'http://www.opengis.net/gml/3.2';
 
 
 /**
+ * @const
+ * @type {Array.<string>}
+ */
+ol.format.GMLBase.NAMESPACE_URIS = [
+  ol.format.GMLBase.GMLNS,
+  ol.format.GMLBase.GMLNS_3_2
+];
+
+
+/**
  * A regular expression that matches if a string only contains whitespace
  * characters. It will e.g. match `''`, `' '`, `'\n'` etc. The non-breaking
  * space (0xa0) is explicitly included as IE doesn't include it in its
@@ -468,14 +478,13 @@ ol.format.GMLBase.prototype.readFlatCoordinatesFromNode_ = function(node, object
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GMLBase.prototype.MULTIPOINT_PARSERS_ = {
-  'http://www.opengis.net/gml': {
-    'pointMember': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.pointMemberParser_),
-    'pointMembers': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.pointMemberParser_)
-  }
-};
+ol.format.GMLBase.prototype.MULTIPOINT_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'pointMember': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.pointMemberParser_),
+      'pointMembers': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.pointMemberParser_)
+    });
 
 
 /**
@@ -483,14 +492,13 @@ ol.format.GMLBase.prototype.MULTIPOINT_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
-  'http://www.opengis.net/gml': {
-    'lineStringMember': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.lineStringMemberParser_),
-    'lineStringMembers': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.lineStringMemberParser_)
-  }
-};
+ol.format.GMLBase.prototype.MULTILINESTRING_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'lineStringMember': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.lineStringMemberParser_),
+      'lineStringMembers': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.lineStringMemberParser_)
+    });
 
 
 /**
@@ -498,14 +506,13 @@ ol.format.GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
-  'http://www.opengis.net/gml': {
-    'polygonMember': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.polygonMemberParser_),
-    'polygonMembers': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.polygonMemberParser_)
-  }
-};
+ol.format.GMLBase.prototype.MULTIPOLYGON_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'polygonMember': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.polygonMemberParser_),
+      'polygonMembers': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.polygonMemberParser_)
+    });
 
 
 /**
@@ -513,12 +520,11 @@ ol.format.GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GMLBase.prototype.POINTMEMBER_PARSERS_ = {
-  'http://www.opengis.net/gml': {
-    'Point': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readFlatCoordinatesFromNode_)
-  }
-};
+ol.format.GMLBase.prototype.POINTMEMBER_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'Point': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.readFlatCoordinatesFromNode_)
+    });
 
 
 /**
@@ -526,12 +532,11 @@ ol.format.GMLBase.prototype.POINTMEMBER_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
-  'http://www.opengis.net/gml': {
-    'LineString': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readLineString)
-  }
-};
+ol.format.GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'LineString': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.readLineString)
+    });
 
 
 /**
@@ -539,12 +544,11 @@ ol.format.GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @private
  */
-ol.format.GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
-  'http://www.opengis.net/gml': {
-    'Polygon': ol.xml.makeArrayPusher(
-        ol.format.GMLBase.prototype.readPolygon)
-  }
-};
+ol.format.GMLBase.prototype.POLYGONMEMBER_PARSERS_ = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'Polygon': ol.xml.makeArrayPusher(
+          ol.format.GMLBase.prototype.readPolygon)
+    });
 
 
 /**
@@ -552,12 +556,11 @@ ol.format.GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
  * @type {Object.<string, Object.<string, ol.XmlParser>>}
  * @protected
  */
-ol.format.GMLBase.prototype.RING_PARSERS = {
-  'http://www.opengis.net/gml': {
-    'LinearRing': ol.xml.makeReplacer(
-        ol.format.GMLBase.prototype.readFlatLinearRing_)
-  }
-};
+ol.format.GMLBase.prototype.RING_PARSERS = ol.xml.makeStructureNS(
+    ol.format.GMLBase.NAMESPACE_URIS, {
+      'LinearRing': ol.xml.makeReplacer(
+          ol.format.GMLBase.prototype.readFlatLinearRing_)
+    });
 
 
 /**


### PR DESCRIPTION
We have tried to access the WFS features from the federal of tyrol from

https://gis.tirol.gv.at/arcgis/services/Service_Public/OGD/MapServer/WFSServer?request=GetCapabilities&service=WFS

and recognized, that the WFS layers are provided as GML version 3.2.

After dissecting the GML3 parsers of ol3, we came up with a patch for adding GML-3.2 read support in a way, that it does not seem to heavily interfere with existing code.

Please review our changes and give us feedback. This is our first contribution to openlayers, so be graceful, whatever regrets may be, we have done our best ;-)

  Best Regards, Wolfgang Glas 