### PR TITLE
Canvas renderer forEachLayerAtCoordinate should proxy to itself

### DIFF
--- a/src/ol/renderer/canvas/layer.js
+++ b/src/ol/renderer/canvas/layer.js
@@ -2,7 +2,6 @@ goog.provide('ol.renderer.canvas.Layer');
 
 goog.require('ol');
 goog.require('ol.extent');
-goog.require('ol.functions');
 goog.require('ol.render.Event');
 goog.require('ol.render.EventType');
 goog.require('ol.render.canvas');

--- a/src/ol/renderer/canvas/layer.js
+++ b/src/ol/renderer/canvas/layer.js
@@ -106,14 +106,7 @@ ol.renderer.canvas.Layer.prototype.dispatchComposeEvent_ = function(type, contex
  * @template S,T,U
  */
 ol.renderer.canvas.Layer.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, callback, thisArg) {
-  var hasFeature = this.forEachFeatureAtCoordinate(
-      coordinate, frameState, 0, ol.functions.TRUE, this);
-
-  if (hasFeature) {
-    return callback.call(thisArg, this.getLayer(), null);
-  } else {
-    return undefined;
-  }
+  this.forEachLayerAtCoordinate(coordinate, frameState, callback, thisArg);
 };
 
 

--- a/src/ol/renderer/canvas/layer.js
+++ b/src/ol/renderer/canvas/layer.js
@@ -106,7 +106,7 @@ ol.renderer.canvas.Layer.prototype.dispatchComposeEvent_ = function(type, contex
  * @template S,T,U
  */
 ol.renderer.canvas.Layer.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, callback, thisArg) {
-  this.forEachLayerAtCoordinate(coordinate, frameState, callback, thisArg);
+  return this.forEachLayerAtCoordinate(coordinate, frameState, callback, thisArg);
 };
 
 


### PR DESCRIPTION
The canvas renderer was calling `forEachFeatureAtCoordinate` inside the `forEachLayerAtCoordinate` method. This seems incorrect, but our knowledge of OL internals is limited. When we started to dig into the canvas render's version of `forEachLayerAtCoordinate` we noticed it appeared to be working with features and not layers. If anything, this may add clarity to why the inconsistent behavior is being seen in #6402 

BTW, from some initial testing, this change appears to resolve the inconsistent behavior seen in #6402 