### PR TITLE
Accept ol.StyleFunction in ol.Feature#setStyle()

### DIFF
--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -172,7 +172,7 @@ ol.Feature.prototype.getGeometryName = function() {
  * Get the feature's style. Will return what was provided to the
  * {@link ol.Feature#setStyle} method.
  * @return {ol.style.Style|Array.<ol.style.Style>|
- *     ol.FeatureStyleFunction} The feature style.
+ *     ol.FeatureStyleFunction|ol.StyleFunction} The feature style.
  * @api stable
  */
 ol.Feature.prototype.getStyle = function() {
@@ -233,7 +233,7 @@ ol.Feature.prototype.setGeometry = function(geometry) {
  * of styles, or a function that takes a resolution and returns an array of
  * styles. If it is `null` the feature has no style (a `null` style).
  * @param {ol.style.Style|Array.<ol.style.Style>|
- *     ol.FeatureStyleFunction} style Style for this feature.
+ *     ol.FeatureStyleFunction|ol.StyleFunction} style Style for this feature.
  * @api stable
  * @fires ol.events.Event#event:change
  */
@@ -291,7 +291,13 @@ ol.Feature.createStyleFunction = function(obj) {
   var styleFunction;
 
   if (typeof obj === 'function') {
-    styleFunction = obj;
+    if (obj.length == 2) {
+      styleFunction = function(resolution) {
+        return /** @type {ol.StyleFunction} */ (obj)(this, resolution);
+      };
+    } else {
+      styleFunction = obj;
+    }
   } else {
     /**
      * @type {Array.<ol.style.Style>}

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -303,7 +303,7 @@ describe('ol.Feature', function() {
     var style = new ol.style.Style();
 
     var styleFunction = function(feature, resolution) {
-      return null;
+      return resolution;
     };
 
     it('accepts a single style', function() {
@@ -322,8 +322,19 @@ describe('ol.Feature', function() {
 
     it('accepts a style function', function() {
       var feature = new ol.Feature();
+      function featureStyleFunction(resolution) {
+        return styleFunction(this, resolution);
+      }
+      feature.setStyle(featureStyleFunction);
+      expect(feature.getStyleFunction()).to.be(featureStyleFunction);
+      expect(feature.getStyleFunction()(42)).to.be(42);
+    });
+
+    it('accepts a layer style function', function() {
+      var feature = new ol.Feature();
       feature.setStyle(styleFunction);
-      expect(feature.getStyleFunction()).to.be(styleFunction);
+      expect(feature.getStyleFunction()).to.not.be(styleFunction);
+      expect(feature.getStyleFunction()(42)).to.be(42);
     });
 
     it('accepts null', function() {


### PR DESCRIPTION
Users should be able to use the same style function on `ol.layer.Vector` and `ol.Feature`.

Fixes #6411.