### PR TITLE
Stop handling down/up sequence only when all fingers have been removed

### DIFF
--- a/src/ol/interaction/pointer.js
+++ b/src/ol/interaction/pointer.js
@@ -187,8 +187,8 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDRAG) {
       this.handleDragEvent_(mapBrowserEvent);
     } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
-      this.handleUpEvent_(mapBrowserEvent);
-      this.handlingDownUpSequence = false;
+      this.handlingDownUpSequence = this.handleUpEvent_(mapBrowserEvent) &&
+          this.targetPointers.length > 0;
     }
   } else {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDOWN) {


### PR DESCRIPTION
Fix #6423

And also fix another issue I discovered :
1. Start translating a feature with one finger. 
2. While still holding that finger, just tap with another finger.
3. On v3.20.1, Translate Interaction stop working. On master, it's more random.