### PR TITLE
Improve tile render performance

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -174,7 +174,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame = function(frameState, layer
   if (!(this.renderedResolution && Date.now() - frameState.time > 16 &&
       (hints[ol.ViewHint.ANIMATING] || hints[ol.ViewHint.INTERACTING])) &&
       (newTiles || !(this.renderedExtent_ &&
-      ol.extent.equals(this.renderedExtent_, imageExtent)) ||
+      ol.extent.containsExtent(this.renderedExtent_, extent)) ||
       this.renderedRevision != sourceRevision) ||
       oversampling != this.oversampling_) {
 


### PR DESCRIPTION
This pull request avoids oversampling when the view resolution is lower than the lowest available tile source resolution. It also avoids redraws when the view extent is still covered by the intermediate canvas's image extent.

Fixes #6415.