### PR TITLE
goog.require cleanup

### DIFF
--- a/src/ol/animation.js
+++ b/src/ol/animation.js
@@ -1,6 +1,5 @@
 goog.provide('ol.animation');
 
-goog.require('ol');
 goog.require('ol.ViewHint');
 goog.require('ol.coordinate');
 goog.require('ol.easing');

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -1,7 +1,5 @@
 goog.provide('ol.array');
 
-goog.require('ol');
-
 
 /**
  * Performs a binary search on the provided sorted list and returns the index of the item if found. If it can't be found it'll return -1.

--- a/src/ol/control.js
+++ b/src/ol/control.js
@@ -1,6 +1,5 @@
 goog.provide('ol.control');
 
-goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.control.Attribution');
 goog.require('ol.control.Rotate');

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -1,6 +1,5 @@
 goog.provide('ol.extent');
 
-goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.extent.Corner');
 goog.require('ol.extent.Relationship');

--- a/src/ol/format/filter.js
+++ b/src/ol/format/filter.js
@@ -1,6 +1,5 @@
 goog.provide('ol.format.filter');
 
-goog.require('ol');
 goog.require('ol.format.filter.And');
 goog.require('ol.format.filter.Bbox');
 goog.require('ol.format.filter.EqualTo');

--- a/src/ol/format/filter/filter.js
+++ b/src/ol/format/filter/filter.js
@@ -1,7 +1,5 @@
 goog.provide('ol.format.filter.Filter');
 
-goog.require('ol');
-
 
 /**
  * @classdesc

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -1,6 +1,5 @@
 goog.provide('ol.format.XSD');
 
-goog.require('ol');
 goog.require('ol.xml');
 goog.require('ol.string');
 

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.closest');
 
-goog.require('ol');
 goog.require('ol.math');
 
 

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.contains');
 
-goog.require('ol');
 goog.require('ol.extent');
 
 

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -1,7 +1,5 @@
 goog.provide('ol.geom.flat.deflate');
 
-goog.require('ol');
-
 
 /**
  * @param {Array.<number>} flatCoordinates Flat coordinates.

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.geodesic');
 
-goog.require('ol');
 goog.require('ol.math');
 goog.require('ol.proj');
 

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.interiorpoint');
 
-goog.require('ol');
 goog.require('ol.array');
 goog.require('ol.geom.flat.contains');
 

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.interpolate');
 
-goog.require('ol');
 goog.require('ol.array');
 goog.require('ol.math');
 

--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.intersectsextent');
 
-goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.flat.contains');
 goog.require('ol.geom.flat.segments');

--- a/src/ol/geom/flat/orient.js
+++ b/src/ol/geom/flat/orient.js
@@ -1,6 +1,5 @@
 goog.provide('ol.geom.flat.orient');
 
-goog.require('ol');
 goog.require('ol.geom.flat.reverse');
 
 

--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -1,6 +1,5 @@
 goog.provide('ol.Graticule');
 
-goog.require('ol');
 goog.require('ol.extent');
 goog.require('ol.geom.GeometryLayout');
 goog.require('ol.geom.LineString');

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -1,6 +1,5 @@
 goog.provide('ol.interaction');
 
-goog.require('ol');
 goog.require('ol.Collection');
 goog.require('ol.Kinetic');
 goog.require('ol.interaction.DoubleClickZoom');

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -1,6 +1,5 @@
 goog.provide('ol.math');
 
-goog.require('ol');
 goog.require('ol.asserts');
 
 

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -1,6 +1,5 @@
 goog.provide('ol.proj.transforms');
 
-goog.require('ol');
 goog.require('ol.obj');
 
 

--- a/src/ol/render/canvas/replay.js
+++ b/src/ol/render/canvas/replay.js
@@ -8,7 +8,6 @@ goog.require('ol.geom.flat.transform');
 goog.require('ol.has');
 goog.require('ol.obj');
 goog.require('ol.render.VectorContext');
-goog.require('ol.render.canvas');
 goog.require('ol.render.canvas.Instruction');
 goog.require('ol.transform');
 

--- a/src/ol/render/webgl.js
+++ b/src/ol/render/webgl.js
@@ -1,5 +1,8 @@
 goog.provide('ol.render.webgl');
 
+goog.require('ol');
+
+
 if (ol.ENABLE_WEBGL) {
 
   /**

--- a/src/ol/render/webgl/imagereplay.js
+++ b/src/ol/render/webgl/imagereplay.js
@@ -5,7 +5,6 @@ goog.require('ol.extent');
 goog.require('ol.obj');
 goog.require('ol.render.webgl.imagereplay.defaultshader');
 goog.require('ol.render.webgl.Replay');
-goog.require('ol.render.webgl');
 goog.require('ol.webgl');
 goog.require('ol.webgl.Buffer');
 goog.require('ol.webgl.Context');

--- a/src/ol/render/webgl/immediate.js
+++ b/src/ol/render/webgl/immediate.js
@@ -6,7 +6,6 @@ goog.require('ol.geom.GeometryType');
 goog.require('ol.render.ReplayType');
 goog.require('ol.render.VectorContext');
 goog.require('ol.render.webgl.ReplayGroup');
-goog.require('ol.render.webgl');
 
 
 if (ol.ENABLE_WEBGL) {

--- a/src/ol/render/webgl/replaygroup.js
+++ b/src/ol/render/webgl/replaygroup.js
@@ -6,7 +6,6 @@ goog.require('ol.extent');
 goog.require('ol.obj');
 goog.require('ol.render.replay');
 goog.require('ol.render.ReplayGroup');
-goog.require('ol.render.webgl');
 goog.require('ol.render.webgl.CircleReplay');
 goog.require('ol.render.webgl.ImageReplay');
 goog.require('ol.render.webgl.LineStringReplay');

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -1,6 +1,5 @@
 goog.provide('ol.reproj');
 
-goog.require('ol');
 goog.require('ol.dom');
 goog.require('ol.extent');
 goog.require('ol.math');

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -1,6 +1,5 @@
 goog.provide('ol.structs.LRUCache');
 
-goog.require('ol');
 goog.require('ol.asserts');
 
 

--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -1,6 +1,5 @@
 goog.provide('ol.structs.PriorityQueue');
 
-goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.obj');
 

--- a/src/ol/style/atlas.js
+++ b/src/ol/style/atlas.js
@@ -1,6 +1,5 @@
 goog.provide('ol.style.Atlas');
 
-goog.require('ol');
 goog.require('ol.dom');
 
 

--- a/src/ol/style/iconimagecache.js
+++ b/src/ol/style/iconimagecache.js
@@ -1,6 +1,5 @@
 goog.provide('ol.style.IconImageCache');
 
-goog.require('ol');
 goog.require('ol.color');
 
 
@@ -87,8 +86,7 @@ ol.style.IconImageCache.prototype.get = function(src, crossOrigin, color) {
  * @param {ol.Color} color Color.
  * @param {ol.style.IconImage} iconImage Icon image.
  */
-ol.style.IconImageCache.prototype.set = function(src, crossOrigin, color,
-                                                 iconImage) {
+ol.style.IconImageCache.prototype.set = function(src, crossOrigin, color, iconImage) {
   var key = ol.style.IconImageCache.getKey(src, crossOrigin, color);
   this.cache_[key] = iconImage;
   ++this.cacheSize_;

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -1,6 +1,5 @@
 goog.provide('ol.TileUrlFunction');
 
-goog.require('ol');
 goog.require('ol.asserts');
 goog.require('ol.math');
 goog.require('ol.tilecoord');

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -1,5 +1,7 @@
 goog.provide('ol.webgl');
 
+goog.require('ol');
+
 
 if (ol.ENABLE_WEBGL) {
 

--- a/src/ol/webgl/shader.js
+++ b/src/ol/webgl/shader.js
@@ -1,7 +1,6 @@
 goog.provide('ol.webgl.Shader');
 
 goog.require('ol.functions');
-goog.require('ol.webgl');
 
 
 if (ol.ENABLE_WEBGL) {

--- a/src/ol/webgl/shader.js
+++ b/src/ol/webgl/shader.js
@@ -1,5 +1,6 @@
 goog.provide('ol.webgl.Shader');
 
+goog.require('ol');
 goog.require('ol.functions');
 
 

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -1,6 +1,5 @@
 goog.provide('ol.xml');
 
-goog.require('ol');
 goog.require('ol.array');
 
 


### PR DESCRIPTION
I've found the unused require by running eslint in the `build/package/` directory from #6302