### PR TITLE
Fix pinch zooming

### DIFF
--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -112,6 +112,11 @@ ol.interaction.DragPan.handleUpEvent_ = function(mapBrowserEvent) {
     view.setHint(ol.ViewHint.INTERACTING, -1);
     return false;
   } else {
+    if (this.kinetic_) {
+      // reset so we don't overestimate the kinetic energy after
+      // after one finger up, tiny drag, second finger up
+      this.kinetic_.begin();
+    }
     this.lastCentroid = null;
     return true;
   }

--- a/src/ol/interaction/pointer.js
+++ b/src/ol/interaction/pointer.js
@@ -187,8 +187,8 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDRAG) {
       this.handleDragEvent_(mapBrowserEvent);
     } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
-      this.handlingDownUpSequence = this.handleUpEvent_(mapBrowserEvent) &&
-          this.targetPointers.length > 0;
+      var handledUp = this.handleUpEvent_(mapBrowserEvent);
+      this.handlingDownUpSequence = handledUp && this.targetPointers.length > 0;
     }
   } else {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDOWN) {

--- a/src/ol/interaction/pointer.js
+++ b/src/ol/interaction/pointer.js
@@ -187,8 +187,8 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDRAG) {
       this.handleDragEvent_(mapBrowserEvent);
     } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
-      this.handleUpEvent_(mapBrowserEvent);
-      this.handlingDownUpSequence = false;
+      this.handlingDownUpSequence = this.handleUpEvent_(mapBrowserEvent) &&
+          this.targetPointers.length > 0;
     }
   } else {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDOWN) {


### PR DESCRIPTION
This incorporates @tchandelle's fix in #6434 and adds to it to fix pinch zooming.

There is some fragile logic in here since both the pinch zoom and drag pan interactions are handling both drag and up events.  I think things could be made simpler if pointer interactions could stop propagation for these events (they currently only stop down events).  But that might be a mess, so I'm not taking it on.

Fixes #6423.
