### PR TITLE
[WIP] More rendering control over tile layers

### DIFF
--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -18,6 +18,7 @@ var key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';
 var map = new ol.Map({
   layers: [
     new ol.layer.VectorTile({
+      renderMode: 'vector',
       source: new ol.source.VectorTile({
         attributions: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
           '© <a href="https://www.openstreetmap.org/copyright">' +

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -25,8 +25,7 @@ var map = new ol.Map({
           'OpenStreetMap contributors</a>',
         format: new ol.format.MVT(),
         tileGrid: ol.tilegrid.createXYZ({
-          maxZoom: 19,
-          loadZooms: [0, 4, 8, 12, 16]
+          levels: [0, 3, 6, 9, 12, 15]
         }),
         url: 'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
               '{z}/{x}/{y}.vector.pbf?access_token=' + key,

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -10,52 +10,26 @@ goog.require('ol.style.Icon');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.style.Text');
-goog.require('ol.tilegrid.TileGrid');
+goog.require('ol.tilegrid');
 
 
 var key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';
 
-// For how many zoom levels do we want to use the same vector tiles?
-// 1 means "use tiles from all zoom levels". 2 means "use the same tiles for 2
-// subsequent zoom levels".
-var reuseZoomLevels = 2;
-
-// Offset of loaded tiles from web mercator zoom level 0.
-// 0 means "At map zoom level 0, use tiles from zoom level 0". 1 means "At map
-// zoom level 0, use tiles from zoom level 1".
-var zoomOffset = 1;
-
-// Calculation of tile urls
-var resolutions = [];
-for (var z = zoomOffset / reuseZoomLevels; z <= 22 / reuseZoomLevels; ++z) {
-  resolutions.push(156543.03392804097 / Math.pow(2, z * reuseZoomLevels));
-}
-function tileUrlFunction(tileCoord) {
-  return ('https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
-      '{z}/{x}/{y}.vector.pbf?access_token=' + key)
-      .replace('{z}', String(tileCoord[0] * reuseZoomLevels + zoomOffset))
-      .replace('{x}', String(tileCoord[1]))
-      .replace('{y}', String(-tileCoord[2] - 1))
-      .replace('{a-d}', 'abcd'.substr(
-          ((tileCoord[1] << tileCoord[0]) + tileCoord[2]) % 4, 1));
-}
-
 var map = new ol.Map({
   layers: [
     new ol.layer.VectorTile({
-      renderMode: 'vector',
-      preload: Infinity,
       source: new ol.source.VectorTile({
         attributions: '© <a href="https://www.mapbox.com/map-feedback/">Mapbox</a> ' +
           '© <a href="https://www.openstreetmap.org/copyright">' +
           'OpenStreetMap contributors</a>',
         format: new ol.format.MVT(),
-        tileGrid: new ol.tilegrid.TileGrid({
-          extent: ol.proj.get('EPSG:3857').getExtent(),
-          resolutions: resolutions
+        tileGrid: ol.tilegrid.createXYZ({
+          maxZoom: 19,
+          loadZooms: [0, 4, 8, 12, 16]
         }),
-        tilePixelRatio: 16,
-        tileUrlFunction: tileUrlFunction
+        url: 'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
+              '{z}/{x}/{y}.vector.pbf?access_token=' + key,
+        tilePixelRatio: 16
       }),
       style: createMapboxStreetsV6Style()
     })

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7421,7 +7421,7 @@ olx.tilegrid;
 
 /**
  * @typedef {{extent: (ol.Extent|undefined),
- *     loadZooms: (Array.<number>|undefined),
+ *     levels: (Array.<number>|undefined),
  *     minZoom: (number|undefined),
  *     origin: (ol.Coordinate|undefined),
  *     origins: (Array.<ol.Coordinate>|undefined),
@@ -7444,13 +7444,12 @@ olx.tilegrid.TileGridOptions.prototype.extent;
 
 
 /**
- * Zoom levels to load from a tile source. This array defines a subset of the
- * available zoom levels. When configured, only tiles for the specified zoom
- * levels will be requested from a tile source.
+ * Sorted array with the zoom levels that will be used. Overrides
+ * {@link olx.tilegrid.TileGridOptions.prototype.minZoom}.
  * @type {Array.<number>|undefined}
  * @api
  */
-olx.tilegrid.TileGridOptions.prototype.loadZooms;
+olx.tilegrid.TileGridOptions.prototype.levels;
 
 
 /**
@@ -7620,7 +7619,7 @@ olx.tilegrid.WMTSOptions.prototype.widths;
 
 /**
  * @typedef {{extent: (ol.Extent|undefined),
- *     loadZooms: (Array.<number>|undefined),
+ *     levels: (Array.<number>|undefined),
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
  *     tileSize: (number|ol.Size|undefined)}}
@@ -7640,13 +7639,13 @@ olx.tilegrid.XYZOptions.prototype.extent;
 
 
 /**
- * Zoom levels to load from a tile source. This array defines a subset of the
- * available zoom levels. When configured, only tiles for the specified zoom
- * levels will be requested from a tile source. Example: `[0, 4, 8, 12]`.
+ * Sorted array with the zoom levels that will be used. Overrides
+ * {@link olx.tilegrid.XYZOptions.prototype.minZoom} and
+ * {@link olx.tilegrid.XYZOptions.prototype.maxZoom}.
  * @type {Array.<number>|undefined}
  * @api
  */
-olx.tilegrid.XYZOptions.prototype.loadZooms;
+olx.tilegrid.XYZOptions.prototype.levels;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7421,6 +7421,7 @@ olx.tilegrid;
 
 /**
  * @typedef {{extent: (ol.Extent|undefined),
+ *     loadZooms: (Array.<number>|undefined),
  *     minZoom: (number|undefined),
  *     origin: (ol.Coordinate|undefined),
  *     origins: (Array.<ol.Coordinate>|undefined),
@@ -7440,6 +7441,16 @@ olx.tilegrid.TileGridOptions;
  * @api
  */
 olx.tilegrid.TileGridOptions.prototype.extent;
+
+
+/**
+ * Zoom levels to load from a tile source. This array defines a subset of the
+ * available zoom levels. When configured, only tiles for the specified zoom
+ * levels will be requested from a tile source.
+ * @type {Array.<number>|undefined}
+ * @api
+ */
+olx.tilegrid.TileGridOptions.prototype.loadZooms;
 
 
 /**
@@ -7609,6 +7620,7 @@ olx.tilegrid.WMTSOptions.prototype.widths;
 
 /**
  * @typedef {{extent: (ol.Extent|undefined),
+ *     loadZooms: (Array.<number>|undefined),
  *     maxZoom: (number|undefined),
  *     minZoom: (number|undefined),
  *     tileSize: (number|ol.Size|undefined)}}
@@ -7625,6 +7637,16 @@ olx.tilegrid.XYZOptions;
  * @api
  */
 olx.tilegrid.XYZOptions.prototype.extent;
+
+
+/**
+ * Zoom levels to load from a tile source. This array defines a subset of the
+ * available zoom levels. When configured, only tiles for the specified zoom
+ * levels will be requested from a tile source. Example: `[0, 4, 8, 12]`.
+ * @type {Array.<number>|undefined}
+ * @api
+ */
+olx.tilegrid.XYZOptions.prototype.loadZooms;
 
 
 /**

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -8,7 +8,8 @@ goog.provide('ol.array');
  * @param {Array.<*>} haystack Items to search through.
  * @param {*} needle The item to look for.
  * @param {Function=} opt_comparator Comparator function.
- * @return {number} The index of the item if found, -1 if not.
+ * @return {number} The index of the item if found, or the bitwise NOT (i.e. a
+ *     negative value) of the closest lower index.
  */
 ol.array.binarySearch = function(haystack, needle, opt_comparator) {
   var mid, cmp;

--- a/src/ol/layer/vectortile.js
+++ b/src/ol/layer/vectortile.js
@@ -43,9 +43,10 @@ ol.layer.VectorTile = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.layer.VectorTileRenderType|string}
+   * @type {ol.layer.VectorTileRenderType}
    */
-  this.renderMode_ = options.renderMode || ol.layer.VectorTileRenderType.HYBRID;
+  this.renderMode_ = /** @type {ol.layer.VectorTileRenderType} */ (options.renderMode) ||
+      ol.layer.VectorTileRenderType.HYBRID;
 
 };
 ol.inherits(ol.layer.VectorTile, ol.layer.Vector);
@@ -76,7 +77,7 @@ ol.layer.VectorTile.prototype.getPreload = function() {
 
 
 /**
- * @return {ol.layer.VectorTileRenderType|string} The render mode.
+ * @return {ol.layer.VectorTileRenderType} The render mode.
  */
 ol.layer.VectorTile.prototype.getRenderMode = function() {
   return this.renderMode_;

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -138,12 +138,10 @@ ol.renderer.canvas.VectorTileLayer.prototype.createReplayGroup_ = function(tile,
   var tileGrid = source.getTileGrid();
   var tileCoord = tile.tileCoord;
   var tileProjection = tile.getProjection();
-  var z = tileCoord[0];
   var resolution = tileGrid.getResolution(tileCoord[0]);
   var extent, reproject, tileResolution;
   if (tileProjection.getUnits() == ol.proj.Units.TILE_PIXELS) {
-    var tilePixelRatio = tileResolution =
-        tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), z);
+    var tilePixelRatio = tileResolution = source.getTilePixelRatio();
     var tileSize = ol.size.toSize(tileGrid.getTileSize(tileCoord[0]));
     extent = [0, 0, tileSize[0] * tilePixelRatio, tileSize[1] * tilePixelRatio];
   } else {
@@ -250,7 +248,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
     }
     if (tile.getProjection().getUnits() === ol.proj.Units.TILE_PIXELS) {
       origin = ol.extent.getTopLeft(tileExtent);
-      tilePixelRatio = tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), tileCoord[0]);
+      tilePixelRatio = source.getTilePixelRatio();
       tileResolution = tileGrid.getResolution(tileCoord[0]) / tilePixelRatio;
       tileSpaceCoordinate = [
         (coordinate[0] - origin[0]) / tileResolution,
@@ -291,9 +289,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.getReplayTransform_ = function(tile
     var source = /** @type {ol.source.VectorTile} */ (layer.getSource());
     var tileGrid = source.getTileGrid();
     var tileCoord = tile.tileCoord;
-    var z = tileCoord[0];
-    var tileResolution =
-        tileGrid.getResolution(z) / tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), z);
+    var tileResolution = tileGrid.getResolution(tileCoord[0]) / source.getTilePixelRatio();
     var viewState = frameState.viewState;
     var pixelRatio = frameState.pixelRatio;
     var renderResolution = viewState.resolution / pixelRatio;
@@ -424,7 +420,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderTileImage_ = function(
     var pixelRatio = frameState.pixelRatio;
     var source = layer.getSource();
     var tileGrid = source.getTileGrid();
-    var tilePixelRatio = tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), z);
+    var tilePixelRatio = source.getTilePixelRatio();
     var transform = ol.transform.reset(this.tmpTransform_);
     if (tile.getProjection().getUnits() == ol.proj.Units.TILE_PIXELS) {
       var renderPixelRatio = pixelRatio / tilePixelRatio;

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -45,9 +45,14 @@ ol.renderer.canvas.VectorTileLayer = function(layer) {
    */
   this.tmpTransform_ = ol.transform.create();
 
+  /**
+   * @private
+   * @type {ol.layer.VectorTileRenderType}
+   */
+  this.renderMode_ = layer.getRenderMode();
+
   // Use lower resolution for pure vector rendering. Closest resolution otherwise.
-  this.zDirection =
-      layer.getRenderMode() == ol.layer.VectorTileRenderType.VECTOR ? 1 : 0;
+  this.zDirection = this.renderMode_ == ol.layer.VectorTileRenderType.VECTOR ? 1 : 0;
 
 };
 ol.inherits(ol.renderer.canvas.VectorTileLayer, ol.renderer.canvas.TileLayer);
@@ -79,17 +84,30 @@ ol.renderer.canvas.VectorTileLayer.VECTOR_REPLAYS = {
 ol.renderer.canvas.VectorTileLayer.prototype.prepareFrame = function(frameState, layerState) {
   var layer = this.getLayer();
   var layerRevision = layer.getRevision();
-  if (this.renderedLayerRevision_ != layerRevision) {
+  var renderMode = this.renderMode_;
+  if (layer.getRenderMode() == ol.layer.VectorTileRenderType.HYBRID) {
+    var tileGrid = layer.getSource().getTileGrid();
+    var minResolution = tileGrid.getResolution(tileGrid.getMaxZoom());
+    var maxResolution = tileGrid.getResolution(tileGrid.getMinZoom());
+    var resolution = frameState.viewState.resolution;
+    renderMode = resolution < minResolution || resolution > maxResolution ?
+        ol.layer.VectorTileRenderType.VECTOR :
+        layer.getRenderMode();
+  }
+  if (!this.context && renderMode != ol.layer.VectorTileRenderType.VECTOR) {
+    this.context = ol.dom.createCanvasContext2D();
+  }
+  if (this.context && renderMode == ol.layer.VectorTileRenderType.VECTOR) {
+    this.context = null;
+  }
+  if (this.renderedLayerRevision_ != layerRevision || this.renderMode_ != renderMode) {
     this.renderedTiles.length = 0;
-    var renderMode = layer.getRenderMode();
-    if (!this.context && renderMode != ol.layer.VectorTileRenderType.VECTOR) {
-      this.context = ol.dom.createCanvasContext2D();
-    }
-    if (this.context && renderMode == ol.layer.VectorTileRenderType.VECTOR) {
-      this.context = null;
+    if (this.context) {
+      this.context.canvas.width = this.context.canvas.width;
     }
   }
   this.renderedLayerRevision_ = layerRevision;
+  this.renderMode_ = renderMode;
   return ol.renderer.canvas.TileLayer.prototype.prepareFrame.apply(this, arguments);
 };
 
@@ -197,7 +215,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.drawTileImage = function(
     tile, frameState, layerState, x, y, w, h, gutter) {
   var vectorTile = /** @type {ol.VectorTile} */ (tile);
   this.createReplayGroup_(vectorTile, frameState);
-  if (this.context) {
+  if (this.renderMode_ != ol.layer.VectorTileRenderType.VECTOR) {
     this.renderTileImage_(vectorTile, frameState, layerState);
     ol.renderer.canvas.TileLayer.prototype.drawTileImage.apply(this, arguments);
   }
@@ -311,8 +329,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.handleStyleImageChange_ = function(
  * @inheritDoc
  */
 ol.renderer.canvas.VectorTileLayer.prototype.postCompose = function(context, frameState, layerState) {
-  var renderMode = this.getLayer().getRenderMode();
-  var replays = ol.renderer.canvas.VectorTileLayer.VECTOR_REPLAYS[renderMode];
+  var replays = ol.renderer.canvas.VectorTileLayer.VECTOR_REPLAYS[this.renderMode_];
   if (replays) {
     var pixelRatio = frameState.pixelRatio;
     var rotation = frameState.viewState.rotation;
@@ -399,7 +416,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderTileImage_ = function(
   var layer = this.getLayer();
   var replayState = tile.getReplayState();
   var revision = layer.getRevision();
-  var replays = ol.renderer.canvas.VectorTileLayer.IMAGE_REPLAYS[layer.getRenderMode()];
+  var replays = ol.renderer.canvas.VectorTileLayer.IMAGE_REPLAYS[this.renderMode_];
   if (replays && replayState.renderedTileRevision !== revision) {
     replayState.renderedTileRevision = revision;
     var tileCoord = tile.tileCoord;

--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -120,10 +120,12 @@ ol.renderer.canvas.VectorTileLayer.prototype.createReplayGroup_ = function(tile,
   var tileGrid = source.getTileGrid();
   var tileCoord = tile.tileCoord;
   var tileProjection = tile.getProjection();
+  var z = tileCoord[0];
   var resolution = tileGrid.getResolution(tileCoord[0]);
   var extent, reproject, tileResolution;
   if (tileProjection.getUnits() == ol.proj.Units.TILE_PIXELS) {
-    var tilePixelRatio = tileResolution = source.getTilePixelRatio();
+    var tilePixelRatio = tileResolution =
+        tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), z);
     var tileSize = ol.size.toSize(tileGrid.getTileSize(tileCoord[0]));
     extent = [0, 0, tileSize[0] * tilePixelRatio, tileSize[1] * tilePixelRatio];
   } else {
@@ -230,7 +232,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
     }
     if (tile.getProjection().getUnits() === ol.proj.Units.TILE_PIXELS) {
       origin = ol.extent.getTopLeft(tileExtent);
-      tilePixelRatio = source.getTilePixelRatio();
+      tilePixelRatio = tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), tileCoord[0]);
       tileResolution = tileGrid.getResolution(tileCoord[0]) / tilePixelRatio;
       tileSpaceCoordinate = [
         (coordinate[0] - origin[0]) / tileResolution,
@@ -271,8 +273,9 @@ ol.renderer.canvas.VectorTileLayer.prototype.getReplayTransform_ = function(tile
     var source = /** @type {ol.source.VectorTile} */ (layer.getSource());
     var tileGrid = source.getTileGrid();
     var tileCoord = tile.tileCoord;
+    var z = tileCoord[0];
     var tileResolution =
-        tileGrid.getResolution(tileCoord[0]) / source.getTilePixelRatio();
+        tileGrid.getResolution(z) / tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), z);
     var viewState = frameState.viewState;
     var pixelRatio = frameState.pixelRatio;
     var renderResolution = viewState.resolution / pixelRatio;
@@ -404,7 +407,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.renderTileImage_ = function(
     var pixelRatio = frameState.pixelRatio;
     var source = layer.getSource();
     var tileGrid = source.getTileGrid();
-    var tilePixelRatio = source.getTilePixelRatio();
+    var tilePixelRatio = tileGrid.adjustTilePixelRatio(source.getTilePixelRatio(), z);
     var transform = ol.transform.reset(this.tmpTransform_);
     if (tile.getProjection().getUnits() == ol.proj.Units.TILE_PIXELS) {
       var renderPixelRatio = pixelRatio / tilePixelRatio;

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -252,9 +252,10 @@ ol.renderer.Layer.prototype.manageTilePyramid = function(
   }
   var wantedTiles = frameState.wantedTiles[tileSourceKey];
   var tileQueue = frameState.tileQueue;
-  var minZoom = tileGrid.getMinZoom();
+  var levels = tileGrid.getLevels();
   var tile, tileRange, tileResolution, x, y, z;
-  for (z = currentZ; z >= minZoom; --z) {
+  for (var i = levels.indexOf(currentZ); i >= 0; --i) {
+    z = levels[i];
     tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z, tileRange);
     tileResolution = tileGrid.getResolution(z);
     for (x = tileRange.minX; x <= tileRange.maxX; ++x) {

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -26,7 +26,8 @@ ol.TileUrlFunction.createFromTemplate = function(template, tileGrid) {
         if (!tileCoord) {
           return undefined;
         } else {
-          return template.replace(zRegEx, tileCoord[0].toString())
+          var z = tileGrid.getLoadZ(tileCoord[0]);
+          return template.replace(zRegEx, z.toString())
               .replace(xRegEx, tileCoord[1].toString())
               .replace(yRegEx, function() {
                 var y = -tileCoord[2] - 1;

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -26,8 +26,7 @@ ol.TileUrlFunction.createFromTemplate = function(template, tileGrid) {
         if (!tileCoord) {
           return undefined;
         } else {
-          var z = tileGrid.getLoadZ(tileCoord[0]);
-          return template.replace(zRegEx, z.toString())
+          return template.replace(zRegEx, tileCoord[0].toString())
               .replace(xRegEx, tileCoord[1].toString())
               .replace(yRegEx, function() {
                 var y = -tileCoord[2] - 1;

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -14,12 +14,14 @@ goog.require('ol.tilegrid');
 describe('ol.source.TileImage', function() {
   function createSource(opt_proj, opt_tileGrid) {
     var proj = opt_proj || 'EPSG:3857';
+    var tileGrid = opt_tileGrid ||
+        ol.tilegrid.createForProjection(proj, undefined, [2, 2]);
     return new ol.source.TileImage({
       projection: proj,
-      tileGrid: opt_tileGrid ||
-          ol.tilegrid.createForProjection(proj, undefined, [2, 2]),
+      tileGrid: tileGrid,
       tileUrlFunction: ol.TileUrlFunction.createFromTemplate(
-          'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=')
+          'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=',
+          tileGrid)
     });
   }
 


### PR DESCRIPTION
This pull request adds a new `loadZooms` option for tile grids. With that option, it is possible to limit the zoom levels that are fetched from the source. For vector tile layers in `hybrid` or `image` rendering mode, images are pre-rendered for all zoom levels of the source. When going beyond minZoom or maxZoom, vector tiles are always rendered in `vector` mode, to avoid up- and downscaling.

Fixes #6453.
Fixes #5580.
Fixes #6510.