### PR TITLE
Make all @api annotations imply stability

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -26,9 +26,6 @@
     "markdown": {
         "parser": "gfm"
     },
-    "stability": {
-      "levels": ["deprecated","experimental","unstable","stable","frozen","locked"]
-    },
     "templates": {
         "cleverLinks": true,
         "monospaceLinks": true,

--- a/config/jsdoc/api/index.md
+++ b/config/jsdoc/api/index.md
@@ -44,21 +44,19 @@ Interactions for [vector features](ol.Feature.html)
 
 #### API change policy
 
-The OpenLayers.x API consists of
-* names of classes, class methods and properties
-* names of static functions and constants
-* order and types of function arguments
-* types of function return values
+The OpenLayers API consists of
+* names and signatures of constructors
+* names and signatures of instance methods and properties
+* names and signatures of functions
+* names of constants
 
-API elements marked as `experimental` provide stable and functioning code, but may change.
-Any changes will be documented in upgrade notes so application code can be changed appropriately
-before using the new version of the library. All other API elements will remain compatible throughout the 3.x releases so that no changes to existing application code are necessary when upgrading to a later version.
+Within a major release series, the API will not be changed.  Any changes to the API will be accompanied by a new major release.
 
-*Note*: The API change policy does not cover CSS class names that are used to theme the
+*Note*: The API change policy does not cover CSS class names that are used to style the
 OpenLayers UI.
 
 *Note for Closure Compiler users compiling their application code together with OpenLayers*:
-The names of types other than those in the list above (e.g. `ol.Pixel`) are subject to change. It
+The names of types other than those in the list above (e.g. `ol.Coordinate`) are subject to change. It
 is therefore recommended to either use the resolved type as listed in the API docs (e.g.
-`Array.<number>` instead of `ol.Pixel`), or pay attention to the upgrade notes, which will list
+`Array.<number>` instead of `ol.Coordinate`), or pay attention to the upgrade notes, which will list
 the changes for those types.

--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -1,10 +1,6 @@
 /**
  * Define an @api tag
  */
-var conf = env.conf.stability;
-var defaultLevels = ["deprecated","experimental","unstable","stable","frozen","locked"];
-var levels = conf.levels || defaultLevels;
-var util = require('util');
 exports.defineTags = function(dictionary) {
   dictionary.defineTag('api', {
     mustHaveValue: false,
@@ -12,13 +8,7 @@ exports.defineTags = function(dictionary) {
     canHaveName: false,
     onTagged: function(doclet, tag) {
       includeTypes(doclet);
-      var level = tag.text || "experimental";
-      if (levels.indexOf(level) >= 0) {
-        doclet.stability = level;
-      } else {
-        var errorText = util.format('Invalid stability level (%s) in %s line %s', tag.text, doclet.meta.filename, doclet.meta.lineno);
-        require('jsdoc/lib/jsdoc/util/error').handle( new Error(errorText) );
-      }
+      doclet.stability = "stable";
     }
   });
 };

--- a/config/jsdoc/api/readme.md
+++ b/config/jsdoc/api/readme.md
@@ -22,7 +22,7 @@ contain Markdown.
 
 The second line tells the Closure compiler the type of the argument.
 
-The third line (`@api`) marks the method as part of the api and thus exportable. The stability can be added as value, e.g. `@api stable`. Without such an api annotation, the method will not be documented in the generated API documentation. Symbols without an api annotation will also not be exportable (unless they are explicitly exported with a `goog.exportProperty` call).
+The third line (`@api`) marks the method as part of the api and thus exportable. Without such an api annotation, the method will not be documented in the generated API documentation. Symbols without an api annotation will also not be exportable.
 
 The `@api` annotation can be used in conjunction with the `@inheritDoc` annotation to export a symbol that is documented on a parent class (where the method may be abstract).  In general, `@api` annotations should never be used on abstract methods (only on their implementations).
 

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -92,30 +92,6 @@ $(function () {
           textParts[1] + '</a>';
     });
 
-    // show/hide unstable items
-    var links = $('a[href^="ol."]');
-    var unstable = $('.unstable');
-    var stabilityToggle = $('#stability-toggle');
-    stabilityToggle.change(function() {
-        unstable.toggleClass('hidden', this.checked);
-        var search = this.checked ? '?stableonly=true' : '';
-        links.each(function(i, el) {
-            this.href = this.pathname + search + this.hash;
-        });
-        if (history.replaceState) {
-            var url = window.location.pathname + search + window.location.hash;
-            history.replaceState({}, '', url);
-        }
-        return false;
-    });
-    var search = window.location.search;
-    links.each(function(i, el) {
-        this.href = this.pathname + search + this.hash;
-    });
-    stabilityToggle.prop('checked', search === '?stableonly=true');
-    unstable.toggleClass('hidden', stabilityToggle[0].checked);
-
-
     // Highlighting current anchor
 
     var anchors = $('.anchor');

--- a/config/jsdoc/api/template/tmpl/layout.tmpl
+++ b/config/jsdoc/api/template/tmpl/layout.tmpl
@@ -23,9 +23,6 @@ var version = obj.packageInfo.version;
   <div class="navbar-inner">
     <div class="container">
       <a class="brand" href="/"><img src="logo-70x70.png"> OpenLayers</a>
-      <label id="stability">
-        <input type="checkbox" id="stability-toggle"> Stable Only
-      </label>
       <ul class="nav navbar-nav pull-right">
         <li><a href="../doc">Docs</a></li>
         <li><a href="../examples">Examples</a></li>

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -18,7 +18,7 @@ olx.AttributionOptions;
 /**
  * HTML markup for this attribution.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.AttributionOptions.prototype.html;
 
@@ -48,7 +48,7 @@ olx.GeolocationOptions;
 /**
  * Start Tracking. Default is `false`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.GeolocationOptions.prototype.tracking;
 
@@ -57,7 +57,7 @@ olx.GeolocationOptions.prototype.tracking;
  * Tracking options. See
  * {@link http://www.w3.org/TR/geolocation-API/#position_options_interface}.
  * @type {GeolocationPositionOptions|undefined}
- * @api stable
+ * @api
  */
 olx.GeolocationOptions.prototype.trackingOptions;
 
@@ -65,7 +65,7 @@ olx.GeolocationOptions.prototype.trackingOptions;
 /**
  * The projection the position is reported in.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.GeolocationOptions.prototype.projection;
 
@@ -182,7 +182,7 @@ olx.MapOptions;
  * Controls initially added to the map. If not specified,
  * {@link ol.control.defaults ol.control.defaults()} is used.
  * @type {ol.Collection.<ol.control.Control>|Array.<ol.control.Control>|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.controls;
 
@@ -200,7 +200,7 @@ olx.MapOptions.prototype.pixelRatio;
  * Interactions that are initially added to the map. If not specified,
  * {@link ol.interaction.defaults ol.interaction.defaults()} is used.
  * @type {ol.Collection.<ol.interaction.Interaction>|Array.<ol.interaction.Interaction>|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.interactions;
 
@@ -225,7 +225,7 @@ olx.MapOptions.prototype.keyboardEventTarget;
  * a vector layer to appear on top of a tile layer, it must come after the tile
  * layer.
  * @type {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.layers;
 
@@ -258,7 +258,7 @@ olx.MapOptions.prototype.loadTilesWhileInteracting;
  * the element will be used. To disable the map logo, set the option to
  * `false`. By default, the OpenLayers logo is shown.
  * @type {boolean|string|olx.LogoOptions|Element|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.logo;
 
@@ -266,7 +266,7 @@ olx.MapOptions.prototype.logo;
 /**
  * Overlays initially added to the map. By default, no overlays are added.
  * @type {ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.overlays;
 
@@ -278,7 +278,7 @@ olx.MapOptions.prototype.overlays;
  * Note that the Canvas renderer fully supports vector data, but WebGL can only
  * render Point geometries.
  * @type {ol.renderer.Type|Array.<ol.renderer.Type>|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.renderer;
 
@@ -288,7 +288,7 @@ olx.MapOptions.prototype.renderer;
  * element. If not specified at construction time, {@link ol.Map#setTarget}
  * must be called for the map to be rendered.
  * @type {Element|string|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.target;
 
@@ -297,7 +297,7 @@ olx.MapOptions.prototype.target;
  * The map's view.  No layer sources will be fetched unless this is specified at
  * construction time or through {@link ol.Map#setView}.
  * @type {ol.View|undefined}
- * @api stable
+ * @api
  */
 olx.MapOptions.prototype.view;
 
@@ -317,7 +317,7 @@ olx.AtPixelOptions;
  * Only layers which are visible and for which this function returns `true`
  * will be tested for features. By default, all visible layers will be tested.
  * @type {((function(ol.layer.Layer): boolean)|undefined)}
- * @api stable
+ * @api
  */
 olx.AtPixelOptions.prototype.layerFilter;
 
@@ -360,7 +360,7 @@ olx.OverlayOptions.prototype.id;
 /**
  * The overlay element.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.OverlayOptions.prototype.element;
 
@@ -371,7 +371,7 @@ olx.OverlayOptions.prototype.element;
  * The second element in the array is the vertical offset. A positive value
  * shifts the overlay down. Default is `[0, 0]`.
  * @type {Array.<number>|undefined}
- * @api stable
+ * @api
  */
 olx.OverlayOptions.prototype.offset;
 
@@ -379,7 +379,7 @@ olx.OverlayOptions.prototype.offset;
 /**
  * The overlay position in map projection.
  * @type {ol.Coordinate|undefined}
- * @api stable
+ * @api
  */
 olx.OverlayOptions.prototype.position;
 
@@ -390,7 +390,7 @@ olx.OverlayOptions.prototype.position;
  * `'bottom-right'`, `'center-left'`, `'center-center'`, `'center-right'`,
  * `'top-left'`, `'top-center'`, and `'top-right'`. Default is `'top-left'`.
  * @type {ol.OverlayPositioning|string|undefined}
- * @api stable
+ * @api
  */
 olx.OverlayOptions.prototype.positioning;
 
@@ -401,7 +401,7 @@ olx.OverlayOptions.prototype.positioning;
  * controls (CSS class name `ol-overlaycontainer-stopevent`); if `false` it is
  * placed in the container with CSS class name `ol-overlaycontainer`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.OverlayOptions.prototype.stopEvent;
 
@@ -412,7 +412,7 @@ olx.OverlayOptions.prototype.stopEvent;
  * the controls (see the `stopEvent` option) you will probably set `insertFirst`
  * to `true` so the overlay is displayed below the controls.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.OverlayOptions.prototype.insertFirst;
 
@@ -489,7 +489,7 @@ olx.ProjectionOptions;
 /**
  * The SRS identifier code, e.g. `EPSG:4326`.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.ProjectionOptions.prototype.code;
 
@@ -497,7 +497,7 @@ olx.ProjectionOptions.prototype.code;
 /**
  * Units. Required unless a proj4 projection is defined for `code`.
  * @type {ol.proj.Units|string|undefined}
- * @api stable
+ * @api
  */
 olx.ProjectionOptions.prototype.units;
 
@@ -505,7 +505,7 @@ olx.ProjectionOptions.prototype.units;
 /**
  * The validity extent for the SRS.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.ProjectionOptions.prototype.extent;
 
@@ -513,7 +513,7 @@ olx.ProjectionOptions.prototype.extent;
 /**
  * The axis orientation as specified in Proj4. The default is `enu`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.ProjectionOptions.prototype.axisOrientation;
 
@@ -521,7 +521,7 @@ olx.ProjectionOptions.prototype.axisOrientation;
 /**
  * Whether the projection is valid for the whole globe. Default is `false`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.ProjectionOptions.prototype.global;
 
@@ -578,7 +578,7 @@ olx.ViewOptions;
  * specified with the `projection` option. Default is `undefined`, and layer
  * sources will not be fetched if this is not set.
  * @type {ol.Coordinate|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.center;
 
@@ -621,7 +621,7 @@ olx.ViewOptions.prototype.extent;
  * (the default) then `maxResolution` defaults to `40075016.68557849 / 256 =
  * 156543.03392804097`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.maxResolution;
 
@@ -634,7 +634,7 @@ olx.ViewOptions.prototype.maxResolution;
  * defaults to `40075016.68557849 / 256 / Math.pow(2, 28) =
  * 0.0005831682455839253`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.minResolution;
 
@@ -645,7 +645,7 @@ olx.ViewOptions.prototype.minResolution;
  * is `28`.  Note that if `minResolution` is also provided, it is given
  * precedence over `maxZoom`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.maxZoom;
 
@@ -656,7 +656,7 @@ olx.ViewOptions.prototype.maxZoom;
  * is `0`. Note that if `maxResolution` is also provided, it is given
  * precedence over `minZoom`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.minZoom;
 
@@ -664,7 +664,7 @@ olx.ViewOptions.prototype.minZoom;
 /**
  * The projection. Default is `EPSG:3857` (Spherical Mercator).
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.projection;
 
@@ -675,7 +675,7 @@ olx.ViewOptions.prototype.projection;
  * `zoom`. Default is `undefined`, and layer sources will not be fetched if
  * neither this nor `zoom` are defined.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.resolution;
 
@@ -685,7 +685,7 @@ olx.ViewOptions.prototype.resolution;
  * `maxResolution`, `minResolution`, `minZoom`, `maxZoom`, and `zoomFactor`
  * options are ignored.
  * @type {Array.<number>|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.resolutions;
 
@@ -694,7 +694,7 @@ olx.ViewOptions.prototype.resolutions;
  * The initial rotation for the view in radians (positive rotation clockwise).
  * Default is `0`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.rotation;
 
@@ -704,7 +704,7 @@ olx.ViewOptions.prototype.rotation;
  * initial resolution for the view. The initial resolution is determined using
  * the `ol.View#constrainResolution` method.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.zoom;
 
@@ -712,7 +712,7 @@ olx.ViewOptions.prototype.zoom;
 /**
  * The zoom factor used to determine the resolution constraint.  Default is `2`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.ViewOptions.prototype.zoomFactor;
 
@@ -1082,7 +1082,7 @@ olx.control.ControlOptions;
  * The element is the control's container element. This only needs to be
  * specified if you're developing a custom control.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.ControlOptions.prototype.element;
 
@@ -1100,7 +1100,7 @@ olx.control.ControlOptions.prototype.render;
  * Specify a target if you want the control to be rendered outside of the map's
  * viewport.
  * @type {Element|string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ControlOptions.prototype.target;
 
@@ -1119,7 +1119,7 @@ olx.control.DefaultsOptions;
 /**
  * Attribution. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.control.DefaultsOptions.prototype.attribution;
 
@@ -1135,7 +1135,7 @@ olx.control.DefaultsOptions.prototype.attributionOptions;
 /**
  * Rotate. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.control.DefaultsOptions.prototype.rotate;
 
@@ -1151,7 +1151,7 @@ olx.control.DefaultsOptions.prototype.rotateOptions;
 /**
  * Zoom. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.control.DefaultsOptions.prototype.zoom;
 
@@ -1247,7 +1247,7 @@ olx.control.MousePositionOptions;
 /**
  * CSS class name. Default is `ol-mouse-position`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.MousePositionOptions.prototype.className;
 
@@ -1255,7 +1255,7 @@ olx.control.MousePositionOptions.prototype.className;
 /**
  * Coordinate format.
  * @type {ol.CoordinateFormatType|undefined}
- * @api stable
+ * @api
  */
 olx.control.MousePositionOptions.prototype.coordinateFormat;
 
@@ -1263,7 +1263,7 @@ olx.control.MousePositionOptions.prototype.coordinateFormat;
 /**
  * Projection.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.control.MousePositionOptions.prototype.projection;
 
@@ -1280,7 +1280,7 @@ olx.control.MousePositionOptions.prototype.render;
 /**
  * Target.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.MousePositionOptions.prototype.target;
 
@@ -1288,7 +1288,7 @@ olx.control.MousePositionOptions.prototype.target;
 /**
  * Markup for undefined coordinates. Default is `` (empty string).
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.MousePositionOptions.prototype.undefinedHTML;
 
@@ -1399,7 +1399,7 @@ olx.control.ScaleLineOptions;
 /**
  * CSS Class name. Default is `ol-scale-line`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ScaleLineOptions.prototype.className;
 
@@ -1407,7 +1407,7 @@ olx.control.ScaleLineOptions.prototype.className;
 /**
  * Minimum width in pixels. Default is `64`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.control.ScaleLineOptions.prototype.minWidth;
 
@@ -1424,7 +1424,7 @@ olx.control.ScaleLineOptions.prototype.render;
 /**
  * Target.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.ScaleLineOptions.prototype.target;
 
@@ -1432,7 +1432,7 @@ olx.control.ScaleLineOptions.prototype.target;
 /**
  * Units. Default is `metric`.
  * @type {ol.control.ScaleLineUnits|string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ScaleLineOptions.prototype.units;
 
@@ -1453,7 +1453,7 @@ olx.control.RotateOptions;
 /**
  * CSS class name. Default is `ol-rotate`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.RotateOptions.prototype.className;
 
@@ -1462,7 +1462,7 @@ olx.control.RotateOptions.prototype.className;
  * Text label to use for the rotate button. Default is `⇧`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
  * @type {string|Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.RotateOptions.prototype.label;
 
@@ -1470,7 +1470,7 @@ olx.control.RotateOptions.prototype.label;
 /**
  * Text label to use for the rotate tip. Default is `Reset rotation`
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.RotateOptions.prototype.tipLabel;
 
@@ -1478,7 +1478,7 @@ olx.control.RotateOptions.prototype.tipLabel;
 /**
  * Animation duration in milliseconds. Default is `250`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.control.RotateOptions.prototype.duration;
 
@@ -1486,7 +1486,7 @@ olx.control.RotateOptions.prototype.duration;
 /**
  * Hide the control when rotation is 0. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.control.RotateOptions.prototype.autoHide;
 
@@ -1512,7 +1512,7 @@ olx.control.RotateOptions.prototype.resetNorth;
 /**
  * Target.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.RotateOptions.prototype.target;
 
@@ -1533,7 +1533,7 @@ olx.control.ZoomOptions;
 /**
  * Animation duration in milliseconds. Default is `250`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.duration;
 
@@ -1541,7 +1541,7 @@ olx.control.ZoomOptions.prototype.duration;
 /**
  * CSS class name. Default is `ol-zoom`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.className;
 
@@ -1550,7 +1550,7 @@ olx.control.ZoomOptions.prototype.className;
  * Text label to use for the zoom-in button. Default is `+`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
  * @type {string|Node|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.zoomInLabel;
 
@@ -1559,7 +1559,7 @@ olx.control.ZoomOptions.prototype.zoomInLabel;
  * Text label to use for the zoom-out button. Default is `-`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
  * @type {string|Node|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.zoomOutLabel;
 
@@ -1567,7 +1567,7 @@ olx.control.ZoomOptions.prototype.zoomOutLabel;
 /**
  * Text label to use for the button tip. Default is `Zoom in`
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.zoomInTipLabel;
 
@@ -1575,7 +1575,7 @@ olx.control.ZoomOptions.prototype.zoomInTipLabel;
 /**
  * Text label to use for the button tip. Default is `Zoom out`
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.zoomOutTipLabel;
 
@@ -1583,7 +1583,7 @@ olx.control.ZoomOptions.prototype.zoomOutTipLabel;
 /**
  * The zoom delta applied on each click.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.delta;
 
@@ -1591,7 +1591,7 @@ olx.control.ZoomOptions.prototype.delta;
 /**
  * Target.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomOptions.prototype.target;
 
@@ -1609,7 +1609,7 @@ olx.control.ZoomSliderOptions;
 /**
  * CSS class name.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomSliderOptions.prototype.className;
 
@@ -1625,7 +1625,7 @@ olx.control.ZoomSliderOptions.prototype.duration;
 /**
  * Maximum resolution.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomSliderOptions.prototype.maxResolution;
 
@@ -1633,7 +1633,7 @@ olx.control.ZoomSliderOptions.prototype.maxResolution;
 /**
  * Minimum resolution.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomSliderOptions.prototype.minResolution;
 
@@ -1660,7 +1660,7 @@ olx.control.ZoomToExtentOptions;
 /**
  * Class name. Default is `ol-zoom-extent`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomToExtentOptions.prototype.className;
 
@@ -1668,7 +1668,7 @@ olx.control.ZoomToExtentOptions.prototype.className;
 /**
  * Target.
  * @type {Element|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomToExtentOptions.prototype.target;
 
@@ -1677,7 +1677,7 @@ olx.control.ZoomToExtentOptions.prototype.target;
  * Text label to use for the button. Default is `E`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
  * @type {string|Node|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomToExtentOptions.prototype.label;
 
@@ -1685,7 +1685,7 @@ olx.control.ZoomToExtentOptions.prototype.label;
 /**
  * Text label to use for the button tip. Default is `Zoom to extent`
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomToExtentOptions.prototype.tipLabel;
 
@@ -1694,7 +1694,7 @@ olx.control.ZoomToExtentOptions.prototype.tipLabel;
  * The extent to zoom to. If undefined the validity extent of the view
  * projection is used.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.control.ZoomToExtentOptions.prototype.extent;
 
@@ -1721,7 +1721,7 @@ olx.format.ReadOptions;
  * the data and if no `defaultDataProjection` is set for a format, the features
  * will not be reprojected.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.ReadOptions.prototype.dataProjection;
 
@@ -1730,7 +1730,7 @@ olx.format.ReadOptions.prototype.dataProjection;
  * Projection of the feature geometries created by the format reader. If not
  * provided, features will be returned in the `dataProjection`.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.ReadOptions.prototype.featureProjection;
 
@@ -1750,7 +1750,7 @@ olx.format.WriteOptions;
  * `defaultDataProjection` is set for a format, the features will be returned
  * in the `featureProjection`.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.WriteOptions.prototype.dataProjection;
 
@@ -1760,7 +1760,7 @@ olx.format.WriteOptions.prototype.dataProjection;
  * writer. If not provided, geometries are assumed to be in the
  * `dataProjection` if that is set; in other words, they are not transformed.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.WriteOptions.prototype.featureProjection;
 
@@ -1776,7 +1776,7 @@ olx.format.WriteOptions.prototype.featureProjection;
  * geometries.
  *
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.WriteOptions.prototype.rightHanded;
 
@@ -1806,7 +1806,7 @@ olx.format.GeoJSONOptions;
 /**
  * Default data projection. Default is `EPSG:4326`.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.GeoJSONOptions.prototype.defaultDataProjection;
 
@@ -1815,7 +1815,7 @@ olx.format.GeoJSONOptions.prototype.defaultDataProjection;
  * Projection for features read or written by the format.  Options passed to
  * read or write methods will take precedence.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.GeoJSONOptions.prototype.featureProjection;
 
@@ -1823,7 +1823,7 @@ olx.format.GeoJSONOptions.prototype.featureProjection;
 /**
  * Geometry name to use when creating features.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.format.GeoJSONOptions.prototype.geometryName;
 
@@ -1903,7 +1903,7 @@ olx.format.PolylineOptions;
  * The factor by which the coordinates values will be scaled.
  * Default is `1e5`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.format.PolylineOptions.prototype.factor;
 
@@ -1926,7 +1926,7 @@ olx.format.TopoJSONOptions;
 /**
  * Default data projection. Default is `EPSG:4326`.
  * @type {ol.ProjectionLike}
- * @api stable
+ * @api
  */
 olx.format.TopoJSONOptions.prototype.defaultDataProjection;
 
@@ -1958,7 +1958,7 @@ olx.format.KMLOptions;
 /**
  * Extract styles from the KML. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.KMLOptions.prototype.extractStyles;
 
@@ -1966,7 +1966,7 @@ olx.format.KMLOptions.prototype.extractStyles;
 /**
  * Show names as labels for placemarks which contain points. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.KMLOptions.prototype.showPointNames;
 
@@ -1974,7 +1974,7 @@ olx.format.KMLOptions.prototype.showPointNames;
 /**
  * Default style. The default default style is the same as Google Earth.
  * @type {Array.<ol.style.Style>|undefined}
- * @api stable
+ * @api
  */
 olx.format.KMLOptions.prototype.defaultStyle;
 
@@ -1982,7 +1982,7 @@ olx.format.KMLOptions.prototype.defaultStyle;
 /**
  * Write styles into KML. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.KMLOptions.prototype.writeStyles;
 
@@ -2009,7 +2009,7 @@ olx.format.GMLOptions;
  * item `topp:states` in the `featureType` array and then there will be a key
  * `topp` in the featureNS object with value `http://www.openplans.org/topp`.
  * @type {Object.<string, string>|string|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.featureNS;
 
@@ -2023,7 +2023,7 @@ olx.format.GMLOptions.prototype.featureNS;
  * there will be a key named `topp` in the featureNS object with value
  * `http://www.openplans.org/topp`.
  * @type {Array.<string>|string|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.featureType;
 
@@ -2040,7 +2040,7 @@ olx.format.GMLOptions.prototype.srsName;
  * Write gml:Surface instead of gml:Polygon elements. This also affects the
  * elements in multi-part geometries. Default is `false`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.surface;
 
@@ -2049,7 +2049,7 @@ olx.format.GMLOptions.prototype.surface;
  * Write gml:Curve instead of gml:LineString elements. This also affects the
  * elements in multi-part geometries. Default is `false`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.curve;
 
@@ -2058,7 +2058,7 @@ olx.format.GMLOptions.prototype.curve;
  * Write gml:MultiCurve instead of gml:MultiLineString. Since the latter is
  * deprecated in GML 3, the default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.multiCurve;
 
@@ -2067,7 +2067,7 @@ olx.format.GMLOptions.prototype.multiCurve;
  * Write gml:multiSurface instead of gml:MultiPolygon. Since the latter is
  * deprecated in GML 3, the default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.multiSurface;
 
@@ -2076,7 +2076,7 @@ olx.format.GMLOptions.prototype.multiSurface;
  * Optional schemaLocation to use when writing out the GML, this will override
  * the default provided.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.format.GMLOptions.prototype.schemaLocation;
 
@@ -2095,7 +2095,7 @@ olx.format.GPXOptions;
  * nodes from `wpt`, `rte` and `trk` can be processed, as those are
  * directly mapped to a feature.
  * @type {function(ol.Feature, Node)|undefined}
- * @api stable
+ * @api
  */
 olx.format.GPXOptions.prototype.readExtensions;
 
@@ -2112,7 +2112,7 @@ olx.format.WFSOptions;
 /**
  * The namespace URI used for features.
  * @type {Object.<string, string>|string|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSOptions.prototype.featureNS;
 
@@ -2120,7 +2120,7 @@ olx.format.WFSOptions.prototype.featureNS;
 /**
  * The feature type to parse. Only used for read operations.
  * @type {Array.<string>|string|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSOptions.prototype.featureType;
 
@@ -2137,7 +2137,7 @@ olx.format.WFSOptions.prototype.gmlFormat;
  * Optional schemaLocation to use for serialization, this will override the
  * default.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSOptions.prototype.schemaLocation;
 
@@ -2164,7 +2164,7 @@ olx.format.WFSWriteGetFeatureOptions;
 /**
  * The namespace URI used for features.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.featureNS;
 
@@ -2172,7 +2172,7 @@ olx.format.WFSWriteGetFeatureOptions.prototype.featureNS;
 /**
  * The prefix for the feature namespace.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.featurePrefix;
 
@@ -2180,7 +2180,7 @@ olx.format.WFSWriteGetFeatureOptions.prototype.featurePrefix;
 /**
  * The feature type names.
  * @type {Array.<string>}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.featureTypes;
 
@@ -2197,7 +2197,7 @@ olx.format.WFSWriteGetFeatureOptions.prototype.srsName;
 /**
  * Handle.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.handle;
 
@@ -2205,7 +2205,7 @@ olx.format.WFSWriteGetFeatureOptions.prototype.handle;
 /**
  * Output format.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.outputFormat;
 
@@ -2213,7 +2213,7 @@ olx.format.WFSWriteGetFeatureOptions.prototype.outputFormat;
 /**
  * Maximum number of features to fetch.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteGetFeatureOptions.prototype.maxFeatures;
 
@@ -2293,7 +2293,7 @@ olx.format.WFSWriteTransactionOptions;
 /**
  * The namespace URI used for features.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteTransactionOptions.prototype.featureNS;
 
@@ -2301,7 +2301,7 @@ olx.format.WFSWriteTransactionOptions.prototype.featureNS;
 /**
  * The prefix for the feature namespace.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteTransactionOptions.prototype.featurePrefix;
 
@@ -2309,7 +2309,7 @@ olx.format.WFSWriteTransactionOptions.prototype.featurePrefix;
 /**
  * The feature type name.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteTransactionOptions.prototype.featureType;
 
@@ -2326,7 +2326,7 @@ olx.format.WFSWriteTransactionOptions.prototype.srsName;
 /**
  * Handle.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteTransactionOptions.prototype.handle;
 
@@ -2342,7 +2342,7 @@ olx.format.WFSWriteTransactionOptions.prototype.nativeElements;
 /**
  * GML options for the WFS transaction writer.
  * @type {olx.format.GMLOptions|undefined}
- * @api stable
+ * @api
  */
 olx.format.WFSWriteTransactionOptions.prototype.gmlOptions;
 
@@ -2357,7 +2357,7 @@ olx.format.WKTOptions;
  * Whether to split GeometryCollections into
  * multiple features on reading. Default is `false`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.format.WKTOptions.prototype.splitCollection;
 
@@ -3420,7 +3420,7 @@ olx.layer.BaseOptions;
 /**
  * Opacity (0, 1). Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.BaseOptions.prototype.opacity;
 
@@ -3428,7 +3428,7 @@ olx.layer.BaseOptions.prototype.opacity;
 /**
  * Visibility. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.BaseOptions.prototype.visible;
 
@@ -3437,7 +3437,7 @@ olx.layer.BaseOptions.prototype.visible;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.BaseOptions.prototype.extent;
 
@@ -3454,7 +3454,7 @@ olx.layer.BaseOptions.prototype.zIndex;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.BaseOptions.prototype.minResolution;
 
@@ -3462,7 +3462,7 @@ olx.layer.BaseOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.BaseOptions.prototype.maxResolution;
 
@@ -3482,7 +3482,7 @@ olx.layer.LayerOptions;
 /**
  * Opacity (0, 1). Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.LayerOptions.prototype.opacity;
 
@@ -3492,7 +3492,7 @@ olx.layer.LayerOptions.prototype.opacity;
  * be set by calling {@link ol.layer.Layer#setSource layer.setSource(source)}
  * after construction.
  * @type {ol.source.Source|undefined}
- * @api stable
+ * @api
  */
 olx.layer.LayerOptions.prototype.source;
 
@@ -3500,7 +3500,7 @@ olx.layer.LayerOptions.prototype.source;
 /**
  * Visibility. Default is `true` (visible).
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.LayerOptions.prototype.visible;
 
@@ -3509,7 +3509,7 @@ olx.layer.LayerOptions.prototype.visible;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.LayerOptions.prototype.extent;
 
@@ -3526,7 +3526,7 @@ olx.layer.LayerOptions.prototype.zIndex;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.LayerOptions.prototype.minResolution;
 
@@ -3534,7 +3534,7 @@ olx.layer.LayerOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.LayerOptions.prototype.maxResolution;
 
@@ -3554,7 +3554,7 @@ olx.layer.GroupOptions;
 /**
  * Opacity (0, 1). Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.GroupOptions.prototype.opacity;
 
@@ -3562,7 +3562,7 @@ olx.layer.GroupOptions.prototype.opacity;
 /**
  * Visibility. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.GroupOptions.prototype.visible;
 
@@ -3571,7 +3571,7 @@ olx.layer.GroupOptions.prototype.visible;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.GroupOptions.prototype.extent;
 
@@ -3588,7 +3588,7 @@ olx.layer.GroupOptions.prototype.zIndex;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.GroupOptions.prototype.minResolution;
 
@@ -3596,7 +3596,7 @@ olx.layer.GroupOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.GroupOptions.prototype.maxResolution;
 
@@ -3604,7 +3604,7 @@ olx.layer.GroupOptions.prototype.maxResolution;
 /**
  * Child layers.
  * @type {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined}
- * @api stable
+ * @api
  */
 olx.layer.GroupOptions.prototype.layers;
 
@@ -3732,7 +3732,7 @@ olx.layer.ImageOptions;
 /**
  * Opacity (0, 1). Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.ImageOptions.prototype.opacity;
 
@@ -3740,7 +3740,7 @@ olx.layer.ImageOptions.prototype.opacity;
 /**
  * Source for this layer.
  * @type {ol.source.Image}
- * @api stable
+ * @api
  */
 olx.layer.ImageOptions.prototype.source;
 
@@ -3759,7 +3759,7 @@ olx.layer.ImageOptions.prototype.map;
 /**
  * Visibility. Default is `true` (visible).
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.ImageOptions.prototype.visible;
 
@@ -3768,7 +3768,7 @@ olx.layer.ImageOptions.prototype.visible;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.ImageOptions.prototype.extent;
 
@@ -3776,7 +3776,7 @@ olx.layer.ImageOptions.prototype.extent;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.ImageOptions.prototype.minResolution;
 
@@ -3784,7 +3784,7 @@ olx.layer.ImageOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.ImageOptions.prototype.maxResolution;
 
@@ -3806,7 +3806,7 @@ olx.layer.TileOptions;
 /**
  * Opacity (0, 1). Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.opacity;
 
@@ -3815,7 +3815,7 @@ olx.layer.TileOptions.prototype.opacity;
  * Preload. Load low-resolution tiles up to `preload` levels. By default
  * `preload` is `0`, which means no preloading.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.preload;
 
@@ -3823,7 +3823,7 @@ olx.layer.TileOptions.prototype.preload;
 /**
  * Source for this layer.
  * @type {ol.source.Tile}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.source;
 
@@ -3842,7 +3842,7 @@ olx.layer.TileOptions.prototype.map;
 /**
  * Visibility. Default is `true` (visible).
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.visible;
 
@@ -3851,7 +3851,7 @@ olx.layer.TileOptions.prototype.visible;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.extent;
 
@@ -3859,7 +3859,7 @@ olx.layer.TileOptions.prototype.extent;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.minResolution;
 
@@ -3867,7 +3867,7 @@ olx.layer.TileOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.maxResolution;
 
@@ -3875,7 +3875,7 @@ olx.layer.TileOptions.prototype.maxResolution;
 /**
  * Use interim tiles on error. Default is `true`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.TileOptions.prototype.useInterimTilesOnError;
 
@@ -3921,7 +3921,7 @@ olx.layer.VectorOptions.prototype.map;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.extent;
 
@@ -3929,7 +3929,7 @@ olx.layer.VectorOptions.prototype.extent;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.minResolution;
 
@@ -3937,7 +3937,7 @@ olx.layer.VectorOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.maxResolution;
 
@@ -3945,7 +3945,7 @@ olx.layer.VectorOptions.prototype.maxResolution;
 /**
  * Opacity. 0-1. Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.opacity;
 
@@ -3964,7 +3964,7 @@ olx.layer.VectorOptions.prototype.renderBuffer;
 /**
  * Source.
  * @type {ol.source.Vector}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.source;
 
@@ -3973,7 +3973,7 @@ olx.layer.VectorOptions.prototype.source;
  * Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.style;
 
@@ -4001,7 +4001,7 @@ olx.layer.VectorOptions.prototype.updateWhileInteracting;
 /**
  * Visibility. Default is `true` (visible).
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorOptions.prototype.visible;
 
@@ -4079,7 +4079,7 @@ olx.layer.VectorTileOptions.prototype.map;
  * The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
  * @type {ol.Extent|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.extent;
 
@@ -4087,7 +4087,7 @@ olx.layer.VectorTileOptions.prototype.extent;
 /**
  * The minimum resolution (inclusive) at which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.minResolution;
 
@@ -4095,7 +4095,7 @@ olx.layer.VectorTileOptions.prototype.minResolution;
 /**
  * The maximum resolution (exclusive) below which this layer will be visible.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.maxResolution;
 
@@ -4103,7 +4103,7 @@ olx.layer.VectorTileOptions.prototype.maxResolution;
 /**
  * Opacity. 0-1. Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.opacity;
 
@@ -4112,7 +4112,7 @@ olx.layer.VectorTileOptions.prototype.opacity;
  * Preload. Load low-resolution tiles up to `preload` levels. By default
  * `preload` is `0`, which means no preloading.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.preload;
 
@@ -4120,7 +4120,7 @@ olx.layer.VectorTileOptions.prototype.preload;
 /**
  * Source.
  * @type {ol.source.VectorTile|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.source;
 
@@ -4129,7 +4129,7 @@ olx.layer.VectorTileOptions.prototype.source;
  * Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
  * @type {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.style;
 
@@ -4157,7 +4157,7 @@ olx.layer.VectorTileOptions.prototype.updateWhileInteracting;
 /**
  * Visibility. Default is `true` (visible).
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.layer.VectorTileOptions.prototype.visible;
 
@@ -4235,7 +4235,7 @@ olx.source.BingMapsOptions.prototype.hidpi;
 /**
  * Culture code. Default is `en-us`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.BingMapsOptions.prototype.culture;
 
@@ -4243,7 +4243,7 @@ olx.source.BingMapsOptions.prototype.culture;
 /**
  * Bing Maps API key. Get yours at http://www.bingmapsportal.com/.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.BingMapsOptions.prototype.key;
 
@@ -4251,7 +4251,7 @@ olx.source.BingMapsOptions.prototype.key;
 /**
  * Type of imagery.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.BingMapsOptions.prototype.imagerySet;
 
@@ -4588,7 +4588,7 @@ olx.source.TileImageOptions.prototype.tileUrlFunction;
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileImageOptions.prototype.url;
 
@@ -4754,7 +4754,7 @@ olx.source.VectorTileOptions.prototype.tileUrlFunction;
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.VectorTileOptions.prototype.url;
 
@@ -4795,7 +4795,7 @@ olx.source.ImageMapGuideOptions;
 /**
  * The mapagent url.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.url;
 
@@ -4803,7 +4803,7 @@ olx.source.ImageMapGuideOptions.prototype.url;
 /**
  * The display resolution. Default is `96`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.displayDpi;
 
@@ -4811,7 +4811,7 @@ olx.source.ImageMapGuideOptions.prototype.displayDpi;
 /**
  * The meters-per-unit value. Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.metersPerUnit;
 
@@ -4828,7 +4828,7 @@ olx.source.ImageMapGuideOptions.prototype.hidpi;
 /**
  * If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
  * @type {boolean|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.useOverlay;
 
@@ -4846,7 +4846,7 @@ olx.source.ImageMapGuideOptions.prototype.projection;
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.ratio;
 
@@ -4854,7 +4854,7 @@ olx.source.ImageMapGuideOptions.prototype.ratio;
 /**
  * Resolutions. If specified, requests will be made for these resolutions only.
  * @type {Array.<number>|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.resolutions;
 
@@ -4870,7 +4870,7 @@ olx.source.ImageMapGuideOptions.prototype.imageLoadFunction;
 /**
  * Additional parameters.
  * @type {Object|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageMapGuideOptions.prototype.params;
 
@@ -4896,7 +4896,7 @@ olx.source.MapQuestOptions.prototype.cacheSize;
 /**
  * Layer. Possible values are `osm`, `sat`, and `hyb`.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.MapQuestOptions.prototype.layer;
 
@@ -4980,7 +4980,7 @@ olx.source.OSMOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.OSMOptions.prototype.attributions;
 
@@ -5002,7 +5002,7 @@ olx.source.OSMOptions.prototype.cacheSize;
  *
  * Default is `anonymous`.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.OSMOptions.prototype.crossOrigin;
 
@@ -5049,7 +5049,7 @@ olx.source.OSMOptions.prototype.tileLoadFunction;
  * URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * Default is `https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.OSMOptions.prototype.url;
 
@@ -5410,7 +5410,7 @@ olx.source.ImageWMSOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.attributions;
 
@@ -5422,7 +5422,7 @@ olx.source.ImageWMSOptions.prototype.attributions;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.crossOrigin;
 
@@ -5456,7 +5456,7 @@ olx.source.ImageWMSOptions.prototype.imageLoadFunction;
 /**
  * Logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.logo;
 
@@ -5466,7 +5466,7 @@ olx.source.ImageWMSOptions.prototype.logo;
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
  * @type {Object.<string,*>}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.params;
 
@@ -5484,7 +5484,7 @@ olx.source.ImageWMSOptions.prototype.projection;
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1.5`.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.ratio;
 
@@ -5492,7 +5492,7 @@ olx.source.ImageWMSOptions.prototype.ratio;
 /**
  * Resolutions. If specified, requests will be made for these resolutions only.
  * @type {Array.<number>|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.resolutions;
 
@@ -5500,7 +5500,7 @@ olx.source.ImageWMSOptions.prototype.resolutions;
 /**
  * WMS service URL.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageWMSOptions.prototype.url;
 
@@ -5528,7 +5528,7 @@ olx.source.StamenOptions.prototype.cacheSize;
 /**
  * Layer.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.StamenOptions.prototype.layer;
 
@@ -5582,7 +5582,7 @@ olx.source.StamenOptions.prototype.tileLoadFunction;
 /**
  * URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.StamenOptions.prototype.url;
 
@@ -5603,7 +5603,7 @@ olx.source.ImageStaticOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageStaticOptions.prototype.attributions;
 
@@ -5615,7 +5615,7 @@ olx.source.ImageStaticOptions.prototype.attributions;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageStaticOptions.prototype.crossOrigin;
 
@@ -5624,7 +5624,7 @@ olx.source.ImageStaticOptions.prototype.crossOrigin;
  * Extent of the image in map coordinates.  This is the [left, bottom, right,
  * top] map coordinates of your image.
  * @type {ol.Extent}
- * @api stable
+ * @api
  */
 olx.source.ImageStaticOptions.prototype.imageExtent;
 
@@ -5640,7 +5640,7 @@ olx.source.ImageStaticOptions.prototype.imageLoadFunction;
 /**
  * Optional logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageStaticOptions.prototype.logo;
 
@@ -5657,7 +5657,7 @@ olx.source.ImageStaticOptions.prototype.projection;
  * Size of the image in pixels. Usually the image size is auto-detected, so this
  * only needs to be set if auto-detection fails for some reason.
  * @type {ol.Size|undefined}
- * @api stable
+ * @api
  */
 olx.source.ImageStaticOptions.prototype.imageSize;
 
@@ -5665,7 +5665,7 @@ olx.source.ImageStaticOptions.prototype.imageSize;
 /**
  * Image URL.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.ImageStaticOptions.prototype.url;
 
@@ -5823,7 +5823,7 @@ olx.source.TileJSONOptions;
  * instead of any attribution data advertised by the server.  If not provided,
  * any attributions advertised by the server will be used.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileJSONOptions.prototype.attributions;
 
@@ -5843,7 +5843,7 @@ olx.source.TileJSONOptions.prototype.cacheSize;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileJSONOptions.prototype.crossOrigin;
 
@@ -5882,7 +5882,7 @@ olx.source.TileJSONOptions.prototype.tileLoadFunction;
 /**
  * URL to the TileJSON file.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.TileJSONOptions.prototype.url;
 
@@ -5918,7 +5918,7 @@ olx.source.TileWMSOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.attributions;
 
@@ -5936,7 +5936,7 @@ olx.source.TileWMSOptions.prototype.cacheSize;
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
  * @type {Object.<string,*>}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.params;
 
@@ -5948,7 +5948,7 @@ olx.source.TileWMSOptions.prototype.params;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.crossOrigin;
 
@@ -5963,7 +5963,7 @@ olx.source.TileWMSOptions.prototype.crossOrigin;
  * example, MapServer has a `tile_map_edge_buffer` configuration parameter for
  * this. See http://mapserver.org/output/tile_mode.html.
  * @type {number|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.gutter;
 
@@ -5980,7 +5980,7 @@ olx.source.TileWMSOptions.prototype.hidpi;
 /**
  * Logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.logo;
 
@@ -5992,7 +5992,7 @@ olx.source.TileWMSOptions.prototype.logo;
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
  * @type {ol.tilegrid.TileGrid|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.tileGrid;
 
@@ -6039,7 +6039,7 @@ olx.source.TileWMSOptions.prototype.tileLoadFunction;
 /**
  * WMS service URL.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.url;
 
@@ -6048,7 +6048,7 @@ olx.source.TileWMSOptions.prototype.url;
  * WMS service urls. Use this instead of `url` when the WMS supports multiple
  * urls for GetMap requests.
  * @type {Array.<string>|undefined}
- * @api stable
+ * @api
  */
 olx.source.TileWMSOptions.prototype.urls;
 
@@ -6082,7 +6082,7 @@ olx.source.VectorOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.VectorOptions.prototype.attributions;
 
@@ -6091,7 +6091,7 @@ olx.source.VectorOptions.prototype.attributions;
  * Features. If provided as {@link ol.Collection}, the features in the source
  * and the collection will stay in sync.
  * @type {Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined}
- * @api stable
+ * @api
  */
 olx.source.VectorOptions.prototype.features;
 
@@ -6118,7 +6118,7 @@ olx.source.VectorOptions.prototype.loader;
 /**
  * Logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.VectorOptions.prototype.logo;
 
@@ -6288,7 +6288,7 @@ olx.source.WMTSOptions.prototype.reprojectionErrorThreshold;
 /**
  * Request encoding. Default is `KVP`.
  * @type {ol.source.WMTSRequestEncoding|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.requestEncoding;
 
@@ -6296,7 +6296,7 @@ olx.source.WMTSOptions.prototype.requestEncoding;
 /**
  * Layer name as advertised in the WMTS capabilities.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.layer;
 
@@ -6304,7 +6304,7 @@ olx.source.WMTSOptions.prototype.layer;
 /**
  * Style name as advertised in the WMTS capabilities.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.style;
 
@@ -6333,7 +6333,7 @@ olx.source.WMTSOptions.prototype.tilePixelRatio;
 /**
  * WMTS version. Default is `1.0.0`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.version;
 
@@ -6341,7 +6341,7 @@ olx.source.WMTSOptions.prototype.version;
 /**
  * Image format. Default is `image/jpeg`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.format;
 
@@ -6349,7 +6349,7 @@ olx.source.WMTSOptions.prototype.format;
 /**
  * Matrix set.
  * @type {string}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.matrixSet;
 
@@ -6358,7 +6358,7 @@ olx.source.WMTSOptions.prototype.matrixSet;
  * Additional "dimensions" for tile requests.  This is an object with properties
  * named like the advertised WMTS dimensions.
  * @type {!Object|undefined}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.dimensions;
 
@@ -6369,7 +6369,7 @@ olx.source.WMTSOptions.prototype.dimensions;
  * for example `subdomain{a-f}.domain.com`, may be used instead of defining
  * each one separately in the `urls` option.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.url;
 
@@ -6390,7 +6390,7 @@ olx.source.WMTSOptions.prototype.tileLoadFunction;
 /**
  * An array of URLs.  Requests will be distributed among the URLs in this array.
  * @type {Array.<string>|undefined}
- * @api stable
+ * @api
  */
 olx.source.WMTSOptions.prototype.urls;
 
@@ -6428,7 +6428,7 @@ olx.source.XYZOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.XYZOptions.prototype.attributions;
 
@@ -6448,7 +6448,7 @@ olx.source.XYZOptions.prototype.cacheSize;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.XYZOptions.prototype.crossOrigin;
 
@@ -6456,7 +6456,7 @@ olx.source.XYZOptions.prototype.crossOrigin;
 /**
  * Logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.XYZOptions.prototype.logo;
 
@@ -6556,7 +6556,7 @@ olx.source.XYZOptions.prototype.tileUrlFunction;
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.XYZOptions.prototype.url;
 
@@ -6564,7 +6564,7 @@ olx.source.XYZOptions.prototype.url;
 /**
  * An array of URL templates.
  * @type {Array.<string>|undefined}
- * @api stable
+ * @api
  */
 olx.source.XYZOptions.prototype.urls;
 
@@ -6595,7 +6595,7 @@ olx.source.CartoDBOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.CartoDBOptions.prototype.attributions;
 
@@ -6615,7 +6615,7 @@ olx.source.CartoDBOptions.prototype.cacheSize;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.CartoDBOptions.prototype.crossOrigin;
 
@@ -6623,7 +6623,7 @@ olx.source.CartoDBOptions.prototype.crossOrigin;
 /**
  * Logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.CartoDBOptions.prototype.logo;
 
@@ -6708,7 +6708,7 @@ olx.source.ZoomifyOptions;
 /**
  * Attributions.
  * @type {ol.AttributionLike|undefined}
- * @api stable
+ * @api
  */
 olx.source.ZoomifyOptions.prototype.attributions;
 
@@ -6728,7 +6728,7 @@ olx.source.ZoomifyOptions.prototype.cacheSize;
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * @type {null|string|undefined}
- * @api stable
+ * @api
  */
 olx.source.ZoomifyOptions.prototype.crossOrigin;
 
@@ -6736,7 +6736,7 @@ olx.source.ZoomifyOptions.prototype.crossOrigin;
 /**
  * Logo.
  * @type {string|olx.LogoOptions|undefined}
- * @api stable
+ * @api
  */
 olx.source.ZoomifyOptions.prototype.logo;
 
@@ -6761,7 +6761,7 @@ olx.source.ZoomifyOptions.prototype.reprojectionErrorThreshold;
 /**
  * Prefix of URL template.
  * @type {!string}
- * @api stable
+ * @api
  */
 olx.source.ZoomifyOptions.prototype.url;
 
@@ -6769,7 +6769,7 @@ olx.source.ZoomifyOptions.prototype.url;
 /**
  * Tier size calculation method: `default` or `truncated`.
  * @type {string|undefined}
- * @api stable
+ * @api
  */
 olx.source.ZoomifyOptions.prototype.tierSizeCalculation;
 
@@ -6777,7 +6777,7 @@ olx.source.ZoomifyOptions.prototype.tierSizeCalculation;
 /**
  * Size of the image.
  * @type {ol.Size}
- * @api stable
+ * @api
  */
 olx.source.ZoomifyOptions.prototype.size;
 
@@ -7449,7 +7449,7 @@ olx.tilegrid.TileGridOptions.prototype.minZoom;
  * Tile coordinates increase left to right and upwards. If not specified,
  * `extent` or `origins` must be provided.
  * @type {ol.Coordinate|undefined}
- * @api stable
+ * @api
  */
 olx.tilegrid.TileGridOptions.prototype.origin;
 
@@ -7461,7 +7461,7 @@ olx.tilegrid.TileGridOptions.prototype.origin;
  * coordinates increase left to right and upwards. If not specified, `extent`
  * or `origin` must be provided.
  * @type {Array.<ol.Coordinate>|undefined}
- * @api stable
+ * @api
  */
 olx.tilegrid.TileGridOptions.prototype.origins;
 
@@ -7471,7 +7471,7 @@ olx.tilegrid.TileGridOptions.prototype.origins;
  * level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`.
  * @type {!Array.<number>}
- * @api stable
+ * @api
  */
 olx.tilegrid.TileGridOptions.prototype.resolutions;
 
@@ -7479,7 +7479,7 @@ olx.tilegrid.TileGridOptions.prototype.resolutions;
 /**
  * Tile size. Default is `[256, 256]`.
  * @type {number|ol.Size|undefined}
- * @api stable
+ * @api
  */
 olx.tilegrid.TileGridOptions.prototype.tileSize;
 
@@ -7488,7 +7488,7 @@ olx.tilegrid.TileGridOptions.prototype.tileSize;
  * Tile sizes. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different tile size.
  * @type {Array.<number|ol.Size>|undefined}
- * @api stable
+ * @api
  */
 olx.tilegrid.TileGridOptions.prototype.tileSizes;
 
@@ -7521,7 +7521,7 @@ olx.tilegrid.WMTSOptions.prototype.extent;
  * Tile coordinates increase left to right and upwards. If not specified,
  * `extent` or `origins` must be provided.
  * @type {ol.Coordinate|undefined}
- * @api stable
+ * @api
  */
 olx.tilegrid.WMTSOptions.prototype.origin;
 
@@ -7533,7 +7533,7 @@ olx.tilegrid.WMTSOptions.prototype.origin;
  * coordinates increase left to right and upwards. If not specified, `extent` or
  * `origin` must be provided.
  * @type {Array.<ol.Coordinate>|undefined}
- * @api stable
+ * @api
  */
 olx.tilegrid.WMTSOptions.prototype.origins;
 

--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -24,7 +24,7 @@ goog.require('ol.tilegrid');
  * @constructor
  * @param {olx.AttributionOptions} options Attribution options.
  * @struct
- * @api stable
+ * @api
  */
 ol.Attribution = function(options) {
 
@@ -46,7 +46,7 @@ ol.Attribution = function(options) {
 /**
  * Get the attribution markup.
  * @return {string} The attribution HTML.
- * @api stable
+ * @api
  */
 ol.Attribution.prototype.getHTML = function() {
   return this.html_;

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -24,7 +24,7 @@ goog.require('ol.events.Event');
  * @fires ol.Collection.Event
  * @param {!Array.<T>=} opt_array Array.
  * @template T
- * @api stable
+ * @api
  */
 ol.Collection = function(opt_array) {
 
@@ -44,7 +44,7 @@ ol.inherits(ol.Collection, ol.Object);
 
 /**
  * Remove all elements from the collection.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.clear = function() {
   while (this.getLength() > 0) {
@@ -58,7 +58,7 @@ ol.Collection.prototype.clear = function() {
  * to the end of the collection.
  * @param {!Array.<T>} arr Array.
  * @return {ol.Collection.<T>} This collection.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.extend = function(arr) {
   var i, ii;
@@ -76,7 +76,7 @@ ol.Collection.prototype.extend = function(arr) {
  *     index and the array). The return value is ignored.
  * @param {S=} opt_this The object to use as `this` in `f`.
  * @template S
- * @api stable
+ * @api
  */
 ol.Collection.prototype.forEach = function(f, opt_this) {
   this.array_.forEach(f, opt_this);
@@ -89,7 +89,7 @@ ol.Collection.prototype.forEach = function(f, opt_this) {
  * collection's "length" property won't be in sync with the actual length
  * of the array.
  * @return {!Array.<T>} Array.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.getArray = function() {
   return this.array_;
@@ -100,7 +100,7 @@ ol.Collection.prototype.getArray = function() {
  * Get the element at the provided index.
  * @param {number} index Index.
  * @return {T} Element.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.item = function(index) {
   return this.array_[index];
@@ -111,7 +111,7 @@ ol.Collection.prototype.item = function(index) {
  * Get the length of this collection.
  * @return {number} The length of the array.
  * @observable
- * @api stable
+ * @api
  */
 ol.Collection.prototype.getLength = function() {
   return /** @type {number} */ (this.get(ol.Collection.Property_.LENGTH));
@@ -122,7 +122,7 @@ ol.Collection.prototype.getLength = function() {
  * Insert an element at the provided index.
  * @param {number} index Index.
  * @param {T} elem Element.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.insertAt = function(index, elem) {
   this.array_.splice(index, 0, elem);
@@ -136,7 +136,7 @@ ol.Collection.prototype.insertAt = function(index, elem) {
  * Remove the last element of the collection and return it.
  * Return `undefined` if the collection is empty.
  * @return {T|undefined} Element.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.pop = function() {
   return this.removeAt(this.getLength() - 1);
@@ -147,7 +147,7 @@ ol.Collection.prototype.pop = function() {
  * Insert the provided element at the end of the collection.
  * @param {T} elem Element.
  * @return {number} New length of the collection.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.push = function(elem) {
   var n = this.getLength();
@@ -160,7 +160,7 @@ ol.Collection.prototype.push = function(elem) {
  * Remove the first occurrence of an element from the collection.
  * @param {T} elem Element.
  * @return {T|undefined} The removed element or undefined if none found.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.remove = function(elem) {
   var arr = this.array_;
@@ -179,7 +179,7 @@ ol.Collection.prototype.remove = function(elem) {
  * Return `undefined` if the collection does not contain this index.
  * @param {number} index Index.
  * @return {T|undefined} Value.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.removeAt = function(index) {
   var prev = this.array_[index];
@@ -195,7 +195,7 @@ ol.Collection.prototype.removeAt = function(index) {
  * Set the element at the provided index.
  * @param {number} index Index.
  * @param {T} elem Element.
- * @api stable
+ * @api
  */
 ol.Collection.prototype.setAt = function(index, elem) {
   var n = this.getLength();
@@ -251,7 +251,7 @@ ol.Collection.Event = function(type, opt_element) {
   /**
    * The element that is added to or removed from the collection.
    * @type {*}
-   * @api stable
+   * @api
    */
   this.element = opt_element;
 

--- a/src/ol/collectioneventtype.js
+++ b/src/ol/collectioneventtype.js
@@ -7,13 +7,13 @@ ol.CollectionEventType = {
   /**
    * Triggered when an item is added to the collection.
    * @event ol.Collection.Event#add
-   * @api stable
+   * @api
    */
   ADD: 'add',
   /**
    * Triggered when an item is removed from the collection.
    * @event ol.Collection.Event#remove
-   * @api stable
+   * @api
    */
   REMOVE: 'remove'
 };

--- a/src/ol/control.js
+++ b/src/ol/control.js
@@ -16,7 +16,7 @@ goog.require('ol.control.Zoom');
  *
  * @param {olx.control.DefaultsOptions=} opt_options Defaults options.
  * @return {ol.Collection.<ol.control.Control>} Controls.
- * @api stable
+ * @api
  */
 ol.control.defaults = function(opt_options) {
 

--- a/src/ol/control/attribution.js
+++ b/src/ol/control/attribution.js
@@ -21,7 +21,7 @@ goog.require('ol.obj');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.AttributionOptions=} opt_options Attribution options.
- * @api stable
+ * @api
  */
 ol.control.Attribution = function(opt_options) {
 
@@ -359,7 +359,7 @@ ol.control.Attribution.prototype.handleToggle_ = function() {
 /**
  * Return `true` if the attribution is collapsible, `false` otherwise.
  * @return {boolean} True if the widget is collapsible.
- * @api stable
+ * @api
  */
 ol.control.Attribution.prototype.getCollapsible = function() {
   return this.collapsible_;
@@ -369,7 +369,7 @@ ol.control.Attribution.prototype.getCollapsible = function() {
 /**
  * Set whether the attribution should be collapsible.
  * @param {boolean} collapsible True if the widget is collapsible.
- * @api stable
+ * @api
  */
 ol.control.Attribution.prototype.setCollapsible = function(collapsible) {
   if (this.collapsible_ === collapsible) {
@@ -388,7 +388,7 @@ ol.control.Attribution.prototype.setCollapsible = function(collapsible) {
  * not do anything if the attribution isn't collapsible or if the current
  * collapsed state is already the one requested.
  * @param {boolean} collapsed True if the widget is collapsed.
- * @api stable
+ * @api
  */
 ol.control.Attribution.prototype.setCollapsed = function(collapsed) {
   if (!this.collapsible_ || this.collapsed_ === collapsed) {
@@ -402,7 +402,7 @@ ol.control.Attribution.prototype.setCollapsed = function(collapsed) {
  * Return `true` when the attribution is currently collapsed or `false`
  * otherwise.
  * @return {boolean} True if the widget is collapsed.
- * @api stable
+ * @api
  */
 ol.control.Attribution.prototype.getCollapsed = function() {
   return this.collapsed_;

--- a/src/ol/control/control.js
+++ b/src/ol/control/control.js
@@ -34,7 +34,7 @@ goog.require('ol.events');
  * @extends {ol.Object}
  * @implements {oli.control.Control}
  * @param {olx.control.ControlOptions} options Control options.
- * @api stable
+ * @api
  */
 ol.control.Control = function(options) {
 
@@ -89,7 +89,7 @@ ol.control.Control.prototype.disposeInternal = function() {
 /**
  * Get the map associated with this control.
  * @return {ol.Map} Map.
- * @api stable
+ * @api
  */
 ol.control.Control.prototype.getMap = function() {
   return this.map_;
@@ -102,7 +102,7 @@ ol.control.Control.prototype.getMap = function() {
  * the map here.
  * @param {ol.Map} map Map.
  * @override
- * @api stable
+ * @api
  */
 ol.control.Control.prototype.setMap = function(map) {
   if (this.map_) {

--- a/src/ol/control/fullscreen.js
+++ b/src/ol/control/fullscreen.js
@@ -23,7 +23,7 @@ goog.require('ol.events.EventType');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.FullScreenOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.control.FullScreen = function(opt_options) {
 
@@ -155,7 +155,7 @@ ol.control.FullScreen.prototype.handleFullScreenChange_ = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.control.FullScreen.prototype.setMap = function(map) {
   ol.control.Control.prototype.setMap.call(this, map);

--- a/src/ol/control/mouseposition.js
+++ b/src/ol/control/mouseposition.js
@@ -21,7 +21,7 @@ goog.require('ol.proj');
  * @extends {ol.control.Control}
  * @param {olx.control.MousePositionOptions=} opt_options Mouse position
  *     options.
- * @api stable
+ * @api
  */
 ol.control.MousePosition = function(opt_options) {
 
@@ -118,7 +118,7 @@ ol.control.MousePosition.prototype.handleProjectionChanged_ = function() {
  * @return {ol.CoordinateFormatType|undefined} The format to render the current
  *     position in.
  * @observable
- * @api stable
+ * @api
  */
 ol.control.MousePosition.prototype.getCoordinateFormat = function() {
   return /** @type {ol.CoordinateFormatType|undefined} */ (
@@ -131,7 +131,7 @@ ol.control.MousePosition.prototype.getCoordinateFormat = function() {
  * @return {ol.proj.Projection|undefined} The projection to report mouse
  *     position in.
  * @observable
- * @api stable
+ * @api
  */
 ol.control.MousePosition.prototype.getProjection = function() {
   return /** @type {ol.proj.Projection|undefined} */ (
@@ -162,7 +162,7 @@ ol.control.MousePosition.prototype.handleMouseOut = function(event) {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.control.MousePosition.prototype.setMap = function(map) {
   ol.control.Control.prototype.setMap.call(this, map);
@@ -183,7 +183,7 @@ ol.control.MousePosition.prototype.setMap = function(map) {
  * @param {ol.CoordinateFormatType} format The format to render the current
  *     position in.
  * @observable
- * @api stable
+ * @api
  */
 ol.control.MousePosition.prototype.setCoordinateFormat = function(format) {
   this.set(ol.control.MousePosition.Property_.COORDINATE_FORMAT, format);
@@ -195,7 +195,7 @@ ol.control.MousePosition.prototype.setCoordinateFormat = function(format) {
  * @param {ol.proj.Projection} projection The projection to report mouse
  *     position in.
  * @observable
- * @api stable
+ * @api
  */
 ol.control.MousePosition.prototype.setProjection = function(projection) {
   this.set(ol.control.MousePosition.Property_.PROJECTION, projection);

--- a/src/ol/control/overviewmap.js
+++ b/src/ol/control/overviewmap.js
@@ -462,7 +462,7 @@ ol.control.OverviewMap.prototype.handleToggle_ = function() {
 /**
  * Return `true` if the overview map is collapsible, `false` otherwise.
  * @return {boolean} True if the widget is collapsible.
- * @api stable
+ * @api
  */
 ol.control.OverviewMap.prototype.getCollapsible = function() {
   return this.collapsible_;
@@ -472,7 +472,7 @@ ol.control.OverviewMap.prototype.getCollapsible = function() {
 /**
  * Set whether the overview map should be collapsible.
  * @param {boolean} collapsible True if the widget is collapsible.
- * @api stable
+ * @api
  */
 ol.control.OverviewMap.prototype.setCollapsible = function(collapsible) {
   if (this.collapsible_ === collapsible) {
@@ -491,7 +491,7 @@ ol.control.OverviewMap.prototype.setCollapsible = function(collapsible) {
  * not do anything if the overview map isn't collapsible or if the current
  * collapsed state is already the one requested.
  * @param {boolean} collapsed True if the widget is collapsed.
- * @api stable
+ * @api
  */
 ol.control.OverviewMap.prototype.setCollapsed = function(collapsed) {
   if (!this.collapsible_ || this.collapsed_ === collapsed) {
@@ -504,7 +504,7 @@ ol.control.OverviewMap.prototype.setCollapsed = function(collapsed) {
 /**
  * Determine if the overview map is collapsed.
  * @return {boolean} The overview map is collapsed.
- * @api stable
+ * @api
  */
 ol.control.OverviewMap.prototype.getCollapsed = function() {
   return this.collapsed_;

--- a/src/ol/control/rotate.js
+++ b/src/ol/control/rotate.js
@@ -17,7 +17,7 @@ goog.require('ol.easing');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.RotateOptions=} opt_options Rotate options.
- * @api stable
+ * @api
  */
 ol.control.Rotate = function(opt_options) {
 

--- a/src/ol/control/scaleline.js
+++ b/src/ol/control/scaleline.js
@@ -24,7 +24,7 @@ goog.require('ol.proj.Units');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.ScaleLineOptions=} opt_options Scale line options.
- * @api stable
+ * @api
  */
 ol.control.ScaleLine = function(opt_options) {
 
@@ -108,7 +108,7 @@ ol.control.ScaleLine.LEADING_DIGITS = [1, 2, 5];
  * @return {ol.control.ScaleLineUnits|undefined} The units to use in the scale
  *     line.
  * @observable
- * @api stable
+ * @api
  */
 ol.control.ScaleLine.prototype.getUnits = function() {
   return /** @type {ol.control.ScaleLineUnits|undefined} */ (
@@ -145,7 +145,7 @@ ol.control.ScaleLine.prototype.handleUnitsChanged_ = function() {
  * Set the units to use in the scale line.
  * @param {ol.control.ScaleLineUnits} units The units to use in the scale line.
  * @observable
- * @api stable
+ * @api
  */
 ol.control.ScaleLine.prototype.setUnits = function(units) {
   this.set(ol.control.ScaleLine.Property_.UNITS, units);

--- a/src/ol/control/zoom.js
+++ b/src/ol/control/zoom.js
@@ -17,7 +17,7 @@ goog.require('ol.easing');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.ZoomOptions=} opt_options Zoom options.
- * @api stable
+ * @api
  */
 ol.control.Zoom = function(opt_options) {
 

--- a/src/ol/control/zoomslider.js
+++ b/src/ol/control/zoomslider.js
@@ -26,7 +26,7 @@ goog.require('ol.pointer.PointerEventHandler');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.ZoomSliderOptions=} opt_options Zoom slider options.
- * @api stable
+ * @api
  */
 ol.control.ZoomSlider = function(opt_options) {
 

--- a/src/ol/control/zoomtoextent.js
+++ b/src/ol/control/zoomtoextent.js
@@ -15,7 +15,7 @@ goog.require('ol.css');
  * @constructor
  * @extends {ol.control.Control}
  * @param {olx.control.ZoomToExtentOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.control.ZoomToExtent = function(opt_options) {
   var options = opt_options ? opt_options : {};

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -17,7 +17,7 @@ goog.require('ol.string');
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {ol.Coordinate} delta Delta.
  * @return {ol.Coordinate} The input coordinate adjusted by the given delta.
- * @api stable
+ * @api
  */
 ol.coordinate.add = function(coordinate, delta) {
   coordinate[0] += delta[0];
@@ -86,7 +86,7 @@ ol.coordinate.closestOnSegment = function(coordinate, segment) {
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {ol.CoordinateFormatType} Coordinate format.
- * @api stable
+ * @api
  */
 ol.coordinate.createStringXY = function(opt_fractionDigits) {
   return (
@@ -144,7 +144,7 @@ ol.coordinate.degreesToStringHDMS_ = function(degrees, hemispheres, opt_fraction
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} Formatted coordinate.
- * @api stable
+ * @api
  */
 ol.coordinate.format = function(coordinate, template, opt_fractionDigits) {
   if (coordinate) {
@@ -188,7 +188,7 @@ ol.coordinate.equals = function(coordinate1, coordinate2) {
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {number} angle Angle in radian.
  * @return {ol.Coordinate} Coordinate.
- * @api stable
+ * @api
  */
 ol.coordinate.rotate = function(coordinate, angle) {
   var cosAngle = Math.cos(angle);
@@ -283,7 +283,7 @@ ol.coordinate.squaredDistanceToSegment = function(coordinate, segment) {
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} Hemisphere, degrees, minutes and seconds.
- * @api stable
+ * @api
  */
 ol.coordinate.toStringHDMS = function(coordinate, opt_fractionDigits) {
   if (coordinate) {
@@ -314,7 +314,7 @@ ol.coordinate.toStringHDMS = function(coordinate, opt_fractionDigits) {
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} XY.
- * @api stable
+ * @api
  */
 ol.coordinate.toStringXY = function(coordinate, opt_fractionDigits) {
   return ol.coordinate.format(coordinate, '{x}, {y}', opt_fractionDigits);

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -12,7 +12,7 @@ goog.require('ol.has');
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the alt key is pressed.
- * @api stable
+ * @api
  */
 ol.events.condition.altKeyOnly = function(mapBrowserEvent) {
   var originalEvent = mapBrowserEvent.originalEvent;
@@ -29,7 +29,7 @@ ol.events.condition.altKeyOnly = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the alt and shift keys are pressed.
- * @api stable
+ * @api
  */
 ol.events.condition.altShiftKeysOnly = function(mapBrowserEvent) {
   var originalEvent = mapBrowserEvent.originalEvent;
@@ -46,7 +46,7 @@ ol.events.condition.altShiftKeysOnly = function(mapBrowserEvent) {
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True.
  * @function
- * @api stable
+ * @api
  */
 ol.events.condition.always = ol.functions.TRUE;
 
@@ -56,7 +56,7 @@ ol.events.condition.always = ol.functions.TRUE;
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `click` event.
- * @api stable
+ * @api
  */
 ol.events.condition.click = function(mapBrowserEvent) {
   return mapBrowserEvent.type == ol.MapBrowserEventType.CLICK;
@@ -85,7 +85,7 @@ ol.events.condition.mouseActionButton = function(mapBrowserEvent) {
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} False.
  * @function
- * @api stable
+ * @api
  */
 ol.events.condition.never = ol.functions.FALSE;
 
@@ -108,7 +108,7 @@ ol.events.condition.pointerMove = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `singleclick` event.
- * @api stable
+ * @api
  */
 ol.events.condition.singleClick = function(mapBrowserEvent) {
   return mapBrowserEvent.type == ol.MapBrowserEventType.SINGLECLICK;
@@ -120,7 +120,7 @@ ol.events.condition.singleClick = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `dblclick` event.
- * @api stable
+ * @api
  */
 ol.events.condition.doubleClick = function(mapBrowserEvent) {
   return mapBrowserEvent.type == ol.MapBrowserEventType.DBLCLICK;
@@ -133,7 +133,7 @@ ol.events.condition.doubleClick = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True only if there no modifier keys are pressed.
- * @api stable
+ * @api
  */
 ol.events.condition.noModifierKeys = function(mapBrowserEvent) {
   var originalEvent = mapBrowserEvent.originalEvent;
@@ -151,7 +151,7 @@ ol.events.condition.noModifierKeys = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the platform modifier key is pressed.
- * @api stable
+ * @api
  */
 ol.events.condition.platformModifierKeyOnly = function(mapBrowserEvent) {
   var originalEvent = mapBrowserEvent.originalEvent;
@@ -168,7 +168,7 @@ ol.events.condition.platformModifierKeyOnly = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the shift key is pressed.
- * @api stable
+ * @api
  */
 ol.events.condition.shiftKeyOnly = function(mapBrowserEvent) {
   var originalEvent = mapBrowserEvent.originalEvent;
@@ -202,7 +202,7 @@ ol.events.condition.targetNotEditable = function(mapBrowserEvent) {
  *
  * @param {ol.MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a mouse device.
- * @api stable
+ * @api
  */
 ol.events.condition.mouseOnly = function(mapBrowserEvent) {
   ol.asserts.assert(mapBrowserEvent.pointerEvent, 56); // mapBrowserEvent must originate from a pointer event

--- a/src/ol/events/event.js
+++ b/src/ol/events/event.js
@@ -25,14 +25,14 @@ ol.events.Event = function(type) {
   /**
    * The event type.
    * @type {string}
-   * @api stable
+   * @api
    */
   this.type = type;
 
   /**
    * The event target.
    * @type {Object}
-   * @api stable
+   * @api
    */
   this.target = null;
 
@@ -43,7 +43,7 @@ ol.events.Event = function(type) {
  * Stop event propagation.
  * @function
  * @override
- * @api stable
+ * @api
  */
 ol.events.Event.prototype.preventDefault =
 
@@ -51,7 +51,7 @@ ol.events.Event.prototype.preventDefault =
  * Stop event propagation.
  * @function
  * @override
- * @api stable
+ * @api
  */
 ol.events.Event.prototype.stopPropagation = function() {
   this.propagationStopped = true;

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -10,7 +10,7 @@ goog.require('ol.extent.Relationship');
  *
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @return {ol.Extent} Bounding extent.
- * @api stable
+ * @api
  */
 ol.extent.boundingExtent = function(coordinates) {
   var extent = ol.extent.createEmpty();
@@ -43,7 +43,7 @@ ol.extent.boundingExtentXYs_ = function(xs, ys, opt_extent) {
  * @param {number} value The amount by which the extent should be buffered.
  * @param {ol.Extent=} opt_extent Extent.
  * @return {ol.Extent} Extent.
- * @api stable
+ * @api
  */
 ol.extent.buffer = function(extent, value, opt_extent) {
   if (opt_extent) {
@@ -115,7 +115,7 @@ ol.extent.closestSquaredDistanceXY = function(extent, x, y) {
  * @param {ol.Extent} extent Extent.
  * @param {ol.Coordinate} coordinate Coordinate.
  * @return {boolean} The coordinate is contained in the extent.
- * @api stable
+ * @api
  */
 ol.extent.containsCoordinate = function(extent, coordinate) {
   return ol.extent.containsXY(extent, coordinate[0], coordinate[1]);
@@ -132,7 +132,7 @@ ol.extent.containsCoordinate = function(extent, coordinate) {
  * @param {ol.Extent} extent2 Extent 2.
  * @return {boolean} The second extent is contained by or on the edge of the
  *     first.
- * @api stable
+ * @api
  */
 ol.extent.containsExtent = function(extent1, extent2) {
   return extent1[0] <= extent2[0] && extent2[2] <= extent1[2] &&
@@ -147,7 +147,7 @@ ol.extent.containsExtent = function(extent1, extent2) {
  * @param {number} x X coordinate.
  * @param {number} y Y coordinate.
  * @return {boolean} The x, y values are contained in the extent.
- * @api stable
+ * @api
  */
 ol.extent.containsXY = function(extent, x, y) {
   return extent[0] <= x && x <= extent[2] && extent[1] <= y && y <= extent[3];
@@ -189,7 +189,7 @@ ol.extent.coordinateRelationship = function(extent, coordinate) {
 /**
  * Create an empty extent.
  * @return {ol.Extent} Empty extent.
- * @api stable
+ * @api
  */
 ol.extent.createEmpty = function() {
   return [Infinity, Infinity, -Infinity, -Infinity];
@@ -283,7 +283,7 @@ ol.extent.createOrUpdateFromRings = function(rings, opt_extent) {
  * @param {ol.Extent} extent1 Extent 1.
  * @param {ol.Extent} extent2 Extent 2.
  * @return {boolean} The two extents are equivalent.
- * @api stable
+ * @api
  */
 ol.extent.equals = function(extent1, extent2) {
   return extent1[0] == extent2[0] && extent1[2] == extent2[2] &&
@@ -296,7 +296,7 @@ ol.extent.equals = function(extent1, extent2) {
  * @param {ol.Extent} extent1 The extent to be modified.
  * @param {ol.Extent} extent2 The extent that will be included in the first.
  * @return {ol.Extent} A reference to the first (extended) extent.
- * @api stable
+ * @api
  */
 ol.extent.extend = function(extent1, extent2) {
   if (extent2[0] < extent1[0]) {
@@ -442,7 +442,7 @@ ol.extent.getArea = function(extent) {
  * Get the bottom left coordinate of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {ol.Coordinate} Bottom left coordinate.
- * @api stable
+ * @api
  */
 ol.extent.getBottomLeft = function(extent) {
   return [extent[0], extent[1]];
@@ -453,7 +453,7 @@ ol.extent.getBottomLeft = function(extent) {
  * Get the bottom right coordinate of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {ol.Coordinate} Bottom right coordinate.
- * @api stable
+ * @api
  */
 ol.extent.getBottomRight = function(extent) {
   return [extent[2], extent[1]];
@@ -464,7 +464,7 @@ ol.extent.getBottomRight = function(extent) {
  * Get the center coordinate of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {ol.Coordinate} Center.
- * @api stable
+ * @api
  */
 ol.extent.getCenter = function(extent) {
   return [(extent[0] + extent[2]) / 2, (extent[1] + extent[3]) / 2];
@@ -546,7 +546,7 @@ ol.extent.getForViewAndSize = function(center, resolution, rotation, size, opt_e
  * Get the height of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {number} Height.
- * @api stable
+ * @api
  */
 ol.extent.getHeight = function(extent) {
   return extent[3] - extent[1];
@@ -570,7 +570,7 @@ ol.extent.getIntersectionArea = function(extent1, extent2) {
  * @param {ol.Extent} extent2 Extent 2.
  * @param {ol.Extent=} opt_extent Optional extent to populate with intersection.
  * @return {ol.Extent} Intersecting extent.
- * @api stable
+ * @api
  */
 ol.extent.getIntersection = function(extent1, extent2, opt_extent) {
   var intersection = opt_extent ? opt_extent : ol.extent.createEmpty();
@@ -613,7 +613,7 @@ ol.extent.getMargin = function(extent) {
  * Get the size (width, height) of an extent.
  * @param {ol.Extent} extent The extent.
  * @return {ol.Size} The extent size.
- * @api stable
+ * @api
  */
 ol.extent.getSize = function(extent) {
   return [extent[2] - extent[0], extent[3] - extent[1]];
@@ -624,7 +624,7 @@ ol.extent.getSize = function(extent) {
  * Get the top left coordinate of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {ol.Coordinate} Top left coordinate.
- * @api stable
+ * @api
  */
 ol.extent.getTopLeft = function(extent) {
   return [extent[0], extent[3]];
@@ -635,7 +635,7 @@ ol.extent.getTopLeft = function(extent) {
  * Get the top right coordinate of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {ol.Coordinate} Top right coordinate.
- * @api stable
+ * @api
  */
 ol.extent.getTopRight = function(extent) {
   return [extent[2], extent[3]];
@@ -646,7 +646,7 @@ ol.extent.getTopRight = function(extent) {
  * Get the width of an extent.
  * @param {ol.Extent} extent Extent.
  * @return {number} Width.
- * @api stable
+ * @api
  */
 ol.extent.getWidth = function(extent) {
   return extent[2] - extent[0];
@@ -658,7 +658,7 @@ ol.extent.getWidth = function(extent) {
  * @param {ol.Extent} extent1 Extent 1.
  * @param {ol.Extent} extent2 Extent.
  * @return {boolean} The two extents intersect.
- * @api stable
+ * @api
  */
 ol.extent.intersects = function(extent1, extent2) {
   return extent1[0] <= extent2[2] &&
@@ -672,7 +672,7 @@ ol.extent.intersects = function(extent1, extent2) {
  * Determine if an extent is empty.
  * @param {ol.Extent} extent Extent.
  * @return {boolean} Is empty.
- * @api stable
+ * @api
  */
 ol.extent.isEmpty = function(extent) {
   return extent[2] < extent[0] || extent[3] < extent[1];
@@ -774,7 +774,7 @@ ol.extent.intersectsSegment = function(extent, start, end) {
  * [minX, minY, maxX, maxY] extent coordinates.
  * @param {ol.Extent=} opt_extent Destination extent.
  * @return {ol.Extent} Extent.
- * @api stable
+ * @api
  */
 ol.extent.applyTransform = function(extent, transformFn, opt_extent) {
   var coordinates = [

--- a/src/ol/feature.js
+++ b/src/ol/feature.js
@@ -52,7 +52,7 @@ goog.require('ol.style.Style');
  *     You may pass a Geometry object directly, or an object literal
  *     containing properties.  If you pass an object literal, you may
  *     include a Geometry associated with a `geometry` key.
- * @api stable
+ * @api
  */
 ol.Feature = function(opt_geometryOrProperties) {
 
@@ -113,7 +113,7 @@ ol.inherits(ol.Feature, ol.Object);
  * Clone this feature. If the original feature has a geometry it
  * is also cloned. The feature id is not set in the clone.
  * @return {ol.Feature} The clone.
- * @api stable
+ * @api
  */
 ol.Feature.prototype.clone = function() {
   var clone = new ol.Feature(this.getProperties());
@@ -135,7 +135,7 @@ ol.Feature.prototype.clone = function() {
  * geometries.  The "default" geometry (the one that is rendered by default) is
  * set when calling {@link ol.Feature#setGeometry}.
  * @return {ol.geom.Geometry|undefined} The default geometry for the feature.
- * @api stable
+ * @api
  * @observable
  */
 ol.Feature.prototype.getGeometry = function() {
@@ -149,7 +149,7 @@ ol.Feature.prototype.getGeometry = function() {
  * is either set when reading data from a remote source or set explicitly by
  * calling {@link ol.Feature#setId}.
  * @return {number|string|undefined} Id.
- * @api stable
+ * @api
  */
 ol.Feature.prototype.getId = function() {
   return this.id_;
@@ -161,7 +161,7 @@ ol.Feature.prototype.getId = function() {
  * geometry is named `geometry`.
  * @return {string} Get the property name associated with the default geometry
  *     for this feature.
- * @api stable
+ * @api
  */
 ol.Feature.prototype.getGeometryName = function() {
   return this.geometryName_;
@@ -173,7 +173,7 @@ ol.Feature.prototype.getGeometryName = function() {
  * {@link ol.Feature#setStyle} method.
  * @return {ol.style.Style|Array.<ol.style.Style>|
  *     ol.FeatureStyleFunction|ol.StyleFunction} The feature style.
- * @api stable
+ * @api
  */
 ol.Feature.prototype.getStyle = function() {
   return this.style_;
@@ -184,7 +184,7 @@ ol.Feature.prototype.getStyle = function() {
  * Get the feature's style function.
  * @return {ol.FeatureStyleFunction|undefined} Return a function
  * representing the current style of this feature.
- * @api stable
+ * @api
  */
 ol.Feature.prototype.getStyleFunction = function() {
   return this.styleFunction_;
@@ -220,7 +220,7 @@ ol.Feature.prototype.handleGeometryChanged_ = function() {
  * Set the default geometry for the feature.  This will update the property
  * with the name returned by {@link ol.Feature#getGeometryName}.
  * @param {ol.geom.Geometry|undefined} geometry The new geometry.
- * @api stable
+ * @api
  * @observable
  */
 ol.Feature.prototype.setGeometry = function(geometry) {
@@ -234,7 +234,7 @@ ol.Feature.prototype.setGeometry = function(geometry) {
  * styles. If it is `null` the feature has no style (a `null` style).
  * @param {ol.style.Style|Array.<ol.style.Style>|
  *     ol.FeatureStyleFunction|ol.StyleFunction} style Style for this feature.
- * @api stable
+ * @api
  * @fires ol.events.Event#event:change
  */
 ol.Feature.prototype.setStyle = function(style) {
@@ -251,7 +251,7 @@ ol.Feature.prototype.setStyle = function(style) {
  * The feature id can be used with the {@link ol.source.Vector#getFeatureById}
  * method.
  * @param {number|string|undefined} id The feature id.
- * @api stable
+ * @api
  * @fires ol.events.Event#event:change
  */
 ol.Feature.prototype.setId = function(id) {
@@ -265,7 +265,7 @@ ol.Feature.prototype.setId = function(id) {
  * When calling {@link ol.Feature#getGeometry}, the value of the property with
  * this name will be returned.
  * @param {string} name The property name of the default geometry.
- * @api stable
+ * @api
  */
 ol.Feature.prototype.setGeometryName = function(name) {
   ol.events.unlisten(

--- a/src/ol/format/feature.js
+++ b/src/ol/format/feature.js
@@ -16,7 +16,7 @@ goog.require('ol.proj');
  *
  * @constructor
  * @abstract
- * @api stable
+ * @api
  */
 ol.format.Feature = function() {
 

--- a/src/ol/format/geojson.js
+++ b/src/ol/format/geojson.js
@@ -26,7 +26,7 @@ goog.require('ol.proj');
  * @constructor
  * @extends {ol.format.JSONFeature}
  * @param {olx.format.GeoJSONOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON = function(opt_options) {
 
@@ -335,7 +335,7 @@ ol.format.GeoJSON.GEOMETRY_WRITERS_ = {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.Feature} Feature.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.readFeature;
 
@@ -349,7 +349,7 @@ ol.format.GeoJSON.prototype.readFeature;
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.readFeatures;
 
@@ -420,7 +420,7 @@ ol.format.GeoJSON.prototype.readFeaturesFromObject = function(
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.geom.Geometry} Geometry.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.readGeometry;
 
@@ -441,7 +441,7 @@ ol.format.GeoJSON.prototype.readGeometryFromObject = function(
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.readProjection;
 
@@ -480,7 +480,7 @@ ol.format.GeoJSON.prototype.readProjectionFromObject = function(object) {
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} GeoJSON.
  * @override
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.writeFeature;
 
@@ -492,7 +492,7 @@ ol.format.GeoJSON.prototype.writeFeature;
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {GeoJSONFeature} Object.
  * @override
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.writeFeatureObject = function(feature, opt_options) {
   opt_options = this.adaptOptions(opt_options);
@@ -529,7 +529,7 @@ ol.format.GeoJSON.prototype.writeFeatureObject = function(feature, opt_options) 
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} GeoJSON.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.writeFeatures;
 
@@ -541,7 +541,7 @@ ol.format.GeoJSON.prototype.writeFeatures;
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {GeoJSONFeatureCollection} GeoJSON Object.
  * @override
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.writeFeaturesObject = function(features, opt_options) {
   opt_options = this.adaptOptions(opt_options);
@@ -564,7 +564,7 @@ ol.format.GeoJSON.prototype.writeFeaturesObject = function(features, opt_options
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} GeoJSON.
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.writeGeometry;
 
@@ -576,7 +576,7 @@ ol.format.GeoJSON.prototype.writeGeometry;
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry|GeoJSONGeometryCollection} Object.
  * @override
- * @api stable
+ * @api
  */
 ol.format.GeoJSON.prototype.writeGeometryObject = function(geometry,
     opt_options) {

--- a/src/ol/format/gml.js
+++ b/src/ol/format/gml.js
@@ -13,7 +13,7 @@ goog.require('ol.format.GML3');
  * @param {olx.format.GMLOptions=} opt_options
  *     Optional configuration object.
  * @extends {ol.format.GMLBase}
- * @api stable
+ * @api
  */
 ol.format.GML = ol.format.GML3;
 
@@ -25,7 +25,7 @@ ol.format.GML = ol.format.GML3;
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
  * @return {string} Result.
- * @api stable
+ * @api
  */
 ol.format.GML.prototype.writeFeatures;
 

--- a/src/ol/format/gml3.js
+++ b/src/ol/format/gml3.js
@@ -1186,7 +1186,7 @@ ol.format.GML3.prototype.writeGeometryNode = function(geometry, opt_options) {
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
  * @return {string} Result.
- * @api stable
+ * @api
  */
 ol.format.GML3.prototype.writeFeatures;
 

--- a/src/ol/format/gmlbase.js
+++ b/src/ol/format/gmlbase.js
@@ -564,7 +564,7 @@ ol.format.GMLBase.prototype.readGeometryFromNode = function(node, opt_options) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.GMLBase.prototype.readFeatures;
 

--- a/src/ol/format/gpx.js
+++ b/src/ol/format/gpx.js
@@ -21,7 +21,7 @@ goog.require('ol.xml');
  * @constructor
  * @extends {ol.format.XMLFeature}
  * @param {olx.format.GPXOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.format.GPX = function(opt_options) {
 
@@ -479,7 +479,7 @@ ol.format.GPX.prototype.handleReadExtensions_ = function(features) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.Feature} Feature.
- * @api stable
+ * @api
  */
 ol.format.GPX.prototype.readFeature;
 
@@ -513,7 +513,7 @@ ol.format.GPX.prototype.readFeatureFromNode = function(node, opt_options) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.GPX.prototype.readFeatures;
 
@@ -546,7 +546,7 @@ ol.format.GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
- * @api stable
+ * @api
  */
 ol.format.GPX.prototype.readProjection;
 
@@ -913,7 +913,7 @@ ol.format.GPX.GPX_SERIALIZERS_ = ol.xml.makeStructureNS(
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} Result.
- * @api stable
+ * @api
  */
 ol.format.GPX.prototype.writeFeatures;
 

--- a/src/ol/format/kml.js
+++ b/src/ol/format/kml.js
@@ -44,7 +44,7 @@ goog.require('ol.xml');
  * @constructor
  * @extends {ol.format.XMLFeature}
  * @param {olx.format.KMLOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.format.KML = function(opt_options) {
 
@@ -1765,7 +1765,7 @@ ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.Feature} Feature.
- * @api stable
+ * @api
  */
 ol.format.KML.prototype.readFeature;
 
@@ -1796,7 +1796,7 @@ ol.format.KML.prototype.readFeatureFromNode = function(node, opt_options) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.KML.prototype.readFeatures;
 
@@ -1847,7 +1847,7 @@ ol.format.KML.prototype.readFeaturesFromNode = function(node, opt_options) {
  *
  * @param {Document|Node|string} source Souce.
  * @return {string|undefined} Name.
- * @api stable
+ * @api
  */
 ol.format.KML.prototype.readName = function(source) {
   if (ol.xml.isDocument(source)) {
@@ -2047,7 +2047,7 @@ ol.format.KML.prototype.readRegionFromNode = function(node) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
- * @api stable
+ * @api
  */
 ol.format.KML.prototype.readProjection;
 
@@ -3006,7 +3006,7 @@ ol.format.KML.OUTER_BOUNDARY_NODE_FACTORY_ =
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Options.
  * @return {string} Result.
- * @api stable
+ * @api
  */
 ol.format.KML.prototype.writeFeatures;
 

--- a/src/ol/format/osmxml.js
+++ b/src/ol/format/osmxml.js
@@ -22,7 +22,7 @@ goog.require('ol.xml');
  *
  * @constructor
  * @extends {ol.format.XMLFeature}
- * @api stable
+ * @api
  */
 ol.format.OSMXML = function() {
   ol.format.XMLFeature.call(this);
@@ -176,7 +176,7 @@ ol.format.OSMXML.NODE_PARSERS_ = ol.xml.makeStructureNS(
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.OSMXML.prototype.readFeatures;
 
@@ -205,7 +205,7 @@ ol.format.OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
- * @api stable
+ * @api
  */
 ol.format.OSMXML.prototype.readProjection;
 

--- a/src/ol/format/polyline.js
+++ b/src/ol/format/polyline.js
@@ -22,7 +22,7 @@ goog.require('ol.proj');
  * @extends {ol.format.TextFeature}
  * @param {olx.format.PolylineOptions=} opt_options
  *     Optional configuration object.
- * @api stable
+ * @api
  */
 ol.format.Polyline = function(opt_options) {
 
@@ -271,7 +271,7 @@ ol.format.Polyline.encodeUnsignedInteger = function(num) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.Feature} Feature.
- * @api stable
+ * @api
  */
 ol.format.Polyline.prototype.readFeature;
 
@@ -293,7 +293,7 @@ ol.format.Polyline.prototype.readFeatureFromText = function(text, opt_options) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.Polyline.prototype.readFeatures;
 
@@ -314,7 +314,7 @@ ol.format.Polyline.prototype.readFeaturesFromText = function(text, opt_options) 
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.geom.Geometry} Geometry.
- * @api stable
+ * @api
  */
 ol.format.Polyline.prototype.readGeometry;
 
@@ -344,7 +344,7 @@ ol.format.Polyline.prototype.readGeometryFromText = function(text, opt_options) 
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.proj.Projection} Projection.
- * @api stable
+ * @api
  */
 ol.format.Polyline.prototype.readProjection;
 
@@ -378,7 +378,7 @@ ol.format.Polyline.prototype.writeFeaturesText = function(features, opt_options)
  * @param {ol.geom.Geometry} geometry Geometry.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} Geometry.
- * @api stable
+ * @api
  */
 ol.format.Polyline.prototype.writeGeometry;
 

--- a/src/ol/format/topojson.js
+++ b/src/ol/format/topojson.js
@@ -21,7 +21,7 @@ goog.require('ol.proj');
  * @constructor
  * @extends {ol.format.JSONFeature}
  * @param {olx.format.TopoJSONOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.format.TopoJSON = function(opt_options) {
 
@@ -259,7 +259,7 @@ ol.format.TopoJSON.readFeatureFromGeometry_ = function(object, arcs,
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.TopoJSON.prototype.readFeatures;
 
@@ -369,7 +369,7 @@ ol.format.TopoJSON.transformVertex_ = function(vertex, scale, translate) {
  * @param {Document|Node|Object|string} object Source.
  * @return {ol.proj.Projection} Projection.
  * @override
- * @api stable
+ * @api
  */
 ol.format.TopoJSON.prototype.readProjection;
 

--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -24,7 +24,7 @@ goog.require('ol.xml');
  * @param {olx.format.WFSOptions=} opt_options
  *     Optional configuration object.
  * @extends {ol.format.XMLFeature}
- * @api stable
+ * @api
  */
 ol.format.WFS = function(opt_options) {
   var options = opt_options ? opt_options : {};
@@ -103,7 +103,7 @@ ol.format.WFS.SCHEMA_LOCATION = 'http://www.opengis.net/wfs ' +
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.WFS.prototype.readFeatures;
 
@@ -137,7 +137,7 @@ ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
  *
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.WFSTransactionResponse|undefined} Transaction response.
- * @api stable
+ * @api
  */
 ol.format.WFS.prototype.readTransactionResponse = function(source) {
   if (ol.xml.isDocument(source)) {
@@ -160,7 +160,7 @@ ol.format.WFS.prototype.readTransactionResponse = function(source) {
  * @param {Document|Node|Object|string} source Source.
  * @return {ol.WFSFeatureCollectionMetadata|undefined}
  *     FeatureCollection metadata.
- * @api stable
+ * @api
  */
 ol.format.WFS.prototype.readFeatureCollectionMetadata = function(source) {
   if (ol.xml.isDocument(source)) {
@@ -778,7 +778,7 @@ ol.format.WFS.writeGetFeature_ = function(node, featureTypes, objectStack) {
  *
  * @param {olx.format.WFSWriteGetFeatureOptions} options Options.
  * @return {Node} Result.
- * @api stable
+ * @api
  */
 ol.format.WFS.prototype.writeGetFeature = function(options) {
   var node = ol.xml.createElementNS(ol.format.WFS.WFSNS, 'GetFeature');
@@ -845,7 +845,7 @@ ol.format.WFS.prototype.writeGetFeature = function(options) {
  * @param {Array.<ol.Feature>} deletes The features to delete.
  * @param {olx.format.WFSWriteTransactionOptions} options Write options.
  * @return {Node} Result.
- * @api stable
+ * @api
  */
 ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
     options) {
@@ -910,7 +910,7 @@ ol.format.WFS.prototype.writeTransaction = function(inserts, updates, deletes,
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @return {?ol.proj.Projection} Projection.
- * @api stable
+ * @api
  */
 ol.format.WFS.prototype.readProjection;
 

--- a/src/ol/format/wkt.js
+++ b/src/ol/format/wkt.js
@@ -24,7 +24,7 @@ goog.require('ol.geom.SimpleGeometry');
  * @constructor
  * @extends {ol.format.TextFeature}
  * @param {olx.format.WKTOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.format.WKT = function(opt_options) {
 
@@ -257,7 +257,7 @@ ol.format.WKT.prototype.parse_ = function(wkt) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.Feature} Feature.
- * @api stable
+ * @api
  */
 ol.format.WKT.prototype.readFeature;
 
@@ -283,7 +283,7 @@ ol.format.WKT.prototype.readFeatureFromText = function(text, opt_options) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.WKT.prototype.readFeatures;
 
@@ -318,7 +318,7 @@ ol.format.WKT.prototype.readFeaturesFromText = function(text, opt_options) {
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Read options.
  * @return {ol.geom.Geometry} Geometry.
- * @api stable
+ * @api
  */
 ol.format.WKT.prototype.readGeometry;
 
@@ -344,7 +344,7 @@ ol.format.WKT.prototype.readGeometryFromText = function(text, opt_options) {
  * @param {ol.Feature} feature Feature.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} WKT string.
- * @api stable
+ * @api
  */
 ol.format.WKT.prototype.writeFeature;
 
@@ -368,7 +368,7 @@ ol.format.WKT.prototype.writeFeatureText = function(feature, opt_options) {
  * @param {Array.<ol.Feature>} features Features.
  * @param {olx.format.WriteOptions=} opt_options Write options.
  * @return {string} WKT string.
- * @api stable
+ * @api
  */
 ol.format.WKT.prototype.writeFeatures;
 
@@ -395,7 +395,7 @@ ol.format.WKT.prototype.writeFeaturesText = function(features, opt_options) {
  * @function
  * @param {ol.geom.Geometry} geometry Geometry.
  * @return {string} WKT string.
- * @api stable
+ * @api
  */
 ol.format.WKT.prototype.writeGeometry;
 

--- a/src/ol/format/wmsgetfeatureinfo.js
+++ b/src/ol/format/wmsgetfeatureinfo.js
@@ -130,7 +130,7 @@ ol.format.WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack
  * @param {Document|Node|Object|string} source Source.
  * @param {olx.format.ReadOptions=} opt_options Options.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.format.WMSGetFeatureInfo.prototype.readFeatures;
 

--- a/src/ol/geolocation.js
+++ b/src/ol/geolocation.js
@@ -38,7 +38,7 @@ goog.require('ol.sphere.WGS84');
  * @constructor
  * @extends {ol.Object}
  * @param {olx.GeolocationOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.Geolocation = function(opt_options) {
 
@@ -182,7 +182,7 @@ ol.Geolocation.prototype.positionError_ = function(error) {
  * @return {number|undefined} The accuracy of the position measurement in
  *     meters.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getAccuracy = function() {
   return /** @type {number|undefined} */ (
@@ -194,7 +194,7 @@ ol.Geolocation.prototype.getAccuracy = function() {
  * Get a geometry of the position accuracy.
  * @return {?ol.geom.Geometry} A geometry of the position accuracy.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getAccuracyGeometry = function() {
   return /** @type {?ol.geom.Geometry} */ (
@@ -207,7 +207,7 @@ ol.Geolocation.prototype.getAccuracyGeometry = function() {
  * @return {number|undefined} The altitude of the position in meters above mean
  *     sea level.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getAltitude = function() {
   return /** @type {number|undefined} */ (
@@ -220,7 +220,7 @@ ol.Geolocation.prototype.getAltitude = function() {
  * @return {number|undefined} The accuracy of the altitude measurement in
  *     meters.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getAltitudeAccuracy = function() {
   return /** @type {number|undefined} */ (
@@ -232,7 +232,7 @@ ol.Geolocation.prototype.getAltitudeAccuracy = function() {
  * Get the heading as radians clockwise from North.
  * @return {number|undefined} The heading of the device in radians from north.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getHeading = function() {
   return /** @type {number|undefined} */ (
@@ -245,7 +245,7 @@ ol.Geolocation.prototype.getHeading = function() {
  * @return {ol.Coordinate|undefined} The current position of the device reported
  *     in the current projection.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getPosition = function() {
   return /** @type {ol.Coordinate|undefined} */ (
@@ -258,7 +258,7 @@ ol.Geolocation.prototype.getPosition = function() {
  * @return {ol.proj.Projection|undefined} The projection the position is
  *     reported in.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getProjection = function() {
   return /** @type {ol.proj.Projection|undefined} */ (
@@ -271,7 +271,7 @@ ol.Geolocation.prototype.getProjection = function() {
  * @return {number|undefined} The instantaneous speed of the device in meters
  *     per second.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getSpeed = function() {
   return /** @type {number|undefined} */ (
@@ -283,7 +283,7 @@ ol.Geolocation.prototype.getSpeed = function() {
  * Determine if the device location is being tracked.
  * @return {boolean} The device location is being tracked.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getTracking = function() {
   return /** @type {boolean} */ (
@@ -298,7 +298,7 @@ ol.Geolocation.prototype.getTracking = function() {
  *     the [HTML5 Geolocation spec
  *     ](http://www.w3.org/TR/geolocation-API/#position_options_interface).
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.getTrackingOptions = function() {
   return /** @type {GeolocationPositionOptions|undefined} */ (
@@ -311,7 +311,7 @@ ol.Geolocation.prototype.getTrackingOptions = function() {
  * @param {ol.proj.Projection} projection The projection the position is
  *     reported in.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.setProjection = function(projection) {
   this.set(ol.GeolocationProperty.PROJECTION, projection);
@@ -322,7 +322,7 @@ ol.Geolocation.prototype.setProjection = function(projection) {
  * Enable or disable tracking.
  * @param {boolean} tracking Enable tracking.
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.setTracking = function(tracking) {
   this.set(ol.GeolocationProperty.TRACKING, tracking);
@@ -336,7 +336,7 @@ ol.Geolocation.prototype.setTracking = function(tracking) {
  *     [HTML5 Geolocation spec
  *     ](http://www.w3.org/TR/geolocation-API/#position_options_interface).
  * @observable
- * @api stable
+ * @api
  */
 ol.Geolocation.prototype.setTrackingOptions = function(options) {
   this.set(ol.GeolocationProperty.TRACKING_OPTIONS, options);

--- a/src/ol/geom/circle.js
+++ b/src/ol/geom/circle.js
@@ -136,7 +136,7 @@ ol.geom.Circle.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.Circle.prototype.intersectsExtent = function(extent) {
   var circleExtent = this.getExtent();
@@ -259,6 +259,6 @@ ol.geom.Circle.prototype.setRadius = function(radius) {
  * @return {ol.geom.Circle} This geometry.  Note that original geometry is
  *     modified in place.
  * @function
- * @api stable
+ * @api
  */
 ol.geom.Circle.prototype.transform;

--- a/src/ol/geom/geometry.js
+++ b/src/ol/geom/geometry.js
@@ -19,7 +19,7 @@ goog.require('ol.proj');
  * @constructor
  * @abstract
  * @extends {ol.Object}
- * @api stable
+ * @api
  */
 ol.geom.Geometry = function() {
 
@@ -84,7 +84,7 @@ ol.geom.Geometry.prototype.closestPointXY = function(x, y, closestPoint, minSqua
  * @param {ol.Coordinate} point Point.
  * @param {ol.Coordinate=} opt_closestPoint Closest point.
  * @return {ol.Coordinate} Closest point.
- * @api stable
+ * @api
  */
 ol.geom.Geometry.prototype.getClosestPoint = function(point, opt_closestPoint) {
   var closestPoint = opt_closestPoint ? opt_closestPoint : [NaN, NaN];
@@ -126,7 +126,7 @@ ol.geom.Geometry.prototype.containsXY = ol.functions.FALSE;
  * Get the extent of the geometry.
  * @param {ol.Extent=} opt_extent Extent.
  * @return {ol.Extent} extent Extent.
- * @api stable
+ * @api
  */
 ol.geom.Geometry.prototype.getExtent = function(opt_extent) {
   if (this.extentRevision_ != this.getRevision()) {
@@ -241,7 +241,7 @@ ol.geom.Geometry.prototype.translate = function(deltaX, deltaY) {};
  *     string identifier or a {@link ol.proj.Projection} object.
  * @return {ol.geom.Geometry} This geometry.  Note that original geometry is
  *     modified in place.
- * @api stable
+ * @api
  */
 ol.geom.Geometry.prototype.transform = function(source, destination) {
   this.applyTransform(ol.proj.getTransform(source, destination));

--- a/src/ol/geom/geometrycollection.js
+++ b/src/ol/geom/geometrycollection.js
@@ -16,7 +16,7 @@ goog.require('ol.obj');
  * @constructor
  * @extends {ol.geom.Geometry}
  * @param {Array.<ol.geom.Geometry>=} opt_geometries Geometries.
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection = function(opt_geometries) {
 
@@ -84,7 +84,7 @@ ol.geom.GeometryCollection.prototype.listenGeometriesChange_ = function() {
  * Make a complete copy of the geometry.
  * @return {!ol.geom.GeometryCollection} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection.prototype.clone = function() {
   var geometryCollection = new ol.geom.GeometryCollection(null);
@@ -142,7 +142,7 @@ ol.geom.GeometryCollection.prototype.computeExtent = function(extent) {
 /**
  * Return the geometries that make up this geometry collection.
  * @return {Array.<ol.geom.Geometry>} Geometries.
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection.prototype.getGeometries = function() {
   return ol.geom.GeometryCollection.cloneGeometries_(this.geometries_);
@@ -202,7 +202,7 @@ ol.geom.GeometryCollection.prototype.getSimplifiedGeometry = function(squaredTol
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection.prototype.getType = function() {
   return ol.geom.GeometryType.GEOMETRY_COLLECTION;
@@ -211,7 +211,7 @@ ol.geom.GeometryCollection.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection.prototype.intersectsExtent = function(extent) {
   var geometries = this.geometries_;
@@ -266,7 +266,7 @@ ol.geom.GeometryCollection.prototype.scale = function(sx, opt_sy, opt_anchor) {
 /**
  * Set the geometries that make up this geometry collection.
  * @param {Array.<ol.geom.Geometry>} geometries Geometries.
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection.prototype.setGeometries = function(geometries) {
   this.setGeometriesArray(
@@ -287,7 +287,7 @@ ol.geom.GeometryCollection.prototype.setGeometriesArray = function(geometries) {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.GeometryCollection.prototype.applyTransform = function(transformFn) {
   var geometries = this.geometries_;

--- a/src/ol/geom/linearring.js
+++ b/src/ol/geom/linearring.js
@@ -21,7 +21,7 @@ goog.require('ol.geom.flat.simplify');
  * @extends {ol.geom.SimpleGeometry}
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.LinearRing = function(coordinates, opt_layout) {
 
@@ -49,7 +49,7 @@ ol.inherits(ol.geom.LinearRing, ol.geom.SimpleGeometry);
  * Make a complete copy of the geometry.
  * @return {!ol.geom.LinearRing} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.LinearRing.prototype.clone = function() {
   var linearRing = new ol.geom.LinearRing(null);
@@ -80,7 +80,7 @@ ol.geom.LinearRing.prototype.closestPointXY = function(x, y, closestPoint, minSq
 /**
  * Return the area of the linear ring on projected plane.
  * @return {number} Area (on projected plane).
- * @api stable
+ * @api
  */
 ol.geom.LinearRing.prototype.getArea = function() {
   return ol.geom.flat.area.linearRing(
@@ -92,7 +92,7 @@ ol.geom.LinearRing.prototype.getArea = function() {
  * Return the coordinates of the linear ring.
  * @return {Array.<ol.Coordinate>} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.LinearRing.prototype.getCoordinates = function() {
   return ol.geom.flat.inflate.coordinates(
@@ -117,7 +117,7 @@ ol.geom.LinearRing.prototype.getSimplifiedGeometryInternal = function(squaredTol
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.LinearRing.prototype.getType = function() {
   return ol.geom.GeometryType.LINEAR_RING;
@@ -135,7 +135,7 @@ ol.geom.LinearRing.prototype.intersectsExtent = function(extent) {};
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.LinearRing.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {

--- a/src/ol/geom/linestring.js
+++ b/src/ol/geom/linestring.js
@@ -24,7 +24,7 @@ goog.require('ol.geom.flat.simplify');
  * @extends {ol.geom.SimpleGeometry}
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.LineString = function(coordinates, opt_layout) {
 
@@ -63,7 +63,7 @@ ol.inherits(ol.geom.LineString, ol.geom.SimpleGeometry);
 /**
  * Append the passed coordinate to the coordinates of the linestring.
  * @param {ol.Coordinate} coordinate Coordinate.
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.appendCoordinate = function(coordinate) {
   if (!this.flatCoordinates) {
@@ -79,7 +79,7 @@ ol.geom.LineString.prototype.appendCoordinate = function(coordinate) {
  * Make a complete copy of the geometry.
  * @return {!ol.geom.LineString} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.clone = function() {
   var lineString = new ol.geom.LineString(null);
@@ -138,7 +138,7 @@ ol.geom.LineString.prototype.forEachSegment = function(callback, opt_this) {
  * @param {number} m M.
  * @param {boolean=} opt_extrapolate Extrapolate. Default is `false`.
  * @return {ol.Coordinate} Coordinate.
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
   if (this.layout != ol.geom.GeometryLayout.XYM &&
@@ -155,7 +155,7 @@ ol.geom.LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
  * Return the coordinates of the linestring.
  * @return {Array.<ol.Coordinate>} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.getCoordinates = function() {
   return ol.geom.flat.inflate.coordinates(
@@ -183,7 +183,7 @@ ol.geom.LineString.prototype.getCoordinateAt = function(fraction, opt_dest) {
 /**
  * Return the length of the linestring on projected plane.
  * @return {number} Length (on projected plane).
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.getLength = function() {
   return ol.geom.flat.length.lineString(
@@ -220,7 +220,7 @@ ol.geom.LineString.prototype.getSimplifiedGeometryInternal = function(squaredTol
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.getType = function() {
   return ol.geom.GeometryType.LINE_STRING;
@@ -229,7 +229,7 @@ ol.geom.LineString.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.intersectsExtent = function(extent) {
   return ol.geom.flat.intersectsextent.lineString(
@@ -243,7 +243,7 @@ ol.geom.LineString.prototype.intersectsExtent = function(extent) {
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.LineString.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {

--- a/src/ol/geom/multilinestring.js
+++ b/src/ol/geom/multilinestring.js
@@ -23,7 +23,7 @@ goog.require('ol.geom.flat.simplify');
  * @extends {ol.geom.SimpleGeometry}
  * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString = function(coordinates, opt_layout) {
 
@@ -56,7 +56,7 @@ ol.inherits(ol.geom.MultiLineString, ol.geom.SimpleGeometry);
 /**
  * Append the passed linestring to the multilinestring.
  * @param {ol.geom.LineString} lineString LineString.
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.appendLineString = function(lineString) {
   if (!this.flatCoordinates) {
@@ -74,7 +74,7 @@ ol.geom.MultiLineString.prototype.appendLineString = function(lineString) {
  * Make a complete copy of the geometry.
  * @return {!ol.geom.MultiLineString} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.clone = function() {
   var multiLineString = new ol.geom.MultiLineString(null);
@@ -123,7 +123,7 @@ ol.geom.MultiLineString.prototype.closestPointXY = function(x, y, closestPoint, 
  * @param {boolean=} opt_extrapolate Extrapolate. Default is `false`.
  * @param {boolean=} opt_interpolate Interpolate. Default is `false`.
  * @return {ol.Coordinate} Coordinate.
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.getCoordinateAtM = function(m, opt_extrapolate, opt_interpolate) {
   if ((this.layout != ol.geom.GeometryLayout.XYM &&
@@ -142,7 +142,7 @@ ol.geom.MultiLineString.prototype.getCoordinateAtM = function(m, opt_extrapolate
  * Return the coordinates of the multilinestring.
  * @return {Array.<Array.<ol.Coordinate>>} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.getCoordinates = function() {
   return ol.geom.flat.inflate.coordinatess(
@@ -162,7 +162,7 @@ ol.geom.MultiLineString.prototype.getEnds = function() {
  * Return the linestring at the specified index.
  * @param {number} index Index.
  * @return {ol.geom.LineString} LineString.
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.getLineString = function(index) {
   if (index < 0 || this.ends_.length <= index) {
@@ -178,7 +178,7 @@ ol.geom.MultiLineString.prototype.getLineString = function(index) {
 /**
  * Return the linestrings of this multilinestring.
  * @return {Array.<ol.geom.LineString>} LineStrings.
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.getLineStrings = function() {
   var flatCoordinates = this.flatCoordinates;
@@ -238,7 +238,7 @@ ol.geom.MultiLineString.prototype.getSimplifiedGeometryInternal = function(squar
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.getType = function() {
   return ol.geom.GeometryType.MULTI_LINE_STRING;
@@ -247,7 +247,7 @@ ol.geom.MultiLineString.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.intersectsExtent = function(extent) {
   return ol.geom.flat.intersectsextent.lineStrings(
@@ -260,7 +260,7 @@ ol.geom.MultiLineString.prototype.intersectsExtent = function(extent) {
  * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiLineString.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {

--- a/src/ol/geom/multipoint.js
+++ b/src/ol/geom/multipoint.js
@@ -20,7 +20,7 @@ goog.require('ol.math');
  * @extends {ol.geom.SimpleGeometry}
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint = function(coordinates, opt_layout) {
   ol.geom.SimpleGeometry.call(this);
@@ -32,7 +32,7 @@ ol.inherits(ol.geom.MultiPoint, ol.geom.SimpleGeometry);
 /**
  * Append the passed point to this multipoint.
  * @param {ol.geom.Point} point Point.
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.appendPoint = function(point) {
   if (!this.flatCoordinates) {
@@ -48,7 +48,7 @@ ol.geom.MultiPoint.prototype.appendPoint = function(point) {
  * Make a complete copy of the geometry.
  * @return {!ol.geom.MultiPoint} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.clone = function() {
   var multiPoint = new ol.geom.MultiPoint(null);
@@ -87,7 +87,7 @@ ol.geom.MultiPoint.prototype.closestPointXY = function(x, y, closestPoint, minSq
  * Return the coordinates of the multipoint.
  * @return {Array.<ol.Coordinate>} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.getCoordinates = function() {
   return ol.geom.flat.inflate.coordinates(
@@ -99,7 +99,7 @@ ol.geom.MultiPoint.prototype.getCoordinates = function() {
  * Return the point at the specified index.
  * @param {number} index Index.
  * @return {ol.geom.Point} Point.
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.getPoint = function(index) {
   var n = !this.flatCoordinates ?
@@ -117,7 +117,7 @@ ol.geom.MultiPoint.prototype.getPoint = function(index) {
 /**
  * Return the points of this multipoint.
  * @return {Array.<ol.geom.Point>} Points.
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.getPoints = function() {
   var flatCoordinates = this.flatCoordinates;
@@ -137,7 +137,7 @@ ol.geom.MultiPoint.prototype.getPoints = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.getType = function() {
   return ol.geom.GeometryType.MULTI_POINT;
@@ -146,7 +146,7 @@ ol.geom.MultiPoint.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.intersectsExtent = function(extent) {
   var flatCoordinates = this.flatCoordinates;
@@ -168,7 +168,7 @@ ol.geom.MultiPoint.prototype.intersectsExtent = function(extent) {
  * @param {Array.<ol.Coordinate>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiPoint.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {

--- a/src/ol/geom/multipolygon.js
+++ b/src/ol/geom/multipolygon.js
@@ -28,7 +28,7 @@ goog.require('ol.geom.flat.simplify');
  * @extends {ol.geom.SimpleGeometry}
  * @param {Array.<Array.<Array.<ol.Coordinate>>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon = function(coordinates, opt_layout) {
 
@@ -85,7 +85,7 @@ ol.inherits(ol.geom.MultiPolygon, ol.geom.SimpleGeometry);
 /**
  * Append the passed polygon to this multipolygon.
  * @param {ol.geom.Polygon} polygon Polygon.
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.appendPolygon = function(polygon) {
   /** @type {Array.<number>} */
@@ -112,7 +112,7 @@ ol.geom.MultiPolygon.prototype.appendPolygon = function(polygon) {
  * Make a complete copy of the geometry.
  * @return {!ol.geom.MultiPolygon} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.clone = function() {
   var multiPolygon = new ol.geom.MultiPolygon(null);
@@ -160,7 +160,7 @@ ol.geom.MultiPolygon.prototype.containsXY = function(x, y) {
 /**
  * Return the area of the multipolygon on projected plane.
  * @return {number} Area (on projected plane).
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.getArea = function() {
   return ol.geom.flat.area.linearRingss(
@@ -180,7 +180,7 @@ ol.geom.MultiPolygon.prototype.getArea = function() {
  *     constructed.
  * @return {Array.<Array.<Array.<ol.Coordinate>>>} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
@@ -224,7 +224,7 @@ ol.geom.MultiPolygon.prototype.getFlatInteriorPoints = function() {
 /**
  * Return the interior points as {@link ol.geom.MultiPoint multipoint}.
  * @return {ol.geom.MultiPoint} Interior points.
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.getInteriorPoints = function() {
   var interiorPoints = new ol.geom.MultiPoint(null);
@@ -276,7 +276,7 @@ ol.geom.MultiPolygon.prototype.getSimplifiedGeometryInternal = function(squaredT
  * Return the polygon at the specified index.
  * @param {number} index Index.
  * @return {ol.geom.Polygon} Polygon.
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.getPolygon = function(index) {
   if (index < 0 || this.endss_.length <= index) {
@@ -307,7 +307,7 @@ ol.geom.MultiPolygon.prototype.getPolygon = function(index) {
 /**
  * Return the polygons of this multipolygon.
  * @return {Array.<ol.geom.Polygon>} Polygons.
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.getPolygons = function() {
   var layout = this.layout;
@@ -336,7 +336,7 @@ ol.geom.MultiPolygon.prototype.getPolygons = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.getType = function() {
   return ol.geom.GeometryType.MULTI_POLYGON;
@@ -345,7 +345,7 @@ ol.geom.MultiPolygon.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.intersectsExtent = function(extent) {
   return ol.geom.flat.intersectsextent.linearRingss(
@@ -358,7 +358,7 @@ ol.geom.MultiPolygon.prototype.intersectsExtent = function(extent) {
  * @param {Array.<Array.<Array.<ol.Coordinate>>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.MultiPolygon.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {

--- a/src/ol/geom/point.js
+++ b/src/ol/geom/point.js
@@ -17,7 +17,7 @@ goog.require('ol.math');
  * @extends {ol.geom.SimpleGeometry}
  * @param {ol.Coordinate} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.Point = function(coordinates, opt_layout) {
   ol.geom.SimpleGeometry.call(this);
@@ -30,7 +30,7 @@ ol.inherits(ol.geom.Point, ol.geom.SimpleGeometry);
  * Make a complete copy of the geometry.
  * @return {!ol.geom.Point} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.Point.prototype.clone = function() {
   var point = new ol.geom.Point(null);
@@ -64,7 +64,7 @@ ol.geom.Point.prototype.closestPointXY = function(x, y, closestPoint, minSquared
  * Return the coordinate of the point.
  * @return {ol.Coordinate} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.Point.prototype.getCoordinates = function() {
   return !this.flatCoordinates ? [] : this.flatCoordinates.slice();
@@ -81,7 +81,7 @@ ol.geom.Point.prototype.computeExtent = function(extent) {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.Point.prototype.getType = function() {
   return ol.geom.GeometryType.POINT;
@@ -90,7 +90,7 @@ ol.geom.Point.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.Point.prototype.intersectsExtent = function(extent) {
   return ol.extent.containsXY(extent,
@@ -100,7 +100,7 @@ ol.geom.Point.prototype.intersectsExtent = function(extent) {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.Point.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {

--- a/src/ol/geom/polygon.js
+++ b/src/ol/geom/polygon.js
@@ -33,7 +33,7 @@ goog.require('ol.math');
  *     is an array of vertices' coordinates where the first coordinate and the
  *     last are equivalent.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
- * @api stable
+ * @api
  */
 ol.geom.Polygon = function(coordinates, opt_layout) {
 
@@ -90,7 +90,7 @@ ol.inherits(ol.geom.Polygon, ol.geom.SimpleGeometry);
 /**
  * Append the passed linear ring to this polygon.
  * @param {ol.geom.LinearRing} linearRing Linear ring.
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.appendLinearRing = function(linearRing) {
   if (!this.flatCoordinates) {
@@ -107,7 +107,7 @@ ol.geom.Polygon.prototype.appendLinearRing = function(linearRing) {
  * Make a complete copy of the geometry.
  * @return {!ol.geom.Polygon} Clone.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.clone = function() {
   var polygon = new ol.geom.Polygon(null);
@@ -148,7 +148,7 @@ ol.geom.Polygon.prototype.containsXY = function(x, y) {
 /**
  * Return the area of the polygon on projected plane.
  * @return {number} Area (on projected plane).
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.getArea = function() {
   return ol.geom.flat.area.linearRings(
@@ -168,7 +168,7 @@ ol.geom.Polygon.prototype.getArea = function() {
  *     constructed.
  * @return {Array.<Array.<ol.Coordinate>>} Coordinates.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
@@ -211,7 +211,7 @@ ol.geom.Polygon.prototype.getFlatInteriorPoint = function() {
 /**
  * Return an interior point of the polygon.
  * @return {ol.geom.Point} Interior point.
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.getInteriorPoint = function() {
   return new ol.geom.Point(this.getFlatInteriorPoint());
@@ -238,7 +238,7 @@ ol.geom.Polygon.prototype.getLinearRingCount = function() {
  *
  * @param {number} index Index.
  * @return {ol.geom.LinearRing} Linear ring.
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.getLinearRing = function(index) {
   if (index < 0 || this.ends_.length <= index) {
@@ -254,7 +254,7 @@ ol.geom.Polygon.prototype.getLinearRing = function(index) {
 /**
  * Return the linear rings of the polygon.
  * @return {Array.<ol.geom.LinearRing>} Linear rings.
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.getLinearRings = function() {
   var layout = this.layout;
@@ -314,7 +314,7 @@ ol.geom.Polygon.prototype.getSimplifiedGeometryInternal = function(squaredTolera
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.getType = function() {
   return ol.geom.GeometryType.POLYGON;
@@ -323,7 +323,7 @@ ol.geom.Polygon.prototype.getType = function() {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.intersectsExtent = function(extent) {
   return ol.geom.flat.intersectsextent.linearRings(
@@ -336,7 +336,7 @@ ol.geom.Polygon.prototype.intersectsExtent = function(extent) {
  * @param {Array.<Array.<ol.Coordinate>>} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @override
- * @api stable
+ * @api
  */
 ol.geom.Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
@@ -375,7 +375,7 @@ ol.geom.Polygon.prototype.setFlatCoordinates = function(layout, flatCoordinates,
  * @param {number=} opt_n Optional number of vertices for the resulting
  *     polygon. Default is `32`.
  * @return {ol.geom.Polygon} The "circular" polygon.
- * @api stable
+ * @api
  */
 ol.geom.Polygon.circular = function(sphere, center, radius, opt_n) {
   var n = opt_n ? opt_n : 32;

--- a/src/ol/geom/simplegeometry.js
+++ b/src/ol/geom/simplegeometry.js
@@ -17,7 +17,7 @@ goog.require('ol.obj');
  * @constructor
  * @abstract
  * @extends {ol.geom.Geometry}
- * @api stable
+ * @api
  */
 ol.geom.SimpleGeometry = function() {
 
@@ -106,7 +106,7 @@ ol.geom.SimpleGeometry.prototype.getCoordinates = function() {};
 /**
  * Return the first coordinate of the geometry.
  * @return {ol.Coordinate} First coordinate.
- * @api stable
+ * @api
  */
 ol.geom.SimpleGeometry.prototype.getFirstCoordinate = function() {
   return this.flatCoordinates.slice(0, this.stride);
@@ -124,7 +124,7 @@ ol.geom.SimpleGeometry.prototype.getFlatCoordinates = function() {
 /**
  * Return the last coordinate of the geometry.
  * @return {ol.Coordinate} Last point.
- * @api stable
+ * @api
  */
 ol.geom.SimpleGeometry.prototype.getLastCoordinate = function() {
   return this.flatCoordinates.slice(this.flatCoordinates.length - this.stride);
@@ -134,7 +134,7 @@ ol.geom.SimpleGeometry.prototype.getLastCoordinate = function() {
 /**
  * Return the {@link ol.geom.GeometryLayout layout} of the geometry.
  * @return {ol.geom.GeometryLayout} Layout.
- * @api stable
+ * @api
  */
 ol.geom.SimpleGeometry.prototype.getLayout = function() {
   return this.layout;
@@ -251,7 +251,7 @@ ol.geom.SimpleGeometry.prototype.setLayout = function(layout, coordinates, nesti
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.SimpleGeometry.prototype.applyTransform = function(transformFn) {
   if (this.flatCoordinates) {
@@ -303,7 +303,7 @@ ol.geom.SimpleGeometry.prototype.scale = function(sx, opt_sy, opt_anchor) {
 
 /**
  * @inheritDoc
- * @api stable
+ * @api
  */
 ol.geom.SimpleGeometry.prototype.translate = function(deltaX, deltaY) {
   var flatCoordinates = this.getFlatCoordinates();

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -36,7 +36,7 @@ ol.has.MAC = ua.indexOf('macintosh') !== -1;
  * (dips) on the device (`window.devicePixelRatio`).
  * @const
  * @type {number}
- * @api stable
+ * @api
  */
 ol.has.DEVICE_PIXEL_RATIO = window.devicePixelRatio || 1;
 
@@ -53,7 +53,7 @@ ol.has.CANVAS_LINE_DASH = false;
  * if `ol.ENABLE_CANVAS` is set to `false` at compile time.
  * @const
  * @type {boolean}
- * @api stable
+ * @api
  */
 ol.has.CANVAS = ol.ENABLE_CANVAS && (
     /**
@@ -83,7 +83,7 @@ ol.has.CANVAS = ol.ENABLE_CANVAS && (
  * Indicates if DeviceOrientation is supported in the user's browser.
  * @const
  * @type {boolean}
- * @api stable
+ * @api
  */
 ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in window;
 
@@ -92,7 +92,7 @@ ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in window;
  * Is HTML5 geolocation supported in the current browser?
  * @const
  * @type {boolean}
- * @api stable
+ * @api
  */
 ol.has.GEOLOCATION = 'geolocation' in navigator;
 
@@ -101,7 +101,7 @@ ol.has.GEOLOCATION = 'geolocation' in navigator;
  * True if browser supports touch events.
  * @const
  * @type {boolean}
- * @api stable
+ * @api
  */
 ol.has.TOUCH = ol.ASSUME_TOUCH || 'ontouchstart' in window;
 
@@ -127,7 +127,7 @@ ol.has.MSPOINTER = !!(navigator.msPointerEnabled);
  * if `ol.ENABLE_WEBGL` is set to `false` at compile time.
  * @const
  * @type {boolean}
- * @api stable
+ * @api
  */
 ol.has.WEBGL;
 

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -34,7 +34,7 @@ goog.require('ol.interaction.PinchZoom');
  * @param {olx.interaction.DefaultsOptions=} opt_options Defaults options.
  * @return {ol.Collection.<ol.interaction.Interaction>} A collection of
  * interactions to be used with the ol.Map constructor's interactions option.
- * @api stable
+ * @api
  */
 ol.interaction.defaults = function(opt_options) {
 

--- a/src/ol/interaction/doubleclickzoom.js
+++ b/src/ol/interaction/doubleclickzoom.js
@@ -12,7 +12,7 @@ goog.require('ol.interaction.Interaction');
  * @constructor
  * @extends {ol.interaction.Interaction}
  * @param {olx.interaction.DoubleClickZoomOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DoubleClickZoom = function(opt_options) {
 

--- a/src/ol/interaction/draganddrop.js
+++ b/src/ol/interaction/draganddrop.js
@@ -19,7 +19,7 @@ goog.require('ol.proj');
  * @extends {ol.interaction.Interaction}
  * @fires ol.interaction.DragAndDrop.Event
  * @param {olx.interaction.DragAndDropOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DragAndDrop = function(opt_options) {
 
@@ -189,7 +189,7 @@ ol.interaction.DragAndDrop.EventType_ = {
   /**
    * Triggered when features are added
    * @event ol.interaction.DragAndDrop.Event#addfeatures
-   * @api stable
+   * @api
    */
   ADD_FEATURES: 'addfeatures'
 };
@@ -215,14 +215,14 @@ ol.interaction.DragAndDrop.Event = function(type, file, opt_features, opt_projec
   /**
    * The features parsed from dropped data.
    * @type {Array.<ol.Feature>|undefined}
-   * @api stable
+   * @api
    */
   this.features = opt_features;
 
   /**
    * The dropped file.
    * @type {File}
-   * @api stable
+   * @api
    */
   this.file = file;
 

--- a/src/ol/interaction/dragbox.js
+++ b/src/ol/interaction/dragbox.js
@@ -32,7 +32,7 @@ ol.DRAG_BOX_HYSTERESIS_PIXELS_SQUARED =
  * @extends {ol.interaction.Pointer}
  * @fires ol.interaction.DragBox.Event
  * @param {olx.interaction.DragBoxOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DragBox = function(opt_options) {
 
@@ -111,7 +111,7 @@ ol.interaction.DragBox.handleDragEvent_ = function(mapBrowserEvent) {
 /**
  * Returns geometry of last drawn box.
  * @return {ol.geom.Polygon} Geometry.
- * @api stable
+ * @api
  */
 ol.interaction.DragBox.prototype.getGeometry = function() {
   return this.box_.getGeometry();
@@ -183,7 +183,7 @@ ol.interaction.DragBox.EventType_ = {
   /**
    * Triggered upon drag box start.
    * @event ol.interaction.DragBox.Event#boxstart
-   * @api stable
+   * @api
    */
   BOXSTART: 'boxstart',
 
@@ -197,7 +197,7 @@ ol.interaction.DragBox.EventType_ = {
   /**
    * Triggered upon drag box end.
    * @event ol.interaction.DragBox.Event#boxend
-   * @api stable
+   * @api
    */
   BOXEND: 'boxend'
 };
@@ -222,7 +222,7 @@ ol.interaction.DragBox.Event = function(type, coordinate, mapBrowserEvent) {
    * The coordinate of the drag event.
    * @const
    * @type {ol.Coordinate}
-   * @api stable
+   * @api
    */
   this.coordinate = coordinate;
 

--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -16,7 +16,7 @@ goog.require('ol.interaction.Pointer');
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.DragPanOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DragPan = function(opt_options) {
 

--- a/src/ol/interaction/dragrotate.js
+++ b/src/ol/interaction/dragrotate.js
@@ -19,7 +19,7 @@ goog.require('ol.interaction.Pointer');
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.DragRotateOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DragRotate = function(opt_options) {
 

--- a/src/ol/interaction/dragrotateandzoom.js
+++ b/src/ol/interaction/dragrotateandzoom.js
@@ -20,7 +20,7 @@ goog.require('ol.interaction.Pointer');
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.DragRotateAndZoomOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DragRotateAndZoom = function(opt_options) {
 

--- a/src/ol/interaction/dragzoom.js
+++ b/src/ol/interaction/dragzoom.js
@@ -19,7 +19,7 @@ goog.require('ol.interaction.DragBox');
  * @constructor
  * @extends {ol.interaction.DragBox}
  * @param {olx.interaction.DragZoomOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.DragZoom = function(opt_options) {
   var options = opt_options ? opt_options : {};

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -34,7 +34,7 @@ goog.require('ol.style.Style');
  * @extends {ol.interaction.Pointer}
  * @fires ol.interaction.Draw.Event
  * @param {olx.interaction.DrawOptions} options Options.
- * @api stable
+ * @api
  */
 ol.interaction.Draw = function(options) {
 
@@ -853,7 +853,7 @@ ol.interaction.Draw.Event = function(type, feature) {
   /**
    * The feature being drawn.
    * @type {ol.Feature}
-   * @api stable
+   * @api
    */
   this.feature = feature;
 

--- a/src/ol/interaction/draweventtype.js
+++ b/src/ol/interaction/draweventtype.js
@@ -8,13 +8,13 @@ ol.interaction.DrawEventType = {
   /**
    * Triggered upon feature draw start
    * @event ol.interaction.Draw.Event#drawstart
-   * @api stable
+   * @api
    */
   DRAWSTART: 'drawstart',
   /**
    * Triggered upon feature draw end
    * @event ol.interaction.Draw.Event#drawend
-   * @api stable
+   * @api
    */
   DRAWEND: 'drawend'
 };

--- a/src/ol/interaction/keyboardpan.js
+++ b/src/ol/interaction/keyboardpan.js
@@ -23,7 +23,7 @@ goog.require('ol.interaction.Interaction');
  * @constructor
  * @extends {ol.interaction.Interaction}
  * @param {olx.interaction.KeyboardPanOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.KeyboardPan = function(opt_options) {
 

--- a/src/ol/interaction/keyboardzoom.js
+++ b/src/ol/interaction/keyboardzoom.js
@@ -21,7 +21,7 @@ goog.require('ol.interaction.Interaction');
  * @constructor
  * @param {olx.interaction.KeyboardZoomOptions=} opt_options Options.
  * @extends {ol.interaction.Interaction}
- * @api stable
+ * @api
  */
 ol.interaction.KeyboardZoom = function(opt_options) {
 

--- a/src/ol/interaction/mousewheelzoom.js
+++ b/src/ol/interaction/mousewheelzoom.js
@@ -16,7 +16,7 @@ goog.require('ol.math');
  * @constructor
  * @extends {ol.interaction.Interaction}
  * @param {olx.interaction.MouseWheelZoomOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.MouseWheelZoom = function(opt_options) {
 

--- a/src/ol/interaction/pinchrotate.js
+++ b/src/ol/interaction/pinchrotate.js
@@ -15,7 +15,7 @@ goog.require('ol.interaction.Pointer');
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.PinchRotateOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.PinchRotate = function(opt_options) {
 

--- a/src/ol/interaction/pinchzoom.js
+++ b/src/ol/interaction/pinchzoom.js
@@ -15,7 +15,7 @@ goog.require('ol.interaction.Pointer');
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @param {olx.interaction.PinchZoomOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.interaction.PinchZoom = function(opt_options) {
 

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -31,7 +31,7 @@ goog.require('ol.style.Style');
  * @extends {ol.interaction.Interaction}
  * @param {olx.interaction.SelectOptions=} opt_options Options.
  * @fires ol.interaction.Select.Event
- * @api stable
+ * @api
  */
 ol.interaction.Select = function(opt_options) {
 
@@ -159,7 +159,7 @@ ol.interaction.Select.prototype.addFeatureLayerAssociation_ = function(feature, 
 /**
  * Get the selected features.
  * @return {ol.Collection.<ol.Feature>} Features collection.
- * @api stable
+ * @api
  */
 ol.interaction.Select.prototype.getFeatures = function() {
   return this.featureOverlay_.getSource().getFeaturesCollection();
@@ -304,7 +304,7 @@ ol.interaction.Select.prototype.setHitTolerance = function(hitTolerance) {
  * map, if any. Pass `null` to just remove the interaction from the current map.
  * @param {ol.Map} map Map.
  * @override
- * @api stable
+ * @api
  */
 ol.interaction.Select.prototype.setMap = function(map) {
   var currentMap = this.getMap();

--- a/src/ol/layer/base.js
+++ b/src/ol/layer/base.js
@@ -19,7 +19,7 @@ goog.require('ol.obj');
  * @abstract
  * @extends {ol.Object}
  * @param {olx.layer.BaseOptions} options Layer options.
- * @api stable
+ * @api
  */
 ol.layer.Base = function(options) {
 
@@ -103,7 +103,7 @@ ol.layer.Base.prototype.getLayerStatesArray = function(opt_states) {};
  * will be visible regardless of extent.
  * @return {ol.Extent|undefined} The layer extent.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.getExtent = function() {
   return /** @type {ol.Extent|undefined} */ (
@@ -115,7 +115,7 @@ ol.layer.Base.prototype.getExtent = function() {
  * Return the maximum resolution of the layer.
  * @return {number} The maximum resolution of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.getMaxResolution = function() {
   return /** @type {number} */ (
@@ -127,7 +127,7 @@ ol.layer.Base.prototype.getMaxResolution = function() {
  * Return the minimum resolution of the layer.
  * @return {number} The minimum resolution of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.getMinResolution = function() {
   return /** @type {number} */ (
@@ -139,7 +139,7 @@ ol.layer.Base.prototype.getMinResolution = function() {
  * Return the opacity of the layer (between 0 and 1).
  * @return {number} The opacity of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.getOpacity = function() {
   return /** @type {number} */ (this.get(ol.layer.Property.OPACITY));
@@ -157,7 +157,7 @@ ol.layer.Base.prototype.getSourceState = function() {};
  * Return the visibility of the layer (`true` or `false`).
  * @return {boolean} The visibility of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.getVisible = function() {
   return /** @type {boolean} */ (this.get(ol.layer.Property.VISIBLE));
@@ -181,7 +181,7 @@ ol.layer.Base.prototype.getZIndex = function() {
  * will be visible at all extents.
  * @param {ol.Extent|undefined} extent The extent of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.setExtent = function(extent) {
   this.set(ol.layer.Property.EXTENT, extent);
@@ -192,7 +192,7 @@ ol.layer.Base.prototype.setExtent = function(extent) {
  * Set the maximum resolution at which the layer is visible.
  * @param {number} maxResolution The maximum resolution of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.setMaxResolution = function(maxResolution) {
   this.set(ol.layer.Property.MAX_RESOLUTION, maxResolution);
@@ -203,7 +203,7 @@ ol.layer.Base.prototype.setMaxResolution = function(maxResolution) {
  * Set the minimum resolution at which the layer is visible.
  * @param {number} minResolution The minimum resolution of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.setMinResolution = function(minResolution) {
   this.set(ol.layer.Property.MIN_RESOLUTION, minResolution);
@@ -214,7 +214,7 @@ ol.layer.Base.prototype.setMinResolution = function(minResolution) {
  * Set the opacity of the layer, allowed values range from 0 to 1.
  * @param {number} opacity The opacity of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.setOpacity = function(opacity) {
   this.set(ol.layer.Property.OPACITY, opacity);
@@ -225,7 +225,7 @@ ol.layer.Base.prototype.setOpacity = function(opacity) {
  * Set the visibility of the layer (`true` or `false`).
  * @param {boolean} visible The visibility of the layer.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Base.prototype.setVisible = function(visible) {
   this.set(ol.layer.Property.VISIBLE, visible);

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -23,7 +23,7 @@ goog.require('ol.source.State');
  * @constructor
  * @extends {ol.layer.Base}
  * @param {olx.layer.GroupOptions=} opt_options Layer options.
- * @api stable
+ * @api
  */
 ol.layer.Group = function(opt_options) {
 
@@ -158,7 +158,7 @@ ol.layer.Group.prototype.handleLayersRemove_ = function(collectionEvent) {
  * @return {!ol.Collection.<ol.layer.Base>} Collection of
  *   {@link ol.layer.Base layers} that are part of this group.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Group.prototype.getLayers = function() {
   return /** @type {!ol.Collection.<ol.layer.Base>} */ (this.get(
@@ -172,7 +172,7 @@ ol.layer.Group.prototype.getLayers = function() {
  * @param {!ol.Collection.<ol.layer.Base>} layers Collection of
  *   {@link ol.layer.Base layers} that are part of this group.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Group.prototype.setLayers = function(layers) {
   this.set(ol.layer.Group.Property_.LAYERS, layers);

--- a/src/ol/layer/image.js
+++ b/src/ol/layer/image.js
@@ -19,7 +19,7 @@ goog.require('ol.renderer.webgl.ImageLayer');
  * @extends {ol.layer.Layer}
  * @fires ol.render.Event
  * @param {olx.layer.ImageOptions=} opt_options Layer options.
- * @api stable
+ * @api
  */
 ol.layer.Image = function(opt_options) {
   var options = opt_options ? opt_options : {};
@@ -47,6 +47,6 @@ ol.layer.Image.prototype.createRenderer = function(mapRenderer) {
  * Return the associated {@link ol.source.Image source} of the image layer.
  * @function
  * @return {ol.source.Image} Source.
- * @api stable
+ * @api
  */
 ol.layer.Image.prototype.getSource;

--- a/src/ol/layer/layer.js
+++ b/src/ol/layer/layer.js
@@ -31,7 +31,7 @@ goog.require('ol.source.State');
  * @extends {ol.layer.Base}
  * @fires ol.render.Event
  * @param {olx.layer.LayerOptions} options Layer options.
- * @api stable
+ * @api
  */
 ol.layer.Layer = function(options) {
 
@@ -110,7 +110,7 @@ ol.layer.Layer.prototype.getLayerStatesArray = function(opt_states) {
  * Get the layer source.
  * @return {ol.source.Source} The layer source (or `null` if not yet set).
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Layer.prototype.getSource = function() {
   var source = this.get(ol.layer.Property.SOURCE);
@@ -196,7 +196,7 @@ ol.layer.Layer.prototype.setMap = function(map) {
  * Set the layer source.
  * @param {ol.source.Source} source The layer source.
  * @observable
- * @api stable
+ * @api
  */
 ol.layer.Layer.prototype.setSource = function(source) {
   this.set(ol.layer.Property.SOURCE, source);

--- a/src/ol/layer/tile.js
+++ b/src/ol/layer/tile.js
@@ -21,7 +21,7 @@ goog.require('ol.renderer.webgl.TileLayer');
  * @extends {ol.layer.Layer}
  * @fires ol.render.Event
  * @param {olx.layer.TileOptions=} opt_options Tile layer options.
- * @api stable
+ * @api
  */
 ol.layer.Tile = function(opt_options) {
   var options = opt_options ? opt_options : {};
@@ -69,7 +69,7 @@ ol.layer.Tile.prototype.getPreload = function() {
  * Return the associated {@link ol.source.Tile tilesource} of the layer.
  * @function
  * @return {ol.source.Tile} Source.
- * @api stable
+ * @api
  */
 ol.layer.Tile.prototype.getSource;
 

--- a/src/ol/layer/vector.js
+++ b/src/ol/layer/vector.js
@@ -20,7 +20,7 @@ goog.require('ol.style.Style');
  * @extends {ol.layer.Layer}
  * @fires ol.render.Event
  * @param {olx.layer.VectorOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.layer.Vector = function(opt_options) {
   var options = opt_options ?
@@ -111,7 +111,7 @@ ol.layer.Vector.prototype.getRenderOrder = function() {
  * Return the associated {@link ol.source.Vector vectorsource} of the layer.
  * @function
  * @return {ol.source.Vector} Source.
- * @api stable
+ * @api
  */
 ol.layer.Vector.prototype.getSource;
 
@@ -121,7 +121,7 @@ ol.layer.Vector.prototype.getSource;
  * option at construction or to the `setStyle` method.
  * @return {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
  *     Layer style.
- * @api stable
+ * @api
  */
 ol.layer.Vector.prototype.getStyle = function() {
   return this.style_;
@@ -131,7 +131,7 @@ ol.layer.Vector.prototype.getStyle = function() {
 /**
  * Get the style function.
  * @return {ol.StyleFunction|undefined} Layer style function.
- * @api stable
+ * @api
  */
 ol.layer.Vector.prototype.getStyleFunction = function() {
   return this.styleFunction_;
@@ -174,7 +174,7 @@ ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {
  * {@link ol.style} for information on the default style.
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|null|undefined}
  *     style Layer style.
- * @api stable
+ * @api
  */
 ol.layer.Vector.prototype.setStyle = function(style) {
   this.style_ = style !== undefined ? style : ol.style.Style.defaultFunction;

--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -131,7 +131,7 @@ ol.DEFAULT_RENDERER_TYPES = [
  * @fires ol.MapEvent
  * @fires ol.render.Event#postcompose
  * @fires ol.render.Event#precompose
- * @api stable
+ * @api
  */
 ol.Map = function(options) {
 
@@ -466,7 +466,7 @@ ol.inherits(ol.Map, ol.Object);
 /**
  * Add the given control to the map.
  * @param {ol.control.Control} control Control.
- * @api stable
+ * @api
  */
 ol.Map.prototype.addControl = function(control) {
   this.getControls().push(control);
@@ -476,7 +476,7 @@ ol.Map.prototype.addControl = function(control) {
 /**
  * Add the given interaction to the map.
  * @param {ol.interaction.Interaction} interaction Interaction to add.
- * @api stable
+ * @api
  */
 ol.Map.prototype.addInteraction = function(interaction) {
   this.getInteractions().push(interaction);
@@ -488,7 +488,7 @@ ol.Map.prototype.addInteraction = function(interaction) {
  * elsewhere in the stack, use `getLayers()` and the methods available on
  * {@link ol.Collection}.
  * @param {ol.layer.Base} layer Layer.
- * @api stable
+ * @api
  */
 ol.Map.prototype.addLayer = function(layer) {
   var layers = this.getLayerGroup().getLayers();
@@ -499,7 +499,7 @@ ol.Map.prototype.addLayer = function(layer) {
 /**
  * Add the given overlay to the map.
  * @param {ol.Overlay} overlay Overlay.
- * @api stable
+ * @api
  */
 ol.Map.prototype.addOverlay = function(overlay) {
   this.getOverlays().push(overlay);
@@ -576,7 +576,7 @@ ol.Map.prototype.disposeInternal = function() {
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
  * @template S,T
- * @api stable
+ * @api
  */
 ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_options) {
   if (!this.frameState_) {
@@ -616,7 +616,7 @@ ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_options) 
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
  * @template S,T,U
- * @api stable
+ * @api
  */
 ol.Map.prototype.forEachLayerAtPixel = function(pixel, callback, opt_this, opt_layerFilter, opt_this2) {
   if (!this.frameState_) {
@@ -660,7 +660,7 @@ ol.Map.prototype.hasFeatureAtPixel = function(pixel, opt_options) {
  * Returns the coordinate in view projection for a browser event.
  * @param {Event} event Event.
  * @return {ol.Coordinate} Coordinate.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getEventCoordinate = function(event) {
   return this.getCoordinateFromPixel(this.getEventPixel(event));
@@ -671,7 +671,7 @@ ol.Map.prototype.getEventCoordinate = function(event) {
  * Returns the map pixel position for a browser event relative to the viewport.
  * @param {Event} event Event.
  * @return {ol.Pixel} Pixel.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getEventPixel = function(event) {
   var viewportPosition = this.viewport_.getBoundingClientRect();
@@ -690,7 +690,7 @@ ol.Map.prototype.getEventPixel = function(event) {
  * @return {Element|string|undefined} The Element or id of the Element that the
  *     map is rendered in.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.getTarget = function() {
   return /** @type {Element|string|undefined} */ (
@@ -722,7 +722,7 @@ ol.Map.prototype.getTargetElement = function() {
  * map view projection.
  * @param {ol.Pixel} pixel Pixel position in the map viewport.
  * @return {ol.Coordinate} The coordinate for the pixel position.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getCoordinateFromPixel = function(pixel) {
   var frameState = this.frameState_;
@@ -738,7 +738,7 @@ ol.Map.prototype.getCoordinateFromPixel = function(pixel) {
  * Get the map controls. Modifying this collection changes the controls
  * associated with the map.
  * @return {ol.Collection.<ol.control.Control>} Controls.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getControls = function() {
   return this.controls_;
@@ -749,7 +749,7 @@ ol.Map.prototype.getControls = function() {
  * Get the map overlays. Modifying this collection changes the overlays
  * associated with the map.
  * @return {ol.Collection.<ol.Overlay>} Overlays.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getOverlays = function() {
   return this.overlays_;
@@ -776,7 +776,7 @@ ol.Map.prototype.getOverlayById = function(id) {
  *
  * Interactions are used for e.g. pan, zoom and rotate.
  * @return {ol.Collection.<ol.interaction.Interaction>} Interactions.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getInteractions = function() {
   return this.interactions_;
@@ -787,7 +787,7 @@ ol.Map.prototype.getInteractions = function() {
  * Get the layergroup associated with this map.
  * @return {ol.layer.Group} A layer group containing the layers in this map.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.getLayerGroup = function() {
   return /** @type {ol.layer.Group} */ (this.get(ol.MapProperty.LAYERGROUP));
@@ -797,7 +797,7 @@ ol.Map.prototype.getLayerGroup = function() {
 /**
  * Get the collection of layers associated with this map.
  * @return {!ol.Collection.<ol.layer.Base>} Layers.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getLayers = function() {
   var layers = this.getLayerGroup().getLayers();
@@ -810,7 +810,7 @@ ol.Map.prototype.getLayers = function() {
  * projection and returns the corresponding pixel.
  * @param {ol.Coordinate} coordinate A map coordinate.
  * @return {ol.Pixel} A pixel position in the map viewport.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getPixelFromCoordinate = function(coordinate) {
   var frameState = this.frameState_;
@@ -836,7 +836,7 @@ ol.Map.prototype.getRenderer = function() {
  * Get the size of this map.
  * @return {ol.Size|undefined} The size in pixels of the map in the DOM.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.getSize = function() {
   return /** @type {ol.Size|undefined} */ (this.get(ol.MapProperty.SIZE));
@@ -848,7 +848,7 @@ ol.Map.prototype.getSize = function() {
  * center and resolution.
  * @return {ol.View} The view that controls this map.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.getView = function() {
   return /** @type {ol.View} */ (this.get(ol.MapProperty.VIEW));
@@ -858,7 +858,7 @@ ol.Map.prototype.getView = function() {
 /**
  * Get the element that serves as the map viewport.
  * @return {Element} Viewport.
- * @api stable
+ * @api
  */
 ol.Map.prototype.getViewport = function() {
   return this.viewport_;
@@ -1140,7 +1140,7 @@ ol.Map.prototype.isRendered = function() {
 
 /**
  * Requests an immediate render in a synchronous manner.
- * @api stable
+ * @api
  */
 ol.Map.prototype.renderSync = function() {
   if (this.animationDelayKey_) {
@@ -1152,7 +1152,7 @@ ol.Map.prototype.renderSync = function() {
 
 /**
  * Request a map rendering (at the next animation frame).
- * @api stable
+ * @api
  */
 ol.Map.prototype.render = function() {
   if (this.animationDelayKey_ === undefined) {
@@ -1167,7 +1167,7 @@ ol.Map.prototype.render = function() {
  * @param {ol.control.Control} control Control.
  * @return {ol.control.Control|undefined} The removed control (or undefined
  *     if the control was not found).
- * @api stable
+ * @api
  */
 ol.Map.prototype.removeControl = function(control) {
   return this.getControls().remove(control);
@@ -1179,7 +1179,7 @@ ol.Map.prototype.removeControl = function(control) {
  * @param {ol.interaction.Interaction} interaction Interaction to remove.
  * @return {ol.interaction.Interaction|undefined} The removed interaction (or
  *     undefined if the interaction was not found).
- * @api stable
+ * @api
  */
 ol.Map.prototype.removeInteraction = function(interaction) {
   return this.getInteractions().remove(interaction);
@@ -1191,7 +1191,7 @@ ol.Map.prototype.removeInteraction = function(interaction) {
  * @param {ol.layer.Base} layer Layer.
  * @return {ol.layer.Base|undefined} The removed layer (or undefined if the
  *     layer was not found).
- * @api stable
+ * @api
  */
 ol.Map.prototype.removeLayer = function(layer) {
   var layers = this.getLayerGroup().getLayers();
@@ -1204,7 +1204,7 @@ ol.Map.prototype.removeLayer = function(layer) {
  * @param {ol.Overlay} overlay Overlay.
  * @return {ol.Overlay|undefined} The removed overlay (or undefined
  *     if the overlay was not found).
- * @api stable
+ * @api
  */
 ol.Map.prototype.removeOverlay = function(overlay) {
   return this.getOverlays().remove(overlay);
@@ -1305,7 +1305,7 @@ ol.Map.prototype.renderFrame_ = function(time) {
  * @param {ol.layer.Group} layerGroup A layer group containing the layers in
  *     this map.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.setLayerGroup = function(layerGroup) {
   this.set(ol.MapProperty.LAYERGROUP, layerGroup);
@@ -1328,7 +1328,7 @@ ol.Map.prototype.setSize = function(size) {
  * @param {Element|string|undefined} target The Element or id of the Element
  *     that the map is rendered in.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.setTarget = function(target) {
   this.set(ol.MapProperty.TARGET, target);
@@ -1339,7 +1339,7 @@ ol.Map.prototype.setTarget = function(target) {
  * Set the view for this map.
  * @param {ol.View} view The view that controls this map.
  * @observable
- * @api stable
+ * @api
  */
 ol.Map.prototype.setView = function(view) {
   this.set(ol.MapProperty.VIEW, view);
@@ -1359,7 +1359,7 @@ ol.Map.prototype.skipFeature = function(feature) {
 /**
  * Force a recalculation of the map viewport size.  This should be called when
  * third-party code changes the size of the map viewport.
- * @api stable
+ * @api
  */
 ol.Map.prototype.updateSize = function() {
   var targetElement = this.getTargetElement();

--- a/src/ol/mapbrowserevent.js
+++ b/src/ol/mapbrowserevent.js
@@ -27,21 +27,21 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_dragging,
    * The original browser event.
    * @const
    * @type {Event}
-   * @api stable
+   * @api
    */
   this.originalEvent = browserEvent;
 
   /**
    * The map pixel relative to the viewport corresponding to the original browser event.
    * @type {ol.Pixel}
-   * @api stable
+   * @api
    */
   this.pixel = map.getEventPixel(browserEvent);
 
   /**
    * The coordinate in view projection corresponding to the original browser event.
    * @type {ol.Coordinate}
-   * @api stable
+   * @api
    */
   this.coordinate = map.getCoordinateFromPixel(this.pixel);
 
@@ -50,7 +50,7 @@ ol.MapBrowserEvent = function(type, map, browserEvent, opt_dragging,
    * `POINTERDRAG` and `POINTERMOVE` events. Default is `false`.
    *
    * @type {boolean}
-   * @api stable
+   * @api
    */
   this.dragging = opt_dragging !== undefined ? opt_dragging : false;
 
@@ -62,7 +62,7 @@ ol.inherits(ol.MapBrowserEvent, ol.MapEvent);
  * Prevents the default browser action.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/event.preventDefault
  * @override
- * @api stable
+ * @api
  */
 ol.MapBrowserEvent.prototype.preventDefault = function() {
   ol.MapEvent.prototype.preventDefault.call(this);
@@ -74,7 +74,7 @@ ol.MapBrowserEvent.prototype.preventDefault = function() {
  * Prevents further propagation of the current event.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/event.stopPropagation
  * @override
- * @api stable
+ * @api
  */
 ol.MapBrowserEvent.prototype.stopPropagation = function() {
   ol.MapEvent.prototype.stopPropagation.call(this);

--- a/src/ol/mapbrowsereventtype.js
+++ b/src/ol/mapbrowsereventtype.js
@@ -13,21 +13,21 @@ ol.MapBrowserEventType = {
    * A true single click with no dragging and no double click. Note that this
    * event is delayed by 250 ms to ensure that it is not a double click.
    * @event ol.MapBrowserEvent#singleclick
-   * @api stable
+   * @api
    */
   SINGLECLICK: 'singleclick',
 
   /**
    * A click with no dragging. A double click will fire two of this.
    * @event ol.MapBrowserEvent#click
-   * @api stable
+   * @api
    */
   CLICK: ol.events.EventType.CLICK,
 
   /**
    * A true double click, with no dragging.
    * @event ol.MapBrowserEvent#dblclick
-   * @api stable
+   * @api
    */
   DBLCLICK: ol.events.EventType.DBLCLICK,
 
@@ -42,7 +42,7 @@ ol.MapBrowserEventType = {
    * Triggered when a pointer is moved. Note that on touch devices this is
    * triggered when the map is panned, so is not the same as mousemove.
    * @event ol.MapBrowserEvent#pointermove
-   * @api stable
+   * @api
    */
   POINTERMOVE: 'pointermove',
 

--- a/src/ol/mapevent.js
+++ b/src/ol/mapevent.js
@@ -23,7 +23,7 @@ ol.MapEvent = function(type, map, opt_frameState) {
   /**
    * The map where the event occurred.
    * @type {ol.Map}
-   * @api stable
+   * @api
    */
   this.map = map;
 

--- a/src/ol/mapeventtype.js
+++ b/src/ol/mapeventtype.js
@@ -15,7 +15,7 @@ ol.MapEventType = {
   /**
    * Triggered after the map is moved.
    * @event ol.MapEvent#moveend
-   * @api stable
+   * @api
    */
   MOVEEND: 'moveend'
 

--- a/src/ol/object.js
+++ b/src/ol/object.js
@@ -96,7 +96,7 @@ ol.Object.getChangeEventType = function(key) {
  * Gets a value.
  * @param {string} key Key name.
  * @return {*} Value.
- * @api stable
+ * @api
  */
 ol.Object.prototype.get = function(key) {
   var value;
@@ -110,7 +110,7 @@ ol.Object.prototype.get = function(key) {
 /**
  * Get a list of object property names.
  * @return {Array.<string>} List of property names.
- * @api stable
+ * @api
  */
 ol.Object.prototype.getKeys = function() {
   return Object.keys(this.values_);
@@ -120,7 +120,7 @@ ol.Object.prototype.getKeys = function() {
 /**
  * Get an object of all property names and values.
  * @return {Object.<string, *>} Object.
- * @api stable
+ * @api
  */
 ol.Object.prototype.getProperties = function() {
   return ol.obj.assign({}, this.values_);
@@ -145,7 +145,7 @@ ol.Object.prototype.notify = function(key, oldValue) {
  * @param {string} key Key name.
  * @param {*} value Value.
  * @param {boolean=} opt_silent Update without triggering an event.
- * @api stable
+ * @api
  */
 ol.Object.prototype.set = function(key, value, opt_silent) {
   if (opt_silent) {
@@ -165,7 +165,7 @@ ol.Object.prototype.set = function(key, value, opt_silent) {
  * properties and adds new ones (it does not remove any existing properties).
  * @param {Object.<string, *>} values Values.
  * @param {boolean=} opt_silent Update without triggering an event.
- * @api stable
+ * @api
  */
 ol.Object.prototype.setProperties = function(values, opt_silent) {
   var key;
@@ -179,7 +179,7 @@ ol.Object.prototype.setProperties = function(values, opt_silent) {
  * Unsets a property.
  * @param {string} key Key name.
  * @param {boolean=} opt_silent Unset without triggering an event.
- * @api stable
+ * @api
  */
 ol.Object.prototype.unset = function(key, opt_silent) {
   if (key in this.values_) {
@@ -209,7 +209,7 @@ ol.Object.Event = function(type, key, oldValue) {
   /**
    * The name of the property whose value is changing.
    * @type {string}
-   * @api stable
+   * @api
    */
   this.key = key;
 
@@ -217,7 +217,7 @@ ol.Object.Event = function(type, key, oldValue) {
    * The old value. To get the new value use `e.target.get(e.key)` where
    * `e` is the event object.
    * @type {*}
-   * @api stable
+   * @api
    */
   this.oldValue = oldValue;
 

--- a/src/ol/objecteventtype.js
+++ b/src/ol/objecteventtype.js
@@ -7,7 +7,7 @@ ol.ObjectEventType = {
   /**
    * Triggered when a property is changed.
    * @event ol.Object.Event#propertychange
-   * @api stable
+   * @api
    */
   PROPERTYCHANGE: 'propertychange'
 };

--- a/src/ol/observable.js
+++ b/src/ol/observable.js
@@ -18,7 +18,7 @@ goog.require('ol.events.EventType');
  * @extends {ol.events.EventTarget}
  * @fires ol.events.Event
  * @struct
- * @api stable
+ * @api
  */
 ol.Observable = function() {
 
@@ -38,7 +38,7 @@ ol.inherits(ol.Observable, ol.events.EventTarget);
  * Removes an event listener using the key returned by `on()` or `once()`.
  * @param {ol.EventsKey|Array.<ol.EventsKey>} key The key returned by `on()`
  *     or `once()` (or an array of keys).
- * @api stable
+ * @api
  */
 ol.Observable.unByKey = function(key) {
   if (Array.isArray(key)) {
@@ -94,7 +94,7 @@ ol.Observable.prototype.getRevision = function() {
  * @return {ol.EventsKey|Array.<ol.EventsKey>} Unique key for the listener. If
  *     called with an array of event types as the first argument, the return
  *     will be an array of keys.
- * @api stable
+ * @api
  */
 ol.Observable.prototype.on = function(type, listener, opt_this) {
   if (Array.isArray(type)) {
@@ -119,7 +119,7 @@ ol.Observable.prototype.on = function(type, listener, opt_this) {
  * @return {ol.EventsKey|Array.<ol.EventsKey>} Unique key for the listener. If
  *     called with an array of event types as the first argument, the return
  *     will be an array of keys.
- * @api stable
+ * @api
  */
 ol.Observable.prototype.once = function(type, listener, opt_this) {
   if (Array.isArray(type)) {
@@ -142,7 +142,7 @@ ol.Observable.prototype.once = function(type, listener, opt_this) {
  * @param {function(?): ?} listener The listener function.
  * @param {Object=} opt_this The object which was used as `this` by the
  * `listener`.
- * @api stable
+ * @api
  */
 ol.Observable.prototype.un = function(type, listener, opt_this) {
   if (Array.isArray(type)) {
@@ -163,6 +163,6 @@ ol.Observable.prototype.un = function(type, listener, opt_this) {
  * @param {ol.EventsKey|Array.<ol.EventsKey>} key The key returned by `on()`
  *     or `once()` (or an array of keys).
  * @function
- * @api stable
+ * @api
  */
 ol.Observable.prototype.unByKey = ol.Observable.unByKey;

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -28,7 +28,7 @@ goog.require('ol.extent');
  * @constructor
  * @extends {ol.Object}
  * @param {olx.OverlayOptions} options Overlay options.
- * @api stable
+ * @api
  */
 ol.Overlay = function(options) {
 
@@ -145,7 +145,7 @@ ol.inherits(ol.Overlay, ol.Object);
  * Get the DOM element of this overlay.
  * @return {Element|undefined} The Element containing the overlay.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.getElement = function() {
   return /** @type {Element|undefined} */ (
@@ -167,7 +167,7 @@ ol.Overlay.prototype.getId = function() {
  * Get the map associated with this overlay.
  * @return {ol.Map|undefined} The map that the overlay is part of.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.getMap = function() {
   return /** @type {ol.Map|undefined} */ (
@@ -179,7 +179,7 @@ ol.Overlay.prototype.getMap = function() {
  * Get the offset of this overlay.
  * @return {Array.<number>} The offset.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.getOffset = function() {
   return /** @type {Array.<number>} */ (
@@ -192,7 +192,7 @@ ol.Overlay.prototype.getOffset = function() {
  * @return {ol.Coordinate|undefined} The spatial point that the overlay is
  *     anchored at.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.getPosition = function() {
   return /** @type {ol.Coordinate|undefined} */ (
@@ -205,7 +205,7 @@ ol.Overlay.prototype.getPosition = function() {
  * @return {ol.OverlayPositioning} How the overlay is positioned
  *     relative to its point on the map.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.getPositioning = function() {
   return /** @type {ol.OverlayPositioning} */ (
@@ -289,7 +289,7 @@ ol.Overlay.prototype.handlePositioningChanged = function() {
  * Set the DOM element to be associated with this overlay.
  * @param {Element|undefined} element The Element containing the overlay.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.setElement = function(element) {
   this.set(ol.Overlay.Property_.ELEMENT, element);
@@ -300,7 +300,7 @@ ol.Overlay.prototype.setElement = function(element) {
  * Set the map to be associated with this overlay.
  * @param {ol.Map|undefined} map The map that the overlay is part of.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.setMap = function(map) {
   this.set(ol.Overlay.Property_.MAP, map);
@@ -311,7 +311,7 @@ ol.Overlay.prototype.setMap = function(map) {
  * Set the offset for this overlay.
  * @param {Array.<number>} offset Offset.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.setOffset = function(offset) {
   this.set(ol.Overlay.Property_.OFFSET, offset);
@@ -324,7 +324,7 @@ ol.Overlay.prototype.setOffset = function(offset) {
  * @param {ol.Coordinate|undefined} position The spatial point that the overlay
  *     is anchored at.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.setPosition = function(position) {
   this.set(ol.Overlay.Property_.POSITION, position);
@@ -415,7 +415,7 @@ ol.Overlay.prototype.getRect_ = function(element, size) {
  * @param {ol.OverlayPositioning} positioning how the overlay is
  *     positioned relative to its point on the map.
  * @observable
- * @api stable
+ * @api
  */
 ol.Overlay.prototype.setPositioning = function(positioning) {
   this.set(ol.Overlay.Property_.POSITIONING, positioning);

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -14,7 +14,7 @@ goog.require('ol.sphere.NORMAL');
  * Meters per unit lookup table.
  * @const
  * @type {Object.<ol.proj.Units, number>}
- * @api stable
+ * @api
  */
 ol.proj.METERS_PER_UNIT = ol.proj.Units.METERS_PER_UNIT;
 
@@ -134,7 +134,7 @@ ol.proj.addEquivalentTransforms = function(projections1, projections2, forwardTr
  * looked up by their code.
  *
  * @param {ol.proj.Projection} projection Projection instance.
- * @api stable
+ * @api
  */
 ol.proj.addProjection = function(projection) {
   ol.proj.projections.add(projection.getCode(), projection);
@@ -195,7 +195,7 @@ ol.proj.createProjection = function(projection, defaultCode) {
  *     function (that is, from the destination projection to the source
  *     projection) that takes a {@link ol.Coordinate} as argument and returns
  *     the transformed {@link ol.Coordinate}.
- * @api stable
+ * @api
  */
 ol.proj.addCoordinateTransforms = function(source, destination, forward, inverse) {
   var sourceProj = ol.proj.get(source);
@@ -247,7 +247,7 @@ ol.proj.createTransformFromCoordinateTransform = function(transform) {
  * @param {ol.ProjectionLike=} opt_projection Target projection. The
  *     default is Web Mercator, i.e. 'EPSG:3857'.
  * @return {ol.Coordinate} Coordinate projected to the target projection.
- * @api stable
+ * @api
  */
 ol.proj.fromLonLat = function(coordinate, opt_projection) {
   return ol.proj.transform(coordinate, 'EPSG:4326',
@@ -262,7 +262,7 @@ ol.proj.fromLonLat = function(coordinate, opt_projection) {
  *     The default is Web Mercator, i.e. 'EPSG:3857'.
  * @return {ol.Coordinate} Coordinate as longitude and latitude, i.e. an array
  *     with longitude as 1st and latitude as 2nd element.
- * @api stable
+ * @api
  */
 ol.proj.toLonLat = function(coordinate, opt_projection) {
   return ol.proj.transform(coordinate,
@@ -277,7 +277,7 @@ ol.proj.toLonLat = function(coordinate, opt_projection) {
  *     a combination of authority and identifier such as "EPSG:4326", or an
  *     existing projection object, or undefined.
  * @return {ol.proj.Projection} Projection object, or null if not in list.
- * @api stable
+ * @api
  */
 ol.proj.get = function(projectionLike) {
   var projection = null;
@@ -332,7 +332,7 @@ ol.proj.equivalent = function(projection1, projection2) {
  * @param {ol.ProjectionLike} source Source.
  * @param {ol.ProjectionLike} destination Destination.
  * @return {ol.TransformFunction} Transform function.
- * @api stable
+ * @api
  */
 ol.proj.getTransform = function(source, destination) {
   var sourceProjection = ol.proj.get(source);
@@ -430,7 +430,7 @@ ol.proj.cloneTransform = function(input, opt_output, opt_dimension) {
  * @param {ol.ProjectionLike} source Source projection-like.
  * @param {ol.ProjectionLike} destination Destination projection-like.
  * @return {ol.Coordinate} Coordinate.
- * @api stable
+ * @api
  */
 ol.proj.transform = function(coordinate, source, destination) {
   var transformFn = ol.proj.getTransform(source, destination);
@@ -446,7 +446,7 @@ ol.proj.transform = function(coordinate, source, destination) {
  * @param {ol.ProjectionLike} source Source projection-like.
  * @param {ol.ProjectionLike} destination Destination projection-like.
  * @return {ol.Extent} The transformed extent.
- * @api stable
+ * @api
  */
 ol.proj.transformExtent = function(extent, source, destination) {
   var transformFn = ol.proj.getTransform(source, destination);

--- a/src/ol/proj/projection.js
+++ b/src/ol/proj/projection.js
@@ -33,7 +33,7 @@ goog.require('ol.proj.proj4');
  * @constructor
  * @param {olx.ProjectionOptions} options Projection options.
  * @struct
- * @api stable
+ * @api
  */
 ol.proj.Projection = function(options) {
  /**
@@ -130,7 +130,7 @@ ol.proj.Projection.prototype.canWrapX = function() {
 /**
  * Get the code for this projection, e.g. 'EPSG:4326'.
  * @return {string} Code.
- * @api stable
+ * @api
  */
 ol.proj.Projection.prototype.getCode = function() {
   return this.code_;
@@ -140,7 +140,7 @@ ol.proj.Projection.prototype.getCode = function() {
 /**
  * Get the validity extent for this projection.
  * @return {ol.Extent} Extent.
- * @api stable
+ * @api
  */
 ol.proj.Projection.prototype.getExtent = function() {
   return this.extent_;
@@ -150,7 +150,7 @@ ol.proj.Projection.prototype.getExtent = function() {
 /**
  * Get the units of this projection.
  * @return {ol.proj.Units} Units.
- * @api stable
+ * @api
  */
 ol.proj.Projection.prototype.getUnits = function() {
   return this.units_;
@@ -162,7 +162,7 @@ ol.proj.Projection.prototype.getUnits = function() {
  * not configured with `metersPerUnit` or a units identifier, the return is
  * `undefined`.
  * @return {number|undefined} Meters.
- * @api stable
+ * @api
  */
 ol.proj.Projection.prototype.getMetersPerUnit = function() {
   return this.metersPerUnit_ || ol.proj.Units.METERS_PER_UNIT[this.units_];
@@ -197,7 +197,7 @@ ol.proj.Projection.prototype.getAxisOrientation = function() {
 /**
  * Is this projection a global projection which spans the whole world?
  * @return {boolean} Whether the projection is global.
- * @api stable
+ * @api
  */
 ol.proj.Projection.prototype.isGlobal = function() {
   return this.global_;
@@ -207,7 +207,7 @@ ol.proj.Projection.prototype.isGlobal = function() {
 /**
 * Set if the projection is a global projection which spans the whole world
 * @param {boolean} global Whether the projection is global.
-* @api stable
+* @api
 */
 ol.proj.Projection.prototype.setGlobal = function(global) {
   this.global_ = global;
@@ -234,7 +234,7 @@ ol.proj.Projection.prototype.setDefaultTileGrid = function(tileGrid) {
 /**
  * Set the validity extent for this projection.
  * @param {ol.Extent} extent Extent.
- * @api stable
+ * @api
  */
 ol.proj.Projection.prototype.setExtent = function(extent) {
   this.extent_ = extent;

--- a/src/ol/proj/units.js
+++ b/src/ol/proj/units.js
@@ -22,7 +22,7 @@ ol.proj.Units = {
  * Meters per unit lookup table.
  * @const
  * @type {Object.<ol.proj.Units, number>}
- * @api stable
+ * @api
  */
 ol.proj.Units.METERS_PER_UNIT = {};
 ol.proj.Units.METERS_PER_UNIT[ol.proj.Units.DEGREES] =

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -52,7 +52,7 @@ ol.size.scale = function(size, ratio, opt_size) {
  * @param {number|ol.Size} size Width and height.
  * @param {ol.Size=} opt_size Optional reusable size array.
  * @return {ol.Size} Size.
- * @api stable
+ * @api
  */
 ol.size.toSize = function(size, opt_size) {
   if (Array.isArray(size)) {

--- a/src/ol/source/bingmaps.js
+++ b/src/ol/source/bingmaps.js
@@ -19,7 +19,7 @@ goog.require('ol.tilegrid');
  * @constructor
  * @extends {ol.source.TileImage}
  * @param {olx.source.BingMapsOptions} options Bing Maps options.
- * @api stable
+ * @api
  */
 ol.source.BingMaps = function(options) {
 

--- a/src/ol/source/imagearcgisrest.js
+++ b/src/ol/source/imagearcgisrest.js
@@ -103,7 +103,7 @@ ol.inherits(ol.source.ImageArcGISRest, ol.source.Image);
  * Get the user-provided params, i.e. those passed to the constructor through
  * the "params" option, and possibly updated using the updateParams method.
  * @return {Object} Params.
- * @api stable
+ * @api
  */
 ol.source.ImageArcGISRest.prototype.getParams = function() {
   return this.params_;
@@ -225,7 +225,7 @@ ol.source.ImageArcGISRest.prototype.getRequestUrl_ = function(extent, size, pixe
 /**
  * Return the URL used for this ArcGIS source.
  * @return {string|undefined} URL.
- * @api stable
+ * @api
  */
 ol.source.ImageArcGISRest.prototype.getUrl = function() {
   return this.url_;
@@ -247,7 +247,7 @@ ol.source.ImageArcGISRest.prototype.setImageLoadFunction = function(imageLoadFun
 /**
  * Set the URL to use for requests.
  * @param {string|undefined} url URL.
- * @api stable
+ * @api
  */
 ol.source.ImageArcGISRest.prototype.setUrl = function(url) {
   if (url != this.url_) {
@@ -261,7 +261,7 @@ ol.source.ImageArcGISRest.prototype.setUrl = function(url) {
 /**
  * Update the user-provided params.
  * @param {Object} params Params.
- * @api stable
+ * @api
  */
 ol.source.ImageArcGISRest.prototype.updateParams = function(params) {
   ol.obj.assign(this.params_, params);

--- a/src/ol/source/imagemapguide.js
+++ b/src/ol/source/imagemapguide.js
@@ -18,7 +18,7 @@ goog.require('ol.uri');
  * @fires ol.source.Image.Event
  * @extends {ol.source.Image}
  * @param {olx.source.ImageMapGuideOptions} options Options.
- * @api stable
+ * @api
  */
 ol.source.ImageMapGuide = function(options) {
 
@@ -106,7 +106,7 @@ ol.inherits(ol.source.ImageMapGuide, ol.source.Image);
  * Get the user-provided params, i.e. those passed to the constructor through
  * the "params" option, and possibly updated using the updateParams method.
  * @return {Object} Params.
- * @api stable
+ * @api
  */
 ol.source.ImageMapGuide.prototype.getParams = function() {
   return this.params_;
@@ -189,7 +189,7 @@ ol.source.ImageMapGuide.getScale = function(extent, size, metersPerUnit, dpi) {
 /**
  * Update the user-provided params.
  * @param {Object} params Params.
- * @api stable
+ * @api
  */
 ol.source.ImageMapGuide.prototype.updateParams = function(params) {
   ol.obj.assign(this.params_, params);

--- a/src/ol/source/imagestatic.js
+++ b/src/ol/source/imagestatic.js
@@ -18,7 +18,7 @@ goog.require('ol.source.Image');
  * @constructor
  * @extends {ol.source.Image}
  * @param {olx.source.ImageStaticOptions} options Options.
- * @api stable
+ * @api
  */
 ol.source.ImageStatic = function(options) {
   var imageExtent = options.imageExtent;

--- a/src/ol/source/imagevector.js
+++ b/src/ol/source/imagevector.js
@@ -193,7 +193,7 @@ ol.source.ImageVector.prototype.getSource = function() {
  * option at construction or to the `setStyle` method.
  * @return {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction}
  *     Layer style.
- * @api stable
+ * @api
  */
 ol.source.ImageVector.prototype.getStyle = function() {
   return this.style_;
@@ -203,7 +203,7 @@ ol.source.ImageVector.prototype.getStyle = function() {
 /**
  * Get the style function.
  * @return {ol.StyleFunction|undefined} Layer style function.
- * @api stable
+ * @api
  */
 ol.source.ImageVector.prototype.getStyleFunction = function() {
   return this.styleFunction_;
@@ -292,7 +292,7 @@ ol.source.ImageVector.prototype.renderFeature_ = function(feature, resolution, p
  * {@link ol.style} for information on the default style.
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined}
  *     style Layer style.
- * @api stable
+ * @api
  */
 ol.source.ImageVector.prototype.setStyle = function(style) {
   this.style_ = style !== undefined ? style : ol.style.Style.defaultFunction;

--- a/src/ol/source/imagewms.js
+++ b/src/ol/source/imagewms.js
@@ -24,7 +24,7 @@ goog.require('ol.uri');
  * @fires ol.source.Image.Event
  * @extends {ol.source.Image}
  * @param {olx.source.ImageWMSOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.source.ImageWMS = function(opt_options) {
 
@@ -131,7 +131,7 @@ ol.source.ImageWMS.GETFEATUREINFO_IMAGE_SIZE_ = [101, 101];
  *     in the `LAYERS` parameter will be used. `VERSION` should not be
  *     specified here.
  * @return {string|undefined} GetFeatureInfo URL.
- * @api stable
+ * @api
  */
 ol.source.ImageWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
   if (this.url_ === undefined) {
@@ -167,7 +167,7 @@ ol.source.ImageWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolut
  * Get the user-provided params, i.e. those passed to the constructor through
  * the "params" option, and possibly updated using the updateParams method.
  * @return {Object} Params.
- * @api stable
+ * @api
  */
 ol.source.ImageWMS.prototype.getParams = function() {
   return this.params_;
@@ -309,7 +309,7 @@ ol.source.ImageWMS.prototype.getRequestUrl_ = function(extent, size, pixelRatio,
 /**
  * Return the URL used for this WMS source.
  * @return {string|undefined} URL.
- * @api stable
+ * @api
  */
 ol.source.ImageWMS.prototype.getUrl = function() {
   return this.url_;
@@ -332,7 +332,7 @@ ol.source.ImageWMS.prototype.setImageLoadFunction = function(
 /**
  * Set the URL to use for requests.
  * @param {string|undefined} url URL.
- * @api stable
+ * @api
  */
 ol.source.ImageWMS.prototype.setUrl = function(url) {
   if (url != this.url_) {
@@ -346,7 +346,7 @@ ol.source.ImageWMS.prototype.setUrl = function(url) {
 /**
  * Update the user-provided params.
  * @param {Object} params Params.
- * @api stable
+ * @api
  */
 ol.source.ImageWMS.prototype.updateParams = function(params) {
   ol.obj.assign(this.params_, params);

--- a/src/ol/source/osm.js
+++ b/src/ol/source/osm.js
@@ -12,7 +12,7 @@ goog.require('ol.source.XYZ');
  * @constructor
  * @extends {ol.source.XYZ}
  * @param {olx.source.OSMOptions=} opt_options Open Street Map options.
- * @api stable
+ * @api
  */
 ol.source.OSM = function(opt_options) {
 

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -19,7 +19,7 @@ goog.require('ol.source.State');
  * @abstract
  * @extends {ol.Object}
  * @param {ol.SourceSourceOptions} options Source options.
- * @api stable
+ * @api
  */
 ol.source.Source = function(options) {
 
@@ -108,7 +108,7 @@ ol.source.Source.prototype.forEachFeatureAtCoordinate = ol.nullFunction;
 /**
  * Get the attributions of the source.
  * @return {Array.<ol.Attribution>} Attributions.
- * @api stable
+ * @api
  */
 ol.source.Source.prototype.getAttributions = function() {
   return this.attributions_;
@@ -118,7 +118,7 @@ ol.source.Source.prototype.getAttributions = function() {
 /**
  * Get the logo of the source.
  * @return {string|olx.LogoOptions|undefined} Logo.
- * @api stable
+ * @api
  */
 ol.source.Source.prototype.getLogo = function() {
   return this.logo_;

--- a/src/ol/source/stamen.js
+++ b/src/ol/source/stamen.js
@@ -13,7 +13,7 @@ goog.require('ol.source.XYZ');
  * @constructor
  * @extends {ol.source.XYZ}
  * @param {olx.source.StamenOptions} options Stamen options.
- * @api stable
+ * @api
  */
 ol.source.Stamen = function(options) {
   var i = options.layer.indexOf('-');

--- a/src/ol/source/tile.js
+++ b/src/ol/source/tile.js
@@ -206,7 +206,7 @@ ol.source.Tile.prototype.getTile = function(z, x, y, pixelRatio, projection) {};
 /**
  * Return the tile grid of the tile source.
  * @return {ol.tilegrid.TileGrid} Tile grid.
- * @api stable
+ * @api
  */
 ol.source.Tile.prototype.getTileGrid = function() {
   return this.tileGrid;

--- a/src/ol/source/tilearcgisrest.js
+++ b/src/ol/source/tilearcgisrest.js
@@ -175,7 +175,7 @@ ol.source.TileArcGISRest.prototype.fixedTileUrlFunction = function(tileCoord, pi
 /**
  * Update the user-provided params.
  * @param {Object} params Params.
- * @api stable
+ * @api
  */
 ol.source.TileArcGISRest.prototype.updateParams = function(params) {
   ol.obj.assign(this.params_, params);

--- a/src/ol/source/tileeventtype.js
+++ b/src/ol/source/tileeventtype.js
@@ -8,21 +8,21 @@ ol.source.TileEventType = {
   /**
    * Triggered when a tile starts loading.
    * @event ol.source.Tile.Event#tileloadstart
-   * @api stable
+   * @api
    */
   TILELOADSTART: 'tileloadstart',
 
   /**
    * Triggered when a tile finishes loading.
    * @event ol.source.Tile.Event#tileloadend
-   * @api stable
+   * @api
    */
   TILELOADEND: 'tileloadend',
 
   /**
    * Triggered if tile loading results in an error.
    * @event ol.source.Tile.Event#tileloaderror
-   * @api stable
+   * @api
    */
   TILELOADERROR: 'tileloaderror'
 

--- a/src/ol/source/tilejson.js
+++ b/src/ol/source/tilejson.js
@@ -24,7 +24,7 @@ goog.require('ol.tilegrid');
  * @constructor
  * @extends {ol.source.TileImage}
  * @param {olx.source.TileJSONOptions} options TileJSON options.
- * @api stable
+ * @api
  */
 ol.source.TileJSON = function(options) {
 

--- a/src/ol/source/tilewms.js
+++ b/src/ol/source/tilewms.js
@@ -24,7 +24,7 @@ goog.require('ol.uri');
  * @constructor
  * @extends {ol.source.TileImage}
  * @param {olx.source.TileWMSOptions=} opt_options Tile WMS options.
- * @api stable
+ * @api
  */
 ol.source.TileWMS = function(opt_options) {
 
@@ -112,7 +112,7 @@ ol.inherits(ol.source.TileWMS, ol.source.TileImage);
  *     in the `LAYERS` parameter will be used. `VERSION` should not be
  *     specified here.
  * @return {string|undefined} GetFeatureInfo URL.
- * @api stable
+ * @api
  */
 ol.source.TileWMS.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
   var projectionObj = ol.proj.get(projection);
@@ -182,7 +182,7 @@ ol.source.TileWMS.prototype.getKeyZXY = function(z, x, y) {
  * Get the user-provided params, i.e. those passed to the constructor through
  * the "params" option, and possibly updated using the updateParams method.
  * @return {Object} Params.
- * @api stable
+ * @api
  */
 ol.source.TileWMS.prototype.getParams = function() {
   return this.params_;
@@ -363,7 +363,7 @@ ol.source.TileWMS.prototype.setUrls = function(urls) {
 /**
  * Update the user-provided params.
  * @param {Object} params Params.
- * @api stable
+ * @api
  */
 ol.source.TileWMS.prototype.updateParams = function(params) {
   ol.obj.assign(this.params_, params);

--- a/src/ol/source/urltile.js
+++ b/src/ol/source/urltile.js
@@ -160,7 +160,7 @@ ol.source.UrlTile.prototype.setTileUrlFunction = function(tileUrlFunction, opt_k
 /**
  * Set the URL to use for requests.
  * @param {string} url URL.
- * @api stable
+ * @api
  */
 ol.source.UrlTile.prototype.setUrl = function(url) {
   var urls = this.urls = ol.TileUrlFunction.expandUrl(url);
@@ -173,7 +173,7 @@ ol.source.UrlTile.prototype.setUrl = function(url) {
 /**
  * Set the URLs to use for requests.
  * @param {Array.<string>} urls URLs.
- * @api stable
+ * @api
  */
 ol.source.UrlTile.prototype.setUrls = function(urls) {
   this.urls = urls;

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -33,7 +33,7 @@ goog.require('ol.structs.RBush');
  * @extends {ol.source.Source}
  * @fires ol.source.Vector.Event
  * @param {olx.source.VectorOptions=} opt_options Vector source options.
- * @api stable
+ * @api
  */
 ol.source.Vector = function(opt_options) {
 
@@ -159,7 +159,7 @@ ol.inherits(ol.source.Vector, ol.source.Source);
  * at once, call {@link ol.source.Vector#addFeatures source.addFeatures()}
  * instead.
  * @param {ol.Feature} feature Feature to add.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.addFeature = function(feature) {
   this.addFeatureInternal(feature);
@@ -239,7 +239,7 @@ ol.source.Vector.prototype.addToIndex_ = function(featureKey, feature) {
 /**
  * Add a batch of features to the source.
  * @param {Array.<ol.Feature>} features Features to add.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.addFeatures = function(features) {
   this.addFeaturesInternal(features);
@@ -337,7 +337,7 @@ ol.source.Vector.prototype.bindFeaturesCollection_ = function(collection) {
 /**
  * Remove all features from the source.
  * @param {boolean=} opt_fast Skip dispatching of {@link removefeature} events.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.clear = function(opt_fast) {
   if (opt_fast) {
@@ -384,7 +384,7 @@ ol.source.Vector.prototype.clear = function(opt_fast) {
  * @param {T=} opt_this The object to use as `this` in the callback.
  * @return {S|undefined} The return value from the last call to the callback.
  * @template T,S
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.forEachFeature = function(callback, opt_this) {
   if (this.featuresRtree_) {
@@ -502,7 +502,7 @@ ol.source.Vector.prototype.getFeaturesCollection = function() {
 /**
  * Get all features on the source in random order.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.getFeatures = function() {
   var features;
@@ -523,7 +523,7 @@ ol.source.Vector.prototype.getFeatures = function() {
  * Get all features whose geometry intersects the provided coordinate.
  * @param {ol.Coordinate} coordinate Coordinate.
  * @return {Array.<ol.Feature>} Features.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.getFeaturesAtCoordinate = function(coordinate) {
   var features = [];
@@ -560,7 +560,7 @@ ol.source.Vector.prototype.getFeaturesInExtent = function(extent) {
  *     The filter function will receive one argument, the {@link ol.Feature feature}
  *     and it should return a boolean value. By default, no filtering is made.
  * @return {ol.Feature} Closest feature.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.getClosestFeatureToCoordinate = function(coordinate, opt_filter) {
   // Find the closest feature using branch and bound.  We start searching an
@@ -611,7 +611,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate = function(coordinate, 
  * This method is not available when the source is configured with
  * `useSpatialIndex` set to `false`.
  * @return {!ol.Extent} Extent.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.getExtent = function() {
   return this.featuresRtree_.getExtent();
@@ -625,7 +625,7 @@ ol.source.Vector.prototype.getExtent = function() {
  *
  * @param {string|number} id Feature identifier.
  * @return {ol.Feature} The feature (or `null` if not found).
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.getFeatureById = function(id) {
   var feature = this.idIndex_[id.toString()];
@@ -763,7 +763,7 @@ ol.source.Vector.prototype.loadFeatures = function(
  * at once, use the {@link ol.source.Vector#clear source.clear()} method
  * instead.
  * @param {ol.Feature} feature Feature to remove.
- * @api stable
+ * @api
  */
 ol.source.Vector.prototype.removeFeature = function(feature) {
   var featureKey = ol.getUid(feature).toString();
@@ -837,7 +837,7 @@ ol.source.Vector.Event = function(type, opt_feature) {
   /**
    * The feature being added or removed.
    * @type {ol.Feature|undefined}
-   * @api stable
+   * @api
    */
   this.feature = opt_feature;
 

--- a/src/ol/source/vectoreventtype.js
+++ b/src/ol/source/vectoreventtype.js
@@ -7,7 +7,7 @@ ol.source.VectorEventType = {
   /**
    * Triggered when a feature is added to the source.
    * @event ol.source.Vector.Event#addfeature
-   * @api stable
+   * @api
    */
   ADDFEATURE: 'addfeature',
 
@@ -29,7 +29,7 @@ ol.source.VectorEventType = {
    * Triggered when a feature is removed from the source.
    * See {@link ol.source.Vector#clear source.clear()} for exceptions.
    * @event ol.source.Vector.Event#removefeature
-   * @api stable
+   * @api
    */
   REMOVEFEATURE: 'removefeature'
 };

--- a/src/ol/source/wmts.js
+++ b/src/ol/source/wmts.js
@@ -19,7 +19,7 @@ goog.require('ol.uri');
  * @constructor
  * @extends {ol.source.TileImage}
  * @param {olx.source.WMTSOptions} options WMTS options.
- * @api stable
+ * @api
  */
 ol.source.WMTS = function(options) {
 

--- a/src/ol/source/xyz.js
+++ b/src/ol/source/xyz.js
@@ -25,7 +25,7 @@ goog.require('ol.tilegrid');
  * @constructor
  * @extends {ol.source.TileImage}
  * @param {olx.source.XYZOptions=} opt_options XYZ options.
- * @api stable
+ * @api
  */
 ol.source.XYZ = function(opt_options) {
   var options = opt_options || {};

--- a/src/ol/source/zoomify.js
+++ b/src/ol/source/zoomify.js
@@ -17,7 +17,7 @@ goog.require('ol.tilegrid.TileGrid');
  * @constructor
  * @extends {ol.source.TileImage}
  * @param {olx.source.ZoomifyOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.source.Zoomify = function(opt_options) {
 

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -18,7 +18,7 @@ goog.require('ol.tilecoord');
  * @constructor
  * @param {olx.tilegrid.TileGridOptions} options Tile grid options.
  * @struct
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid = function(options) {
 
@@ -208,7 +208,7 @@ ol.tilegrid.TileGrid.prototype.getMinZoom = function() {
  * Get the origin for the grid at the given zoom level.
  * @param {number} z Z.
  * @return {ol.Coordinate} Origin.
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
   if (this.origin_) {
@@ -223,7 +223,7 @@ ol.tilegrid.TileGrid.prototype.getOrigin = function(z) {
  * Get the resolution for the given zoom level.
  * @param {number} z Z.
  * @return {number} Resolution.
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getResolution = function(z) {
   return this.resolutions_[z];
@@ -233,7 +233,7 @@ ol.tilegrid.TileGrid.prototype.getResolution = function(z) {
 /**
  * Get the list of resolutions for the tile grid.
  * @return {Array.<number>} Resolutions.
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getResolutions = function() {
   return this.resolutions_;
@@ -426,7 +426,7 @@ ol.tilegrid.TileGrid.prototype.getTileCoordResolution = function(tileCoord) {
  * get an `ol.Size`, run the result through `ol.size.toSize()`.
  * @param {number} z Z.
  * @return {number|ol.Size} Tile size.
- * @api stable
+ * @api
  */
 ol.tilegrid.TileGrid.prototype.getTileSize = function(z) {
   if (this.tileSize_) {

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -75,7 +75,7 @@ goog.require('ol.proj.Units');
  * @constructor
  * @extends {ol.Object}
  * @param {olx.ViewOptions=} opt_options View options.
- * @api stable
+ * @api
  */
 ol.View = function(opt_options) {
   ol.Object.call(this);
@@ -460,7 +460,7 @@ ol.View.prototype.constrainRotation = function(rotation, opt_delta) {
  * Get the view center.
  * @return {ol.Coordinate|undefined} The center of the view.
  * @observable
- * @api stable
+ * @api
  */
 ol.View.prototype.getCenter = function() {
   return /** @type {ol.Coordinate|undefined} */ (
@@ -491,7 +491,7 @@ ol.View.prototype.getHints = function(opt_hints) {
  * @param {ol.Size=} opt_size Box pixel size. If not provided, the size of the
  * first map that uses this view will be used.
  * @return {ol.Extent} Extent.
- * @api stable
+ * @api
  */
 ol.View.prototype.calculateExtent = function(opt_size) {
   var size = opt_size || this.getSizeFromViewport_();
@@ -529,7 +529,7 @@ ol.View.prototype.getMinResolution = function() {
 /**
  * Get the view projection.
  * @return {ol.proj.Projection} The projection of the view.
- * @api stable
+ * @api
  */
 ol.View.prototype.getProjection = function() {
   return this.projection_;
@@ -540,7 +540,7 @@ ol.View.prototype.getProjection = function() {
  * Get the view resolution.
  * @return {number|undefined} The resolution of the view.
  * @observable
- * @api stable
+ * @api
  */
 ol.View.prototype.getResolution = function() {
   return /** @type {number|undefined} */ (
@@ -552,7 +552,7 @@ ol.View.prototype.getResolution = function() {
  * Get the resolutions for the view. This returns the array of resolutions
  * passed to the constructor of the {ol.View}, or undefined if none were given.
  * @return {Array.<number>|undefined} The resolutions of the view.
- * @api stable
+ * @api
  */
 ol.View.prototype.getResolutions = function() {
   return this.resolutions_;
@@ -600,7 +600,7 @@ ol.View.prototype.getResolutionForValueFunction = function(opt_power) {
  * Get the view rotation.
  * @return {number} The rotation of the view in radians.
  * @observable
- * @api stable
+ * @api
  */
 ol.View.prototype.getRotation = function() {
   return /** @type {number} */ (this.get(ol.ViewProperty.ROTATION));
@@ -652,7 +652,7 @@ ol.View.prototype.getState = function() {
  * Get the current zoom level. Return undefined if the current
  * resolution is undefined or not within the "resolution constraints".
  * @return {number|undefined} Zoom.
- * @api stable
+ * @api
  */
 ol.View.prototype.getZoom = function() {
   var zoom;
@@ -687,7 +687,7 @@ ol.View.prototype.getZoom = function() {
  * @param {ol.geom.SimpleGeometry|ol.Extent} geometryOrExtent The geometry or
  *     extent to fit the view to.
  * @param {olx.view.FitOptions=} opt_options Options.
- * @api stable
+ * @api
  */
 ol.View.prototype.fit = function(geometryOrExtent, opt_options) {
   var options = opt_options || {};
@@ -822,7 +822,7 @@ ol.View.prototype.isDef = function() {
  * Rotate the view around a given coordinate.
  * @param {number} rotation New rotation value for the view.
  * @param {ol.Coordinate=} opt_anchor The rotation center.
- * @api stable
+ * @api
  */
 ol.View.prototype.rotate = function(rotation, opt_anchor) {
   if (opt_anchor !== undefined) {
@@ -837,7 +837,7 @@ ol.View.prototype.rotate = function(rotation, opt_anchor) {
  * Set the center of the current view.
  * @param {ol.Coordinate|undefined} center The center of the view.
  * @observable
- * @api stable
+ * @api
  */
 ol.View.prototype.setCenter = function(center) {
   this.set(ol.ViewProperty.CENTER, center);
@@ -863,7 +863,7 @@ ol.View.prototype.setHint = function(hint, delta) {
  * Set the resolution for this view.
  * @param {number|undefined} resolution The resolution of the view.
  * @observable
- * @api stable
+ * @api
  */
 ol.View.prototype.setResolution = function(resolution) {
   this.set(ol.ViewProperty.RESOLUTION, resolution);
@@ -877,7 +877,7 @@ ol.View.prototype.setResolution = function(resolution) {
  * Set the rotation for this view.
  * @param {number} rotation The rotation of the view in radians.
  * @observable
- * @api stable
+ * @api
  */
 ol.View.prototype.setRotation = function(rotation) {
   this.set(ol.ViewProperty.ROTATION, rotation);
@@ -890,7 +890,7 @@ ol.View.prototype.setRotation = function(rotation) {
 /**
  * Zoom to a specific zoom level.
  * @param {number} zoom Zoom level.
- * @api stable
+ * @api
  */
 ol.View.prototype.setZoom = function(zoom) {
   var resolution = this.constrainResolution(


### PR DESCRIPTION
This branch suggests removing the stability level from `@api` annotations - treating all `@api` annotated symbols as stable.