### PR TITLE
Remove console.assert in ol.structs.PriorityQueue tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,15 +89,6 @@
       "openlayers-internal"
     ],
     "rules": {
-      "no-console": [
-        2,
-        {
-          "allow": [
-            "assert",
-            "warn"
-          ]
-        }
-      ],
       "no-constant-condition": 0,
       "openlayers-internal/enum": 2,
       "openlayers-internal/no-duplicate-requires": 2,

--- a/test/spec/ol/structs/priorityqueue.test.js
+++ b/test/spec/ol/structs/priorityqueue.test.js
@@ -11,19 +11,9 @@ describe('ol.structs.PriorityQueue', function() {
 
   describe('when empty', function() {
 
-    var pq, origAssert;
+    var pq;
     beforeEach(function() {
-      origAssert = console.assert;
-      console.assert = function(assertion, message) {
-        if (!assertion) {
-          throw new Error(message);
-        }
-      };
-      pq = new ol.structs.PriorityQueue(
-          identity, identity);
-    });
-    afterEach(function() {
-      console.assert = origAssert;
+      pq = new ol.structs.PriorityQueue(identity, identity);
     });
 
     it('is empty', function() {


### PR DESCRIPTION
All `console.assert` have been removed