### PR TITLE
Do not set center when touches count has changed

### DIFF
--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -70,21 +70,23 @@ ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
   var targetPointers = this.targetPointers;
   var centroid =
       ol.interaction.Pointer.centroid(targetPointers);
-  if (this.kinetic_) {
-    this.kinetic_.update(centroid[0], centroid[1]);
-  }
-  if (this.lastCentroid && targetPointers.length == this.lastPointersCount_) {
-    var deltaX = this.lastCentroid[0] - centroid[0];
-    var deltaY = centroid[1] - this.lastCentroid[1];
-    var map = mapBrowserEvent.map;
-    var view = map.getView();
-    var viewState = view.getState();
-    var center = [deltaX, deltaY];
-    ol.coordinate.scale(center, viewState.resolution);
-    ol.coordinate.rotate(center, viewState.rotation);
-    ol.coordinate.add(center, viewState.center);
-    center = view.constrainCenter(center);
-    view.setCenter(center);
+  if (targetPointers.length == this.lastPointersCount_) {
+    if (this.kinetic_) {
+      this.kinetic_.update(centroid[0], centroid[1]);
+    }
+    if (this.lastCentroid) {
+      var deltaX = this.lastCentroid[0] - centroid[0];
+      var deltaY = centroid[1] - this.lastCentroid[1];
+      var map = mapBrowserEvent.map;
+      var view = map.getView();
+      var viewState = view.getState();
+      var center = [deltaX, deltaY];
+      ol.coordinate.scale(center, viewState.resolution);
+      ol.coordinate.rotate(center, viewState.rotation);
+      ol.coordinate.add(center, viewState.center);
+      center = view.constrainCenter(center);
+      view.setCenter(center);
+    }
   }
   this.lastCentroid = centroid;
   this.lastPointersCount_ = targetPointers.length;

--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -87,6 +87,10 @@ ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
       center = view.constrainCenter(center);
       view.setCenter(center);
     }
+  } else if (this.kinetic_) {
+    // reset so we don't overestimate the kinetic energy after
+    // after one finger down, tiny drag, second finger down
+    this.kinetic_.begin();
   }
   this.lastCentroid = centroid;
   this.lastPointersCount_ = targetPointers.length;

--- a/src/ol/interaction/dragpan.js
+++ b/src/ol/interaction/dragpan.js
@@ -40,6 +40,11 @@ ol.interaction.DragPan = function(opt_options) {
   this.lastCentroid = null;
 
   /**
+   * @type {number}
+   */
+  this.lastPointersCount_;
+
+  /**
    * @private
    * @type {ol.EventsConditionType}
    */
@@ -62,12 +67,13 @@ ol.inherits(ol.interaction.DragPan, ol.interaction.Pointer);
  * @private
  */
 ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
+  var targetPointers = this.targetPointers;
   var centroid =
-      ol.interaction.Pointer.centroid(this.targetPointers);
+      ol.interaction.Pointer.centroid(targetPointers);
   if (this.kinetic_) {
     this.kinetic_.update(centroid[0], centroid[1]);
   }
-  if (this.lastCentroid) {
+  if (this.lastCentroid && targetPointers.length == this.lastPointersCount_) {
     var deltaX = this.lastCentroid[0] - centroid[0];
     var deltaY = centroid[1] - this.lastCentroid[1];
     var map = mapBrowserEvent.map;
@@ -81,6 +87,7 @@ ol.interaction.DragPan.handleDragEvent_ = function(mapBrowserEvent) {
     view.setCenter(center);
   }
   this.lastCentroid = centroid;
+  this.lastPointersCount_ = targetPointers.length;
 };
 
 


### PR DESCRIPTION
Currently, the DragPan interaction always sets a center when dragging. On touch devices, when a touch is added or removed, it can drastically change the centroid of all touches. So it is better to not set a center when the number of touches differs from the one in the previous drag.

Fixes #6485.