### PR TITLE
Do not draw circle when pointer not moved and freehand is on

### DIFF
--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -376,6 +376,7 @@ ol.interaction.Draw.handleUpEvent_ = function(event) {
     pass = false;
   } else if (circleMode && this.freehand_) {
     this.finishCoordinate_ = null;
+    this.abortDrawing_();
   }
   return pass;
 };

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -374,7 +374,7 @@ ol.interaction.Draw.handleUpEvent_ = function(event) {
       this.addToDrawing_(event);
     }
     pass = false;
-  } else if (circleMode) {
+  } else if (circleMode && this.freehand_) {
     this.finishCoordinate_ = null;
   }
   return pass;


### PR DESCRIPTION
Fix #6481

Also improves #6067 by clearing the sketch feature if user draw a circle in freehand mode with a single click.