### PR TITLE
Travis failing on master - use Node v6.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: node_js
 
 node_js:
-  - "6"
+  - "6.1"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 before_script:
   - "rm src/ol/renderer/webgl/*shader.js"
   - "sh -e /etc/init.d/xvfb start"
-  - "npm ls"
+  - "npm ls || true"
 
 script: "make ci"
 


### PR DESCRIPTION
Travis is currently failing. ~~It seems dependency versions are not parsed correctly by npm~~ . This pull request is mostly there to debug the issue. If it makes Travis pass, then I think it is a valid change and should be merged.