### PR TITLE
Update ol package to include Browserify config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,4 +308,5 @@ package:
 	@cp -r package build
 	@cd ./src && cp -r ol/* ../build/package
 	@rm build/package/typedefs.js
+	@cp css/ol.css build/package
 	./node_modules/.bin/jscodeshift --transform transforms/module.js build/package

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol",
-  "version": "4.0.1-beta.1",
+  "version": "4.0.1-beta.2",
   "description": "OpenLayers as ES2015 modules",
   "main": "index.js",
   "module": "index.js",
@@ -10,5 +10,15 @@
     "pixelworks": "1.1.0",
     "rbush": "2.0.1",
     "vector-tile": "1.3.0"
+  },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "plugins": ["transform-es2015-modules-commonjs"]
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
This makes it easier for people consuming the `ol` package with Browserify.  Instead of needing to apply the `babelify` transform globally (which can seriously slow down builds), it can be applied just where needed.

I've already published `ol@4.0.1-beta.2` so anyone interested can try this out.  I've also [updated](https://gist.github.com/tschaub/4bfb209a8f809823f1495b2e4436018e/revisions) the Gist that is serving as our example [using OpenLayers & Browserify](https://gist.github.com/tschaub/4bfb209a8f809823f1495b2e4436018e).

In addition, this puts our `ol.css` in the package archive.  This makes it accessible for people who like to use a CSS loader from their JavaScript (e.g. with webpack).