### PR TITLE
Complete animations at target values

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -323,18 +323,20 @@ ol.View.prototype.updateAnimations_ = function() {
         var y = y0 + progress * (y1 - y0);
         this.set(ol.ViewProperty.CENTER, [x, y]);
       }
-      if (animation.sourceResolution) {
-        var resolution = animation.sourceResolution +
-            progress * (animation.targetResolution - animation.sourceResolution);
+      if (animation.sourceResolution && animation.targetResolution) {
+        var resolution = progress === 1 ?
+            animation.targetResolution :
+            animation.sourceResolution + progress * (animation.targetResolution - animation.sourceResolution);
         if (animation.anchor) {
           this.set(ol.ViewProperty.CENTER,
               this.calculateCenterZoom(resolution, animation.anchor));
         }
         this.set(ol.ViewProperty.RESOLUTION, resolution);
       }
-      if (animation.sourceRotation !== undefined) {
-        var rotation = animation.sourceRotation +
-            progress * (animation.targetRotation - animation.sourceRotation);
+      if (animation.sourceRotation !== undefined && animation.targetRotation !== undefined) {
+        var rotation = progress === 1 ?
+            animation.targetRotation :
+            animation.sourceRotation + progress * (animation.targetRotation - animation.sourceRotation);
         if (animation.anchor) {
           this.set(ol.ViewProperty.CENTER,
               this.calculateCenterRotate(rotation, animation.anchor));

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -406,6 +406,26 @@ describe('ol.View', function() {
       });
     });
 
+    it('avoids going under minResolution', function(done) {
+      var maxZoom = 14;
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 0,
+        maxZoom: maxZoom
+      });
+
+      var minResolution = view.getMinResolution();
+      view.animate({
+        resolution: minResolution,
+        duration: 10
+      }, function(complete) {
+        expect(complete).to.be(true);
+        expect(view.getResolution()).to.be(minResolution);
+        expect(view.getZoom()).to.be(maxZoom);
+        done();
+      });
+    });
+
     it('calls a callback when animation completes', function(done) {
       var view = new ol.View({
         center: [0, 0],
@@ -558,7 +578,7 @@ describe('ol.View', function() {
           duration: 25
         }, function() {
           expect(calls).to.be(1);
-          expect(view.getZoom()).to.roughlyEqual(2, 1e-8);
+          expect(view.getZoom()).to.be(2);
           expect(view.getAnimating()).to.be(false);
           done();
         });
@@ -599,7 +619,7 @@ describe('ol.View', function() {
         duration: 25
       }, function() {
         ++calls;
-        expect(view.getResolution()).to.roughlyEqual(2, 1e-8);
+        expect(view.getResolution()).to.be(2);
         onAnimateEnd();
       });
 


### PR DESCRIPTION
Animations over large ranges of resolution can currently end at values slightly different than the target resolution.  This is due to floating point issues like this:
```js
var sourceResolution = 156543.03392804097;
var targetResolution = 9.554628535647032;
var diff = targetResolution - sourceResolution;
console.assert(sourceResolution + diff === targetResolution, 'Addition is commutative, right?');
// unfortunately not: 9.554628535639495 !== 9.554628535647032
```

Fixes #4333.