### PR TITLE
Add view methods for getting max zoom, min zoom, and any zoom for a resolution

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -659,8 +659,22 @@ ol.View.prototype.getState = function() {
 ol.View.prototype.getZoom = function() {
   var zoom;
   var resolution = this.getResolution();
-  if (resolution !== undefined &&
-      resolution >= this.minResolution_ && resolution <= this.maxResolution_) {
+  if (resolution !== undefined) {
+    zoom = this.getZoomForResolution(resolution);
+  }
+  return zoom;
+};
+
+
+/**
+ * Get the zoom level for a resolution.
+ * @param {number} resolution The resolution.
+ * @return {number|undefined} The zoom level for the provided resolution.
+ * @api
+ */
+ol.View.prototype.getZoomForResolution = function(resolution) {
+  var zoom;
+  if (resolution >= this.minResolution_ && resolution <= this.maxResolution_) {
     var offset = this.minZoom_ || 0;
     var max, zoomFactor;
     if (this.resolutions_) {

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -529,6 +529,26 @@ ol.View.prototype.getMinResolution = function() {
 
 
 /**
+ * Get the maximum zoom level for the view.
+ * @return {number} The maximum zoom level.
+ * @api
+ */
+ol.View.prototype.getMaxZoom = function() {
+  return /** @type {number} */ (this.getZoomForResolution(this.minResolution_));
+};
+
+
+/**
+ * Get the minimum zoom level for the view.
+ * @return {number} The minimum zoom level.
+ * @api
+ */
+ol.View.prototype.getMinZoom = function() {
+  return /** @type {number} */ (this.getZoomForResolution(this.maxResolution_));
+};
+
+
+/**
  * Get the view projection.
  * @return {ol.proj.Projection} The projection of the view.
  * @api

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -904,6 +904,38 @@ describe('ol.View', function() {
 
   });
 
+  describe('#getMaxZoom', function() {
+
+    it('returns the zoom level for the min resolution', function() {
+      var view = new ol.View();
+      expect(view.getMaxZoom()).to.be(view.getZoomForResolution(view.getMinResolution()));
+    });
+
+    it('works for a view configured with a maxZoom', function() {
+      var view = new ol.View({
+        maxZoom: 10
+      });
+      expect(view.getMaxZoom()).to.be(10);
+    });
+
+  });
+
+  describe('#getMinZoom', function() {
+
+    it('returns the zoom level for the max resolution', function() {
+      var view = new ol.View();
+      expect(view.getMinZoom()).to.be(view.getZoomForResolution(view.getMaxResolution()));
+    });
+
+    it('works for views configured with a minZoom', function() {
+      var view = new ol.View({
+        minZoom: 3
+      });
+      expect(view.getMinZoom()).to.be(3);
+    });
+
+  });
+
   describe('#calculateExtent', function() {
     it('returns the expected extent', function() {
       var view = new ol.View({

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -7,7 +7,6 @@ goog.require('ol.extent');
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');
 
-
 describe('ol.View', function() {
 
   describe('constructor (defaults)', function() {
@@ -872,6 +871,37 @@ describe('ol.View', function() {
       view.setZoom(0);
       expect(view.getResolution()).to.be(100);
     });
+  });
+
+  describe('#getZoomForResolution', function() {
+
+    it('returns correct zoom levels', function() {
+      var view = new ol.View();
+      var max = view.getMaxResolution();
+
+      expect(view.getZoomForResolution(max)).to.be(0);
+
+      expect(view.getZoomForResolution(max / 2)).to.be(1);
+
+      expect(view.getZoomForResolution(max / 4)).to.be(2);
+    });
+
+    it('returns correct zoom levels for specifically configured resolutions', function() {
+      var view = new ol.View({
+        resolutions: [10, 8, 6, 4, 2]
+      });
+
+      expect(view.getZoomForResolution(10)).to.be(0);
+
+      expect(view.getZoomForResolution(8)).to.be(1);
+
+      expect(view.getZoomForResolution(6)).to.be(2);
+
+      expect(view.getZoomForResolution(4)).to.be(3);
+
+      expect(view.getZoomForResolution(2)).to.be(4);
+    });
+
   });
 
   describe('#calculateExtent', function() {


### PR DESCRIPTION
This adds `view.getMaxZoom()`, `view.getMinZoom()`, and `view.getZoomForResolution()`.