### PR TITLE
Add Gml2 serializers to support WFS-T 1.0.0

### DIFF
--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -498,6 +498,16 @@ ol.format.GML2.prototype.writeMultiCurveOrLineString_ = function(node, geometry,
  * @private
  */
 ol.format.GML2.prototype.writePoint_ = function(node, geometry, objectStack) {
+  var context = objectStack[objectStack.length - 1];
+  var srsName = context['srsName'];
+  if (srsName) {
+    node.setAttribute('srsName', srsName);
+  }
+  var coordinates = this.createCoordinatesNode_(node.namespaceURI);
+  node.appendChild(coordinates);
+  var point = geometry.getCoordinates();
+  var coord = this.getCoords_(point, srsName);
+  ol.format.XSD.writeStringTextNode(coordinates, coord);
 };
 
 

--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -517,7 +517,31 @@ ol.format.GML2.prototype.writePoint_ = function(node, geometry, objectStack) {
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
-ol.format.GML2.prototype.writeMultiPoint_ = function(node, geometry, objectStack) {
+ol.format.GML2.prototype.writeMultiPoint_ = function(node, geometry,
+    objectStack) {
+  var context = objectStack[objectStack.length - 1];
+  var srsName = context['srsName'];
+  if (srsName) {
+    node.setAttribute('srsName', srsName);
+  }
+  var points = geometry.getPoints();
+  ol.xml.pushSerializeAndPop({node: node, srsName: srsName},
+      ol.format.GML2.POINTMEMBER_SERIALIZERS_,
+      ol.xml.makeSimpleNodeFactory('pointMember'), points,
+      objectStack, undefined, this);
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.Point} point Point geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writePointMember_ = function(node, point, objectStack) {
+  var child = ol.xml.createElementNS(node.namespaceURI, 'Point');
+  node.appendChild(child);
+  this.writePoint_(child, point, objectStack);
 };
 
 
@@ -610,5 +634,17 @@ ol.format.GML2.RING_SERIALIZERS_ = {
   'http://www.opengis.net/gml': {
     'outerBoundaryIs': ol.xml.makeChildAppender(ol.format.GML2.prototype.writeRing_),
     'innerBoundaryIs': ol.xml.makeChildAppender(ol.format.GML2.prototype.writeRing_)
+  }
+};
+
+
+/**
+ * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
+ * @private
+ */
+ol.format.GML2.POINTMEMBER_SERIALIZERS_ = {
+  'http://www.opengis.net/gml': {
+    'pointMember': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writePointMember_)
   }
 };

--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -2,8 +2,10 @@ goog.provide('ol.format.GML2');
 
 goog.require('ol');
 goog.require('ol.extent');
+goog.require('ol.format.Feature');
 goog.require('ol.format.GMLBase');
 goog.require('ol.format.XSD');
+goog.require('ol.obj');
 goog.require('ol.proj');
 goog.require('ol.xml');
 
@@ -202,5 +204,237 @@ ol.format.GML2.prototype.GEOMETRY_PARSERS_ = {
     'MultiPolygon': ol.xml.makeReplacer(
         ol.format.GMLBase.prototype.readMultiPolygon),
     'Box': ol.xml.makeReplacer(ol.format.GML2.prototype.readBox_)
+  }
+};
+
+
+/**
+ * @const
+ * @param {*} value Value.
+ * @param {Array.<*>} objectStack Object stack.
+ * @param {string=} opt_nodeName Node name.
+ * @return {Node|undefined} Node.
+ * @private
+ */
+ol.format.GML2.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
+  var context = objectStack[objectStack.length - 1];
+  var multiSurface = context['multiSurface'];
+  var surface = context['surface'];
+  var curve = context['curve'];
+  var multiCurve = context['multiCurve'];
+  var nodeName;
+  if (!Array.isArray(value)) {
+    nodeName = /** @type {ol.geom.Geometry} */ (value).getType();
+    if (nodeName === 'MultiPolygon' && multiSurface === true) {
+      nodeName = 'MultiSurface';
+    } else if (nodeName === 'Polygon' && surface === true) {
+      nodeName = 'Surface';
+    } else if (nodeName === 'LineString' && curve === true) {
+      nodeName = 'Curve';
+    } else if (nodeName === 'MultiLineString' && multiCurve === true) {
+      nodeName = 'MultiCurve';
+    }
+  } else {
+    nodeName = 'Envelope';
+  }
+  return ol.xml.createElementNS('http://www.opengis.net/gml',
+      nodeName);
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.Feature} feature Feature.
+ * @param {Array.<*>} objectStack Node stack.
+ */
+ol.format.GML2.prototype.writeFeatureElement = function(node, feature, objectStack) {
+  var fid = feature.getId();
+  if (fid) {
+    node.setAttribute('fid', fid);
+  }
+  var context = /** @type {Object} */ (objectStack[objectStack.length - 1]);
+  var featureNS = context['featureNS'];
+  var geometryName = feature.getGeometryName();
+  if (!context.serializers) {
+    context.serializers = {};
+    context.serializers[featureNS] = {};
+  }
+  var properties = feature.getProperties();
+  var keys = [], values = [];
+  for (var key in properties) {
+    var value = properties[key];
+    if (value !== null) {
+      keys.push(key);
+      values.push(value);
+      if (key == geometryName || value instanceof ol.geom.Geometry) {
+        if (!(key in context.serializers[featureNS])) {
+          context.serializers[featureNS][key] = ol.xml.makeChildAppender(
+              this.writeGeometryElement, this);
+        }
+      } else {
+        if (!(key in context.serializers[featureNS])) {
+          context.serializers[featureNS][key] = ol.xml.makeChildAppender(
+              ol.format.XSD.writeStringTextNode);
+        }
+      }
+    }
+  }
+  var item = ol.obj.assign({}, context);
+  item.node = node;
+  ol.xml.pushSerializeAndPop(/** @type {ol.XmlNodeStackItem} */
+      (item), context.serializers,
+      ol.xml.makeSimpleNodeFactory(undefined, featureNS),
+      values,
+      objectStack, keys);
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.Geometry|ol.Extent} geometry Geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ */
+ol.format.GML2.prototype.writeGeometryElement = function(node, geometry, objectStack) {
+  var context = /** @type {olx.format.WriteOptions} */ (objectStack[objectStack.length - 1]);
+  var item = ol.obj.assign({}, context);
+  item.node = node;
+  var value;
+  if (Array.isArray(geometry)) {
+    if (context.dataProjection) {
+      value = ol.proj.transformExtent(
+          geometry, context.featureProjection, context.dataProjection);
+    } else {
+      value = geometry;
+    }
+  } else {
+    value =
+        ol.format.Feature.transformWithOptions(/** @type {ol.geom.Geometry} */ (geometry), true, context);
+  }
+  ol.xml.pushSerializeAndPop(/** @type {ol.XmlNodeStackItem} */
+      (item), ol.format.GML2.GEOMETRY_SERIALIZERS_,
+      this.GEOMETRY_NODE_FACTORY_, [value],
+      objectStack, undefined, this);
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.LineString} geometry LineString geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeCurveOrLineString_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.MultiLineString} geometry MultiLineString geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeMultiCurveOrLineString_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.Point} geometry Point geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writePoint_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.MultiPoint} geometry MultiPoint geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeMultiPoint_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.LineString} line LineString geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeLineStringOrCurveMember_ = function(node, line, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.LinearRing} geometry LinearRing geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeLinearRing_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.Polygon} geometry Polygon geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeSurfaceOrPolygon_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.geom.MultiPolygon} geometry MultiPolygon geometry.
+ * @param {Array.<*>} objectStack Node stack.
+ * @private
+ */
+ol.format.GML2.prototype.writeMultiSurfaceOrPolygon_ = function(node, geometry, objectStack) {
+};
+
+
+/**
+ * @param {Node} node Node.
+ * @param {ol.Extent} extent Extent.
+ * @param {Array.<*>} objectStack Node stack.
+ */
+ol.format.GML2.prototype.writeEnvelope = function(node, extent, objectStack) {
+};
+
+
+/**
+ * @const
+ * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
+ * @private
+ */
+ol.format.GML2.GEOMETRY_SERIALIZERS_ = {
+  'http://www.opengis.net/gml': {
+    'Curve': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeCurveOrLineString_),
+    'MultiCurve': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeMultiCurveOrLineString_),
+    'Point': ol.xml.makeChildAppender(ol.format.GML2.prototype.writePoint_),
+    'MultiPoint': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeMultiPoint_),
+    'LineString': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeCurveOrLineString_),
+    'MultiLineString': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeMultiCurveOrLineString_),
+    'LinearRing': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeLinearRing_),
+    'Polygon': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeSurfaceOrPolygon_),
+    'MultiPolygon': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeMultiSurfaceOrPolygon_),
+    'Surface': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeSurfaceOrPolygon_),
+    'MultiSurface': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeMultiSurfaceOrPolygon_),
+    'Envelope': ol.xml.makeChildAppender(
+        ol.format.GML2.prototype.writeEnvelope)
   }
 };

--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -633,6 +633,18 @@ ol.format.GML2.prototype.writeSurfaceOrPolygonMember_ = function(node, polygon, 
  * @private
  */
 ol.format.GML2.prototype.writeEnvelope = function(node, extent, objectStack) {
+  var context = objectStack[objectStack.length - 1];
+  var srsName = context['srsName'];
+  if (srsName) {
+    node.setAttribute('srsName', srsName);
+  }
+  var keys = ['lowerCorner', 'upperCorner'];
+  var values = [extent[0] + ' ' + extent[1], extent[2] + ' ' + extent[3]];
+  ol.xml.pushSerializeAndPop(/** @type {ol.XmlNodeStackItem} */
+      ({node: node}), ol.format.GML2.ENVELOPE_SERIALIZERS_,
+      ol.xml.OBJECT_PROPERTY_NODE_FACTORY,
+      values,
+      objectStack, keys, this);
 };
 
 
@@ -746,5 +758,17 @@ ol.format.GML2.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
         ol.format.GML2.prototype.writeSurfaceOrPolygonMember_),
     'polygonMember': ol.xml.makeChildAppender(
         ol.format.GML2.prototype.writeSurfaceOrPolygonMember_)
+  }
+};
+
+
+/**
+ * @type {Object.<string, Object.<string, ol.XmlSerializer>>}
+ * @private
+ */
+ol.format.GML2.ENVELOPE_SERIALIZERS_ = {
+  'http://www.opengis.net/gml': {
+    'lowerCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode),
+    'upperCorner': ol.xml.makeChildAppender(ol.format.XSD.writeStringTextNode)
   }
 };

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -136,12 +136,12 @@ describe('ol.format.GML2', function() {
     var node;
     var featureNS = 'http://www.openlayers.org/';
     beforeEach(function() {
-      node = ol.xml.createElementNS(featureNS, 'lines');
+      node = ol.xml.createElementNS(featureNS, 'layer');
     });
 
     it('can serialize a LineString', function() {
       var expected =
-        '<lines xmlns="http://www.openlayers.org/" fid="1">' +
+        '<layer xmlns="http://www.openlayers.org/" fid="1">' +
         '  <geometry>' +
         '     <LineString xmlns="http://www.opengis.net/gml" ' +
         '                  srsName="EPSG:4326">' +
@@ -155,6 +155,37 @@ describe('ol.format.GML2', function() {
 
       var feature = new ol.Feature({
         geometry: new ol.geom.LineString([[1.1, 2], [3, 4.2]])
+      });
+      feature.setId(1);
+      var objectStack = [{
+        featureNS: featureNS,
+        srsName: 'EPSG:4326'
+      }];
+      format.writeFeatureElement(node, feature, objectStack);
+
+      expect(node).to.xmleql(ol.xml.parse(expected));
+    });
+
+    it('can serialize a Polygon', function() {
+      var expected =
+        '<layer xmlns="http://www.openlayers.org/" fid="1">' +
+        '  <geometry>' +
+        '     <Polygon xmlns="http://www.opengis.net/gml" ' +
+        '                  srsName="EPSG:4326">' +
+        '       <outerBoundaryIs>' +
+        '         <LinearRing srsName="EPSG:4326">' +
+        '           <coordinates ' +
+        '                        decimal="." cs="," ts=" ">' +
+        '              2,1.1 4.2,3 6,5.2' +
+        '           </coordinates>' +
+        '         </LinearRing>' +
+        '       </outerBoundaryIs>' +
+        '      </Polygon>' +
+        '    </geometry>' +
+        '  </layer>';
+
+      var feature = new ol.Feature({
+        geometry: new ol.geom.Polygon([[[1.1, 2], [3, 4.2], [5.2, 6]]])
       });
       feature.setId(1);
       var objectStack = [{

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -223,6 +223,37 @@ describe('ol.format.GML2', function() {
 
       expect(node).to.xmleql(ol.xml.parse(expected));
     });
+
+    it('can serialize a Multi Point', function() {
+      var expected =
+        '<layer xmlns="http://www.openlayers.org/" fid="1">' +
+        '  <geometry>' +
+        '     <MultiPoint xmlns="http://www.opengis.net/gml" ' +
+        '                 srsName="EPSG:4326">' +
+        '       <pointMember>' +
+        '         <Point srsName="EPSG:4326">' +
+        '           <coordinates ' +
+        '                    decimal="." cs="," ts=" ">' +
+        '              2,1.1' +
+        '           </coordinates>' +
+        '         </Point>' +
+        '       </pointMember>' +
+        '      </MultiPoint>' +
+        '    </geometry>' +
+        '  </layer>';
+
+      var feature = new ol.Feature({
+        geometry: new ol.geom.MultiPoint([[1.1, 2]])
+      });
+      feature.setId(1);
+      var objectStack = [{
+        featureNS: featureNS,
+        srsName: 'EPSG:4326'
+      }];
+      format.writeFeatureElement(node, feature, objectStack);
+
+      expect(node).to.xmleql(ol.xml.parse(expected));
+    });
   });
 });
 

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -196,6 +196,33 @@ describe('ol.format.GML2', function() {
 
       expect(node).to.xmleql(ol.xml.parse(expected));
     });
+
+    it('can serialize a Point', function() {
+      var expected =
+        '<layer xmlns="http://www.openlayers.org/" fid="1">' +
+        '  <geometry>' +
+        '     <Point xmlns="http://www.opengis.net/gml" ' +
+        '            srsName="EPSG:4326">' +
+        '       <coordinates ' +
+        '                    decimal="." cs="," ts=" ">' +
+        '              2,1.1' +
+        '       </coordinates>' +
+        '      </Point>' +
+        '    </geometry>' +
+        '  </layer>';
+
+      var feature = new ol.Feature({
+        geometry: new ol.geom.Point([1.1, 2])
+      });
+      feature.setId(1);
+      var objectStack = [{
+        featureNS: featureNS,
+        srsName: 'EPSG:4326'
+      }];
+      format.writeFeatureElement(node, feature, objectStack);
+
+      expect(node).to.xmleql(ol.xml.parse(expected));
+    });
   });
 });
 

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -254,6 +254,37 @@ describe('ol.format.GML2', function() {
 
       expect(node).to.xmleql(ol.xml.parse(expected));
     });
+
+    it('can serialize a Multi Line String', function() {
+      var expected =
+        '<layer xmlns="http://www.openlayers.org/" fid="1">' +
+        '  <geometry>' +
+        '     <MultiLineString xmlns="http://www.opengis.net/gml" ' +
+        '                 srsName="EPSG:4326">' +
+        '       <lineStringMember>' +
+        '         <LineString srsName="EPSG:4326">' +
+        '           <coordinates ' +
+        '                    decimal="." cs="," ts=" ">' +
+        '              2,1.1 4.2,3' +
+        '           </coordinates>' +
+        '         </LineString>' +
+        '       </lineStringMember>' +
+        '      </MultiLineString>' +
+        '    </geometry>' +
+        '  </layer>';
+
+      var feature = new ol.Feature({
+        geometry: new ol.geom.MultiLineString([[[1.1, 2], [3, 4.2]]])
+      });
+      feature.setId(1);
+      var objectStack = [{
+        featureNS: featureNS,
+        srsName: 'EPSG:4326'
+      }];
+      format.writeFeatureElement(node, feature, objectStack);
+
+      expect(node).to.xmleql(ol.xml.parse(expected));
+    });
   });
 });
 

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -285,6 +285,41 @@ describe('ol.format.GML2', function() {
 
       expect(node).to.xmleql(ol.xml.parse(expected));
     });
+
+    it('can serialize a Multi Polygon', function() {
+      var expected =
+        '<layer xmlns="http://www.openlayers.org/" fid="1">' +
+        '  <geometry>' +
+        '     <MultiPolygon xmlns="http://www.opengis.net/gml" ' +
+        '                 srsName="EPSG:4326">' +
+        '       <polygonMember>' +
+        '         <Polygon srsName="EPSG:4326">' +
+        '           <outerBoundaryIs>' +
+        '             <LinearRing srsName="EPSG:4326">' +
+        '               <coordinates ' +
+        '                        decimal="." cs="," ts=" ">' +
+        '                  2,1.1 4.2,3 6,5.2' +
+        '               </coordinates>' +
+        '             </LinearRing>' +
+        '           </outerBoundaryIs>' +
+        '         </Polygon>' +
+        '       </polygonMember>' +
+        '      </MultiPolygon>' +
+        '    </geometry>' +
+        '  </layer>';
+
+      var feature = new ol.Feature({
+        geometry: new ol.geom.MultiPolygon([[[[1.1, 2], [3, 4.2], [5.2, 6]]]])
+      });
+      feature.setId(1);
+      var objectStack = [{
+        featureNS: featureNS,
+        srsName: 'EPSG:4326'
+      }];
+      format.writeFeatureElement(node, feature, objectStack);
+
+      expect(node).to.xmleql(ol.xml.parse(expected));
+    });
   });
 });
 

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -131,6 +131,41 @@ describe('ol.format.GML2', function() {
       });
     });
   });
+
+  describe('#writeFeatureElement', function() {
+    var node;
+    var featureNS = 'http://www.openlayers.org/';
+    beforeEach(function() {
+      node = ol.xml.createElementNS(featureNS, 'lines');
+    });
+
+    it('can serialize a LineString', function() {
+      var expected =
+        '<lines xmlns="http://www.openlayers.org/" fid="1">' +
+        '  <geometry>' +
+        '     <LineString xmlns="http://www.opengis.net/gml" ' +
+        '                  srsName="EPSG:4326">' +
+        '       <coordinates ' +
+        '                     decimal="." cs="," ts=" ">' +
+        '         2,1.1 4.2,3' +
+        '       </coordinates>' +
+        '      </LineString>' +
+        '    </geometry>' +
+        '  </lines>';
+
+      var feature = new ol.Feature({
+        geometry: new ol.geom.LineString([[1.1, 2], [3, 4.2]])
+      });
+      feature.setId(1);
+      var objectStack = [{
+        featureNS: featureNS,
+        srsName: 'EPSG:4326'
+      }];
+      format.writeFeatureElement(node, feature, objectStack);
+
+      expect(node).to.xmleql(ol.xml.parse(expected));
+    });
+  });
 });
 
 describe('ol.format.GML3', function() {


### PR DESCRIPTION
This PR adds `writeFeatureElement` and related serializers to `ol.format.GML2`. This will allow support for WFS-T version 1.0.0 (currently only 1.1.0 is supported witch GML3) I tested the serializers against a WFS 1.0.0 server (GeoServer) for these geometries:
- Lines
- Polygons
- Points
- MultiLines
- MultiPoints
- MultiPolygons

For these tests, in addition to these patches, I also applied a patch to use `ol.format.GML2.prototype.writeFeatureElement` in `ol.format.WFS.prototype.writeTransaction`. For those interested, the patch is [here](https://github.com/Jenselme/ol3/commit/857c6994043110c99392dc3258d1b45665c0dd22). I intend to open a PR for this as soon as this one is merged.