### PR TITLE
Added loaderror event to ol.source.vector

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -22,7 +22,7 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
        * @param {ol.Extent} extent Extent.
        * @param {number} resolution Resolution.
        * @param {ol.proj.Projection} projection Projection.
-       * @this {ol.source.Vector|ol.VectorTile}
+       * @this {ol.source.Vector|ol.VectorTile} Openlayers object
        */
       function(extent, resolution, projection) {
         var xhr = new XMLHttpRequest();

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -64,6 +64,11 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
             failure.call(this);
           }
         }.bind(this);
+
+        xhr.onerror = function() {
+          failure.call(this);
+        }.bind(this);
+
         xhr.send();
       });
 };
@@ -78,7 +83,7 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
  * @return {ol.FeatureLoader} The feature loader.
  * @api
  */
-ol.featureloader.xhr = function(url, format) {
+ol.featureloader.xhr = function(url, format, failure) {
   return ol.featureloader.loadFeaturesXhr(url, format,
       /**
        * @param {Array.<ol.Feature>} features The loaded features.
@@ -87,5 +92,5 @@ ol.featureloader.xhr = function(url, format) {
        */
       function(features, dataProjection) {
         this.addFeatures(features);
-      }, /* FIXME handle error */ ol.nullFunction);
+      }, failure);
 };

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -4,7 +4,6 @@ goog.require('ol');
 goog.require('ol.format.FormatType');
 goog.require('ol.xml');
 
-
 /**
  * @param {string|ol.FeatureUrlFunction} url Feature URL service.
  * @param {ol.format.Feature} format Feature format.
@@ -22,8 +21,9 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
        * @param {ol.Extent} extent Extent.
        * @param {number} resolution Resolution.
        * @param {ol.proj.Projection} projection Projection.
-       * @this {ol.source.Vector|ol.VectorTile} Openlayers object
+       * @this {ol.source.Vector|ol.VectorTile}
        */
+
       function(extent, resolution, projection) {
         var xhr = new XMLHttpRequest();
         xhr.open('GET',

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -80,6 +80,9 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
  * vector source.
  * @param {string|ol.FeatureUrlFunction} url Feature URL service.
  * @param {ol.format.Feature} format Feature format.
+ * @param {function(this:ol.VectorTile)|function(this:ol.source.Vector)} failure
+ *     Function called when loading failed. Called with the vector tile or
+ *     source as `this`.
  * @return {ol.FeatureLoader} The feature loader.
  * @api
  */

--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -76,7 +76,7 @@ ol.source.Vector = function(opt_options) {
   } else if (this.url_ !== undefined) {
     ol.asserts.assert(this.format_, 7); // `format` must be set when `url` is set
     // create a XHR feature loader for "url" and "format"
-    this.loader_ = ol.featureloader.xhr(this.url_, /** @type {ol.format.Feature} */ (this.format_));
+    this.loader_ = ol.featureloader.xhr(this.url_, /** @type {ol.format.Feature} */ (this.format_), this.featureLoadFailure);
   }
 
   /**
@@ -246,6 +246,14 @@ ol.source.Vector.prototype.addFeatures = function(features) {
   this.changed();
 };
 
+/**
+ * Fire a loaderror event if feature fails to load.
+ * @api
+ */
+ol.source.Vector.prototype.featureLoadFailure = function() {
+  this.dispatchEvent(new ol.source.Vector.Event(
+      ol.source.VectorEventType.LOADERROR, undefined));
+};
 
 /**
  * Add features without firing a `change` event.

--- a/src/ol/source/vectoreventtype.js
+++ b/src/ol/source/vectoreventtype.js
@@ -19,6 +19,13 @@ ol.source.VectorEventType = {
   CHANGEFEATURE: 'changefeature',
 
   /**
+   * Triggered when the source not be loaded.
+   * @event ol.source.Vector.Event#loaderror
+   * @api
+   */
+  LOADERROR: 'loaderror',
+
+  /**
    * Triggered when the clear method is called on the source.
    * @event ol.source.Vector.Event#clear
    * @api

--- a/src/ol/source/vectoreventtype.js
+++ b/src/ol/source/vectoreventtype.js
@@ -19,7 +19,7 @@ ol.source.VectorEventType = {
   CHANGEFEATURE: 'changefeature',
 
   /**
-   * Triggered when the source not be loaded.
+   * Triggered if the XHR data source fails to load.
    * @event ol.source.Vector.Event#loaderror
    * @api
    */


### PR DESCRIPTION
Fires a loaderror event on an XHR load failure. This allows XHR errors
to be caught by defining an on loaderror event handler.

Issue reference: 
https://github.com/openlayers/openlayers/issues/6531