### PR TITLE
Trigger when nothing has been (de)selected

### DIFF
--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -282,6 +282,10 @@ ol.interaction.Select.handleEvent = function(mapBrowserEvent) {
     this.dispatchEvent(
         new ol.interaction.Select.Event(ol.interaction.Select.EventType_.SELECT,
             selected, deselected, mapBrowserEvent));
+  } else {
+    this.dispatchEvent(
+        new ol.interaction.Select.Event(ol.interaction.Select.EventType_.EMPTY,
+            selected, deselected, mapBrowserEvent));
   }
   return ol.events.condition.pointerMove(mapBrowserEvent);
 };
@@ -425,5 +429,11 @@ ol.interaction.Select.EventType_ = {
    * @event ol.interaction.Select.Event#select
    * @api
    */
-  SELECT: 'select'
+  SELECT: 'select',
+  /**
+   * Triggered when no feature has been (de)selected.
+   * @event ol.interaction.Select.Event#empty
+   * @api
+   */
+  empty: 'empty'
 };

--- a/src/ol/interaction/select.js
+++ b/src/ol/interaction/select.js
@@ -435,5 +435,5 @@ ol.interaction.Select.EventType_ = {
    * @event ol.interaction.Select.Event#empty
    * @api
    */
-  empty: 'empty'
+  EMPTY: 'empty'
 };


### PR DESCRIPTION
In the past ol.interaction.Select used to fire a 'select' event even when there were no features selected/deselected.  A condition was added to prevent this event from firing when there was nothing selected/deselected.  I'm proposing a new event, "empty", which fires when nothing was selected/deselected.  Without this I believe an explicit map.on("click") handler is required and managing the interaction with the map click and the select interaction gets messy.