### PR TITLE
Don’t crash if feature loader xhr response returns 500

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -64,6 +64,12 @@ ol.featureloader.loadFeaturesXhr = function(url, format, success, failure) {
             failure.call(this);
           }
         }.bind(this);
+        /**
+         * @private
+         */
+        xhr.onerror = function() {
+          failure.call(this);
+        }.bind(this);
         xhr.send();
       });
 };


### PR DESCRIPTION
xhr.onload doesn't catch 500 responses and therefore failure callback is not called if server crashes.

This PR fixes #6561