### PR TITLE
Overlay visible before updating render position

### DIFF
--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -465,7 +465,7 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
   var positioning = this.getPositioning();
 
   this.setVisible(true);
-  
+
   var offsetX = offset[0];
   var offsetY = offset[1];
   if (positioning == ol.OverlayPositioning.BOTTOM_RIGHT ||

--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -464,6 +464,8 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
 
   var positioning = this.getPositioning();
 
+  this.setVisible(true);
+  
   var offsetX = offset[0];
   var offsetY = offset[1];
   if (positioning == ol.OverlayPositioning.BOTTOM_RIGHT ||
@@ -514,8 +516,6 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
       this.rendered_.top_ = style.top = top;
     }
   }
-
-  this.setVisible(true);
 };
 
 


### PR DESCRIPTION
Make the overlay visible before updating the render position
so that the `offsetWidth` and `offsetHeight` can be 
considered in evaluating the offset and positioning of the 
element

Fixes #6566