### PR TITLE
Add ol.RenderOrderFunction typedef

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3881,7 +3881,7 @@ olx.layer.TileOptions.prototype.useInterimTilesOnError;
 
 
 /**
- * @typedef {{renderOrder: (function(ol.Feature, ol.Feature):number|null|undefined),
+ * @typedef {{renderOrder: (ol.RenderOrderFunction|null|undefined),
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined),
  *     opacity: (number|undefined),
@@ -3900,7 +3900,7 @@ olx.layer.VectorOptions;
  * Render order. Function to be used when sorting features before rendering. By
  * default features are drawn in the order that they are created. Use `null` to
  * avoid the sort, but get an undefined draw order.
- * @type {function(ol.Feature, ol.Feature):number|null|undefined}
+ * @type {ol.RenderOrderFunction|null|undefined}
  * @api
  */
 olx.layer.VectorOptions.prototype.renderOrder;
@@ -4015,7 +4015,7 @@ olx.layer.VectorOptions.prototype.visible;
  *     preload: (number|undefined),
  *     renderBuffer: (number|undefined),
  *     renderMode: (ol.layer.VectorTileRenderType|string|undefined),
- *     renderOrder: (function(ol.Feature, ol.Feature):number|undefined),
+ *     renderOrder: (ol.RenderOrderFunction|undefined),
  *     source: (ol.source.VectorTile|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
  *     updateWhileAnimating: (boolean|undefined),
@@ -4058,7 +4058,7 @@ olx.layer.VectorTileOptions.prototype.renderMode;
 /**
  * Render order. Function to be used when sorting features before rendering. By
  * default features are drawn in the order that they are created.
- * @type {function(ol.Feature, ol.Feature):number|undefined}
+ * @type {ol.RenderOrderFunction|undefined}
  * @api
  */
 olx.layer.VectorTileOptions.prototype.renderOrder;

--- a/src/ol/layer/vector.js
+++ b/src/ol/layer/vector.js
@@ -102,7 +102,7 @@ ol.layer.Vector.prototype.getRenderBuffer = function() {
  *     order.
  */
 ol.layer.Vector.prototype.getRenderOrder = function() {
-  return /** @type {function(ol.Feature, ol.Feature):number|null|undefined} */ (
+  return /** @type {ol.RenderOrderFunction|null|undefined} */ (
       this.get(ol.layer.Vector.Property_.RENDER_ORDER));
 };
 
@@ -157,7 +157,7 @@ ol.layer.Vector.prototype.getUpdateWhileInteracting = function() {
 
 
 /**
- * @param {function(ol.Feature, ol.Feature):number|null|undefined} renderOrder
+ * @param {ol.RenderOrderFunction|null|undefined} renderOrder
  *     Render order.
  */
 ol.layer.Vector.prototype.setRenderOrder = function(renderOrder) {

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -443,6 +443,15 @@ ol.RegularShapeRenderOptions;
 
 
 /**
+ * A function to be used when sorting features before rendering.
+ * It takes two instances of {@link ol.Feature} and returns a `{number}`.
+ *
+ * @typedef {function(ol.Feature, ol.Feature):number}
+ */
+ol.RenderOrderFunction;
+
+
+/**
  * @typedef {function(ol.Extent, number, number) : ol.ImageBase}
  */
 ol.ReprojImageFunctionType;
@@ -631,7 +640,7 @@ ol.TilePriorityFunction;
 /**
  * @typedef {{
  *     dirty: boolean,
- *     renderedRenderOrder: (null|function(ol.Feature, ol.Feature):number),
+ *     renderedRenderOrder: (null|ol.RenderOrderFunction),
  *     renderedTileRevision: number,
  *     renderedRevision: number,
  *     replayGroup: ol.render.ReplayGroup}}


### PR DESCRIPTION
The `renderOption` property on `olx.layer.VectorOptions` shows up as `function` in the documentation instead of `function|null|undefined`. This is the current `@type`.
```
@type {function(ol.Feature, ol.Feature):number|null|undefined}
```
If you rewrite it to the following it works correctly.
```
@type {undefined|null|function(ol.Feature, ol.Feature):number}
```
I took it a step further and added the `ol.RenderOrderFunction` type so that it could have some documentation.