### PR TITLE
Fix RegularShape documentation

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7093,7 +7093,7 @@ olx.style.RegularShapeOptions.prototype.radius;
 
 
 /**
- * Inner radius of a star.
+ * Outer radius of a star.
  * @type {number|undefined}
  * @api
  */
@@ -7101,7 +7101,7 @@ olx.style.RegularShapeOptions.prototype.radius1;
 
 
 /**
- * Outer radius of a star.
+ * Inner radius of a star.
  * @type {number|undefined}
  * @api
  */


### PR DESCRIPTION
This documentation flaw was reported in http://stackoverflow.com/questions/42869908/how-should-openlayers-regularshape-radius-1-and-radius-2-be-used-to-generate-a-s.