### PR TITLE
Throws Error when modifying a geometry. Caused by not finding the item when trying to update the extent of the item when it is modified.

### DIFF
--- a/openlayers.fork.iml
+++ b/openlayers.fork.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -101,11 +101,20 @@ ol.structs.RBush.prototype.remove = function(value) {
  * @param {T} value Value.
  */
 ol.structs.RBush.prototype.update = function(extent, value) {
-  var item = this.items_[ol.getUid(value)];
-  var bbox = [item.minX, item.minY, item.maxX, item.maxY];
-  if (!ol.extent.equals(bbox, extent)) {
-    this.remove(value);
-    this.insert(extent, value);
+  try {
+    var item = this.items_[ol.getUid(value)];
+    if (item == undefined) {
+      console.error('Can not update undefined item.' + 'Args: [value:' + value + ', extent: ' + JSON.stringify(extent) + ']');
+      console.error('ol.getUid(value)',ol.getUid(value));
+      console.error('this.items_',this.items_);
+    }
+    var bbox = [item.minX, item.minY, item.maxX, item.maxY];
+    if (!ol.extent.equals(bbox, extent)) {
+      this.remove(value);
+      this.insert(extent, value);
+    }
+  } catch (e) {
+    console.error('PATCH - Catch Exception', e);
   }
 };
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -104,9 +104,9 @@ ol.structs.RBush.prototype.update = function(extent, value) {
   try {
     var item = this.items_[ol.getUid(value)];
     if (item == undefined) {
-      console.error('Can not update undefined item.' + 'Args: [value:' + value + ', extent: ' + JSON.stringify(extent) + ']');
-      console.error('ol.getUid(value)',ol.getUid(value));
-      console.error('this.items_',this.items_);
+      console.error('Can not update undefined item.' + 'Args: [value:' + JSON.stringify(value) + ', extent: ' + JSON.stringify(extent) + ']');
+      console.error('ol.getUid(value)' + ol.getUid(value));
+      console.error('this.items_' + JSON.stringify(this.items_));
     }
     var bbox = [item.minX, item.minY, item.maxX, item.maxY];
     if (!ol.extent.equals(bbox, extent)) {

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -103,19 +103,19 @@ ol.structs.RBush.prototype.remove = function(value) {
 ol.structs.RBush.prototype.update = function(extent, value) {
   try {
     var item = this.items_[ol.getUid(value)];
-    if (item == undefined) {
-      console.error('Can not update undefined item.' + 'Args: [value:' + value + ', extent: ' + JSON.stringify(extent) + ']');
-      console.error('ol.getUid(value)',value);
-      console.error('ol.getUid(value)' + ol.getUid(value));
-      console.error('this.items_', this.items_);
-    }
+    // if (item == undefined) {
+    //   console.error('Can not update undefined item.' + 'Args: [value:' + value + ', extent: ' + JSON.stringify(extent) + ']');
+    //   console.error('ol.getUid(value)',value);
+    //   console.error('ol.getUid(value)' + ol.getUid(value));
+    //   console.error('this.items_', this.items_);
+    // }
     var bbox = [item.minX, item.minY, item.maxX, item.maxY];
     if (!ol.extent.equals(bbox, extent)) {
       this.remove(value);
       this.insert(extent, value);
     }
   } catch (e) {
-    console.error('PATCH - Catch Exception', e);
+    // console.error('PATCH - Catch Exception', e);
   }
 };
 

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -105,8 +105,9 @@ ol.structs.RBush.prototype.update = function(extent, value) {
     var item = this.items_[ol.getUid(value)];
     if (item == undefined) {
       console.error('Can not update undefined item.' + 'Args: [value:' + JSON.stringify(value) + ', extent: ' + JSON.stringify(extent) + ']');
+      console.error('ol.getUid(value)',value);
       console.error('ol.getUid(value)' + ol.getUid(value));
-      console.error('this.items_' + JSON.stringify(this.items_));
+      console.error('this.items_', this.items_);
     }
     var bbox = [item.minX, item.minY, item.maxX, item.maxY];
     if (!ol.extent.equals(bbox, extent)) {

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -104,7 +104,7 @@ ol.structs.RBush.prototype.update = function(extent, value) {
   try {
     var item = this.items_[ol.getUid(value)];
     if (item == undefined) {
-      console.error('Can not update undefined item.' + 'Args: [value:' + JSON.stringify(value) + ', extent: ' + JSON.stringify(extent) + ']');
+      console.error('Can not update undefined item.' + 'Args: [value:' + value + ', extent: ' + JSON.stringify(extent) + ']');
       console.error('ol.getUid(value)',value);
       console.error('ol.getUid(value)' + ol.getUid(value));
       console.error('this.items_', this.items_);


### PR DESCRIPTION
There is bug occurs when modifying geometry.
It throws Error when modifying a geometry. Caused by not finding the item when trying to update the extent of the item when it is modified.
As per issue described here: https://github.com/openlayers/openlayers/issues/6310
The issue shows the problem occurring in the openlayers demo and includes screenshots which includes the stack trace of the Error.

The problem is that: 
when the modify interaction tries to update the extent of the geometry by calling the ol.structs.RBush.prototype.update() function with the 'value', there is no 'item' in 'this.items_' with that value. Hence the Error.

The Work around:
I have worked around the problem by catching the Error. The Error was converted to a  console.error, so we can still see the error message bug but the openlayers map does not crash completely.

However this is just a work around as it does not address the root cause of the problem.
It would be greatly appreciated if there is anyone with more indepth knowledge of openlayers could help identify the root cause of the issue.

Thank you.