### PR TITLE
Reset dragSegments after vertex deletion

### DIFF
--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -1088,6 +1088,7 @@ ol.interaction.Modify.prototype.removeVertex_ = function() {
         this.overlay_.getSource().removeFeature(this.vertexFeature_);
         this.vertexFeature_ = null;
       }
+      dragSegments.length = 0;
     }
 
   }


### PR DESCRIPTION
When deleting a vertex, the drag segments need to be reset, because there the vertex that the drag segments belong to is no longer existent.

Fixes #6310.