### PR TITLE
Allow an array of conditions in And/Or filter

### DIFF
--- a/src/ol/format/filter/and.js
+++ b/src/ol/format/filter/and.js
@@ -8,12 +8,17 @@ goog.require('ol.format.filter.LogicalNary');
  * Represents a logical `<And>` operator between two or more filter conditions.
  *
  * @constructor
- * @param {...ol.format.filter.Filter} conditions Conditions.
+ * @param {...ol.format.filter.Filter|Array.<ol.format.filter.Filter>} conditions Conditions.
  * @extends {ol.format.filter.LogicalNary}
  * @api
  */
 ol.format.filter.And = function(conditions) {
-  var params = ['And'].concat(Array.prototype.slice.call(arguments));
+  var params = ['And'];
+  if (Array.isArray(arguments[0])) {
+    params = params.concat(Array.prototype.slice.call(arguments)[0]);
+  } else {
+    params = params.concat(Array.prototype.slice.call(arguments));
+  }
   ol.format.filter.LogicalNary.apply(this, params);
 };
 ol.inherits(ol.format.filter.And, ol.format.filter.LogicalNary);

--- a/src/ol/format/filter/or.js
+++ b/src/ol/format/filter/or.js
@@ -9,12 +9,17 @@ goog.require('ol.format.filter.LogicalNary');
  * Represents a logical `<Or>` operator between two ore more filter conditions.
  *
  * @constructor
- * @param {...ol.format.filter.Filter} conditions Conditions.
+ * @param {...ol.format.filter.Filter|Array.<ol.format.filter.Filter>} conditions Conditions.
  * @extends {ol.format.filter.LogicalNary}
  * @api
  */
 ol.format.filter.Or = function(conditions) {
-  var params = ['Or'].concat(Array.prototype.slice.call(arguments));
+  var params = ['Or'];
+  if (Array.isArray(arguments[0])) {
+    params = params.concat(Array.prototype.slice.call(arguments)[0]);
+  } else {
+    params = params.concat(Array.prototype.slice.call(arguments));
+  }
   ol.format.filter.LogicalNary.apply(this, params);
 };
 ol.inherits(ol.format.filter.Or, ol.format.filter.LogicalNary);


### PR DESCRIPTION
This PR allows giving an array of conditions to the `ol.format.filter.And` and `ol.format.filter.Or` filters. Giving several separate conditions as arguments still work.

This is useful when the number of conditions is indeterminated.