### PR TITLE
Fix event type case of MSPointerDown

### DIFF
--- a/src/ol/events/eventtype.js
+++ b/src/ol/events/eventtype.js
@@ -26,7 +26,7 @@ ol.events.EventType = {
   MOUSEOUT: 'mouseout',
   MOUSEUP: 'mouseup',
   MOUSEWHEEL: 'mousewheel',
-  MSPOINTERDOWN: 'mspointerdown',
+  MSPOINTERDOWN: 'MSPointerDown',
   RESIZE: 'resize',
   TOUCHSTART: 'touchstart',
   TOUCHMOVE: 'touchmove',


### PR DESCRIPTION
This one was hard to find, but finally I managed to fix the overlay container event handling for IE10. Thanks @jlap for the bug report and the investigation.

Fixes #5478.