### PR TITLE
Filter write util method

### DIFF
--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -783,6 +783,21 @@ ol.format.WFS.GETFEATURE_SERIALIZERS_ = {
 
 
 /**
+ * Encode filter as WFS `Filter` and return the Node.
+ *
+ * @param {ol.format.filter.Filter} filter Filter.
+ * @return {Node} Result.
+ * @api
+ */
+ol.format.WFS.writeFilter = function(filter) {
+  var child = ol.xml.createElementNS(ol.format.WFS.OGCNS, 'Filter');
+  var objectStack = [];
+  ol.format.WFS.writeFilterCondition_(child, filter, objectStack);
+  return child;
+};
+
+
+/**
  * @param {Node} node Node.
  * @param {Array.<string>} featureTypes Feature types.
  * @param {Array.<*>} objectStack Node stack.

--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -791,8 +791,7 @@ ol.format.WFS.GETFEATURE_SERIALIZERS_ = {
  */
 ol.format.WFS.writeFilter = function(filter) {
   var child = ol.xml.createElementNS(ol.format.WFS.OGCNS, 'Filter');
-  var objectStack = [];
-  ol.format.WFS.writeFilterCondition_(child, filter, objectStack);
+  ol.format.WFS.writeFilterCondition_(child, filter, []);
   return child;
 };
 

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1014,4 +1014,29 @@ describe('ol.format.WFS', function() {
 
   });
 
+  describe('when writing out a WFS Filter', function() {
+    it('creates a filter', function() {
+      var text =
+          '<Filter>' +
+          '  <And>' +
+          '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+          '      <PropertyName>name</PropertyName>' +
+          '      <Literal>Mississippi*</Literal>' +
+          '    </PropertyIsLike>' +
+          '    <PropertyIsEqualTo>' +
+          '      <PropertyName>waterway</PropertyName>' +
+          '      <Literal>riverbank</Literal>' +
+          '    </PropertyIsEqualTo>' +
+          '  </And>' +
+          '</Filter>';
+      var serialized = ol.format.WFS.writeFilter(
+        ol.format.filter.and(
+          ol.format.filter.like('name', 'Mississippi*'),
+          ol.format.filter.equalTo('waterway', 'riverbank')
+        )
+      );
+      expect(serialized).to.xmleql(ol.xml.parse(text));
+    });
+  });
+
 });

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1017,7 +1017,7 @@ describe('ol.format.WFS', function() {
   describe('when writing out a WFS Filter', function() {
     it('creates a filter', function() {
       var text =
-          '<Filter>' +
+          '<Filter xmlns="http://www.opengis.net/ogc">' +
           '  <And>' +
           '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
           '      <PropertyName>name</PropertyName>' +


### PR DESCRIPTION
As suggested in #5691, it would be nice to have a utility method that could write a `Filter` node only.  This PR features the addition of a `ol.format.WFS.writeFilter` method that does that.