### PR TITLE
Use GeoServer/GWC caching when possible

### DIFF
--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -11,7 +11,8 @@ var layers = [
     source: new ol.source.TileWMS({
       url: 'https://ahocevar.com/geoserver/wms',
       params: {
-        'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
+        'LAYERS': 'ne:NE1_HR_LC_SR_W_DR',
+        'TILED': true
       }
     })
   })

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -6,7 +6,7 @@ goog.require('ol.source.TileWMS');
 
 var wmsSource = new ol.source.TileWMS({
   url: 'https://ahocevar.com/geoserver/wms',
-  params: {'LAYERS': 'ne:ne'},
+  params: {'LAYERS': 'ne:ne', 'TILED': true},
   serverType: 'geoserver',
   crossOrigin: 'anonymous'
 });

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -72,7 +72,8 @@ layers['wms4326'] = new ol.layer.Tile({
     url: 'https://ahocevar.com/geoserver/wms',
     crossOrigin: '',
     params: {
-      'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
+      'LAYERS': 'ne:NE1_HR_LC_SR_W_DR',
+      'TILED': true
     },
     projection: 'EPSG:4326'
   })
@@ -133,7 +134,7 @@ layers['states'] = new ol.layer.Tile({
   source: new ol.source.TileWMS({
     url: 'https://ahocevar.com/geoserver/wms',
     crossOrigin: '',
-    params: {'LAYERS': 'topp:states', 'TILED': true},
+    params: {'LAYERS': 'topp:states'},
     serverType: 'geoserver',
     tileGrid: new ol.tilegrid.TileGrid({
       extent: [-13884991, 2870341, -7455066, 6338219],

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -22,7 +22,8 @@ var map4326 = new ol.Map({
       source: new ol.source.TileWMS({
         url: 'https://ahocevar.com/geoserver/wms',
         params: {
-          'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
+          'LAYERS': 'ne:NE1_HR_LC_SR_W_DR',
+          'TILED': true
         }
       })
     }),
@@ -42,7 +43,8 @@ var map3857 = new ol.Map({
       source: new ol.source.TileWMS({
         url: 'https://ahocevar.com/geoserver/wms',
         params: {
-          'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
+          'LAYERS': 'ne:NE1_HR_LC_SR_W_DR',
+          'TILED': true
         }
       })
     }),


### PR DESCRIPTION
Now that my GeoServer instance is getting popular, I'd like to use its GeoWebCache integration so CloudFlare can cache tiles and reduce my server traffic.