### PR TITLE
Fix the parsing of flat coordinates in GML2 for 3D geometies

### DIFF
--- a/src/ol/format/gml2.js
+++ b/src/ol/format/gml2.js
@@ -59,7 +59,6 @@ ol.format.GML2.prototype.readFlatCoordinates_ = function(node, objectStack) {
   var s = ol.xml.getAllTextContent(node, false).replace(/^\s*|\s*$/g, '');
   var context = /** @type {ol.XmlNodeStackItem} */ (objectStack[0]);
   var containerSrs = context['srsName'];
-  var containerDimension = node.parentNode.getAttribute('srsDimension');
   var axisOrientation = 'enu';
   if (containerSrs) {
     var proj = ol.proj.get(containerSrs);
@@ -67,24 +66,14 @@ ol.format.GML2.prototype.readFlatCoordinates_ = function(node, objectStack) {
       axisOrientation = proj.getAxisOrientation();
     }
   }
-  var coords = s.split(/[\s,]+/);
-  // The "dimension" attribute is from the GML 3.0.1 spec.
-  var dim = 2;
-  if (node.getAttribute('srsDimension')) {
-    dim = ol.format.XSD.readNonNegativeIntegerString(
-        node.getAttribute('srsDimension'));
-  } else if (node.getAttribute('dimension')) {
-    dim = ol.format.XSD.readNonNegativeIntegerString(
-        node.getAttribute('dimension'));
-  } else if (containerDimension) {
-    dim = ol.format.XSD.readNonNegativeIntegerString(containerDimension);
-  }
+  var coordsGroups = s.trim().split(/\s+/);
   var x, y, z;
   var flatCoordinates = [];
-  for (var i = 0, ii = coords.length; i < ii; i += dim) {
-    x = parseFloat(coords[i]);
-    y = parseFloat(coords[i + 1]);
-    z = (dim === 3) ? parseFloat(coords[i + 2]) : 0;
+  for (var i = 0, ii = coordsGroups.length; i < ii; i++) {
+    var coords = coordsGroups[i].split(/,+/);
+    x = parseFloat(coords[0]);
+    y = parseFloat(coords[1]);
+    z = (coords.length === 3) ? parseFloat(coords[2]) : 0;
     if (axisOrientation.substr(0, 2) === 'en') {
       flatCoordinates.push(x, y, z);
     } else {

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -62,6 +62,17 @@ describe('ol.format.GML2', function() {
         expect(g.getCoordinates()).to.eql([-180, -90, 0]);
       });
 
+      it('can read a 3D point geometry', function() {
+        var text = '<gml:Point xmlns:gml="http://www.opengis.net/gml" ' +
+            '    srsName="urn:x-ogc:def:crs:EPSG:4326">' +
+            '  <gml:coordinates>-90,-180,42</gml:coordinates>' +
+            '</gml:Point>';
+
+        var g = readGeometry(format, text);
+        expect(g).to.be.an(ol.geom.Point);
+        expect(g.getCoordinates()).to.eql([-180, -90, 42]);
+      });
+
       it('can read a box element', function() {
         var text = '<gml:Box xmlns:gml="http://www.opengis.net/gml" ' +
             'srsName="EPSG:4326">' +
@@ -86,17 +97,17 @@ describe('ol.format.GML2', function() {
             '             -0.768746,47.358268 ' +
             '             -0.574463,47.684285 -0.347374,47.854602 ' +
             '             -0.006740,47.925567 ' +
-            '             0.135191,47.726864 0.149384,47.599127 0.419052,' +
-            '             47.670092 0.532597,47.428810 ' +
-            '             0.305508,47.443003 0.475824,47.144948 0.064225,' +
-            '             47.201721 ' +
+            '             0.135191,47.726864 0.149384,47.599127 ' +
+            '             0.419052,47.670092 0.532597,47.428810 ' +
+            '             0.305508,47.443003 0.475824,47.144948 ' +
+            '             0.064225,47.201721 ' +
             '             -0.318987,47.003018 </gml:coordinates>' +
             '        </gml:LinearRing>' +
             '      </gml:outerBoundaryIs>' +
             '      <gml:innerBoundaryIs>' +
             '        <gml:LinearRing>' +
-            '          <gml:coordinates>-0.035126,47.485582 -0.035126,' +
-            '             47.485582 ' +
+            '          <gml:coordinates>-0.035126,47.485582 ' +
+            '             -0.035126,47.485582 ' +
             '             -0.049319,47.641706 -0.233829,47.655899 ' +
             '             -0.375760,47.457196 ' +
             '             -0.276408,47.286879 -0.035126,47.485582 ' +


### PR DESCRIPTION
The code used to rely on the dimension. However, the dimension can only
be read from a GML3 document. This caused, for 3D geometries:
- An assertion error to be raised since the flatCoordinates list
contains more than 3 elements: "Assertion failed: flatCoordinates should
have a length of 3" The value of flatCoordinates for a 3D point was
something like `[2586394, 1232407, 0, 731, NaN, 0]`
- The value of the Z coordinates to be incorrect and always set to 0

This patch simplifies and correct the parsing of the coordinates:
- Don't parse groups of coords and the coordonates at the same time.
- Detect the dimension for the coordinates.
- If the Z coordinate exists, its value is used, otherwise, we use 0.
- Correct the presentation of test data to make it work with the new
parser.
- Add a test for a 3D point.