### PR TITLE
Fix proj4 type

### DIFF
--- a/externs/proj4js.js
+++ b/externs/proj4js.js
@@ -7,25 +7,31 @@
 /**
  * @constructor
  */
-var proj4 = function() {};
+var Proj4 = function() {};
 
 
 /**
- * @type {function(Array.<number>): Array.<number>}
+ * @param {ol.Coordinate} coordinates
+ * @return {ol.Coordinate}
  */
-proj4.prototype.forward;
+Proj4.prototype.forward = function(coordinates) {};
 
 
 /**
- * @type {function(Array.<number>): Array.<number>}
+ * @param {ol.Coordinate} coordinates
+ * @return {ol.Coordinate}
  */
-proj4.prototype.inverse;
+Proj4.prototype.inverse = function(coordinates) {};
 
 
 /**
  * @param {string} name
  * @param {(string|Object)=} opt_def
- * @return {undefined|Object.<string, Object.<{axis: string, units: string,
- *     to_meter: number}>>}
+ * @return {undefined|Object.<string, Object.<{axis: string, units: string, to_meter: number}>>}
  */
-proj4.defs = function(name, opt_def) {};
+Proj4.prototype.defs = function(name, opt_def) {};
+
+/**
+ * @type {Proj4}
+ */
+var proj4;

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -29,7 +29,7 @@ if (ol.ENABLE_PROJ4JS) {
    *     import proj4 from 'proj4';
    *     ol.proj.setProj4(proj4);
    *
-   * @param {proj4} proj4 Proj4.
+   * @param {Proj4} proj4 Proj4.
    * @api
    */
   ol.proj.setProj4 = function(proj4) {

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -3,14 +3,14 @@ goog.provide('ol.proj.proj4');
 
 /**
  * @private
- * @type {proj4}
+ * @type {Proj4}
  */
 ol.proj.proj4.cache_ = null;
 
 
 /**
  * Store the proj4 function.
- * @param {proj4} proj4 The proj4 function.
+ * @param {Proj4} proj4 The proj4 function.
  */
 ol.proj.proj4.set = function(proj4) {
   ol.proj.proj4.cache_ = proj4;
@@ -19,7 +19,7 @@ ol.proj.proj4.set = function(proj4) {
 
 /**
  * Get proj4.
- * @return {proj4} The proj4 function set above or available globally.
+ * @return {Proj4} The proj4 function set above or available globally.
  */
 ol.proj.proj4.get = function() {
   return ol.proj.proj4.cache_ || window['proj4'];


### PR DESCRIPTION
Previous typing was confusing the compiler. It could not figure out the difference between the proj4 property and the constructor, which lead to errors such as:

- ol.proj.setProj4(proj4)
ERR! compile /home/gberaudo/dev/ngeo/src/proj/epsg21781.js:8: ERROR - actual parameter 1 of ol.proj.setProj4 does not match formal parameter
ERR! compile found   : function (new:proj4): ?
ERR! compile required: (null|proj4)
ERR! compile   ol.proj.setProj4(proj4);
ERR! compile                    ^^^^^

- ol.proj.proj4.get().defs('EPSG:21781', epsg21781def)
ERR! compile /home/gberaudo/dev/ngeo/src/proj/epsg21781.js:26: ERROR - Property defs never defined on proj4
ERR! compile   ol.proj.proj4.get().defs('EPSG:21781', epsg21781def);
ERR! compile                       ^^^^