### PR TITLE
Fix outerWidth and outerHeight calculation in IE

### DIFF
--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -28,7 +28,7 @@ ol.dom.createCanvasContext2D = function(opt_width, opt_height) {
  */
 ol.dom.outerWidth = function(element) {
   var width = element.offsetWidth;
-  var style = element.currentStyle || getComputedStyle(element);
+  var style = getComputedStyle(element);
   width += parseInt(style.marginLeft, 10) + parseInt(style.marginRight, 10);
 
   return width;
@@ -44,7 +44,7 @@ ol.dom.outerWidth = function(element) {
  */
 ol.dom.outerHeight = function(element) {
   var height = element.offsetHeight;
-  var style = element.currentStyle || getComputedStyle(element);
+  var style = getComputedStyle(element);
   height += parseInt(style.marginTop, 10) + parseInt(style.marginBottom, 10);
 
   return height;


### PR DESCRIPTION
`DOMElement.currentStyle` is not the right way to calculate css metrics, because `marginLeft` and `marginRight` can have `auto` values. All our supported browsers have `window.getComputedStyle`, where `marginLeft` and `marginRight` are returned in pixels.

This issue was brought up in http://stackoverflow.com/questions/42943679/autopanmargin-in-openlayers-is-not-working-in-ie and can also be seen in the `popup.html` example.