### PR TITLE
Fix custom build when openlayers is installed from yarn package manager

### DIFF
--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -17,6 +17,7 @@ var infoPath = path.join(__dirname, '..', 'build', 'info.json');
 /**
  * Get checked path of a binary.
  * @param {string} binaryName Binary name of the binary path to find.
+ * @return {string} Path.
  */
 function getBinaryPath(binaryName) {
   if (isWindows) {

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -20,14 +20,14 @@ var infoPath = path.join(__dirname, '..', 'build', 'info.json');
  */
 function getBinaryPath(binaryName) {
   if (isWindows) {
-    binaryName += '.cmd'
+    binaryName += '.cmd';
   }
 
   var jsdocResolved = require.resolve('jsdoc/jsdoc.js');
   var expectedPaths = [
     path.join(__dirname, '..', 'node_modules', '.bin', binaryName),
     path.resolve(path.join(path.dirname(jsdocResolved), '..', '.bin', binaryName))
-  ]
+  ];
 
   for (var i = 0; i < expectedPaths.length; i++) {
     var expectedPath = expectedPaths[i];
@@ -36,7 +36,7 @@ function getBinaryPath(binaryName) {
     }
   }
 
-  throw Error("JsDoc binary was not found in any of the expected paths: " + expectedPaths);
+  throw Error('JsDoc binary was not found in any of the expected paths: ' + expectedPaths);
 }
 
 var jsdoc = getBinaryPath('jsdoc');

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -14,13 +14,32 @@ var externsPaths = [
 ];
 var infoPath = path.join(__dirname, '..', 'build', 'info.json');
 
-var jsdocResolved = require.resolve('jsdoc/jsdoc.js');
-var jsdoc = path.resolve(path.dirname(jsdocResolved), '../.bin/jsdoc');
+/**
+ * Get checked path of a binary.
+ * @param {string} binaryName Binary name of the binary path to find.
+ */
+function getBinaryPath(binaryName) {
+  if (isWindows) {
+    binaryName += '.cmd'
+  }
 
-// on Windows, use jsdoc.cmd
-if (isWindows) {
-  jsdoc += '.cmd';
+  var jsdocResolved = require.resolve('jsdoc/jsdoc.js');
+  var expectedPaths = [
+    path.join(__dirname, '..', 'node_modules', '.bin', binaryName),
+    path.resolve(path.join(path.dirname(jsdocResolved), '..', '.bin', binaryName))
+  ]
+
+  for (var i = 0; i < expectedPaths.length; i++) {
+    var expectedPath = expectedPaths[i];
+    if (fs.existsSync(expectedPath)) {
+      return expectedPath;
+    }
+  }
+
+  throw Error("JsDoc binary was not found in any of the expected paths: " + expectedPaths);
 }
+
+var jsdoc = getBinaryPath('jsdoc');
 
 var jsdocConfig = path.join(
     __dirname, '..', 'config', 'jsdoc', 'info', 'conf.json');


### PR DESCRIPTION
This enhance the procedure to find path of jsdoc binary by checking if the file exists.
It also use 2 possible paths to perform this check, one for npm and the other for yarn.

Close #6633