### PR TITLE
Add common transforms by default

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -30,7 +30,6 @@ goog.require('ol.has');
 goog.require('ol.interaction');
 goog.require('ol.layer.Group');
 goog.require('ol.obj');
-goog.require('ol.proj.common');
 goog.require('ol.renderer.Map');
 goog.require('ol.renderer.Type');
 goog.require('ol.renderer.canvas.Map');
@@ -1501,5 +1500,3 @@ ol.Map.createOptionsInternal = function(options) {
   };
 
 };
-
-ol.proj.common.add();

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -2,6 +2,8 @@ goog.provide('ol.proj');
 
 goog.require('ol');
 goog.require('ol.extent');
+goog.require('ol.proj.EPSG3857');
+goog.require('ol.proj.EPSG4326');
 goog.require('ol.proj.Projection');
 goog.require('ol.proj.Units');
 goog.require('ol.proj.proj4');
@@ -467,3 +469,24 @@ ol.proj.transformWithProjections = function(point, sourceProjection, destination
       sourceProjection, destinationProjection);
   return transformFn(point);
 };
+
+/**
+ * Add transforms to and from EPSG:4326 and EPSG:3857.  This function is called
+ * by when this module is executed and should only need to be called again after
+ * `ol.proj.clearAllProjections()` is called (e.g. in tests).
+ */
+ol.proj.addCommon = function() {
+  // Add transformations that don't alter coordinates to convert within set of
+  // projections with equal meaning.
+  ol.proj.addEquivalentProjections(ol.proj.EPSG3857.PROJECTIONS);
+  ol.proj.addEquivalentProjections(ol.proj.EPSG4326.PROJECTIONS);
+  // Add transformations to convert EPSG:4326 like coordinates to EPSG:3857 like
+  // coordinates and back.
+  ol.proj.addEquivalentTransforms(
+      ol.proj.EPSG4326.PROJECTIONS,
+      ol.proj.EPSG3857.PROJECTIONS,
+      ol.proj.EPSG3857.fromEPSG4326,
+      ol.proj.EPSG3857.toEPSG4326);
+};
+
+ol.proj.addCommon();

--- a/src/ol/proj/common.js
+++ b/src/ol/proj/common.js
@@ -1,24 +1,13 @@
 goog.provide('ol.proj.common');
 
 goog.require('ol.proj');
-goog.require('ol.proj.EPSG3857');
-goog.require('ol.proj.EPSG4326');
 
 
 /**
- * FIXME empty description for jsdoc
+ * Deprecated.  Transforms between EPSG:4326 and EPSG:3857 are now included by
+ * default.  There is no need to call this function in application code and it
+ * will be removed in a future major release.
+ * @deprecated This function is no longer necessary.
  * @api
  */
-ol.proj.common.add = function() {
-  // Add transformations that don't alter coordinates to convert within set of
-  // projections with equal meaning.
-  ol.proj.addEquivalentProjections(ol.proj.EPSG3857.PROJECTIONS);
-  ol.proj.addEquivalentProjections(ol.proj.EPSG4326.PROJECTIONS);
-  // Add transformations to convert EPSG:4326 like coordinates to EPSG:3857 like
-  // coordinates and back.
-  ol.proj.addEquivalentTransforms(
-      ol.proj.EPSG4326.PROJECTIONS,
-      ol.proj.EPSG3857.PROJECTIONS,
-      ol.proj.EPSG3857.fromEPSG4326,
-      ol.proj.EPSG3857.toEPSG4326);
-};
+ol.proj.common.add = ol.proj.addCommon;

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -2,7 +2,6 @@ goog.provide('ol.proj.EPSG3857');
 
 goog.require('ol');
 goog.require('ol.math');
-goog.require('ol.proj');
 goog.require('ol.proj.Projection');
 goog.require('ol.proj.Units');
 
@@ -16,7 +15,7 @@ goog.require('ol.proj.Units');
  * @param {string} code Code.
  * @private
  */
-ol.proj.EPSG3857_ = function(code) {
+ol.proj.EPSG3857.Projection_ = function(code) {
   ol.proj.Projection.call(this, {
     code: code,
     units: ol.proj.Units.METERS,
@@ -28,7 +27,7 @@ ol.proj.EPSG3857_ = function(code) {
     }
   });
 };
-ol.inherits(ol.proj.EPSG3857_, ol.proj.Projection);
+ol.inherits(ol.proj.EPSG3857.Projection_, ol.proj.Projection);
 
 
 /**
@@ -85,7 +84,7 @@ ol.proj.EPSG3857.CODES = [
  * @type {Array.<ol.proj.Projection>}
  */
 ol.proj.EPSG3857.PROJECTIONS = ol.proj.EPSG3857.CODES.map(function(code) {
-  return new ol.proj.EPSG3857_(code);
+  return new ol.proj.EPSG3857.Projection_(code);
 });
 
 

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -1,7 +1,6 @@
 goog.provide('ol.proj.EPSG4326');
 
 goog.require('ol');
-goog.require('ol.proj');
 goog.require('ol.proj.Projection');
 goog.require('ol.proj.Units');
 goog.require('ol.sphere.WGS84');
@@ -21,7 +20,7 @@ goog.require('ol.sphere.WGS84');
  * @param {string=} opt_axisOrientation Axis orientation.
  * @private
  */
-ol.proj.EPSG4326_ = function(code, opt_axisOrientation) {
+ol.proj.EPSG4326.Projection_ = function(code, opt_axisOrientation) {
   ol.proj.Projection.call(this, {
     code: code,
     units: ol.proj.Units.DEGREES,
@@ -32,7 +31,7 @@ ol.proj.EPSG4326_ = function(code, opt_axisOrientation) {
     worldExtent: ol.proj.EPSG4326.EXTENT
   });
 };
-ol.inherits(ol.proj.EPSG4326_, ol.proj.Projection);
+ol.inherits(ol.proj.EPSG4326.Projection_, ol.proj.Projection);
 
 
 /**
@@ -58,12 +57,12 @@ ol.proj.EPSG4326.METERS_PER_UNIT = Math.PI * ol.sphere.WGS84.radius / 180;
  * @type {Array.<ol.proj.Projection>}
  */
 ol.proj.EPSG4326.PROJECTIONS = [
-  new ol.proj.EPSG4326_('CRS:84'),
-  new ol.proj.EPSG4326_('EPSG:4326', 'neu'),
-  new ol.proj.EPSG4326_('urn:ogc:def:crs:EPSG::4326', 'neu'),
-  new ol.proj.EPSG4326_('urn:ogc:def:crs:EPSG:6.6:4326', 'neu'),
-  new ol.proj.EPSG4326_('urn:ogc:def:crs:OGC:1.3:CRS84'),
-  new ol.proj.EPSG4326_('urn:ogc:def:crs:OGC:2:84'),
-  new ol.proj.EPSG4326_('http://www.opengis.net/gml/srs/epsg.xml#4326', 'neu'),
-  new ol.proj.EPSG4326_('urn:x-ogc:def:crs:EPSG:4326', 'neu')
+  new ol.proj.EPSG4326.Projection_('CRS:84'),
+  new ol.proj.EPSG4326.Projection_('EPSG:4326', 'neu'),
+  new ol.proj.EPSG4326.Projection_('urn:ogc:def:crs:EPSG::4326', 'neu'),
+  new ol.proj.EPSG4326.Projection_('urn:ogc:def:crs:EPSG:6.6:4326', 'neu'),
+  new ol.proj.EPSG4326.Projection_('urn:ogc:def:crs:OGC:1.3:CRS84'),
+  new ol.proj.EPSG4326.Projection_('urn:ogc:def:crs:OGC:2:84'),
+  new ol.proj.EPSG4326.Projection_('http://www.opengis.net/gml/srs/epsg.xml#4326', 'neu'),
+  new ol.proj.EPSG4326.Projection_('urn:x-ogc:def:crs:EPSG:4326', 'neu')
 ];

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -1,13 +1,12 @@
 goog.provide('ol.test.proj.EPSG3857');
 
 goog.require('ol.proj');
-goog.require('ol.proj.common');
 
 describe('ol.proj.EPSG3857', function() {
 
   afterEach(function() {
     ol.proj.clearAllProjections();
-    ol.proj.common.add();
+    ol.proj.addCommon();
   });
 
   describe('fromEPSG4326()', function() {

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -3,14 +3,13 @@ goog.provide('ol.test.proj');
 goog.require('ol.proj');
 goog.require('ol.proj.EPSG4326');
 goog.require('ol.proj.Projection');
-goog.require('ol.proj.common');
 
 
 describe('ol.proj', function() {
 
   afterEach(function() {
     ol.proj.clearAllProjections();
-    ol.proj.common.add();
+    ol.proj.addCommon();
   });
 
   describe('projection equivalence', function() {

--- a/test/spec/ol/renderer/webgl/imagelayer.test.js
+++ b/test/spec/ol/renderer/webgl/imagelayer.test.js
@@ -2,7 +2,6 @@ goog.provide('ol.test.renderer.webgl.ImageLayer');
 
 goog.require('ol.transform');
 goog.require('ol.Map');
-goog.require('ol.proj.common');
 goog.require('ol.layer.Image');
 goog.require('ol.source.Image');
 goog.require('ol.renderer.webgl.ImageLayer');
@@ -21,8 +20,6 @@ describe('ol.renderer.webgl.ImageLayer', function() {
     var imageExtent;
 
     beforeEach(function() {
-      ol.proj.common.add();
-
       map = new ol.Map({
         target: document.createElement('div')
       });


### PR DESCRIPTION
The `ol.proj.fromLonLat()` and `ol.proj.toLonLat()` functions only work (when called with one argument) if `ol.proj.common.add()` has been called first.  This is fragile and non-obvious.  Instead, we can make them always work by adding common transforms when the `proj.js` module is first executed.

This branch adds a `ol.proj.addCommon()` function that can be called in tests to restore common transforms after `ol.proj.clearAllProjections()` is called.  Neither of these functions is exportable.  

The `ol.proj.common.add()` function gets a deprecation notice and some documentation.  Though it had a `@api` annotation previously, it was absent any documentation.  People were getting common transforms added by depending on `map.js`.  Now they get the same when depending on `proj.js`.