### PR TITLE
Add new constrainResolution option to olx.interaction.DefaultsOptions

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,16 @@
 
 ### Next release
 
+#### Simpler `constrainResolution` configuration
+
+The `constrainResolution` configuration for `ol.interaction.PinchZoom` and `ol.interaction.MouseWheelZoom`
+can now be set directly with an option in `ol.interaction.defaults`:
+```js
+ol.interaction.defaults({
+  constrainResolution: true
+});
+```
+
 ### v4.0.0
 
 #### Simpler `ol.source.Zoomify` `url` configuration

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2398,7 +2398,9 @@ olx.interaction;
 
 /**
  * Interactions for the map. Default is `true` for all options.
- * @typedef {{altShiftDragRotate: (boolean|undefined),
+ * @typedef {{
+ *     altShiftDragRotate: (boolean|undefined),
+ *     constrainResolution: (boolean|undefined),
  *     doubleClickZoom: (boolean|undefined),
  *     keyboard: (boolean|undefined),
  *     mouseWheelZoom: (boolean|undefined),
@@ -2407,7 +2409,8 @@ olx.interaction;
  *     pinchRotate: (boolean|undefined),
  *     pinchZoom: (boolean|undefined),
  *     zoomDelta: (number|undefined),
- *     zoomDuration: (number|undefined)}}
+ *     zoomDuration: (number|undefined)
+ * }}
  */
 olx.interaction.DefaultsOptions;
 
@@ -2418,6 +2421,15 @@ olx.interaction.DefaultsOptions;
  * @api
  */
 olx.interaction.DefaultsOptions.prototype.altShiftDragRotate;
+
+
+/**
+ * Zoom to the closest integer zoom level after the wheel/trackpad or
+ * pinch gesture ends. Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.interaction.DefaultsOptions.prototype.constrainResolution;
 
 
 /**

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -75,6 +75,7 @@ ol.interaction.defaults = function(opt_options) {
   var pinchZoom = options.pinchZoom !== undefined ? options.pinchZoom : true;
   if (pinchZoom) {
     interactions.push(new ol.interaction.PinchZoom({
+      constrainResolution: options.constrainResolution,
       duration: options.zoomDuration
     }));
   }
@@ -92,6 +93,7 @@ ol.interaction.defaults = function(opt_options) {
       options.mouseWheelZoom : true;
   if (mouseWheelZoom) {
     interactions.push(new ol.interaction.MouseWheelZoom({
+      constrainResolution: options.constrainResolution,
       duration: options.zoomDuration
     }));
   }

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -378,9 +378,34 @@ describe('ol.Map', function() {
         var interactions = ol.interaction.defaults(options);
         expect(interactions.getLength()).to.eql(1);
         expect(interactions.item(0)).to.be.a(ol.interaction.MouseWheelZoom);
+        expect(interactions.item(0).constrainResolution_).to.eql(false);
         expect(interactions.item(0).useAnchor_).to.eql(true);
         interactions.item(0).setMouseAnchor(false);
         expect(interactions.item(0).useAnchor_).to.eql(false);
+      });
+    });
+
+    describe('create pinchZoom interaction', function() {
+      it('creates pinchZoom interaction', function() {
+        options.pinchZoom = true;
+        var interactions = ol.interaction.defaults(options);
+        expect(interactions.getLength()).to.eql(1);
+        expect(interactions.item(0)).to.be.a(ol.interaction.PinchZoom);
+        expect(interactions.item(0).constrainResolution_).to.eql(false);
+      });
+    });
+
+    describe('set constrainResolution option', function() {
+      it('set constrainResolution option', function() {
+        options.pinchZoom = true;
+        options.mouseWheelZoom = true;
+        options.constrainResolution = true;
+        var interactions = ol.interaction.defaults(options);
+        expect(interactions.getLength()).to.eql(2);
+        expect(interactions.item(0)).to.be.a(ol.interaction.PinchZoom);
+        expect(interactions.item(0).constrainResolution_).to.eql(true);
+        expect(interactions.item(1)).to.be.a(ol.interaction.MouseWheelZoom);
+        expect(interactions.item(1).constrainResolution_).to.eql(true);
       });
     });
 


### PR DESCRIPTION
If `constrainResolution` is needed for both the pinch and mouse wheel interaction, the interactions initialization is something like:
```js
ol.interaction.defaults({
  pinchZoom: false,
  mouseWheelZoom: false
}).extend([
  new ol.interaction.PinchZoom({
    constrainResolution: true
  }),
  new ol.interaction.MouseWheelZoom({
    constrainResolution: true
  })
]);
```
This PR suggest to add a new option to `ol.interaction.defaults` to be able to write:
```js
ol.interaction.defaults({
  constrainResolution: true
});
```

