### PR TITLE
Improve docs for MouseWheelZoom constrainResolution

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3112,7 +3112,8 @@ olx.interaction.MouseWheelZoomOptions.prototype.timeout;
 
 
 /**
- * Zoom to the closest integer zoom level after the wheel/trackpad gesture ends.
+ * When using a trackpad or magic mouse, zoom to the closest integer zoom level
+ * after the scroll gesture ends.
  * Default is `false`.
  * @type {boolean|undefined}
  * @api


### PR DESCRIPTION
This change makes it clear that the `constrainResolution` option only has an effect for trackpad or magic mouse users.