### PR TITLE
Unique layers

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,18 @@
 
 ### Next release
 
+#### Adding duplicate layers to a map throws
+
+Previously, you could do this:
+```js
+map.addLayer(layer);
+map.addLayer(layer);
+```
+
+However, after adding a duplicate layer, things failed if you tried to remove that layer.
+
+Now, `map.addLayer()` throws if you try adding a layer that has already been added to the map.
+
 #### Simpler `constrainResolution` configuration
 
 The `constrainResolution` configuration for `ol.interaction.PinchZoom` and `ol.interaction.MouseWheelZoom`

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -9,6 +9,21 @@ var olx;
 
 
 /**
+ * @typedef {{unique: (boolean|undefined)}}
+ */
+olx.CollectionOptions;
+
+
+/**
+ * Disallow the same item from being added to the collection twice.  Default is
+ * false.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.CollectionOptions.prototype.unique;
+
+
+/**
  * @typedef {{html: string,
  *     tileRanges: (Object.<string, Array.<ol.TileRange>>|undefined)}}
  */

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -23,18 +23,33 @@ goog.require('ol.events.Event');
  * @extends {ol.Object}
  * @fires ol.Collection.Event
  * @param {!Array.<T>=} opt_array Array.
+ * @param {olx.CollectionOptions=} opt_options Collection options.
  * @template T
  * @api
  */
-ol.Collection = function(opt_array) {
+ol.Collection = function(opt_array, opt_options) {
 
   ol.Object.call(this);
+
+  var options = opt_options || {};
+
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.unique_ = !!options.unique;
 
   /**
    * @private
    * @type {!Array.<T>}
    */
   this.array_ = opt_array ? opt_array : [];
+
+  if (this.unique_) {
+    for (var i = 0, ii = this.array_.length; i < ii; ++i) {
+      this.assertUnique_(this.array_[i], i);
+    }
+  }
 
   this.updateLength_();
 
@@ -125,6 +140,9 @@ ol.Collection.prototype.getLength = function() {
  * @api
  */
 ol.Collection.prototype.insertAt = function(index, elem) {
+  if (this.unique_) {
+    this.assertUnique_(elem);
+  }
   this.array_.splice(index, 0, elem);
   this.updateLength_();
   this.dispatchEvent(
@@ -150,6 +168,9 @@ ol.Collection.prototype.pop = function() {
  * @api
  */
 ol.Collection.prototype.push = function(elem) {
+  if (this.unique_) {
+    this.assertUnique_(elem);
+  }
   var n = this.getLength();
   this.insertAt(n, elem);
   return this.getLength();
@@ -200,6 +221,9 @@ ol.Collection.prototype.removeAt = function(index) {
 ol.Collection.prototype.setAt = function(index, elem) {
   var n = this.getLength();
   if (index < n) {
+    if (this.unique_) {
+      this.assertUnique_(elem, index);
+    }
     var prev = this.array_[index];
     this.array_[index] = elem;
     this.dispatchEvent(
@@ -221,6 +245,20 @@ ol.Collection.prototype.setAt = function(index, elem) {
  */
 ol.Collection.prototype.updateLength_ = function() {
   this.set(ol.Collection.Property_.LENGTH, this.array_.length);
+};
+
+
+/**
+ * @private
+ * @param {T} elem Element.
+ * @param {number=} opt_except Optional index to ignore.
+ */
+ol.Collection.prototype.assertUnique_ = function(elem, opt_except) {
+  for (var i = 0, ii = this.array_.length; i < ii; ++i) {
+    if (this.array_[i] === elem && i !== opt_except) {
+      throw new Error('Duplicate item added to a unique collection');
+    }
+  }
 };
 
 

--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -54,14 +54,14 @@ ol.layer.Group = function(opt_options) {
 
   if (layers) {
     if (Array.isArray(layers)) {
-      layers = new ol.Collection(layers.slice());
+      layers = new ol.Collection(layers.slice(), {unique: true});
     } else {
       ol.asserts.assert(layers instanceof ol.Collection,
           43); // Expected `layers` to be an array or an `ol.Collection`
       layers = layers;
     }
   } else {
-    layers = new ol.Collection();
+    layers = new ol.Collection(undefined, {unique: true});
   }
 
   this.setLayers(layers);

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -298,4 +298,67 @@ describe('ol.collection', function() {
     });
   });
 
+  describe('unique collection', function() {
+    it('allows unique items in the constructor', function() {
+      new ol.Collection([{}, {}, {}], {unique: true});
+    });
+
+    it('throws if duplicate items are passed to the contructor', function() {
+      var item = {};
+      var call = function() {
+        new ol.Collection([item, item], {unique: true});
+      };
+      expect(call).to.throwException();
+    });
+
+    it('allows unique items to be added via push', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      unique.push({});
+      unique.push({});
+    });
+
+    it('throws if duplicate items are added via push', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      var item = {};
+      unique.push(item);
+      var call = function() {
+        unique.push(item);
+      };
+      expect(call).to.throwException();
+    });
+
+    it('allows unique items to be added via insertAt', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      unique.insertAt(0, {});
+      unique.insertAt(0, {});
+    });
+
+    it('throws if duplicate items are added via insertAt', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      var item = {};
+      unique.insertAt(0, item);
+      var call = function() {
+        unique.insertAt(0, item);
+      };
+      expect(call).to.throwException();
+    });
+
+    it('allows unique items to be added via setAt', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      unique.setAt(0, {});
+      unique.setAt(1, {});
+    });
+
+    it('throws if duplicate items are added via setAt', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      var item = {};
+      unique.setAt(0, item);
+      var call = function() {
+        unique.setAt(1, item);
+      };
+      expect(call).to.throwException();
+    });
+
+  });
+
 });

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -303,7 +303,7 @@ describe('ol.collection', function() {
       new ol.Collection([{}, {}, {}], {unique: true});
     });
 
-    it('throws if duplicate items are passed to the contructor', function() {
+    it('throws if duplicate items are passed to the constructor', function() {
       var item = {};
       var call = function() {
         new ol.Collection([item, item], {unique: true});
@@ -347,6 +347,13 @@ describe('ol.collection', function() {
       var unique = new ol.Collection(undefined, {unique: true});
       unique.setAt(0, {});
       unique.setAt(1, {});
+    });
+
+    it('allows items to be reset via setAt', function() {
+      var unique = new ol.Collection(undefined, {unique: true});
+      var item = {};
+      unique.setAt(0, item);
+      unique.setAt(0, item);
     });
 
     it('throws if duplicate items are added via setAt', function() {

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -50,6 +50,27 @@ describe('ol.Map', function() {
 
   });
 
+  describe('#addLayer()', function() {
+    it('adds a layer to the map', function() {
+      var map = new ol.Map({});
+      var layer = new ol.layer.Tile();
+      map.addLayer(layer);
+
+      expect(map.getLayers().item(0)).to.be(layer);
+    });
+
+    it('throws if a layer is added twice', function() {
+      var map = new ol.Map({});
+      var layer = new ol.layer.Tile();
+      map.addLayer(layer);
+
+      var call = function() {
+        map.addLayer(layer);
+      };
+      expect(call).to.throwException();
+    });
+  });
+
   describe('#addInteraction()', function() {
     it('adds an interaction to the map', function() {
       var map = new ol.Map({});


### PR DESCRIPTION
This adds support for unique collections and makes it so map layers must be unique.

![image](https://cloud.githubusercontent.com/assets/41094/24940108/5c122f98-1efe-11e7-9ea9-f4bcd89faf9c.png)

![image](https://cloud.githubusercontent.com/assets/41094/24940117/6eab29ac-1efe-11e7-87c0-5150570a3054.png)

It is already a requirement that map layers be unique.  This just makes it so we fail faster and more clearly.

Fixes #6694.