### PR TITLE
Include typedefs.js in closure compiler tutorial build configurations

### DIFF
--- a/doc/tutorials/closure.md
+++ b/doc/tutorials/closure.md
@@ -172,6 +172,7 @@ The minimum config file looks like this:
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [
+      "node_modules/openlayers/src/ol/typedefs.js",
       "node_modules/openlayers/externs/olx.js",
       "node_modules/openlayers/externs/oli.js"
     ],
@@ -223,6 +224,7 @@ Here is a version of `config.json` with more compilation checks enabled:
       "ol.ENABLE_WEBGL=false"
     ],
     "js": [
+      "node_modules/openlayers/src/ol/typedefs.js",
       "node_modules/openlayers/externs/olx.js",
       "node_modules/openlayers/externs/oli.js"
     ],


### PR DESCRIPTION
This changes the configurations used in https://openlayers.org/en/latest/doc/tutorials/closure.html to include `typedefs.js`.

Fixes #6698 

Please review.
