### PR TITLE
Set version when building ol package

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -220,3 +220,7 @@ The `{-y}` placeholder requires a tile grid with extent.
 ### 57
 
 At least 2 conditions are required.
+
+### 58
+
+Duplicate item added to a unique collection.  For example, it may be that you tried to add the same layer to a map twice.  Check for calls to `map.addLayer()` or other places where the map's layer collection is modified.

--- a/src/ol/assertionerror.js
+++ b/src/ol/assertionerror.js
@@ -13,11 +13,12 @@ goog.require('ol');
  */
 ol.AssertionError = function(code) {
 
+  var path = ol.VERSION ? ol.VERSION.split('-')[0] : 'latest';
+
   /**
    * @type {string}
    */
-  this.message = 'Assertion failed. See ' +
-      (ol.VERSION ? 'https://openlayers.org/en/' + ol.VERSION.split('-')[0] : '') +
+  this.message = 'Assertion failed. See https://openlayers.org/en/' + path +
       '/doc/errors/#' + code + ' for details.';
 
   /**

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -6,6 +6,7 @@
 goog.provide('ol.Collection');
 
 goog.require('ol');
+goog.require('ol.AssertionError');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Object');
 goog.require('ol.events.Event');
@@ -256,7 +257,7 @@ ol.Collection.prototype.updateLength_ = function() {
 ol.Collection.prototype.assertUnique_ = function(elem, opt_except) {
   for (var i = 0, ii = this.array_.length; i < ii; ++i) {
     if (this.array_[i] === elem && i !== opt_except) {
-      throw new Error('Duplicate item added to a unique collection');
+      throw new ol.AssertionError(58);
     }
   }
 };

--- a/test/spec/ol/assertionerror.test.js
+++ b/test/spec/ol/assertionerror.test.js
@@ -6,8 +6,9 @@ goog.require('ol.AssertionError');
 describe('ol.AssertionError', function() {
   it('generates a message', function() {
     var error = new ol.AssertionError(42);
-    expect(error.message).to.be('Assertion failed. See /doc/errors/#42 for details.');
+    expect(error.message).to.be('Assertion failed. See https://openlayers.org/en/latest/doc/errors/#42 for details.');
   });
+
   it('generates a message with a versioned url', function() {
     var origVersion = ol.VERSION;
     ol.VERSION = 'foo';
@@ -15,10 +16,12 @@ describe('ol.AssertionError', function() {
     expect(error.message).to.be('Assertion failed. See https://openlayers.org/en/foo/doc/errors/#42 for details.');
     ol.VERSION = origVersion;
   });
+
   it('has an error code', function() {
     var error = new ol.AssertionError(42);
     expect(error.code).to.be(42);
   });
+
   it('has a name', function() {
     var error = new ol.AssertionError(42);
     expect(error.name).to.be('AssertionError');

--- a/transforms/module.js
+++ b/transforms/module.js
@@ -1,4 +1,5 @@
 const pkg = require('../package.json');
+const version = require('../package/package.json').version;
 
 const defines = {
   'ol.ENABLE_WEBGL': false
@@ -117,6 +118,12 @@ module.exports = function(info, api) {
 
   // store any initial comments
   const {comments} = root.find(j.Program).get('body', 0).node;
+
+  // replace `ol.VERSION = ''` with correct version
+  root.find(j.ExpressionStatement, getMemberExpressionAssignment('ol.VERSION'))
+    .forEach(path => {
+      path.value.expression.right = j.literal(version);
+    });
 
   const replacements = {};
 


### PR DESCRIPTION
This makes `VERSION` available in the `ol` package.

```js
import ol from 'ol';

console.log(ol.VERSION);
```

In addition, if `ol.VERSION` is not set, assertion errors report the "latest" URL (e.g. https://openlayers.org/en/latest/doc/errors/#43).

The final change here replaces a normal `Error` with an `AssertionError` and moves the message to the website.