### PR TITLE
Correct path to cleancss

### DIFF
--- a/package/readme.md
+++ b/package/readme.md
@@ -2,8 +2,6 @@
 
 OpenLayers as ES2015 modules.
 
-**Note: This package is in beta and the API is subject to change before a final stable release.**
-
 ## Usage
 
 Add the `ol` package as a dependency to your project.
@@ -51,5 +49,4 @@ Utility functions are available as properties of the default export from utility
 
 ## Caveats
 
- * Module identifiers and the structure of the exports are subject to change while this package is in beta.
  * The WebGL renderer is not available in this package.

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -72,7 +72,7 @@ build_js() {
 }
 
 build_css() {
-  ./node_modules/clean-css/bin/cleancss css/ol.css -o ${BUILDS}/ol.css
+  ./node_modules/.bin/cleancss css/ol.css -o ${BUILDS}/ol.css
   cp css/ol.css ${BUILDS}/ol-debug.css
 }
 


### PR DESCRIPTION
This corrects the path to `cleancss` and removes the "beta" language from the `ol` package readme.