### PR TITLE
Added View#getInteracting() to the api

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -318,6 +318,16 @@ ol.View.prototype.getAnimating = function() {
 
 
 /**
+ * Determine if the user is interacting with the view, such as panning or zooming.
+ * @return {boolean} The view is being interacted with.
+ * @api
+ */
+ol.View.prototype.getInteracting = function() {
+  return this.getHints()[ol.ViewHint.INTERACTING] > 0;
+};
+
+
+/**
  * Cancel any ongoing animations.
  * @api
  */

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -310,11 +310,11 @@ describe('ol.View', function() {
       });
 
       expect(view.getHints()).to.eql([0, 0]);
-      expect(view.getInteracting()).to.eql(0);
+      expect(view.getInteracting()).to.eql(false);
 
       view.setHint(ol.ViewHint.INTERACTING, 1);
       expect(view.getHints()).to.eql([0, 1]);
-      expect(view.getInteracting()).to.eql(1);
+      expect(view.getInteracting()).to.eql(true);
     });
 
     it('triggers the change event', function(done) {
@@ -325,7 +325,7 @@ describe('ol.View', function() {
 
       view.on('change', function() {
         expect(view.getHints()).to.eql([0, 1]);
-        expect(view.getInteracting()).to.eql(1);
+        expect(view.getInteracting()).to.eql(true);
         done();
       });
       view.setHint(ol.ViewHint.INTERACTING, 1);

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -310,9 +310,11 @@ describe('ol.View', function() {
       });
 
       expect(view.getHints()).to.eql([0, 0]);
+      expect(view.getInteracting()).to.eql(0);
 
       view.setHint(ol.ViewHint.INTERACTING, 1);
       expect(view.getHints()).to.eql([0, 1]);
+      expect(view.getInteracting()).to.eql(1);
     });
 
     it('triggers the change event', function(done) {
@@ -323,6 +325,7 @@ describe('ol.View', function() {
 
       view.on('change', function() {
         expect(view.getHints()).to.eql([0, 1]);
+        expect(view.getInteracting()).to.eql(1);
         done();
       });
       view.setHint(ol.ViewHint.INTERACTING, 1);


### PR DESCRIPTION
Pull request for issue https://github.com/openlayers/openlayers/issues/6762

`View#getInteracting()` returns `true` when a user interaction is ongoing, e.g. during panning.
It is similar to `View#getAnimating()` for animations.

Note that a number interactions are continued by an animation, e.g. the view continues to pan after dragging it. In this case `View#getInteracting()` becomes `false` when the user releases the mouse button, but `View#getAnimating()` is `true` while the animation is running.