### PR TITLE
Add getId method for ol.render.Feature

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next release
 
+#### Removal of `ol.render.Feature#getGeometry()`
+
+The `ol.render.Feature#getGeometry()` function simply returns the feature itself. Users who relied on this function can use the `ol.render.Feature` instance directly instead.
+
 ### v4.1.0
 
 #### Adding duplicate layers to a map throws

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1981,9 +1981,9 @@ olx.format.MVTOptions;
  * {@link ol.Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link ol.render.Feature},
  * which is optimized for rendering and hit detection.
- * @type {undefined|function((ol.geom.Geometry|Object.<string, *>)=)|
+ * @type {undefined|function((ol.geom.Geometry|Object.<string,*>)=)|
  *     function(ol.geom.GeometryType,Array.<number>,
- *         (Array.<number>|Array.<Array.<number>>),Object.<string, *>)}
+ *         (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
  * @api
  */
 olx.format.MVTOptions.prototype.featureClass;

--- a/src/ol/format/mvt.js
+++ b/src/ol/format/mvt.js
@@ -44,9 +44,9 @@ ol.format.MVT = function(opt_options) {
 
   /**
    * @private
-   * @type {function((ol.geom.Geometry|Object.<string, *>)=)|
+   * @type {function((ol.geom.Geometry|Object.<string,*>)=)|
    *     function(ol.geom.GeometryType,Array.<number>,
-   *         (Array.<number>|Array.<Array.<number>>),Object.<string, *>)}
+   *         (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
    */
   this.featureClass_ = options.featureClass ?
       options.featureClass : ol.render.Feature;
@@ -137,8 +137,9 @@ ol.format.MVT.prototype.readRenderFeature_ = function(rawFeature, layer) {
 
   var values = rawFeature.properties;
   values[this.layerName_] = layer;
+  var id = rawFeature.id;
 
-  return new this.featureClass_(geometryType, flatCoordinates, ends, values);
+  return new this.featureClass_(geometryType, flatCoordinates, ends, values, id);
 };
 
 

--- a/src/ol/render/feature.js
+++ b/src/ol/render/feature.js
@@ -104,7 +104,6 @@ ol.render.Feature.prototype.getFlatCoordinates =
 /**
  * Get the feature for working with its geometry.
  * @return {ol.render.Feature} Feature.
- * @api
  */
 ol.render.Feature.prototype.getGeometry = function() {
   return this;

--- a/src/ol/render/feature.js
+++ b/src/ol/render/feature.js
@@ -16,13 +16,20 @@ goog.require('ol.geom.GeometryType');
  *     to be right-handed for polygons.
  * @param {Array.<number>|Array.<Array.<number>>} ends Ends or Endss.
  * @param {Object.<string, *>} properties Properties.
+ * @param {number|string|undefined} id Feature id.
  */
-ol.render.Feature = function(type, flatCoordinates, ends, properties) {
+ol.render.Feature = function(type, flatCoordinates, ends, properties, id) {
   /**
    * @private
    * @type {ol.Extent|undefined}
    */
   this.extent_;
+
+  /**
+   * @private
+   * @type {number|string|undefined}
+   */
+  this.id_ = id;
 
   /**
    * @private
@@ -83,6 +90,16 @@ ol.render.Feature.prototype.getExtent = function() {
 
   }
   return this.extent_;
+};
+
+/**
+ * Get the feature identifier.  This is a stable identifier for the feature and
+ * is set when reading data from a remote source.
+ * @return {number|string|undefined} Id.
+ * @api
+ */
+ol.render.Feature.prototype.getId = function() {
+  return this.id_;
 };
 
 

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -73,11 +73,18 @@ where('ArrayBuffer.isView').describe('ol.format.MVT', function() {
     });
 
     it('parses id property', function() {
+      // ol.Feature
       var format = new ol.format.MVT({
         featureClass: ol.Feature,
         layers: ['building']
       });
       var features = format.readFeatures(data);
+      expect(features[0].getId()).to.be(2);
+      // ol.render.Feature
+      format = new ol.format.MVT({
+        layers: ['building']
+      });
+      features = format.readFeatures(data);
       expect(features[0].getId()).to.be(2);
     });
 

--- a/test/spec/ol/render/feature.test.js
+++ b/test/spec/ol/render/feature.test.js
@@ -14,7 +14,7 @@ describe('ol.render.Feature', function() {
   describe('Constructor', function() {
     it('creates an instance', function() {
       renderFeature =
-          new ol.render.Feature(type, flatCoordinates, ends, properties);
+          new ol.render.Feature(type, flatCoordinates, ends, properties, 'foo');
       expect(renderFeature).to.be.a(ol.render.Feature);
     });
   });
@@ -54,6 +54,12 @@ describe('ol.render.Feature', function() {
   describe('#getGeometry()', function() {
     it('returns itself as geometry', function() {
       expect(renderFeature.getGeometry()).to.equal(renderFeature);
+    });
+  });
+
+  describe('#getId()', function() {
+    it('returns the feature id', function() {
+      expect(renderFeature.getId()).to.be('foo');
     });
   });
 


### PR DESCRIPTION
This pull request also removes the `getGeometry()` function from the API, which was not really useful.

Fixes #6800.