### PR TITLE
Remove unused setFeatures and getFormat methods

### DIFF
--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -260,16 +260,6 @@ ol.VectorImageTile.prototype.load = function() {
 
 
 /**
- * @param {Array.<ol.Feature>} features Features.
- * @api
- */
-ol.VectorImageTile.prototype.setFeatures = function(features) {
-  this.features_ = features;
-  this.setState(ol.TileState.LOADED);
-};
-
-
-/**
  * @param {ol.TileState} tileState Tile state.
  */
 ol.VectorImageTile.prototype.setState = function(tileState) {

--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -44,12 +44,6 @@ ol.VectorImageTile = function(tileCoord, state, src, format, tileLoadFunction,
 
   /**
    * @private
-   * @type {ol.format.Feature}
-   */
-  this.format_ = format;
-
-  /**
-   * @private
    * @type {ol.FeatureLoader}
    */
   this.loader_;
@@ -168,16 +162,6 @@ ol.VectorImageTile.prototype.getContext = function() {
 ol.VectorImageTile.prototype.getImage = function() {
   return this.replayState_.renderedTileRevision == -1 ?
       null : this.context_.canvas;
-};
-
-
-/**
- * Get the feature format assigned for reading this tile's features.
- * @return {ol.format.Feature} Feature format.
- * @api
- */
-ol.VectorImageTile.prototype.getFormat = function() {
-  return this.format_;
 };
 
 


### PR DESCRIPTION
The new `ol.VectorImageTile` class has a `setFeatures` API method, which is neither working nor used. This pull request suggests to remove it, along with the unused `getFormat` method.