### PR TITLE
Prepend the version with a v

### DIFF
--- a/transforms/module.js
+++ b/transforms/module.js
@@ -132,7 +132,7 @@ module.exports = function(info, api) {
   // replace `ol.VERSION = ''` with correct version
   root.find(j.ExpressionStatement, getMemberExpressionAssignment('ol.VERSION'))
     .forEach(path => {
-      path.value.expression.right = j.literal(thisPackage.version);
+      path.value.expression.right = j.literal('v' + thisPackage.version);
     });
 
   const replacements = {};


### PR DESCRIPTION
Errors in the `ol` package have messages like this:

> AssertionError: Assertion failed. See https://openlayers.org/en/4.1.1/doc/errors/#25 for details.

Instead, the URL should be https://openlayers.org/en/v4.1.1/doc/errors/#25