### PR TITLE
Re-add ol.render.Feature#getGeometry()

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,10 +2,6 @@
 
 ### Next release
 
-#### Removal of `ol.render.Feature#getGeometry()`
-
-The `ol.render.Feature#getGeometry()` function simply returns the feature itself. Users who relied on this function can use the `ol.render.Feature` instance directly instead.
-
 ### v4.1.0
 
 #### Adding duplicate layers to a map throws

--- a/src/ol/render/feature.js
+++ b/src/ol/render/feature.js
@@ -119,7 +119,8 @@ ol.render.Feature.prototype.getFlatCoordinates =
 
 
 /**
- * Get the feature for working with its geometry.
+ * For API compatibility with {@link ol.Feature}, this method is useful when
+ * determining the geometry type in style function (see {@link #getType}).
  * @return {ol.render.Feature} Feature.
  * @api
  */

--- a/src/ol/render/feature.js
+++ b/src/ol/render/feature.js
@@ -121,6 +121,7 @@ ol.render.Feature.prototype.getFlatCoordinates =
 /**
  * Get the feature for working with its geometry.
  * @return {ol.render.Feature} Feature.
+ * @api
  */
 ol.render.Feature.prototype.getGeometry = function() {
   return this;


### PR DESCRIPTION
#6801 broke the `mapbox-vector-tiles.html` and `mapbox-vector-tiles-advanced.html` examples by removing the `ol.render.Feature#getGeometry()` method. This pull request reverts that commit and improves the documentation of the `#getGeometry()` method.