### PR TITLE
Add tileJSON option to ol.source.TileJSON

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -6004,8 +6004,9 @@ olx.source.TileArcGISRestOptions.prototype.urls;
  *     crossOrigin: (null|string|undefined),
  *     jsonp: (boolean|undefined),
  *     reprojectionErrorThreshold: (number|undefined),
+ *     tileJSON: (TileJSON|undefined),
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: string,
+ *     url: (string|undefined),
  *     wrapX: (boolean|undefined)}}
  */
 olx.source.TileJSONOptions;
@@ -6060,6 +6061,15 @@ olx.source.TileJSONOptions.prototype.reprojectionErrorThreshold;
 
 
 /**
+ * TileJSON configuration for this source. If not provided, `url` must be
+ * configured.
+ * @type {TileJSON|undefined}
+ * @api
+ */
+olx.source.TileJSONOptions.prototype.tileJSON;
+
+
+/**
  * Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
@@ -6073,8 +6083,8 @@ olx.source.TileJSONOptions.prototype.tileLoadFunction;
 
 
 /**
- * URL to the TileJSON file.
- * @type {string}
+ * URL to the TileJSON file. If not provided, `tileJSON` must be configured.
+ * @type {string|undefined}
  * @api
  */
 olx.source.TileJSONOptions.prototype.url;

--- a/externs/tilejson.js
+++ b/externs/tilejson.js
@@ -5,7 +5,6 @@
  */
 
 
-
 /**
  * @constructor
  */

--- a/src/ol/source/tilejson.js
+++ b/src/ol/source/tilejson.js
@@ -9,6 +9,7 @@ goog.provide('ol.source.TileJSON');
 goog.require('ol');
 goog.require('ol.Attribution');
 goog.require('ol.TileUrlFunction');
+goog.require('ol.asserts');
 goog.require('ol.extent');
 goog.require('ol.net');
 goog.require('ol.proj');
@@ -45,15 +46,21 @@ ol.source.TileJSON = function(options) {
     wrapX: options.wrapX !== undefined ? options.wrapX : true
   });
 
-  if (options.jsonp) {
-    ol.net.jsonp(options.url, this.handleTileJSONResponse.bind(this),
-        this.handleTileJSONError.bind(this));
+  if (options.url) {
+    if (options.jsonp) {
+      ol.net.jsonp(options.url, this.handleTileJSONResponse.bind(this),
+          this.handleTileJSONError.bind(this));
+    } else {
+      var client = new XMLHttpRequest();
+      client.addEventListener('load', this.onXHRLoad_.bind(this));
+      client.addEventListener('error', this.onXHRError_.bind(this));
+      client.open('GET', options.url);
+      client.send();
+    }
+  } else if (options.tileJSON) {
+    this.handleTileJSONResponse(options.tileJSON);
   } else {
-    var client = new XMLHttpRequest();
-    client.addEventListener('load', this.onXHRLoad_.bind(this));
-    client.addEventListener('error', this.onXHRError_.bind(this));
-    client.open('GET', options.url);
-    client.send();
+    ol.asserts.assert(false, 51); // Either `url` or `tileJSON` options must be provided
   }
 
 };

--- a/test/spec/ol/source/tilejson.test.js
+++ b/test/spec/ol/source/tilejson.test.js
@@ -32,6 +32,45 @@ describe('ol.source.TileJSON', function() {
         }
       });
     });
+
+    it ('parses inline TileJSON', function() {
+      var tileJSON = {
+        bounds: [
+          -180,
+          -85.05112877980659,
+          180,
+          85.05112877980659
+        ],
+        center: [
+          0,
+          0,
+          4
+        ],
+        created: 1322764050886,
+        description: 'One of the example maps that comes with TileMill - a bright & colorful world map that blends retro and high-tech with its folded paper texture and interactive flag tooltips. ',
+        download: 'https://a.tiles.mapbox.com/v3/mapbox.geography-class.mbtiles',
+        embed: 'https://a.tiles.mapbox.com/v3/mapbox.geography-class.html',
+        id: 'mapbox.geography-class',
+        mapbox_logo: true,
+        maxzoom: 8,
+        minzoom: 0,
+        name: 'Geography Class',
+        private: false,
+        scheme: 'xyz',
+        tilejson: '2.2.0',
+        tiles: [
+          'https://a.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png',
+          'https://b.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png'
+        ],
+        version: '1.0.0',
+        webpage: 'https://a.tiles.mapbox.com/v3/mapbox.geography-class/page.html'
+      };
+      var source = new ol.source.TileJSON({
+        tileJSON: tileJSON
+      });
+      expect(source.getState()).to.be('ready');
+      expect(source.getTileUrlFunction()([0, 0, -1])).to.be('https://b.tiles.mapbox.com/v3/mapbox.geography-class/0/0/0.png');
+    });
   });
 
   describe('#getState', function() {


### PR DESCRIPTION
Like #5120 did for `ol.source.TileUTFGrid`, this pull request adds a `tileJSON` option to `ol.source.TileJSON` for support of inline TileJSON.