### PR TITLE
Adjust/fix API for working with vector tile features

### DIFF
--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -108,7 +108,8 @@ ol.renderer.canvas.VectorTileLayer.prototype.createReplayGroup_ = function(
   var pixelRatio = frameState.pixelRatio;
   var projection = frameState.viewState.projection;
   var revision = layer.getRevision();
-  var renderOrder = layer.getRenderOrder() || null;
+  var renderOrder = /** @type {ol.RenderOrderFunction} */
+      (layer.getRenderOrder()) || null;
 
   var replayState = tile.getReplayState();
   if (!replayState.dirty && replayState.renderedRevision == revision &&

--- a/src/ol/source/vectortile.js
+++ b/src/ol/source/vectortile.js
@@ -4,8 +4,6 @@ goog.require('ol');
 goog.require('ol.TileState');
 goog.require('ol.VectorImageTile');
 goog.require('ol.VectorTile');
-goog.require('ol.events');
-goog.require('ol.events.EventType');
 goog.require('ol.proj');
 goog.require('ol.size');
 goog.require('ol.tilegrid');
@@ -114,9 +112,8 @@ ol.source.VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projectio
         tileUrl !== undefined ? tileUrl : '',
         this.format_, this.tileLoadFunction, urlTileCoord, this.tileUrlFunction,
         this.tileGrid, this.getTileGridForProjection(projection),
-        this.sourceTiles_, pixelRatio, projection, this.tileClass);
-    ol.events.listen(tile, ol.events.EventType.CHANGE,
-        this.handleTileChange, this);
+        this.sourceTiles_, pixelRatio, projection, this.tileClass,
+        this.handleTileChange.bind(this));
 
     this.tileCache.set(tileCoordKey, tile);
     return tile;

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -453,9 +453,11 @@ ol.RegularShapeRenderOptions;
 
 /**
  * A function to be used when sorting features before rendering.
- * It takes two instances of {@link ol.Feature} and returns a `{number}`.
+ * It takes two instances of {@link ol.Feature} or {@link ol.render.Feature} and
+ * returns a `{number}`.
  *
- * @typedef {function(ol.Feature, ol.Feature):number}
+ * @typedef {function((ol.Feature|ol.render.Feature), (ol.Feature|ol.render.Feature)):
+ *     number}
  */
 ol.RenderOrderFunction;
 

--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -168,7 +168,6 @@ ol.VectorImageTile.prototype.getContext = function() {
 /**
  * Get the Canvas for this tile.
  * @return {HTMLCanvasElement} Canvas.
- * @api
  */
 ol.VectorImageTile.prototype.getImage = function() {
   return this.replayState_.renderedTileRevision == -1 ?

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -77,7 +77,10 @@ ol.VectorTile.prototype.getFormat = function() {
 
 
 /**
- * @return {Array.<ol.Feature>} Features.
+ * Get the features for this tile. Geometries will be in the projection returned
+ * by {@link #getProjection}.
+ * @return {Array.<ol.Feature|ol.render.Feature>} Features.
+ * @api
  */
 ol.VectorTile.prototype.getFeatures = function() {
   return this.features_;
@@ -93,7 +96,9 @@ ol.VectorTile.prototype.getKey = function() {
 
 
 /**
+ * Get the feature projection of features returned by {@link #getFeatures}.
  * @return {ol.proj.Projection} Feature projection.
+ * @api
  */
 ol.VectorTile.prototype.getProjection = function() {
   return this.projection_;

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -67,6 +67,18 @@ ol.inherits(ol.VectorTile, ol.Tile);
 
 
 /**
+ * @inheritDoc
+ */
+ol.VectorTile.prototype.disposeInternal = function() {
+  this.features_ = null;
+  this.replayGroups_ = {};
+  this.state = ol.TileState.ABORT;
+  this.changed();
+  ol.Tile.prototype.disposeInternal.call(this);
+};
+
+
+/**
  * Get the feature format assigned for reading this tile's features.
  * @return {ol.format.Feature} Feature format.
  * @api

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -13,7 +13,8 @@ describe('ol.source.VectorTile', function() {
   var source = new ol.source.VectorTile({
     format: format,
     tileGrid: ol.tilegrid.createXYZ({tileSize: 512}),
-    url: '{z}/{x}/{y}.pbf'
+    tilePixelRatio: 8,
+    url: 'spec/ol/data/{z}-{x}-{y}.vector.pbf'
   });
   var tile;
 
@@ -44,6 +45,23 @@ describe('ol.source.VectorTile', function() {
     it('creates a tile grid with the source tile grid\'s tile size', function() {
       var tileGrid = source.getTileGridForProjection(ol.proj.get('EPSG:3857'));
       expect(tileGrid.getTileSize(0)).to.be(512);
+    });
+  });
+
+  describe('Tile load events', function() {
+    it('triggers tileloadstart and tileloadend with ol.VectorTile', function(done) {
+      tile = source.getTile(14, 8938, -5681, 1, ol.proj.get('EPSG:3857'));
+      var started = false;
+      source.on('tileloadstart', function() {
+        started = true;
+      });
+      source.on('tileloadend', function(e) {
+        expect(started).to.be(true);
+        expect(e.tile).to.be.a(ol.VectorTile);
+        expect(e.tile.getFeatures().length).to.be(1327);
+        done();
+      });
+      tile.load();
     });
   });
 

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -16,7 +16,7 @@ describe('ol.VectorImageTile', function() {
         ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
-        1, ol.proj.get('EPSG:3857'), ol.VectorTile);
+        1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
 
     tile.load();
     var sourceTile = tile.getTile(tile.tileKeys[0]);
@@ -36,7 +36,7 @@ describe('ol.VectorImageTile', function() {
         ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
-        1, ol.proj.get('EPSG:3857'), ol.VectorTile);
+        1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
 
     tile.load();
 
@@ -52,7 +52,7 @@ describe('ol.VectorImageTile', function() {
     var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
         ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {},
         ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
-        1, ol.proj.get('EPSG:3857'), ol.VectorTile);
+        1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
 
     tile.load();
 
@@ -69,7 +69,7 @@ describe('ol.VectorImageTile', function() {
         ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ({tileSize: 512}), {},
-        1, ol.proj.get('EPSG:3857'), ol.VectorTile);
+        1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
 
     tile.load();
     expect(tile.loadListenerKeys_.length).to.be(4);
@@ -89,7 +89,7 @@ describe('ol.VectorImageTile', function() {
         ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ({tileSize: 512}), {},
-        1, ol.proj.get('EPSG:3857'), ol.VectorTile);
+        1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
 
     tile.load();
     ol.events.listenOnce(tile, 'change', function() {


### PR DESCRIPTION
This pull request suggests three changes:

1. Fix tile load events for `ol.source.VectorTile`: Before #6779, when registering for tile load events on `ol.source.VectorTile`, load events were fired for `ol.VectorTile` instances. Now they are fired with `ol.VectorImageTile` instances, which is problematic because these tiles neither match the `tileGrid` that the source is configured with, nor the tiles that are passed to the `tileLoadFunction` of the source.
2. Make `ol.VectorTile#getFeatures` and `#getProjection` exportable.
3. Remove `ol.VectorImageTile` from the API.

**Background:**
For applications that need to work with vector tile features/geometries, it is currently impossible to do so. By monitoring tile loads, and having access to the tile grid and each tile's features, it should be possible to transform feature geometries from tile pixels to view coordinates. A possible workflow would be the following:
```js
var tiles = {};
vectorTileSource.on('tileloadend', function(e) {
  tiles[e.tile.getTileCoord()] = e.tile;
});
// Now we know the loaded tiles, let's get the geometries inside the viewport
vectorTileSource.getTileGrid().forEachTileCoord(view.calculateExtent(), Math.round(view.getZoom()), function(tileCoord) {
  var tile = tiles[tileCoord];
  var features = tile.getFeatures();
  var projection = tile.getProjection();
  if (projection.getUnits() == 'tile-pixels') {
    // Transform feature geometry coordinates
    // Do something with geometries
  }
});
```
