### PR TITLE
Webgl vector improvements

### DIFF
--- a/src/ol/render/webgl/linestringreplay.js
+++ b/src/ol/render/webgl/linestringreplay.js
@@ -324,16 +324,19 @@ if (ol.ENABLE_WEBGL) {
    */
   ol.render.webgl.LineStringReplay.prototype.drawMultiLineString = function(multiLineStringGeometry, feature) {
     var indexCount = this.indices.length;
-    var lineStringGeometries = multiLineStringGeometry.getLineStrings();
+    var ends = multiLineStringGeometry.getEnds();
+    ends.unshift(0);
+    var flatCoordinates = multiLineStringGeometry.getFlatCoordinates();
+    var stride = multiLineStringGeometry.getStride();
     var i, ii;
-    for (i = 0, ii = lineStringGeometries.length; i < ii; ++i) {
-      var flatCoordinates = lineStringGeometries[i].getFlatCoordinates();
-      var stride = lineStringGeometries[i].getStride();
-      if (this.isValid_(flatCoordinates, 0, flatCoordinates.length, stride)) {
-        flatCoordinates = ol.geom.flat.transform.translate(flatCoordinates, 0, flatCoordinates.length,
-            stride, -this.origin[0], -this.origin[1]);
-        this.drawCoordinates_(
-            flatCoordinates, 0, flatCoordinates.length, stride);
+    if (ends.length > 1) {
+      for (i = 1, ii = ends.length; i < ii; ++i) {
+        if (this.isValid_(flatCoordinates, ends[i - 1], ends[i], stride)) {
+          var lineString = ol.geom.flat.transform.translate(flatCoordinates, ends[i - 1], ends[i],
+              stride, -this.origin[0], -this.origin[1]);
+          this.drawCoordinates_(
+              lineString, 0, lineString.length, stride);
+        }
       }
     }
     if (this.indices.length > indexCount) {

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -215,3 +215,14 @@ ol.structs.RBush.prototype.getExtent = function(opt_extent) {
   var data = this.rbush_.data;
   return ol.extent.createOrUpdate(data.minX, data.minY, data.maxX, data.maxY, opt_extent);
 };
+
+
+/**
+ * @param {ol.structs.RBush} rbush R-Tree.
+ */
+ol.structs.RBush.prototype.concat = function(rbush) {
+  this.rbush_.load(rbush.rbush_.all());
+  for (var i in rbush.items_) {
+    this.items_[i | 0] = rbush.items_[i | 0];
+  }
+};

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -313,4 +313,29 @@ describe('ol.structs.RBush', function() {
 
   });
 
+  describe('#concat', function() {
+
+    it('concatenates two RBush objects', function() {
+      var obj1 = {};
+      var obj2 = {};
+      var rBush2 = new ol.structs.RBush();
+      rBush.insert([0, 0, 1, 1], obj1);
+      rBush2.insert([0, 0, 2, 2], obj2);
+      rBush.concat(rBush2);
+      expect(rBush.getExtent()).to.eql([0, 0, 2, 2]);
+      expect(rBush.getAll().length).to.be(2);
+    });
+
+    it('preserves the concatenated object\'s references', function() {
+      var obj1 = {};
+      var obj2 = {};
+      var rBush2 = new ol.structs.RBush();
+      rBush.insert([0, 0, 1, 1], obj1);
+      rBush2.insert([0, 0, 2, 2], obj2);
+      rBush.concat(rBush2);
+      rBush.update([0, 0, 3, 3], obj2);
+      expect(rBush.getExtent()).to.eql([0, 0, 3, 3]);
+    });
+  });
+
 });


### PR DESCRIPTION
Some minor improvements in rendering vectors with the WebGL renderer.

- Fixes #6823's rendering problems.
- Makes WebGL vector replays compatible with `ol.render.Feature`.
- Maps flat coordinates to numbers (see also #6823).