### PR TITLE
Remove the mouse only limitation for ol.interaction.DragBox

### DIFF
--- a/src/ol/interaction/dragbox.js
+++ b/src/ol/interaction/dragbox.js
@@ -17,8 +17,6 @@ goog.require('ol.render.Box');
  * (see {@link ol.interaction.DragZoom} and
  * {@link ol.interaction.DragRotateAndZoom}).
  *
- * This interaction is only supported for mouse devices.
- *
  * @constructor
  * @extends {ol.interaction.Pointer}
  * @fires ol.interaction.DragBox.Event
@@ -93,10 +91,6 @@ ol.interaction.DragBox.defaultBoxEndCondition = function(mapBrowserEvent, startP
  * @private
  */
 ol.interaction.DragBox.handleDragEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return;
-  }
-
   this.box_.setPixels(this.startPixel_, mapBrowserEvent.pixel);
 
   this.dispatchEvent(new ol.interaction.DragBox.Event(ol.interaction.DragBox.EventType_.BOXDRAG,
@@ -130,10 +124,6 @@ ol.interaction.DragBox.prototype.onBoxEnd = ol.nullFunction;
  * @private
  */
 ol.interaction.DragBox.handleUpEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return true;
-  }
-
   this.box_.setMap(null);
 
   if (this.boxEndCondition_(mapBrowserEvent,
@@ -153,12 +143,7 @@ ol.interaction.DragBox.handleUpEvent_ = function(mapBrowserEvent) {
  * @private
  */
 ol.interaction.DragBox.handleDownEvent_ = function(mapBrowserEvent) {
-  if (!ol.events.condition.mouseOnly(mapBrowserEvent)) {
-    return false;
-  }
-
-  if (ol.events.condition.mouseActionButton(mapBrowserEvent) &&
-      this.condition_(mapBrowserEvent)) {
+  if (ol.events.condition.primaryAction(mapBrowserEvent) && this.condition_(mapBrowserEvent)) {
     this.startPixel_ = mapBrowserEvent.pixel;
     this.box_.setMap(mapBrowserEvent.map);
     this.box_.setPixels(this.startPixel_, this.startPixel_);

--- a/src/ol/interaction/pointer.js
+++ b/src/ol/interaction/pointer.js
@@ -183,7 +183,11 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
 
   var stopEvent = false;
   this.updateTrackedPointers_(mapBrowserEvent);
-  if (this.handlingDownUpSequence) {
+  if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDOWN) {
+    var handled = this.handleDownEvent_(mapBrowserEvent);
+    this.handlingDownUpSequence = this.handlingDownUpSequence || handled;
+    stopEvent = this.shouldStopEvent(handled);
+  } else if (this.handlingDownUpSequence) {
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDRAG) {
       this.handleDragEvent_(mapBrowserEvent);
     } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
@@ -191,11 +195,7 @@ ol.interaction.Pointer.handleEvent = function(mapBrowserEvent) {
       this.handlingDownUpSequence = handledUp && this.targetPointers.length > 0;
     }
   } else {
-    if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERDOWN) {
-      var handled = this.handleDownEvent_(mapBrowserEvent);
-      this.handlingDownUpSequence = handled;
-      stopEvent = this.shouldStopEvent(handled);
-    } else if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERMOVE) {
+    if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERMOVE) {
       this.handleMoveEvent_(mapBrowserEvent);
     }
   }


### PR DESCRIPTION
Following up on #3690, and add the ability for `DragBox` to handle 2 pointers.

However, I didn't think it was useful to remove the mouse-only limitation on `DragRotate` and `DragRotateAndZoom`, since `PinchZoom` and `PinchRotate` work.