### PR TITLE
Center map on proper earth, not one to the left

### DIFF
--- a/examples/rotation.js
+++ b/examples/rotation.js
@@ -18,7 +18,7 @@ var map = new ol.Map({
     })
   }),
   view: new ol.View({
-    center: [-25860000, 4130000],
+    center: [[14200000, 4130000],
     rotation: Math.PI / 6,
     zoom: 10
   })

--- a/examples/rotation.js
+++ b/examples/rotation.js
@@ -18,7 +18,7 @@ var map = new ol.Map({
     })
   }),
   view: new ol.View({
-    center: [[14200000, 4130000],
+    center: [14200000, 4130000],
     rotation: Math.PI / 6,
     zoom: 10
   })


### PR DESCRIPTION
The previous x coordinate was one earth to the left which led to confusing results with everything.
This change makes sure the map is centered in a proper location (pretty much the same as before) WITHIN proper bounds.