### PR TITLE
Remove unused var from ol.proj

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -148,10 +148,7 @@ ol.proj.addProjection = function(projection) {
  * @param {Array.<ol.proj.Projection>} projections Projections.
  */
 ol.proj.addProjections = function(projections) {
-  var addedProjections = [];
-  projections.forEach(function(projection) {
-    addedProjections.push(ol.proj.addProjection(projection));
-  });
+  projections.forEach(ol.proj.addProjection);
 };
 
 


### PR DESCRIPTION
A minor tidy-up I noticed when looking at proj. `addProjections()` used to return the added projections, but looks like it stopped doing so in #1228, so the variable is no longer used.