### PR TITLE
Fix decimals options when writing features

### DIFF
--- a/src/ol/format/feature.js
+++ b/src/ol/format/feature.js
@@ -190,7 +190,7 @@ ol.format.Feature.transformWithOptions = function(
   } else {
     transformed = geometry;
   }
-  if (write && opt_options && opt_options.decimals) {
+  if (write && opt_options && opt_options.decimals !== undefined) {
     var power = Math.pow(10, opt_options.decimals);
     // if decimals option on write, round each coordinate appropriately
     /**

--- a/src/ol/format/feature.js
+++ b/src/ol/format/feature.js
@@ -183,9 +183,9 @@ ol.format.Feature.transformWithOptions = function(
       // FIXME this is necessary because ol.format.GML treats extents
       // as geometries
       transformed = ol.proj.transformExtent(
-          write ? geometry.slice() : geometry,
-          write ? featureProjection : dataProjection,
-          write ? dataProjection : featureProjection);
+          geometry,
+          dataProjection,
+          featureProjection);
     }
   } else {
     transformed = geometry;
@@ -203,14 +203,10 @@ ol.format.Feature.transformWithOptions = function(
       }
       return coordinates;
     };
-    if (Array.isArray(transformed)) {
-      transform(transformed);
-    } else {
-      if (transformed === geometry) {
-        transformed = transformed.clone();
-      }
-      transformed.applyTransform(transform);
+    if (transformed === geometry) {
+      transformed = transformed.clone();
     }
+    transformed.applyTransform(transform);
   }
   return transformed;
 };

--- a/src/ol/format/feature.js
+++ b/src/ol/format/feature.js
@@ -206,6 +206,9 @@ ol.format.Feature.transformWithOptions = function(
     if (Array.isArray(transformed)) {
       transform(transformed);
     } else {
+      if (transformed === geometry) {
+        transformed = transformed.clone();
+      }
       transformed.applyTransform(transform);
     }
   }

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -829,6 +829,18 @@ describe('ol.format.GeoJSON', function() {
       expect(linestring.getCoordinates()).to.eql(
           [[42.123456789, 38.987654321], [43, 39]]);
     });
+
+    it('rounds a linestring with decimals option = 0', function() {
+      var linestring = new ol.geom.LineString([[42.123456789, 38.987654321],
+          [43, 39]]);
+      var geojson = format.writeGeometry(linestring, {
+        decimals: 0
+      });
+      expect(format.readGeometry(geojson).getCoordinates()).to.eql(
+          [[42, 39], [43, 39]]);
+      expect(linestring.getCoordinates()).to.eql(
+          [[42.123456789, 38.987654321], [43, 39]]);
+    });
   });
 
 });

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -826,6 +826,8 @@ describe('ol.format.GeoJSON', function() {
       });
       expect(format.readGeometry(geojson).getCoordinates()).to.eql(
           [[42.123457, 38.987654], [43, 39]]);
+      expect(linestring.getCoordinates()).to.eql(
+          [[42.123456789, 38.987654321], [43, 39]]);
     });
   });
 


### PR DESCRIPTION
Fixes #6881.

And also removes some dead code (`write` is always `false` when `geometry` is an `Extent`) and allows `decimals = 0`.