### PR TITLE
Change overlay positioning to use percentage of mapSize

### DIFF
--- a/src/ol/overlay.js
+++ b/src/ol/overlay.js
@@ -475,7 +475,7 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
     if (this.rendered_.left_ !== '') {
       this.rendered_.left_ = style.left = '';
     }
-    var right = Math.round(mapSize[0] - pixel[0] - offsetX) + 'px';
+    var right = (Math.round(mapSize[0] - pixel[0] - offsetX) * 100 / mapSize[0]) + '%';
     if (this.rendered_.right_ != right) {
       this.rendered_.right_ = style.right = right;
     }
@@ -488,7 +488,7 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
         positioning == ol.OverlayPositioning.TOP_CENTER) {
       offsetX -= this.element_.offsetWidth / 2;
     }
-    var left = Math.round(pixel[0] + offsetX) + 'px';
+    var left = (Math.round(pixel[0] + offsetX) * 100 / mapSize[0]) + '%';
     if (this.rendered_.left_ != left) {
       this.rendered_.left_ = style.left = left;
     }
@@ -499,7 +499,7 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
     if (this.rendered_.top_ !== '') {
       this.rendered_.top_ = style.top = '';
     }
-    var bottom = Math.round(mapSize[1] - pixel[1] - offsetY) + 'px';
+    var bottom = (Math.round(mapSize[1] - pixel[1] - offsetY) * 100 / mapSize[1]) + '%';
     if (this.rendered_.bottom_ != bottom) {
       this.rendered_.bottom_ = style.bottom = bottom;
     }
@@ -512,7 +512,7 @@ ol.Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
         positioning == ol.OverlayPositioning.CENTER_RIGHT) {
       offsetY -= this.element_.offsetHeight / 2;
     }
-    var top = Math.round(pixel[1] + offsetY) + 'px';
+    var top = (Math.round(pixel[1] + offsetY) * 100 / mapSize[1]) + '%';
     if (this.rendered_.top_ != top) {
       this.rendered_.top_ = style.top = top;
     }


### PR DESCRIPTION

Change overlay positioning to use percentage of mapSize rather than absolute pixel values.

This resolves overlay position appearing differently in print preview
or when printing from the browser. I believe the problem is the rasterization of
the image for printing causes a different effective pixel size for the map,
but no javascript events fire during printing or print preview preparation that
allow map to be reloaded or overlays repositioned.

By positioning overlay using percentage of the parent, it avoids this problem and
the print preview in the browser shows the correct overlay position.