### PR TITLE
Fix minor type strength inconsistency

### DIFF
--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -614,7 +614,7 @@ ol.source.Vector.prototype.getClosestFeatureToCoordinate = function(coordinate, 
  * `useSpatialIndex` set to `false`.
  * @param {ol.Extent=} opt_extent Destination extent. If provided, no new extent
  *     will be created. Instead, that extent's coordinates will be overwritten.
- * @return {!ol.Extent} Extent.
+ * @return {ol.Extent} Extent.
  * @api
  */
 ol.source.Vector.prototype.getExtent = function(opt_extent) {

--- a/src/ol/structs/rbush.js
+++ b/src/ol/structs/rbush.js
@@ -208,7 +208,7 @@ ol.structs.RBush.prototype.clear = function() {
 
 /**
  * @param {ol.Extent=} opt_extent Extent.
- * @return {!ol.Extent} Extent.
+ * @return {ol.Extent} Extent.
  */
 ol.structs.RBush.prototype.getExtent = function(opt_extent) {
   // FIXME add getExtent() to rbush


### PR DESCRIPTION
There is a minor type-strength issue (we are still using plovr on some projects and this actually causes the compilation to fail).

It's quite simple matter of nullability:
`ol.structs.RBush#getExtent` directly returns result of `ol.extent.createOrUpdate`, which is more loosely typed.

The more common "code style" seems to be to assume everything nullable and omit the `!` almost everywhere, so I created this PR this way.

Alternatively, it would be possible to strengthen the return type of 
`ol.extent.createOrUpdate` (https://github.com/openlayers/openlayers/blob/master/src/ol/extent.js#L208) to `{!ol.Extent}` - this would work as well, but create a minor code style inconsistency.

