### PR TITLE
Improve proj.get() logic

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -291,9 +291,9 @@ ol.proj.get = function(projectionLike) {
   } else if (typeof projectionLike === 'string') {
     var code = projectionLike;
     projection = ol.proj.projections.get(code);
-    if (ol.ENABLE_PROJ4JS) {
+    if (ol.ENABLE_PROJ4JS && !projection) {
       var proj4js = ol.proj.proj4.get();
-      if (!projection && typeof proj4js == 'function' &&
+      if (typeof proj4js == 'function' &&
           proj4js.defs(code) !== undefined) {
         projection = new ol.proj.Projection({code: code});
         ol.proj.addProjection(projection);


### PR DESCRIPTION
The majority case is that there is already a projection in `projections`, in which case there's no need to access proj4 whether it's enabled or not.