### PR TITLE
Queue tiles before loading

### DIFF
--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -220,8 +220,6 @@ ol.source.Raster.prototype.getImage = function(extent, resolution, pixelRatio, p
   var frameState = this.updateFrameState_(extent, resolution, projection);
   this.requestedFrameState_ = frameState;
 
-  frameState.tileQueue.loadMoreTiles(16, 16);
-
   // check if we can't reuse the existing ol.ImageCanvas
   if (this.renderedImageCanvas_) {
     var renderedResolution = this.renderedImageCanvas_.getResolution();
@@ -235,6 +233,7 @@ ol.source.Raster.prototype.getImage = function(extent, resolution, pixelRatio, p
     this.processSources_();
   }
 
+  frameState.tileQueue.loadMoreTiles(16, 16);
   return this.renderedImageCanvas_;
 };
 


### PR DESCRIPTION
In the raster source's `getImage()` method we need to initiate tile loading.  This currently happens *before* asking the underlying sources to queue up tiles.  Things work since there are often extra render calls.  But in cases where a raster source is added to the map and the underlying source is not, you have to rely on this extra render to get things going.

Instead, underlying sources should first queue up tiles and then the raster source can ask for more tile loads.
