### PR TITLE
Add RoadOnDemand imagery set to Bing example

### DIFF
--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -12,7 +12,8 @@ cloak:
  <select id="layer-select">
    <option value="Aerial">Aerial</option>
    <option value="AerialWithLabels" selected>Aerial with labels</option>
-   <option value="Road">Road</option>
+   <option value="Road">Road (static)</option>
+   <option value="RoadOnDemand">Road (dynamic)</option>
    <option value="collinsBart">Collins Bart</option>
    <option value="ordnanceSurvey">Ordnance Survey</option>
  </select>

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -6,6 +6,7 @@ goog.require('ol.source.BingMaps');
 
 var styles = [
   'Road',
+  'RoadOnDemand',
   'Aerial',
   'AerialWithLabels',
   'collinsBart',


### PR DESCRIPTION
This pull request adds the dynamic `RoadOnDemand` imagery set mentioned in #6708 to the `bing-maps` example.