### PR TITLE
Handle error tiles properly

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -144,9 +144,14 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame = function(frameState, layer
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
       tile = tileSource.getTile(z, x, y, pixelRatio, projection);
-      // When useInterimTilesOnError is false, we consider the error tile as loaded.
-      if (tile.getState() == ol.TileState.ERROR && !this.getLayer().getUseInterimTilesOnError()) {
-        tile.setState(ol.TileState.LOADED);
+      if (tile.getState() == ol.TileState.ERROR) {
+        if (!tileLayer.getUseInterimTilesOnError()) {
+          // When useInterimTilesOnError is false, we consider the error tile as loaded.
+          tile.setState(ol.TileState.LOADED);
+        } else if (tileLayer.getPreload() > 0) {
+          // Preloaded tiles for lower resolutions might have finished loading.
+          newTiles = true;
+        }
       }
       if (!this.isDrawableTile_(tile)) {
         tile = tile.getInterimTile();

--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -244,17 +244,18 @@ ol.VectorImageTile.prototype.load = function() {
  */
 ol.VectorImageTile.prototype.finishLoading_ = function() {
   var errors = false;
-  var tile;
-  for (var i = this.tileKeys.length - 1; i >= 0; --i) {
-    tile = this.getTile(this.tileKeys[i]);
-    if (tile.getState() == ol.TileState.ERROR) {
-      errors = true;
-    }
-    if (tile.getState() != ol.TileState.LOADED) {
-      this.tileKeys.splice(i, 1);
+  var loaded = this.tileKeys.length;
+  var state;
+  for (var i = loaded - 1; i >= 0; --i) {
+    state = this.getTile(this.tileKeys[i]).getState();
+    if (state != ol.TileState.LOADED) {
+      if (state == ol.TileState.ERROR) {
+        errors = true;
+      }
+      --loaded;
     }
   }
-  this.setState(this.tileKeys.length > 0 ?
+  this.setState(loaded > 0 ?
     ol.TileState.LOADED :
     (errors ? ol.TileState.ERROR : ol.TileState.EMPTY));
 };


### PR DESCRIPTION
Fixes #6969.

By deleting tile keys for error or empty tiles that belong to a VectorImageTile, the queue/cache key of the VectorImageTile changes. This pull request changes things so tile keys are no longer deleted when determining whether the tile should get an `ol.TileState.ERROR` or `ol.TileState.EMPTY`.

An additional issue is with the renderer when there are error tiles. When the layer is configured with a `preload`, lower resolution tiles will replace error tiles. But these were not displayed immediately, because they were not detected as loaded tiles.