### PR TITLE
Utilize `deviceorientationabsolute` event.

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -39,7 +39,8 @@ olx.AttributionOptions.prototype.html;
 
 
 /**
- * @typedef {{tracking: (boolean|undefined)}}
+ * @typedef {{tracking: (boolean|undefined),
+ *    absolute: (boolean|undefined)}}
  */
 olx.DeviceOrientationOptions;
 
@@ -50,6 +51,15 @@ olx.DeviceOrientationOptions;
  * @api
  */
 olx.DeviceOrientationOptions.prototype.tracking;
+
+
+/**
+ * Utilize the `deviceorientationabsolute` event on supported
+ * browsers. Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.DeviceOrientationOptions.prototype.absolute;
 
 
 /**

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -41,9 +41,9 @@ goog.require('ol.math');
  * much the device has been rotated around the Y axis, or how much it is tilted
  * from left to right.
  *
- * For most browsers, the `alpha` value returns the compass heading so if the
- * device points north, it will be 0.  With Safari on iOS, the 0 value of
- * `alpha` is calculated from when device orientation was first requested.
+ * For some browsers, the `alpha` value returns the compass heading so if the
+ * device points north, it will be 0.  With Google Chrome and Safari on iOS, the
+ * value of `alpha` is relative to when device orientation was first requested.
  * ol.DeviceOrientation provides the `heading` property which normalizes this
  * behavior across all browsers for you.
  *
@@ -66,7 +66,9 @@ ol.DeviceOrientation = function(opt_options) {
 
   ol.Object.call(this);
 
-  var options = opt_options ? opt_options : {};
+  var options = opt_options ? opt_options : {
+    absolute: false,
+  };
 
   /**
    * @private
@@ -80,6 +82,7 @@ ol.DeviceOrientation = function(opt_options) {
 
   this.setTracking(options.tracking !== undefined ? options.tracking : false);
 
+  this.absolute_ = options.absolute;
 };
 ol.inherits(ol.DeviceOrientation, ol.Object);
 
@@ -194,7 +197,13 @@ ol.DeviceOrientation.prototype.handleTrackingChanged_ = function() {
   if (ol.has.DEVICE_ORIENTATION) {
     var tracking = this.getTracking();
     if (tracking && !this.listenerKey_) {
-      this.listenerKey_ = ol.events.listen(window, 'deviceorientation',
+      var eventType;
+      if (this.absolute_ && ol.has.DEVICE_ORIENTATION_ABSOLUTE) {
+        eventType = 'deviceorientationabsolute';
+      } else {
+        eventType = 'deviceorientation';
+      }
+      this.listenerKey_ = ol.events.listen(window, eventType,
           this.orientationChange_, this);
     } else if (!tracking && this.listenerKey_ !== null) {
       ol.events.unlistenByKey(this.listenerKey_);

--- a/src/ol/deviceorientation.js
+++ b/src/ol/deviceorientation.js
@@ -67,7 +67,7 @@ ol.DeviceOrientation = function(opt_options) {
   ol.Object.call(this);
 
   var options = opt_options ? opt_options : {
-    absolute: false,
+    absolute: false
   };
 
   /**

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -89,6 +89,16 @@ ol.has.DEVICE_ORIENTATION = 'DeviceOrientationEvent' in window;
 
 
 /**
+ * Indicates if the `deviceorientationabsolute` DOM event is supported in the
+ * user's browser.
+ * @const
+ * @type {boolean}
+ * @api
+ */
+ol.has.DEVICE_ORIENTATION_ABSOLUTE = 'ondeviceorientationabsolute' in window;
+
+
+/**
  * Is HTML5 geolocation supported in the current browser?
  * @const
  * @type {boolean}


### PR DESCRIPTION
See #6974.

I have further changes to address the gamma offset, but will commit them tomorrow, possibly under separate pull request to facilitate easier testing.