### PR TITLE
Example - Earthquake Clusters - Change evt.type of interaction

### DIFF
--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -144,7 +144,7 @@ var map = new ol.Map({
   layers: [raster, vector],
   interactions: ol.interaction.defaults().extend([new ol.interaction.Select({
     condition: function(evt) {
-      return evt.originalEvent.type == 'mousemove' ||
+      return  evt.type == 'pointermove' ||
           evt.type == 'singleclick';
     },
     style: selectStyleFunction


### PR DESCRIPTION
OriginalEvent 'mousemove' break default OL interaction move of map canvas. Using OL event 'pointermove' have same function and allow move of map canvas.