### PR TITLE
Add missing type annotations

### DIFF
--- a/src/ol/renderer/canvas/vectortilelayer.js
+++ b/src/ol/renderer/canvas/vectortilelayer.js
@@ -260,7 +260,7 @@ ol.renderer.canvas.VectorTileLayer.prototype.forEachFeatureAtCoordinate = functi
       } else {
         tileSpaceCoordinate = coordinate;
       }
-      replayGroup = sourceTile.getReplayGroup(tile.tileCoord);
+      replayGroup = sourceTile.getReplayGroup(tile.tileCoord.toString());
       found = found || replayGroup.forEachFeatureAtCoordinate(
           tileSpaceCoordinate, resolution, rotation, hitTolerance, {},
           /**

--- a/src/ol/vectortile.js
+++ b/src/ol/vectortile.js
@@ -48,6 +48,10 @@ ol.VectorTile = function(tileCoord, state, src, format, tileLoadFunction) {
    */
   this.projection_;
 
+  /**
+   * @private
+   * @type {Object.<string, ol.render.ReplayGroup>}
+   */
   this.replayGroups_ = {};
 
   /**
@@ -117,6 +121,10 @@ ol.VectorTile.prototype.getProjection = function() {
 };
 
 
+/**
+ * @param {string} key Key.
+ * @return {ol.render.ReplayGroup} Replay group.
+ */
 ol.VectorTile.prototype.getReplayGroup = function(key) {
   return this.replayGroups_[key];
 };
@@ -173,6 +181,10 @@ ol.VectorTile.prototype.setProjection = function(projection) {
 };
 
 
+/**
+ * @param {string} key Key.
+ * @param {ol.render.ReplayGroup} replayGroup Replay group.
+ */
 ol.VectorTile.prototype.setReplayGroup = function(key, replayGroup) {
   this.replayGroups_[key] = replayGroup;
 };


### PR DESCRIPTION
Some type annotations were missing in ol.render.VectorTile. This pull request adds them.