### PR TITLE
6987: Memory leak with WMS time source with reprojection

### DIFF
--- a/src/ol/source/tileimage.js
+++ b/src/ol/source/tileimage.js
@@ -269,6 +269,7 @@ ol.source.TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection
 
       if (tile) {
         newTile.interimTile = tile;
+        newTile.refreshInterimChain();
         cache.replace(tileCoordKey, newTile);
       } else {
         cache.set(tileCoordKey, newTile);


### PR DESCRIPTION
As discussed, the collection of interimTile for the reproj.Tile was never being cleaned up and thus the references would still hang around. The fix is to perform:

tileImage.js:

newTile.refreshInterimChain(); 

after the line:
newTile.interimTile = tile 

The refreshInterimChain is only done inside the creation of a reproj.Tile (called within getTileInternal) for an ol.ImageTile. It wasn't being done on the created reproj.Tile.