### PR TITLE
Update tile size and resolutions of vector tile examples

### DIFF
--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -17,7 +17,7 @@ var key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';
 
 // Calculation of resolutions that match zoom levels 1, 3, 5, 7, 9, 11, 13, 15.
 var resolutions = [];
-for (var i = 0; i <= 7; ++i) {
+for (var i = 0; i <= 8; ++i) {
   resolutions.push(156543.03392804097 / Math.pow(2, i * 2));
 }
 // Calculation of tile urls for zoom levels 1, 3, 5, 7, 9, 11, 13, 15.

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -23,8 +23,8 @@ var map = new ol.Map({
           '© <a href="https://www.openstreetmap.org/copyright">' +
           'OpenStreetMap contributors</a>',
         format: new ol.format.MVT(),
-        tileGrid: ol.tilegrid.createXYZ({maxZoom: 22}),
-        tilePixelRatio: 16,
+        tileGrid: ol.tilegrid.createXYZ({tileSize: 512, maxZoom: 22}),
+        tilePixelRatio: 8,
         url: 'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
             '{z}/{x}/{y}.vector.pbf?access_token=' + key
       }),

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -70,7 +70,7 @@ var map = new ol.Map({
           layerName: 'layer',
           layers: ['water', 'roads', 'buildings']
         }),
-        tileGrid: ol.tilegrid.createXYZ({maxZoom: 19}),
+        tileGrid: ol.tilegrid.createXYZ({tileSize: 512, maxZoom: 19}),
         url: 'https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson?api_key=' + key
       }),
       style: function(feature, resolution) {


### PR DESCRIPTION
512px has become the de-facto standard tile size for vector tile layers, so we're using that now as well. This pull request also fixes a mismatch between code and documentation in the mapbox-vector-tiles-advanced example.