### PR TITLE
Fix Graticule use of incorrect min/maxLon values

### DIFF
--- a/src/ol/graticule.js
+++ b/src/ol/graticule.js
@@ -519,7 +519,7 @@ ol.Graticule.prototype.getMeridians = function() {
 ol.Graticule.prototype.getParallel_ = function(lat, minLon, maxLon,
     squaredTolerance, index) {
   var flatCoordinates = ol.geom.flat.geodesic.parallel(lat,
-      this.minLon_, this.maxLon_, this.projection_, squaredTolerance);
+      minLon, maxLon, this.projection_, squaredTolerance);
   var lineString = this.parallels_[index] !== undefined ?
     this.parallels_[index] : new ol.geom.LineString(null);
   lineString.setFlatCoordinates(ol.geom.GeometryLayout.XY, flatCoordinates);


### PR DESCRIPTION
Appears to have just been a typeo, using the minLon_, maxLon_ member variables which represent the world extent rather than the function parameters provided which are the viewport extent.

This was creating very wide lines of parallel which were sometimes very slow in Chrome.

Fixes #7020 