### PR TITLE
Fix KML Export Icon Anchor

### DIFF
--- a/src/ol/format/kml.js
+++ b/src/ol/format/kml.js
@@ -2260,7 +2260,7 @@ ol.format.KML.writeIconStyle_ = function(node, style, objectStack) {
       iconProperties['y'] = iconImageSize[1] - (origin[1] + size[1]);
     }
 
-    if (anchor && anchor[0] !== 0 && anchor[1] !== size[1]) {
+    if (anchor && (anchor[0] !== size[0] / 2 || anchor[1] !== size[1] / 2)) {
       var /** @type {ol.KMLVec2_} */ hotSpot = {
         x: anchor[0],
         xunits: ol.style.IconAnchorUnits.PIXELS,


### PR DESCRIPTION
Fixes #6995 

The anchor gets converted to relative pixels anyway so if you do a percentage of 0 for the X or 1 for the Y, the position won't be included. Dates back to when the format was made.

Otherwise, default icon position is 0.5, 0.5--so ignore it. 