### PR TITLE
Create restrictExtent option

### DIFF
--- a/examples/restricted-extent.html
+++ b/examples/restricted-extent.html
@@ -1,0 +1,13 @@
+---
+layout: example.html
+title: restricExtent example
+shortdesc: Example of restricting a view's extent to the viewport.
+docs: >
+  By passing the restrictExtent option, the center constraint is changed to nicely fit the edges of the viewport, rather than the center point.
+tags: "restricted, extent, constraint"
+---
+<div class="row-fluid">
+  <div class="span12">
+    <div id="map" class="map"></div>
+  </div>
+</div>

--- a/examples/restricted-extent.js
+++ b/examples/restricted-extent.js
@@ -3,6 +3,7 @@ goog.require('ol.View');
 goog.require('ol.control');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');
+goog.require('ol.extent');
 
 
 /**
@@ -22,7 +23,7 @@ var view = new ol.View({
   center: ol.extent.getCenter(maxExtent),
   minZoom: 6,
   zoom: 6,
-  restrictExtent: true,
+  restrictExtent: true
 });
 
 map = new ol.Map({
@@ -34,7 +35,7 @@ map = new ol.Map({
   controls: ol.control.defaults({
     attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
       collapsible: false
-    }),
+    })
   }),
   renderer: common.getRendererFromQueryString(),
   target: 'map',

--- a/examples/restricted-extent.js
+++ b/examples/restricted-extent.js
@@ -1,0 +1,42 @@
+goog.require('ol.Map');
+goog.require('ol.View');
+goog.require('ol.control');
+goog.require('ol.layer.Tile');
+goog.require('ol.source.OSM');
+
+
+/**
+ * @type {ol.Map}
+ */
+var map;
+
+// The extent we want to restrict the map to.
+var maxExtent = [-546677.6272683458, 5244890.488572459,
+  920913.3158070382, 6516802.639237792];
+
+
+/**
+ * @type {ol.View}
+ */
+var view = new ol.View({
+  center: ol.extent.getCenter(maxExtent),
+  minZoom: 6,
+  zoom: 6,
+  restrictExtent: true,
+});
+
+map = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM()
+    })
+  ],
+  controls: ol.control.defaults({
+    attributionOptions: /** @type {olx.control.AttributionOptions} */ ({
+      collapsible: false
+    }),
+  }),
+  renderer: common.getRendererFromQueryString(),
+  target: 'map',
+  view: view
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -694,6 +694,7 @@ olx.ProjectionOptions.prototype.getPointResolution;
  *     constrainRotation: (boolean|number|undefined),
  *     enableRotation: (boolean|undefined),
  *     extent: (ol.Extent|undefined),
+ *     restrictExtent: (boolean|undefined),
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined),
  *     minZoom: (number|undefined),
@@ -747,6 +748,13 @@ olx.ViewOptions.prototype.enableRotation;
  */
 olx.ViewOptions.prototype.extent;
 
+/**
+ * Force the extent to fit the edges of the Viewport instead of the center point.
+ * Has no effect if enableRotation is set to `true`. Default `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.ViewOptions.prototype.restrictExtent;
 
 /**
  * The maximum resolution used to determine the resolution constraint. It is

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -13,7 +13,7 @@ ol.CenterConstraint.createExtent = function(extent, view) {
   // Extent doesn't change, so we can store the size and center.
   var extentSize = [
     extent[2] - extent[0],
-    extent[3] - extent[1],
+    extent[3] - extent[1]
   ];
   var extentCenter = ol.extent.getCenter(extent);
   return (
@@ -34,12 +34,11 @@ ol.CenterConstraint.createExtent = function(extent, view) {
           // Clamp to the center when the restrictExtent has smaller display than the Viewport.
           var deltaX = Math.max((extentSize[0] - (viewportSize[0] * viewResolution)) / 2, 0);
           var deltaY = Math.max((extentSize[1] - (viewportSize[1] * viewResolution)) / 2, 0);
-          var c = ol.extent.getCenter(extent);
           extent_ = [
             extentCenter[0] - deltaX,
             extentCenter[1] - deltaY,
             extentCenter[0] + deltaX,
-            extentCenter[1] + deltaY,
+            extentCenter[1] + deltaY
           ];
         }
         return [

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -1,13 +1,21 @@
 goog.provide('ol.CenterConstraint');
 
+goog.require('ol.extent');
 goog.require('ol.math');
 
 
 /**
  * @param {ol.Extent} extent Extent.
+ * @param {ol.View|undefined} view Restrict to viewport of this view, if given.
  * @return {ol.CenterConstraintType} The constraint.
  */
-ol.CenterConstraint.createExtent = function(extent) {
+ol.CenterConstraint.createExtent = function(extent, view) {
+  // Extent doesn't change, so we can store the size and center.
+  var extentSize = [
+    extent[2] - extent[0],
+    extent[3] - extent[1],
+  ];
+  var extentCenter = ol.extent.getCenter(extent);
   return (
     /**
      * @param {ol.Coordinate|undefined} center Center.
@@ -15,9 +23,28 @@ ol.CenterConstraint.createExtent = function(extent) {
      */
     function(center) {
       if (center) {
+        var extent_ = extent;
+        // TODO: Handle rotated views?
+        // Restrict the extent further if a view was given.
+        if (view) {
+          // TODO: Improve performance and readability by tracking viewport (and resolution) changes.
+          var viewportSize = view.getSizeFromViewport();
+          var viewResolution = view.getResolution();
+          // Deltas can not be negative or we will create an invalid extent.
+          // Clamp to the center when the restrictExtent has smaller display than the Viewport.
+          var deltaX = Math.max((extentSize[0] - (viewportSize[0] * viewResolution)) / 2, 0);
+          var deltaY = Math.max((extentSize[1] - (viewportSize[1] * viewResolution)) / 2, 0);
+          var c = ol.extent.getCenter(extent);
+          extent_ = [
+            extentCenter[0] - deltaX,
+            extentCenter[1] - deltaY,
+            extentCenter[0] + deltaX,
+            extentCenter[1] + deltaY,
+          ];
+        }
         return [
-          ol.math.clamp(center[0], extent[0], extent[2]),
-          ol.math.clamp(center[1], extent[1], extent[3])
+          ol.math.clamp(center[0], extent_[0], extent_[2]),
+          ol.math.clamp(center[1], extent_[1], extent_[3])
         ];
       } else {
         return undefined;

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -1048,6 +1048,7 @@ ol.View.prototype.setZoom = function(zoom) {
 
 /**
  * @param {olx.ViewOptions} options View options.
+ * @param {ol.View} view View to restrict to, if restrictExtent is enabled.
  * @private
  * @return {ol.CenterConstraintType} The constraint.
  */

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1089,7 +1089,7 @@ describe('ol.View', function() {
     });
   });
 
-  describe('#getSizeFromViewport_()', function() {
+  describe('#getSizeFromViewport()', function() {
     var map, target;
     beforeEach(function() {
       target = document.createElement('div');
@@ -1105,7 +1105,7 @@ describe('ol.View', function() {
       document.body.removeChild(target);
     });
     it('calculates the size correctly', function() {
-      var size = map.getView().getSizeFromViewport_();
+      var size = map.getView().getSizeFromViewport();
       expect(size).to.eql([200, 150]);
     });
   });


### PR DESCRIPTION
Mimics functionality that used to be in openlayers 2: http://dev.openlayers.org/examples/restricted-extent.html.

A while ago a workaround for this was created through issue  https://github.com/openlayers/openlayers/pull/2777, but it never got completed (I may have shamelessly adapted the example for this pull request).

I added a `restrictExtent` to ViewOptions. If enabled (and rotation is disabled, because I'm not sure how to tackle that particular combination), the center constraint will re-calculate the configured extent so the edges of the extent match the edges of the viewport.

I also added a `constrainCenter` call to the view's animation function when the option is enabled, so when zooming out the center stays within the restricted extent (which is different based the view's resolution, and this changes throughout the animation). Although I'm unsure if this is the correct way to do this.

Currently, when zooming out further than the restricted extent can handle (the extent no longer covers the entire viewport) the extent simply sticks to the center (horizontal, vertical or both). The view's maxresolution needs to be set manually in the configuration to avoid this behavior, I don't think this should be set automatically (except maybe if no limits in resolution are given?).

Another improvement that can be looked into is keeping track of the resolution and viewport size so they don't need to be requested every time the constrain center function is called. I fear the current implementation introduces more overhead than necessary, but I didn't see an immediate way to improve on it.

I've also been struggling with getting the examples running, so I'm not sure if that actually works. Hopefully I can confirm that in a couple days.