### PR TITLE
Only use API functions in example

### DIFF
--- a/examples/street-labels.js
+++ b/examples/street-labels.js
@@ -20,7 +20,7 @@ function measureText(text) {
 
 var extent, letters; // Will be set in the style's renderer function
 function collectDrawData(letter, x, y, angle) {
-  ol.extent.extendCoordinate(extent, [x, y]);
+  ol.extent.extend(extent, [x, y, x, y]);
   letters.push([x, y, angle, letter]);
 }
 


### PR DESCRIPTION
This is a follow-up on #7022 to fix the `street-labels.html` example , which only works in debug mode because it uses the non-API function `ol.extent.extendCoordinate`.