### PR TITLE
Make ol.layer.Group change handling consistent

### DIFF
--- a/src/ol/layer/group.js
+++ b/src/ol/layer/group.js
@@ -80,9 +80,7 @@ ol.layer.Group.prototype.createRenderer = function(mapRenderer) {};
  * @private
  */
 ol.layer.Group.prototype.handleLayerChange_ = function() {
-  if (this.getVisible()) {
-    this.changed();
-  }
+  this.changed();
 };
 
 


### PR DESCRIPTION
Changes to the layer were only propagated in some cases like addition/removal of a layer to the group.

To make it consistent both with the rest of the group.js file and with the layer.js file, the changes are now always notified.