### PR TITLE
Fix a typo in the street-labels example

### DIFF
--- a/examples/street-labels.js
+++ b/examples/street-labels.js
@@ -68,7 +68,7 @@ fetch('https://overpass-api.de/api/interpreter', {
 var vectorLayer = new ol.layer.Vector({
   source: source,
   style: function(feature) {
-    if (feature.getGeometry().getType() == 'LineString' && feature.get('text')) {
+    if (feature.getGeometry().getType() == 'LineString' && feature.get('name')) {
       return style;
     }
   }


### PR DESCRIPTION
The street-labels example should get the street names through the 'name' attribute, not 'text'.