### PR TITLE
Allow modify interaction to be configured with a source

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,20 @@
 
 ### Next release
 
+#### `ol.interaction.Modify` deletes with `alt` key only
+
+To delete features with the modify interaction, press the `alt` key while clicking on an existing vertex.  If you want to configure the modify interaction with a different delete condition, use the `deleteCondition` option.  For example, to allow deletion on a single click with no modifier keys, configure the interaction like this:
+```js
+var interaction = new ol.interaction.Modify({
+  source: source,
+  deleteCondition: function(event) {
+    return ol.events.condition.noModifierKeys(event) && ol.events.condition.singleClick(event);
+  }
+});
+```
+
+The motivation for this change is to make the modify, draw, and snap interactions all work well together.  Previously, the use of these interactions with the default configuration would make it so you couldn't reliably add new vertices (click with no modifier) and delete existing vertices (click with no modifier).
+
 #### `ol.source.VectorTile` no longer has a `tilePixelRatio` option
 
 The `tilePixelRatio` option was only used for tiles in projections with `tile-pixels` as units. For tiles read with `ol.format.MVT` and the default tile loader, or tiles with the default pixel size of 4096 pixels, no changes are necessary. For the very rare cases that do not fall under these categories, a custom `tileLoadFunction` now needs to be configured on the `ol.source.VectorTile`. In addition to calling `tile.setFeatures()` and `tile.setProjection()`, it also needs to contain code like the following:

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3219,7 +3219,8 @@ olx.interaction.KeyboardZoomOptions.prototype.delta;
  *     insertVertexCondition: (ol.EventsConditionType|undefined),
  *     pixelTolerance: (number|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     features: ol.Collection.<ol.Feature>,
+ *     source: (ol.source.Vector|undefined),
+ *     features: (ol.Collection.<ol.Feature>|undefined),
  *     wrapX: (boolean|undefined)
  * }}
  */
@@ -3277,8 +3278,18 @@ olx.interaction.ModifyOptions.prototype.style;
 
 
 /**
- * The features the interaction works on.
- * @type {ol.Collection.<ol.Feature>}
+ * The vector source with features to modify.  If a vector source is not
+ * provided, a feature collection must be provided with the features option.
+ * @type {ol.source.Vector|undefined}
+ * @api
+ */
+olx.interaction.ModifyOptions.prototype.source;
+
+
+/**
+ * The features the interaction works on.  If a feature collection is not
+ * provided, a vector source must be provided with the source option.
+ * @type {ol.Collection.<ol.Feature>|undefined}
  * @api
  */
 olx.interaction.ModifyOptions.prototype.features;

--- a/src/ol/collection.js
+++ b/src/ol/collection.js
@@ -23,7 +23,7 @@ goog.require('ol.events.Event');
  * @constructor
  * @extends {ol.Object}
  * @fires ol.Collection.Event
- * @param {!Array.<T>=} opt_array Array.
+ * @param {Array.<T>=} opt_array Array.
  * @param {olx.CollectionOptions=} opt_options Collection options.
  * @template T
  * @api

--- a/src/ol/interaction/modify.js
+++ b/src/ol/interaction/modify.js
@@ -1,6 +1,7 @@
 goog.provide('ol.interaction.Modify');
 
 goog.require('ol');
+goog.require('ol.Collection');
 goog.require('ol.CollectionEventType');
 goog.require('ol.Feature');
 goog.require('ol.MapBrowserEventType');
@@ -19,13 +20,22 @@ goog.require('ol.interaction.ModifyEventType');
 goog.require('ol.interaction.Pointer');
 goog.require('ol.layer.Vector');
 goog.require('ol.source.Vector');
+goog.require('ol.source.VectorEventType');
 goog.require('ol.structs.RBush');
 goog.require('ol.style.Style');
 
-
 /**
  * @classdesc
- * Interaction for modifying feature geometries.
+ * Interaction for modifying feature geometries.  To modify features that have
+ * been added to an existing source, construct the modify interaction with the
+ * `source` option.  If you want to modify features in a collection (for example,
+ * the collection used by a select interaction), construct the interaction with
+ * the `features` option.  The interaction must be constructed with either a
+ * `source` or `features` option.
+ *
+ * By default, the interaction will allow deletion of vertices when the `alt`
+ * key is pressed.  To configure the interaction with a different condition
+ * for deletion, use the `deleteCondition` option.
  *
  * @constructor
  * @extends {ol.interaction.Pointer}
@@ -56,7 +66,7 @@ ol.interaction.Modify = function(options) {
    * @return {boolean} Combined condition result.
    */
   this.defaultDeleteCondition_ = function(mapBrowserEvent) {
-    return ol.events.condition.noModifierKeys(mapBrowserEvent) &&
+    return ol.events.condition.altKeyOnly(mapBrowserEvent) &&
       ol.events.condition.singleClick(mapBrowserEvent);
   };
 
@@ -175,11 +185,33 @@ ol.interaction.Modify = function(options) {
     'GeometryCollection': this.writeGeometryCollectionGeometry_
   };
 
+
+  /**
+   * @type {ol.source.Vector}
+   * @private
+   */
+  this.source_ = null;
+
+  var features;
+  if (options.source) {
+    this.source_ = options.source;
+    features = new ol.Collection(this.source_.getFeatures());
+    ol.events.listen(this.source_, ol.source.VectorEventType.ADDFEATURE,
+        this.handleSourceAdd_, this);
+    ol.events.listen(this.source_, ol.source.VectorEventType.REMOVEFEATURE,
+        this.handleSourceRemove_, this);
+  } else {
+    features = options.features;
+  }
+  if (!features) {
+    throw new Error('The modify interaction requires features or a source');
+  }
+
   /**
    * @type {ol.Collection.<ol.Feature>}
    * @private
    */
-  this.features_ = options.features;
+  this.features_ = features;
 
   this.features_.forEach(this.addFeature_, this);
   ol.events.listen(this.features_, ol.CollectionEventType.ADD,
@@ -298,6 +330,28 @@ ol.interaction.Modify.prototype.setActive = function(active) {
 ol.interaction.Modify.prototype.setMap = function(map) {
   this.overlay_.setMap(map);
   ol.interaction.Pointer.prototype.setMap.call(this, map);
+};
+
+
+/**
+ * @param {ol.source.Vector.Event} event Event.
+ * @private
+ */
+ol.interaction.Modify.prototype.handleSourceAdd_ = function(event) {
+  if (event.feature) {
+    this.features_.push(event.feature);
+  }
+};
+
+
+/**
+ * @param {ol.source.Vector.Event} event Event.
+ * @private
+ */
+ol.interaction.Modify.prototype.handleSourceRemove_ = function(event) {
+  if (event.feature) {
+    this.features_.remove(event.feature);
+  }
 };
 
 

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -74,19 +74,20 @@ describe('ol.interaction.Modify', function() {
    * @param {string} type Event type.
    * @param {number} x Horizontal offset from map center.
    * @param {number} y Vertical offset from map center.
-   * @param {boolean=} opt_shiftKey Shift key is pressed.
+   * @param {Object} modifiers Lookup of modifier keys.
    * @param {number} button The mouse button.
    */
-  function simulateEvent(type, x, y, opt_shiftKey, button) {
+  function simulateEvent(type, x, y, modifiers, button) {
+    modifiers = modifiers || {};
     var viewport = map.getViewport();
     // calculated in case body has top < 0 (test runner with small window)
     var position = viewport.getBoundingClientRect();
-    var shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
     var pointerEvent = new ol.pointer.PointerEvent(type, {
       type: type,
       clientX: position.left + x + width / 2,
       clientY: position.top + y + height / 2,
-      shiftKey: shiftKey
+      shiftKey: modifiers.shift || false,
+      altKey: modifiers.alt || false
     }, {
       button: button,
       isPrimary: true
@@ -177,6 +178,16 @@ describe('ol.interaction.Modify', function() {
       expect(rbushEntries[0].feature).to.be(feature);
     });
 
+    it('accepts a source', function() {
+      var feature = new ol.Feature(
+          new ol.geom.Point([0, 0]));
+      var source = new ol.source.Vector({features: [feature]});
+      var modify = new ol.interaction.Modify({source: source});
+      var rbushEntries = modify.rBush_.getAll();
+      expect(rbushEntries.length).to.be(1);
+      expect(rbushEntries[0].feature).to.be(feature);
+    });
+
   });
 
   describe('vertex deletion', function() {
@@ -201,10 +212,10 @@ describe('ol.interaction.Modify', function() {
       expect(second.getGeometry().getRevision()).to.equal(secondRevision);
       expect(second.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointerdown', 10, -20, false, 0);
-      simulateEvent('pointerup', 10, -20, false, 0);
-      simulateEvent('click', 10, -20, false, 0);
-      simulateEvent('singleclick', 10, -20, false, 0);
+      simulateEvent('pointerdown', 10, -20, {alt: true}, 0);
+      simulateEvent('pointerup', 10, -20, {alt: true}, 0);
+      simulateEvent('click', 10, -20, {alt: true}, 0);
+      simulateEvent('singleclick', 10, -20, {alt: true}, 0);
 
       expect(first.getGeometry().getRevision()).to.equal(firstRevision + 1);
       expect(first.getGeometry().getCoordinates()[0]).to.have.length(4);
@@ -237,10 +248,10 @@ describe('ol.interaction.Modify', function() {
       expect(first.getGeometry().getRevision()).to.equal(firstRevision);
       expect(first.getGeometry().getCoordinates()).to.have.length(5);
 
-      simulateEvent('pointerdown', 0, 0, false, 0);
-      simulateEvent('pointerup', 0, 0, false, 0);
-      simulateEvent('click', 0, 0, false, 0);
-      simulateEvent('singleclick', 0, 0, false, 0);
+      simulateEvent('pointerdown', 0, 0, {alt: true}, 0);
+      simulateEvent('pointerup', 0, 0, {alt: true}, 0);
+      simulateEvent('click', 0, 0, {alt: true}, 0);
+      simulateEvent('singleclick', 0, 0, {alt: true}, 0);
 
       expect(first.getGeometry().getRevision()).to.equal(firstRevision + 1);
       expect(first.getGeometry().getCoordinates()).to.have.length(4);
@@ -273,10 +284,10 @@ describe('ol.interaction.Modify', function() {
       expect(first.getGeometry().getRevision()).to.equal(firstRevision);
       expect(first.getGeometry().getCoordinates()).to.have.length(5);
 
-      simulateEvent('pointerdown', 40, 0, false, 0);
-      simulateEvent('pointerup', 40, 0, false, 0);
-      simulateEvent('click', 40, 0, false, 0);
-      simulateEvent('singleclick', 40, 0, false, 0);
+      simulateEvent('pointerdown', 40, 0, {alt: true}, 0);
+      simulateEvent('pointerup', 40, 0, {alt: true}, 0);
+      simulateEvent('click', 40, 0, {alt: true}, 0);
+      simulateEvent('singleclick', 40, 0, {alt: true}, 0);
 
       expect(first.getGeometry().getRevision()).to.equal(firstRevision + 1);
       expect(first.getGeometry().getCoordinates()).to.have.length(4);
@@ -309,8 +320,8 @@ describe('ol.interaction.Modify', function() {
       expect(first.getGeometry().getRevision()).to.equal(firstRevision);
       expect(first.getGeometry().getCoordinates()).to.have.length(5);
 
-      simulateEvent('pointerdown', 40, 0, false, 0);
-      simulateEvent('pointerup', 40, 0, false, 0);
+      simulateEvent('pointerdown', 40, 0, null, 0);
+      simulateEvent('pointerup', 40, 0, null, 0);
 
       var removed = modify.removePoint();
 
@@ -343,25 +354,25 @@ describe('ol.interaction.Modify', function() {
       map.addInteraction(modify);
 
       // Move first vertex
-      simulateEvent('pointermove', 0, 0, false, 0);
-      simulateEvent('pointerdown', 0, 0, false, 0);
-      simulateEvent('pointermove', -10, -10, false, 0);
-      simulateEvent('pointerdrag', -10, -10, false, 0);
-      simulateEvent('pointerup', -10, -10, false, 0);
+      simulateEvent('pointermove', 0, 0, null, 0);
+      simulateEvent('pointerdown', 0, 0, null, 0);
+      simulateEvent('pointermove', -10, -10, null, 0);
+      simulateEvent('pointerdrag', -10, -10, null, 0);
+      simulateEvent('pointerup', -10, -10, null, 0);
 
       // Move middle vertex
-      simulateEvent('pointermove', 0, -40, false, 0);
-      simulateEvent('pointerdown', 0, -40, false, 0);
-      simulateEvent('pointermove', 10, -30, false, 0);
-      simulateEvent('pointerdrag', 10, -30, false, 0);
-      simulateEvent('pointerup', 10, -30, false, 0);
+      simulateEvent('pointermove', 0, -40, null, 0);
+      simulateEvent('pointerdown', 0, -40, null, 0);
+      simulateEvent('pointermove', 10, -30, null, 0);
+      simulateEvent('pointerdrag', 10, -30, null, 0);
+      simulateEvent('pointerup', 10, -30, null, 0);
 
       // Move last vertex
-      simulateEvent('pointermove', 40, 0, false, 0);
-      simulateEvent('pointerdown', 40, 0, false, 0);
-      simulateEvent('pointermove', 50, -10, false, 0);
-      simulateEvent('pointerdrag', 50, -10, false, 0);
-      simulateEvent('pointerup', 50, -10, false, 0);
+      simulateEvent('pointermove', 40, 0, null, 0);
+      simulateEvent('pointerdown', 40, 0, null, 0);
+      simulateEvent('pointermove', 50, -10, null, 0);
+      simulateEvent('pointerdrag', 50, -10, null, 0);
+      simulateEvent('pointerup', 50, -10, null, 0);
 
       expect(lineFeature.getGeometry().getCoordinates()[0][2]).to.equal(10);
       expect(lineFeature.getGeometry().getCoordinates()[2][2]).to.equal(30);
@@ -382,21 +393,21 @@ describe('ol.interaction.Modify', function() {
       map.addInteraction(modify);
 
       // Change center
-      simulateEvent('pointermove', 10, -10, false, 0);
-      simulateEvent('pointerdown', 10, -10, false, 0);
-      simulateEvent('pointermove', 5, -5, false, 0);
-      simulateEvent('pointerdrag', 5, -5, false, 0);
-      simulateEvent('pointerup', 5, -5, false, 0);
+      simulateEvent('pointermove', 10, -10, null, 0);
+      simulateEvent('pointerdown', 10, -10, null, 0);
+      simulateEvent('pointermove', 5, -5, null, 0);
+      simulateEvent('pointerdrag', 5, -5, null, 0);
+      simulateEvent('pointerup', 5, -5, null, 0);
 
       expect(circleFeature.getGeometry().getRadius()).to.equal(20);
       expect(circleFeature.getGeometry().getCenter()).to.eql([5, 5]);
 
       // Increase radius
-      simulateEvent('pointermove', 25, -4, false, 0);
-      simulateEvent('pointerdown', 25, -4, false, 0);
-      simulateEvent('pointermove', 30, -5, false, 0);
-      simulateEvent('pointerdrag', 30, -5, false, 0);
-      simulateEvent('pointerup', 30, -5, false, 0);
+      simulateEvent('pointermove', 25, -4, null, 0);
+      simulateEvent('pointerdown', 25, -4, null, 0);
+      simulateEvent('pointermove', 30, -5, null, 0);
+      simulateEvent('pointerdrag', 30, -5, null, 0);
+      simulateEvent('pointerup', 30, -5, null, 0);
 
       expect(circleFeature.getGeometry().getRadius()).to.equal(25);
       expect(circleFeature.getGeometry().getCenter()).to.eql([5, 5]);
@@ -421,10 +432,10 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointerdown', 10, -20, false, 0);
-      simulateEvent('pointerup', 10, -20, false, 0);
-      simulateEvent('click', 10, -20, false, 0);
-      simulateEvent('singleclick', 10, -20, false, 0);
+      simulateEvent('pointerdown', 10, -20, {alt: true}, 0);
+      simulateEvent('pointerup', 10, -20, {alt: true}, 0);
+      simulateEvent('click', 10, -20, {alt: true}, 0);
+      simulateEvent('singleclick', 10, -20, {alt: true}, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(4);
@@ -436,10 +447,10 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointerdown', 40, -20, false, 0);
-      simulateEvent('pointerup', 40, -20, false, 0);
-      simulateEvent('click', 40, -20, false, 0);
-      simulateEvent('singleclick', 40, -20, false, 0);
+      simulateEvent('pointerdown', 40, -20, null, 0);
+      simulateEvent('pointerup', 40, -20, null, 0);
+      simulateEvent('click', 40, -20, null, 0);
+      simulateEvent('singleclick', 40, -20, null, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(6);
@@ -451,10 +462,10 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointerdown', 40, -20, false, 0);
-      simulateEvent('pointerup', 40, -20, false, 0);
-      simulateEvent('click', 40, -20, false, 0);
-      simulateEvent('singleclick', 40, -20, false, 0);
+      simulateEvent('pointerdown', 40, -20, null, 0);
+      simulateEvent('pointerup', 40, -20, null, 0);
+      simulateEvent('click', 40, -20, null, 0);
+      simulateEvent('singleclick', 40, -20, null, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(6);
@@ -462,10 +473,10 @@ describe('ol.interaction.Modify', function() {
       validateEvents(events, [feature]);
       events.length = 0;
 
-      simulateEvent('pointerdown', 40, -20, false, 0);
-      simulateEvent('pointerup', 40, -20, false, 0);
-      simulateEvent('click', 40, -20, false, 0);
-      simulateEvent('singleclick', 40, -20, false, 0);
+      simulateEvent('pointerdown', 40, -20, {alt: true}, 0);
+      simulateEvent('pointerup', 40, -20, {alt: true}, 0);
+      simulateEvent('click', 40, -20, {alt: true}, 0);
+      simulateEvent('singleclick', 40, -20, {alt: true}, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(3);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
@@ -477,11 +488,11 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointermove', 40, -20, false, 0);
-      simulateEvent('pointerdown', 40, -20, false, 0);
-      simulateEvent('pointermove', 30, -20, false, 0);
-      simulateEvent('pointerdrag', 30, -20, false, 0);
-      simulateEvent('pointerup', 30, -20, false, 0);
+      simulateEvent('pointermove', 40, -20, null, 0);
+      simulateEvent('pointerdown', 40, -20, null, 0);
+      simulateEvent('pointermove', 30, -20, null, 0);
+      simulateEvent('pointerdrag', 30, -20, null, 0);
+      simulateEvent('pointerup', 30, -20, null, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(4);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(6);
@@ -493,12 +504,12 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointermove', 40, -20, false, 0);
+      simulateEvent('pointermove', 40, -20, null, 0);
       // right click
-      simulateEvent('pointerdown', 40, -20, false, 1);
-      simulateEvent('pointermove', 30, -20, false, 1);
-      simulateEvent('pointerdrag', 30, -20, false, 1);
-      simulateEvent('pointerup', 30, -20, false, 1);
+      simulateEvent('pointerdown', 40, -20, null, 1);
+      simulateEvent('pointermove', 30, -20, null, 1);
+      simulateEvent('pointerdrag', 30, -20, null, 1);
+      simulateEvent('pointerup', 30, -20, null, 1);
 
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
@@ -528,13 +539,13 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointerdown', 10, -20, false, 0);
-      simulateEvent('pointerup', 10, -20, false, 0);
-      simulateEvent('click', 10, -20, false, 0);
-      simulateEvent('pointerdown', 10, -20, false, 0);
-      simulateEvent('pointerup', 10, -20, false, 0);
-      simulateEvent('click', 10, -20, false, 0);
-      simulateEvent('dblclick', 10, -20, false, 0);
+      simulateEvent('pointerdown', 10, -20, null, 0);
+      simulateEvent('pointerup', 10, -20, null, 0);
+      simulateEvent('click', 10, -20, null, 0);
+      simulateEvent('pointerdown', 10, -20, null, 0);
+      simulateEvent('pointerup', 10, -20, null, 0);
+      simulateEvent('click', 10, -20, null, 0);
+      simulateEvent('dblclick', 10, -20, null, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(2);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(4);
@@ -547,10 +558,10 @@ describe('ol.interaction.Modify', function() {
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
-      simulateEvent('pointerdown', 10, -20, false, 0);
-      simulateEvent('pointerup', 10, -20, false, 0);
-      simulateEvent('click', 10, -20, false, 0);
-      simulateEvent('singleclick', 10, -20, false, 0);
+      simulateEvent('pointerdown', 10, -20, null, 0);
+      simulateEvent('pointerup', 10, -20, null, 0);
+      simulateEvent('click', 10, -20, null, 0);
+      simulateEvent('singleclick', 10, -20, null, 0);
 
       expect(feature.getGeometry().getRevision()).to.equal(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
@@ -573,20 +584,20 @@ describe('ol.interaction.Modify', function() {
       var feature = features[0];
 
       // move first vertex
-      simulateEvent('pointermove', 0, 0, false, 0);
-      simulateEvent('pointerdown', 0, 0, false, 0);
-      simulateEvent('pointermove', -10, -10, false, 0);
-      simulateEvent('pointerdrag', -10, -10, false, 0);
-      simulateEvent('pointerup', -10, -10, false, 0);
+      simulateEvent('pointermove', 0, 0, null, 0);
+      simulateEvent('pointerdown', 0, 0, null, 0);
+      simulateEvent('pointermove', -10, -10, null, 0);
+      simulateEvent('pointerdrag', -10, -10, null, 0);
+      simulateEvent('pointerup', -10, -10, null, 0);
 
       expect(listenerSpy.callCount).to.be(0);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
 
       // try to add vertex
-      simulateEvent('pointerdown', 40, -20, false, 0);
-      simulateEvent('pointerup', 40, -20, false, 0);
-      simulateEvent('click', 40, -20, false, 0);
-      simulateEvent('singleclick', 40, -20, false, 0);
+      simulateEvent('pointerdown', 40, -20, null, 0);
+      simulateEvent('pointerup', 40, -20, null, 0);
+      simulateEvent('click', 40, -20, null, 0);
+      simulateEvent('singleclick', 40, -20, null, 0);
 
       expect(listenerSpy.callCount).to.be(1);
       expect(feature.getGeometry().getCoordinates()[0]).to.have.length(5);
@@ -693,7 +704,7 @@ describe('ol.interaction.Modify', function() {
       map.addInteraction(modify);
       expect(modify.vertexFeature_).to.be(null);
 
-      simulateEvent('pointermove', 10, -20, false, 0);
+      simulateEvent('pointermove', 10, -20, null, 0);
       expect(modify.vertexFeature_).to.not.be(null);
 
       modify.setActive(false);


### PR DESCRIPTION
This makes it so the modify interaction can be configured with a vector source (like the draw interaction).