### PR TITLE
Add new Map#getFeaturesAtPixel method

### DIFF
--- a/src/ol/map.js
+++ b/src/ol/map.js
@@ -541,7 +541,7 @@ ol.Map.prototype.disposeInternal = function() {
 /**
  * Detect features that intersect a pixel on the viewport, and execute a
  * callback with each intersecting feature. Layers included in the detection can
- * be configured through `opt_layerFilter`.
+ * be configured through the `layerFilter` option in `opt_options`.
  * @param {ol.Pixel} pixel Pixel.
  * @param {function(this: S, (ol.Feature|ol.render.Feature),
  *     ol.layer.Layer): T} callback Feature callback. The callback will be
@@ -572,6 +572,25 @@ ol.Map.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_options) 
       layerFilter, null);
 };
 
+
+/**
+ * Get all features that intersect a pixel on the viewport.
+ * @param {ol.Pixel} pixel Pixel.
+ * @param {olx.AtPixelOptions=} opt_options Optional options.
+ * @return {Array.<ol.Feature|ol.render.Feature>} The detected features or
+ * `null` if none were found.
+ * @api
+ */
+ol.Map.prototype.getFeaturesAtPixel = function(pixel, opt_options) {
+  var features = null;
+  this.forEachFeatureAtPixel(pixel, function(feature) {
+    if (!features) {
+      features = [];
+    }
+    features.push(feature);
+  }, opt_options);
+  return features;
+};
 
 /**
  * Detect layers that have a color value at a pixel on the viewport, and

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -183,6 +183,57 @@ describe('ol.Map', function() {
 
   });
 
+  describe('#getFeaturesAtPixel', function() {
+
+    var target, map;
+    beforeEach(function() {
+      target = document.createElement('div');
+      target.style.width = target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new ol.Map({
+        target: target,
+        layers: [new ol.layer.Vector({
+          source: new ol.source.Vector({
+            features: [new ol.Feature(new ol.geom.Point([0, 0]))]
+          })
+        })],
+        view: new ol.View({
+          center: [0, 0],
+          zoom: 2
+        })
+      });
+      map.renderSync();
+    });
+    afterEach(function() {
+      document.body.removeChild(target);
+    });
+
+    it('returns null if no feature was found', function() {
+      var features = map.getFeaturesAtPixel([0, 0]);
+      expect(features).to.be(null);
+    });
+
+    it('returns an array of found features', function() {
+      var features = map.getFeaturesAtPixel([50, 50]);
+      expect(features).to.be.an(Array);
+      expect(features[0]).to.be.an(ol.Feature);
+    });
+
+    it('respects options', function() {
+      var otherLayer = new ol.layer.Vector({
+        source: new ol.source.Vector
+      });
+      map.addLayer(otherLayer);
+      var features = map.getFeaturesAtPixel([50, 50], {
+        layerFilter: function(layer) {
+          return layer == otherLayer;
+        }
+      });
+      expect(features).to.be(null);
+    });
+
+  });
+
   describe('#forEachLayerAtPixel()', function()  {
 
     var target, map, original, log;


### PR DESCRIPTION
In most cases, users want quick access to the features at a pixel, without the need to specify a callback in `Map#forEachFeatureAtPixel()`. So I think it makes sense to introduce a `Map#getFeaturesAtPixel()` method.
