### PR TITLE
Allow drag and drop interaction to be configured with a source

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2710,6 +2710,7 @@ olx.interaction.DoubleClickZoomOptions.prototype.delta;
 
 /**
  * @typedef {{formatConstructors: (Array.<function(new: ol.format.Feature)>|undefined),
+ *     source: (ol.source.Vector|undefined),
  *     projection: ol.ProjectionLike,
  *     target: (Element|undefined)}}
  */
@@ -2722,6 +2723,18 @@ olx.interaction.DragAndDropOptions;
  * @api
  */
 olx.interaction.DragAndDropOptions.prototype.formatConstructors;
+
+
+/**
+ * Optional vector source where features will be added.  If a source is provided
+ * all existing features will be removed and new features will be added when
+ * they are dropped on the target.  If you want to add features to a vector
+ * source without removing the existing features (append only), instead of
+ * providing the source option listen for the "addfeatures" event.
+ * @type {ol.source.Vector|undefined}
+ * @api
+ */
+olx.interaction.DragAndDropOptions.prototype.source;
 
 
 /**

--- a/src/ol/interaction/draganddrop.js
+++ b/src/ol/interaction/draganddrop.js
@@ -51,6 +51,12 @@ ol.interaction.DragAndDrop = function(opt_options) {
 
   /**
    * @private
+   * @type {ol.source.Vector}
+   */
+  this.source_ = options.source || null;
+
+  /**
+   * @private
    * @type {Element}
    */
   this.target = options.target ? options.target : null;
@@ -121,6 +127,10 @@ ol.interaction.DragAndDrop.prototype.handleResult_ = function(file, event) {
     if (features && features.length > 0) {
       break;
     }
+  }
+  if (this.source_) {
+    this.source_.clear();
+    this.source_.addFeatures(features);
   }
   this.dispatchEvent(
       new ol.interaction.DragAndDrop.Event(


### PR DESCRIPTION
When you want dropped features to replace any features on an existing source, you can now do this:
```js
var source = new ol.source.Vector();
var drop = new ol.interaction.DragAndDrop({
  source: source,
  formatConstructors: constructors
});
```