### PR TITLE
Functions for spherical calculations

### DIFF
--- a/examples/measure.html
+++ b/examples/measure.html
@@ -1,20 +1,24 @@
 ---
 layout: example.html
 title: Measure
-shortdesc: Example of using the ol.interaction.Draw interaction to create a simple measuring application.
+shortdesc: Using a draw interaction to measure lengths and areas.
 docs: >
-  <p><i>NOTE: By default, length and area are calculated using the projected coordinates. This is not accurate for projections like Mercator where the projected meters do not correspond to meters on the ground. To get a standarized measurement across all projections, use the geodesic measures.</i></p>
+  <p>The <code>ol.Sphere.getLength()</code> and <code>ol.Sphere.getArea()</code>
+  functions calculate spherical lengths and areas for geometries.  Lengths are
+  calculated by assuming great circle segments between geometry coordinates.
+  Areas are calculated as if edges of polygons were great circle segments.</p>
+  <p>Note that the <code>geometry.getLength()</code> and <code>geometry.getArea()</code>
+  methods return measures of projected (planar) geometries.  These can be very
+  different than on-the-ground measures in certain situations — in northern
+  and southern latitudes using Web Mercator for example.  For better results,
+  use the functions on <code>ol.Sphere</code>.</p>
 tags: "draw, edit, measure, vector"
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">
   <label>Measurement type &nbsp;</label>
-    <select id="type">
-      <option value="length">Length (LineString)</option>
-      <option value="area">Area (Polygon)</option>
-    </select>
-    <label class="checkbox">
-      <input type="checkbox" id="geodesic">
-      use geodesic measures
-    </label>
+  <select id="type">
+    <option value="length">Length (LineString)</option>
+    <option value="area">Area (Polygon)</option>
+  </select>
 </form>

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -8,7 +8,6 @@ goog.require('ol.geom.Polygon');
 goog.require('ol.interaction.Draw');
 goog.require('ol.layer.Tile');
 goog.require('ol.layer.Vector');
-goog.require('ol.proj');
 goog.require('ol.source.OSM');
 goog.require('ol.source.Vector');
 goog.require('ol.style.Circle');
@@ -16,8 +15,6 @@ goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 
-
-var wgs84Sphere = new ol.Sphere(6378137);
 
 var raster = new ol.layer.Tile({
   source: new ol.source.OSM()
@@ -137,7 +134,6 @@ map.getViewport().addEventListener('mouseout', function() {
 });
 
 var typeSelect = document.getElementById('type');
-var geodesicCheckbox = document.getElementById('geodesic');
 
 var draw; // global so we can remove it later
 
@@ -148,19 +144,7 @@ var draw; // global so we can remove it later
  * @return {string} The formatted length.
  */
 var formatLength = function(line) {
-  var length;
-  if (geodesicCheckbox.checked) {
-    var coordinates = line.getCoordinates();
-    length = 0;
-    var sourceProj = map.getView().getProjection();
-    for (var i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-      var c1 = ol.proj.transform(coordinates[i], sourceProj, 'EPSG:4326');
-      var c2 = ol.proj.transform(coordinates[i + 1], sourceProj, 'EPSG:4326');
-      length += wgs84Sphere.haversineDistance(c1, c2);
-    }
-  } else {
-    length = Math.round(line.getLength() * 100) / 100;
-  }
+  var length = ol.Sphere.getLength(line);
   var output;
   if (length > 100) {
     output = (Math.round(length / 1000 * 100) / 100) +
@@ -179,16 +163,7 @@ var formatLength = function(line) {
  * @return {string} Formatted area.
  */
 var formatArea = function(polygon) {
-  var area;
-  if (geodesicCheckbox.checked) {
-    var sourceProj = map.getView().getProjection();
-    var geom = /** @type {ol.geom.Polygon} */(polygon.clone().transform(
-        sourceProj, 'EPSG:4326'));
-    var coordinates = geom.getLinearRing(0).getCoordinates();
-    area = Math.abs(wgs84Sphere.geodesicArea(coordinates));
-  } else {
-    area = polygon.getArea();
-  }
+  var area = ol.Sphere.getArea(polygon);
   var output;
   if (area > 10000) {
     output = (Math.round(area / 1000000 * 100) / 100) +

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -437,6 +437,32 @@ olx.MapOptions.prototype.view;
 
 
 /**
+ * Object literal with options for the {@link ol.Sphere.getLength}.
+ * @typedef {{projection: (ol.ProjectionLike|undefined),
+ *    radius: (number|undefined)}}
+ */
+olx.SphereLengthOptions;
+
+
+/**
+ * Projection of the geometry.  By default, the geometry is assumed to be in
+ * EPSG:3857 (Web Mercator).
+ * @type {(ol.ProjectionLike|undefined)}
+ * @api
+ */
+olx.SphereLengthOptions.prototype.projection;
+
+
+/**
+ * Sphere radius.  By default, the radius of the earth is used (Clarke 1866
+ * Authalic Sphere).
+ * @type {(number|undefined)}
+ * @api
+ */
+olx.SphereLengthOptions.prototype.radius;
+
+
+/**
  * Object literal with options for the {@link ol.Map#forEachFeatureAtPixel} and
  * {@link ol.Map#hasFeatureAtPixel} methods.
  * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -437,11 +437,12 @@ olx.MapOptions.prototype.view;
 
 
 /**
- * Object literal with options for the {@link ol.Sphere.getLength}.
+ * Object literal with options for the {@link ol.Sphere.getLength} or
+ * {@link ol.Sphere.getArea} functions.
  * @typedef {{projection: (ol.ProjectionLike|undefined),
  *    radius: (number|undefined)}}
  */
-olx.SphereLengthOptions;
+olx.SphereMetricOptions;
 
 
 /**
@@ -450,7 +451,7 @@ olx.SphereLengthOptions;
  * @type {(ol.ProjectionLike|undefined)}
  * @api
  */
-olx.SphereLengthOptions.prototype.projection;
+olx.SphereMetricOptions.prototype.projection;
 
 
 /**
@@ -459,7 +460,7 @@ olx.SphereLengthOptions.prototype.projection;
  * @type {(number|undefined)}
  * @api
  */
-olx.SphereLengthOptions.prototype.radius;
+olx.SphereMetricOptions.prototype.radius;
 
 
 /**

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -22,11 +22,11 @@ ol.proj.METERS_PER_UNIT = ol.proj.Units.METERS_PER_UNIT;
 
 
 /**
- * A place to store the radius of the Clarke 1866 Authalic Sphere.
+ * A place to store the mean radius of the Earth.
  * @private
  * @type {ol.Sphere}
  */
-ol.proj.AUTHALIC_SPHERE_ = new ol.Sphere(6370997);
+ol.proj.SPHERE_ = new ol.Sphere(ol.Sphere.DEFAULT_RADIUS);
 
 
 if (ol.ENABLE_PROJ4JS) {
@@ -90,9 +90,9 @@ ol.proj.getPointResolution = function(projection, resolution, point, opt_units) 
         point[0], point[1] + resolution / 2
       ];
       vertices = toEPSG4326(vertices, vertices, 2);
-      var width = ol.proj.AUTHALIC_SPHERE_.haversineDistance(
+      var width = ol.proj.SPHERE_.haversineDistance(
           vertices.slice(0, 2), vertices.slice(2, 4));
-      var height = ol.proj.AUTHALIC_SPHERE_.haversineDistance(
+      var height = ol.proj.SPHERE_.haversineDistance(
           vertices.slice(4, 6), vertices.slice(6, 8));
       pointResolution = (width + height) / 2;
       var metersPerUnit = opt_units ?

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -204,7 +204,7 @@ ol.Sphere.getDistance_ = function(c1, c2, radius) {
  * @param {olx.SphereMetricOptions} opt_options Options for the area
  *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  *     You can change this by providing a `projection` option.
- * @return {number} The spherical area (in meters).
+ * @return {number} The spherical area (in square meters).
  */
 ol.Sphere.getArea = function(geometry, opt_options) {
   var options = opt_options || {};
@@ -268,7 +268,7 @@ ol.Sphere.getArea = function(geometry, opt_options) {
  * ring. If the ring is oriented clockwise, the area will be positive,
  * otherwise it will be negative.
  * @param {number} radius The sphere radius.
- * @return {number} Area (in meters).
+ * @return {number} Area (in square meters).
  */
 ol.Sphere.getArea_ = function(coordinates, radius) {
   var area = 0, len = coordinates.length;

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -106,7 +106,7 @@ ol.Sphere.DEFAULT_RADIUS = 6371008.8;
  * the sum of all rings.  For points, the length is zero.  For multi-part
  * geometries, the length is the sum of the length of each part.
  * @param {ol.geom.Geometry} geometry A geometry.
- * @param {olx.SphereMetricOptions} opt_options Options for the length
+ * @param {olx.SphereMetricOptions=} opt_options Options for the length
  *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  *     You can change this by providing a `projection` option.
  * @return {number} The spherical length (in meters).
@@ -201,7 +201,7 @@ ol.Sphere.getDistance_ = function(c1, c2, radius) {
  * Get the spherical area of a geometry.  This is the area (in meters) assuming
  * that polygon edges are segments of great circles on a sphere.
  * @param {ol.geom.Geometry} geometry A geometry.
- * @param {olx.SphereMetricOptions} opt_options Options for the area
+ * @param {olx.SphereMetricOptions=} opt_options Options for the area
  *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  *     You can change this by providing a `projection` option.
  * @return {number} The spherical area (in square meters).

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -221,21 +221,21 @@ describe('ol.proj', function() {
     });
     it('returns the correct point resolution for EPSG:4326 with custom units', function() {
       var pointResolution = ol.proj.getPointResolution('EPSG:4326', 1, [0, 0], 'm');
-      expect (pointResolution).to.roughlyEqual(111194.874284, 1e-5);
+      expect(pointResolution).to.roughlyEqual(111195.0802335329, 1e-5);
       pointResolution = ol.proj.getPointResolution('EPSG:4326', 1, [0, 52], 'm');
-      expect (pointResolution).to.roughlyEqual(89826.367538, 1e-5);
+      expect(pointResolution).to.roughlyEqual(89826.53390979706, 1e-5);
     });
     it('returns the correct point resolution for EPSG:3857', function() {
       var pointResolution = ol.proj.getPointResolution('EPSG:3857', 1, [0, 0]);
-      expect (pointResolution).to.be(1);
+      expect(pointResolution).to.be(1);
       pointResolution = ol.proj.getPointResolution('EPSG:3857', 1, ol.proj.fromLonLat([0, 52]));
-      expect (pointResolution).to.roughlyEqual(0.615661, 1e-5);
+      expect(pointResolution).to.roughlyEqual(0.615661, 1e-5);
     });
     it('returns the correct point resolution for EPSG:3857 with custom units', function() {
       var pointResolution = ol.proj.getPointResolution('EPSG:3857', 1, [0, 0], 'degrees');
-      expect (pointResolution).to.be(1);
+      expect(pointResolution).to.be(1);
       pointResolution = ol.proj.getPointResolution('EPSG:4326', 1, ol.proj.fromLonLat([0, 52]), 'degrees');
-      expect (pointResolution).to.be(1);
+      expect(pointResolution).to.be(1);
     });
   });
 

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -177,3 +177,23 @@ describe('ol.Sphere.getLength()', function() {
   });
 
 });
+
+describe('ol.Sphere.getArea()', function() {
+  var geometry;
+  before(function(done) {
+    afterLoadText('spec/ol/format/wkt/illinois.wkt', function(wkt) {
+      try {
+        var format = new ol.format.WKT();
+        geometry = format.readGeometry(wkt);
+      } catch (e) {
+        done(e);
+      }
+      done();
+    });
+  });
+
+  it('calculates the area of Ilinois', function() {
+    var area = ol.Sphere.getArea(geometry, {projection: 'EPSG:4326'});
+    expect(area).to.equal(145652224192.4434);
+  });
+});

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -108,3 +108,72 @@ describe('ol.Sphere', function() {
   });
 
 });
+
+describe('ol.Sphere.getLength()', function() {
+  var cases = [{
+    geometry: new ol.geom.Point([0, 0]),
+    length: 0
+  }, {
+    geometry: new ol.geom.MultiPoint([[0, 0], [1, 1]]),
+    length: 0
+  }, {
+    geometry: new ol.geom.LineString([
+      [12801741.441226462, -3763310.627144653],
+      [14582853.293918837, -2511525.2348457114],
+      [15918687.18343812, -2875744.624352243],
+      [16697923.618991036, -4028802.0261344076]
+    ]),
+    length: 4407939.124914191
+  }, {
+    geometry: new ol.geom.LineString([
+      [115, -32],
+      [131, -22],
+      [143, -25],
+      [150, -34]
+    ]),
+    options: {projection: 'EPSG:4326'},
+    length: 4407939.124914191
+  }, {
+    geometry: new ol.geom.MultiLineString([
+      [
+        [115, -32],
+        [131, -22],
+        [143, -25],
+        [150, -34]
+      ], [
+        [115, -32],
+        [131, -22],
+        [143, -25],
+        [150, -34]
+      ]
+    ]),
+    options: {projection: 'EPSG:4326'},
+    length: 2 * 4407939.124914191
+  }, {
+    geometry: new ol.geom.GeometryCollection([
+      new ol.geom.LineString([
+        [115, -32],
+        [131, -22],
+        [143, -25],
+        [150, -34]
+      ]),
+      new ol.geom.LineString([
+        [115, -32],
+        [131, -22],
+        [143, -25],
+        [150, -34]
+      ])
+    ]),
+    options: {projection: 'EPSG:4326'},
+    length: 2 * 4407939.124914191
+  }];
+
+  cases.forEach(function(c, i) {
+    it('works for case ' + i, function() {
+      var c = cases[i];
+      var length = ol.Sphere.getLength(c.geometry, c.options);
+      expect(length).to.equal(c.length);
+    });
+  });
+
+});


### PR DESCRIPTION
This adds `getLength()` and `getArea()` methods for doing spherical calculations on geometries.  By default, the [mean radius of the earth](https://en.wikipedia.org/wiki/Earth_radius#Mean_radius) is used (from the WGS84 ellipsoid).  And by default, geometries are assumed to be in Web Mercator.  Both the sphere radius and the projection can be provided as options.

Previously, spherical calculations used by `ol.proj.pointResolution()` were using the radius for the Clarke 1866 Authalic Sphere.  I'm not sure where this came from, but I think using the mean radius with WGS84 ellipsoid values is the right thing to do.

Tacking these functions onto `ol.Sphere` is awkward, because users never need to construct a sphere.  It would be nice to have `ol.sphere` instead.  We can get rid of the `ol.Sphere` constructor and use `ol.sphere` in a major release.  For now, `ol` package users can still have nice things:

```js
import sphere from 'ol/sphere';
// ...
sphere.getArea(polygon);
```
