### PR TITLE
IE11: Avoid text selection when using Shift + Click in Map

### DIFF
--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -202,7 +202,7 @@ ol.MapBrowserEventHandler.prototype.isMouseActionButton_ = function(pointerEvent
  * @private
  */
 ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
-  var isIE11 = navigator.userAgent.match(/Trident\/7.0; rv 11.0/);
+  var isIE11 = navigator.userAgent.indexOf('rv:11.0') >= 0;
   if (isE11) {
     pointerEvent.preventDefault();
   }

--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -202,7 +202,10 @@ ol.MapBrowserEventHandler.prototype.isMouseActionButton_ = function(pointerEvent
  * @private
  */
 ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
-  pointerEvent.preventDefault();
+  var isIE11 = navigator.userAgent.match(/Trident\/7.0; rv 11.0/);
+  if (isE11) {
+    pointerEvent.preventDefault();
+  }
   this.updateActivePointers_(pointerEvent);
   var newEvent = new ol.MapBrowserPointerEvent(
       ol.MapBrowserEventType.POINTERDOWN, this.map_, pointerEvent);

--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -202,6 +202,7 @@ ol.MapBrowserEventHandler.prototype.isMouseActionButton_ = function(pointerEvent
  * @private
  */
 ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
+  pointerEvent.preventDefault();
   this.updateActivePointers_(pointerEvent);
   var newEvent = new ol.MapBrowserPointerEvent(
       ol.MapBrowserEventType.POINTERDOWN, this.map_, pointerEvent);

--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -203,7 +203,7 @@ ol.MapBrowserEventHandler.prototype.isMouseActionButton_ = function(pointerEvent
  */
 ol.MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
   var isIE11 = navigator.userAgent.indexOf('rv:11.0') >= 0;
-  if (isE11) {
+  if (isIE11) {
     pointerEvent.preventDefault();
   }
   this.updateActivePointers_(pointerEvent);


### PR DESCRIPTION
When using Shift + Click on the map inside IE 11 for zooming to an area or free hand drawing a linesegement all Text around the map get selected by the browser.

Make sure these boxes are checked before submitting your pull request. Thank you!

- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label.
- [x ] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x ] I have used clear commit messages.
