### PR TITLE
Immediately complete no-op animations

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -302,7 +302,14 @@ ol.View.prototype.animate = function(var_args) {
     }
 
     animation.callback = callback;
-    start += animation.duration;
+
+    // check if animation is a no-op
+    if (ol.View.isNoopAnimation(animation)) {
+      animation.complete = true;
+      // we still push it onto the series for callback handling
+    } else {
+      start += animation.duration;
+    }
     series.push(animation);
   }
   this.animations_.push(series);
@@ -1157,4 +1164,28 @@ ol.View.createRotationConstraint_ = function(options) {
   } else {
     return ol.RotationConstraint.disable;
   }
+};
+
+
+/**
+ * Determine if an animation involves no view change.
+ * @param {ol.ViewAnimation} animation The animation.
+ * @return {boolean} The animation involves no view change.
+ */
+ol.View.isNoopAnimation = function(animation) {
+  if (animation.sourceCenter) {
+    if (animation.sourceCenter[0] !== animation.targetCenter[0]) {
+      return false;
+    }
+    if (animation.sourceCenter[1] !== animation.targetCenter[1]) {
+      return false;
+    }
+  }
+  if (animation.sourceResolution !== animation.targetResolution) {
+    return false;
+  }
+  if (animation.sourceRotation !== animation.targetRotation) {
+    return false;
+  }
+  return true;
 };

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -1173,11 +1173,8 @@ ol.View.createRotationConstraint_ = function(options) {
  * @return {boolean} The animation involves no view change.
  */
 ol.View.isNoopAnimation = function(animation) {
-  if (animation.sourceCenter) {
-    if (animation.sourceCenter[0] !== animation.targetCenter[0]) {
-      return false;
-    }
-    if (animation.sourceCenter[1] !== animation.targetCenter[1]) {
+  if (animation.sourceCenter && animation.targetCenter) {
+    if (!ol.coordinate.equals(animation.sourceCenter, animation.targetCenter)) {
       return false;
     }
   }

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -457,6 +457,20 @@ describe('ol.View', function() {
       }, 10);
     });
 
+    it('immediately completes for no-op animations', function() {
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 5
+      });
+
+      view.animate({
+        zoom: 5,
+        center: [0, 0],
+        duration: 25
+      });
+      expect(view.getAnimating()).to.eql(false);
+    });
+
     it('prefers zoom over resolution', function(done) {
       var view = new ol.View({
         center: [0, 0],
@@ -556,6 +570,21 @@ describe('ol.View', function() {
       view.setCenter([1, 2]); // interrupt the animation
     });
 
+    it('calls a callback even if animation is a no-op', function(done) {
+      var view = new ol.View({
+        center: [0, 0],
+        zoom: 0
+      });
+
+      view.animate({
+        zoom: 0,
+        duration: 25
+      }, function(complete) {
+        expect(complete).to.be(true);
+        done();
+      });
+    });
+
     it('can run multiple animations in series', function(done) {
       var view = new ol.View({
         center: [0, 0],
@@ -613,7 +642,7 @@ describe('ol.View', function() {
       expect(view.getHints()[ol.ViewHint.ANIMATING]).to.be(2);
 
       view.animate({
-        rotate: Math.PI,
+        rotation: Math.PI,
         duration: 25
       }, decrement);
       expect(view.getHints()[ol.ViewHint.ANIMATING]).to.be(3);
@@ -640,7 +669,7 @@ describe('ol.View', function() {
       expect(view.getHints()[ol.ViewHint.ANIMATING]).to.be(2);
 
       view.animate({
-        rotate: Math.PI,
+        rotation: Math.PI,
         duration: 25
       });
       expect(view.getHints()[ol.ViewHint.ANIMATING]).to.be(3);
@@ -1281,4 +1310,75 @@ describe('ol.View', function() {
       expect(view.getCenter()[1]).to.roughlyEqual(46000, 1e-9);
     });
   });
+});
+
+describe('ol.View.isNoopAnimation()', function() {
+
+  var cases = [{
+    animation: {
+      sourceCenter: [0, 0], targetCenter: [0, 0],
+      sourceResolution: 1, targetResolution: 1,
+      sourceRotation: 0, targetRotation: 0
+    },
+    noop: true
+  }, {
+    animation: {
+      sourceCenter: [0, 0], targetCenter: [0, 1],
+      sourceResolution: 1, targetResolution: 1,
+      sourceRotation: 0, targetRotation: 0
+    },
+    noop: false
+  }, {
+    animation: {
+      sourceCenter: [0, 0], targetCenter: [0, 0],
+      sourceResolution: 1, targetResolution: 0,
+      sourceRotation: 0, targetRotation: 0
+    },
+    noop: false
+  }, {
+    animation: {
+      sourceCenter: [0, 0], targetCenter: [0, 0],
+      sourceResolution: 1, targetResolution: 1,
+      sourceRotation: 0, targetRotation: 1
+    },
+    noop: false
+  }, {
+    animation: {
+      sourceCenter: [0, 0], targetCenter: [0, 0]
+    },
+    noop: true
+  }, {
+    animation: {
+      sourceCenter: [1, 0], targetCenter: [0, 0]
+    },
+    noop: false
+  }, {
+    animation: {
+      sourceResolution: 1, targetResolution: 1
+    },
+    noop: true
+  }, {
+    animation: {
+      sourceResolution: 0, targetResolution: 1
+    },
+    noop: false
+  }, {
+    animation: {
+      sourceRotation: 10, targetRotation: 10
+    },
+    noop: true
+  }, {
+    animation: {
+      sourceRotation: 0, targetRotation: 10
+    },
+    noop: false
+  }];
+
+  cases.forEach(function(c, i) {
+    it('works for case ' + i, function() {
+      var noop = ol.View.isNoopAnimation(c.animation);
+      expect(noop).to.equal(c.noop);
+    });
+  });
+
 });


### PR DESCRIPTION
Currently, if you call `view.animate()` with properties that imply no view change, the view stays "animating" for the duration of the animation.  This means that no tiles load for the default case.  Instead, this no-op animation should immediately complete (and any others in the series should start).
