### PR TITLE
Make view.animate() tolerate undefined views

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -255,16 +255,33 @@ ol.View.prototype.getUpdatedOptions_ = function(newOptions) {
  * @api
  */
 ol.View.prototype.animate = function(var_args) {
-  var start = Date.now();
-  var center = this.getCenter().slice();
-  var resolution = this.getResolution();
-  var rotation = this.getRotation();
   var animationCount = arguments.length;
   var callback;
   if (animationCount > 1 && typeof arguments[animationCount - 1] === 'function') {
     callback = arguments[animationCount - 1];
     --animationCount;
   }
+  if (!this.isDef()) {
+    // if view properties are not yet set, shortcut to the final state
+    var state = arguments[animationCount - 1];
+    if (state.center) {
+      this.setCenter(state.center);
+    }
+    if (state.zoom !== undefined) {
+      this.setZoom(state.zoom);
+    }
+    if (state.rotation !== undefined) {
+      this.setRotation(state.rotation);
+    }
+    if (callback) {
+      callback(true);
+    }
+    return;
+  }
+  var start = Date.now();
+  var center = this.getCenter().slice();
+  var resolution = this.getResolution();
+  var rotation = this.getRotation();
   var series = [];
   for (var i = 0; i < animationCount; ++i) {
     var options = /** @type {olx.AnimationOptions} */ (arguments[i]);

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -471,6 +471,24 @@ describe('ol.View', function() {
       expect(view.getAnimating()).to.eql(false);
     });
 
+    it('immediately completes if view is not defined before', function() {
+      var view = new ol.View();
+      var center = [1, 2];
+      var zoom = 3;
+      var rotation = 0.4;
+
+      view.animate({
+        zoom: zoom,
+        center: center,
+        rotation: rotation,
+        duration: 25
+      });
+      expect(view.getAnimating()).to.eql(false);
+      expect(view.getCenter()).to.eql(center);
+      expect(view.getZoom()).to.eql(zoom);
+      expect(view.getRotation()).to.eql(rotation);
+    });
+
     it('prefers zoom over resolution', function(done) {
       var view = new ol.View({
         center: [0, 0],
@@ -580,6 +598,19 @@ describe('ol.View', function() {
         zoom: 0,
         duration: 25
       }, function(complete) {
+        expect(complete).to.be(true);
+        done();
+      });
+    });
+
+    it('calls a callback if view is not defined before', function(done) {
+      var view = new ol.View();
+
+      view.animate({
+        zoom: 10,
+        duration: 25
+      }, function(complete) {
+        expect(view.getZoom()).to.be(10);
         expect(complete).to.be(true);
         done();
       });

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -489,6 +489,31 @@ describe('ol.View', function() {
       expect(view.getRotation()).to.eql(rotation);
     });
 
+    it('sets final animation state if view is not defined before', function() {
+      var view = new ol.View();
+
+      var center = [1, 2];
+      var zoom = 3;
+      var rotation = 0.4;
+
+      view.animate({
+        zoom: 1
+      }, {
+        center: [2, 3]
+      }, {
+        rotation: 4
+      }, {
+        zoom: zoom,
+        center: center,
+        rotation: rotation,
+        duration: 25
+      });
+      expect(view.getAnimating()).to.eql(false);
+      expect(view.getCenter()).to.eql(center);
+      expect(view.getZoom()).to.eql(zoom);
+      expect(view.getRotation()).to.eql(rotation);
+    });
+
     it('prefers zoom over resolution', function(done) {
       var view = new ol.View({
         center: [0, 0],


### PR DESCRIPTION
Currently, `view.animate()` throws if `view.isDef()` is `false`.  This branch makes it so we set the view to the final animation state if the view is not defined before the `view.animate()` call.