### PR TITLE
Improvements to the new test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "mocha-phantomjs-core": "^2.1.0",
     "mustache": "2.3.0",
     "phantomjs-prebuilt": "2.1.15",
+    "pixelmatch": "^4.0.2",
     "proj4": "2.4.4",
-    "resemblejs": "2.2.4",
     "serve-files": "1.0.1",
     "sinon": "3.2.0",
     "slimerjs": "0.10.3"

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -14,7 +14,7 @@
     "expect": false,
     "expectResemble": false,
     "proj4": false,
-    "resemble": false,
+    "pixelmatch": false,
     "resembleCanvas": false,
     "sinon": false,
     "where": false

--- a/test/README.md
+++ b/test/README.md
@@ -29,7 +29,7 @@ in Chrome by default).
 # Rendering tests
 
 The `test/rendering` directory contains rendering tests which compare a rendered map with a
-reference image using [resemble.js](http://huddle.github.io/Resemble.js/).
+reference image using [pixelmatch](https://github.com/mapbox/pixelmatch).
 
 To run the tests in the browser, make sure the development server is running
 (`make serve`) and open the URL

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -19,6 +19,9 @@ module.exports = function(karma) {
     },
     files: [
       {
+        pattern: 'module-global.js',
+        watched: false
+      }, {
         pattern: path.resolve(__dirname, require.resolve('jquery/dist/jquery.js')),
         watched: false
       }, {
@@ -31,7 +34,7 @@ module.exports = function(karma) {
         pattern: path.resolve(__dirname, require.resolve('proj4/dist/proj4.js')),
         watched: false
       }, {
-        pattern: path.resolve(__dirname, require.resolve('resemblejs/resemble.js')),
+        pattern: path.resolve(__dirname, require.resolve('pixelmatch/index.js')),
         watched: false
       }, {
         pattern: path.resolve(__dirname, './test-extensions.js')

--- a/test/module-global.js
+++ b/test/module-global.js
@@ -1,0 +1,1 @@
+window.module = {};

--- a/test/rendering/ol/layer/clip.test.js
+++ b/test/rendering/ol/layer/clip.test.js
@@ -41,6 +41,7 @@ describe('layer clipping', function() {
     var map = null;
     beforeEach(function() {
       map = new ol.Map({
+        pixelRatio: 1,
         target: createMapDiv(256, 256),
         view: new ol.View({
           center: [0, 0],

--- a/test/rendering/ol/layer/image.test.js
+++ b/test/rendering/ol/layer/image.test.js
@@ -15,6 +15,7 @@ describe('ol.rendering.layer.Image', function() {
 
   function createMap(renderer) {
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(50, 50),
       renderer: renderer,
       view: new ol.View({

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -21,6 +21,7 @@ describe('ol.rendering.layer.Vector', function() {
   var map;
   function createMap(renderer) {
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(80, 80),
       renderer: renderer,
       view: new ol.View({
@@ -249,12 +250,12 @@ describe('ol.rendering.layer.Vector', function() {
       map.once('postrender', function() {
         var canvas = map.getRenderer().canvas_;
         // take a snapshot of this `overlaps: true` image
-        var referenceImage = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
+        var referenceImage = canvas.toDataURL('image/png');
         // now render the same with `overlaps: false`
         layer.setSource(createSource(false));
-        // result should be similar to `overlaps: true`
-        map.once('postrender', function() {
-          expectResemble(map, referenceImage, 2, done);
+        // result should be the same as with `overlaps: true`
+        map.once('postrender', function(e) {
+          expectResemble(map, referenceImage, 1e-9, done);
         });
       });
     });
@@ -300,12 +301,12 @@ describe('ol.rendering.layer.Vector', function() {
       map.once('postrender', function() {
         var canvas = map.getRenderer().canvas_;
         // take a snapshot of this `overlaps: true` image
-        var referenceImage = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
+        var referenceImage = canvas.toDataURL('image/png');
         // now render the same with `overlaps: false`
         layer.setSource(createSource(false));
         // result should be exactly the same as with `overlaps: true`
         map.once('postrender', function() {
-          expectResemble(map, referenceImage, 0, done);
+          expectResemble(map, referenceImage, 1e-9, done);
         });
       });
     });
@@ -316,6 +317,7 @@ describe('ol.rendering.layer.Vector', function() {
     var map2;
     beforeEach(function() {
       map2 = new ol.Map({
+        pixelRatio: 1,
         target: createMapDiv(128, 128),
         view: new ol.View({
           center: [0, 0],
@@ -404,6 +406,7 @@ describe('ol.rendering.layer.Vector', function() {
       });
 
       map3 = new ol.Map({
+        pixelRatio: 1,
         layers: [layer],
         target: createMapDiv(100, 100),
         view: view

--- a/test/rendering/ol/layer/vectortile.test.js
+++ b/test/rendering/ol/layer/vectortile.test.js
@@ -15,7 +15,7 @@ describe('ol.rendering.layer.VectorTile', function() {
 
   function createMap(renderer, opt_pixelRatio) {
     map = new ol.Map({
-      pixelRatio: opt_pixelRatio,
+      pixelRatio: opt_pixelRatio || 1,
       target: createMapDiv(50, 50),
       renderer: renderer,
       view: new ol.View({

--- a/test/rendering/ol/map.test.js
+++ b/test/rendering/ol/map.test.js
@@ -21,6 +21,7 @@ describe('ol.rendering.Map', function() {
     });
 
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(50, 50),
       renderer: renderer,
       layers: [vectorLayer],

--- a/test/rendering/ol/render.test.js
+++ b/test/rendering/ol/render.test.js
@@ -20,14 +20,20 @@ describe('ol.render', function() {
   describe('ol.render.toContext()', function() {
 
     it('creates a vector context from a Canvas 2d context', function() {
-      var vectorContext = ol.render.toContext(getContext(), {size: [100, 100]});
+      var vectorContext = ol.render.toContext(getContext(), {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
       expect(vectorContext).to.be.a(ol.render.VectorContext);
       expect(vectorContext).to.be.a(ol.render.canvas.Immediate);
     });
 
     it('can be used to render a point geometry', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         image: new ol.style.Circle({
@@ -48,7 +54,10 @@ describe('ol.render', function() {
 
     it('can be used to render a linestring geometry', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         stroke: new ol.style.Stroke({
@@ -69,7 +78,10 @@ describe('ol.render', function() {
 
     it('respects lineCap for linestring', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         stroke: new ol.style.Stroke({
@@ -91,7 +103,10 @@ describe('ol.render', function() {
 
     it('respects lineJoin for linestring', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         stroke: new ol.style.Stroke({
@@ -113,7 +128,10 @@ describe('ol.render', function() {
 
     it('can be used to render a polygon geometry', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         stroke: new ol.style.Stroke({
@@ -139,7 +157,10 @@ describe('ol.render', function() {
 
     it('supports lineDash styles', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         stroke: new ol.style.Stroke({
@@ -161,7 +182,10 @@ describe('ol.render', function() {
 
     it('supports lineDashOffset', function(done) {
       var context = getContext();
-      var vectorContext = ol.render.toContext(context, {size: [100, 100]});
+      var vectorContext = ol.render.toContext(context, {
+        pixelRatio: 1,
+        size: [100, 100]
+      });
 
       var style = new ol.style.Style({
         stroke: new ol.style.Stroke({

--- a/test/rendering/ol/style/circle.test.js
+++ b/test/rendering/ol/style/circle.test.js
@@ -23,6 +23,7 @@ describe('ol.rendering.style.Circle', function() {
     });
 
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(50, 50),
       renderer: renderer,
       layers: [vectorLayer],

--- a/test/rendering/ol/style/icon.test.js
+++ b/test/rendering/ol/style/icon.test.js
@@ -30,6 +30,7 @@ describe('ol.rendering.style.Icon', function() {
     });
 
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(width ? width : 50, height ? height : 50),
       renderer: renderer,
       layers: [vectorLayer],

--- a/test/rendering/ol/style/polygon.test.js
+++ b/test/rendering/ol/style/polygon.test.js
@@ -24,6 +24,7 @@ describe('ol.rendering.style.Polygon', function() {
     });
 
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(size, size),
       renderer: renderer,
       layers: [vectorLayer],

--- a/test/rendering/ol/style/regularshape.test.js
+++ b/test/rendering/ol/style/regularshape.test.js
@@ -23,6 +23,7 @@ describe('ol.rendering.style.RegularShape', function() {
     });
 
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(50, 50),
       renderer: renderer,
       layers: [vectorLayer],

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -22,6 +22,7 @@ describe('ol.rendering.style.Text', function() {
     });
 
     map = new ol.Map({
+      pixelRatio: 1,
       target: createMapDiv(200, 200),
       renderer: renderer,
       layers: [vectorLayer],


### PR DESCRIPTION
This change replaces resemble.js with pixelmaps so renderer tests ignor antialiasing difference between browsers, and adds a `pixelRatio` option to all maps so generated test images have the same size regardless of the browser's device pixel ratio.

Fixes #4288