### PR TITLE
Adds unit test to test the projection inside the geometry of esriJson

### DIFF
--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -1063,6 +1063,18 @@ describe('ol.format.EsriJSON', function() {
       expect(esrijson.attributes).to.eql({});
     });
 
+    it('adds the projection inside the geometry correctly', function() {
+      var str = JSON.stringify(data);
+      var array = format.readFeatures(str);
+      var esrijson = format.writeFeaturesObject(array, {
+        featureProjection: 'EPSG:4326'
+      });
+      esrijson.features.forEach(function(feature) {
+        var spatialReference = feature.geometry.spatialReference;
+        expect(Number(spatialReference.wkid)).to.equal(4326);
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This pull request was requested in my previous pull request for the issue 6992, since I forgot to add unit testing.

This adds a simple unit test that tests weather the projection (spatial reference)
is being added inside the geometry object when writing features as
esriJson.

Make sure these boxes are checked before submitting your pull request. Thank you!

- [x] This pull request addresses an issue that has been marked with the 'Pull request accepted' label.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
