### PR TITLE
Spaceless provides

### DIFF
--- a/test/rendering/ol/layer/clip.test.js
+++ b/test/rendering/ol/layer/clip.test.js
@@ -1,4 +1,4 @@
-goog.provide('layer clipping');
+goog.provide('ol.test.rendering.layer.Clipping');
 
 goog.require('ol.Map');
 goog.require('ol.View');


### PR DESCRIPTION
This ensures that we don't have `goog.provide('a name with spaces')` (these won't work with `import`/`export`).