### PR TITLE
Remove unnecessary import in events.test.js

### DIFF
--- a/test/spec/ol/events.test.js
+++ b/test/spec/ol/events.test.js
@@ -2,7 +2,6 @@ goog.provide('ol.test.events');
 
 goog.require('ol.events');
 goog.require('ol.events.EventTarget');
-goog.require('ol');
 
 describe('ol.events', function() {
   var add, remove, target;
@@ -45,7 +44,7 @@ describe('ol.events', function() {
         bindTo: bindTo,
         callOnce: true
       };
-      var unlistenSpy = sinon.spy(ol.events, 'unlistenByKey');
+      var unlistenSpy = sinon.spy(ol.events, 'unlistenByKey'); // eslint-disable-line openlayers-internal/no-missing-requires
       listenerObj.listener = function() {
         expect(this).to.equal(bindTo);
         expect(unlistenSpy.firstCall.args[0]).to.eql(listenerObj);


### PR DESCRIPTION
The `no-missing-requires` rule (correctly) assumes that our use of `ol.events` means we need to import `ol`.  In this case, we are actually using the export from `ol/events`.  Modifying exports like this (in the tests) won't always work, so we will likely need to find another way to test stuff like this eventually.  But for now it should work.
