### PR TITLE
Get rid of useless test exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "install": "node tasks/install.js",
     "postinstall": "closure-util update",
     "start": "node tasks/serve.js",
-    "lint": "eslint tasks test src examples",
+    "lint": "eslint tasks test src examples transforms",
     "lint-package": "eslint --fix build/package",
     "pretest": "npm run lint",
     "test": "npm run karma -- --single-run",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,9 +2,6 @@
   "env": {
     "mocha": true
   },
-  "rules": {
-    "openlayers-internal/valid-provide": 0
-  },
   "globals": {
     "IMAGE_TOLERANCE": false,
     "afterLoadText": false,

--- a/test/rendering/ol/layer/clip.test.js
+++ b/test/rendering/ol/layer/clip.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.layer.Clipping');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/rendering/ol/layer/image.test.js
+++ b/test/rendering/ol/layer/image.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.layer.Image');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/rendering/ol/layer/tile.test.js
+++ b/test/rendering/ol/layer/tile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.layer.Tile');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.layer.Vector');
+
 
 goog.require('ol.Feature');
 goog.require('ol.Map');

--- a/test/rendering/ol/layer/vectortile.test.js
+++ b/test/rendering/ol/layer/vectortile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.layer.VectorTile');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/rendering/ol/map.test.js
+++ b/test/rendering/ol/map.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.Map');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/rendering/ol/render.test.js
+++ b/test/rendering/ol/render.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.render');
+
 
 goog.require('ol.geom.LineString');
 goog.require('ol.geom.Point');

--- a/test/rendering/ol/reproj/image.test.js
+++ b/test/rendering/ol/reproj/image.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.reproj.Image');
+
 
 goog.require('ol.events');
 goog.require('ol.proj');

--- a/test/rendering/ol/reproj/tile.test.js
+++ b/test/rendering/ol/reproj/tile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.reproj.Tile');
+
 
 goog.require('ol.TileState');
 goog.require('ol.events');

--- a/test/rendering/ol/source/tilewms.test.js
+++ b/test/rendering/ol/source/tilewms.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.source.TileWMS');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/rendering/ol/style/circle.test.js
+++ b/test/rendering/ol/style/circle.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.style.Circle');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/rendering/ol/style/icon.test.js
+++ b/test/rendering/ol/style/icon.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.style.Icon');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/rendering/ol/style/linestring.test.js
+++ b/test/rendering/ol/style/linestring.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.style.LineString');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.LineString');

--- a/test/rendering/ol/style/polygon.test.js
+++ b/test/rendering/ol/style/polygon.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.style.Polygon');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Polygon');

--- a/test/rendering/ol/style/regularshape.test.js
+++ b/test/rendering/ol/style/regularshape.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.style.RegularShape');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.rendering.style.Text');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/spec/ol/array.test.js
+++ b/test/spec/ol/array.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.array');
+
 
 goog.require('ol.array');
 

--- a/test/spec/ol/assertionerror.test.js
+++ b/test/spec/ol/assertionerror.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.AssertionError.test');
+
 
 goog.require('ol');
 goog.require('ol.AssertionError');

--- a/test/spec/ol/asserts.test.js
+++ b/test/spec/ol/asserts.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.asserts.asserts.test');
+
 
 goog.require('ol.asserts');
 

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Collection');
+
 
 goog.require('ol.events');
 goog.require('ol.Collection');

--- a/test/spec/ol/color.test.js
+++ b/test/spec/ol/color.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.color');
+
 
 goog.require('ol.color');
 goog.require('ol');

--- a/test/spec/ol/control/attribution.test.js
+++ b/test/spec/ol/control/attribution.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.Attribution');
+
 
 goog.require('ol.Map');
 goog.require('ol.Tile');

--- a/test/spec/ol/control/control.test.js
+++ b/test/spec/ol/control/control.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.Control');
+
 
 goog.require('ol.Map');
 goog.require('ol.control.Control');

--- a/test/spec/ol/control/fullscreen.test.js
+++ b/test/spec/ol/control/fullscreen.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.FullScreen');
+
 
 goog.require('ol.control.FullScreen');
 

--- a/test/spec/ol/control/mouseposition.test.js
+++ b/test/spec/ol/control/mouseposition.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.MousePosition');
+
 
 goog.require('ol.control.MousePosition');
 

--- a/test/spec/ol/control/overviewmap.test.js
+++ b/test/spec/ol/control/overviewmap.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.OverviewMap');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/spec/ol/control/rotate.test.js
+++ b/test/spec/ol/control/rotate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.Rotate');
+
 
 goog.require('ol.control.Rotate');
 

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.ScaleLine');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/spec/ol/control/zoom.test.js
+++ b/test/spec/ol/control/zoom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.Zoom');
+
 
 goog.require('ol.control.Zoom');
 

--- a/test/spec/ol/control/zoomslider.test.js
+++ b/test/spec/ol/control/zoomslider.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.ZoomSlider');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/spec/ol/control/zoomtoextent.test.js
+++ b/test/spec/ol/control/zoomtoextent.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.control.ZoomToExtent');
+
 
 goog.require('ol.control.ZoomToExtent');
 

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.coordinate');
+
 
 goog.require('ol.coordinate');
 goog.require('ol.geom.Circle');

--- a/test/spec/ol/deviceorientation.test.js
+++ b/test/spec/ol/deviceorientation.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.DeviceOrientation');
+
 
 goog.require('ol.DeviceOrientation');
 

--- a/test/spec/ol/disposable.test.js
+++ b/test/spec/ol/disposable.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Disposable');
+
 
 goog.require('ol.Disposable');
 

--- a/test/spec/ol/dom/dom.test.js
+++ b/test/spec/ol/dom/dom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.dom');
+
 
 goog.require('ol.dom');
 

--- a/test/spec/ol/events.test.js
+++ b/test/spec/ol/events.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.events');
+
 
 goog.require('ol.events');
 goog.require('ol.events.EventTarget');

--- a/test/spec/ol/events/event.test.js
+++ b/test/spec/ol/events/event.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.events.Event');
+
 
 goog.require('ol.events.Event');
 

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.events.EventTarget');
+
 
 goog.require('ol.Disposable');
 goog.require('ol.events');

--- a/test/spec/ol/expect.test.js
+++ b/test/spec/ol/expect.test.js
@@ -1,4 +1,3 @@
-goog.provide('ol.test.expect.js');
 
 
 describe('expect.js', function() {

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.extent');
+
 
 goog.require('ol.extent');
 goog.require('ol.proj');

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Feature');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/spec/ol/featureloader.test.js
+++ b/test/spec/ol/featureloader.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.featureloader');
+
 
 goog.require('ol.featureloader');
 goog.require('ol.format.GeoJSON');

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.reader.EsriJSON');
+
 
 goog.require('ol.Feature');
 goog.require('ol.extent');

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.reader.GeoJSON');
+
 
 goog.require('ol.Feature');
 goog.require('ol.extent');

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.GML');
+
 
 goog.require('ol.Feature');
 goog.require('ol.format.GML');

--- a/test/spec/ol/format/gpx.test.js
+++ b/test/spec/ol/format/gpx.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.GPX');
+
 
 goog.require('ol.Feature');
 goog.require('ol.format.GPX');

--- a/test/spec/ol/format/igc.test.js
+++ b/test/spec/ol/format/igc.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.IGC');
+
 
 goog.require('ol.format.IGC');
 goog.require('ol.Feature');

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.KML');
+
 
 goog.require('ol.Feature');
 goog.require('ol.array');

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.MVT');
+
 
 goog.require('ol.Feature');
 goog.require('ol.ext.PBF');

--- a/test/spec/ol/format/osmxml.test.js
+++ b/test/spec/ol/format/osmxml.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.OSMXML');
+
 
 goog.require('ol.Feature');
 goog.require('ol.format.OSMXML');

--- a/test/spec/ol/format/ows.test.js
+++ b/test/spec/ol/format/ows.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.OWS');
+
 
 goog.require('ol.format.OWS');
 goog.require('ol.xml');

--- a/test/spec/ol/format/polyline.test.js
+++ b/test/spec/ol/format/polyline.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.Polyline');
+
 
 goog.require('ol.Feature');
 goog.require('ol.format.Polyline');

--- a/test/spec/ol/format/topojson.test.js
+++ b/test/spec/ol/format/topojson.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.TopoJSON');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.MultiPolygon');

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.WFS');
+
 
 goog.require('ol.Feature');
 goog.require('ol.format.GML2');

--- a/test/spec/ol/format/wkt.test.js
+++ b/test/spec/ol/format/wkt.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.WKT');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/spec/ol/format/wmscapabilities.test.js
+++ b/test/spec/ol/format/wmscapabilities.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.WMSCapabilities');
+
 
 goog.require('ol.format.WMSCapabilities');
 

--- a/test/spec/ol/format/wmsgetfeatureinfo.test.js
+++ b/test/spec/ol/format/wmsgetfeatureinfo.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.WMSGetFeatureInfo');
+
 
 goog.require('ol.format.WMSGetFeatureInfo');
 

--- a/test/spec/ol/format/wmtscapabilities.test.js
+++ b/test/spec/ol/format/wmtscapabilities.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.format.WMTSCapabilities');
+
 
 goog.require('ol.format.WMTSCapabilities');
 

--- a/test/spec/ol/format/xsd.test.js
+++ b/test/spec/ol/format/xsd.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.XSD');
+
 
 goog.require('ol.format.XSD');
 

--- a/test/spec/ol/geolocation.test.js
+++ b/test/spec/ol/geolocation.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Geolocation');
+
 
 goog.require('ol.Geolocation');
 

--- a/test/spec/ol/geom/circle.test.js
+++ b/test/spec/ol/geom/circle.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.Circle');
+
 
 goog.require('ol.geom.Circle');
 

--- a/test/spec/ol/geom/flat/area.test.js
+++ b/test/spec/ol/geom/flat/area.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.area');
+
 
 goog.require('ol.geom.flat.area');
 

--- a/test/spec/ol/geom/flat/center.test.js
+++ b/test/spec/ol/geom/flat/center.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.center');
+
 
 goog.require('ol.geom.flat.center');
 goog.require('ol.geom.MultiPolygon');

--- a/test/spec/ol/geom/flat/closest.test.js
+++ b/test/spec/ol/geom/flat/closest.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.closest');
+
 
 goog.require('ol.geom.flat.closest');
 

--- a/test/spec/ol/geom/flat/contains.test.js
+++ b/test/spec/ol/geom/flat/contains.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.contains');
+
 
 goog.require('ol.geom.flat.contains');
 

--- a/test/spec/ol/geom/flat/deflate.test.js
+++ b/test/spec/ol/geom/flat/deflate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.deflate');
+
 
 goog.require('ol.geom.flat.deflate');
 

--- a/test/spec/ol/geom/flat/flip.test.js
+++ b/test/spec/ol/geom/flat/flip.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.flip');
+
 
 goog.require('ol.geom.flat.flip');
 

--- a/test/spec/ol/geom/flat/inflate.test.js
+++ b/test/spec/ol/geom/flat/inflate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.inflate');
+
 
 goog.require('ol.geom.flat.inflate');
 

--- a/test/spec/ol/geom/flat/interpolate.test.js
+++ b/test/spec/ol/geom/flat/interpolate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.interpolate');
+
 
 goog.require('ol.geom.flat.interpolate');
 

--- a/test/spec/ol/geom/flat/intersectsextent.test.js
+++ b/test/spec/ol/geom/flat/intersectsextent.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.intersectsextent');
+
 
 goog.require('ol.geom.flat.intersectsextent');
 

--- a/test/spec/ol/geom/flat/length.test.js
+++ b/test/spec/ol/geom/flat/length.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.length');
+
 
 goog.require('ol.geom.flat.length');
 

--- a/test/spec/ol/geom/flat/orient.test.js
+++ b/test/spec/ol/geom/flat/orient.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.orient');
+
 
 goog.require('ol.geom.flat.orient');
 

--- a/test/spec/ol/geom/flat/reverse.test.js
+++ b/test/spec/ol/geom/flat/reverse.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.reverse');
+
 
 goog.require('ol.geom.flat.reverse');
 

--- a/test/spec/ol/geom/flat/segments.test.js
+++ b/test/spec/ol/geom/flat/segments.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.segments');
+
 
 goog.require('ol.geom.flat.segments');
 

--- a/test/spec/ol/geom/flat/simplify.test.js
+++ b/test/spec/ol/geom/flat/simplify.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.simplify');
+
 
 goog.require('ol.geom.flat.simplify');
 

--- a/test/spec/ol/geom/flat/topologyflatgeom.test.js
+++ b/test/spec/ol/geom/flat/topologyflatgeom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.topology');
+
 
 goog.require('ol.geom.flat.topology');
 

--- a/test/spec/ol/geom/flat/transform.test.js
+++ b/test/spec/ol/geom/flat/transform.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.flat.transform');
+
 
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.SimpleGeometry');

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.GeometryCollection');
+
 
 goog.require('ol.geom.Geometry');
 goog.require('ol.geom.GeometryCollection');

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.LineString');
+
 
 goog.require('ol.extent');
 goog.require('ol.geom.LineString');

--- a/test/spec/ol/geom/multilinestring.test.js
+++ b/test/spec/ol/geom/multilinestring.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.MultiLineString');
+
 
 goog.require('ol.extent');
 goog.require('ol.geom.LineString');

--- a/test/spec/ol/geom/multipoint.test.js
+++ b/test/spec/ol/geom/multipoint.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.MultiPoint');
+
 
 goog.require('ol.extent');
 goog.require('ol.geom.MultiPoint');

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.MultiPolygon');
+
 
 goog.require('ol.geom.MultiPolygon');
 goog.require('ol.geom.Polygon');

--- a/test/spec/ol/geom/point.test.js
+++ b/test/spec/ol/geom/point.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.Point');
+
 
 goog.require('ol.geom.Point');
 

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.geom.Polygon');
+
 
 goog.require('ol.extent');
 goog.require('ol.geom.Circle');

--- a/test/spec/ol/graticule.test.js
+++ b/test/spec/ol/graticule.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Graticule');
+
 
 goog.require('ol.Graticule');
 goog.require('ol.Map');

--- a/test/spec/ol/imagetile.test.js
+++ b/test/spec/ol/imagetile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.ImageTile');
+
 
 goog.require('ol.ImageTile');
 goog.require('ol.TileState');

--- a/test/spec/ol/index.test.js
+++ b/test/spec/ol/index.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test');
+
 goog.require('ol');
 
 describe('getUid()', function() {

--- a/test/spec/ol/interaction/draganddrop.test.js
+++ b/test/spec/ol/interaction/draganddrop.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.DragAndDrop');
+
 
 goog.require('ol');
 goog.require('ol.View');

--- a/test/spec/ol/interaction/dragrotateandzoom.test.js
+++ b/test/spec/ol/interaction/dragrotateandzoom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.DragRotateAndZoom');
+
 
 goog.require('ol.Map');
 goog.require('ol.MapBrowserPointerEvent');

--- a/test/spec/ol/interaction/dragzoom.test.js
+++ b/test/spec/ol/interaction/dragzoom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.DragZoom');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Draw');
+
 
 goog.require('ol.Feature');
 goog.require('ol.Map');

--- a/test/spec/ol/interaction/extent.test.js
+++ b/test/spec/ol/interaction/extent.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Extent');
+
 
 goog.require('ol.Map');
 goog.require('ol.MapBrowserPointerEvent');

--- a/test/spec/ol/interaction/interaction.test.js
+++ b/test/spec/ol/interaction/interaction.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Interaction');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/spec/ol/interaction/keyboardpan.test.js
+++ b/test/spec/ol/interaction/keyboardpan.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.KeyboardPan');
+
 
 goog.require('ol.Map');
 goog.require('ol.MapBrowserEvent');

--- a/test/spec/ol/interaction/keyboardzoom.test.js
+++ b/test/spec/ol/interaction/keyboardzoom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.KeyboardZoom');
+
 
 goog.require('ol.Map');
 goog.require('ol.MapBrowserEvent');

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Modify');
+
 
 goog.require('ol.Collection');
 goog.require('ol.Feature');

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.MouseWheelZoom');
+
 
 goog.require('ol.Map');
 goog.require('ol.MapBrowserEvent');

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Select');
+
 
 goog.require('ol.Collection');
 goog.require('ol.Feature');

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Snap');
+
 
 goog.require('ol.Collection');
 goog.require('ol.Feature');

--- a/test/spec/ol/interaction/translate.test.js
+++ b/test/spec/ol/interaction/translate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.interaction.Translate');
+
 
 goog.require('ol.Collection');
 goog.require('ol.Feature');

--- a/test/spec/ol/layer/group.test.js
+++ b/test/spec/ol/layer/group.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.layer.Group');
+
 
 goog.require('ol');
 goog.require('ol.array');

--- a/test/spec/ol/layer/heatmap.test.js
+++ b/test/spec/ol/layer/heatmap.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.layer.Heatmap');
+
 
 goog.require('ol.layer.Heatmap');
 

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.layer.Layer');
+
 
 goog.require('ol');
 goog.require('ol.Map');

--- a/test/spec/ol/layer/tile.test.js
+++ b/test/spec/ol/layer/tile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.layer.Tile');
+
 
 goog.require('ol.layer.Tile');
 goog.require('ol.source.OSM');

--- a/test/spec/ol/layer/vector.test.js
+++ b/test/spec/ol/layer/vector.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.layer.Vector');
+
 
 goog.require('ol.layer.Layer');
 goog.require('ol.layer.Vector');

--- a/test/spec/ol/layer/vectortile.test.js
+++ b/test/spec/ol/layer/vectortile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.layer.VectorTile');
+
 
 goog.require('ol.layer.VectorTile');
 goog.require('ol.source.VectorTile');

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Map');
+
 
 goog.require('ol.Feature');
 goog.require('ol.Map');

--- a/test/spec/ol/mapbrowserevent.test.js
+++ b/test/spec/ol/mapbrowserevent.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.MapBrowserEventHandler');
+
 
 goog.require('ol.Map');
 goog.require('ol.MapBrowserEventHandler');

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.math');
+
 
 goog.require('ol.math');
 

--- a/test/spec/ol/net.test.js
+++ b/test/spec/ol/net.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.net');
+
 
 goog.require('ol');
 goog.require('ol.net');

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Object');
+
 
 goog.require('ol.Object');
 goog.require('ol.events');

--- a/test/spec/ol/objectutil.test.js
+++ b/test/spec/ol/objectutil.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.object');
+
 
 goog.require('ol.obj');
 

--- a/test/spec/ol/observable.test.js
+++ b/test/spec/ol/observable.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Observable');
+
 
 goog.require('ol.events.EventTarget');
 goog.require('ol.Observable');

--- a/test/spec/ol/overlay.test.js
+++ b/test/spec/ol/overlay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Overlay');
+
 
 goog.require('ol.Map');
 goog.require('ol.Overlay');

--- a/test/spec/ol/pointer/mousesource.test.js
+++ b/test/spec/ol/pointer/mousesource.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.pointer.MouseSource');
+
 
 goog.require('ol.events');
 goog.require('ol.events.EventTarget');

--- a/test/spec/ol/pointer/pointereventhandler.test.js
+++ b/test/spec/ol/pointer/pointereventhandler.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.pointer.PointerEventHandler');
+
 
 goog.require('ol.events');
 goog.require('ol.events.EventTarget');

--- a/test/spec/ol/pointer/touchsource.test.js
+++ b/test/spec/ol/pointer/touchsource.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.pointer.TouchSource');
+
 
 goog.require('ol.events');
 goog.require('ol.events.Event');

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.proj.EPSG3857');
+
 
 goog.require('ol.proj');
 

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.proj');
+
 
 goog.require('ol.proj');
 goog.require('ol.proj.EPSG4326');

--- a/test/spec/ol/proj/transforms.test.js
+++ b/test/spec/ol/proj/transforms.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.proj.transforms');
+
 
 goog.require('ol.proj.Projection');
 goog.require('ol.proj.transforms');

--- a/test/spec/ol/render.test.js
+++ b/test/spec/ol/render.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render');
+
 
 goog.require('ol.array');
 goog.require('ol.has');

--- a/test/spec/ol/render/box.test.js
+++ b/test/spec/ol/render/box.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.Box');
+
 
 goog.require('ol.Disposable');
 goog.require('ol.Map');

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.canvas.Immediate');
+
 
 goog.require('ol.geom.Circle');
 goog.require('ol.geom.GeometryCollection');

--- a/test/spec/ol/render/canvas/index.test.js
+++ b/test/spec/ol/render/canvas/index.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.canvas');
+
 
 goog.require('ol.render.canvas');
 

--- a/test/spec/ol/render/canvas/replaygroup.test.js
+++ b/test/spec/ol/render/canvas/replaygroup.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.canvas.ReplayGroup');
+
 
 goog.require('ol.render.canvas.ReplayGroup');
 

--- a/test/spec/ol/render/feature.test.js
+++ b/test/spec/ol/render/feature.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.Feature');
+
 
 goog.require('ol.render.Feature');
 

--- a/test/spec/ol/render/webgl/circlereplay.test.js
+++ b/test/spec/ol/render/webgl/circlereplay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.CircleReplay');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/render/webgl/imagereplay.test.js
+++ b/test/spec/ol/render/webgl/imagereplay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.ImageReplay');
+
 
 goog.require('ol.geom.MultiPoint');
 goog.require('ol.geom.Point');

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.Immediate');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Circle');

--- a/test/spec/ol/render/webgl/index.test.js
+++ b/test/spec/ol/render/webgl/index.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.Replay');
+
 
 goog.require('ol.render.webgl.Replay');
 

--- a/test/spec/ol/render/webgl/linestringreplay.test.js
+++ b/test/spec/ol/render/webgl/linestringreplay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.LineStringReplay');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/render/webgl/polygonreplay.test.js
+++ b/test/spec/ol/render/webgl/polygonreplay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.PolygonReplay');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/render/webgl/textreplay.test.js
+++ b/test/spec/ol/render/webgl/textreplay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.TextReplay');
+
 
 goog.require('ol.dom');
 goog.require('ol.render.webgl.TextReplay');

--- a/test/spec/ol/render/webgl/texturereplay.test.js
+++ b/test/spec/ol/render/webgl/texturereplay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.render.webgl.TextureReplay');
+
 
 goog.require('ol.render.webgl.TextureReplay');
 goog.require('ol.render.webgl.texturereplay.defaultshader');

--- a/test/spec/ol/renderer/canvas/intermediatecanvas.test.js
+++ b/test/spec/ol/renderer/canvas/intermediatecanvas.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.canvas.Layer');
+
 
 goog.require('ol.transform');
 goog.require('ol.layer.Image');

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.canvas.Map');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.canvas.Replay');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/tilelayer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.canvas.TileLayer');
+
 
 goog.require('ol.Map');
 goog.require('ol.View');

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.canvas.VectorLayer');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.canvas.VectorTileLayer');
+
 
 goog.require('ol');
 goog.require('ol.Feature');

--- a/test/spec/ol/renderer/layer.test.js
+++ b/test/spec/ol/renderer/layer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.Layer');
+
 
 goog.require('ol.Image');
 goog.require('ol.layer.Layer');

--- a/test/spec/ol/renderer/map.test.js
+++ b/test/spec/ol/renderer/map.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.Map');
+
 
 goog.require('ol.Disposable');
 goog.require('ol.Map');

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.vector');
+
 
 goog.require('ol');
 goog.require('ol.events');

--- a/test/spec/ol/renderer/webgl/imagelayer.test.js
+++ b/test/spec/ol/renderer/webgl/imagelayer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.renderer.webgl.ImageLayer');
+
 
 goog.require('ol.transform');
 goog.require('ol.Map');

--- a/test/spec/ol/reproj/image.test.js
+++ b/test/spec/ol/reproj/image.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.reproj.Image');
+
 
 goog.require('ol.Image');
 goog.require('ol.events');

--- a/test/spec/ol/reproj/reproj.test.js
+++ b/test/spec/ol/reproj/reproj.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.reproj');
+
 
 goog.require('ol.reproj');
 goog.require('ol.proj');

--- a/test/spec/ol/reproj/tile.test.js
+++ b/test/spec/ol/reproj/tile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.reproj.Tile');
+
 
 goog.require('ol.ImageTile');
 goog.require('ol.events');

--- a/test/spec/ol/reproj/triangulation.test.js
+++ b/test/spec/ol/reproj/triangulation.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.reproj.Triangulation');
+
 
 goog.require('ol.proj');
 goog.require('ol.reproj.Triangulation');

--- a/test/spec/ol/resolutionconstraint.test.js
+++ b/test/spec/ol/resolutionconstraint.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.ResolutionConstraint');
+
 
 goog.require('ol.ResolutionConstraint');
 

--- a/test/spec/ol/rotationconstraint.test.js
+++ b/test/spec/ol/rotationconstraint.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.RotationConstraint');
+
 
 goog.require('ol.RotationConstraint');
 

--- a/test/spec/ol/size.test.js
+++ b/test/spec/ol/size.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.size');
+
 
 goog.require('ol.size');
 

--- a/test/spec/ol/source/bingmaps.test.js
+++ b/test/spec/ol/source/bingmaps.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.BingMaps');
+
 
 goog.require('ol.net');
 goog.require('ol.source.BingMaps');

--- a/test/spec/ol/source/cartodb.test.js
+++ b/test/spec/ol/source/cartodb.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.CartoDBSource');
+
 
 goog.require('ol.source.CartoDB');
 goog.require('ol.source.XYZ');

--- a/test/spec/ol/source/cluster.test.js
+++ b/test/spec/ol/source/cluster.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.ClusterSource');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.LineString');

--- a/test/spec/ol/source/imagearcgisrest.test.js
+++ b/test/spec/ol/source/imagearcgisrest.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.ImageArcGISRest');
+
 
 goog.require('ol.source.ImageArcGISRest');
 goog.require('ol.proj');

--- a/test/spec/ol/source/imagestatic.test.js
+++ b/test/spec/ol/source/imagestatic.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.ImageStatic');
+
 
 goog.require('ol.source.ImageStatic');
 goog.require('ol.proj');

--- a/test/spec/ol/source/imagewms.test.js
+++ b/test/spec/ol/source/imagewms.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.ImageWMS');
+
 
 goog.require('ol.source.ImageWMS');
 goog.require('ol.proj');

--- a/test/spec/ol/source/raster.test.js
+++ b/test/spec/ol/source/raster.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.RasterSource');
+
 
 goog.require('ol.Map');
 goog.require('ol.TileState');

--- a/test/spec/ol/source/source.test.js
+++ b/test/spec/ol/source/source.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.Source');
+
 
 goog.require('ol.Attribution');
 goog.require('ol.proj');

--- a/test/spec/ol/source/stamen.test.js
+++ b/test/spec/ol/source/stamen.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.Stamen');
+
 
 goog.require('ol.source.Stamen');
 

--- a/test/spec/ol/source/tile.test.js
+++ b/test/spec/ol/source/tile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.TileSource');
+goog.provide('ol.test.source.TileSource'); // eslint-disable-line openlayers-internal/valid-provide
 
 goog.require('ol');
 goog.require('ol.Tile');

--- a/test/spec/ol/source/tilearcgisrest.test.js
+++ b/test/spec/ol/source/tilearcgisrest.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.TileArcGISRest');
+
 
 goog.require('ol.ImageTile');
 goog.require('ol.source.TileArcGISRest');

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.TileImageSource');
+
 
 goog.require('ol.ImageTile');
 goog.require('ol.TileUrlFunction');

--- a/test/spec/ol/source/tilejson.test.js
+++ b/test/spec/ol/source/tilejson.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.TileJSON');
+
 
 goog.require('ol.source.Source');
 goog.require('ol.source.TileJSON');

--- a/test/spec/ol/source/tileutfgrid.test.js
+++ b/test/spec/ol/source/tileutfgrid.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.TileUTFGrid');
+
 
 goog.require('ol.proj');
 goog.require('ol.source.Tile');

--- a/test/spec/ol/source/tilewms.test.js
+++ b/test/spec/ol/source/tilewms.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.TileWMS');
+
 
 goog.require('ol.ImageTile');
 goog.require('ol.proj');

--- a/test/spec/ol/source/urltile.test.js
+++ b/test/spec/ol/source/urltile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.UrlTile');
+
 
 goog.require('ol.proj');
 goog.require('ol.source.UrlTile');

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.Vector');
+
 
 goog.require('ol.events');
 goog.require('ol.Collection');

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.VectorTile');
+
 
 goog.require('ol.VectorImageTile');
 goog.require('ol.VectorTile');

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.WMTS');
+
 
 goog.require('ol.format.WMTSCapabilities');
 goog.require('ol.proj');

--- a/test/spec/ol/source/xyz.test.js
+++ b/test/spec/ol/source/xyz.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.XYZ');
+
 
 goog.require('ol.source.Tile');
 goog.require('ol.source.TileImage');

--- a/test/spec/ol/source/zoomify.test.js
+++ b/test/spec/ol/source/zoomify.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.source.Zoomify');
+
 
 goog.require('ol.dom');
 goog.require('ol.events');

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -1,7 +1,6 @@
 // See http://www.movable-type.co.uk/scripts/latlong.html
 // FIXME add tests for offset
 
-goog.provide('ol.test.Sphere');
 
 goog.require('ol.Sphere');
 goog.require('ol.format.WKT');

--- a/test/spec/ol/string.test.js
+++ b/test/spec/ol/string.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.string');
+
 
 goog.require('ol.string');
 

--- a/test/spec/ol/structs/linkedlist.test.js
+++ b/test/spec/ol/structs/linkedlist.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.structs.LinkedList');
+
 
 goog.require('ol.structs.LinkedList');
 

--- a/test/spec/ol/structs/lrucache.test.js
+++ b/test/spec/ol/structs/lrucache.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.LRUCache');
+
 
 goog.require('ol.structs.LRUCache');
 

--- a/test/spec/ol/structs/priorityqueue.test.js
+++ b/test/spec/ol/structs/priorityqueue.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.structs.PriorityQueue');
+
 
 goog.require('ol.structs.PriorityQueue');
 

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.structs.RBush');
+
 
 goog.require('ol.structs.RBush');
 

--- a/test/spec/ol/style/atlasmanager.test.js
+++ b/test/spec/ol/style/atlasmanager.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.AtlasManager');
+
 
 goog.require('ol.style.Atlas');
 goog.require('ol.style.AtlasManager');

--- a/test/spec/ol/style/circle.test.js
+++ b/test/spec/ol/style/circle.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.Circle');
+
 
 goog.require('ol.style.AtlasManager');
 goog.require('ol.style.Circle');

--- a/test/spec/ol/style/fill.test.js
+++ b/test/spec/ol/style/fill.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.Fill');
+
 
 goog.require('ol.style.Fill');
 

--- a/test/spec/ol/style/icon.test.js
+++ b/test/spec/ol/style/icon.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.Icon');
+
 
 goog.require('ol');
 goog.require('ol.style');

--- a/test/spec/ol/style/iconimagecache.test.js
+++ b/test/spec/ol/style/iconimagecache.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.IconImageCache');
+
 
 goog.require('ol');
 goog.require('ol.events');

--- a/test/spec/ol/style/regularshape.test.js
+++ b/test/spec/ol/style/regularshape.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.RegularShape');
+
 
 goog.require('ol.style.AtlasManager');
 goog.require('ol.style.RegularShape');

--- a/test/spec/ol/style/stroke.test.js
+++ b/test/spec/ol/style/stroke.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.Stroke');
+
 
 goog.require('ol.style.Stroke');
 

--- a/test/spec/ol/style/style.test.js
+++ b/test/spec/ol/style/style.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.Style');
+
 
 goog.require('ol.Feature');
 goog.require('ol.geom.Point');

--- a/test/spec/ol/style/text.test.js
+++ b/test/spec/ol/style/text.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.style.Text');
+
 
 goog.require('ol.style.Fill');
 goog.require('ol.style.Stroke');

--- a/test/spec/ol/tile.test.js
+++ b/test/spec/ol/tile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.Tile');
+
 
 goog.require('ol');
 goog.require('ol.ImageTile');

--- a/test/spec/ol/tilecoord.test.js
+++ b/test/spec/ol/tilecoord.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.TileCoord');
+
 
 goog.require('ol.tilecoord');
 goog.require('ol.tilegrid.TileGrid');

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.TileGrid');
+
 
 goog.require('ol');
 goog.require('ol.TileRange');

--- a/test/spec/ol/tilegrid/wmts.test.js
+++ b/test/spec/ol/tilegrid/wmts.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.tilegrid.WMTS');
+
 
 goog.require('ol.format.WMTSCapabilities');
 goog.require('ol.tilegrid.WMTS');

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.TileQueue');
+
 
 goog.require('ol.ImageTile');
 goog.require('ol.Tile');

--- a/test/spec/ol/tilerange.test.js
+++ b/test/spec/ol/tilerange.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.TileRange');
+
 
 goog.require('ol.TileRange');
 

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.TileUrlFunction');
+
 
 goog.require('ol.TileUrlFunction');
 goog.require('ol.tilegrid');

--- a/test/spec/ol/transform.test.js
+++ b/test/spec/ol/transform.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.transform');
+
 
 goog.require('ol.transform');
 

--- a/test/spec/ol/uri.test.js
+++ b/test/spec/ol/uri.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.uri');
+
 
 goog.require('ol.uri');
 

--- a/test/spec/ol/vec/mat4.test.js
+++ b/test/spec/ol/vec/mat4.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.vec.Mat4');
+
 
 goog.require('ol.vec.Mat4');
 

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.VectorImageTile');
+
 
 goog.require('ol.TileState');
 goog.require('ol.VectorImageTile');

--- a/test/spec/ol/vectortile.test.js
+++ b/test/spec/ol/vectortile.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.VectorTile');
+
 
 goog.require('ol.Feature');
 goog.require('ol.VectorImageTile');

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.View');
+
 
 goog.require('ol');
 goog.require('ol.Map');

--- a/test/spec/ol/webgl/buffer.test.js
+++ b/test/spec/ol/webgl/buffer.test.js
@@ -1,4 +1,4 @@
-goog.provide('ol.test.webgl.Buffer');
+
 
 goog.require('ol.webgl.Buffer');
 


### PR DESCRIPTION
The `goog.provide()` calls in our tests were serving no purpose.  This removes them.