### PR TITLE
Scripts for in-place transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "pretest": "npm run lint",
     "test": "npm run karma -- --single-run",
     "debug-server": "node tasks/serve-lib.js",
-    "karma": "node tasks/test.js start test/karma.config.js"
+    "karma": "node tasks/test.js start test/karma.config.js",
+    "transform-src": "jscodeshift --transform transforms/module.js src",
+    "transform-examples": "jscodeshift --transform transforms/module.js examples",
+    "transform-test-spec": "jscodeshift --transform transforms/module.js test/spec",
+    "transform-test-rendering": "jscodeshift --transform transforms/module.js test/rendering",
+    "transform": "npm run transform-src && npm run transform-examples && npm run transform-test-spec && npm run transform-test-rendering && npm run lint -- --fix"
   },
   "main": "dist/ol.js",
   "repository": {
@@ -83,6 +88,9 @@
   },
   "eslintConfig": {
     "extends": "openlayers",
+    "parserOptions": {
+      "sourceType": "module"
+    },
     "globals": {
       "ArrayBuffer": false,
       "Float32Array": false,


### PR DESCRIPTION
This updates the transform for ES modules so that it works for scripts without a `goog.provide()` (like our examples and tests).