### PR TITLE
Retain comments when replacing nodes

### DIFF
--- a/transforms/module.js
+++ b/transforms/module.js
@@ -157,7 +157,9 @@ module.exports = function(info, api) {
       })
       .replaceWith(path => {
         const name = `${path.value.object.name}.${path.value.property.name}`;
-        return j.literal(defines[name]);
+        const expression = j.literal(defines[name]);
+        expression.comments = path.value.comments;
+        return expression;
       });
 
   // remove goog.provide()
@@ -232,10 +234,18 @@ module.exports = function(info, api) {
   Object.keys(replacements).sort().reverse().forEach(name => {
     if (name.indexOf('.') > 0) {
       root.find(j.MemberExpression, getMemberExpression(name))
-          .replaceWith(j.identifier(replacements[name]));
+          .replaceWith(path => {
+            const expression = j.identifier(replacements[name]);
+            expression.comments = path.value.comments;
+            return expression;
+          });
     } else {
       root.find(j.Identifier, {name: name})
-          .replaceWith(j.identifier(replacements[name]));
+          .replaceWith(path => {
+            const identifier = j.identifier(replacements[name]);
+            identifier.comments = path.value.comments;
+            return identifier;
+          });
     }
   });
 


### PR DESCRIPTION
When using [`node.replaceWith()`](https://github.com/facebook/jscodeshift/wiki/jscodeshift-Documentation#replacewith) we need to be careful to add back any comments from the original node.

Before:
```js
new _ol_source_WMTS_( (options))
```

After:
```js
new _ol_source_WMTS_(/** @type {!olx.source.WMTSOptions} */ (options))
```
