### PR TITLE
Remove bundling magic for the Mapbox styles script

### DIFF
--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -1,4 +1,3 @@
-/* eslint-disable openlayers-internal/no-unused-requires */
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.format.MVT');
@@ -11,6 +10,7 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.style.Text');
 goog.require('ol.tilegrid.TileGrid');
+goog.require('createMapboxStreetsV6Style');
 
 
 var key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';
@@ -46,7 +46,8 @@ var map = new ol.Map({
         }),
         tileUrlFunction: tileUrlFunction
       }),
-      style: createMapboxStreetsV6Style()
+      style: createMapboxStreetsV6Style(
+          ol.style.Style, ol.style.Fill, ol.style.Stroke, ol.style.Icon, ol.style.Text)
     })
   ],
   target: 'map',
@@ -56,6 +57,3 @@ var map = new ol.Map({
     zoom: 2
   })
 });
-
-// ol.style.Fill, ol.style.Icon, ol.style.Stroke, ol.style.Style and
-// ol.style.Text are required for createMapboxStreetsV6Style()

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -1,5 +1,3 @@
-/* eslint-disable openlayers-internal/no-unused-requires */
-
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.format.MVT');
@@ -25,7 +23,8 @@ var map = new ol.Map({
         url: 'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/' +
             '{z}/{x}/{y}.vector.pbf?access_token=' + key
       }),
-      style: createMapboxStreetsV6Style()
+      style: createMapboxStreetsV6Style(
+          ol.style.Style, ol.style.Fill, ol.style.Stroke, ol.style.Icon, ol.style.Text)
     })
   ],
   target: 'map',
@@ -34,6 +33,3 @@ var map = new ol.Map({
     zoom: 2
   })
 });
-
-// ol.style.Fill, ol.style.Icon, ol.style.Stroke, ol.style.Style and
-// ol.style.Text are required for createMapboxStreetsV6Style()

--- a/examples/resources/mapbox-streets-v6-style.js
+++ b/examples/resources/mapbox-streets-v6-style.js
@@ -1,20 +1,28 @@
 // Styles for the mapbox-streets-v6 vector tile data set. Loosely based on
 // http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6.json
 
-function createMapboxStreetsV6Style() {
-  var fill = new ol.style.Fill({color: ''});
-  var stroke = new ol.style.Stroke({color: '', width: 1});
-  var polygon = new ol.style.Style({fill: fill});
-  var strokedPolygon = new ol.style.Style({fill: fill, stroke: stroke});
-  var line = new ol.style.Style({stroke: stroke});
-  var text = new ol.style.Style({text: new ol.style.Text({
+/**
+ * @param {function(olx.StyleOptions):ol.style.Style} Style constructor.
+ * @param {function(olx.FillOptions):ol.style.fill} Fill constructor.
+ * @param {function(olx.StrokeOptions):ol.style.Stroke} Stroke constructor.
+ * @param {function(olx.IconOptions):ol.style.Icon} Icon constructor.
+ * @param {function(olx.TextOptions):ol.style.Text} Text constructor.
+ * @return {function((ol.Feature|ol.render.Feature), number): (ol.style.Style|Array.<ol.style.Style>|undefined)} Style function.
+ */
+function createMapboxStreetsV6Style(Style, Fill, Stroke, Icon, Text) {
+  var fill = new Fill({color: ''});
+  var stroke = new Stroke({color: '', width: 1});
+  var polygon = new Style({fill: fill});
+  var strokedPolygon = new Style({fill: fill, stroke: stroke});
+  var line = new Style({stroke: stroke});
+  var text = new Style({text: new Text({
     text: '', fill: fill, stroke: stroke
   })});
   var iconCache = {};
   function getIcon(iconName) {
     var icon = iconCache[iconName];
     if (!icon) {
-      icon = new ol.style.Style({image: new ol.style.Icon({
+      icon = new Style({image: new Icon({
         src: 'https://cdn.rawgit.com/mapbox/maki/master/icons/' + iconName + '-15.svg',
         imgSize: [15, 15]
       })});


### PR DESCRIPTION
By passing the style constructors as arguments to the `resources/mapbox-streets-v6-style.js`, we no longer need to require files that are not used.