### PR TITLE
ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet fails when tileMatrix identifiers are not prefixed by their tileMatrixSet identifier

### DIFF
--- a/src/ol/tilegrid/wmts.js
+++ b/src/ol/tilegrid/wmts.js
@@ -111,6 +111,11 @@ ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet = function(matrixSet, opt_exten
     if (matrixLimits.length > 0) {
       matrixAvailable = ol.array.find(matrixLimits,
           function(elt_ml, index_ml, array_ml) {
+            // Fix for tileMatrix identifiers that don't get prefixed
+            // by their tileMatrixSet identifiers.
+            if (elt[identifierPropName].indexOf(':') === -1) {
+              return (matrixSet[identifierPropName] + ':' + elt[identifierPropName]) == elt_ml[matrixIdsPropName];
+            }
             return elt[identifierPropName] == elt_ml[matrixIdsPropName];
           });
     } else {

--- a/src/ol/tilegrid/wmts.js
+++ b/src/ol/tilegrid/wmts.js
@@ -111,12 +111,15 @@ ol.tilegrid.WMTS.createFromCapabilitiesMatrixSet = function(matrixSet, opt_exten
     if (matrixLimits.length > 0) {
       matrixAvailable = ol.array.find(matrixLimits,
           function(elt_ml, index_ml, array_ml) {
-            // Fix for tileMatrix identifiers that don't get prefixed
+            if (elt[identifierPropName] === elt_ml[matrixIdsPropName]) {
+              return true;
+            }
+            // Fallback for tileMatrix identifiers that don't get prefixed
             // by their tileMatrixSet identifiers.
             if (elt[identifierPropName].indexOf(':') === -1) {
-              return (matrixSet[identifierPropName] + ':' + elt[identifierPropName]) == elt_ml[matrixIdsPropName];
+              return matrixSet[identifierPropName] + ':' + elt[identifierPropName] === elt_ml[matrixIdsPropName];
             }
-            return elt[identifierPropName] == elt_ml[matrixIdsPropName];
+            return false;
           });
     } else {
       matrixAvailable = true;


### PR DESCRIPTION
This PR references to issue #6699 .

I don't know if checking for a colon in tileMatrix identifier is the best approach here. Maybe checking for whole matrixSet identifier prefix is cleaner? 

I'm open to any feedback.