### PR TITLE
Exclude greenkeeper merges from changelog

### DIFF
--- a/tasks/changelog.sh
+++ b/tasks/changelog.sh
@@ -44,20 +44,27 @@ main() {
   git log --first-parent --format='%aN|%s %b' ${1} |
   {
     while read l; do
-      if ! [[ ${l} =~ "openlayers/greenkeeper" ]] ; then
-        if [[ ${l} =~ ${MERGE_RE} ]] ; then
-          number="${BASH_REMATCH[1]}"
-          author="${BASH_REMATCH[2]}"
-          summary="${BASH_REMATCH[3]}"
-          echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([@${author}](${GITHUB_URL}/${author}))"
-        elif [[ ${l} =~ ${SQUASH_RE} ]] ; then
-          number="${BASH_REMATCH[3]}"
-          author="${BASH_REMATCH[1]}"
-          summary="${BASH_REMATCH[2]}"
-          echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([${author}](${GITHUB_URL}/search?q=${author}&type=Users))"
-        fi
+      output="`[[ ${l} =~ "openlayers/greenkeeper" ]] && echo greenkeeper || echo main`_output"
+      if [[ ${l} =~ ${MERGE_RE} ]] ; then
+        number="${BASH_REMATCH[1]}"
+        author="${BASH_REMATCH[2]}"
+        summary="${BASH_REMATCH[3]}"
+        declare $output+=" * [#${number}](${PULLS_URL}/${number}) - ${summary} ([@${author}](${GITHUB_URL}/${author}))\n"
+      elif [[ ${l} =~ ${SQUASH_RE} ]] ; then
+        number="${BASH_REMATCH[3]}"
+        author="${BASH_REMATCH[1]}"
+        summary="${BASH_REMATCH[2]}"
+        declare $output+=" * [#${number}](${PULLS_URL}/${number}) - ${summary} ([${author}](${GITHUB_URL}/search?q=${author}&type=Users))\n"
       fi
     done
+
+    echo -e "$main_output"
+
+    if [ -n "$greenkeeper_output" ]; then
+      echo
+      echo "Additionally a number of updates where made to our dependencies:"
+      echo -e "$greenkeeper_output"
+    fi
   }
 }
 

--- a/tasks/changelog.sh
+++ b/tasks/changelog.sh
@@ -44,16 +44,18 @@ main() {
   git log --first-parent --format='%aN|%s %b' ${1} |
   {
     while read l; do
-      if [[ ${l} =~ ${MERGE_RE} ]] ; then
-        number="${BASH_REMATCH[1]}"
-        author="${BASH_REMATCH[2]}"
-        summary="${BASH_REMATCH[3]}"
-        echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([@${author}](${GITHUB_URL}/${author}))"
-      elif [[ ${l} =~ ${SQUASH_RE} ]] ; then
-        number="${BASH_REMATCH[3]}"
-        author="${BASH_REMATCH[1]}"
-        summary="${BASH_REMATCH[2]}"
-        echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([${author}](${GITHUB_URL}/search?q=${author}&type=Users))"
+      if ! [[ ${l} =~ "openlayers/greenkeeper" ]] ; then
+        if [[ ${l} =~ ${MERGE_RE} ]] ; then
+          number="${BASH_REMATCH[1]}"
+          author="${BASH_REMATCH[2]}"
+          summary="${BASH_REMATCH[3]}"
+          echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([@${author}](${GITHUB_URL}/${author}))"
+        elif [[ ${l} =~ ${SQUASH_RE} ]] ; then
+          number="${BASH_REMATCH[3]}"
+          author="${BASH_REMATCH[1]}"
+          summary="${BASH_REMATCH[2]}"
+          echo " * [#${number}](${PULLS_URL}/${number}) - ${summary} ([${author}](${GITHUB_URL}/search?q=${author}&type=Users))"
+        fi
       fi
     done
   }


### PR DESCRIPTION
There is a great deal of lines about Greenkeeper merges in the changelog, making it hard to find real changes to the code.

This commit modifies the changelog task to exclude such lines.