### PR TITLE
Use the `input` option for rollup

### DIFF
--- a/tasks/build-ext.js
+++ b/tasks/build-ext.js
@@ -48,7 +48,7 @@ function main() {
     const moduleName = ext.name || ext.module;
     const options = {
       extend: true,
-      entry: require.resolve(ext.module),
+      input: require.resolve(ext.module),
       format: 'iife',
       exports: 'named',
       plugins: [


### PR DESCRIPTION
This is a followup to #7166.  The `entry` option has been renamed to `input` (see rollup/rollup#1479).
