### PR TITLE
added clear method to vectortile source

### DIFF
--- a/src/ol/source/vectortile.js
+++ b/src/ol/source/vectortile.js
@@ -101,6 +101,13 @@ ol.source.VectorTile.prototype.getOverlaps = function() {
   return this.overlaps_;
 };
 
+/**
+ * clear {@link ol.TileCache} and delete all source tiles
+ */
+ol.source.VectorTile.prototype.clear = function() {
+  this.tileCache.clear();
+  this.sourceTiles_ = {};
+};
 
 /**
  * @inheritDoc

--- a/src/ol/source/vectortile.js
+++ b/src/ol/source/vectortile.js
@@ -103,6 +103,7 @@ ol.source.VectorTile.prototype.getOverlaps = function() {
 
 /**
  * clear {@link ol.TileCache} and delete all source tiles
+ * @api
  */
 ol.source.VectorTile.prototype.clear = function() {
   this.tileCache.clear();


### PR DESCRIPTION
https://github.com/openlayers/openlayers/issues/5032

Added an clear Method to `ol.source.VectorTile` to force the source reloading all tiles.
* cleared tile cache
* deleted sourceTiles

To redraw a `ol.source.VectorTile.refresh` is needed.
