### PR TITLE
[WIP] Reenable testing WebGL

### DIFF
--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -469,7 +469,7 @@ goog.require('ol.has');
     'ArrayBuffer.isView': 'ArrayBuffer' in global && !!ArrayBuffer.isView,
     FileReader: 'FileReader' in global,
     Uint8ClampedArray: ('Uint8ClampedArray' in global),
-    WebGL: false
+    WebGL: ol.has.WEBGL
   };
 
   /**


### PR DESCRIPTION
This PR suggests to use `ol.has.WEBGL` to reenable WebGL tests where they are supported.

On Sauce Labs that is currently not the case, see e.g. here: https://saucelabs.ideas.aha.io/ideas/SLIDEA-I-54 (Comment from Chiarng Lin of Sauce Labs from April 8, 2017, 02:28).

Funny enough for @ahocevar s Mac the tests would execute successfully, for @tschaub s not.

This PR should probably not be merged until we know what is going on.
