### PR TITLE
Fix KML links for documents created locally in Safari

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ branches:
   only:
   - master
 addons:
-  sauce_connect:
-    username: openlayers
+  hosts:
+    - travis.dev
   jwt:
     # This is the encrypted SAUCE_ACCESS_KEY
     secure: bb2Ibzu9RLe6ZlIG7JVcuH7IoLMxa/i3LTM7t8mbsPjVOGs5ycyJ7M9MbvqB/F2EzbeV4XB2c9ufI4TkaLYceY5kdWjfZVN8iasr+GFqKMv1uR4i6bpu8KmHJ+blxwfY1QOQ/cGwEx+fbeycMtpTc3Y3GyXaPlCQLhbZvesMg88=

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "jquery": "3.2.1",
     "jscodeshift": "^0.3.30",
     "karma": "^1.7.0",
-    "karma-coverage": "^1.1.1",
     "karma-chrome-launcher": "^2.1.1",
+    "karma-coverage": "^1.1.1",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-sauce-launcher": "^1.1.0",
@@ -83,7 +83,8 @@
     "proj4": "2.4.4",
     "serve-files": "1.0.1",
     "sinon": "3.2.1",
-    "slimerjs": "0.10.3"
+    "slimerjs": "0.10.3",
+    "url-polyfill": "^1.0.7"
   },
   "eslintConfig": {
     "extends": "openlayers",

--- a/src/ol/format/kml.js
+++ b/src/ol/format/kml.js
@@ -488,8 +488,12 @@ ol.format.KML.readFlatCoordinates_ = function(node) {
  */
 ol.format.KML.readURI_ = function(node) {
   var s = ol.xml.getAllTextContent(node, false).trim();
-  if (node.baseURI && node.baseURI !== 'about:blank') {
-    var url = new URL(s, node.baseURI);
+  var baseURI = node.baseURI;
+  if (!baseURI || baseURI == 'about:blank') {
+    baseURI = window.location.href;
+  }
+  if (baseURI) {
+    var url = new URL(s, baseURI);
     return url.href;
   } else {
     return s;
@@ -1744,8 +1748,12 @@ ol.format.KML.prototype.readSharedStyle_ = function(node, objectStack) {
     var style = ol.format.KML.readStyle_(node, objectStack);
     if (style) {
       var styleUri;
-      if (node.baseURI && node.baseURI !== 'about:blank') {
-        var url = new URL('#' + id, node.baseURI);
+      var baseURI = node.baseURI;
+      if (!baseURI || baseURI == 'about:blank') {
+        baseURI = window.location.href;
+      }
+      if (baseURI) {
+        var url = new URL('#' + id, baseURI);
         styleUri = url.href;
       } else {
         styleUri = '#' + id;
@@ -1771,8 +1779,12 @@ ol.format.KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
     return;
   }
   var styleUri;
-  if (node.baseURI && node.baseURI !== 'about:blank') {
-    var url = new URL('#' + id, node.baseURI);
+  var baseURI = node.baseURI;
+  if (!baseURI || baseURI == 'about:blank') {
+    baseURI = window.location.href;
+  }
+  if (baseURI) {
+    var url = new URL('#' + id, baseURI);
     styleUri = url.href;
   } else {
     styleUri = '#' + id;

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -15,11 +15,14 @@ module.exports = function(karma) {
   karma.set({
     frameworks: ['mocha'],
     client: {
-      runInParent: true
+      runInParent: true,
+      mocha: {
+        timeout: 2500
+      }
     },
     files: [
       {
-        pattern: 'https://cdn.polyfill.io/v2/polyfill.min.js?features=URL|gated',
+        pattern: path.resolve(__dirname, require.resolve('url-polyfill/url-polyfill.js')),
         watched: false
       },
       {
@@ -98,7 +101,7 @@ module.exports = function(karma) {
       // },
       SL_Safari: {
         base: 'SauceLabs',
-        platform: 'macos 10.12',
+        platform: 'macOS 10.12',
         browserName: 'safari'
       }
     };
@@ -106,15 +109,18 @@ module.exports = function(karma) {
       sauceLabs: {
         testName: testName,
         recordScreenshots: false,
-        connectOptions: {
-          port: 5757
-        },
-        startConnect: false,
+        startConnect: true,
         tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
         username: 'openlayers',
-        accessKey: process.env.SAUCE_ACCESS_KEY
+        accessKey: process.env.SAUCE_ACCESS_KEY,
+        connectOptions: {
+          noSslBumpDomains: 'all'
+        }
       },
+      hostname: 'travis.dev',
       reporters: ['dots', 'saucelabs', 'coverage'],
+      browserDisconnectTimeout: 10000,
+      browserDisconnectTolerance: 1,
       captureTimeout: 240000,
       browserNoActivityTimeout: 240000,
       customLaunchers: customLaunchers,

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -19,6 +19,10 @@ module.exports = function(karma) {
     },
     files: [
       {
+        pattern: 'https://cdn.polyfill.io/v2/polyfill.min.js?features=URL|gated',
+        watched: false
+      },
+      {
         pattern: 'module-global.js',
         watched: false
       }, {
@@ -86,16 +90,16 @@ module.exports = function(karma) {
       SL_Firefox: {
         base: 'SauceLabs',
         browserName: 'firefox'
-      // },
+      },
       // SL_Edge: {
       //   base: 'SauceLabs',
       //   platform: 'Windows 10',
       //   browserName: 'MicrosoftEdge'
       // },
-      // SL_Safari: {
-      //   base: 'SauceLabs',
-      //   platform: 'macos 10.12',
-      //   browserName: 'safari'
+      SL_Safari: {
+        base: 'SauceLabs',
+        platform: 'macos 10.12',
+        browserName: 'safari'
       }
     };
     karma.set({


### PR DESCRIPTION
This pull request fixes relative links in KML documents that were locally created in Safari, where `document.baseURI` would be `about:blank` instead of the URL of the document that created the KML.

To make sure this is fixed, I also enabled tests in Safari for Travis.