### PR TITLE
renderSync() to make sure overlay is initially visible

### DIFF
--- a/test/spec/ol/overlay.test.js
+++ b/test/spec/ol/overlay.test.js
@@ -91,8 +91,7 @@ describe('ol.Overlay', function() {
         position: [0, 0]
       });
       map.addOverlay(overlay);
-      expect(overlay.element_.style.display).to.be('none');
-      overlay.setVisible(true);
+      map.renderSync();
       expect(overlay.element_.style.display).not.to.be('none');
       overlay.setVisible(false);
       expect(overlay.element_.style.display).to.be('none');


### PR DESCRIPTION
Fixes #7169.

Depending on whether the map was already rendered or not, the first test for `display: 'none'` passed or failed. Now we call `renderSync()` on the map before testing, so we know that the overlay is visible.