### PR TITLE
Only load source tiles that intersect the source tile grid's extent

### DIFF
--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -94,6 +94,10 @@ ol.VectorImageTile = function(tileCoord, state, src, format, tileLoadFunction,
     sourceTileGrid.forEachTileCoord(extent, sourceZ, function(sourceTileCoord) {
       var sharedExtent = ol.extent.getIntersection(extent,
           sourceTileGrid.getTileCoordExtent(sourceTileCoord));
+      var sourceExtent = sourceTileGrid.getExtent();
+      if (sourceExtent) {
+        sharedExtent = ol.extent.getIntersection(sharedExtent, sourceExtent);
+      }
       if (ol.extent.getWidth(sharedExtent) / resolution >= 0.5 &&
           ol.extent.getHeight(sharedExtent) / resolution >= 0.5) {
         // only include source tile if overlap is at least 1 pixel

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -7,6 +7,7 @@ goog.require('ol.events');
 goog.require('ol.format.GeoJSON');
 goog.require('ol.proj');
 goog.require('ol.tilegrid');
+goog.require('ol.tilegrid.TileGrid');
 
 
 describe('ol.VectorImageTile', function() {
@@ -107,6 +108,26 @@ describe('ol.VectorImageTile', function() {
       expect(tile.getState()).to.be(ol.TileState.EMPTY);
       done();
     });
+  });
+
+  it('only loads tiles within the source tileGrid\'s extent', function() {
+    var format = new ol.format.GeoJSON();
+    var url = 'spec/ol/data/point.json';
+    var tileGrid = new ol.tilegrid.TileGrid({
+      resolutions: [0.02197265625, 0.010986328125, 0.0054931640625],
+      origin: [-180, 90],
+      extent: [-88, 35, -87, 36]
+    });
+    var sourceTiles = {};
+    var tile = new ol.VectorImageTile([1, 0, -1], 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [1, 0, -1], function(zxy) {
+          return url;
+        }, tileGrid,
+        ol.tilegrid.createXYZ({extent: [-180, -90, 180, 90], tileSize: 512}),
+        sourceTiles, 1, ol.proj.get('EPSG:4326'), ol.VectorTile, function() {});
+    tile.load();
+    expect(tile.tileKeys.length).to.be(1);
+    expect(tile.getTile(tile.tileKeys[0]).tileCoord).to.eql([0, 16, -10]);
   });
 
   it('#dispose() while loading', function() {

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -15,8 +15,8 @@ describe('ol.VectorImageTile', function() {
   it('configures loader that sets features on the source tile', function(done) {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/point.json';
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
+    var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
@@ -35,8 +35,8 @@ describe('ol.VectorImageTile', function() {
   it('sets LOADED state when source tiles fail to load', function(done) {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/unavailable.json';
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
+    var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
@@ -53,11 +53,11 @@ describe('ol.VectorImageTile', function() {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/unavailable.json';
     var sourceTile;
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
+    var tile = new ol.VectorImageTile([0, 0, 0] /* one world away */, 0, url, format,
         function(tile, url) {
           sourceTile = tile;
           ol.VectorImageTile.defaultLoadFunction(tile, url);
-        }, [0, 0, 0], function() {
+        }, [0, 0, -1], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
@@ -80,8 +80,8 @@ describe('ol.VectorImageTile', function() {
   it('sets EMPTY state when all source tiles fail to load', function(done) {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/unavailable.json';
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
+    var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
@@ -97,8 +97,8 @@ describe('ol.VectorImageTile', function() {
   it('sets EMPTY state when tile has only empty source tiles', function(done) {
     var format = new ol.format.GeoJSON();
     var url = '';
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {},
+    var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {},
         ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
 
@@ -133,8 +133,8 @@ describe('ol.VectorImageTile', function() {
   it('#dispose() while loading', function() {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/point.json';
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
+    var tile = new ol.VectorImageTile([0, 0, 0] /* one world away */, 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ({tileSize: 512}), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
@@ -153,8 +153,8 @@ describe('ol.VectorImageTile', function() {
   it('#dispose() when loaded', function(done) {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/point.json';
-    var tile = new ol.VectorImageTile([0, 0, 0], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, 0], function() {
+    var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
+        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ({tileSize: 512}), {},
         1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});


### PR DESCRIPTION
Replaces #7200.

Fixes #7199.