### PR TITLE
Remove grid.getTileRangeForExtentAndResolution()

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -147,8 +147,7 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame = function(frameState, layer
     return false;
   }
 
-  var tileRange = tileGrid.getTileRangeForExtentAndResolution(
-      extent, tileResolution);
+  var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
   var imageExtent = tileGrid.getTileRangeExtent(z, tileRange);
 
   var tilePixelRatio = tileSource.getTilePixelRatio(pixelRatio);

--- a/src/ol/renderer/webgl/tilelayer.js
+++ b/src/ol/renderer/webgl/tilelayer.js
@@ -186,8 +186,7 @@ ol.renderer.webgl.TileLayer.prototype.prepareFrame = function(frameState, layerS
 
   var center = viewState.center;
   var extent = frameState.extent;
-  var tileRange = tileGrid.getTileRangeForExtentAndResolution(
-      extent, tileResolution);
+  var tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
 
   var framebufferExtent;
   if (this.renderedTileRange_ &&

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -11,14 +11,12 @@ goog.require('ol.tilegrid.TileGrid');
 
 
 describe('ol.tilegrid.TileGrid', function() {
-  var extent;
   var resolutions;
   var origin;
   var tileSize;
 
   beforeEach(function() {
     resolutions = [1000, 500, 250, 100];
-    extent = [0, 0, 100000, 100000];
     origin = [0, 0];
     tileSize = 100;
   });
@@ -812,45 +810,6 @@ describe('ol.tilegrid.TileGrid', function() {
       expect(tileCoordExtent[1]).to.eql(90000);
       expect(tileCoordExtent[2]).to.eql(10000);
       expect(tileCoordExtent[3]).to.eql(100000);
-    });
-  });
-
-  describe('getTileRangeForExtentAndResolution', function() {
-    it('returns the expected TileRange', function() {
-      var tileGrid = new ol.tilegrid.TileGrid({
-        resolutions: resolutions,
-        origin: origin,
-        tileSize: tileSize
-      });
-      var tileRange;
-
-      tileRange = tileGrid.getTileRangeForExtentAndResolution(extent,
-          resolutions[0]);
-      expect(tileRange.minY).to.eql(0);
-      expect(tileRange.minX).to.eql(0);
-      expect(tileRange.maxX).to.eql(0);
-      expect(tileRange.maxY).to.eql(0);
-
-      tileRange = tileGrid.getTileRangeForExtentAndResolution(extent,
-          resolutions[1]);
-      expect(tileRange.minX).to.eql(0);
-      expect(tileRange.minY).to.eql(0);
-      expect(tileRange.maxX).to.eql(1);
-      expect(tileRange.maxY).to.eql(1);
-
-      tileRange = tileGrid.getTileRangeForExtentAndResolution(extent,
-          resolutions[2]);
-      expect(tileRange.minX).to.eql(0);
-      expect(tileRange.minY).to.eql(0);
-      expect(tileRange.maxX).to.eql(3);
-      expect(tileRange.maxY).to.eql(3);
-
-      tileRange = tileGrid.getTileRangeForExtentAndResolution(extent,
-          resolutions[3]);
-      expect(tileRange.minX).to.eql(0);
-      expect(tileRange.minY).to.eql(0);
-      expect(tileRange.maxX).to.eql(9);
-      expect(tileRange.maxY).to.eql(9);
     });
   });
 


### PR DESCRIPTION
The `grid.getTileRangeForExtentAndResolution()` method handles scaling for resolutions that correspond to non-integer zoom levels.  We call this method in `renderer.prepareFrame()` after we already calculate[ the tile resolution](https://github.com/openlayers/openlayers/blob/3860ef0198173ef9e87d49692ec0db64bd6f887d/src/ol/renderer/canvas/tilelayer.js#L138) by doing a lookup for [the nearest integer zoom level](https://github.com/openlayers/openlayers/blob/3860ef0198173ef9e87d49692ec0db64bd6f887d/src/ol/renderer/canvas/tilelayer.js#L137) for the view resolution.

So, instead of calling a method that handles resolutions for non-integer zoom levels, we can call one that handles only integer zoom levels.  We already have `grid.getTileRangeForExtentAndZ()`, but it calls the less efficient `grid.getTileRangeForExtentAndResolution()` (after doing another lookup for the resolution corresponding to the nearest integer zoom level).  This branch reworks `grid.getTileRangeForExtentAndZ()` and removes the unused `grid.getTileRangeForExtentAndResolution()`.

