### PR TITLE
Avoid unnecessary calculations for a zoom factor of 2

### DIFF
--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -37,6 +37,30 @@ ol.tilegrid.TileGrid = function(options) {
     return b - a;
   }, true), 17); // `resolutions` must be sorted in descending order
 
+
+  // check if we've got a consistent zoom factor and origin
+  var zoomFactor;
+  if (!options.origins) {
+    for (var i = 0, ii = this.resolutions_.length - 1; i < ii; ++i) {
+      if (!zoomFactor) {
+        zoomFactor = this.resolutions_[i] / this.resolutions_[i + 1];
+      } else {
+        if (this.resolutions_[i] / this.resolutions_[i + 1] !== zoomFactor) {
+          zoomFactor = undefined;
+          break;
+        }
+      }
+    }
+  }
+
+
+  /**
+   * @private
+   * @type {number|undefined}
+   */
+  this.zoomFactor_ = zoomFactor;
+
+
   /**
    * @protected
    * @type {number}
@@ -248,12 +272,16 @@ ol.tilegrid.TileGrid.prototype.getResolutions = function() {
  */
 ol.tilegrid.TileGrid.prototype.getTileCoordChildTileRange = function(tileCoord, opt_tileRange, opt_extent) {
   if (tileCoord[0] < this.maxZoom) {
+    if (this.zoomFactor_ === 2) {
+      var minX = tileCoord[1] * 2;
+      var minY = tileCoord[2] * 2;
+      return ol.TileRange.createOrUpdate(minX, minX + 1, minY, minY + 1, opt_tileRange);
+    }
     var tileCoordExtent = this.getTileCoordExtent(tileCoord, opt_extent);
     return this.getTileRangeForExtentAndZ(
         tileCoordExtent, tileCoord[0] + 1, opt_tileRange);
-  } else {
-    return null;
   }
+  return null;
 };
 
 

--- a/src/ol/tilegrid/tilegrid.js
+++ b/src/ol/tilegrid/tilegrid.js
@@ -186,11 +186,24 @@ ol.tilegrid.TileGrid.prototype.forEachTileCoord = function(extent, zoom, callbac
  * @template T
  */
 ol.tilegrid.TileGrid.prototype.forEachTileCoordParentTileRange = function(tileCoord, callback, opt_this, opt_tileRange, opt_extent) {
-  var tileCoordExtent = this.getTileCoordExtent(tileCoord, opt_extent);
+  var tileRange, x, y;
+  var tileCoordExtent = null;
   var z = tileCoord[0] - 1;
+  if (this.zoomFactor_ === 2) {
+    x = tileCoord[1];
+    y = tileCoord[2];
+  } else {
+    tileCoordExtent = this.getTileCoordExtent(tileCoord, opt_extent);
+  }
   while (z >= this.minZoom) {
-    if (callback.call(opt_this, z,
-        this.getTileRangeForExtentAndZ(tileCoordExtent, z, opt_tileRange))) {
+    if (this.zoomFactor_ === 2) {
+      x = Math.floor(x / 2);
+      y = Math.floor(y / 2);
+      tileRange = ol.TileRange.createOrUpdate(x, x, y, y, opt_tileRange);
+    } else {
+      tileRange = this.getTileRangeForExtentAndZ(tileCoordExtent, z, opt_tileRange);
+    }
+    if (callback.call(opt_this, z, tileRange)) {
       return true;
     }
     --z;

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -287,6 +287,26 @@ describe('ol.tilegrid.TileGrid', function() {
     });
   });
 
+  describe('#zoomFactor_', function() {
+    it('is set for a consistent zoom factor', function() {
+      var grid = new ol.tilegrid.TileGrid({
+        resolutions: [10, 5, 2.5, 1.25],
+        origin: origin,
+        tileSize: tileSize
+      });
+      expect(grid.zoomFactor_).to.be(2);
+    });
+
+    it('is not set for an inconsistent zoom factor', function() {
+      var grid = new ol.tilegrid.TileGrid({
+        resolutions: [10, 5, 3, 1.25],
+        origin: origin,
+        tileSize: tileSize
+      });
+      expect(grid.zoomFactor_).to.be(undefined);
+    });
+  });
+
   describe('createForProjection', function() {
 
     it('allows easier creation of a tile grid', function() {


### PR DESCRIPTION
When the tile grid has a consistent integer zoom factor and fixed origin (the most common case), we don't need to work with resolutions and tile extent when getting the child or parent tile coordinate ranges.  This change creates a fast path for `grid.getTileCoordChildTileRange()` and `grid.forEachTileCoordParentTileRange()` (what a mouthful!) to handle cases where the zoom factor is 2 (this could be altered a bit to work with any integer zoom factor, but I don't think there is a real use case for this).