### PR TITLE
Mark ol.format.filter.Spatial as abstract class

### DIFF
--- a/src/ol/format/filter/spatial.js
+++ b/src/ol/format/filter/spatial.js
@@ -6,6 +6,7 @@ goog.require('ol.format.filter.Filter');
 
 /**
  * @classdesc
+ * Abstract class; normally only used for creating subclasses and not instantiated in apps.
  * Represents a spatial operator to test whether a geometry-valued property
  * relates to a given geometry.
  *


### PR DESCRIPTION
Add missing abstract class description for class ol.format.filter.Spatial like in all other abstract classes.