### PR TITLE
update zoomify source to accept tileIndex placeholders and handle iip…

### DIFF
--- a/examples/zoomify.html
+++ b/examples/zoomify.html
@@ -3,7 +3,13 @@ layout: example.html
 title: Zoomify
 shortdesc: Example of a Zoomify source.
 docs: >
-  Zoomify is a format for deep-zooming into high resolution images. This example shows how to use the Zoomify source with a pixel projection.
-tags: "zoomify, deep zoom, pixel, projection"
+  Zoomify is a format for deep-zooming into high resolution images. This example shows how to use the Zoomify source with a pixel projection. Internet Imaging Protocol (IIP) with JTL extension is also handled.
+tags: "zoomify, deep zoom, IIP, pixel, projection"
 ---
 <div id="map" class="map"></div>
+<div class="controls">
+  <select id="zoomifyProtocol">
+    <option value="zoomify">Zoomify</option>
+    <option value="iip">IIP</option>
+  </select>
+</div>

--- a/examples/zoomify.js
+++ b/examples/zoomify.js
@@ -6,26 +6,47 @@ goog.require('ol.source.Zoomify');
 var imgWidth = 9911;
 var imgHeight = 6100;
 
-var source = new ol.source.Zoomify({
-  url: 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?zoomify=' +
-      '/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF/',
-  size: [imgWidth, imgHeight],
-  crossOrigin: 'anonymous'
+var zoomifyUrl = 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?zoomify=' +
+    '/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF/';
+var iipUrl = 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?FIF=' + '/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF' +  '&JTL={z},{tileIndex}';
+
+var layer = new ol.layer.Tile({
+  source: new ol.source.Zoomify({
+    url: zoomifyUrl,
+    size: [imgWidth, imgHeight],
+    crossOrigin: 'anonymous'
+  })
 });
+
 var extent = [0, -imgHeight, imgWidth, 0];
 
 var map = new ol.Map({
-  layers: [
-    new ol.layer.Tile({
-      source: source
-    })
-  ],
+  layers: [layer],
   target: 'map',
   view: new ol.View({
     // adjust zoom levels to those provided by the source
-    resolutions: source.getTileGrid().getResolutions(),
+    resolutions: layer.getSource().getTileGrid().getResolutions(),
     // constrain the center: center cannot be set outside this extent
     extent: extent
   })
 });
 map.getView().fit(extent);
+
+var control = document.getElementById('zoomifyProtocol');
+control.addEventListener('change', function(event) {
+  var value = event.currentTarget.value;
+  if (value === 'iip') {
+    layer.setSource(new ol.source.Zoomify({
+      url: iipUrl,
+      size: [imgWidth, imgHeight],
+      crossOrigin: 'anonymous'
+    }));
+  } else if (value === 'zoomify') {
+    layer.setSource(new ol.source.Zoomify({
+      url: zoomifyUrl,
+      size: [imgWidth, imgHeight],
+      crossOrigin: 'anonymous'
+    }));
+  }
+
+});

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7175,6 +7175,9 @@ olx.source.ZoomifyOptions.prototype.reprojectionErrorThreshold;
  * `http://my.zoomify.info/IMAGE.TIF/`. A URL template must include
  * `{TileGroup}`, `{x}`, `{y}`, and `{z}` placeholders, e.g.
  * `http://my.zoomify.info/IMAGE.TIF/{TileGroup}/{z}-{x}-{y}.jpg`.
+ * Internet Imaging Protocol (IIP) with JTL extension can be also used with
+ * `{tileIndex}` and `{z}` placeholders, e.g.
+ * `http://my.zoomify.info?FIF=IMAGE.TIF&JTL={z},{tileIndex}`.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
  * @type {!string}

--- a/src/ol/source/zoomify.js
+++ b/src/ol/source/zoomify.js
@@ -13,7 +13,8 @@ goog.require('ol.tilegrid.TileGrid');
 
 /**
  * @classdesc
- * Layer source for tile data in Zoomify format.
+ * Layer source for tile data in Zoomify format (both Zoomify and Internet
+ * Imaging Protocol are supported).
  *
  * @constructor
  * @extends {ol.source.TileImage}
@@ -84,7 +85,7 @@ ol.source.Zoomify = function(opt_options) {
   });
 
   var url = options.url;
-  if (url && url.indexOf('{TileGroup}') == -1) {
+  if (url && url.indexOf('{TileGroup}') == -1 && url.indexOf('{tileIndex}') == -1) {
     url += '{TileGroup}/{z}-{x}-{y}.jpg';
   }
   var urls = ol.TileUrlFunction.expandUrl(url);
@@ -111,13 +112,13 @@ ol.source.Zoomify = function(opt_options) {
           var tileCoordY = -tileCoord[2] - 1;
           var tileIndex =
               tileCoordX +
-              tileCoordY * tierSizeInTiles[tileCoordZ][0] +
-              tileCountUpToTier[tileCoordZ];
-          var tileGroup = (tileIndex / ol.DEFAULT_TILE_SIZE) | 0;
+              tileCoordY * tierSizeInTiles[tileCoordZ][0];
+          var tileGroup = ((tileIndex + tileCountUpToTier[tileCoordZ]) / ol.DEFAULT_TILE_SIZE) | 0;
           var localContext = {
             'z': tileCoordZ,
             'x': tileCoordX,
             'y': tileCoordY,
+            'tileIndex': tileIndex,
             'TileGroup': 'TileGroup' + tileGroup
           };
           return template.replace(/\{(\w+?)\}/g, function(m, p) {


### PR DESCRIPTION
Adds a `{tileIndex}` placeholder to `ol.source.Zoomify`.
One can use 

```javascript

new ol.source.Zoomify({
  url: 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?FIF=/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF&WID=256&JTL={z},{tileIndex}',
  // ...
});
```
to use IIP protocol.