### PR TITLE
Transform updates

### DIFF
--- a/transforms/module.js
+++ b/transforms/module.js
@@ -259,5 +259,17 @@ module.exports = function(info, api) {
   // replace any initial comments
   root.get().node.comments = comments;
 
+  // add @module annotation for src modules
+  if (info.path.startsWith('src')) {
+    const name = info.path.replace(/^src\//, '').replace(/\.js$/, '');
+    const comment = j.commentBlock(`*\n * @module ${name}\n `);
+    const node = root.get().node;
+    if (!node.comments) {
+      node.comments = [comment];
+    } else {
+      node.comments.unshift(comment);
+    }
+  }
+
   return root.toSource({quote: 'single'});
 };

--- a/transforms/module.js
+++ b/transforms/module.js
@@ -61,7 +61,7 @@ function resolve(fromName, toName) {
   if (relative.endsWith('/')) {
     relative += 'index';
   }
-  return relative;
+  return relative + '.js';
 }
 
 function getUnprovided(path) {


### PR DESCRIPTION
This updates the modules transform so we get code like this:
```js
/**
 * @module ol/control/zoom
 */
import _ol_ from '../index.js';
import _ol_events_ from '../events.js';
import _ol_events_EventType_ from '../events/eventtype.js';
import _ol_control_Control_ from '../control/control.js';
import _ol_css_ from '../css.js';
import _ol_easing_ from '../easing.js';

// ...
```

The first change is to use `.js` extensions on import specifiers.  While it isn't really practical (or possible) to use `<script type="module">` with the `ol` package (the package has dependencies on 3rd party modules so it uses "bare" import specifiers ((e.g. `import rbush from 'rbush';`)) and those dependencies aren't always ES modules ((e.g. `rbush`))), the change to using `.js` extensions is safe and at least lets people play around with `<script type="module">`.

The second change adding the `@module` annotation is for documentation tools.  Note that we intentionally don't use the `.js` extension here.