### PR TITLE
Fix JSDoc paths for custom builds

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -1,7 +1,7 @@
 {
     "opts": {
         "recurse": true,
-        "template": "../../config/jsdoc/api/template"
+        "template": "config/jsdoc/api/template"
     },
     "tags": {
         "allowUnknownTags": true
@@ -17,11 +17,11 @@
     },
     "plugins": [
         "plugins/markdown",
-        "../../config/jsdoc/api/plugins/inheritdoc",
-        "../../config/jsdoc/api/plugins/typedefs",
-        "../../config/jsdoc/api/plugins/events",
-        "../../config/jsdoc/api/plugins/observable",
-        "../../config/jsdoc/api/plugins/api"
+        "config/jsdoc/api/plugins/inheritdoc",
+        "config/jsdoc/api/plugins/typedefs",
+        "config/jsdoc/api/plugins/events",
+        "config/jsdoc/api/plugins/observable",
+        "config/jsdoc/api/plugins/api"
     ],
     "markdown": {
         "parser": "gfm"

--- a/config/jsdoc/info/conf.json
+++ b/config/jsdoc/info/conf.json
@@ -1,7 +1,7 @@
 {
     "opts": {
         "recurse": true,
-        "template": "../../config/jsdoc/info"
+        "template": "config/jsdoc/info"
     },
     "tags": {
         "allowUnknownTags": true
@@ -10,8 +10,8 @@
         "includePattern": "\\.js$"
     },
     "plugins": [
-        "../../config/jsdoc/info/api-plugin",
-        "../../config/jsdoc/info/define-plugin",
-        "../../config/jsdoc/info/virtual-plugin"
+        "config/jsdoc/info/api-plugin",
+        "config/jsdoc/info/define-plugin",
+        "config/jsdoc/info/virtual-plugin"
     ]
 }


### PR DESCRIPTION
This pull request reverts most of 4d0e106d982079232a61d1b2ecf5f334d03dad40. Looks like the path change necessary back then was not due to a JSDoc API change, but due to a JSDoc bug. With more recent JSDoc versions, the previous paths work again.

Fixes #7215.