### PR TITLE
Make it possible to customize the map background color in WebGL context.

### DIFF
--- a/src/ol/renderer/webgl/map.js
+++ b/src/ol/renderer/webgl/map.js
@@ -431,8 +431,6 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
   this.textureCache_.set((-frameState.index).toString(), null);
   ++this.textureCacheFrameMarkerCount_;
 
-  this.dispatchComposeEvent_(ol.render.EventType.PRECOMPOSE, frameState);
-
   /** @type {Array.<ol.LayerState>} */
   var layerStatesToDraw = [];
   var layerStatesArray = frameState.layerStatesArray;
@@ -464,6 +462,8 @@ ol.renderer.webgl.Map.prototype.renderFrame = function(frameState) {
   gl.clear(ol.webgl.COLOR_BUFFER_BIT);
   gl.enable(ol.webgl.BLEND);
   gl.viewport(0, 0, this.canvas_.width, this.canvas_.height);
+
+  this.dispatchComposeEvent_(ol.render.EventType.PRECOMPOSE, frameState);
 
   for (i = 0, ii = layerStatesToDraw.length; i < ii; ++i) {
     layerState = layerStatesToDraw[i];

--- a/src/ol/style/regularshape.js
+++ b/src/ol/style/regularshape.js
@@ -58,29 +58,6 @@ ol.style.RegularShape = function(options) {
   this.points_ = options.points;
 
   /**
-   * If <code>options.points</code> is a Array.<number> object, 
-   * <code>this.quotients_</code> will hold the Array.<number> instance 
-   * and <code>this.points_</code> will be still assigned with the number
-   * of points for stars and polygons.
-   * @private
-   * @type {null|Array.<number>}
-   */
-  this.quotients_ = null;
-
-  if (goog.isArray(this.points_)) {
-    this.quotients_ = this.points_.map(number => {
-      if (number > 10) {
-        return number / 100;
-      }
-      if (number > 1) {
-        return number / 10;
-      }
-      return number;
-    });
-    this.points_ = this.quotients_.length;
-  }
-
-  /**
    * @protected
    * @type {number}
    */
@@ -166,15 +143,9 @@ ol.inherits(ol.style.RegularShape, ol.style.Image);
  * @api
  */
 ol.style.RegularShape.prototype.clone = function() {
-  let points;  
-  if (goog.isArray(this.quotients_)) {
-    points = this.quotients_;
-  } else {
-    points = this.getPoints();
-  }
   var style = new ol.style.RegularShape({
     fill: this.getFill() ? this.getFill().clone() : undefined,
-    points: points,
+    points: this.getPoints(),
     radius: this.getRadius(),
     radius2: this.getRadius2(),
     angle: this.getAngle(),
@@ -472,12 +443,7 @@ ol.style.RegularShape.prototype.draw_ = function(renderOptions, context, x, y) {
       points = 2 * points;
     }
     for (i = 0; i <= points; i++) {
-      if (goog.isArray(this.quotients_)) {
-        const sum = this.quotients_.slice(0, i + 1).reduce((sum, current) => sum + current, 0);
-        angle0 = sum * 2 * Math.PI - Math.PI / 2 + this.angle_;
-      } else {
-        angle0 = i * 2 * Math.PI / points - Math.PI / 2 + this.angle_;
-      }      
+      angle0 = i * 2 * Math.PI / points - Math.PI / 2 + this.angle_;
       radiusC = i % 2 === 0 ? this.radius_ : radius2;
       context.lineTo(renderOptions.size / 2 + radiusC * Math.cos(angle0),
           renderOptions.size / 2 + radiusC * Math.sin(angle0));

--- a/src/ol/style/regularshape.js
+++ b/src/ol/style/regularshape.js
@@ -58,6 +58,29 @@ ol.style.RegularShape = function(options) {
   this.points_ = options.points;
 
   /**
+   * If <code>options.points</code> is a Array.<number> object, 
+   * <code>this.quotients_</code> will hold the Array.<number> instance 
+   * and <code>this.points_</code> will be still assigned with the number
+   * of points for stars and polygons.
+   * @private
+   * @type {null|Array.<number>}
+   */
+  this.quotients_ = null;
+
+  if (goog.isArray(this.points_)) {
+    this.quotients_ = this.points_.map(number => {
+      if (number > 10) {
+        return number / 100;
+      }
+      if (number > 1) {
+        return number / 10;
+      }
+      return number;
+    });
+    this.points_ = this.quotients_.length;
+  }
+
+  /**
    * @protected
    * @type {number}
    */
@@ -143,9 +166,15 @@ ol.inherits(ol.style.RegularShape, ol.style.Image);
  * @api
  */
 ol.style.RegularShape.prototype.clone = function() {
+  let points;  
+  if (goog.isArray(this.quotients_)) {
+    points = this.quotients_;
+  } else {
+    points = this.getPoints();
+  }
   var style = new ol.style.RegularShape({
     fill: this.getFill() ? this.getFill().clone() : undefined,
-    points: this.getPoints(),
+    points: points,
     radius: this.getRadius(),
     radius2: this.getRadius2(),
     angle: this.getAngle(),
@@ -443,7 +472,12 @@ ol.style.RegularShape.prototype.draw_ = function(renderOptions, context, x, y) {
       points = 2 * points;
     }
     for (i = 0; i <= points; i++) {
-      angle0 = i * 2 * Math.PI / points - Math.PI / 2 + this.angle_;
+      if (goog.isArray(this.quotients_)) {
+        const sum = this.quotients_.slice(0, i + 1).reduce((sum, current) => sum + current, 0);
+        angle0 = sum * 2 * Math.PI - Math.PI / 2 + this.angle_;
+      } else {
+        angle0 = i * 2 * Math.PI / points - Math.PI / 2 + this.angle_;
+      }      
       radiusC = i % 2 === 0 ? this.radius_ : radius2;
       context.lineTo(renderOptions.size / 2 + radiusC * Math.cos(angle0),
           renderOptions.size / 2 + radiusC * Math.sin(angle0));


### PR DESCRIPTION
Mimicking the class "ol.renderer.canvas.Map.prototype.renderFrame", trigger the render event "PRECOMPOSE" after the viewport clear-up operation so that I have a good chance of customizing the map background color. The custom background color is feasible for Canvas 2D, because the render event "PRECOMPOSE" happens after the context.clearRect() invocation.

Thank you for your interest in making OpenLayers better!

In order to get your proposed changes merged into the master branch, we ask you to please make sure the following boxes are checked *before* submitting your pull request.

- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [ ] I have used clear commit messages.
- [ ] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
