### PR TITLE
Fix abort handling of tileload events

### DIFF
--- a/src/ol/source/tileeventtype.js
+++ b/src/ol/source/tileeventtype.js
@@ -13,7 +13,8 @@ ol.source.TileEventType = {
   TILELOADSTART: 'tileloadstart',
 
   /**
-   * Triggered when a tile finishes loading.
+   * Triggered when a tile finishes loading, either when its data is loaded,
+   * or when loading was aborted because the tile is no longer needed.
    * @event ol.source.Tile.Event#tileloadend
    * @api
    */


### PR DESCRIPTION
Tile loading events, like used in the `tile-load-events.html` example, get out of sync between loading and loaded when tiles are aborted, e.g. because of a small and full tile cache.

By keeping track of which tiles are being loaded, and also dispatching a tileloadend event for aborted tiles, this issue can be fixed.