### PR TITLE
Use EMPTY and LOADED state properly on ol.VectorImageTile

### DIFF
--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -273,7 +273,7 @@ ol.VectorImageTile.prototype.finishLoading_ = function() {
     this.loadListenerKeys_.forEach(ol.events.unlistenByKey);
     this.loadListenerKeys_.length = 0;
   }
-  this.setState(loaded > 0 ? ol.TileState.LOADED : ol.TileState.EMPTY);
+  this.setState(loaded > 0 ? ol.TileState.LOADED : ol.TileState.ERROR);
 };
 
 

--- a/src/ol/vectorimagetile.js
+++ b/src/ol/vectorimagetile.js
@@ -263,17 +263,23 @@ ol.VectorImageTile.prototype.load = function() {
  */
 ol.VectorImageTile.prototype.finishLoading_ = function() {
   var loaded = this.tileKeys.length;
+  var empty = 0;
   for (var i = loaded - 1; i >= 0; --i) {
     var state = this.getTile(this.tileKeys[i]).getState();
     if (state != ol.TileState.LOADED) {
       --loaded;
     }
+    if (state == ol.TileState.EMPTY) {
+      ++empty;
+    }
   }
   if (loaded == this.tileKeys.length) {
     this.loadListenerKeys_.forEach(ol.events.unlistenByKey);
     this.loadListenerKeys_.length = 0;
+    this.setState(ol.TileState.LOADED);
+  } else {
+    this.setState(empty == this.tileKeys.length ? ol.TileState.EMPTY : ol.TileState.ERROR);
   }
-  this.setState(loaded > 0 ? ol.TileState.LOADED : ol.TileState.ERROR);
 };
 
 

--- a/test/rendering/ol/layer/vectortile.test.js
+++ b/test/rendering/ol/layer/vectortile.test.js
@@ -65,7 +65,6 @@ describe('ol.rendering.layer.VectorTile', function() {
       source = new ol.source.VectorTile({
         format: new ol.format.MVT(),
         tileGrid: ol.tilegrid.createXYZ(),
-        tilePixelRatio: 16,
         url: 'rendering/ol/data/tiles/mvt/{z}-{x}-{y}.vector.pbf'
       });
     });

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -49,7 +49,7 @@ describe('ol.VectorImageTile', function() {
     var calls = 0;
     ol.events.listen(tile, 'change', function(e) {
       ++calls;
-      expect(tile.getState()).to.be(calls == 2 ? ol.TileState.LOADED : ol.TileState.EMPTY);
+      expect(tile.getState()).to.be(calls == 2 ? ol.TileState.LOADED : ol.TileState.ERROR);
       if (calls == 2) {
         done();
       } else {
@@ -60,7 +60,7 @@ describe('ol.VectorImageTile', function() {
     });
   });
 
-  it('sets EMPTY state when all source tiles fail to load', function(done) {
+  it('sets ERROR state when source tiles fail to load', function(done) {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/unavailable.json';
     var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
@@ -72,7 +72,7 @@ describe('ol.VectorImageTile', function() {
     tile.load();
 
     ol.events.listen(tile, 'change', function(e) {
-      expect(tile.getState()).to.be(ol.TileState.EMPTY);
+      expect(tile.getState()).to.be(ol.TileState.ERROR);
       done();
     });
   });

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -32,23 +32,6 @@ describe('ol.VectorImageTile', function() {
     });
   });
 
-  it('sets LOADED state when source tiles fail to load', function(done) {
-    var format = new ol.format.GeoJSON();
-    var url = 'spec/ol/data/unavailable.json';
-    var tile = new ol.VectorImageTile([0, 0, -1], 0, url, format,
-        ol.VectorImageTile.defaultLoadFunction, [0, 0, -1], function() {
-          return url;
-        }, ol.tilegrid.createXYZ(), ol.tilegrid.createXYZ(), {},
-        1, ol.proj.get('EPSG:3857'), ol.VectorTile, function() {});
-
-    tile.load();
-
-    ol.events.listen(tile, 'change', function(e) {
-      expect(tile.getState()).to.be(ol.TileState.EMPTY);
-      done();
-    });
-  });
-
   it('sets LOADED state when previously failed source tiles are loaded', function(done) {
     var format = new ol.format.GeoJSON();
     var url = 'spec/ol/data/unavailable.json';


### PR DESCRIPTION
Currently, vector image tiles with ERROR source tiles are set to EMPTY state. But the EMPTY state means that the renderer has nothing to do for the extent of that tile. Instead, we want the `loadInterimTilesOnError` logic to kick in when there are error tiles, so tiles from lower resolutions can fill the spots with error tiles. For this to work, we have to set the state to ERROR instead.

With #7206 fixed, we also no longer need to set a vector image tile to LOADED when only some of its source tiles are loaded, because source tiles will only be created if they are available on the source. By setting an ERROR state when just one source tile has an ERROR state, we ensure that the `loadInterimTilesOnError` logic works here too.