### PR TITLE
Raise tolerance of rendering tests to pass on Firefox 55 (GNU/Linux)

### DIFF
--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -142,7 +142,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      expectResemble(map, 'rendering/ol/style/expected/text-align-offset-canvas.png', 5, done);
+      expectResemble(map, 'rendering/ol/style/expected/text-align-offset-canvas.png', 6, done);
     });
 
     it('renders multiline text with positioning options', function(done) {
@@ -188,7 +188,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      expectResemble(map, 'rendering/ol/style/expected/text-align-offset-canvas.png', 5, done);
+      expectResemble(map, 'rendering/ol/style/expected/text-align-offset-canvas.png', 6, done);
     });
 
     where('WebGL').it('tests the webgl renderer without rotation', function(done) {


### PR DESCRIPTION
Title says it all.

Test pass locally for me now as well:

```
12 09 2017 09:39:34.837:INFO [karma]: Karma v1.7.0 server started at http://0.0.0.0:9876/
12 09 2017 09:39:34.839:INFO [launcher]: Launching browser Firefox with unlimited concurrency
12 09 2017 09:39:34.845:INFO [launcher]: Starting browser Firefox
12 09 2017 09:39:37.722:INFO [Firefox 55.0.0 (Ubuntu 0.0.0)]: Connected on socket UY3p4ukuo3SWnONPAAAA with id 72429099
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 1446 of 2818 (skipped 29) SUCCESS (0 secs / 6.633 secs)
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 2228 of 2818 (skipped 29) SUCCESS (0 secs / 11.575 secs)
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 2237 of 2818 (skipped 29) SUCCESS (0 secs / 11.6 secs)
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 2662 of 2818 (skipped 29) SUCCESS (0 secs / 13.112 secs)
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 2676 of 2818 (skipped 29) SUCCESS (0 secs / 13.126 secs)
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 2683 of 2818 (skipped 29) SUCCESS (0 secs / 13.14 secs)
Firefox 55.0.0 (Ubuntu 0.0.0): Executed 2789 of 2818 (skipped 29) SUCCESS (18.129 secs / 13.822 secs)
```

Fixes #7245 

Please review.