### PR TITLE
Script to rename files so the case matches the module name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '8'
+- '8.4'
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "changecase-src": "node tasks/filename-case-from-module.js",
     "transform-examples": "jscodeshift --transform transforms/module.js examples",
     "transform-test": "jscodeshift --transform transforms/module.js test",
-    "transform": "npm run transform-src && npm run changecase-src && npm run transform-examples && npm run transform-test && npm run lint -- --fix"
+    "transform": "npm run changecase-src && npm run transform-src && npm run transform-examples && npm run transform-test && npm run lint -- --fix"
   },
   "main": "dist/ol.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "debug-server": "node tasks/serve-lib.js",
     "karma": "node tasks/test.js start test/karma.config.js",
     "transform-src": "jscodeshift --transform transforms/module.js src",
+    "changecase-src": "node tasks/filename-case-from-module.js",
     "transform-examples": "jscodeshift --transform transforms/module.js examples",
     "transform-test": "jscodeshift --transform transforms/module.js test",
-    "transform": "npm run transform-src && npm run transform-examples && npm run transform-test && npm run lint -- --fix"
+    "transform": "npm run transform-src && npm run changecase-src && npm run transform-examples && npm run transform-test && npm run lint -- --fix"
   },
   "main": "dist/ol.js",
   "repository": {

--- a/tasks/filename-case-from-module.js
+++ b/tasks/filename-case-from-module.js
@@ -11,7 +11,7 @@ glob('src/**/*.js', {}, function(err, files) {
       const lines = contents.split('\n');
       for (let i = lines.length - 1; i >= 0; --i) {
         const line = lines[i];
-        const match = line.match(/export default _.*_([^;]*)_;$/);
+        const match = line.match(/goog\.provide\('.*\.([^']*)'\);$/);
         if (match && match.length) {
           const newName = match[1] + '.js';
           if (newName != newName.toLowerCase()) {

--- a/tasks/filename-case-from-module.js
+++ b/tasks/filename-case-from-module.js
@@ -1,0 +1,29 @@
+const glob = require('glob');
+const fs = require('fs');
+const path = require('path');
+
+glob('src/**/*.js', {}, function(err, files) {
+  if (!err) {
+    process.stdout.write(`Checking ${files.length} files...\n`);
+    let renamed = 0;
+    files.forEach(function(filename) {
+      const contents = fs.readFileSync(filename, 'utf-8');
+      const lines = contents.split('\n');
+      for (let i = lines.length - 1; i >= 0; --i) {
+        const line = lines[i];
+        const match = line.match(/export default _.*_([^;]*)_;$/);
+        if (match && match.length) {
+          var newName = match[1] + '.js';
+          if (newName != newName.toLowerCase()) {
+            fs.renameSync(filename, path.resolve(path.dirname(filename), newName));
+            ++renamed;
+          }
+        }
+      }
+    });
+    process.stdout.write(`Renamed ${renamed} files.\n`);
+  } else {
+    process.stdout.write(err.message);
+    process.exit(1);
+  }
+});

--- a/tasks/filename-case-from-module.js
+++ b/tasks/filename-case-from-module.js
@@ -13,7 +13,7 @@ glob('src/**/*.js', {}, function(err, files) {
         const line = lines[i];
         const match = line.match(/export default _.*_([^;]*)_;$/);
         if (match && match.length) {
-          var newName = match[1] + '.js';
+          const newName = match[1] + '.js';
           if (newName != newName.toLowerCase()) {
             fs.renameSync(filename, path.resolve(path.dirname(filename), newName));
             ++renamed;

--- a/transforms/module.js
+++ b/transforms/module.js
@@ -57,7 +57,7 @@ function resolve(fromName, toName) {
   }
 
   const back = new Array(fromLength - commonDepth).join('../') || './';
-  let relative = back + toParts.slice(commonDepth).join('/').toLowerCase();
+  let relative = back + toParts.slice(commonDepth).join('/');
   if (relative.endsWith('/')) {
     relative += 'index';
   }


### PR DESCRIPTION
This pull request modifies the `npm run transform` script so the module file names match the case of the default export.