### PR TITLE
Add ability to change the loader of a vector source

### DIFF
--- a/src/ol/source/vector.js
+++ b/src/ol/source/vector.js
@@ -824,6 +824,17 @@ ol.source.Vector.prototype.removeFromIdIndex_ = function(feature) {
 
 
 /**
+ * Set the new loader of the source. The next loadFeatures call will use the
+ * new loader.
+ * @param {ol.FeatureLoader} loader The loader to set.
+ * @api
+ */
+ol.source.Vector.prototype.setLoader = function(loader) {
+  this.loader_ = loader;
+};
+
+
+/**
  * @classdesc
  * Events emitted by {@link ol.source.Vector} instances are instances of this
  * type.

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -430,6 +430,29 @@ describe('ol.source.Vector', function() {
       });
     });
 
+    describe('with setLoader', function() {
+
+      it('it will change the loader function', function() {
+        var count1 = 0;
+        var loader1 = function(bbox, resolution, projection) {
+          count1++;
+        };
+        var count2 = 0;
+        var loader2 = function(bbox, resolution, projection) {
+          count2++;
+        };
+        var source = new ol.source.Vector({loader: loader1});
+        source.loadFeatures([-10000, -10000, 10000, 10000], 1,
+            ol.proj.get('EPSG:3857'));
+        source.setLoader(loader2);
+        source.clear();
+        source.loadFeatures([-10000, -10000, 10000, 10000], 1,
+            ol.proj.get('EPSG:3857'));
+        expect(count1).to.eql(1);
+        expect(count2).to.eql(1);
+      });
+    });
+
   });
 
   describe('the feature id index', function() {


### PR DESCRIPTION
Currently there is no option to change the loader of a vector source. This PR adds that ability.