### PR TITLE
Convert pointerId to string for object lookups

### DIFF
--- a/src/ol/interaction/pointer.js
+++ b/src/ol/interaction/pointer.js
@@ -69,7 +69,7 @@ ol.interaction.Pointer = function(opt_options) {
   this.handlingDownUpSequence = false;
 
   /**
-   * @type {Object.<number, ol.pointer.PointerEvent>}
+   * @type {Object.<string, ol.pointer.PointerEvent>}
    * @private
    */
   this.trackedPointers_ = {};
@@ -123,14 +123,15 @@ ol.interaction.Pointer.prototype.updateTrackedPointers_ = function(mapBrowserEve
   if (this.isPointerDraggingEvent_(mapBrowserEvent)) {
     var event = mapBrowserEvent.pointerEvent;
 
+    var id = event.pointerId.toString();
     if (mapBrowserEvent.type == ol.MapBrowserEventType.POINTERUP) {
-      delete this.trackedPointers_[event.pointerId];
+      delete this.trackedPointers_[id];
     } else if (mapBrowserEvent.type ==
         ol.MapBrowserEventType.POINTERDOWN) {
-      this.trackedPointers_[event.pointerId] = event;
-    } else if (event.pointerId in this.trackedPointers_) {
+      this.trackedPointers_[id] = event;
+    } else if (id in this.trackedPointers_) {
       // update only when there was a pointerdown event for this pointer
-      this.trackedPointers_[event.pointerId] = event;
+      this.trackedPointers_[id] = event;
     }
     this.targetPointers = ol.obj.getValues(this.trackedPointers_);
   }


### PR DESCRIPTION
We're using the expression [`property in object`](https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/pointer.js#L131) where `property` is a number, and apparently Safari on IOS11 doesn't like that when the number is negative.  Although `event.pointerId` [is a number](https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerId) it is legitimate to convert to a string when we use it as an object property name.  So even if this is a Safari bug, I think it is a legitimate change to make.

Thanks @ogo-adp for debugging and identifying the fix.

Fixes #7202.