### PR TITLE
Enable mouse wheel in freehand draw mode

### DIFF
--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -309,13 +309,16 @@ ol.interaction.Draw.prototype.setMap = function(map) {
  */
 ol.interaction.Draw.handleEvent = function(event) {
   this.freehand_ = this.mode_ !== ol.interaction.Draw.Mode_.POINT && this.freehandCondition_(event);
-  var pass = !this.freehand_;
+  var pass = true;
   if (this.freehand_ &&
-      event.type === ol.MapBrowserEventType.POINTERDRAG && this.sketchFeature_ !== null) {
+      event.type === ol.MapBrowserEventType.POINTERDRAG &&
+      this.sketchFeature_ !== null) {
     this.addToDrawing_(event);
     pass = false;
-  } else if (event.type ===
-      ol.MapBrowserEventType.POINTERMOVE) {
+  } else if (this.freehand_ &&
+      event.type === ol.MapBrowserEventType.POINTERDOWN) {
+    pass = false;
+  } else if (event.type === ol.MapBrowserEventType.POINTERMOVE) {
     pass = this.handlePointerMove_(event);
   } else if (event.type === ol.MapBrowserEventType.DBLCLICK) {
     pass = false;


### PR DESCRIPTION
Previously, events weren't being propagated if the active draw interaction had its `freehand` property set to `true`. This means that you can't use your mouse wheel to zoom the map in freehand mode.

This change sets the default `pass` value to `true` and adds additional logic to determine when it should be set to `false` (and stop event propagation).

Closes https://github.com/openlayers/openlayers/issues/7300
