### PR TITLE
Use lowercase module identifiers until ol@5

### DIFF
--- a/transforms/module.js
+++ b/transforms/module.js
@@ -57,7 +57,8 @@ function resolve(fromName, toName) {
   }
 
   const back = new Array(fromLength - commonDepth).join('../') || './';
-  let relative = back + toParts.slice(commonDepth).join('/');
+  // TODO: remove .toLowerCase() after running tasks/filename-case-from-module.js
+  let relative = back + toParts.slice(commonDepth).join('/').toLowerCase();
   if (relative.endsWith('/')) {
     relative += 'index';
   }


### PR DESCRIPTION
This was a minor oversight in #7249.  We might have been thinking that our next release would be a major at that point.  Until 5.0, we need to keep module identifiers in the `ol` package all lowercase.

I'll publish a patch release with this change.