### PR TITLE
Only clear the canvas when needed

### DIFF
--- a/src/ol/renderer/canvas/tilelayer.js
+++ b/src/ol/renderer/canvas/tilelayer.js
@@ -228,7 +228,9 @@ ol.renderer.canvas.TileLayer.prototype.prepareFrame = function(frameState, layer
         canvas.width = width;
         canvas.height = height;
       } else {
-        context.clearRect(0, 0, width, height);
+        if (this.renderedExtent_ && !ol.extent.equals(imageExtent, this.renderedExtent_)) {
+          context.clearRect(0, 0, width, height);
+        }
         oversampling = this.oversampling_;
       }
     }


### PR DESCRIPTION
Instead of always clearing the canvas before rendering new tiles, we should be able to only clear when the extent has changed.  After tile transitions have completed, we already [clear before rendering](https://github.com/tschaub/openlayers/blob/ad4a258c87574f76397ed719cf4ac4a529ce7632/src/ol/renderer/canvas/tilelayer.js#L318-L320) at alpha 1, so this should be enough for non-opaque layers.

Fixes #7322.