### PR TITLE
Reworked attribution handling

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,36 @@
 
 ### Next Release
 
+#### Deprecation of `ol.Attribution`
+
+`ol.Attribution` is deprecated and will be removed in the next major version.  Instead, you can construct a source with a string attribution or an array of strings.  For dynamic attributions, you can provide a function that gets called with the current frame state.
+
+Before:
+```js
+var source = new ol.source.XYZ({
+  attributions: [
+    new ol.Attribution({html: 'some attribution'})
+  ]
+});
+```
+
+After:
+```js
+var source = new ol.source.XYZ({
+  attributions: 'some attribution'
+});
+```
+
+In addition to passing a string or an array of strings for the `attributions` option, you can also pass a function that will get called with the current frame state.
+```js
+var source = new ol.source.XYZ({
+  attributions: function(frameState) {
+    // inspect the frame state and return attributions
+    return 'some attribution'; // or ['multiple', 'attributions'] or null
+  }
+});
+```
+
 ### v4.4.0
 
 #### Behavior change for polygon labels

--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -1,4 +1,3 @@
-goog.require('ol.Attribution');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control');
@@ -50,11 +49,9 @@ var ign_source = new ol.source.WMTS({
   projection: 'EPSG:3857',
   tileGrid: tileGrid,
   style: 'normal',
-  attributions: [new ol.Attribution({
-    html: '<a href="http://www.geoportail.fr/" target="_blank">' +
+  attributions: '<a href="http://www.geoportail.fr/" target="_blank">' +
         '<img src="https://api.ign.fr/geoportail/api/js/latest/' +
         'theme/geoportal/img/logo_gp.gif"></a>'
-  })]
 });
 
 var ign = new ol.layer.Tile({

--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -1,13 +1,8 @@
-goog.require('ol.Attribution');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.proj');
 goog.require('ol.source.XYZ');
-
-var attribution = new ol.Attribution({
-  html: 'Copyright:© 2013 ESRI, i-cubed, GeoEye'
-});
 
 var projection = ol.proj.get('EPSG:4326');
 
@@ -22,7 +17,7 @@ var map = new ol.Map({
   layers: [
     new ol.layer.Tile({
       source: new ol.source.XYZ({
-        attributions: [attribution],
+        attributions: 'Copyright:© 2013 ESRI, i-cubed, GeoEye',
         maxZoom: 16,
         projection: projection,
         tileSize: tileSize,

--- a/examples/xyz-esri.js
+++ b/examples/xyz-esri.js
@@ -1,4 +1,3 @@
-goog.require('ol.Attribution');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.layer.Tile');
@@ -6,17 +5,13 @@ goog.require('ol.proj');
 goog.require('ol.source.XYZ');
 
 
-var attribution = new ol.Attribution({
-  html: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/' +
-      'rest/services/World_Topo_Map/MapServer">ArcGIS</a>'
-});
-
 var map = new ol.Map({
   target: 'map',
   layers: [
     new ol.layer.Tile({
       source: new ol.source.XYZ({
-        attributions: [attribution],
+        attributions: 'Tiles © <a href="https://services.arcgisonline.com/ArcGIS/' +
+            'rest/services/World_Topo_Map/MapServer">ArcGIS</a>',
         url: 'https://server.arcgisonline.com/ArcGIS/rest/services/' +
             'World_Topo_Map/MapServer/tile/{z}/{y}/{x}'
       })

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -5487,7 +5487,7 @@ olx.source.OSMOptions.prototype.wrapX;
 
 
 /**
- * @typedef {{attributions: (Array.<ol.Attribution>|undefined),
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
  *     crossOrigin: (null|string|undefined),
  *     hidpi: (boolean|undefined),
  *     logo: (string|olx.LogoOptions|undefined),
@@ -5503,7 +5503,7 @@ olx.source.ImageArcGISRestOptions;
 
 /**
  * Attributions.
- * @type {Array.<ol.Attribution>|undefined}
+ * @type {ol.AttributionLike|undefined}
  * @api
  */
 olx.source.ImageArcGISRestOptions.prototype.attributions;
@@ -8329,7 +8329,6 @@ olx.view.FitOptions.prototype.callback;
 
 /**
  * @typedef {{animate: boolean,
- *     attributions: Object.<string, ol.Attribution>,
  *     coordinateToPixelTransform: ol.Transform,
  *     extent: (null|ol.Extent),
  *     focus: ol.Coordinate,
@@ -8377,7 +8376,8 @@ olx.FrameState.prototype.viewState;
  * @typedef {{center: ol.Coordinate,
  *     projection: ol.proj.Projection,
  *     resolution: number,
- *     rotation: number}}
+ *     rotation: number,
+ *     zoom: number}}
  */
 olx.ViewState;
 
@@ -8408,6 +8408,14 @@ olx.ViewState.prototype.resolution;
  * @api
  */
 olx.ViewState.prototype.rotation;
+
+
+/**
+ * The current zoom level.
+ * @type {number}
+ * @api
+ */
+olx.ViewState.prototype.zoom;
 
 
 /**

--- a/src/ol/attribution.js
+++ b/src/ol/attribution.js
@@ -22,6 +22,7 @@ goog.require('ol.tilegrid');
  *     ..
  *
  * @constructor
+ * @deprecated This class is deprecated and will removed in the next major release.
  * @param {olx.AttributionOptions} options Attribution options.
  * @struct
  * @api

--- a/src/ol/image.js
+++ b/src/ol/image.js
@@ -14,16 +14,13 @@ goog.require('ol.extent');
  * @param {ol.Extent} extent Extent.
  * @param {number|undefined} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {Array.<ol.Attribution>} attributions Attributions.
  * @param {string} src Image source URI.
  * @param {?string} crossOrigin Cross origin.
  * @param {ol.ImageLoadFunctionType} imageLoadFunction Image load function.
  */
-ol.Image = function(extent, resolution, pixelRatio, attributions, src,
-    crossOrigin, imageLoadFunction) {
+ol.Image = function(extent, resolution, pixelRatio, src, crossOrigin, imageLoadFunction) {
 
-  ol.ImageBase.call(this, extent, resolution, pixelRatio, ol.ImageState.IDLE,
-      attributions);
+  ol.ImageBase.call(this, extent, resolution, pixelRatio, ol.ImageState.IDLE);
 
   /**
    * @private

--- a/src/ol/imagebase.js
+++ b/src/ol/imagebase.js
@@ -13,17 +13,10 @@ goog.require('ol.events.EventType');
  * @param {number|undefined} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
  * @param {ol.ImageState} state State.
- * @param {Array.<ol.Attribution>} attributions Attributions.
  */
-ol.ImageBase = function(extent, resolution, pixelRatio, state, attributions) {
+ol.ImageBase = function(extent, resolution, pixelRatio, state) {
 
   ol.events.EventTarget.call(this);
-
-  /**
-   * @private
-   * @type {Array.<ol.Attribution>}
-   */
-  this.attributions_ = attributions;
 
   /**
    * @protected
@@ -58,14 +51,6 @@ ol.inherits(ol.ImageBase, ol.events.EventTarget);
  */
 ol.ImageBase.prototype.changed = function() {
   this.dispatchEvent(ol.events.EventType.CHANGE);
-};
-
-
-/**
- * @return {Array.<ol.Attribution>} Attributions.
- */
-ol.ImageBase.prototype.getAttributions = function() {
-  return this.attributions_;
 };
 
 

--- a/src/ol/imagecanvas.js
+++ b/src/ol/imagecanvas.js
@@ -11,13 +11,11 @@ goog.require('ol.ImageState');
  * @param {ol.Extent} extent Extent.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {Array.<ol.Attribution>} attributions Attributions.
  * @param {HTMLCanvasElement} canvas Canvas.
  * @param {ol.ImageCanvasLoader=} opt_loader Optional loader function to
  *     support asynchronous canvas drawing.
  */
-ol.ImageCanvas = function(extent, resolution, pixelRatio, attributions,
-    canvas, opt_loader) {
+ol.ImageCanvas = function(extent, resolution, pixelRatio, canvas, opt_loader) {
 
   /**
    * Optional canvas loader function.
@@ -29,7 +27,7 @@ ol.ImageCanvas = function(extent, resolution, pixelRatio, attributions,
   var state = opt_loader !== undefined ?
     ol.ImageState.IDLE : ol.ImageState.LOADED;
 
-  ol.ImageBase.call(this, extent, resolution, pixelRatio, state, attributions);
+  ol.ImageBase.call(this, extent, resolution, pixelRatio, state);
 
   /**
    * @private

--- a/src/ol/renderer/canvas/imagelayer.js
+++ b/src/ol/renderer/canvas/imagelayer.js
@@ -134,7 +134,6 @@ ol.renderer.canvas.ImageLayer.prototype.prepareFrame = function(frameState, laye
         0,
         -viewCenter[0], -viewCenter[1]);
 
-    this.updateAttributions(frameState.attributions, image.getAttributions());
     this.updateLogos(frameState, imageSource);
     this.renderedResolution = imageResolution * pixelRatio / imagePixelRatio;
   }

--- a/src/ol/renderer/canvas/vectorlayer.js
+++ b/src/ol/renderer/canvas/vectorlayer.js
@@ -261,8 +261,6 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame = function(frameState, lay
   var vectorLayer = /** @type {ol.layer.Vector} */ (this.getLayer());
   var vectorSource = vectorLayer.getSource();
 
-  this.updateAttributions(
-      frameState.attributions, vectorSource.getAttributions());
   this.updateLogos(frameState, vectorSource);
 
   var animating = frameState.viewHints[ol.ViewHint.ANIMATING];

--- a/src/ol/renderer/layer.js
+++ b/src/ol/renderer/layer.js
@@ -166,23 +166,6 @@ ol.renderer.Layer.prototype.scheduleExpireCache = function(frameState, tileSourc
 
 
 /**
- * @param {Object.<string, ol.Attribution>} attributionsSet Attributions
- *     set (target).
- * @param {Array.<ol.Attribution>} attributions Attributions (source).
- * @protected
- */
-ol.renderer.Layer.prototype.updateAttributions = function(attributionsSet, attributions) {
-  if (attributions) {
-    var attribution, i, ii;
-    for (i = 0, ii = attributions.length; i < ii; ++i) {
-      attribution = attributions[i];
-      attributionsSet[ol.getUid(attribution).toString()] = attribution;
-    }
-  }
-};
-
-
-/**
  * @param {olx.FrameState} frameState Frame state.
  * @param {ol.source.Source} source Source.
  * @protected

--- a/src/ol/renderer/webgl/imagelayer.js
+++ b/src/ol/renderer/webgl/imagelayer.js
@@ -190,7 +190,6 @@ ol.renderer.webgl.ImageLayer.prototype.prepareFrame = function(frameState, layer
     this.image_ = image;
     this.texture = texture;
 
-    this.updateAttributions(frameState.attributions, image.getAttributions());
     this.updateLogos(frameState, imageSource);
   }
 

--- a/src/ol/renderer/webgl/vectorlayer.js
+++ b/src/ol/renderer/webgl/vectorlayer.js
@@ -215,8 +215,6 @@ ol.renderer.webgl.VectorLayer.prototype.prepareFrame = function(frameState, laye
   var vectorLayer = /** @type {ol.layer.Vector} */ (this.getLayer());
   var vectorSource = vectorLayer.getSource();
 
-  this.updateAttributions(
-      frameState.attributions, vectorSource.getAttributions());
   this.updateLogos(frameState, vectorSource);
 
   var animating = frameState.viewHints[ol.ViewHint.ANIMATING];

--- a/src/ol/reproj/image.js
+++ b/src/ol/reproj/image.js
@@ -100,15 +100,12 @@ ol.reproj.Image = function(sourceProj, targetProj,
 
 
   var state = ol.ImageState.LOADED;
-  var attributions = [];
 
   if (this.sourceImage_) {
     state = ol.ImageState.IDLE;
-    attributions = this.sourceImage_.getAttributions();
   }
 
-  ol.ImageBase.call(this, targetExtent, targetResolution, this.sourcePixelRatio_,
-      state, attributions);
+  ol.ImageBase.call(this, targetExtent, targetResolution, this.sourcePixelRatio_, state);
 };
 ol.inherits(ol.reproj.Image, ol.ImageBase);
 

--- a/src/ol/source/imagearcgisrest.js
+++ b/src/ol/source/imagearcgisrest.js
@@ -169,7 +169,7 @@ ol.source.ImageArcGISRest.prototype.getImageInternal = function(extent, resoluti
       projection, params);
 
   this.image_ = new ol.Image(extent, resolution, pixelRatio,
-      this.getAttributions(), url, this.crossOrigin_, this.imageLoadFunction_);
+      url, this.crossOrigin_, this.imageLoadFunction_);
 
   this.renderedRevision_ = this.getRevision();
 

--- a/src/ol/source/imagecanvas.js
+++ b/src/ol/source/imagecanvas.js
@@ -78,8 +78,7 @@ ol.source.ImageCanvas.prototype.getImageInternal = function(extent, resolution, 
   var canvasElement = this.canvasFunction_(
       extent, resolution, pixelRatio, size, projection);
   if (canvasElement) {
-    canvas = new ol.ImageCanvas(extent, resolution, pixelRatio,
-        this.getAttributions(), canvasElement);
+    canvas = new ol.ImageCanvas(extent, resolution, pixelRatio, canvasElement);
   }
   this.canvas_ = canvas;
   this.renderedRevision_ = this.getRevision();

--- a/src/ol/source/imagemapguide.js
+++ b/src/ol/source/imagemapguide.js
@@ -141,7 +141,7 @@ ol.source.ImageMapGuide.prototype.getImageInternal = function(extent, resolution
     var imageUrl = this.getUrl(this.url_, this.params_, extent, size,
         projection);
     image = new ol.Image(extent, resolution, pixelRatio,
-        this.getAttributions(), imageUrl, this.crossOrigin_,
+        imageUrl, this.crossOrigin_,
         this.imageLoadFunction_);
     ol.events.listen(image, ol.events.EventType.CHANGE,
         this.handleImageChange, this);

--- a/src/ol/source/imagestatic.js
+++ b/src/ol/source/imagestatic.js
@@ -40,8 +40,7 @@ ol.source.ImageStatic = function(options) {
    * @private
    * @type {ol.Image}
    */
-  this.image_ = new ol.Image(imageExtent, undefined, 1, this.getAttributions(),
-      options.url, crossOrigin, imageLoadFunction);
+  this.image_ = new ol.Image(imageExtent, undefined, 1, options.url, crossOrigin, imageLoadFunction);
 
   /**
    * @private

--- a/src/ol/source/imagewms.js
+++ b/src/ol/source/imagewms.js
@@ -225,7 +225,7 @@ ol.source.ImageWMS.prototype.getImageInternal = function(extent, resolution, pix
       projection, params);
 
   this.image_ = new ol.Image(requestExtent, resolution, pixelRatio,
-      this.getAttributions(), url, this.crossOrigin_, this.imageLoadFunction_);
+      url, this.crossOrigin_, this.imageLoadFunction_);
 
   this.renderedRevision_ = this.getRevision();
 

--- a/src/ol/source/osm.js
+++ b/src/ol/source/osm.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.OSM');
 
 goog.require('ol');
-goog.require('ol.Attribution');
 goog.require('ol.source.XYZ');
 
 
@@ -51,11 +50,9 @@ ol.inherits(ol.source.OSM, ol.source.XYZ);
  * The attribution containing a link to the OpenStreetMap Copyright and License
  * page.
  * @const
- * @type {ol.Attribution}
+ * @type {string}
  * @api
  */
-ol.source.OSM.ATTRIBUTION = new ol.Attribution({
-  html: '&copy; ' +
+ol.source.OSM.ATTRIBUTION = '&copy; ' +
       '<a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-      'contributors.'
-});
+      'contributors.';

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -292,8 +292,7 @@ ol.source.Raster.prototype.onWorkerComplete_ = function(frameState, err, output,
     var width = Math.round(ol.extent.getWidth(extent) / resolution);
     var height = Math.round(ol.extent.getHeight(extent) / resolution);
     context = ol.dom.createCanvasContext2D(width, height);
-    this.renderedImageCanvas_ = new ol.ImageCanvas(
-        extent, resolution, 1, this.getAttributions(), context.canvas);
+    this.renderedImageCanvas_ = new ol.ImageCanvas(extent, resolution, 1, context.canvas);
   }
   context.putImageData(output, 0, 0);
 

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -35,7 +35,13 @@ ol.source.Source = function(options) {
    * @private
    * @type {Array.<ol.Attribution>}
    */
-  this.attributions_ = ol.source.Source.toAttributionsArray_(options.attributions);
+  this.attributions_ = null;
+
+  /**
+   * @private
+   * @type {?ol.Attribution2}
+   */
+  this.attributions2_ = this.adaptAttributions_(options.attributions);
 
   /**
    * @private
@@ -60,36 +66,60 @@ ol.source.Source = function(options) {
 ol.inherits(ol.source.Source, ol.Object);
 
 /**
- * Turns various ways of defining an attribution to an array of `ol.Attributions`.
- *
- * @param {ol.AttributionLike|undefined}
- *     attributionLike The attributions as string, array of strings,
- *     `ol.Attribution`, array of `ol.Attribution` or undefined.
- * @return {Array.<ol.Attribution>} The array of `ol.Attribution` or null if
- *     `undefined` was given.
+ * Turns the attributions option into an attributions function.
+ * @param {ol.AttributionLike|undefined} attributionLike The attribution option.
+ * @return {?ol.Attribution2} An attribution function (or null).
  */
-ol.source.Source.toAttributionsArray_ = function(attributionLike) {
-  if (typeof attributionLike === 'string') {
-    return [new ol.Attribution({html: attributionLike})];
-  } else if (attributionLike instanceof ol.Attribution) {
-    return [attributionLike];
-  } else if (Array.isArray(attributionLike)) {
-    var len = attributionLike.length;
-    var attributions = new Array(len);
-    for (var i = 0; i < len; i++) {
-      var item = attributionLike[i];
-      if (typeof item === 'string') {
-        attributions[i] = new ol.Attribution({html: item});
-      } else {
-        attributions[i] = item;
-      }
-    }
-    return attributions;
-  } else {
+ol.source.Source.prototype.adaptAttributions_ = function(attributionLike) {
+  if (!attributionLike) {
     return null;
   }
-};
+  if (attributionLike instanceof ol.Attribution) {
 
+    // TODO: remove attributions_ in next major release
+    this.attributions_ = [attributionLike];
+
+    return function(frameState) {
+      return [attributionLike.getHTML()];
+    };
+  }
+  if (Array.isArray(attributionLike)) {
+    if (attributionLike[0] instanceof ol.Attribution) {
+
+      // TODO: remove attributions_ in next major release
+      this.attributions_ = attributionLike;
+
+      var attributions = attributionLike.map(function(attribution) {
+        return attribution.getHTML();
+      });
+      return function(frameState) {
+        return attributions;
+      };
+    }
+
+    // TODO: remove attributions_ in next major release
+    this.attributions_ = attributionLike.map(function(attribution) {
+      return new ol.Attribution({html: attribution});
+    });
+
+    return function(frameState) {
+      return attributionLike;
+    };
+  }
+
+  if (typeof attributionLike === 'function') {
+    return attributionLike;
+  }
+
+  // TODO: remove attributions_ in next major release
+  this.attributions_ = [
+    new ol.Attribution({html: attributionLike})
+  ];
+
+  return function(frameState) {
+    return [attributionLike];
+  };
+};
 
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
@@ -112,6 +142,15 @@ ol.source.Source.prototype.forEachFeatureAtCoordinate = ol.nullFunction;
  */
 ol.source.Source.prototype.getAttributions = function() {
   return this.attributions_;
+};
+
+
+/**
+ * Get the attribution function for the source.
+ * @return {?ol.Attribution2} Attribution function.
+ */
+ol.source.Source.prototype.getAttributions2 = function() {
+  return this.attributions2_;
 };
 
 
@@ -172,12 +211,12 @@ ol.source.Source.prototype.refresh = function() {
 /**
  * Set the attributions of the source.
  * @param {ol.AttributionLike|undefined} attributions Attributions.
- *     Can be passed as `string`, `Array<string>`, `{@link ol.Attribution}`,
- *     `Array<{@link ol.Attribution}>` or `undefined`.
+ *     Can be passed as `string`, `Array<string>`, `{@link ol.Attribution2}`,
+ *     or `undefined`.
  * @api
  */
 ol.source.Source.prototype.setAttributions = function(attributions) {
-  this.attributions_ = ol.source.Source.toAttributionsArray_(attributions);
+  this.attributions2_ = this.adaptAttributions_(attributions);
   this.changed();
 };
 

--- a/src/ol/source/source.js
+++ b/src/ol/source/source.js
@@ -67,6 +67,7 @@ ol.inherits(ol.source.Source, ol.Object);
 
 /**
  * Turns the attributions option into an attributions function.
+ * @suppress {deprecated}
  * @param {ol.AttributionLike|undefined} attributionLike The attribution option.
  * @return {?ol.Attribution2} An attribution function (or null).
  */

--- a/src/ol/source/stamen.js
+++ b/src/ol/source/stamen.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.Stamen');
 
 goog.require('ol');
-goog.require('ol.Attribution');
 goog.require('ol.source.OSM');
 goog.require('ol.source.XYZ');
 
@@ -44,14 +43,12 @@ ol.inherits(ol.source.Stamen, ol.source.XYZ);
 
 /**
  * @const
- * @type {Array.<ol.Attribution>}
+ * @type {Array.<string>}
  */
 ol.source.Stamen.ATTRIBUTIONS = [
-  new ol.Attribution({
-    html: 'Map tiles by <a href="https://stamen.com/">Stamen Design</a>, ' +
+  'Map tiles by <a href="https://stamen.com/">Stamen Design</a>, ' +
         'under <a href="https://creativecommons.org/licenses/by/3.0/">CC BY' +
-        ' 3.0</a>.'
-  }),
+        ' 3.0</a>.',
   ol.source.OSM.ATTRIBUTION
 ];
 

--- a/src/ol/source/tilejson.js
+++ b/src/ol/source/tilejson.js
@@ -7,7 +7,6 @@
 goog.provide('ol.source.TileJSON');
 
 goog.require('ol');
-goog.require('ol.Attribution');
 goog.require('ol.TileUrlFunction');
 goog.require('ol.asserts');
 goog.require('ol.extent');
@@ -136,23 +135,17 @@ ol.source.TileJSON.prototype.handleTileJSONResponse = function(tileJSON) {
   this.tileUrlFunction =
       ol.TileUrlFunction.createFromTemplates(tileJSON.tiles, tileGrid);
 
-  if (tileJSON.attribution !== undefined && !this.getAttributions()) {
+  if (tileJSON.attribution !== undefined && !this.getAttributions2()) {
     var attributionExtent = extent !== undefined ?
       extent : epsg4326Projection.getExtent();
-    /** @type {Object.<string, Array.<ol.TileRange>>} */
-    var tileRanges = {};
-    var z, zKey;
-    for (z = minZoom; z <= maxZoom; ++z) {
-      zKey = z.toString();
-      tileRanges[zKey] =
-          [tileGrid.getTileRangeForExtentAndZ(attributionExtent, z)];
-    }
-    this.setAttributions([
-      new ol.Attribution({
-        html: tileJSON.attribution,
-        tileRanges: tileRanges
-      })
-    ]);
+
+    this.setAttributions(function(frameState) {
+      if (ol.extent.intersects(attributionExtent, frameState.extent)) {
+        return [tileJSON.attribution];
+      }
+      return null;
+    });
+
   }
   this.tileJSON_ = tileJSON;
   this.setState(ol.source.State.READY);

--- a/src/ol/source/tileutfgrid.js
+++ b/src/ol/source/tileutfgrid.js
@@ -1,7 +1,6 @@
 goog.provide('ol.source.TileUTFGrid');
 
 goog.require('ol');
-goog.require('ol.Attribution');
 goog.require('ol.Tile');
 goog.require('ol.TileState');
 goog.require('ol.TileUrlFunction');
@@ -198,20 +197,13 @@ ol.source.TileUTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
   if (tileJSON.attribution !== undefined) {
     var attributionExtent = extent !== undefined ?
       extent : epsg4326Projection.getExtent();
-    /** @type {Object.<string, Array.<ol.TileRange>>} */
-    var tileRanges = {};
-    var z, zKey;
-    for (z = minZoom; z <= maxZoom; ++z) {
-      zKey = z.toString();
-      tileRanges[zKey] =
-          [tileGrid.getTileRangeForExtentAndZ(attributionExtent, z)];
-    }
-    this.setAttributions([
-      new ol.Attribution({
-        html: tileJSON.attribution,
-        tileRanges: tileRanges
-      })
-    ]);
+
+    this.setAttributions(function(frameState) {
+      if (ol.extent.intersects(attributionExtent, frameState.extent)) {
+        return [tileJSON.attribution];
+      }
+      return null;
+    });
   }
 
   this.setState(ol.source.State.READY);

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -46,13 +46,23 @@ ol.AtlasManagerInfo;
  * A type that can be used to provide attribution information for data sources.
  *
  * It represents either
- * * a simple string (e.g. `'© Acme Inc.'`),
- * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`),
- * * an instance of `{@link ol.Attribution}`,
- * * or an array with multiple `{@link ol.Attribution}` instances.
- * @typedef {string|Array.<string>|ol.Attribution|Array.<ol.Attribution>}
+ * * a simple string (e.g. `'© Acme Inc.'`)
+ * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
+ * * a function that returns a string or array of strings (`{@link ol.Attribution2}`)
+ *
+ * Note that the `{@link ol.Attribution}` constructor is deprecated.
+ * @typedef {string|Array.<string>|ol.Attribution2|ol.Attribution|Array.<ol.Attribution>}
  */
 ol.AttributionLike;
+
+
+/**
+ * A function that returns a string or an array of strings representing source
+ * attributions.
+ *
+ * @typedef {function(olx.FrameState): (string|Array.<string>)}
+ */
+ol.Attribution2;
 
 
 /**

--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -781,7 +781,8 @@ ol.View.prototype.getState = function() {
     center: center.slice(),
     projection: projection !== undefined ? projection : null,
     resolution: resolution,
-    rotation: rotation
+    rotation: rotation,
+    zoom: this.getZoom()
   });
 };
 

--- a/test/spec/ol/renderer/layer.test.js
+++ b/test/spec/ol/renderer/layer.test.js
@@ -22,12 +22,10 @@ describe('ol.renderer.Layer', function() {
       var extent = [];
       var resolution = 1;
       var pixelRatio = 1;
-      var attributions = [];
       var src = '';
       var crossOrigin = '';
       imageLoadFunction = sinon.spy();
-      image = new ol.Image(extent, resolution, pixelRatio, attributions,
-          src, crossOrigin, imageLoadFunction);
+      image = new ol.Image(extent, resolution, pixelRatio, src, crossOrigin, imageLoadFunction);
     });
 
     describe('load IDLE image', function() {

--- a/test/spec/ol/reproj/image.test.js
+++ b/test/spec/ol/reproj/image.test.js
@@ -12,7 +12,7 @@ describe('ol.reproj.Image', function() {
         ol.proj.get('EPSG:3857'), ol.proj.get('EPSG:4326'),
         [-180, -85, 180, 85], 10, pixelRatio,
         function(extent, resolution, pixelRatio) {
-          return new ol.Image(extent, resolution, pixelRatio, [],
+          return new ol.Image(extent, resolution, pixelRatio,
               'data:image/gif;base64,' +
               'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=', null,
               function(image, src) {

--- a/test/spec/ol/source/source.test.js
+++ b/test/spec/ol/source/source.test.js
@@ -1,5 +1,3 @@
-
-
 goog.require('ol.Attribution');
 goog.require('ol.proj');
 goog.require('ol.source.Source');
@@ -19,68 +17,52 @@ describe('ol.source.Source', function() {
   describe('config option `attributions`', function() {
     it('accepts undefined', function() {
       var source = new ol.source.Source({});
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.be(null);
     });
+
     it('accepts a single string', function() {
       var source = new ol.source.Source({
         attributions: 'Humpty'
       });
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(1);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0].getHTML()).to.be('Humpty');
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql(['Humpty']);
     });
+
     it('accepts an array of strings', function() {
       var source = new ol.source.Source({
         attributions: ['Humpty', 'Dumpty']
       });
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(2);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0].getHTML()).to.be('Humpty');
-      expect(attributions[1]).to.be.an(ol.Attribution);
-      expect(attributions[1].getHTML()).to.be('Dumpty');
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql(['Humpty', 'Dumpty']);
     });
-    it('accepts a single ol.Attribution', function() {
-      var passedAttribution = new ol.Attribution({html: 'Humpty'});
+
+    it('accepts a function that returns a string', function() {
       var source = new ol.source.Source({
-        attributions: passedAttribution
+        attributions: function() {
+          return 'Humpty';
+        }
       });
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(1);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0]).to.be(passedAttribution);
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.be('Humpty');
     });
-    it('accepts an array of ol.Attribution', function() {
-      var firstAttribution = new ol.Attribution({html: 'Humpty'});
-      var secondAttribution = new ol.Attribution({html: 'Dumpty'});
+
+    it('accepts a function that returns an array of strings', function() {
       var source = new ol.source.Source({
-        attributions: [firstAttribution, secondAttribution]
+        attributions: function() {
+          return ['Humpty', 'Dumpty'];
+        }
       });
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(2);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0]).to.be(firstAttribution);
-      expect(attributions[1]).to.be.an(ol.Attribution);
-      expect(attributions[1]).to.be(secondAttribution);
-    });
-    it('accepts an array with a string and an ol.Attribution', function() {
-      var attribution = new ol.Attribution({html: 'Dumpty'});
-      var source = new ol.source.Source({
-        attributions: ['Humpty', attribution]
-      });
-      var attributions = source.getAttributions();
-      expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(2);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0].getHTML()).to.be('Humpty');
-      expect(attributions[1]).to.be.an(ol.Attribution);
-      expect(attributions[1]).to.be(attribution);
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql(['Humpty', 'Dumpty']);
     });
   });
 
@@ -96,7 +78,56 @@ describe('ol.source.Source', function() {
     });
   });
 
-  describe('#setAttributions`', function() {
+  describe('#getAttributions()', function() {
+    it('maintains backwards compatibility for string option', function() {
+      var source = new ol.source.Source({
+        attributions: 'foo'
+      });
+      var attributions = source.getAttributions();
+      expect(attributions.length).to.be(1);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('foo');
+    });
+
+    it('maintains backwards compatibility for array of strings option', function() {
+      var source = new ol.source.Source({
+        attributions: ['foo', 'bar']
+      });
+      var attributions = source.getAttributions();
+      expect(attributions.length).to.be(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('foo');
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1].getHTML()).to.be('bar');
+    });
+
+    it('maintains backwards compatibility for ol.Attribution option', function() {
+      var source = new ol.source.Source({
+        attributions: new ol.Attribution({html: 'foo'})
+      });
+      var attributions = source.getAttributions();
+      expect(attributions.length).to.be(1);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('foo');
+    });
+
+    it('maintains backwards compatibility for array of strings option', function() {
+      var source = new ol.source.Source({
+        attributions: [
+          new ol.Attribution({html: 'foo'}),
+          new ol.Attribution({html: 'bar'})
+        ]
+      });
+      var attributions = source.getAttributions();
+      expect(attributions.length).to.be(2);
+      expect(attributions[0]).to.be.an(ol.Attribution);
+      expect(attributions[0].getHTML()).to.be('foo');
+      expect(attributions[1]).to.be.an(ol.Attribution);
+      expect(attributions[1].getHTML()).to.be('bar');
+    });
+  });
+
+  describe('#setAttributions()', function() {
     var source = null;
 
     beforeEach(function() {
@@ -104,64 +135,51 @@ describe('ol.source.Source', function() {
         attributions: 'before'
       });
     });
+
     afterEach(function() {
       source = null;
     });
 
     it('accepts undefined', function() {
       source.setAttributions();
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.be(null);
     });
+
     it('accepts a single string', function() {
       source.setAttributions('Humpty');
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(1);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0].getHTML()).to.be('Humpty');
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql(['Humpty']);
     });
+
     it('accepts an array of strings', function() {
       source.setAttributions(['Humpty', 'Dumpty']);
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(2);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0].getHTML()).to.be('Humpty');
-      expect(attributions[1]).to.be.an(ol.Attribution);
-      expect(attributions[1].getHTML()).to.be('Dumpty');
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql(['Humpty', 'Dumpty']);
     });
-    it('accepts a single ol.Attribution', function() {
-      var passedAttribution = new ol.Attribution({html: 'Humpty'});
-      source.setAttributions(passedAttribution);
-      var attributions = source.getAttributions();
+
+    it('accepts a function that returns a string', function() {
+      source.setAttributions(function() {
+        return 'Humpty';
+      });
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(1);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0]).to.be(passedAttribution);
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql('Humpty');
     });
-    it('accepts an array of ol.Attribution', function() {
-      var firstAttribution = new ol.Attribution({html: 'Humpty'});
-      var secondAttribution = new ol.Attribution({html: 'Dumpty'});
-      source.setAttributions([firstAttribution, secondAttribution]);
-      var attributions = source.getAttributions();
+
+    it('accepts a function that returns an array of strings', function() {
+      source.setAttributions(function() {
+        return ['Humpty', 'Dumpty'];
+      });
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(2);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0]).to.be(firstAttribution);
-      expect(attributions[1]).to.be.an(ol.Attribution);
-      expect(attributions[1]).to.be(secondAttribution);
-    });
-    it('accepts an array with a string and an ol.Attribution', function() {
-      var attribution = new ol.Attribution({html: 'Dumpty'});
-      source.setAttributions(['Humpty', attribution]);
-      var attributions = source.getAttributions();
-      expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(2);
-      expect(attributions[0]).to.be.an(ol.Attribution);
-      expect(attributions[0].getHTML()).to.be('Humpty');
-      expect(attributions[1]).to.be.an(ol.Attribution);
-      expect(attributions[1]).to.be(attribution);
+      expect(typeof attributions).to.be('function');
+      expect(attributions()).to.eql(['Humpty', 'Dumpty']);
     });
   });
 

--- a/test/spec/ol/source/tileutfgrid.test.js
+++ b/test/spec/ol/source/tileutfgrid.test.js
@@ -165,21 +165,15 @@ describe('ol.source.TileUTFGrid', function() {
 
     it('sets up correct attribution', function() {
       var source = getTileUTFGrid();
-      expect(source.getAttributions()).to.be(null);
+      expect(source.getAttributions2()).to.be(null);
 
       // call the handleTileJSONResponse method with our
       // locally available tileJson (from `before`)
       source.handleTileJSONResponse(tileJson);
 
-      var attributions = source.getAttributions();
+      var attributions = source.getAttributions2();
       expect(attributions).to.not.be(null);
-      expect(attributions).to.have.length(1);
-      expect(attributions[0].getHTML()).to.be(tileJson.attribution);
-      var tileRanges = attributions[0].tileRanges_;
-      for (var z = tileJson.minzoom; z <= tileJson.maxzoom; z++) {
-        var key = z.toString();
-        expect(key in tileRanges).to.be(true);
-      }
+      expect(typeof attributions).to.be('function');
     });
 
     it('sets correct state', function() {


### PR DESCRIPTION
This adds support for attribution functions and removes the need for `ol.Attribution`.

The `attributions` option for sources can now be a function that returns a single string attribution or an array of strings.
```js
var source = new ol.source.XYZ({
  attributions: function(frameState) {
    // inspect the frame state and return attributions
    return 'some attribution'; // or ['multiple', 'attributions'] or null
  }
});
```

As before, the `attributions` option can also just be a string or an array of strings.  Providing a function supports conditionally showing attribution based on extent, resolution, etc.  And for backwards compatibility, the option can still be a `ol.Attribution` or an array of the same.  The attribution control deduplicates visible attributions and renders them in layer order.

Since `source.getAttributions()` was marked with `@api`, that method still returns an array of `ol.Attribution`.  That method returns `null` if a source is constructed with the new function type attribution.

In the next major release, we can replace the old `source.getAttributions()` method with the new `source.getAttributions2()` method.  In the meantime, `source.getAttributions2()` is not documented as part of the API.

This reworks the internal handling of attributions so that the renderers no longer deal with them.  Instead, the attribution control is in charge of rendering visible attributions.  So if you don't have an attribution control, no unnecessary work is done.  (Next up, logos.)

Fixes #6237.
