### PR TITLE
Clear label cache when fonts become available

### DIFF
--- a/examples/vector-labels.html
+++ b/examples/vector-labels.html
@@ -6,7 +6,8 @@ docs: >
   This example showcases a number of options that can be set on text styles.
   When "Text/Wrap" is chosen (for example for the line features), the label is
   wrapped by inserting the character `\n`, which will create a multi-line
-  label.
+  label. The "Open Sans" web font will be loaded on demand, to show dynamic font
+  loading.
 tags: "geojson, vector, openstreetmap, label"
 ---
 <div id="map" class="map"></div>
@@ -70,7 +71,7 @@ tags: "geojson, vector, openstreetmap, label"
     <select id="points-font">
       <option value="Arial" selected="selected">Arial</option>
       <option value="Courier New">Courier New</option>
-      <option value="Quattrocento Sans">Quattrocento</option>
+      <option value="Open Sans">Open Sans</option>
       <option value="Verdana">Verdana</option>
     </select>
     <br />
@@ -179,7 +180,7 @@ tags: "geojson, vector, openstreetmap, label"
     <select id="lines-font">
       <option value="Arial">Arial</option>
       <option value="Courier New" selected="selected">Courier New</option>
-      <option value="Quattrocento Sans">Quattrocento</option>
+      <option value="Open Sans">Open Sans</option>
       <option value="Verdana">Verdana</option>
     </select>
     <br />
@@ -288,7 +289,7 @@ tags: "geojson, vector, openstreetmap, label"
     <select id="polygons-font">
       <option value="Arial">Arial</option>
       <option value="Courier New">Courier New</option>
-      <option value="Quattrocento Sans">Quattrocento</option>
+      <option value="Open Sans">Open Sans</option>
       <option value="Verdana" selected="selected">Verdana</option>
     </select>
     <br />

--- a/examples/vector-labels.html
+++ b/examples/vector-labels.html
@@ -70,8 +70,8 @@ tags: "geojson, vector, openstreetmap, label"
     <label>Font: </label>
     <select id="points-font">
       <option value="Arial" selected="selected">Arial</option>
-      <option value="Courier New">Courier New</option>
-      <option value="Open Sans">Open Sans</option>
+      <option value="'Courier New'">Courier New</option>
+      <option value="'Open Sans'">Open Sans</option>
       <option value="Verdana">Verdana</option>
     </select>
     <br />
@@ -179,8 +179,8 @@ tags: "geojson, vector, openstreetmap, label"
     <label>Font: </label>
     <select id="lines-font">
       <option value="Arial">Arial</option>
-      <option value="Courier New" selected="selected">Courier New</option>
-      <option value="Open Sans">Open Sans</option>
+      <option value="'Courier New'" selected="selected">Courier New</option>
+      <option value="'Open Sans'">Open Sans</option>
       <option value="Verdana">Verdana</option>
     </select>
     <br />
@@ -288,8 +288,8 @@ tags: "geojson, vector, openstreetmap, label"
     <label>Font: </label>
     <select id="polygons-font">
       <option value="Arial">Arial</option>
-      <option value="Courier New">Courier New</option>
-      <option value="Open Sans">Open Sans</option>
+      <option value="'Courier New'">Courier New</option>
+      <option value="'Open Sans'">Open Sans</option>
       <option value="Verdana" selected="selected">Verdana</option>
     </select>
     <br />

--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -11,6 +11,7 @@ goog.require('ol.style.Stroke');
 goog.require('ol.style.Style');
 goog.require('ol.style.Text');
 
+var openSansAdded = false;
 
 var myDom = {
   points: {
@@ -96,6 +97,13 @@ var createTextStyle = function(feature, resolution, dom) {
   var maxAngle = dom.maxangle ? parseFloat(dom.maxangle.value) : undefined;
   var exceedLength = dom.exceedlength ? (dom.exceedlength.value == 'true') : undefined;
   var rotation = parseFloat(dom.rotation.value);
+  if (dom.font.value == 'Open Sans' && !openSansAdded) {
+    var openSans = document.createElement('link');
+    openSans.href = 'https://fonts.googleapis.com/css?family=Open+Sans';
+    openSans.rel = 'stylesheet';
+    document.getElementsByTagName('head')[0].appendChild(openSans);
+    openSansAdded = true;
+  }
   var font = weight + ' ' + size + ' ' + dom.font.value;
   var fillColor = dom.color.value;
   var outlineColor = dom.outline.value;

--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -97,7 +97,7 @@ var createTextStyle = function(feature, resolution, dom) {
   var maxAngle = dom.maxangle ? parseFloat(dom.maxangle.value) : undefined;
   var exceedLength = dom.exceedlength ? (dom.exceedlength.value == 'true') : undefined;
   var rotation = parseFloat(dom.rotation.value);
-  if (dom.font.value == 'Open Sans' && !openSansAdded) {
+  if (dom.font.value == '\'Open Sans\'' && !openSansAdded) {
     var openSans = document.createElement('link');
     openSans.href = 'https://fonts.googleapis.com/css?family=Open+Sans';
     openSans.rel = 'stylesheet';

--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -49,7 +49,7 @@ ol.css.CLASS_CONTROL = 'ol-control';
  * Get the list of font families from a font spec.  Note that this doesn't work
  * for font families that have commas in them.
  * @param {string} The CSS font property.
- * @return {Array.<string>} The font families (or null if the input spec is invalid).
+ * @return {Object.<string>} The font families (or null if the input spec is invalid).
  */
 ol.css.getFontFamilies = (function() {
   var style;

--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -43,3 +43,30 @@ ol.css.CLASS_UNSUPPORTED = 'ol-unsupported';
  * @type {string}
  */
 ol.css.CLASS_CONTROL = 'ol-control';
+
+
+/**
+ * Get the list of font families from a font spec.  Note that this doesn't work
+ * for font families that have commas in them.
+ * @param {string} The CSS font property.
+ * @return {Array.<string>} The font families (or null if the input spec is invalid).
+ */
+ol.css.getFontFamilies = (function() {
+  var style;
+  var cache = {};
+  return function(font) {
+    if (!style) {
+      style = document.createElement('div').style;
+    }
+    if (!(font in cache)) {
+      style.font = font;
+      var family = style.fontFamily;
+      style.font = '';
+      if (!family) {
+        return null;
+      }
+      cache[font] = family.split(/,\s?/);
+    }
+    return cache[font];
+  };
+})();

--- a/src/ol/events/eventtype.js
+++ b/src/ol/events/eventtype.js
@@ -12,6 +12,7 @@ ol.events.EventType = {
    */
   CHANGE: 'change',
 
+  CLEAR: 'clear',
   CLICK: 'click',
   DBLCLICK: 'dblclick',
   DRAGENTER: 'dragenter',

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -108,7 +108,7 @@ ol.render.canvas.checkFont = (function() {
 
   function isAvailable(fontFamily) {
     if (!context) {
-      context = ol.dom.createCanvasContext2D();
+      context = ol.dom.createCanvasContext2D(1, 1);
       context.font = '32px monospace';
       referenceWidth = context.measureText(text).width;
     }
@@ -120,6 +120,10 @@ ol.render.canvas.checkFont = (function() {
       // fallback was used instead of the font we wanted, so the font is not
       // available.
       available = width != referenceWidth;
+      // Setting the font back to a different one works around an issue in
+      // Safari where subsequent `context.font` assignments with the same font
+      // will not re-attempt to use a font that is currently loading.
+      context.font = '32px monospace';
     }
     return available;
   }

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -103,13 +103,14 @@ ol.render.canvas.checkedFonts_ = {};
 ol.render.canvas.checkFont = (function() {
   var checked = ol.render.canvas.checkedFonts_;
   var labelCache = ol.render.canvas.labelCache;
+  var font = '32px monospace';
   var text = 'wmytzilWMYTZIL@#/&?$%10';
   var context, referenceWidth;
 
   function isAvailable(fontFamily) {
     if (!context) {
       context = ol.dom.createCanvasContext2D(1, 1);
-      context.font = '32px monospace';
+      context.font = font;
       referenceWidth = context.measureText(text).width;
     }
     var available = true;
@@ -123,7 +124,7 @@ ol.render.canvas.checkFont = (function() {
       // Setting the font back to a different one works around an issue in
       // Safari where subsequent `context.font` assignments with the same font
       // will not re-attempt to use a font that is currently loading.
-      context.font = '32px monospace';
+      context.font = font;
     }
     return available;
   }

--- a/src/ol/render/canvas/replay.js
+++ b/src/ol/render/canvas/replay.js
@@ -596,7 +596,7 @@ ol.render.canvas.Replay.prototype.replay_ = function(
                 chars = /** @type {string} */ (part[4]);
                 label = /** @type {ol.render.canvas.TextReplay} */ (this).getImage(chars, false, true);
                 anchorX = /** @type {number} */ (part[2]) + strokeWidth;
-                anchorY = baseline * label.height + (0.5 - baseline) * strokeWidth - offsetY;
+                anchorY = baseline * label.height + (0.5 - baseline) * 2 * strokeWidth - offsetY;
                 this.replayImage_(context,
                     /** @type {number} */ (part[0]), /** @type {number} */ (part[1]), label,
                     anchorX, anchorY, declutterGroup, label.height, 1, 0, 0,

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -94,6 +94,7 @@ ol.renderer.vector.renderFeature = function(
   }
   ol.renderer.vector.renderFeature_(replayGroup, feature, style,
       squaredTolerance);
+
   return loading;
 };
 

--- a/test/spec/ol/css.test.js
+++ b/test/spec/ol/css.test.js
@@ -1,0 +1,47 @@
+goog.require('ol.css');
+
+describe('ol.css', function() {
+
+  describe('getFontFamilies()', function() {
+    var cases = [{
+      font: '2em "Open Sans"',
+      families: ['"Open Sans"']
+    }, {
+      font: '2em \'Open Sans\'',
+      families: ['"Open Sans"']
+    }, {
+      font: '2em "Open Sans", sans-serif',
+      families: ['"Open Sans"', 'sans-serif']
+    }, {
+      font: 'italic small-caps bolder 16px/3 cursive',
+      families: ['cursive']
+    }, {
+      font: 'garbage 2px input',
+      families: null
+    }, {
+      font: '100% fantasy',
+      families: ['fantasy']
+    }];
+
+    cases.forEach(function(c, i) {
+      it('works for ' + c.font, function() {
+        var families = ol.css.getFontFamilies(c.font);
+        if (c.families === null) {
+          expect(families).to.be(null);
+          return;
+        }
+        families.forEach(function(family, j) {
+          // Safari uses single quotes for font families, so we have to do extra work
+          if (family.charAt(0) === '\'') {
+            // we wouldn't want to do this in the lib since it doesn't properly escape quotes
+            // but we know that our test cases don't include quotes in font names
+            families[j] = '"' + family.slice(1, -1) + '"';
+          }
+        });
+        expect(families).to.eql(c.families);
+      });
+    });
+
+  });
+
+});

--- a/test/spec/ol/render/canvas/index.test.js
+++ b/test/spec/ol/render/canvas/index.test.js
@@ -1,9 +1,71 @@
-
-
+goog.require('ol.events');
+goog.require('ol.obj');
 goog.require('ol.render.canvas');
 
 
 describe('ol.render.canvas', function() {
+
+  var font = document.createElement('link');
+  font.href = 'https://fonts.googleapis.com/css?family=Inconsolata';
+  font.rel = 'stylesheet';
+  var head = document.getElementsByTagName('head')[0];
+
+  describe('ol.render.canvas.checkFont()', function() {
+
+    var checkFont = ol.render.canvas.checkFont;
+
+    it('does not clear the label cache for unavailable fonts', function(done) {
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      var spy = sinon.spy();
+      ol.events.listen(ol.render.canvas.labelCache, 'clear', spy);
+      checkFont('12px foo,sans-serif');
+      setTimeout(function() {
+        ol.events.unlisten(ol.render.canvas.labelCache, 'clear', spy);
+        expect(spy.callCount).to.be(0);
+        done();
+      }, 1600);
+    });
+
+    it('does not clear the label cache for available fonts', function(done) {
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      var spy = sinon.spy();
+      ol.events.listen(ol.render.canvas.labelCache, 'clear', spy);
+      checkFont('12px sans-serif');
+      setTimeout(function() {
+        ol.events.unlisten(ol.render.canvas.labelCache, 'clear', spy);
+        expect(spy.callCount).to.be(0);
+        done();
+      }, 800);
+    });
+
+    it('does not clear the label cache for the \'monospace\' font', function(done) {
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      var spy = sinon.spy();
+      ol.events.listen(ol.render.canvas.labelCache, 'clear', spy);
+      checkFont('12px monospace');
+      setTimeout(function() {
+        ol.events.unlisten(ol.render.canvas.labelCache, 'clear', spy);
+        expect(spy.callCount).to.be(0);
+        done();
+      }, 800);
+    });
+
+    it('clears the label cache for fonts that become available', function(done) {
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      head.appendChild(font);
+      var spy = sinon.spy();
+      ol.events.listen(ol.render.canvas.labelCache, 'clear', spy);
+      checkFont('12px Inconsolata');
+      setTimeout(function() {
+        ol.events.unlisten(ol.render.canvas.labelCache, 'clear', spy);
+        head.removeChild(font);
+        expect(spy.callCount).to.be(1);
+        done();
+      }, 1600);
+    });
+
+  });
+
 
   describe('rotateAtOffset', function() {
     it('rotates a canvas at an offset point', function() {

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -1,6 +1,7 @@
 
 
 goog.require('ol');
+goog.require('ol.obj');
 goog.require('ol.Feature');
 goog.require('ol.Map');
 goog.require('ol.TileState');
@@ -13,6 +14,7 @@ goog.require('ol.geom.Point');
 goog.require('ol.layer.VectorTile');
 goog.require('ol.proj');
 goog.require('ol.proj.Projection');
+goog.require('ol.render.canvas');
 goog.require('ol.render.Feature');
 goog.require('ol.renderer.canvas.VectorTileLayer');
 goog.require('ol.source.VectorTile');
@@ -25,7 +27,12 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
 
   describe('constructor', function() {
 
-    var map, layer, source, feature1, feature2, feature3, target, tileCallback;
+    var head = document.getElementsByTagName('head')[0];
+    var font = document.createElement('link');
+    font.href = 'https://fonts.googleapis.com/css?family=Dancing+Script';
+    font.rel = 'stylesheet';
+
+    var map, layer, layerStyle, source, feature1, feature2, feature3, target, tileCallback;
 
     beforeEach(function() {
       tileCallback = function() {};
@@ -40,7 +47,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         }),
         target: target
       });
-      var layerStyle = [new ol.style.Style({
+      layerStyle = [new ol.style.Style({
         text: new ol.style.Text({
           text: 'layer'
         })
@@ -145,6 +152,44 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       expect(spy.getCall(0).args[2]).to.be(layer.getStyle());
       expect(spy.getCall(1).args[2]).to.be(feature2.getStyle());
       spy.restore();
+    });
+
+    it('does not re-render for unavailable fonts', function(done) {
+      map.renderSync();
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      layerStyle[0].getText().setFont('12px "Unavailable font",sans-serif');
+      layer.changed();
+      var revision = layer.getRevision();
+      setTimeout(function() {
+        expect(layer.getRevision()).to.be(revision);
+        done();
+      }, 800);
+    });
+
+    it('does not re-render for available fonts', function(done) {
+      map.renderSync();
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      layerStyle[0].getText().setFont('12px sans-serif');
+      layer.changed();
+      var revision = layer.getRevision();
+      setTimeout(function() {
+        expect(layer.getRevision()).to.be(revision);
+        done();
+      }, 800);
+    });
+
+    it('re-renders for fonts that become available', function(done) {
+      map.renderSync();
+      ol.obj.clear(ol.render.canvas.checkedFonts_);
+      head.appendChild(font);
+      layerStyle[0].getText().setFont('12px "Dancing Script",sans-serif');
+      layer.changed();
+      var revision = layer.getRevision();
+      setTimeout(function() {
+        head.removeChild(font);
+        expect(layer.getRevision()).to.be(revision + 1);
+        done();
+      }, 1600);
     });
 
     it('transforms geometries when tile and view projection are different', function() {


### PR DESCRIPTION
With this pull request, web fonts will be used when they become available, just like in OpenLayers < v4.4.0 when fillText/strokeText was used. This fixes the problem mentioned in https://github.com/openlayers/openlayers/issues/7334#issuecomment-335154208.