### PR TITLE
Pass pixel tolerance as a parameter to constructor of ol.interaction.Extent

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3138,6 +3138,7 @@ olx.interaction.DrawOptions.prototype.wrapX;
 /**
  * @typedef {{extent: (ol.Extent|undefined),
  *     boxStyle: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     pixelTolerance: (number|undefined),
  *     pointerStyle: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
  *     wrapX: (boolean|undefined)}}
  * @api
@@ -3158,6 +3159,14 @@ olx.interaction.ExtentOptions.prototype.extent;
  * @api
  */
 olx.interaction.ExtentOptions.prototype.boxStyle;
+
+/**
+ * Pixel tolerance for considering the pointer close enough to a segment or
+ * vertex for editing. Default is `10`.
+ * @type {number|undefined}
+ * @api
+ */
+olx.interaction.ExtentOptions.prototype.pixelTolerance;
 
 /**
  * Style for the cursor used to draw the extent.

--- a/src/ol/interaction/extent.js
+++ b/src/ol/interaction/extent.js
@@ -31,7 +31,7 @@ goog.require('ol.style.Style');
  */
 ol.interaction.Extent = function(opt_options) {
 
-  var options = opt_options ? opt_options : {};
+  var options = opt_options || {};
 
   /**
    * Extent of the drawn box

--- a/src/ol/interaction/extent.js
+++ b/src/ol/interaction/extent.js
@@ -31,6 +31,8 @@ goog.require('ol.style.Style');
  */
 ol.interaction.Extent = function(opt_options) {
 
+  var options = opt_options ? opt_options : {};
+
   /**
    * Extent of the drawn box
    * @type {ol.Extent}
@@ -50,7 +52,8 @@ ol.interaction.Extent = function(opt_options) {
    * @type {number}
    * @private
    */
-  this.pixelTolerance_ = 10;
+  this.pixelTolerance_ = options.pixelTolerance !== undefined ?
+    options.pixelTolerance : 10;
 
   /**
    * Is the pointer snapped to an extent vertex


### PR DESCRIPTION
This adds the pixelTolerance option parameter to the constructor of ol.interaction.Extent, as requested in issue #7054 
In this way the user can override the current default value of 10.

