### PR TITLE
Added option to the ol.format.GeoJSON to allow the reading of the geometry_name from the geojson

### DIFF
--- a/externs/geojson.js
+++ b/externs/geojson.js
@@ -140,6 +140,11 @@ GeoJSONFeature.prototype.id;
 GeoJSONFeature.prototype.properties;
 
 
+/**
+ * @type {string|undefined}
+ */
+GeoJSONFeature.prototype.geometry_name;
+
 
 /**
  * @constructor

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2029,7 +2029,8 @@ olx.format.GeoJSONOptions.prototype.geometryName;
  * Certain GeoJSON providers include the geometry_name field in the feature
  * geoJSON. If set to `true` the geoJSON reader will look for that field to
  * set the geometry name. If both this field is set to `true` and a
- * `geometryName` is provided the `geometryName` will take precedence.
+ * `geometryName` is provided, the `geometryName` will take precedence.
+ * Default is `false`.
  * @type {boolean|undefined}
  * @api
  */

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1994,7 +1994,7 @@ olx.format.WriteOptions.prototype.decimals;
 /**
  * @typedef {{defaultDataProjection: ol.ProjectionLike,
  *     geometryName: (string|undefined),
- *     readGeometryNameFromGeoJSON: (boolean|undefined),
+ *     extractGeometryName: (boolean|undefined),
  *     featureProjection: ol.ProjectionLike}}
  */
 olx.format.GeoJSONOptions;
@@ -2034,7 +2034,7 @@ olx.format.GeoJSONOptions.prototype.geometryName;
  * @type {boolean|undefined}
  * @api
  */
-olx.format.GeoJSONOptions.prototype.readGeometryNameFromGeoJSON;
+olx.format.GeoJSONOptions.prototype.extractGeometryName;
 
 
 /**

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -1994,6 +1994,7 @@ olx.format.WriteOptions.prototype.decimals;
 /**
  * @typedef {{defaultDataProjection: ol.ProjectionLike,
  *     geometryName: (string|undefined),
+ *     readGeometryNameFromGeoJSON: (boolean|undefined),
  *     featureProjection: ol.ProjectionLike}}
  */
 olx.format.GeoJSONOptions;
@@ -2022,6 +2023,17 @@ olx.format.GeoJSONOptions.prototype.featureProjection;
  * @api
  */
 olx.format.GeoJSONOptions.prototype.geometryName;
+
+
+/**
+ * Certain GeoJSON providers include the geometry_name field in the feature
+ * geoJSON. If set to `true` the geoJSON reader will look for that field to
+ * set the geometry name. If both this field is set to `true` and a
+ * `geometryName` is provided the `geometryName` will take precedence.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.format.GeoJSONOptions.prototype.readGeometryNameFromGeoJSON;
 
 
 /**

--- a/src/ol/format/geojson.js
+++ b/src/ol/format/geojson.js
@@ -53,6 +53,13 @@ ol.format.GeoJSON = function(opt_options) {
    */
   this.geometryName_ = options.geometryName;
 
+  /**
+   * Look for the geometry name in the feature GeoJSON
+   * @type {boolean|undefined}
+   * @private
+   */
+  this.readGeometryNameFromGeoJSON_ = options.readGeometryNameFromGeoJSON;
+
 };
 ol.inherits(ol.format.GeoJSON, ol.format.JSONFeature);
 
@@ -377,6 +384,8 @@ ol.format.GeoJSON.prototype.readFeatureFromObject = function(
   var feature = new ol.Feature();
   if (this.geometryName_) {
     feature.setGeometryName(this.geometryName_);
+  } else if (this.readGeometryNameFromGeoJSON_ && geoJSONFeature.geometry_name !== undefined) {
+    feature.setGeometryName(geoJSONFeature.geometry_name);
   }
   feature.setGeometry(geometry);
   if (geoJSONFeature.id !== undefined) {

--- a/src/ol/format/geojson.js
+++ b/src/ol/format/geojson.js
@@ -58,7 +58,7 @@ ol.format.GeoJSON = function(opt_options) {
    * @type {boolean|undefined}
    * @private
    */
-  this.readGeometryNameFromGeoJSON_ = options.readGeometryNameFromGeoJSON;
+  this.extractGeometryName_ = options.extractGeometryName;
 
 };
 ol.inherits(ol.format.GeoJSON, ol.format.JSONFeature);
@@ -384,7 +384,7 @@ ol.format.GeoJSON.prototype.readFeatureFromObject = function(
   var feature = new ol.Feature();
   if (this.geometryName_) {
     feature.setGeometryName(this.geometryName_);
-  } else if (this.readGeometryNameFromGeoJSON_ && geoJSONFeature.geometry_name !== undefined) {
+  } else if (this.extractGeometryName_ && geoJSONFeature.geometry_name !== undefined) {
     feature.setGeometryName(geoJSONFeature.geometry_name);
   }
   feature.setGeometry(geometry);


### PR DESCRIPTION
This PR provides a solution to the issue #7303. In spite of the geometry_name field not being in the geojson specification, some mapping servers like geoserver add the geometry_name field to it. It can be useful that the geojson reader reads that field from the geojson, because if the loaded features are used to write WFS transactions to update that feature after some modifications and in that case if the geometry name doesn't match the one in the server it throws an error.
