### PR TITLE
Enable z-index for select interactions

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2941,7 +2941,8 @@ olx.interaction.PointerOptions.prototype.handleUpEvent;
  *     features: (ol.Collection.<ol.Feature>|undefined),
  *     filter: (ol.SelectFilterFunction|undefined),
  *     wrapX: (boolean|undefined),
- *     hitTolerance: (number|undefined)}}
+ *     hitTolerance: (number|undefined),
+ *     zIndex: (number|undefined)}}
  */
 olx.interaction.SelectOptions;
 

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3067,6 +3067,14 @@ olx.interaction.SelectOptions.prototype.hitTolerance;
 
 
 /**
+ * The z-index for layer rendering. The default Z-index is 0.
+ * @type {number|undefined}
+ * @api
+ */
+olx.interaction.SelectOptions.prototype.zIndex;
+
+
+/**
  * Options for snap
  * @typedef {{
  *     features: (ol.Collection.<ol.Feature>|undefined),

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -96,7 +96,8 @@ var Select = function(opt_options) {
     style: options.style ? options.style :
       Select.getDefaultStyleFunction(),
     updateWhileAnimating: true,
-    updateWhileInteracting: true
+    updateWhileInteracting: true,
+    zIndex: goog.isDef(options.zIndex) ? options.zIndex : Infinity
   });
 
   /**
@@ -188,6 +189,16 @@ Select.prototype.getHitTolerance = function() {
 Select.prototype.getLayer = function(feature) {
   var key = getUid(feature);
   return /** @type {ol.layer.Vector} */ (this.featureLayerAssociation_[key]);
+};
+
+
+/**
+ * Returns the Z-Index for the overlay layer
+ * @returns {number} Z-index
+ * @api
+ */
+ol.interaction.Select.prototype.getZIndex = function() {
+  return this.featureOverlay_.getZIndex();
 };
 
 

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -97,7 +97,7 @@ var Select = function(opt_options) {
       Select.getDefaultStyleFunction(),
     updateWhileAnimating: true,
     updateWhileInteracting: true,
-    zIndex: goog.isDef(options.zIndex) ? options.zIndex : Infinity
+    zIndex: options.zIndex !== undefined ? options.zIndex : 0
   });
 
   /**

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -154,11 +154,11 @@ Layer.prototype.handleSourcePropertyChange_ = function() {
 
 
 /**
- * Sets the layer to be rendered on top of other layers on a map. The map will
- * not manage this layer in its layers collection, and the callback in
- * {@link ol.Map#forEachLayerAtPixel} will receive `null` as layer. This
- * is useful for temporary layers. To remove an unmanaged layer from the map,
- * use `#setMap(null)`.
+ * Sets the layer to be rendered on top of other layers on a map (unless
+ * a Z-index is specified). The map will not manage this layer in its layers
+ * collection, and the callback in {@link ol.Map#forEachLayerAtPixel} will
+ * receive `null` as layer. This is useful for temporary layers. To remove an
+ * unmanaged layer from the map, use `#setMap(null)`.
  *
  * To add the layer to a map and have it managed by the map, use
  * {@link ol.Map#addLayer} instead.
@@ -181,8 +181,9 @@ Layer.prototype.setMap = function(map) {
     this.mapPrecomposeKey_ = _ol_events_.listen(
         map, RenderEventType.PRECOMPOSE, function(evt) {
           var layerState = this.getLayerState();
+          var zIndex = this.getZIndex();
           layerState.managed = false;
-          layerState.zIndex = Infinity;
+          layerState.zIndex = (goog.isDef(zIndex) && zIndex !== 0) ? zIndex : Infinity;
           evt.frameState.layerStatesArray.push(layerState);
           evt.frameState.layerStates[getUid(this)] = layerState;
         }, this);

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -183,7 +183,7 @@ Layer.prototype.setMap = function(map) {
           var layerState = this.getLayerState();
           var zIndex = this.getZIndex();
           layerState.managed = false;
-          layerState.zIndex = (goog.isDef(zIndex) && zIndex !== 0) ? zIndex : Infinity;
+          layerState.zIndex = zIndex !== undefined ? zIndex : Infinity;
           evt.frameState.layerStatesArray.push(layerState);
           evt.frameState.layerStates[getUid(this)] = layerState;
         }, this);

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -442,4 +442,15 @@ describe('ol.interaction.Select', function() {
       });
     });
   });
+
+  describe('setting zIndex', function() {
+    it('Should have zIndex property when rendering', function() {
+      var zIndex = 20;
+      var select = new ol.interaction.Select({
+        zIndex: zIndex
+      });
+      map.addInteraction(select);
+      expect(select.getZIndex()).to.equal(zIndex);
+    });
+  });
 });

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -406,6 +406,25 @@ describe('ol.layer.Layer', function() {
         expect(layerState.layer).to.equal(layer);
         expect(frameState.layerStates[getUid(layer)]).to.equal(layerState);
       });
+
+      it('gets the Z-index', function() {
+        var zIndex = 20;
+        var layer = new ol.layer.Layer({
+          map: map,
+          zIndex: zIndex
+        });
+        var frameState = {
+          layerStatesArray: [],
+          layerStates: {}
+        };
+        map.dispatchEvent(new ol.render.Event('precompose', null,
+            frameState, null, null));
+        expect(frameState.layerStatesArray.length).to.be(1);
+        var layerState = frameState.layerStatesArray[0];
+        expect(layerState.layer).to.equal(layer);
+        expect(layerState.zIndex).to.equal(zIndex);
+        expect(frameState.layerStates[ol.getUid(layer)]).to.equal(layerState);
+      });
     });
 
     describe('setMap sequences', function() {


### PR DESCRIPTION
When creating a select interaction, the layer that's created is not managed by the layercollection of the map.

This commit allows you to set a Z-index when creating the layer, so that the layers can be ordered.

This PR is based on the same issue as discussed in #4298

----

- [x] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
