### PR TITLE
WFS: add srsName handling into WFS, and don't let GMLbase overwrite it

### DIFF
--- a/src/ol/format/gmlbase.js
+++ b/src/ol/format/gmlbase.js
@@ -197,14 +197,19 @@ ol.format.GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
  */
 ol.format.GMLBase.prototype.readGeometryElement = function(node, objectStack) {
   var context = /** @type {Object} */ (objectStack[0]);
-  context['srsName'] = node.firstElementChild.getAttribute('srsName');
-  context['srsDimension'] = node.firstElementChild.getAttribute('srsDimension');
+  var newContext = ol.obj.assign({}, context);
+  if (node.firstElementChild.hasAttribute('srsName')) {
+    newContext['srsName'] = node.firstElementChild.getAttribute('srsName');
+  }
+  if (node.firstElementChild.hasAttribute('srsDimension')) {
+    newContext['srsDimension'] = node.firstElementChild.getAttribute('srsDimension');
+  }
   /** @type {ol.geom.Geometry} */
   var geometry = ol.xml.pushParseAndPop(null,
       this.GEOMETRY_PARSERS_, node, objectStack, this);
   if (geometry) {
     return /** @type {ol.geom.Geometry} */ (
-      ol.format.Feature.transformWithOptions(geometry, false, context));
+      ol.format.Feature.transformWithOptions(geometry, false, newContext));
   } else {
     return undefined;
   }

--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -134,7 +134,8 @@ ol.format.WFS.prototype.readFeatures;
 ol.format.WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
   var context = /** @type {ol.XmlNodeStackItem} */ ({
     'featureType': this.featureType_,
-    'featureNS': this.featureNS_
+    'featureNS': this.featureNS_,
+    'srsName': this.readProjectionFromNode(node)
   });
   ol.obj.assign(context, this.getReadOptions(node,
       opt_options ? opt_options : {}));
@@ -1075,6 +1076,9 @@ ol.format.WFS.prototype.readProjectionFromNode = function(node) {
   if (node.firstElementChild &&
       node.firstElementChild.firstElementChild) {
     node = node.firstElementChild.firstElementChild;
+    if (node.hasAttribute('srsName')) {
+      return node.getAttribute('srsName');
+    }
     for (var n = node.firstElementChild; n; n = n.nextElementSibling) {
       if (!(n.childNodes.length === 0 ||
           (n.childNodes.length === 1 &&


### PR DESCRIPTION
it fixed the srsName for gml inside wfs, for example `gml:Envelope`
that fixed that the objects is read with the correct srs and specially the axes rotation works

Fixed #6688

---
- [x] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
