### PR TITLE
Always request the Bing API with the 'culture' value

### DIFF
--- a/src/ol/source/bingmaps.js
+++ b/src/ol/source/bingmaps.js
@@ -67,7 +67,8 @@ ol.source.BingMaps = function(options) {
 
   var url = 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
       this.imagerySet_ +
-      '?uriScheme=https&include=ImageryProviders&key=' + this.apiKey_;
+      '?uriScheme=https&include=ImageryProviders&key=' + this.apiKey_ +
+      '&c=' + this.culture_;
 
   ol.net.jsonp(url, this.handleImageryMetadataResponse.bind(this), undefined,
       'jsonp');


### PR DESCRIPTION
fixes #7279 

For `RoadOnDemand` (at least) the `{culture}` placeholder is not present in the returned url: the configured culture in not set. See: 
https://github.com/openlayers/openlayers/blob/master/src/ol/source/bingmaps.js#L153

Instead the `mkt` parameter is set and equal to the `c` parameter (default to `us-US`)