### PR TITLE
Add method to set max cache size in ol.style.IconImageCache

### DIFF
--- a/src/ol/style.js
+++ b/src/ol/style.js
@@ -2,4 +2,8 @@ goog.provide('ol.style');
 
 goog.require('ol.style.IconImageCache');
 
+/**
+ * The {@link ol.style.IconImageCache} for {@link ol.style.Icon} images.
+ * @api
+ */
 ol.style.iconImageCache = new ol.style.IconImageCache();

--- a/src/ol/style/iconimagecache.js
+++ b/src/ol/style/iconimagecache.js
@@ -4,6 +4,7 @@ goog.require('ol.color');
 
 
 /**
+ * Singleton class. Available through {@link ol.style.iconImageCache}.
  * @constructor
  */
 ol.style.IconImageCache = function() {
@@ -93,10 +94,13 @@ ol.style.IconImageCache.prototype.set = function(src, crossOrigin, color, iconIm
 
 
 /**
- * Set cache max size.
+ * Set the cache size of the icon cache. Default is `32`. Change this value when
+ * your map uses more than 32 different icon images and you are not caching icon
+ * styles on the application level.
  * @param {number} maxCacheSize Cache max size.
+ * @api
  */
-ol.style.IconImageCache.prototype.setMaxCacheSize = function(maxCacheSize) {
+ol.style.IconImageCache.prototype.setSize = function(maxCacheSize) {
   this.maxCacheSize_ = maxCacheSize;
   this.expire();
 };

--- a/src/ol/style/iconimagecache.js
+++ b/src/ol/style/iconimagecache.js
@@ -21,7 +21,6 @@ ol.style.IconImageCache = function() {
   this.cacheSize_ = 0;
 
   /**
-   * @const
    * @type {number}
    * @private
    */
@@ -90,4 +89,14 @@ ol.style.IconImageCache.prototype.set = function(src, crossOrigin, color, iconIm
   var key = ol.style.IconImageCache.getKey(src, crossOrigin, color);
   this.cache_[key] = iconImage;
   ++this.cacheSize_;
+};
+
+
+/**
+ * Set cache max size.
+ * @param {number} maxCacheSize Cache max size.
+ */
+ol.style.IconImageCache.prototype.setMaxCacheSize = function(maxCacheSize) {
+  this.maxCacheSize_ = maxCacheSize;
+  this.expire();
 };

--- a/test/spec/ol/style/iconimagecache.test.js
+++ b/test/spec/ol/style/iconimagecache.test.js
@@ -66,4 +66,25 @@ describe('ol.style.IconImageCache', function() {
       expect(cache.get('4', null, null)).to.not.be(null);
     });
   });
+
+  describe('#setMaxCacheSize', function() {
+    it('sets max cache size and expires cache', function() {
+      var cache = ol.style.iconImageCache;
+
+      var i, src, iconImage;
+
+      for (i = 0; i < 3; ++i) {
+        src = i + '';
+        iconImage = new ol.style.IconImage(null, src);
+        cache.set(src, null, null, iconImage);
+      }
+
+      expect(cache.cacheSize_).to.eql(3);
+
+      cache.setMaxCacheSize(2);
+
+      expect(cache.maxCacheSize_).to.eql(2);
+      expect(cache.cacheSize_).to.eql(2);
+    });
+  });
 });

--- a/test/spec/ol/style/iconimagecache.test.js
+++ b/test/spec/ol/style/iconimagecache.test.js
@@ -67,7 +67,7 @@ describe('ol.style.IconImageCache', function() {
     });
   });
 
-  describe('#setMaxCacheSize', function() {
+  describe('#setSize', function() {
     it('sets max cache size and expires cache', function() {
       var cache = ol.style.iconImageCache;
 
@@ -81,7 +81,7 @@ describe('ol.style.IconImageCache', function() {
 
       expect(cache.cacheSize_).to.eql(3);
 
-      cache.setMaxCacheSize(2);
+      cache.setSize(2);
 
       expect(cache.maxCacheSize_).to.eql(2);
       expect(cache.cacheSize_).to.eql(2);


### PR DESCRIPTION
This adds a method to set max cache size as requested in #7233 