### PR TITLE
Handle null tile coordinates correctly

### DIFF
--- a/src/ol/source/vectortile.js
+++ b/src/ol/source/vectortile.js
@@ -120,7 +120,7 @@ ol.source.VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projectio
         tileCoord, projection);
     var tile = new ol.VectorImageTile(
         tileCoord,
-        urlTileCoord !== undefined ? ol.TileState.IDLE : ol.TileState.EMPTY,
+        urlTileCoord !== null ? ol.TileState.IDLE : ol.TileState.EMPTY,
         this.getRevision(),
         this.format_, this.tileLoadFunction, urlTileCoord, this.tileUrlFunction,
         this.tileGrid, this.getTileGridForProjection(projection),


### PR DESCRIPTION
This is a follow-up on #7349, which introduced a potential bug by comparing `urlTileCoord` with `undefined` instead of `null`.