### PR TITLE
Add the axis orientation and the extent compare to ol.proj.equivalent function

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -331,12 +331,15 @@ ol.proj.equivalent = function(projection1, projection2) {
     return true;
   }
   var equalUnits = projection1.getUnits() === projection2.getUnits();
+  var equalAxis = projection1.getAxisOrientation() === projection2.getAxisOrientation();
+  var equalExtent = projection1.getExtent() === projection2.getExtent();
+  var equal = equalUnits && equalAxis && equalExtent;
   if (projection1.getCode() === projection2.getCode()) {
-    return equalUnits;
+    return equal;
   } else {
     var transformFn = ol.proj.getTransformFromProjections(
         projection1, projection2);
-    return transformFn === ol.proj.cloneTransform && equalUnits;
+    return transformFn === ol.proj.cloneTransform && equal;
   }
 };
 

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -54,27 +54,25 @@ describe('ol.proj', function() {
     });
 
     it('gives that urn:ogc:def:crs:EPSG:6.6:4326, EPSG:4326 are ' +
-        'equivalent',
-    function() {
+        'equivalent', function() {
       _testAllEquivalent([
         'urn:ogc:def:crs:EPSG:6.6:4326',
         'EPSG:4326'
       ]);
     });
 
-    it('gives that CRS:84, EPSG:4326 are ' +
-       'not equivalent',
-    function() {
-      var proj1 = new ol.proj.Projection({
-        code: 'CRS:84'
-      });
-      var proj2 = new ol.proj.Projection({
-        code: 'EPSG:4326'
-      });
-      expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
-    });
+    it('gives that CRS:84, EPSG:4326 are not equivalent',
+        function() {
+          var proj1 = new ol.proj.Projection({
+            code: 'CRS:84'
+          });
+          var proj2 = new ol.proj.Projection({
+            code: 'EPSG:4326'
+          });
+          expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
+        });
 
-    it('requires code and units to be equal for projection evquivalence',
+    it('requires code and units to be equal for projection equivalence',
         function() {
           var proj1 = new ol.proj.Projection({
             code: 'EPSG:3857',
@@ -87,20 +85,21 @@ describe('ol.proj', function() {
           expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
         });
 
-    it('requires code and axis orientation to be equal for projection evquivalence',
-        function() {
-          var proj1 = new ol.proj.Projection({
-            code: 'EPSG:3857',
-            axisOrientation: 'enu'
-          });
-          var proj2 = new ol.proj.Projection({
-            code: 'EPSG:3857',
-            axisOrientation: 'neu'
-          });
-          expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
-        });
+    it('requires code and axis orientation to be equal for projection' +
+        'equivalence',
+    function() {
+      var proj1 = new ol.proj.Projection({
+        code: 'EPSG:3857',
+        axisOrientation: 'enu'
+      });
+      var proj2 = new ol.proj.Projection({
+        code: 'EPSG:3857',
+        axisOrientation: 'neu'
+      });
+      expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
+    });
 
-    it('requires code and extent to be equal for projection evquivalence',
+    it('requires code and extent to be equal for projection equivalence',
         function() {
           var proj1 = new ol.proj.Projection({
             code: 'EPSG:3857'
@@ -112,7 +111,7 @@ describe('ol.proj', function() {
           expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
         });
 
-    it('requires code and units to be equal for projection evquivalence',
+    it('requires code and units to be equal for projection equivalence',
         function() {
           var proj1 = new ol.proj.Projection({
             code: 'EPSG:3857',

--- a/test/spec/ol/proj/index.test.js
+++ b/test/spec/ol/proj/index.test.js
@@ -53,15 +53,64 @@ describe('ol.proj', function() {
       ]);
     });
 
-    it('gives that CRS:84, urn:ogc:def:crs:EPSG:6.6:4326, EPSG:4326 are ' +
+    it('gives that urn:ogc:def:crs:EPSG:6.6:4326, EPSG:4326 are ' +
         'equivalent',
     function() {
       _testAllEquivalent([
-        'CRS:84',
         'urn:ogc:def:crs:EPSG:6.6:4326',
         'EPSG:4326'
       ]);
     });
+
+    it('gives that CRS:84, EPSG:4326 are ' +
+       'not equivalent',
+    function() {
+      var proj1 = new ol.proj.Projection({
+        code: 'CRS:84'
+      });
+      var proj2 = new ol.proj.Projection({
+        code: 'EPSG:4326'
+      });
+      expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
+    });
+
+    it('requires code and units to be equal for projection evquivalence',
+        function() {
+          var proj1 = new ol.proj.Projection({
+            code: 'EPSG:3857',
+            units: 'm'
+          });
+          var proj2 = new ol.proj.Projection({
+            code: 'EPSG:3857',
+            units: 'tile-pixels'
+          });
+          expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
+        });
+
+    it('requires code and axis orientation to be equal for projection evquivalence',
+        function() {
+          var proj1 = new ol.proj.Projection({
+            code: 'EPSG:3857',
+            axisOrientation: 'enu'
+          });
+          var proj2 = new ol.proj.Projection({
+            code: 'EPSG:3857',
+            axisOrientation: 'neu'
+          });
+          expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
+        });
+
+    it('requires code and extent to be equal for projection evquivalence',
+        function() {
+          var proj1 = new ol.proj.Projection({
+            code: 'EPSG:3857'
+          });
+          var proj2 = new ol.proj.Projection({
+            code: 'EPSG:3857',
+            extent: [-1000, -1000, 1000, 1000]
+          });
+          expect(ol.proj.equivalent(proj1, proj2)).to.not.be.ok();
+        });
 
     it('requires code and units to be equal for projection evquivalence',
         function() {


### PR DESCRIPTION
#7386 
Please note that CRC:84 and EPSG:4326 are not equivalent because of the axis orientation. 
The standard EPSG:4326 is lat-long axis. CRC:84 changing the axis from lat-long to long-lat. 

- [x] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
