### PR TITLE
Add getFeatureType and setFeatureType functions to ol.format.WFS

### DIFF
--- a/src/ol/format/wfs.js
+++ b/src/ol/format/wfs.js
@@ -117,6 +117,22 @@ ol.format.WFS.DEFAULT_VERSION = '1.1.0';
 
 
 /**
+ * @return {Array.<string>|string|undefined} featureType
+ */
+ol.format.WFS.prototype.getFeatureType = function() {
+  return this.featureType_;
+};
+
+
+/**
+ * @param {Array.<string>|string|undefined} featureType Feature type(s) to parse.
+ */
+ol.format.WFS.prototype.setFeatureType = function(featureType) {
+  this.featureType_ = featureType;
+};
+
+
+/**
  * Read all features from a WFS FeatureCollection.
  *
  * @function

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1,5 +1,3 @@
-
-
 goog.require('ol.Feature');
 goog.require('ol.format.GML2');
 goog.require('ol.format.WFS');
@@ -13,6 +11,20 @@ goog.require('ol.proj');
 goog.require('ol.xml');
 
 describe('ol.format.WFS', function() {
+
+  describe('featureType', function() {
+
+    it('#getFeatureType #setFeatureType', function() {
+      var format = new ol.format.WFS({
+        featureNS: 'http://www.openplans.org/topp',
+        featureType: ['foo', 'bar']
+      });
+      expect(format.getFeatureType()).to.eql(['foo', 'bar']);
+      format.setFeatureType('baz');
+      expect(format.getFeatureType()).to.eql('baz');
+    });
+
+  });
 
   describe('when parsing TOPP states GML from WFS', function() {
 


### PR DESCRIPTION
To be able to change the `featureType` of an exiting `ol.format.WFS` instance