### PR TITLE
Avoid returning undefined zoom

### DIFF
--- a/src/ol/view.js
+++ b/src/ol/view.js
@@ -788,8 +788,9 @@ ol.View.prototype.getState = function() {
 
 
 /**
- * Get the current zoom level. Return undefined if the current
- * resolution is undefined or not within the "resolution constraints".
+ * Get the current zoom level.  If you configured your view with a resolutions
+ * array (this is rare), this method may return non-integer zoom levels (so
+ * the zoom level is not safe to use as an index into a resolutions array).
  * @return {number|undefined} Zoom.
  * @api
  */
@@ -810,25 +811,22 @@ ol.View.prototype.getZoom = function() {
  * @api
  */
 ol.View.prototype.getZoomForResolution = function(resolution) {
-  var zoom;
-  if (resolution >= this.minResolution_ && resolution <= this.maxResolution_) {
-    var offset = this.minZoom_ || 0;
-    var max, zoomFactor;
-    if (this.resolutions_) {
-      var nearest = ol.array.linearFindNearest(this.resolutions_, resolution, 1);
-      offset += nearest;
-      if (nearest == this.resolutions_.length - 1) {
-        return offset;
-      }
-      max = this.resolutions_[nearest];
-      zoomFactor = max / this.resolutions_[nearest + 1];
+  var offset = this.minZoom_ || 0;
+  var max, zoomFactor;
+  if (this.resolutions_) {
+    var nearest = ol.array.linearFindNearest(this.resolutions_, resolution, 1);
+    offset += nearest;
+    max = this.resolutions_[nearest];
+    if (nearest == this.resolutions_.length - 1) {
+      zoomFactor = 2;
     } else {
-      max = this.maxResolution_;
-      zoomFactor = this.zoomFactor_;
+      zoomFactor = max / this.resolutions_[nearest + 1];
     }
-    zoom = offset + Math.log(max / resolution) / Math.log(zoomFactor);
+  } else {
+    max = this.maxResolution_;
+    zoomFactor = this.zoomFactor_;
   }
-  return zoom;
+  return offset + Math.log(max / resolution) / Math.log(zoomFactor);
 };
 
 

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1,5 +1,3 @@
-
-
 goog.require('ol');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -943,12 +941,12 @@ describe('ol.View', function() {
       });
     });
 
-    it('returns correct zoom levels', function() {
+    it('returns correct zoom levels (with resolutions array)', function() {
       view.setResolution(undefined);
       expect(view.getZoom()).to.be(undefined);
 
       view.setResolution(513);
-      expect(view.getZoom()).to.be(undefined);
+      expect(view.getZoom()).to.roughlyEqual(Math.log(512 / 513) / Math.LN2, 1e-9);
 
       view.setResolution(512);
       expect(view.getZoom()).to.be(0);
@@ -966,7 +964,7 @@ describe('ol.View', function() {
       expect(view.getZoom()).to.be(5);
 
       view.setResolution(15);
-      expect(view.getZoom()).to.be(undefined);
+      expect(view.getZoom()).to.roughlyEqual(Math.log(512 / 15) / Math.LN2, 1e-9);
     });
 
     it('works for resolution arrays with variable zoom factors', function() {
@@ -1070,6 +1068,8 @@ describe('ol.View', function() {
       expect(view.getZoomForResolution(max / 2)).to.be(1);
 
       expect(view.getZoomForResolution(max / 4)).to.be(2);
+
+      expect(view.getZoomForResolution(2 * max)).to.be(-1);
     });
 
     it('returns correct zoom levels for specifically configured resolutions', function() {


### PR DESCRIPTION
There is still a bit of (user hostile) legacy in our handling of zoom levels.  This is based on the misperception that people would stop caring about zoom and would find true meaning in resolution.  Part of the remaining legacy is that `view.getZoom()` sometimes returns `undefined` instead of a number.

The goal of this change is to make it so that `view.getZoom()` always returns a number if the view resolution is defined.  Specifically:
 * When resolution is `undefined`, the method returns `undefined`.
 * When the resolution is higher than the max resolution, it returns a number that is lower than the min zoom.
 * When the resolution is lower than the min resolution, it returns a number that is higher than the max zoom.

I hope the parallels are clear.