### PR TITLE
Always use source projection loading image tiles

### DIFF
--- a/src/ol/source/tileimage.js
+++ b/src/ol/source/tileimage.js
@@ -241,7 +241,8 @@ ol.source.TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection
       !this.getProjection() ||
       !projection ||
       ol.proj.equivalent(this.getProjection(), projection)) {
-    return this.getTileInternal(z, x, y, pixelRatio, /** @type {!ol.proj.Projection} */ (projection));
+    var sourceProjection = this.getProjection() || projection;
+    return this.getTileInternal(z, x, y, pixelRatio, /** @type {!ol.proj.Projection} */ (sourceProjection));
   } else {
     var cache = this.getTileCacheForProjection(projection);
     var tileCoord = [z, x, y];


### PR DESCRIPTION
Related issue: https://github.com/openlayers/openlayers/issues/7434

Use the defined source projection despite it being equivalent to the rendering projection to enable using the specified alias code name instead of the code provided by the renderer's projection object. For example: The server only knows the name "EPSG:900913", which is an alias for the equivalent "EPSG:3857", that the renderer uses (by default).

<hr>

- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
