### PR TITLE
Attempt to make font loading tests more stable

### DIFF
--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -105,7 +105,7 @@ ol.render.canvas.checkFont = (function() {
   var labelCache = ol.render.canvas.labelCache;
   var font = '32px monospace';
   var text = 'wmytzilWMYTZIL@#/&?$%10';
-  var context, referenceWidth;
+  var context, interval, referenceWidth;
 
   function isAvailable(fontFamily) {
     if (!context) {
@@ -142,8 +142,9 @@ ol.render.canvas.checkFont = (function() {
         }
       }
     }
-    if (!done) {
-      window.setTimeout(check, 32);
+    if (done) {
+      window.clearInterval(interval);
+      interval = undefined;
     }
   }
 
@@ -158,7 +159,9 @@ ol.render.canvas.checkFont = (function() {
         checked[fontFamily] = 60;
         if (!isAvailable(fontFamily)) {
           checked[fontFamily] = 0;
-          window.setTimeout(check, 25);
+          if (interval === undefined) {
+            interval = window.setInterval(check, 32);
+          }
         }
       }
     }

--- a/test/spec/ol/render/canvas/index.test.js
+++ b/test/spec/ol/render/canvas/index.test.js
@@ -6,7 +6,7 @@ goog.require('ol.render.canvas');
 describe('ol.render.canvas', function() {
 
   var font = document.createElement('link');
-  font.href = 'https://fonts.googleapis.com/css?family=Inconsolata';
+  font.href = 'https://fonts.googleapis.com/css?family=Abel&text=wmytzilWMYTZIL%40%23%2F%26%3F%24%2510';
   font.rel = 'stylesheet';
   var head = document.getElementsByTagName('head')[0];
 
@@ -55,7 +55,7 @@ describe('ol.render.canvas', function() {
       head.appendChild(font);
       var spy = sinon.spy();
       ol.events.listen(ol.render.canvas.labelCache, 'clear', spy);
-      checkFont('12px Inconsolata');
+      checkFont('12px Abel');
       setTimeout(function() {
         ol.events.unlisten(ol.render.canvas.labelCache, 'clear', spy);
         head.removeChild(font);


### PR DESCRIPTION
Also changes things to use setInterval() instead of setTimeout().

This should fix the checkFont() test that sometimes fails in Edge (see https://github.com/openlayers/openlayers/issues/7437#issue-272294985).