### PR TITLE
Retry if sauce connect fails

### DIFF
--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -108,7 +108,8 @@ module.exports = function(karma) {
         username: 'openlayers',
         accessKey: process.env.SAUCE_ACCESS_KEY,
         connectOptions: {
-          noSslBumpDomains: 'all'
+          noSslBumpDomains: 'all',
+          connectRetries: 5
         }
       },
       hostname: 'travis.dev',


### PR DESCRIPTION
We periodically get test failures due to [things like this](https://travis-ci.org/openlayers/openlayers/builds/298793515):
```
07 11 2017 21:56:26.178:ERROR [launcher.sauce]: Can not start chrome
  Failed to start Sauce Connect:
  7 Nov 21:56:26 - Sauce Connect could not establish a connection.
07 11 2017 21:56:26.179:ERROR [launcher.sauce]: Can not start firefox
  Failed to start Sauce Connect:
  7 Nov 21:56:26 - Sauce Connect could not establish a connection.
07 11 2017 21:56:26.180:ERROR [launcher.sauce]: Can not start MicrosoftEdge (Windows 10)
  Failed to start Sauce Connect:
  7 Nov 21:56:26 - Sauce Connect could not establish a connection.
07 11 2017 21:56:26.180:ERROR [launcher.sauce]: Can not start safari (macOS 10.12)
  Failed to start Sauce Connect:
  7 Nov 21:56:26 - Sauce Connect could not establish a connection.
```

This adds a `connectRetries: 5` option.  See [the docs](https://github.com/bermi/sauce-connect-launcher/blob/master/README.md#advanced-usage) for more detail.

See #7437.