### PR TITLE
Add new API-key for HERE example

### DIFF
--- a/examples/here-maps.html
+++ b/examples/here-maps.html
@@ -7,8 +7,8 @@ docs: >
   <p>Be sure to respect the <a href="https://legal.here.com/en/terms/serviceterms/us/">HERE Service Terms</a> when using their tile API.</p>
 tags: "here, here-maps, here-tile-api"
 cloak:
-  a2qhegvZZFIuJDkkqjhQ: Your HERE Maps appId from https://developer.here.com/
-  lPJ3iaFLJDhD8fIAyU582A: Your HERE Maps appCode from https://developer.here.com/
+  kDm0Jq1K4Ak7Bwtn8uvk: Your HERE Maps appId from https://developer.here.com/
+  xnmvc4dKZrDfGlvQHXSvwQ: Your HERE Maps appCode from https://developer.here.com/
 ---
 <div id="map" class="map"></div>
 <select id="layer-select">

--- a/examples/here-maps.js
+++ b/examples/here-maps.js
@@ -3,8 +3,8 @@ goog.require('ol.View');
 goog.require('ol.layer.Tile');
 goog.require('ol.source.XYZ');
 
-var appId = 'a2qhegvZZFIuJDkkqjhQ';
-var appCode = 'lPJ3iaFLJDhD8fIAyU582A';
+var appId = 'kDm0Jq1K4Ak7Bwtn8uvk';
+var appCode = 'xnmvc4dKZrDfGlvQHXSvwQ';
 var hereLayers = [
   {
     base: 'base',


### PR DESCRIPTION
This replaces the existing API-key for the 'HERE Map Tile API' example with a new one with a longer validity (~ 4 month) since the old one will expire at 2017-11-16.
See also the discussion on the dev-mailing-list: https://lists.osgeo.org/pipermail/openlayers-dev/2017-November/009267.html

Thank you for your interest in making OpenLayers better!

In order to get your proposed changes merged into the master branch, we ask you to please make sure the following boxes are checked *before* submitting your pull request.

- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
