### PR TITLE
Remove attributions from olx.FrameState instances

### DIFF
--- a/src/ol/pluggablemap.js
+++ b/src/ol/pluggablemap.js
@@ -1141,7 +1141,6 @@ ol.PluggableMap.prototype.renderFrame_ = function(time) {
     viewState = view.getState();
     frameState = /** @type {olx.FrameState} */ ({
       animate: false,
-      attributions: {},
       coordinateToPixelTransform: this.coordinateToPixelTransform_,
       extent: extent,
       focus: !this.focus_ ? viewState.center : this.focus_,

--- a/src/ol/source/raster.js
+++ b/src/ol/source/raster.js
@@ -107,7 +107,6 @@ ol.source.Raster = function(options) {
    */
   this.frameState_ = {
     animate: false,
-    attributions: {},
     coordinateToPixelTransform: ol.transform.create(),
     extent: null,
     focus: null,


### PR DESCRIPTION
`attributions` was removed from `olx.FrameState` in #7329 