### PR TITLE
Make strokeKey safer

### DIFF
--- a/src/ol/render/canvas/textreplay.js
+++ b/src/ol/render/canvas/textreplay.js
@@ -533,7 +533,7 @@ ol.render.canvas.TextReplay.prototype.setTextStyle = function(textStyle, declutt
       strokeState.lineCap + strokeState.lineDashOffset + '|' + strokeState.lineWidth +
       strokeState.lineJoin + strokeState.miterLimit + '[' + strokeState.lineDash.join() + ']' :
       '';
-    this.textKey_ = textState.font + (textState.textAlign || '?') + textState.scale;
+    this.textKey_ = textState.font + textState.scale + (textState.textAlign || '?');
     this.fillKey_ = fillState ?
       (typeof fillState.fillStyle == 'string' ? fillState.fillStyle : ('|' + ol.getUid(fillState.fillStyle))) :
       '';


### PR DESCRIPTION
This is quite minor, but the `strokeKey` for the label cache currently ends with the scale, which is an arbitrary number. Since the text itself is appended to the `strokeKey` for the `cacheKey`, it is possible that they interfer.

By changing the order so the `strokeKey` ends with the `textAlign`, which is a known value, we can avoid that potential glitch.

Note: we do not use a delimiter because generating these cache keys is on the hot path, and string concatenation gets drastically slower with an increased number of chunks.