### PR TITLE
Prune the label cache less aggressively

### DIFF
--- a/src/ol/render/canvas/textreplay.js
+++ b/src/ol/render/canvas/textreplay.js
@@ -129,6 +129,9 @@ ol.render.canvas.TextReplay = function(
    */
   this.widths_ = {};
 
+  var labelCache = ol.render.canvas.labelCache;
+  labelCache.prune();
+
 };
 ol.inherits(ol.render.canvas.TextReplay, ol.render.canvas.Replay);
 
@@ -301,7 +304,7 @@ ol.render.canvas.TextReplay.prototype.getImage = function(text, textKey, fillKey
         Math.ceil(renderWidth * scale),
         Math.ceil((height + strokeWidth) * scale));
     label = context.canvas;
-    labelCache.pruneAndSet(key, label);
+    labelCache.set(key, label);
     if (scale != 1) {
       context.scale(scale, scale);
     }

--- a/src/ol/structs/lrucache.js
+++ b/src/ol/structs/lrucache.js
@@ -268,12 +268,10 @@ ol.structs.LRUCache.prototype.set = function(key, value) {
 
 
 /**
- * @param {string} key Key.
- * @param {T} value Value.
+ * Prune the cache.
  */
-ol.structs.LRUCache.prototype.pruneAndSet = function(key, value) {
+ol.structs.LRUCache.prototype.prune = function() {
   while (this.canExpireCache()) {
     this.pop();
   }
-  this.set(key, value);
 };


### PR DESCRIPTION
When there are too many labels, pruning the cache as it is done now (during replays when interacting with the map, whenever a single label is added) has a heavy impact on map responsiveness.

This can be fixed by pruning the label cache less aggressively, when a new replay is created.