### PR TITLE
Allow clicks to be stopped while drawing

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3005,6 +3005,7 @@ olx.interaction.DragZoomOptions.prototype.out;
  *     source: (ol.source.Vector|undefined),
  *     snapTolerance: (number|undefined),
  *     type: (ol.geom.GeometryType|string),
+ *     stopClick: (boolean|undefined),
  *     maxPoints: (number|undefined),
  *     minPoints: (number|undefined),
  *     finishCondition: (ol.EventsConditionType|undefined),
@@ -3062,6 +3063,15 @@ olx.interaction.DrawOptions.prototype.snapTolerance;
  * @api
  */
 olx.interaction.DrawOptions.prototype.type;
+
+
+/**
+ * Stop click, singleclick, and doubleclick events from firing during drawing.
+ * Default is `false`.
+ * @type {boolean|undefined}
+ * @api
+ */
+olx.interaction.DrawOptions.prototype.stopClick;
 
 
 /**

--- a/src/ol/interaction/draw.js
+++ b/src/ol/interaction/draw.js
@@ -98,6 +98,14 @@ ol.interaction.Draw = function(options) {
   this.mode_ = ol.interaction.Draw.getMode_(this.type_);
 
   /**
+   * Stop click, singleclick, and doubleclick events from firing during drawing.
+   * Default is `false`.
+   * @type {boolean}
+   * @private
+   */
+  this.stopClick_ = !!options.stopClick;
+
+  /**
    * The number of points that must be drawn before a polygon ring or line
    * string can be finished.  The default is 3 for polygon rings and 2 for
    * line strings.
@@ -383,6 +391,9 @@ ol.interaction.Draw.handleUpEvent_ = function(event) {
   } else if (this.freehand_) {
     this.finishCoordinate_ = null;
     this.abortDrawing_();
+  }
+  if (!pass && this.stopClick_) {
+    event.stopPropagation();
   }
   return pass;
 };

--- a/src/ol/mapbrowsereventhandler.js
+++ b/src/ol/mapbrowsereventhandler.js
@@ -172,7 +172,9 @@ ol.MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
   // contact. isMouseActionButton returns true in these cases (evt.button is set
   // to 0).
   // See http://www.w3.org/TR/pointerevents/#button-states
-  if (!this.dragging_ && this.isMouseActionButton_(pointerEvent)) {
+  // We only fire click, singleclick, and doubleclick if nobody has called
+  // event.stopPropagation() or event.preventDefault().
+  if (!newEvent.propagationStopped && !this.dragging_ && this.isMouseActionButton_(pointerEvent)) {
     this.emulateClick_(this.down_);
   }
 


### PR DESCRIPTION
This makes it possible to stop clicks, singleclicks, and doubleclicks while drawing.

Fixes #529.