### PR TITLE
Check forward/back 1 world if wrapping

### DIFF
--- a/src/ol/renderer/canvas/vectorlayer.js
+++ b/src/ol/renderer/canvas/vectorlayer.js
@@ -181,11 +181,11 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame = function(frameState, lay
     ol.render.canvas.rotateAtOffset(replayContext, -rotation,
         width / 2, height / 2);
     replayGroup.replay(replayContext, transform, rotation, skippedFeatureUids);
-    if (vectorSource.getWrapX() && projection.canWrapX() &&
-        !ol.extent.containsExtent(projectionExtent, extent)) {
+    if (vectorSource.getWrapX() && projection.canWrapX()) {
       var startX = extent[0];
       var worldWidth = ol.extent.getWidth(projectionExtent);
       var world = 0;
+      startX -= worldWidth;
       var offsetX;
       while (startX < projectionExtent[0]) {
         --world;
@@ -196,6 +196,7 @@ ol.renderer.canvas.VectorLayer.prototype.composeFrame = function(frameState, lay
       }
       world = 0;
       startX = extent[2];
+      startX += worldWidth;
       while (startX > projectionExtent[2]) {
         ++world;
         offsetX = worldWidth * world;
@@ -325,8 +326,7 @@ ol.renderer.canvas.VectorLayer.prototype.prepareFrame = function(frameState, lay
       vectorLayerRenderBuffer * resolution);
   var projectionExtent = viewState.projection.getExtent();
 
-  if (vectorSource.getWrapX() && viewState.projection.canWrapX() &&
-      !ol.extent.containsExtent(projectionExtent, frameState.extent)) {
+  if (vectorSource.getWrapX() && viewState.projection.canWrapX()) {
     // For the replay group, we need an extent that intersects the real world
     // (-180° to +180°). To support geometries in a coordinate range from -540°
     // to +540°, we add at least 1 world width on each side of the projection


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/6088

Before:
![https://gfycat.com/gifs/detail/OrnateZealousFrog](https://thumbs.gfycat.com/OrnateZealousFrog-size_restricted.gif)

After:
![https://gfycat.com/gifs/detail/TimelyFrigidIggypops](https://thumbs.gfycat.com/TimelyFrigidIggypops-size_restricted.gif)