### PR TITLE
Donut polygon labels do not get a chance to get rendered

### DIFF
--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -24,18 +24,20 @@ ol.geom.flat.interiorpoint.linearRings = function(flatCoordinates, offset,
   /** @type {Array.<number>} */
   var intersections = [];
   // Calculate intersections with the horizontal line
-  var end = ends[0];
-  x1 = flatCoordinates[end - stride];
-  y1 = flatCoordinates[end - stride + 1];
-  for (i = offset; i < end; i += stride) {
-    x2 = flatCoordinates[i];
-    y2 = flatCoordinates[i + 1];
-    if ((y <= y1 && y2 <= y) || (y1 <= y && y <= y2)) {
-      x = (y - y1) / (y2 - y1) * (x2 - x1) + x1;
-      intersections.push(x);
+  for (var r = 0, rr = ends.length; r < rr; ++r) {
+    var end = ends[r];
+    x1 = flatCoordinates[end - stride];
+    y1 = flatCoordinates[end - stride + 1];
+    for (i = offset; i < end; i += stride) {
+      x2 = flatCoordinates[i];
+      y2 = flatCoordinates[i + 1];
+      if ((y <= y1 && y2 <= y) || (y1 <= y && y <= y2)) {
+        x = (y - y1) / (y2 - y1) * (x2 - x1) + x1;
+        intersections.push(x);
+      }
+      x1 = x2;
+      y1 = y2;
     }
-    x1 = x2;
-    y1 = y2;
   }
   // Find the longest segment of the horizontal line that has its center point
   // inside the linear ring.

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -550,6 +550,17 @@ describe('ol.geom.Polygon', function() {
       expect(interiorPoint.layout).to.be('XYM');
       expect(interiorPoint.getCoordinates()).to.eql([0.5, 0.5, 1]);
     });
+
+    it('returns XYM point for donut polygons', function() {
+      var geom = new ol.geom.Polygon([
+        [[0.5, 0.5], [0.5, 2.5], [2.5, 2.5], [2.5, 0.5], [0.5, 0.5]],
+        [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]
+      ]);
+      var interiorPoint = geom.getInteriorPoint();
+      expect(interiorPoint.getType()).to.be('Point');
+      expect(interiorPoint.layout).to.be('XYM');
+      expect(interiorPoint.getCoordinates()).to.eql([0.75, 1.5, 0.5]);
+    });
   });
 
   describe('ol.geom.Polygon.fromExtent', function() {


### PR DESCRIPTION
Since polygon labels are by default only rendered when they do not overflow the polygon, donut polygons with the label point inside an inner ring do not get labels rendered any more. This is because intersections are only calculated for the outer ring, and not for all rings of a polygon.