### PR TITLE
Remove unused, confusing projection code

### DIFF
--- a/src/ol/format/mvt.js
+++ b/src/ol/format/mvt.js
@@ -40,7 +40,7 @@ ol.format.MVT = function(opt_options) {
    * @type {ol.proj.Projection}
    */
   this.defaultDataProjection = new ol.proj.Projection({
-    code: 'EPSG:3857',
+    code: '',
     units: ol.proj.Units.TILE_PIXELS
   });
 


### PR DESCRIPTION
This is a purely cosmetic change, which just avoids confusion or concerns like the one raised in #7560. The projection code is not used or read anywhere.

Fixes #7560.