### PR TITLE
Use full precision for the declutter box

### DIFF
--- a/src/ol/render/canvas/replay.js
+++ b/src/ol/render/canvas/replay.js
@@ -226,10 +226,6 @@ ol.render.canvas.Replay.prototype.replayImage_ = function(context, x, y, image,
   anchorY *= scale;
   x -= anchorX;
   y -= anchorY;
-  if (snapToPixel) {
-    x = Math.round(x);
-    y = Math.round(y);
-  }
 
   var w = (width + originX > image.width) ? image.width - originX : width;
   var h = (height + originY > image.height) ? image.height - originY : height;
@@ -271,6 +267,12 @@ ol.render.canvas.Replay.prototype.replayImage_ = function(context, x, y, image,
   }
   var canvas = context.canvas;
   var intersects = box[0] <= canvas.width && box[2] >= 0 && box[1] <= canvas.height && box[3] >= 0;
+
+  if (snapToPixel) {
+    x = Math.round(x);
+    y = Math.round(y);
+  }
+
   if (declutterGroup) {
     if (!intersects && declutterGroup[4] == 1) {
       return;

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -571,11 +571,11 @@ describe('ol.rendering.layer.Vector', function() {
       });
       source.addFeature(centerFeature);
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] - 540, center[1]]),
         text: 'west'
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] + 540, center[1]]),
         text: 'east'
       }));
 
@@ -612,11 +612,11 @@ describe('ol.rendering.layer.Vector', function() {
       });
       source.addFeature(centerFeature);
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] - 540, center[1]]),
         text: 'west'
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] + 540, center[1]]),
         text: 'east'
       }));
 
@@ -652,12 +652,12 @@ describe('ol.rendering.layer.Vector', function() {
         zIndex: 2
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] - 540, center[1]]),
         text: 'west',
         zIndex: 3
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] + 540, center[1]]),
         text: 'east',
         zIndex: 1
       }));
@@ -691,10 +691,10 @@ describe('ol.rendering.layer.Vector', function() {
       });
       source.addFeature(centerFeature);
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]])
+        geometry: new ol.geom.Point([center[0] - 540, center[1]])
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]])
+        geometry: new ol.geom.Point([center[0] + 540, center[1]])
       }));
 
       layer.setDeclutter(true);
@@ -731,10 +731,10 @@ describe('ol.rendering.layer.Vector', function() {
       });
       source.addFeature(centerFeature);
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]])
+        geometry: new ol.geom.Point([center[0] - 540, center[1]])
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]])
+        geometry: new ol.geom.Point([center[0] + 540, center[1]])
       }));
 
       layer.setDeclutter(true);
@@ -770,11 +770,11 @@ describe('ol.rendering.layer.Vector', function() {
         zIndex: 2
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] - 540, center[1]]),
         zIndex: 3
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] + 540, center[1]]),
         zIndex: 1
       }));
 
@@ -809,11 +809,11 @@ describe('ol.rendering.layer.Vector', function() {
         text: 'center'
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] - 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] - 540, center[1]]),
         text: 'west'
       }));
       source.addFeature(new ol.Feature({
-        geometry: new ol.geom.Point([center[0] + 550, center[1]]),
+        geometry: new ol.geom.Point([center[0] + 540, center[1]]),
         text: 'east'
       }));
 


### PR DESCRIPTION
On rotated maps, the view is not snapped to a pixel because of the rotation transform. When using rounded pixel coordinates (`snapToPixel: true`) for the declutter box, the outcome of the decluttering is different depending on the map center. To avoid this, we have to calculate the declutter box with full precision coordinates, and round only for the image positioning.

Fixes #7561.