### PR TITLE
Proper projection construction

### DIFF
--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -95,7 +95,7 @@ describe('ol.source.VectorTile', function() {
         loaded.push(src);
       }
 
-      var proj = ol.proj.Projection({
+      var proj = new ol.proj.Projection({
         code: 'EPSG:3006',
         units: 'm'
       });


### PR DESCRIPTION
The tests were missing a `new` when constructing a projection (since ffb7d72c905ccbb542974bbf4597197eb3f24993).  This causes a test failure when we transform the sources to modules (`this` is undefined in the projection function).