### PR TITLE
Remove unnecessary require

### DIFF
--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -1,4 +1,3 @@
-goog.require('ol');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.ScaleLine');


### PR DESCRIPTION
The scaleline test got an extra require in 9c45f9a8d666451d2ae2e040cb64ae29669821e0.