### PR TITLE
No default export from lowercase modules

### DIFF
--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -119,15 +119,3 @@ var uidCounter_ = 0;
 export function getUid(obj) {
   return obj.ol_uid || (obj.ol_uid = ++uidCounter_);
 }
-
-
-export default {
-  getUid: getUid,
-  nullFunction: nullFunction,
-  inherits: inherits,
-  VERSION: VERSION,
-  DEBUG_WEBGL: DEBUG_WEBGL,
-  HAS_WEBGL: HAS_WEBGL,
-  WEBGL_MAX_TEXTURE_SIZE: WEBGL_MAX_TEXTURE_SIZE,
-  WEBGL_EXTENSIONS: WEBGL_EXTENSIONS
-};


### PR DESCRIPTION
We had originally thought we would provide a default export in addition to named exports from modules like `ol/proj` and `ol/extent`.  The reason for this was to make upgrading from the ol@4 package easier - we would provide a code transform that updated the case of import specifiers for things like `ol/Map` and leave `ol/proj` type imports untouched.

Instead, we can follow these rules:
 * if a module name is uppercase (e.g. `ol/Map`), it has a default export (in the future, it may also have named exports, but this is not currently the case)
 * if a module name is lowercase (e.g. `ol/proj`), it has named exports and no default export.

So our code transform for the 4 to 5 upgrade will do this:
```js
// before, using ol@4
import extent from 'ol/extent';
```
```js
// after, using ol@5
import * as extent from 'ol/extent';
```