### PR TITLE
Named exports from ol/proj

### DIFF
--- a/examples/animation.js
+++ b/examples/animation.js
@@ -2,14 +2,14 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import {easeIn, easeOut} from '../src/ol/easing.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
-var london = _ol_proj_.fromLonLat([-0.12755, 51.507222]);
-var moscow = _ol_proj_.fromLonLat([37.6178, 55.7517]);
-var istanbul = _ol_proj_.fromLonLat([28.9744, 41.0128]);
-var rome = _ol_proj_.fromLonLat([12.5, 41.9]);
-var bern = _ol_proj_.fromLonLat([7.4458, 46.95]);
+var london = fromLonLat([-0.12755, 51.507222]);
+var moscow = fromLonLat([37.6178, 55.7517]);
+var istanbul = fromLonLat([28.9744, 41.0128]);
+var rome = fromLonLat([12.5, 41.9]);
+var bern = fromLonLat([7.4458, 46.95]);
 
 var view = new _ol_View_({
   center: istanbul,

--- a/examples/canvas-gradient-pattern.js
+++ b/examples/canvas-gradient-pattern.js
@@ -4,7 +4,7 @@ import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_format_GeoJSON_ from '../src/ol/format/GeoJSON.js';
 import _ol_has_ from '../src/ol/has.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
 import _ol_style_Stroke_ from '../src/ol/style/Stroke.js';
@@ -96,7 +96,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([7, 52]),
+    center: fromLonLat([7, 52]),
     zoom: 3
   })
 });

--- a/examples/canvas-tiles.js
+++ b/examples/canvas-tiles.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileDebug_ from '../src/ol/source/TileDebug.js';
 
@@ -27,8 +27,7 @@ var map = new _ol_Map_({
     }
   }),
   view: new _ol_View_({
-    center: _ol_proj_.transform(
-        [-0.1275, 51.507222], 'EPSG:4326', 'EPSG:3857'),
+    center: fromLonLat([-0.1275, 51.507222]),
     zoom: 10
   })
 });

--- a/examples/d3.js
+++ b/examples/d3.js
@@ -1,10 +1,10 @@
 // NOCOMPILE
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import * as _ol_extent_ from '../src/ol/extent.js';
+import {getWidth, getCenter} from '../src/ol/extent.js';
 import _ol_layer_Image_ from '../src/ol/layer/Image.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat, toLonLat} from '../src/ol/proj.js';
 import _ol_source_ImageCanvas_ from '../src/ol/source/ImageCanvas.js';
 import _ol_source_Stamen_ from '../src/ol/source/Stamen.js';
 
@@ -19,7 +19,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-97, 38]),
+    center: fromLonLat([-97, 38]),
     zoom: 4
   })
 });
@@ -57,13 +57,11 @@ d3.json('data/topojson/us.json', function(error, us) {
     var pixelBoundsHeight = pixelBounds[1][1] - pixelBounds[0][1];
 
     var geoBounds = d3.geoBounds(features);
-    var geoBoundsLeftBottom = _ol_proj_.transform(
-        geoBounds[0], 'EPSG:4326', projection);
-    var geoBoundsRightTop = _ol_proj_.transform(
-        geoBounds[1], 'EPSG:4326', projection);
+    var geoBoundsLeftBottom = fromLonLat(geoBounds[0], projection);
+    var geoBoundsRightTop = fromLonLat(geoBounds[1], projection);
     var geoBoundsWidth = geoBoundsRightTop[0] - geoBoundsLeftBottom[0];
     if (geoBoundsWidth < 0) {
-      geoBoundsWidth += _ol_extent_.getWidth(projection.getExtent());
+      geoBoundsWidth += getWidth(projection.getExtent());
     }
     var geoBoundsHeight = geoBoundsRightTop[1] - geoBoundsLeftBottom[1];
 
@@ -72,8 +70,7 @@ d3.json('data/topojson/us.json', function(error, us) {
     var r = Math.max(widthResolution, heightResolution);
     var scale = r / (resolution / pixelRatio);
 
-    var center = _ol_proj_.transform(_ol_extent_.getCenter(extent),
-        projection, 'EPSG:4326');
+    var center = toLonLat(getCenter(extent), projection);
     d3Projection.scale(scale).center(center)
         .translate([canvasWidth / 2, canvasHeight / 2]);
     d3Path = d3Path.projection(d3Projection).context(context);

--- a/examples/device-orientation.js
+++ b/examples/device-orientation.js
@@ -4,14 +4,10 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_math_ from '../src/ol/math.js';
-import _ol_proj_ from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
-var projection = _ol_proj_.get('EPSG:3857');
 var view = new _ol_View_({
   center: [0, 0],
-  projection: projection,
-  extent: projection.getExtent(),
   zoom: 2
 });
 var map = new _ol_Map_({

--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -7,7 +7,7 @@ import {easeOut} from '../src/ol/easing.js';
 import _ol_geom_Point_ from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -46,8 +46,7 @@ map.addLayer(vector);
 function addRandomFeature() {
   var x = Math.random() * 360 - 180;
   var y = Math.random() * 180 - 90;
-  var geom = new _ol_geom_Point_(_ol_proj_.transform([x, y],
-      'EPSG:4326', 'EPSG:3857'));
+  var geom = new _ol_geom_Point_(fromLonLat([x, y]));
   var feature = new _ol_Feature_(geom);
   source.addFeature(feature);
 }

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -5,7 +5,6 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
 import _ol_source_Stamen_ from '../src/ol/source/Stamen.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Stroke_ from '../src/ol/style/Stroke.js';
@@ -94,7 +93,7 @@ flightsSource = new _ol_source_Vector_({
         var arcLine = arcGenerator.Arc(100, {offset: 10});
         if (arcLine.geometries.length === 1) {
           var line = new _ol_geom_LineString_(arcLine.geometries[0].coords);
-          line.transform(_ol_proj_.get('EPSG:4326'), _ol_proj_.get('EPSG:3857'));
+          line.transform('EPSG:4326', 'EPSG:3857');
 
           var feature = new _ol_Feature_({
             geometry: line,

--- a/examples/geolocation-orientation.js
+++ b/examples/geolocation-orientation.js
@@ -5,12 +5,12 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
 // creating the view
 var view = new _ol_View_({
-  center: _ol_proj_.fromLonLat([5.8713, 45.6452]),
+  center: fromLonLat([5.8713, 45.6452]),
   zoom: 19
 });
 
@@ -214,9 +214,7 @@ function simulatePositionChange(position) {
   var coords = position.coords;
   geolocation.set('accuracy', coords.accuracy);
   geolocation.set('heading', degToRad(coords.heading));
-  var position_ = [coords.longitude, coords.latitude];
-  var projectedPosition = _ol_proj_.transform(position_, 'EPSG:4326',
-      'EPSG:3857');
+  var projectedPosition = fromLonLat([coords.longitude, coords.latitude]);
   geolocation.set('position', projectedPosition);
   geolocation.set('speed', coords.speed);
   geolocation.changed();

--- a/examples/graticule.js
+++ b/examples/graticule.js
@@ -2,7 +2,7 @@ import _ol_Graticule_ from '../src/ol/Graticule.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_style_Stroke_ from '../src/ol/style/Stroke.js';
 
@@ -17,8 +17,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([4.8, 47.75]),
-    extent: _ol_proj_.get('EPSG:3857').getExtent(),
+    center: fromLonLat([4.8, 47.75]),
     zoom: 5
   })
 });

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -4,7 +4,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_geom_Point_ from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_TileJSON_ from '../src/ol/source/TileJSON.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Icon_ from '../src/ol/style/Icon.js';
@@ -12,15 +12,15 @@ import _ol_style_Style_ from '../src/ol/style/Style.js';
 
 
 var rome = new _ol_Feature_({
-  geometry: new _ol_geom_Point_(_ol_proj_.fromLonLat([12.5, 41.9]))
+  geometry: new _ol_geom_Point_(fromLonLat([12.5, 41.9]))
 });
 
 var london = new _ol_Feature_({
-  geometry: new _ol_geom_Point_(_ol_proj_.fromLonLat([-0.12755, 51.507222]))
+  geometry: new _ol_geom_Point_(fromLonLat([-0.12755, 51.507222]))
 });
 
 var madrid = new _ol_Feature_({
-  geometry: new _ol_geom_Point_(_ol_proj_.fromLonLat([-3.683333, 40.4]))
+  geometry: new _ol_geom_Point_(fromLonLat([-3.683333, 40.4]))
 });
 
 rome.setStyle(new _ol_style_Style_({
@@ -67,7 +67,7 @@ var map = new _ol_Map_({
   layers: [rasterLayer, vectorLayer],
   target: document.getElementById('map'),
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([2.896372, 44.60240]),
+    center: fromLonLat([2.896372, 44.60240]),
     zoom: 3
   })
 });

--- a/examples/image-filter.js
+++ b/examples/image-filter.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
 
 var key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
@@ -14,7 +14,7 @@ var map = new _ol_Map_({
   layers: [imagery],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-120, 50]),
+    center: fromLonLat([-120, 50]),
     zoom: 6
   })
 });

--- a/examples/jsts.js
+++ b/examples/jsts.js
@@ -5,7 +5,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_format_GeoJSON_ from '../src/ol/format/GeoJSON.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 
@@ -45,7 +45,7 @@ var map = new _ol_Map_({
   layers: [rasterLayer, vectorLayer],
   target: document.getElementById('map'),
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([126.979293, 37.528787]),
+    center: fromLonLat([126.979293, 37.528787]),
     zoom: 15
   })
 });

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -3,11 +3,8 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_format_KML_ from '../src/ol/format/KML.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
-
-var projection = _ol_proj_.get('EPSG:3857');
 
 var raster = new _ol_layer_Tile_({
   source: new _ol_source_BingMaps_({
@@ -28,7 +25,7 @@ var map = new _ol_Map_({
   target: document.getElementById('map'),
   view: new _ol_View_({
     center: [876970.8463461736, 5859807.853963373],
-    projection: projection,
+    projection: 'EPSG:3857',
     zoom: 10
   })
 });

--- a/examples/layer-extent.js
+++ b/examples/layer-extent.js
@@ -1,11 +1,11 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {transformExtent} from '../src/ol/proj.js';
 import _ol_source_TileJSON_ from '../src/ol/source/TileJSON.js';
 
 function transform(extent) {
-  return _ol_proj_.transformExtent(extent, 'EPSG:4326', 'EPSG:3857');
+  return transformExtent(extent, 'EPSG:4326', 'EPSG:3857');
 }
 
 var extents = {

--- a/examples/layer-group.js
+++ b/examples/layer-group.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Group_ from '../src/ol/layer/Group.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileJSON_ from '../src/ol/source/TileJSON.js';
 
@@ -29,7 +29,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([37.40570, 8.81566]),
+    center: fromLonLat([37.40570, 8.81566]),
     zoom: 4
   })
 });

--- a/examples/layer-spy.js
+++ b/examples/layer-spy.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
 
 var key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
@@ -20,7 +20,7 @@ var map = new _ol_Map_({
   layers: [roads, imagery],
   target: container,
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-109, 46.5]),
+    center: fromLonLat([-109, 46.5]),
     zoom: 6
   })
 });

--- a/examples/magnify.js
+++ b/examples/magnify.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
 
 var key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
@@ -16,7 +16,7 @@ var map = new _ol_Map_({
   layers: [imagery],
   target: container,
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-109, 46.5]),
+    center: fromLonLat([-109, 46.5]),
     zoom: 6
   })
 });

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_format_MVT_ from '../src/ol/format/MVT.js';
 import _ol_layer_VectorTile_ from '../src/ol/layer/VectorTile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {get as getProjection} from '../src/ol/proj.js';
 import _ol_source_VectorTile_ from '../src/ol/source/VectorTile.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
 import _ol_style_Icon_ from '../src/ol/style/Icon.js';
@@ -39,7 +39,7 @@ var map = new _ol_Map_({
           'OpenStreetMap contributors</a>',
         format: new _ol_format_MVT_(),
         tileGrid: new _ol_tilegrid_TileGrid_({
-          extent: _ol_proj_.get('EPSG:3857').getExtent(),
+          extent: getProjection('EPSG:3857').getExtent(),
           resolutions: resolutions,
           tileSize: 512
         }),

--- a/examples/moveend.js
+++ b/examples/moveend.js
@@ -3,7 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {toLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
 
@@ -37,10 +37,8 @@ function wrapLon(value) {
 function onMoveEnd(evt) {
   var map = evt.map;
   var extent = map.getView().calculateExtent(map.getSize());
-  var bottomLeft = _ol_proj_.transform(_ol_extent_.getBottomLeft(extent),
-      'EPSG:3857', 'EPSG:4326');
-  var topRight = _ol_proj_.transform(_ol_extent_.getTopRight(extent),
-      'EPSG:3857', 'EPSG:4326');
+  var bottomLeft = toLonLat(_ol_extent_.getBottomLeft(extent));
+  var topRight = toLonLat(_ol_extent_.getTopRight(extent));
   display('left', wrapLon(bottomLeft[0]));
   display('bottom', bottomLeft[1]);
   display('right', wrapLon(topRight[0]));

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_format_TopoJSON_ from '../src/ol/format/TopoJSON.js';
 import _ol_layer_VectorTile_ from '../src/ol/layer/VectorTile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_VectorTile_ from '../src/ol/source/VectorTile.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
 import _ol_style_Stroke_ from '../src/ol/style/Stroke.js';
@@ -83,7 +83,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-74.0064, 40.7142]),
+    center: fromLonLat([-74.0064, 40.7142]),
     maxZoom: 19,
     zoom: 15
   })

--- a/examples/overlay.js
+++ b/examples/overlay.js
@@ -3,7 +3,7 @@ import _ol_Overlay_ from '../src/ol/Overlay.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_coordinate_ from '../src/ol/coordinate.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat, toLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
 
@@ -20,7 +20,7 @@ var map = new _ol_Map_({
   })
 });
 
-var pos = _ol_proj_.fromLonLat([16.3725, 48.208889]);
+var pos = fromLonLat([16.3725, 48.208889]);
 
 // Vienna marker
 var marker = new _ol_Overlay_({
@@ -47,8 +47,7 @@ map.addOverlay(popup);
 map.on('click', function(evt) {
   var element = popup.getElement();
   var coordinate = evt.coordinate;
-  var hdms = _ol_coordinate_.toStringHDMS(_ol_proj_.transform(
-      coordinate, 'EPSG:3857', 'EPSG:4326'));
+  var hdms = _ol_coordinate_.toStringHDMS(toLonLat(coordinate));
 
   $(element).popover('destroy');
   popup.setPosition(coordinate);

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -3,7 +3,7 @@ import _ol_Overlay_ from '../src/ol/Overlay.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_coordinate_ from '../src/ol/coordinate.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {toLonLat} from '../src/ol/proj.js';
 import _ol_source_TileJSON_ from '../src/ol/source/TileJSON.js';
 
 
@@ -64,8 +64,7 @@ var map = new _ol_Map_({
  */
 map.on('singleclick', function(evt) {
   var coordinate = evt.coordinate;
-  var hdms = _ol_coordinate_.toStringHDMS(_ol_proj_.transform(
-      coordinate, 'EPSG:3857', 'EPSG:4326'));
+  var hdms = _ol_coordinate_.toStringHDMS(toLonLat(coordinate));
 
   content.innerHTML = '<p>You clicked here:</p><code>' + hdms +
       '</code>';

--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Image_ from '../src/ol/layer/Image.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
 import _ol_source_Raster_ from '../src/ol/source/Raster.js';
 
@@ -98,7 +98,7 @@ var map = new _ol_Map_({
   layers: [imagery, rasterImage],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-119.07, 47.65]),
+    center: fromLonLat([-119.07, 47.65]),
     zoom: 11
   })
 });

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {get as getProjection, getTransform} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileImage_ from '../src/ol/source/TileImage.js';
 
@@ -42,8 +42,8 @@ function setProjection(code, name, proj4def, bbox) {
 
   var newProjCode = 'EPSG:' + code;
   proj4.defs(newProjCode, proj4def);
-  var newProj = _ol_proj_.get(newProjCode);
-  var fromLonLat = _ol_proj_.getTransform('EPSG:4326', newProj);
+  var newProj = getProjection(newProjCode);
+  var fromLonLat = getTransform('EPSG:4326', newProj);
 
   // very approximate calculation of projection extent
   var extent = _ol_extent_.applyTransform(

--- a/examples/reprojection-image.js
+++ b/examples/reprojection-image.js
@@ -1,9 +1,9 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import * as _ol_extent_ from '../src/ol/extent.js';
+import {getCenter} from '../src/ol/extent.js';
 import _ol_layer_Image_ from '../src/ol/layer/Image.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {transform} from '../src/ol/proj.js';
 import _ol_source_ImageStatic_ from '../src/ol/source/ImageStatic.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
@@ -31,8 +31,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.transform(
-        _ol_extent_.getCenter(imageExtent), 'EPSG:27700', 'EPSG:3857'),
+    center: transform(getCenter(imageExtent), 'EPSG:27700', 'EPSG:3857'),
     zoom: 4
   })
 });

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -3,7 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_format_WMTSCapabilities_ from '../src/ol/format/WMTSCapabilities.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {get as getProjection} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileImage_ from '../src/ol/source/TileImage.js';
 import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
@@ -16,39 +16,39 @@ proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 ' +
     '+x_0=400000 +y_0=-100000 +ellps=airy ' +
     '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
     '+units=m +no_defs');
-var proj27700 = _ol_proj_.get('EPSG:27700');
+var proj27700 = getProjection('EPSG:27700');
 proj27700.setExtent([0, 0, 700000, 1300000]);
 
 proj4.defs('EPSG:23032', '+proj=utm +zone=32 +ellps=intl ' +
     '+towgs84=-87,-98,-121,0,0,0,0 +units=m +no_defs');
-var proj23032 = _ol_proj_.get('EPSG:23032');
+var proj23032 = getProjection('EPSG:23032');
 proj23032.setExtent([-1206118.71, 4021309.92, 1295389.00, 8051813.28]);
 
 proj4.defs('EPSG:5479', '+proj=lcc +lat_1=-76.66666666666667 +lat_2=' +
     '-79.33333333333333 +lat_0=-78 +lon_0=163 +x_0=7000000 +y_0=5000000 ' +
     '+ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-var proj5479 = _ol_proj_.get('EPSG:5479');
+var proj5479 = getProjection('EPSG:5479');
 proj5479.setExtent([6825737.53, 4189159.80, 9633741.96, 5782472.71]);
 
 proj4.defs('EPSG:21781', '+proj=somerc +lat_0=46.95240555555556 ' +
     '+lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
     '+towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs');
-var proj21781 = _ol_proj_.get('EPSG:21781');
+var proj21781 = getProjection('EPSG:21781');
 proj21781.setExtent([485071.54, 75346.36, 828515.78, 299941.84]);
 
 proj4.defs('EPSG:3413', '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 ' +
     '+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
-var proj3413 = _ol_proj_.get('EPSG:3413');
+var proj3413 = getProjection('EPSG:3413');
 proj3413.setExtent([-4194304, -4194304, 4194304, 4194304]);
 
 proj4.defs('EPSG:2163', '+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 ' +
     '+a=6370997 +b=6370997 +units=m +no_defs');
-var proj2163 = _ol_proj_.get('EPSG:2163');
+var proj2163 = getProjection('EPSG:2163');
 proj2163.setExtent([-8040784.5135, -2577524.9210, 3668901.4484, 4785105.1096]);
 
 proj4.defs('ESRI:54009', '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 ' +
     '+units=m +no_defs');
-var proj54009 = _ol_proj_.get('ESRI:54009');
+var proj54009 = getProjection('ESRI:54009');
 proj54009.setExtent([-18e6, -9e6, 18e6, 9e6]);
 
 
@@ -124,7 +124,7 @@ layers['grandcanyon'] = new _ol_layer_Tile_({
 });
 
 var startResolution =
-    _ol_extent_.getWidth(_ol_proj_.get('EPSG:3857').getExtent()) / 256;
+    _ol_extent_.getWidth(getProjection('EPSG:3857').getExtent()) / 256;
 var resolutions = new Array(22);
 for (var i = 0, ii = resolutions.length; i < ii; ++i) {
   resolutions[i] = startResolution / Math.pow(2, i);
@@ -167,7 +167,7 @@ var renderEdgesCheckbox = document.getElementById('render-edges');
 var renderEdges = false;
 
 function updateViewProjection() {
-  var newProj = _ol_proj_.get(viewProjSelect.value);
+  var newProj = getProjection(viewProjSelect.value);
   var newProjExtent = newProj.getExtent();
   var newView = new _ol_View_({
     projection: newProj,
@@ -178,7 +178,7 @@ function updateViewProjection() {
   map.setView(newView);
 
   // Example how to prevent double occurrence of map by limiting layer extent
-  if (newProj == _ol_proj_.get('EPSG:3857')) {
+  if (newProj == getProjection('EPSG:3857')) {
     layers['bng'].setExtent([-1057216, 6405988, 404315, 8759696]);
   } else {
     layers['bng'].setExtent(undefined);

--- a/examples/scaleline-indiana-east.js
+++ b/examples/scaleline-indiana-east.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ScaleLine_ from '../src/ol/control/ScaleLine.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat, transformExtent} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
 proj4.defs('Indiana-East', 'PROJCS["IN83-EF",GEOGCS["LL83",DATUM["NAD83",' +
@@ -24,9 +24,9 @@ var map = new _ol_Map_({
   target: 'map',
   view: new _ol_View_({
     projection: 'Indiana-East',
-    center: _ol_proj_.fromLonLat([-85.685, 39.891], 'Indiana-East'),
+    center: fromLonLat([-85.685, 39.891], 'Indiana-East'),
     zoom: 7,
-    extent: _ol_proj_.transformExtent([-172.54, 23.81, -47.74, 86.46],
+    extent: transformExtent([-172.54, 23.81, -47.74, 86.46],
         'EPSG:4326', 'Indiana-East'),
     minZoom: 6
   })

--- a/examples/sea-level.js
+++ b/examples/sea-level.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Image_ from '../src/ol/layer/Image.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_Raster_ from '../src/ol/source/Raster.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
 
@@ -49,7 +49,7 @@ var map = new _ol_Map_({
     })
   ],
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-122.3267, 37.8377]),
+    center: fromLonLat([-122.3267, 37.8377]),
     zoom: 11
   })
 });
@@ -74,6 +74,6 @@ for (var i = 0, ii = locations.length; i < ii; ++i) {
 function relocate(event) {
   var data = event.target.dataset;
   var view = map.getView();
-  view.setCenter(_ol_proj_.fromLonLat(data.center.split(',').map(Number)));
+  view.setCenter(fromLonLat(data.center.split(',').map(Number)));
   view.setZoom(Number(data.zoom));
 }

--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileJSON_ from '../src/ol/source/TileJSON.js';
 
@@ -20,7 +20,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-77.93255, 37.9555]),
+    center: fromLonLat([-77.93255, 37.9555]),
     zoom: 7
   })
 });

--- a/examples/stamen.js
+++ b/examples/stamen.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_Stamen_ from '../src/ol/source/Stamen.js';
 
 
@@ -20,8 +20,7 @@ var map = new _ol_Map_({
   ],
   target: 'map',
   view: new _ol_View_({
-    center: _ol_proj_.transform(
-        [-122.416667, 37.783333], 'EPSG:4326', 'EPSG:3857'),
+    center: fromLonLat([-122.416667, 37.783333]),
     zoom: 12
   })
 });

--- a/examples/turf.js
+++ b/examples/turf.js
@@ -5,7 +5,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_format_GeoJSON_ from '../src/ol/format/GeoJSON.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 
@@ -50,7 +50,7 @@ var map = new _ol_Map_({
   layers: [rasterLayer, vectorLayer],
   target: document.getElementById('map'),
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([126.980366, 37.526540]),
+    center: fromLonLat([126.980366, 37.526540]),
     zoom: 15
   })
 });

--- a/examples/vector-esri-edit.js
+++ b/examples/vector-esri-edit.js
@@ -8,7 +8,7 @@ import _ol_interaction_Select_ from '../src/ol/interaction/Select.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_loadingstrategy_ from '../src/ol/loadingstrategy.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
 import _ol_tilegrid_ from '../src/ol/tilegrid.js';
@@ -81,7 +81,7 @@ var map = new _ol_Map_({
   layers: [raster, vector],
   target: document.getElementById('map'),
   view: new _ol_View_({
-    center: _ol_proj_.transform([-122.619, 45.512], 'EPSG:4326', 'EPSG:3857'),
+    center: fromLonLat([-122.619, 45.512]),
     zoom: 12
   })
 });

--- a/examples/vector-esri.js
+++ b/examples/vector-esri.js
@@ -4,7 +4,7 @@ import _ol_format_EsriJSON_ from '../src/ol/format/EsriJSON.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_loadingstrategy_ from '../src/ol/loadingstrategy.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
@@ -108,7 +108,7 @@ var map = new _ol_Map_({
   layers: [raster, vector],
   target: document.getElementById('map'),
   view: new _ol_View_({
-    center: _ol_proj_.transform([-97.6114, 38.8403], 'EPSG:4326', 'EPSG:3857'),
+    center: fromLonLat([-97.6114, 38.8403]),
     zoom: 7
   })
 });

--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -5,7 +5,7 @@ import _ol_format_OSMXML_ from '../src/ol/format/OSMXML.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_loadingstrategy_ from '../src/ol/loadingstrategy.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {transformExtent} from '../src/ol/proj.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -80,8 +80,7 @@ var styles = {
 var vectorSource = new _ol_source_Vector_({
   format: new _ol_format_OSMXML_(),
   loader: function(extent, resolution, projection) {
-    var epsg4326Extent =
-        _ol_proj_.transformExtent(extent, projection, 'EPSG:4326');
+    var epsg4326Extent = transformExtent(extent, projection, 'EPSG:4326');
     var client = new XMLHttpRequest();
     client.open('POST', 'https://overpass-api.de/api/interpreter');
     client.addEventListener('load', function() {

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -3,7 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_control_ScaleLine_ from '../src/ol/control/ScaleLine.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {addProjection, addCoordinateTransforms, transform} from '../src/ol/proj.js';
 import _ol_proj_Projection_ from '../src/ol/proj/Projection.js';
 import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
 
@@ -20,13 +20,13 @@ var projection = new _ol_proj_Projection_({
   extent: [485869.5728, 76443.1884, 837076.5648, 299941.7864],
   units: 'm'
 });
-_ol_proj_.addProjection(projection);
+addProjection(projection);
 
 // We also declare EPSG:21781/EPSG:4326 transform functions. These functions
 // are necessary for the ScaleLine control and when calling ol.proj.transform
 // for setting the view's initial center (see below).
 
-_ol_proj_.addCoordinateTransforms('EPSG:4326', projection,
+addCoordinateTransforms('EPSG:4326', projection,
     function(coordinate) {
       return [
         WGStoCHy(coordinate[1], coordinate[0]),
@@ -79,7 +79,7 @@ var map = new _ol_Map_({
   target: 'map',
   view: new _ol_View_({
     projection: projection,
-    center: _ol_proj_.transform([8.23, 46.86], 'EPSG:4326', 'EPSG:21781'),
+    center: transform([8.23, 46.86], 'EPSG:4326', 'EPSG:21781'),
     extent: extent,
     zoom: 2
   })

--- a/examples/wms-custom-tilegrid-512x256.js
+++ b/examples/wms-custom-tilegrid-512x256.js
@@ -2,13 +2,13 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {get as getProjection} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
 import _ol_tilegrid_TileGrid_ from '../src/ol/tilegrid/TileGrid.js';
 
 
-var projExtent = _ol_proj_.get('EPSG:3857').getExtent();
+var projExtent = getProjection('EPSG:3857').getExtent();
 var startResolution = _ol_extent_.getWidth(projExtent) / 256;
 var resolutions = new Array(22);
 for (var i = 0, ii = resolutions.length; i < ii; ++i) {

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -3,7 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_control_ScaleLine_ from '../src/ol/control/ScaleLine.js';
 import _ol_layer_Image_ from '../src/ol/layer/Image.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_proj_Projection_ from '../src/ol/proj/Projection.js';
 import _ol_source_ImageWMS_ from '../src/ol/source/ImageWMS.js';
 
@@ -65,7 +65,7 @@ var map = new _ol_Map_({
   target: 'map',
   view: new _ol_View_({
     projection: projection,
-    center: _ol_proj_.fromLonLat([8.23, 46.86], projection),
+    center: fromLonLat([8.23, 46.86], projection),
     extent: extent,
     zoom: 2
   })

--- a/examples/wms-time.js
+++ b/examples/wms-time.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {transformExtent} from '../src/ol/proj.js';
 import _ol_source_Stamen_ from '../src/ol/source/Stamen.js';
 import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
 
@@ -10,7 +10,7 @@ function threeHoursAgo() {
   return new Date(Math.round(Date.now() / 3600000) * 3600000 - 3600000 * 3);
 }
 
-var extent = _ol_proj_.transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857');
+var extent = transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857');
 var startDate = threeHoursAgo();
 var frameRate = 0.5; // frames per second
 var animationId = null;

--- a/examples/wmts-dimensions.js
+++ b/examples/wmts-dimensions.js
@@ -2,14 +2,14 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {get as getProjection} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_WMTS_ from '../src/ol/source/WMTS.js';
 import _ol_tilegrid_WMTS_ from '../src/ol/tilegrid/WMTS.js';
 
 
 // create the WMTS tile grid in the google projection
-var projection = _ol_proj_.get('EPSG:3857');
+var projection = getProjection('EPSG:3857');
 var tileSizePixels = 256;
 var tileSizeMtrs = _ol_extent_.getWidth(projection.getExtent()) / tileSizePixels;
 var matrixIds = [];

--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -3,7 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat, get as getProjection} from '../src/ol/proj.js';
 import _ol_source_WMTS_ from '../src/ol/source/WMTS.js';
 import _ol_tilegrid_WMTS_ from '../src/ol/tilegrid/WMTS.js';
 
@@ -17,13 +17,13 @@ var map = new _ol_Map_({
   }),
   view: new _ol_View_({
     zoom: 5,
-    center: _ol_proj_.transform([5, 45], 'EPSG:4326', 'EPSG:3857')
+    center: fromLonLat([5, 45])
   })
 });
 
 var resolutions = [];
 var matrixIds = [];
-var proj3857 = _ol_proj_.get('EPSG:3857');
+var proj3857 = getProjection('EPSG:3857');
 var maxResolution = _ol_extent_.getWidth(proj3857.getExtent()) / 256;
 
 for (var i = 0; i < 18; i++) {

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -3,13 +3,13 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {get as getProjection} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_WMTS_ from '../src/ol/source/WMTS.js';
 import _ol_tilegrid_WMTS_ from '../src/ol/tilegrid/WMTS.js';
 
 
-var projection = _ol_proj_.get('EPSG:3857');
+var projection = getProjection('EPSG:3857');
 var projectionExtent = projection.getExtent();
 var size = _ol_extent_.getWidth(projectionExtent) / 256;
 var resolutions = new Array(14);

--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -1,10 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
-
-var projection = _ol_proj_.get('EPSG:4326');
 
 // The tile size supported by the ArcGIS tile service.
 var tileSize = 512;
@@ -19,7 +16,7 @@ var map = new _ol_Map_({
       source: new _ol_source_XYZ_({
         attributions: 'Copyright:© 2013 ESRI, i-cubed, GeoEye',
         maxZoom: 16,
-        projection: projection,
+        projection: 'EPSG:4326',
         tileSize: tileSize,
         tileUrlFunction: function(tileCoord) {
           return urlTemplate.replace('{z}', (tileCoord[0] - 1).toString())
@@ -32,7 +29,7 @@ var map = new _ol_Map_({
   ],
   view: new _ol_View_({
     center: [0, 0],
-    projection: projection,
+    projection: 'EPSG:4326',
     zoom: 2,
     minZoom: 2
   })

--- a/examples/xyz-esri.js
+++ b/examples/xyz-esri.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
 
 
@@ -18,7 +18,7 @@ var map = new _ol_Map_({
     })
   ],
   view: new _ol_View_({
-    center: _ol_proj_.fromLonLat([-121.1, 47.5]),
+    center: fromLonLat([-121.1, 47.5]),
     zoom: 7
   })
 });

--- a/examples/xyz-retina.js
+++ b/examples/xyz-retina.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
-import _ol_proj_ from '../src/ol/proj.js';
+import {transform, transformExtent} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
 
@@ -16,7 +16,7 @@ var map = new _ol_Map_({
       source: new _ol_source_OSM_()
     }),
     new _ol_layer_Tile_({
-      extent: _ol_proj_.transformExtent(mapExtent, 'EPSG:4326', 'EPSG:3857'),
+      extent: transformExtent(mapExtent, 'EPSG:4326', 'EPSG:3857'),
       source: new _ol_source_XYZ_({
         attributions: 'Tiles © USGS, rendered with ' +
             '<a href="http://www.maptiler.com/">MapTiler</a>',
@@ -29,7 +29,7 @@ var map = new _ol_Map_({
   ],
   view: new _ol_View_({
     projection: 'EPSG:3857',
-    center: _ol_proj_.transform([-112.18688965, 36.057944835],
+    center: transform([-112.18688965, 36.057944835],
         'EPSG:4326', 'EPSG:3857'),
     zoom: 12
   })

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jscodeshift": "^0.4.0",
     "jsdoc": "3.5.5",
     "karma": "^1.7.1",
-    "karma-chrome-launcher": "^2.1.1",
+    "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "^1.1.1",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "1.3.0",

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -12,7 +12,7 @@ import _ol_events_EventType_ from './events/EventType.js';
 import _ol_geom_Polygon_ from './geom/Polygon.js';
 import _ol_has_ from './has.js';
 import _ol_math_ from './math.js';
-import _ol_proj_ from './proj.js';
+import {get as getProjection, getTransformFromProjections, identityTransform} from './proj.js';
 import _ol_proj_EPSG4326_ from './proj/EPSG4326.js';
 
 /**
@@ -58,7 +58,7 @@ var _ol_Geolocation_ = function(opt_options) {
    * @private
    * @type {ol.TransformFunction}
    */
-  this.transform_ = _ol_proj_.identityTransform;
+  this.transform_ = identityTransform;
 
   /**
    * @private
@@ -108,8 +108,8 @@ _ol_Geolocation_.prototype.disposeInternal = function() {
 _ol_Geolocation_.prototype.handleProjectionChanged_ = function() {
   var projection = this.getProjection();
   if (projection) {
-    this.transform_ = _ol_proj_.getTransformFromProjections(
-        _ol_proj_.get('EPSG:4326'), projection);
+    this.transform_ = getTransformFromProjections(
+        getProjection('EPSG:4326'), projection);
     if (this.position_) {
       this.set(
           _ol_GeolocationProperty_.POSITION, this.transform_(this.position_));
@@ -332,7 +332,7 @@ _ol_Geolocation_.prototype.getTrackingOptions = function() {
  * @api
  */
 _ol_Geolocation_.prototype.setProjection = function(projection) {
-  this.set(_ol_GeolocationProperty_.PROJECTION, _ol_proj_.get(projection));
+  this.set(_ol_GeolocationProperty_.PROJECTION, getProjection(projection));
 };
 
 

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -8,7 +8,7 @@ import _ol_geom_LineString_ from './geom/LineString.js';
 import _ol_geom_Point_ from './geom/Point.js';
 import _ol_geom_flat_geodesic_ from './geom/flat/geodesic.js';
 import _ol_math_ from './math.js';
-import _ol_proj_ from './proj.js';
+import {get as getProjection, equivalent as equivalentProjection, getTransform, transformExtent} from './proj.js';
 import _ol_render_EventType_ from './render/EventType.js';
 import _ol_style_Fill_ from './style/Fill.js';
 import _ol_style_Stroke_ from './style/Stroke.js';
@@ -372,7 +372,7 @@ _ol_Graticule_.prototype.createGraticule_ = function(extent, center, resolution,
     Math.min(extent[3], this.maxLatP_)
   ];
 
-  validExtent = _ol_proj_.transformExtent(validExtent, this.projection_,
+  validExtent = transformExtent(validExtent, this.projection_,
       'EPSG:4326');
   var maxLat = validExtent[3];
   var maxLon = validExtent[2];
@@ -554,7 +554,7 @@ _ol_Graticule_.prototype.handlePostCompose_ = function(e) {
       resolution * resolution / (4 * pixelRatio * pixelRatio);
 
   var updateProjectionInfo = !this.projection_ ||
-      !_ol_proj_.equivalent(this.projection_, projection);
+      !equivalentProjection(this.projection_, projection);
 
   if (updateProjectionInfo) {
     this.updateProjectionInfo_(projection);
@@ -598,11 +598,11 @@ _ol_Graticule_.prototype.handlePostCompose_ = function(e) {
  * @private
  */
 _ol_Graticule_.prototype.updateProjectionInfo_ = function(projection) {
-  var epsg4326Projection = _ol_proj_.get('EPSG:4326');
+  var epsg4326Projection = getProjection('EPSG:4326');
 
   var extent = projection.getExtent();
   var worldExtent = projection.getWorldExtent();
-  var worldExtentP = _ol_proj_.transformExtent(worldExtent,
+  var worldExtentP = transformExtent(worldExtent,
       epsg4326Projection, projection);
 
   var maxLat = worldExtent[3];
@@ -626,11 +626,9 @@ _ol_Graticule_.prototype.updateProjectionInfo_ = function(projection) {
   this.minLonP_ = minLonP;
 
 
-  this.fromLonLatTransform_ = _ol_proj_.getTransform(
-      epsg4326Projection, projection);
+  this.fromLonLatTransform_ = getTransform(epsg4326Projection, projection);
 
-  this.toLonLatTransform_ = _ol_proj_.getTransform(
-      projection, epsg4326Projection);
+  this.toLonLatTransform_ = getTransform(projection, epsg4326Projection);
 
   this.projectionCenterLonLat_ = this.toLonLatTransform_(getCenter(extent));
 

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -19,7 +19,7 @@ import _ol_geom_Polygon_ from './geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from './geom/SimpleGeometry.js';
 import _ol_math_ from './math.js';
 import _ol_obj_ from './obj.js';
-import _ol_proj_ from './proj.js';
+import {createProjection, METERS_PER_UNIT} from './proj.js';
 import _ol_proj_Units_ from './proj/Units.js';
 
 
@@ -116,7 +116,7 @@ var _ol_View_ = function(opt_options) {
    * @const
    * @type {ol.proj.Projection}
    */
-  this.projection_ = _ol_proj_.createProjection(options.projection, 'EPSG:3857');
+  this.projection_ = createProjection(options.projection, 'EPSG:3857');
 
   this.applyOptions_(options);
 };
@@ -1129,11 +1129,11 @@ _ol_View_.createResolutionConstraint_ = function(options) {
         resolutions);
   } else {
     // calculate the default min and max resolution
-    var projection = _ol_proj_.createProjection(options.projection, 'EPSG:3857');
+    var projection = createProjection(options.projection, 'EPSG:3857');
     var extent = projection.getExtent();
     var size = !extent ?
       // use an extent that can fit the whole world if need be
-      360 * _ol_proj_.METERS_PER_UNIT[_ol_proj_Units_.DEGREES] /
+      360 * METERS_PER_UNIT[_ol_proj_Units_.DEGREES] /
             projection.getMetersPerUnit() :
       Math.max(getWidth(extent), getHeight(extent));
 

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -7,7 +7,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import _ol_Object_ from '../Object.js';
 import _ol_control_Control_ from '../control/Control.js';
-import _ol_proj_ from '../proj.js';
+import {getTransformFromProjections, identityTransform, get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -200,7 +200,7 @@ _ol_control_MousePosition_.prototype.setCoordinateFormat = function(format) {
  * @api
  */
 _ol_control_MousePosition_.prototype.setProjection = function(projection) {
-  this.set(_ol_control_MousePosition_.Property_.PROJECTION, _ol_proj_.get(projection));
+  this.set(_ol_control_MousePosition_.Property_.PROJECTION, getProjection(projection));
 };
 
 
@@ -214,10 +214,10 @@ _ol_control_MousePosition_.prototype.updateHTML_ = function(pixel) {
     if (!this.transform_) {
       var projection = this.getProjection();
       if (projection) {
-        this.transform_ = _ol_proj_.getTransformFromProjections(
+        this.transform_ = getTransformFromProjections(
             this.mapProjection_, projection);
       } else {
-        this.transform_ = _ol_proj_.identityTransform;
+        this.transform_ = identityTransform;
       }
     }
     var map = this.getMap();

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -8,7 +8,7 @@ import _ol_control_Control_ from '../control/Control.js';
 import _ol_control_ScaleLineUnits_ from '../control/ScaleLineUnits.js';
 import _ol_css_ from '../css.js';
 import _ol_events_ from '../events.js';
-import _ol_proj_ from '../proj.js';
+import {getPointResolution, METERS_PER_UNIT} from '../proj.js';
 import _ol_proj_Units_ from '../proj/Units.js';
 
 /**
@@ -175,7 +175,7 @@ _ol_control_ScaleLine_.prototype.updateElement_ = function() {
     _ol_proj_Units_.DEGREES :
     _ol_proj_Units_.METERS;
   var pointResolution =
-      _ol_proj_.getPointResolution(projection, viewState.resolution, center, pointResolutionUnits);
+      getPointResolution(projection, viewState.resolution, center, pointResolutionUnits);
   if (units != _ol_control_ScaleLineUnits_.DEGREES) {
     pointResolution *= projection.getMetersPerUnit();
   }
@@ -183,7 +183,7 @@ _ol_control_ScaleLine_.prototype.updateElement_ = function() {
   var nominalCount = this.minWidth_ * pointResolution;
   var suffix = '';
   if (units == _ol_control_ScaleLineUnits_.DEGREES) {
-    var metersPerDegree = _ol_proj_.METERS_PER_UNIT[_ol_proj_Units_.DEGREES];
+    var metersPerDegree = METERS_PER_UNIT[_ol_proj_Units_.DEGREES];
     if (projection.getUnits() == _ol_proj_Units_.DEGREES) {
       nominalCount *= metersPerDegree;
     } else {

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -19,7 +19,7 @@ import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_orient_ from '../geom/flat/orient.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -547,7 +547,7 @@ _ol_format_EsriJSON_.prototype.readProjectionFromObject = function(object) {
   var esriJSONObject = /** @type {EsriJSONObject} */ (object);
   if (esriJSONObject.spatialReference && esriJSONObject.spatialReference.wkid) {
     var crs = esriJSONObject.spatialReference.wkid;
-    return _ol_proj_.get('EPSG:' + crs);
+    return getProjection('EPSG:' + crs);
   } else {
     return null;
   }
@@ -627,8 +627,7 @@ _ol_format_EsriJSON_.prototype.writeFeatureObject = function(
       _ol_format_EsriJSON_.writeGeometry_(geometry, opt_options);
     if (opt_options && opt_options.featureProjection) {
       object['geometry']['spatialReference'] = /** @type {EsriJSONCRS} */({
-        wkid: _ol_proj_.get(
-            opt_options.featureProjection).getCode().split(':').pop()
+        wkid: getProjection(opt_options.featureProjection).getCode().split(':').pop()
       });
     }
   }

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -3,7 +3,7 @@
  */
 import _ol_geom_Geometry_ from '../geom/Geometry.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, equivalent as equivalentProjection, transformExtent} from '../proj.js';
 
 /**
  * @classdesc
@@ -175,15 +175,15 @@ _ol_format_Feature_.prototype.writeGeometry = function(geometry, opt_options) {}
 _ol_format_Feature_.transformWithOptions = function(
     geometry, write, opt_options) {
   var featureProjection = opt_options ?
-    _ol_proj_.get(opt_options.featureProjection) : null;
+    getProjection(opt_options.featureProjection) : null;
   var dataProjection = opt_options ?
-    _ol_proj_.get(opt_options.dataProjection) : null;
+    getProjection(opt_options.dataProjection) : null;
   /**
    * @type {ol.geom.Geometry|ol.Extent}
    */
   var transformed;
   if (featureProjection && dataProjection &&
-      !_ol_proj_.equivalent(featureProjection, dataProjection)) {
+      !equivalentProjection(featureProjection, dataProjection)) {
     if (geometry instanceof _ol_geom_Geometry_) {
       transformed = (write ? geometry.clone() : geometry).transform(
           write ? featureProjection : dataProjection,
@@ -191,7 +191,7 @@ _ol_format_Feature_.transformWithOptions = function(
     } else {
       // FIXME this is necessary because ol.format.GML treats extents
       // as geometries
-      transformed = _ol_proj_.transformExtent(
+      transformed = transformExtent(
           geometry,
           dataProjection,
           featureProjection);

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -8,7 +8,7 @@ import _ol_format_GMLBase_ from '../format/GMLBase.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_Geometry_ from '../geom/Geometry.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, transformExtent} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
 /**
@@ -63,7 +63,7 @@ _ol_format_GML2_.prototype.readFlatCoordinates_ = function(node, objectStack) {
   var containerSrs = context['srsName'];
   var axisOrientation = 'enu';
   if (containerSrs) {
-    var proj = _ol_proj_.get(containerSrs);
+    var proj = getProjection(containerSrs);
     if (proj) {
       axisOrientation = proj.getAxisOrientation();
     }
@@ -289,7 +289,7 @@ _ol_format_GML2_.prototype.writeGeometryElement = function(node, geometry, objec
   var value;
   if (Array.isArray(geometry)) {
     if (context.dataProjection) {
-      value = _ol_proj_.transformExtent(
+      value = transformExtent(
           geometry, context.featureProjection, context.dataProjection);
     } else {
       value = geometry;
@@ -467,7 +467,7 @@ _ol_format_GML2_.prototype.writeRing_ = function(node, ring, objectStack) {
 _ol_format_GML2_.prototype.getCoords_ = function(point, opt_srsName, opt_hasZ) {
   var axisOrientation = 'enu';
   if (opt_srsName) {
-    axisOrientation = _ol_proj_.get(opt_srsName).getAxisOrientation();
+    axisOrientation = getProjection(opt_srsName).getAxisOrientation();
   }
   var coords = ((axisOrientation.substr(0, 2) === 'en') ?
     point[0] + ',' + point[1] :

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -14,7 +14,7 @@ import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, transformExtent} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
 /**
@@ -320,7 +320,7 @@ _ol_format_GML3_.prototype.readFlatPos_ = function(node, objectStack) {
   var containerSrs = context['srsName'];
   var axisOrientation = 'enu';
   if (containerSrs) {
-    var proj = _ol_proj_.get(containerSrs);
+    var proj = getProjection(containerSrs);
     axisOrientation = proj.getAxisOrientation();
   }
   if (axisOrientation === 'neu') {
@@ -356,7 +356,7 @@ _ol_format_GML3_.prototype.readFlatPosList_ = function(node, objectStack) {
   var contextDimension = context['srsDimension'];
   var axisOrientation = 'enu';
   if (containerSrs) {
-    var proj = _ol_proj_.get(containerSrs);
+    var proj = getProjection(containerSrs);
     axisOrientation = proj.getAxisOrientation();
   }
   var coords = s.split(/\s+/);
@@ -582,7 +582,7 @@ _ol_format_GML3_.prototype.writePos_ = function(node, value, objectStack) {
   var srsName = context['srsName'];
   var axisOrientation = 'enu';
   if (srsName) {
-    axisOrientation = _ol_proj_.get(srsName).getAxisOrientation();
+    axisOrientation = getProjection(srsName).getAxisOrientation();
   }
   var point = value.getCoordinates();
   var coords;
@@ -611,7 +611,7 @@ _ol_format_GML3_.prototype.writePos_ = function(node, value, objectStack) {
 _ol_format_GML3_.prototype.getCoords_ = function(point, opt_srsName, opt_hasZ) {
   var axisOrientation = 'enu';
   if (opt_srsName) {
-    axisOrientation = _ol_proj_.get(opt_srsName).getAxisOrientation();
+    axisOrientation = getProjection(opt_srsName).getAxisOrientation();
   }
   var coords = ((axisOrientation.substr(0, 2) === 'en') ?
     point[0] + ' ' + point[1] :
@@ -956,7 +956,7 @@ _ol_format_GML3_.prototype.writeGeometryElement = function(node, geometry, objec
   var value;
   if (Array.isArray(geometry)) {
     if (context.dataProjection) {
-      value = _ol_proj_.transformExtent(
+      value = transformExtent(
           geometry, context.featureProjection, context.dataProjection);
     } else {
       value = geometry;

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -18,7 +18,7 @@ import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
 /**
@@ -592,7 +592,7 @@ _ol_format_GMLBase_.prototype.readFeaturesFromNode = function(node, opt_options)
  * @inheritDoc
  */
 _ol_format_GMLBase_.prototype.readProjectionFromNode = function(node) {
-  return _ol_proj_.get(this.srsName ? this.srsName :
+  return getProjection(this.srsName ? this.srsName :
     node.firstElementChild.getAttribute('srsName'));
 };
 export default _ol_format_GMLBase_;

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -11,7 +11,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_Point_ from '../geom/Point.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
 /**
@@ -32,7 +32,7 @@ var _ol_format_GPX_ = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get('EPSG:4326');
+  this.defaultDataProjection = getProjection('EPSG:4326');
 
   /**
    * @type {function(ol.Feature, Node)|undefined}

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -17,7 +17,7 @@ import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -37,13 +37,13 @@ var _ol_format_GeoJSON_ = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get(
+  this.defaultDataProjection = getProjection(
       options.defaultDataProjection ?
         options.defaultDataProjection : 'EPSG:4326');
 
 
   if (options.featureProjection) {
-    this.defaultFeatureProjection = _ol_proj_.get(options.featureProjection);
+    this.defaultFeatureProjection = getProjection(options.featureProjection);
   }
 
   /**
@@ -467,7 +467,7 @@ _ol_format_GeoJSON_.prototype.readProjectionFromObject = function(object) {
   var projection;
   if (crs) {
     if (crs.type == 'name') {
-      projection = _ol_proj_.get(crs.properties.name);
+      projection = getProjection(crs.properties.name);
     } else {
       _ol_asserts_.assert(false, 36); // Unknown SRS type
     }

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -8,7 +8,7 @@ import _ol_format_IGCZ_ from '../format/IGCZ.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -28,7 +28,7 @@ var _ol_format_IGC_ = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get('EPSG:4326');
+  this.defaultDataProjection = getProjection('EPSG:4326');
 
   /**
    * @private

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -24,7 +24,7 @@ import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_math_ from '../math.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_style_Fill_ from '../style/Fill.js';
 import _ol_style_Icon_ from '../style/Icon.js';
 import _ol_style_IconAnchorUnits_ from '../style/IconAnchorUnits.js';
@@ -59,7 +59,7 @@ var _ol_format_KML_ = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get('EPSG:4326');
+  this.defaultDataProjection = getProjection('EPSG:4326');
 
   /**
    * @private

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -12,7 +12,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_Point_ from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
 /**
@@ -30,7 +30,7 @@ var _ol_format_OSMXML_ = function() {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get('EPSG:4326');
+  this.defaultDataProjection = getProjection('EPSG:4326');
 };
 
 inherits(_ol_format_OSMXML_, _ol_format_XMLFeature_);

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -11,7 +11,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_flip_ from '../geom/flat/flip.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -33,7 +33,7 @@ var _ol_format_Polyline_ = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get('EPSG:4326');
+  this.defaultDataProjection = getProjection('EPSG:4326');
 
   /**
    * @private

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -11,7 +11,7 @@ import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -43,7 +43,7 @@ var _ol_format_TopoJSON_ = function(opt_options) {
   /**
    * @inheritDoc
    */
-  this.defaultDataProjection = _ol_proj_.get(
+  this.defaultDataProjection = getProjection(
       options.defaultDataProjection ?
         options.defaultDataProjection : 'EPSG:4326');
 

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -11,7 +11,7 @@ import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_Geometry_ from '../geom/Geometry.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
 /**
@@ -1098,7 +1098,7 @@ _ol_format_WFS_.prototype.readProjectionFromNode = function(node) {
           n.firstChild.nodeType === 3))) {
         var objectStack = [{}];
         this.gmlFormat_.readGeometryElement(n, objectStack);
-        return _ol_proj_.get(objectStack.pop().srsName);
+        return getProjection(objectStack.pop().srsName);
       }
     }
   }

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -6,7 +6,7 @@ import _ol_Object_ from '../Object.js';
 import {createEmpty, getHeight, returnOrUpdate} from '../extent.js';
 import _ol_functions_ from '../functions.js';
 import _ol_geom_flat_transform_ from '../geom/flat/transform.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, getTransform} from '../proj.js';
 import _ol_proj_Units_ from '../proj/Units.js';
 import _ol_transform_ from '../transform.js';
 
@@ -255,7 +255,7 @@ _ol_geom_Geometry_.prototype.translate = function(deltaX, deltaY) {};
  */
 _ol_geom_Geometry_.prototype.transform = function(source, destination) {
   var tmpTransform = this.tmpTransform_;
-  source = _ol_proj_.get(source);
+  source = getProjection(source);
   var transformFn = source.getUnits() == _ol_proj_Units_.TILE_PIXELS ?
     function(inCoordinates, outCoordinates, stride) {
       var pixelExtent = source.getExtent();
@@ -267,9 +267,9 @@ _ol_geom_Geometry_.prototype.transform = function(source, destination) {
           0, 0);
       _ol_geom_flat_transform_.transform2D(inCoordinates, 0, inCoordinates.length, stride,
           tmpTransform, outCoordinates);
-      return _ol_proj_.getTransform(source, destination)(inCoordinates, outCoordinates, stride);
+      return getTransform(source, destination)(inCoordinates, outCoordinates, stride);
     } :
-    _ol_proj_.getTransform(source, destination);
+    getTransform(source, destination);
   this.applyTransform(transformFn);
   return this;
 };

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -2,7 +2,7 @@
  * @module ol/geom/flat/geodesic
  */
 import _ol_math_ from '../../math.js';
-import _ol_proj_ from '../../proj.js';
+import {get as getProjection, getTransform} from '../../proj.js';
 var _ol_geom_flat_geodesic_ = {};
 
 
@@ -93,7 +93,7 @@ _ol_geom_flat_geodesic_.line_ = function(interpolate, transform, squaredToleranc
 _ol_geom_flat_geodesic_.greatCircleArc = function(
     lon1, lat1, lon2, lat2, projection, squaredTolerance) {
 
-  var geoProjection = _ol_proj_.get('EPSG:4326');
+  var geoProjection = getProjection('EPSG:4326');
 
   var cosLat1 = Math.cos(_ol_math_.toRadians(lat1));
   var sinLat1 = Math.sin(_ol_math_.toRadians(lat1));
@@ -123,7 +123,7 @@ _ol_geom_flat_geodesic_.greatCircleArc = function(
             Math.atan2(Math.sin(theta) * sinD * cosLat1,
                 cosD - sinLat1 * Math.sin(lat));
         return [_ol_math_.toDegrees(lon), _ol_math_.toDegrees(lat)];
-      }, _ol_proj_.getTransform(geoProjection, projection), squaredTolerance);
+      }, getTransform(geoProjection, projection), squaredTolerance);
 };
 
 
@@ -137,7 +137,7 @@ _ol_geom_flat_geodesic_.greatCircleArc = function(
  * @return {Array.<number>} Flat coordinates.
  */
 _ol_geom_flat_geodesic_.meridian = function(lon, lat1, lat2, projection, squaredTolerance) {
-  var epsg4326Projection = _ol_proj_.get('EPSG:4326');
+  var epsg4326Projection = getProjection('EPSG:4326');
   return _ol_geom_flat_geodesic_.line_(
       /**
        * @param {number} frac Fraction.
@@ -146,7 +146,7 @@ _ol_geom_flat_geodesic_.meridian = function(lon, lat1, lat2, projection, squared
       function(frac) {
         return [lon, lat1 + ((lat2 - lat1) * frac)];
       },
-      _ol_proj_.getTransform(epsg4326Projection, projection), squaredTolerance);
+      getTransform(epsg4326Projection, projection), squaredTolerance);
 };
 
 
@@ -160,7 +160,7 @@ _ol_geom_flat_geodesic_.meridian = function(lon, lat1, lat2, projection, squared
  * @return {Array.<number>} Flat coordinates.
  */
 _ol_geom_flat_geodesic_.parallel = function(lat, lon1, lon2, projection, squaredTolerance) {
-  var epsg4326Projection = _ol_proj_.get('EPSG:4326');
+  var epsg4326Projection = getProjection('EPSG:4326');
   return _ol_geom_flat_geodesic_.line_(
       /**
        * @param {number} frac Fraction.
@@ -169,6 +169,6 @@ _ol_geom_flat_geodesic_.parallel = function(lat, lon1, lon2, projection, squared
       function(frac) {
         return [lon1 + ((lon2 - lon1) * frac), lat];
       },
-      _ol_proj_.getTransform(epsg4326Projection, projection), squaredTolerance);
+      getTransform(epsg4326Projection, projection), squaredTolerance);
 };
 export default _ol_geom_flat_geodesic_;

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -9,7 +9,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_Event_ from '../events/Event.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import _ol_interaction_Interaction_ from '../interaction/Interaction.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 
 /**
  * @classdesc
@@ -41,7 +41,7 @@ var _ol_interaction_DragAndDrop_ = function(opt_options) {
    * @type {ol.proj.Projection}
    */
   this.projection_ = options.projection ?
-    _ol_proj_.get(options.projection) : null;
+    getProjection(options.projection) : null;
 
   /**
    * @private

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -10,7 +10,7 @@ import _ol_events_EventType_ from '../../events/EventType.js';
 import _ol_ext_rbush_ from 'rbush';
 import {buffer, containsCoordinate, equals, getIntersection, getTopLeft, intersects} from '../../extent.js';
 import _ol_layer_VectorTileRenderType_ from '../../layer/VectorTileRenderType.js';
-import _ol_proj_ from '../../proj.js';
+import {equivalent as equivalentProjection} from '../../proj.js';
 import _ol_proj_Units_ from '../../proj/Units.js';
 import _ol_render_ReplayType_ from '../../render/ReplayType.js';
 import _ol_render_canvas_ from '../../render/canvas.js';
@@ -185,7 +185,7 @@ _ol_renderer_canvas_VectorTileLayer_.prototype.createReplayGroup_ = function(
       buffer(sharedExtent, layer.getRenderBuffer() * resolution);
     var tileProjection = sourceTile.getProjection();
     var reproject = false;
-    if (!_ol_proj_.equivalent(projection, tileProjection)) {
+    if (!equivalentProjection(projection, tileProjection)) {
       reproject = true;
       sourceTile.setProjection(projection);
     }

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -4,7 +4,7 @@
 import _ol_dom_ from './dom.js';
 import {containsCoordinate, createEmpty, extend, getHeight, getTopLeft, getWidth} from './extent.js';
 import _ol_math_ from './math.js';
-import _ol_proj_ from './proj.js';
+import {getPointResolution, transform} from './proj.js';
 var _ol_reproj_ = {};
 
 
@@ -23,11 +23,10 @@ var _ol_reproj_ = {};
 _ol_reproj_.calculateSourceResolution = function(sourceProj, targetProj,
     targetCenter, targetResolution) {
 
-  var sourceCenter = _ol_proj_.transform(targetCenter, targetProj, sourceProj);
+  var sourceCenter = transform(targetCenter, targetProj, sourceProj);
 
   // calculate the ideal resolution of the source data
-  var sourceResolution =
-      _ol_proj_.getPointResolution(targetProj, targetResolution, targetCenter);
+  var sourceResolution = getPointResolution(targetProj, targetResolution, targetCenter);
 
   var targetMetersPerUnit = targetProj.getMetersPerUnit();
   if (targetMetersPerUnit !== undefined) {
@@ -44,8 +43,7 @@ _ol_reproj_.calculateSourceResolution = function(sourceProj, targetProj,
 
   var sourceExtent = sourceProj.getExtent();
   if (!sourceExtent || containsCoordinate(sourceExtent, sourceCenter)) {
-    var compensationFactor =
-        _ol_proj_.getPointResolution(sourceProj, sourceResolution, sourceCenter) /
+    var compensationFactor = getPointResolution(sourceProj, sourceResolution, sourceCenter) /
         sourceResolution;
     if (isFinite(compensationFactor) && compensationFactor > 0) {
       sourceResolution /= compensationFactor;

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -4,7 +4,7 @@
 import {boundingExtent, createEmpty, extendCoordinate, getBottomLeft, getBottomRight,
   getTopLeft, getTopRight, getWidth, intersects} from '../extent.js';
 import _ol_math_ from '../math.js';
-import _ol_proj_ from '../proj.js';
+import {getTransform} from '../proj.js';
 
 
 /**
@@ -58,7 +58,7 @@ var _ol_reproj_Triangulation_ = function(sourceProj, targetProj, targetExtent,
 
   /** @type {!Object.<string, ol.Coordinate>} */
   var transformInvCache = {};
-  var transformInv = _ol_proj_.getTransform(this.targetProj_, this.sourceProj_);
+  var transformInv = getTransform(this.targetProj_, this.sourceProj_);
 
   /**
    * @param {ol.Coordinate} c A coordinate.

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_TileUrlFunction_ from '../TileUrlFunction.js';
 import {applyTransform, intersects} from '../extent.js';
 import _ol_net_ from '../net.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import _ol_source_State_ from '../source/State.js';
 import _ol_source_TileImage_ from '../source/TileImage.js';
 import _ol_tilecoord_ from '../tilecoord.js';
@@ -32,7 +32,7 @@ var _ol_source_BingMaps_ = function(options) {
     cacheSize: options.cacheSize,
     crossOrigin: 'anonymous',
     opaque: true,
-    projection: _ol_proj_.get('EPSG:3857'),
+    projection: getProjection('EPSG:3857'),
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,
     state: _ol_source_State_.LOADING,
     tileLoadFunction: options.tileLoadFunction,
@@ -178,8 +178,8 @@ _ol_source_BingMaps_.prototype.handleImageryMetadataResponse = function(response
       }));
 
   if (resource.imageryProviders) {
-    var transform = _ol_proj_.getTransformFromProjections(
-        _ol_proj_.get('EPSG:4326'), this.getProjection());
+    var transform = getTransformFromProjections(
+        getProjection('EPSG:4326'), this.getProjection());
 
     this.setAttributions(function(frameState) {
       var attributions = [];

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -7,7 +7,7 @@ import _ol_ImageState_ from '../ImageState.js';
 import _ol_array_ from '../array.js';
 import _ol_events_Event_ from '../events/Event.js';
 import {equals} from '../extent.js';
-import _ol_proj_ from '../proj.js';
+import {equivalent} from '../proj.js';
 import _ol_reproj_Image_ from '../reproj/Image.js';
 import _ol_source_Source_ from '../source/Source.js';
 
@@ -92,7 +92,7 @@ _ol_source_Image_.prototype.getImage = function(extent, resolution, pixelRatio, 
   if (!ENABLE_RASTER_REPROJECTION ||
       !sourceProjection ||
       !projection ||
-      _ol_proj_.equivalent(sourceProjection, projection)) {
+      equivalent(sourceProjection, projection)) {
     if (sourceProjection) {
       projection = sourceProjection;
     }
@@ -100,7 +100,7 @@ _ol_source_Image_.prototype.getImage = function(extent, resolution, pixelRatio, 
   } else {
     if (this.reprojectedImage_) {
       if (this.reprojectedRevision_ == this.getRevision() &&
-          _ol_proj_.equivalent(
+          equivalent(
               this.reprojectedImage_.getProjection(), projection) &&
           this.reprojectedImage_.getResolution() == resolution &&
           equals(this.reprojectedImage_.getExtent(), extent)) {

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -8,7 +8,7 @@ import _ol_dom_ from '../dom.js';
 import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {intersects, getHeight, getWidth} from '../extent.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_source_Image_ from '../source/Image.js';
 
 /**
@@ -33,7 +33,7 @@ var _ol_source_ImageStatic_ = function(options) {
   _ol_source_Image_.call(this, {
     attributions: options.attributions,
     logo: options.logo,
-    projection: _ol_proj_.get(options.projection)
+    projection: getProjection(options.projection)
   });
 
   /**

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -10,7 +10,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {containsExtent, getCenter, getForViewAndSize, getHeight, getWidth} from '../extent.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, transform} from '../proj.js';
 import _ol_reproj_ from '../reproj.js';
 import _ol_source_Image_ from '../source/Image.js';
 import _ol_source_WMSServerType_ from '../source/WMSServerType.js';
@@ -138,12 +138,12 @@ _ol_source_ImageWMS_.prototype.getGetFeatureInfoUrl = function(coordinate, resol
   if (this.url_ === undefined) {
     return undefined;
   }
-  var projectionObj = _ol_proj_.get(projection);
+  var projectionObj = getProjection(projection);
   var sourceProjectionObj = this.getProjection();
 
   if (sourceProjectionObj && sourceProjectionObj !== projectionObj) {
     resolution = _ol_reproj_.calculateSourceResolution(sourceProjectionObj, projectionObj, coordinate, resolution);
-    coordinate = _ol_proj_.transform(coordinate, projectionObj, sourceProjectionObj);
+    coordinate = transform(coordinate, projectionObj, sourceProjectionObj);
   }
 
   var extent = getForViewAndSize(coordinate, resolution, 0,

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -3,7 +3,7 @@
  */
 import {inherits, nullFunction} from '../index.js';
 import _ol_Object_ from '../Object.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_source_State_ from '../source/State.js';
 
 /**
@@ -28,7 +28,7 @@ var _ol_source_Source_ = function(options) {
    * @private
    * @type {ol.proj.Projection}
    */
-  this.projection_ = _ol_proj_.get(options.projection);
+  this.projection_ = getProjection(options.projection);
 
   /**
    * @private

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -5,7 +5,7 @@ import {inherits, nullFunction} from '../index.js';
 import _ol_TileCache_ from '../TileCache.js';
 import _ol_TileState_ from '../TileState.js';
 import _ol_events_Event_ from '../events/Event.js';
-import _ol_proj_ from '../proj.js';
+import {equivalent} from '../proj.js';
 import _ol_size_ from '../size.js';
 import _ol_source_Source_ from '../source/Source.js';
 import _ol_tilecoord_ from '../tilecoord.js';
@@ -230,7 +230,7 @@ _ol_source_Tile_.prototype.getTileGridForProjection = function(projection) {
  */
 _ol_source_Tile_.prototype.getTileCacheForProjection = function(projection) {
   var thisProj = this.getProjection();
-  if (thisProj && !_ol_proj_.equivalent(thisProj, projection)) {
+  if (thisProj && !equivalent(thisProj, projection)) {
     return null;
   } else {
     return this.tileCache;

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -8,7 +8,7 @@ import _ol_TileCache_ from '../TileCache.js';
 import _ol_TileState_ from '../TileState.js';
 import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
-import _ol_proj_ from '../proj.js';
+import {equivalent, get as getProjection} from '../proj.js';
 import _ol_reproj_Tile_ from '../reproj/Tile.js';
 import _ol_source_UrlTile_ from '../source/UrlTile.js';
 import _ol_tilecoord_ from '../tilecoord.js';
@@ -131,8 +131,7 @@ _ol_source_TileImage_.prototype.expireCache = function(projection, usedTiles) {
  */
 _ol_source_TileImage_.prototype.getGutter = function(projection) {
   if (ENABLE_RASTER_REPROJECTION &&
-      this.getProjection() && projection &&
-      !_ol_proj_.equivalent(this.getProjection(), projection)) {
+      this.getProjection() && projection && !equivalent(this.getProjection(), projection)) {
     return 0;
   } else {
     return this.getGutterInternal();
@@ -154,8 +153,7 @@ _ol_source_TileImage_.prototype.getGutterInternal = function() {
  */
 _ol_source_TileImage_.prototype.getOpaque = function(projection) {
   if (ENABLE_RASTER_REPROJECTION &&
-      this.getProjection() && projection &&
-      !_ol_proj_.equivalent(this.getProjection(), projection)) {
+      this.getProjection() && projection && !equivalent(this.getProjection(), projection)) {
     return false;
   } else {
     return _ol_source_UrlTile_.prototype.getOpaque.call(this, projection);
@@ -171,8 +169,7 @@ _ol_source_TileImage_.prototype.getTileGridForProjection = function(projection) 
     return _ol_source_UrlTile_.prototype.getTileGridForProjection.call(this, projection);
   }
   var thisProj = this.getProjection();
-  if (this.tileGrid &&
-      (!thisProj || _ol_proj_.equivalent(thisProj, projection))) {
+  if (this.tileGrid && (!thisProj || equivalent(thisProj, projection))) {
     return this.tileGrid;
   } else {
     var projKey = getUid(projection).toString();
@@ -192,8 +189,7 @@ _ol_source_TileImage_.prototype.getTileCacheForProjection = function(projection)
   if (!ENABLE_RASTER_REPROJECTION) {
     return _ol_source_UrlTile_.prototype.getTileCacheForProjection.call(this, projection);
   }
-  var thisProj = this.getProjection();
-  if (!thisProj || _ol_proj_.equivalent(thisProj, projection)) {
+  var thisProj = this.getProjection(); if (!thisProj || equivalent(thisProj, projection)) {
     return this.tileCache;
   } else {
     var projKey = getUid(projection).toString();
@@ -241,8 +237,7 @@ _ol_source_TileImage_.prototype.createTile_ = function(z, x, y, pixelRatio, proj
 _ol_source_TileImage_.prototype.getTile = function(z, x, y, pixelRatio, projection) {
   var sourceProjection = /** @type {!ol.proj.Projection} */ (this.getProjection());
   if (!ENABLE_RASTER_REPROJECTION ||
-      !sourceProjection || !projection ||
-      _ol_proj_.equivalent(sourceProjection, projection)) {
+      !sourceProjection || !projection || equivalent(sourceProjection, projection)) {
     return this.getTileInternal(z, x, y, pixelRatio, sourceProjection || projection);
   } else {
     var cache = this.getTileCacheForProjection(projection);
@@ -356,7 +351,7 @@ _ol_source_TileImage_.prototype.setRenderReprojectionEdges = function(render) {
  */
 _ol_source_TileImage_.prototype.setTileGridForProjection = function(projection, tilegrid) {
   if (ENABLE_RASTER_REPROJECTION) {
-    var proj = _ol_proj_.get(projection);
+    var proj = getProjection(projection);
     if (proj) {
       var projKey = getUid(proj).toString();
       if (!(projKey in this.tileGridForProjection)) {

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -12,7 +12,7 @@ import _ol_TileUrlFunction_ from '../TileUrlFunction.js';
 import _ol_asserts_ from '../asserts.js';
 import {applyTransform, intersects} from '../extent.js';
 import _ol_net_ from '../net.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import _ol_source_State_ from '../source/State.js';
 import _ol_source_TileImage_ from '../source/TileImage.js';
 import _ol_tilegrid_ from '../tilegrid.js';
@@ -38,7 +38,7 @@ var _ol_source_TileJSON_ = function(options) {
     attributions: options.attributions,
     cacheSize: options.cacheSize,
     crossOrigin: options.crossOrigin,
-    projection: _ol_proj_.get('EPSG:3857'),
+    projection: getProjection('EPSG:3857'),
     reprojectionErrorThreshold: options.reprojectionErrorThreshold,
     state: _ol_source_State_.LOADING,
     tileLoadFunction: options.tileLoadFunction,
@@ -114,12 +114,12 @@ _ol_source_TileJSON_.prototype.getTileJSON = function() {
  */
 _ol_source_TileJSON_.prototype.handleTileJSONResponse = function(tileJSON) {
 
-  var epsg4326Projection = _ol_proj_.get('EPSG:4326');
+  var epsg4326Projection = getProjection('EPSG:4326');
 
   var sourceProjection = this.getProjection();
   var extent;
   if (tileJSON.bounds !== undefined) {
-    var transform = _ol_proj_.getTransformFromProjections(
+    var transform = getTransformFromProjections(
         epsg4326Projection, sourceProjection);
     extent = applyTransform(tileJSON.bounds, transform);
   }

--- a/src/ol/source/TileUTFGrid.js
+++ b/src/ol/source/TileUTFGrid.js
@@ -10,7 +10,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {applyTransform, intersects} from '../extent.js';
 import _ol_net_ from '../net.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import _ol_source_State_ from '../source/State.js';
 import _ol_source_Tile_ from '../source/Tile.js';
 import _ol_tilecoord_ from '../tilecoord.js';
@@ -27,7 +27,7 @@ import _ol_tilegrid_ from '../tilegrid.js';
  */
 var _ol_source_TileUTFGrid_ = function(options) {
   _ol_source_Tile_.call(this, {
-    projection: _ol_proj_.get('EPSG:3857'),
+    projection: getProjection('EPSG:3857'),
     state: _ol_source_State_.LOADING
   });
 
@@ -166,12 +166,12 @@ _ol_source_TileUTFGrid_.prototype.handleTileJSONError = function() {
  */
 _ol_source_TileUTFGrid_.prototype.handleTileJSONResponse = function(tileJSON) {
 
-  var epsg4326Projection = _ol_proj_.get('EPSG:4326');
+  var epsg4326Projection = getProjection('EPSG:4326');
 
   var sourceProjection = this.getProjection();
   var extent;
   if (tileJSON.bounds !== undefined) {
-    var transform = _ol_proj_.getTransformFromProjections(
+    var transform = getTransformFromProjections(
         epsg4326Projection, sourceProjection);
     extent = applyTransform(tileJSON.bounds, transform);
   }

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -8,7 +8,7 @@ import _ol_asserts_ from '../asserts.js';
 import {buffer, createEmpty} from '../extent.js';
 import _ol_obj_ from '../obj.js';
 import _ol_math_ from '../math.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, transform, transformExtent} from '../proj.js';
 import _ol_reproj_ from '../reproj.js';
 import _ol_size_ from '../size.js';
 import _ol_source_TileImage_ from '../source/TileImage.js';
@@ -110,7 +110,7 @@ inherits(_ol_source_TileWMS_, _ol_source_TileImage_);
  * @api
  */
 _ol_source_TileWMS_.prototype.getGetFeatureInfoUrl = function(coordinate, resolution, projection, params) {
-  var projectionObj = _ol_proj_.get(projection);
+  var projectionObj = getProjection(projection);
   var sourceProjectionObj = this.getProjection();
 
   var tileGrid = this.getTileGrid();
@@ -137,8 +137,8 @@ _ol_source_TileWMS_.prototype.getGetFeatureInfoUrl = function(coordinate, resolu
 
   if (sourceProjectionObj && sourceProjectionObj !== projectionObj) {
     tileResolution = _ol_reproj_.calculateSourceResolution(sourceProjectionObj, projectionObj, coordinate, tileResolution);
-    tileExtent = _ol_proj_.transformExtent(tileExtent, projectionObj, sourceProjectionObj);
-    coordinate = _ol_proj_.transform(coordinate, projectionObj, sourceProjectionObj);
+    tileExtent = transformExtent(tileExtent, projectionObj, sourceProjectionObj);
+    coordinate = transform(coordinate, projectionObj, sourceProjectionObj);
   }
 
   var baseParams = {

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -6,7 +6,7 @@ import _ol_TileUrlFunction_ from '../TileUrlFunction.js';
 import _ol_array_ from '../array.js';
 import {containsExtent} from '../extent.js';
 import _ol_obj_ from '../obj.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection, equivalent, transformExtent} from '../proj.js';
 import _ol_source_TileImage_ from '../source/TileImage.js';
 import _ol_source_WMTSRequestEncoding_ from '../source/WMTSRequestEncoding.js';
 import _ol_tilegrid_WMTS_ from '../tilegrid/WMTS.js';
@@ -330,11 +330,11 @@ _ol_source_WMTS_.optionsFromCapabilities = function(wmtsCap, config) {
               return el['Identifier'] == elt['TileMatrixSet'];
             });
             var supportedCRS = tileMatrixSet['SupportedCRS'];
-            var proj1 = _ol_proj_.get(supportedCRS.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')) ||
-                _ol_proj_.get(supportedCRS);
-            var proj2 = _ol_proj_.get(config['projection']);
+            var proj1 = getProjection(supportedCRS.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')) ||
+                getProjection(supportedCRS);
+            var proj2 = getProjection(config['projection']);
             if (proj1 && proj2) {
-              return _ol_proj_.equivalent(proj1, proj2);
+              return equivalent(proj1, proj2);
             } else {
               return supportedCRS == config['projection'];
             }
@@ -392,13 +392,13 @@ _ol_source_WMTS_.optionsFromCapabilities = function(wmtsCap, config) {
   var projection;
   var code = matrixSetObj['SupportedCRS'];
   if (code) {
-    projection = _ol_proj_.get(code.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')) ||
-        _ol_proj_.get(code);
+    projection = getProjection(code.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')) ||
+        getProjection(code);
   }
   if ('projection' in config) {
-    var projConfig = _ol_proj_.get(config['projection']);
+    var projConfig = getProjection(config['projection']);
     if (projConfig) {
-      if (!projection || _ol_proj_.equivalent(projConfig, projection)) {
+      if (!projection || equivalent(projConfig, projection)) {
         projection = projConfig;
       }
     }
@@ -407,10 +407,10 @@ _ol_source_WMTS_.optionsFromCapabilities = function(wmtsCap, config) {
   var wgs84BoundingBox = l['WGS84BoundingBox'];
   var extent, wrapX;
   if (wgs84BoundingBox !== undefined) {
-    var wgs84ProjectionExtent = _ol_proj_.get('EPSG:4326').getExtent();
+    var wgs84ProjectionExtent = getProjection('EPSG:4326').getExtent();
     wrapX = (wgs84BoundingBox[0] == wgs84ProjectionExtent[0] &&
         wgs84BoundingBox[2] == wgs84ProjectionExtent[2]);
-    extent = _ol_proj_.transformExtent(
+    extent = transformExtent(
         wgs84BoundingBox, 'EPSG:4326', projection);
     var projectionExtent = projection.getExtent();
     if (projectionExtent) {

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -6,7 +6,7 @@ import _ol_size_ from './size.js';
 import {containsCoordinate, createOrUpdate, getCorner, getHeight, getWidth} from './extent.js';
 import Corner from './extent/Corner.js';
 import _ol_obj_ from './obj.js';
-import _ol_proj_ from './proj.js';
+import {get as getProjection, METERS_PER_UNIT} from './proj.js';
 import _ol_proj_Units_ from './proj/Units.js';
 import _ol_tilegrid_TileGrid_ from './tilegrid/TileGrid.js';
 var _ol_tilegrid_ = {};
@@ -83,7 +83,7 @@ _ol_tilegrid_.createXYZ = function(opt_options) {
   _ol_obj_.assign(options, opt_options !== undefined ?
     opt_options : /** @type {olx.tilegrid.XYZOptions} */ ({}));
   if (options.extent === undefined) {
-    options.extent = _ol_proj_.get('EPSG:3857').getExtent();
+    options.extent = getProjection('EPSG:3857').getExtent();
   }
   options.resolutions = _ol_tilegrid_.resolutionsFromExtent(
       options.extent, options.maxZoom, options.tileSize);
@@ -147,10 +147,10 @@ _ol_tilegrid_.createForProjection = function(projection, opt_maxZoom, opt_tileSi
  * @return {ol.Extent} Extent.
  */
 _ol_tilegrid_.extentFromProjection = function(projection) {
-  projection = _ol_proj_.get(projection);
+  projection = getProjection(projection);
   var extent = projection.getExtent();
   if (!extent) {
-    var half = 180 * _ol_proj_.METERS_PER_UNIT[_ol_proj_Units_.DEGREES] /
+    var half = 180 * METERS_PER_UNIT[_ol_proj_Units_.DEGREES] /
         projection.getMetersPerUnit();
     extent = createOrUpdate(-half, -half, half, half);
   }

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
-import _ol_proj_ from '../proj.js';
+import {get as getProjection} from '../proj.js';
 import _ol_tilegrid_TileGrid_ from '../tilegrid/TileGrid.js';
 
 /**
@@ -94,8 +94,8 @@ _ol_tilegrid_WMTS_.createFromCapabilitiesMatrixSet = function(matrixSet, opt_ext
   var tileHeightPropName = 'TileHeight';
 
   var code = matrixSet[supportedCRSPropName];
-  var projection = _ol_proj_.get(code.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')) ||
-      _ol_proj_.get(code);
+  var projection = getProjection(code.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')) ||
+      getProjection(code);
   var metersPerUnit = projection.getMetersPerUnit();
   // swap origin x and y coordinates if axis orientation is lat/long
   var switchOriginXY = projection.getAxisOrientation().substr(0, 2) == 'ne';

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -5,6 +5,7 @@ const pkg = require('../package.json');
 
 module.exports = function(karma) {
   karma.set({
+    browserDisconnectTolerance: 2,
     frameworks: ['mocha'],
     client: {
       runInParent: true,

--- a/test/rendering/ol/layer/image.test.js
+++ b/test/rendering/ol/layer/image.test.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Image_ from '../../../../src/ol/layer/Image.js';
 import _ol_obj_ from '../../../../src/ol/obj.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform, transformExtent} from '../../../../src/ol/proj.js';
 import _ol_source_ImageStatic_ from '../../../../src/ol/source/ImageStatic.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
 
@@ -17,7 +17,7 @@ describe('ol.rendering.layer.Image', function() {
       target: createMapDiv(50, 50),
       renderer: renderer,
       view: new _ol_View_({
-        center: _ol_proj_.transform(
+        center: transform(
             [-122.416667, 37.783333], 'EPSG:4326', 'EPSG:3857'),
         zoom: 5
       })
@@ -69,7 +69,7 @@ describe('ol.rendering.layer.Image', function() {
         url: 'rendering/ol/data/tiles/osm/5/5/12.png',
         imageExtent: _ol_tilegrid_.createXYZ().getTileCoordExtent(
             [5, 5, -12 - 1]),
-        projection: _ol_proj_.get('EPSG:3857')
+        projection: getProjection('EPSG:3857')
       });
     });
 
@@ -97,7 +97,7 @@ describe('ol.rendering.layer.Image', function() {
     beforeEach(function() {
       source = new _ol_source_ImageStatic_({
         url: 'rendering/ol/data/tiles/osm/5/5/12.png',
-        imageExtent: _ol_proj_.transformExtent(
+        imageExtent: transformExtent(
             [-123, 37, -122, 38], 'EPSG:4326', 'EPSG:3857')
       });
     });

--- a/test/rendering/ol/layer/tile.test.js
+++ b/test/rendering/ol/layer/tile.test.js
@@ -4,7 +4,7 @@ import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../../../../src/ol/layer/Tile.js';
 import _ol_obj_ from '../../../../src/ol/obj.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {transform} from '../../../../src/ol/proj.js';
 import _ol_source_TileImage_ from '../../../../src/ol/source/TileImage.js';
 import _ol_source_XYZ_ from '../../../../src/ol/source/XYZ.js';
 import _ol_style_Circle_ from '../../../../src/ol/style/Circle.js';
@@ -25,7 +25,7 @@ describe('ol.rendering.layer.Tile', function() {
       target: createMapDiv(size[0], size[1]),
       renderer: renderer,
       view: new _ol_View_({
-        center: opt_center !== undefined ? opt_center : _ol_proj_.transform(
+        center: opt_center !== undefined ? opt_center : transform(
             [-122.416667, 37.783333], 'EPSG:4326', 'EPSG:3857'),
         resolutions: opt_resolutions,
         zoom: 5
@@ -285,7 +285,7 @@ describe('ol.rendering.layer.Tile', function() {
             stroke: new _ol_style_Stroke_({color: 'red', width: 1})
           }));
           e.vectorContext.drawPoint(new _ol_geom_Point_(
-              _ol_proj_.transform([-123, 38], 'EPSG:4326', 'EPSG:3857')));
+              transform([-123, 38], 'EPSG:4326', 'EPSG:3857')));
         });
       };
     });

--- a/test/rendering/ol/reproj/image.test.js
+++ b/test/rendering/ol/reproj/image.test.js
@@ -1,5 +1,5 @@
 import _ol_events_ from '../../../../src/ol/events.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
 import _ol_reproj_Image_ from '../../../../src/ol/reproj/Image.js';
 import _ol_source_ImageStatic_ from '../../../../src/ol/source/ImageStatic.js';
@@ -14,7 +14,7 @@ describe('ol.rendering.reproj.Image', function() {
 
     var imagesRequested = 0;
 
-    var image = new _ol_reproj_Image_(sourceProj, _ol_proj_.get(targetProj),
+    var image = new _ol_reproj_Image_(sourceProj, getProjection(targetProj),
         targetExtent, targetResolution, pixelRatio,
         function(extent, resolution, pixelRatio) {
           imagesRequested++;
@@ -38,7 +38,7 @@ describe('ol.rendering.reproj.Image', function() {
       source = new _ol_source_ImageStatic_({
         url: 'rendering/ol/data/tiles/osm/5/5/12.png',
         imageExtent: _ol_tilegrid_.createXYZ().getTileCoordExtent([5, 5, -13]),
-        projection: _ol_proj_.get('EPSG:3857')
+        projection: getProjection('EPSG:3857')
       });
     });
 

--- a/test/rendering/ol/reproj/tile.test.js
+++ b/test/rendering/ol/reproj/tile.test.js
@@ -1,6 +1,6 @@
 import _ol_TileState_ from '../../../../src/ol/TileState.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_reproj_Tile_ from '../../../../src/ol/reproj/Tile.js';
 import _ol_source_XYZ_ from '../../../../src/ol/source/XYZ.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
@@ -16,7 +16,7 @@ describe('ol.rendering.reproj.Tile', function() {
     var tilesRequested = 0;
 
     var tile = new _ol_reproj_Tile_(sourceProjection, source.getTileGrid(),
-        _ol_proj_.get(targetProjection), targetTileGrid,
+        getProjection(targetProjection), targetTileGrid,
         [z, x, y], null, pixelRatio, sourceGutter,
         function(z, x, y, pixelRatio) {
           tilesRequested++;
@@ -58,7 +58,7 @@ describe('ol.rendering.reproj.Tile', function() {
       proj4.defs('EPSG:5070',
           '+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +x_0=0 ' +
           '+y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-      var proj5070 = _ol_proj_.get('EPSG:5070');
+      var proj5070 = getProjection('EPSG:5070');
       proj5070.setExtent([-6e6, 0, 4e6, 6e6]);
 
       var tileGrid = _ol_tilegrid_.createForProjection('EPSG:5070', 5, [64, 64]);
@@ -69,7 +69,7 @@ describe('ol.rendering.reproj.Tile', function() {
     it('to ESRI:54009', function(done) {
       proj4.defs('ESRI:54009',
           '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
-      var proj54009 = _ol_proj_.get('ESRI:54009');
+      var proj54009 = getProjection('ESRI:54009');
       proj54009.setExtent([-18e6, -9e6, 18e6, 9e6]);
 
       var tileGrid = _ol_tilegrid_.createForProjection('ESRI:54009', 7, [64, 64]);
@@ -96,7 +96,7 @@ describe('ol.rendering.reproj.Tile', function() {
       proj4.defs('EPSG:3740',
           '+proj=utm +zone=10 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 ' +
           '+units=m +no_defs');
-      var proj3740 = _ol_proj_.get('EPSG:3740');
+      var proj3740 = getProjection('EPSG:3740');
       proj3740.setExtent([318499.05, 2700792.39, 4359164.89, 7149336.98]);
 
       var tileGrid = _ol_tilegrid_.createForProjection('EPSG:3740', 4, [64, 64]);
@@ -158,7 +158,7 @@ describe('ol.rendering.reproj.Tile', function() {
 
     it('wraps X when prime meridian is shifted', function(done) {
       proj4.defs('merc_180', '+proj=merc +lon_0=180 +units=m +no_defs');
-      var proj_ = _ol_proj_.get('merc_180');
+      var proj_ = getProjection('merc_180');
       proj_.setExtent([-20026376.39, -20048966.10, 20026376.39, 20048966.10]);
 
       var tileGrid = _ol_tilegrid_.createForProjection('merc_180', 0, [64, 64]);
@@ -169,7 +169,7 @@ describe('ol.rendering.reproj.Tile', function() {
     it('displays north pole correctly (EPSG:3413)', function(done) {
       proj4.defs('EPSG:3413', '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 ' +
           '+k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
-      var proj3413 = _ol_proj_.get('EPSG:3413');
+      var proj3413 = getProjection('EPSG:3413');
       proj3413.setExtent([-4194304, -4194304, 4194304, 4194304]);
 
       var tileGrid = _ol_tilegrid_.createForProjection('EPSG:3413', 0, [64, 64]);

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_control_ScaleLine_ from '../../../../src/ol/control/ScaleLine.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {fromLonLat} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 
 describe('ol.control.ScaleLine', function() {
@@ -249,7 +249,7 @@ describe('ol.control.ScaleLine', function() {
       var ctrl = new _ol_control_ScaleLine_();
       ctrl.setMap(map);
       map.setView(new _ol_View_({
-        center: _ol_proj_.fromLonLat([7, 52]),
+        center: fromLonLat([7, 52]),
         zoom: 2,
         projection: 'EPSG:3857'
       }));
@@ -306,7 +306,7 @@ describe('ol.control.ScaleLine', function() {
       var ctrl = new _ol_control_ScaleLine_();
       ctrl.setMap(map);
       map.setView(new _ol_View_({
-        center: _ol_proj_.fromLonLat([7, 0]),
+        center: fromLonLat([7, 0]),
         zoom: 2,
         projection: 'EPSG:4326'
       }));
@@ -324,7 +324,7 @@ describe('ol.control.ScaleLine', function() {
       });
       ctrl.setMap(map);
       map.setView(new _ol_View_({
-        center: _ol_proj_.fromLonLat([7, 0]),
+        center: fromLonLat([7, 0]),
         zoom: 2,
         projection: 'EPSG:4326'
       }));

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -1,5 +1,5 @@
 import * as _ol_extent_ from '../../../src/ol/extent.js';
-import _ol_proj_ from '../../../src/ol/proj.js';
+import {getTransform} from '../../../src/ol/proj.js';
 
 
 describe('ol.extent', function() {
@@ -737,7 +737,7 @@ describe('ol.extent', function() {
   describe('#applyTransform()', function() {
 
     it('does transform', function() {
-      var transformFn = _ol_proj_.getTransform('EPSG:4326', 'EPSG:3857');
+      var transformFn = getTransform('EPSG:4326', 'EPSG:3857');
       var sourceExtent = [-15, -30, 45, 60];
       var destinationExtent = _ol_extent_.applyTransform(
           sourceExtent, transformFn);

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -8,7 +8,7 @@ import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 
 describe('ol.format.EsriJSON', function() {
@@ -239,7 +239,7 @@ describe('ol.format.EsriJSON', function() {
       });
       expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+          transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
 
     it('can read and transform a feature collection', function() {
@@ -249,18 +249,18 @@ describe('ol.format.EsriJSON', function() {
       });
       expect(features[0].getGeometry()).to.be.an(_ol_geom_Point_);
       expect(features[0].getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+          transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
       expect(features[1].getGeometry().getCoordinates()).to.eql([
-        _ol_proj_.transform([102.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([103.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([104.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([105.0, 1.0], 'EPSG:4326', 'EPSG:3857')
+        transform([102.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([103.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([104.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([105.0, 1.0], 'EPSG:4326', 'EPSG:3857')
       ]);
       expect(features[2].getGeometry().getCoordinates()).to.eql([[
-        _ol_proj_.transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([100.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([101.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([101.0, 0.0], 'EPSG:4326', 'EPSG:3857')
+        transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([100.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([101.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([101.0, 0.0], 'EPSG:4326', 'EPSG:3857')
       ]]);
     });
 
@@ -753,7 +753,7 @@ describe('ol.format.EsriJSON', function() {
       expect(second.get('bam')).to.be('baz');
       expect(second.getGeometry()).to.be.a(_ol_geom_LineString_);
 
-      expect(format.readProjection(json)).to.be(_ol_proj_.get('EPSG:3857'));
+      expect(format.readProjection(json)).to.be(getProjection('EPSG:3857'));
 
     });
 

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -8,7 +8,7 @@ import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {fromLonLat, get as getProjection, toLonLat, transform} from '../../../../src/ol/proj.js';
 
 
 describe('ol.format.GeoJSON', function() {
@@ -211,7 +211,7 @@ describe('ol.format.GeoJSON', function() {
       });
       expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+          transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
 
     it('uses featureProjection passed to the constructor', function() {
@@ -219,7 +219,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeatures(pointGeoJSON);
       expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+          transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
 
     it('gives precedence to options passed to the read method', function() {
@@ -229,7 +229,7 @@ describe('ol.format.GeoJSON', function() {
       });
       expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+          transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
 
     it('can read and transform a feature collection', function() {
@@ -238,18 +238,18 @@ describe('ol.format.GeoJSON', function() {
       });
       expect(features[0].getGeometry()).to.be.an(_ol_geom_Point_);
       expect(features[0].getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+          transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
       expect(features[1].getGeometry().getCoordinates()).to.eql([
-        _ol_proj_.transform([102.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([103.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([104.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([105.0, 1.0], 'EPSG:4326', 'EPSG:3857')
+        transform([102.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([103.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([104.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([105.0, 1.0], 'EPSG:4326', 'EPSG:3857')
       ]);
       expect(features[2].getGeometry().getCoordinates()).to.eql([[
-        _ol_proj_.transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([100.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([101.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-        _ol_proj_.transform([101.0, 0.0], 'EPSG:4326', 'EPSG:3857')
+        transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([100.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([101.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+        transform([101.0, 0.0], 'EPSG:4326', 'EPSG:3857')
       ]]);
     });
 
@@ -342,7 +342,7 @@ describe('ol.format.GeoJSON', function() {
       expect(first.get('bam')).to.be('baz');
       expect(first.getGeometry()).to.be.a(_ol_geom_LineString_);
 
-      expect(format.readProjection(json)).to.be(_ol_proj_.get('EPSG:4326'));
+      expect(format.readProjection(json)).to.be(getProjection('EPSG:4326'));
     });
 
   });
@@ -471,7 +471,7 @@ describe('ol.format.GeoJSON', function() {
       expect(second.get('bam')).to.be('baz');
       expect(second.getGeometry()).to.be.a(_ol_geom_LineString_);
 
-      expect(format.readProjection(json)).to.be(_ol_proj_.get('EPSG:3857'));
+      expect(format.readProjection(json)).to.be(getProjection('EPSG:3857'));
 
     });
 
@@ -514,7 +514,7 @@ describe('ol.format.GeoJSON', function() {
       expect(second.get('bam')).to.be('baz');
       expect(second.getGeometry()).to.be.a(_ol_geom_LineString_);
 
-      expect(format.readProjection(json)).to.be(_ol_proj_.get('EPSG:4326'));
+      expect(format.readProjection(json)).to.be(getProjection('EPSG:4326'));
 
     });
 
@@ -597,18 +597,18 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('accepts featureProjection', function() {
-      var point = new _ol_geom_Point_(_ol_proj_.fromLonLat([10, 20]));
+      var point = new _ol_geom_Point_(fromLonLat([10, 20]));
       var geojson = format.writeGeometry(point, {featureProjection: 'EPSG:3857'});
       var obj = JSON.parse(geojson);
-      expect(obj.coordinates).to.eql(_ol_proj_.toLonLat(point.getCoordinates()));
+      expect(obj.coordinates).to.eql(toLonLat(point.getCoordinates()));
     });
 
     it('respects featureProjection passed to constructor', function() {
       var format = new _ol_format_GeoJSON_({featureProjection: 'EPSG:3857'});
-      var point = new _ol_geom_Point_(_ol_proj_.fromLonLat([10, 20]));
+      var point = new _ol_geom_Point_(fromLonLat([10, 20]));
       var geojson = format.writeGeometry(point);
       var obj = JSON.parse(geojson);
-      expect(obj.coordinates).to.eql(_ol_proj_.toLonLat(point.getCoordinates()));
+      expect(obj.coordinates).to.eql(toLonLat(point.getCoordinates()));
     });
 
     it('encodes linestring', function() {

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -8,7 +8,7 @@ import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
 var readGeometry = function(format, text, opt_options) {
@@ -393,7 +393,7 @@ describe('ol.format.GML3', function() {
         expect(g).to.be.an(_ol_geom_Point_);
         var coordinates = g.getCoordinates();
         expect(coordinates.splice(0, 2)).to.eql(
-            _ol_proj_.transform([1, 2], 'CRS:84', 'EPSG:3857'));
+            transform([1, 2], 'CRS:84', 'EPSG:3857'));
         config.dataProjection = 'CRS:84';
         var serialized = format.writeGeometryNode(g, config);
         var pos = serialized.firstElementChild.firstElementChild.textContent;
@@ -415,7 +415,7 @@ describe('ol.format.GML3', function() {
         expect(g).to.be.an(_ol_geom_Point_);
         var coordinates = g.getCoordinates();
         expect(coordinates.splice(0, 2)).to.eql(
-            _ol_proj_.transform([1, 2], 'CRS:84', 'EPSG:3857'));
+            transform([1, 2], 'CRS:84', 'EPSG:3857'));
       });
 
       it('can read and write a point geometry in EPSG:4326', function() {
@@ -462,9 +462,9 @@ describe('ol.format.GML3', function() {
         expect(g).to.be.an(_ol_geom_LineString_);
         var coordinates = g.getCoordinates();
         expect(coordinates[0].slice(0, 2)).to.eql(
-            _ol_proj_.transform([1, 2], 'CRS:84', 'EPSG:3857'));
+            transform([1, 2], 'CRS:84', 'EPSG:3857'));
         expect(coordinates[1].slice(0, 2)).to.eql(
-            _ol_proj_.transform([3, 4], 'CRS:84', 'EPSG:3857'));
+            transform([3, 4], 'CRS:84', 'EPSG:3857'));
         var serialized = format.writeGeometryNode(g, config);
         var poss = serialized.firstElementChild.firstElementChild.textContent;
         var coordinate = poss.split(' ');

--- a/test/spec/ol/format/gpx.test.js
+++ b/test/spec/ol/format/gpx.test.js
@@ -4,7 +4,7 @@ import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
 describe('ol.format.GPX', function() {
@@ -17,12 +17,12 @@ describe('ol.format.GPX', function() {
   describe('#readProjection', function() {
     it('returns the default projection from document', function() {
       var projection = format.readProjectionFromDocument();
-      expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.eql(getProjection('EPSG:4326'));
     });
 
     it('returns the default projection from node', function() {
       var projection = format.readProjectionFromNode();
-      expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.eql(getProjection('EPSG:4326'));
     });
   });
 
@@ -121,8 +121,8 @@ describe('ol.format.GPX', function() {
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
       expect(g).to.be.an(_ol_geom_LineString_);
-      var p1 = _ol_proj_.transform([2, 1], 'EPSG:4326', 'EPSG:3857');
-      var p2 = _ol_proj_.transform([6, 5], 'EPSG:4326', 'EPSG:3857');
+      var p1 = transform([2, 1], 'EPSG:4326', 'EPSG:3857');
+      var p2 = transform([6, 5], 'EPSG:4326', 'EPSG:3857');
       expect(g.getCoordinates()).to.eql([p1, p2]);
       expect(g.getLayout()).to.be('XY');
       var serialized = format.writeFeaturesNode(fs, {
@@ -285,9 +285,9 @@ describe('ol.format.GPX', function() {
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
       expect(g).to.be.an(_ol_geom_MultiLineString_);
-      var p1 = _ol_proj_.transform([2, 1], 'EPSG:4326', 'EPSG:3857');
+      var p1 = transform([2, 1], 'EPSG:4326', 'EPSG:3857');
       p1.push(3, 1263115752);
-      var p2 = _ol_proj_.transform([6, 5], 'EPSG:4326', 'EPSG:3857');
+      var p2 = transform([6, 5], 'EPSG:4326', 'EPSG:3857');
       p2.push(7, 1263115812);
       expect(g.getCoordinates()).to.eql([[p1, p2]]);
       expect(g.getLayout()).to.be('XYZM');
@@ -416,7 +416,7 @@ describe('ol.format.GPX', function() {
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
       expect(g).to.be.an(_ol_geom_Point_);
-      var expectedPoint = _ol_proj_.transform([2, 1], 'EPSG:4326', 'EPSG:3857');
+      var expectedPoint = transform([2, 1], 'EPSG:4326', 'EPSG:3857');
       expect(g.getCoordinates()).to.eql(expectedPoint);
       expect(g.getLayout()).to.be('XY');
       var serialized = format.writeFeaturesNode(fs, {

--- a/test/spec/ol/format/igc.test.js
+++ b/test/spec/ol/format/igc.test.js
@@ -1,6 +1,6 @@
 import _ol_format_IGC_ from '../../../../src/ol/format/IGC.js';
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 
 describe('ol.format.IGC', function() {
@@ -35,7 +35,7 @@ describe('ol.format.IGC', function() {
   describe('#readProjectionFromText', function() {
     it('returns the default projection', function() {
       var projection = format.readProjectionFromText(igc);
-      expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.eql(getProjection('EPSG:4326'));
     });
   });
 
@@ -64,16 +64,16 @@ describe('ol.format.IGC', function() {
       var geom = feature.getGeometry();
       expect(geom.getType()).to.eql('LineString');
 
-      var expectedPoint1 = _ol_proj_.transform(
+      var expectedPoint1 = transform(
           [6.851583333333333, 45.9376], 'EPSG:4326', 'EPSG:3857');
       expectedPoint1.push(1303202928);
-      var expectedPoint2 = _ol_proj_.transform(
+      var expectedPoint2 = transform(
           [6.850183333333334, 45.93395], 'EPSG:4326', 'EPSG:3857');
       expectedPoint2.push(1303203353);
-      var expectedPoint3 = _ol_proj_.transform(
+      var expectedPoint3 = transform(
           [6.800816666666667, 45.916066666666666], 'EPSG:4326', 'EPSG:3857');
       expectedPoint3.push(1303203815);
-      var expectedPoint4 = _ol_proj_.transform(
+      var expectedPoint4 = transform(
           [6.851583333333333, 45.9376], 'EPSG:4326', 'EPSG:3857');
       expectedPoint4.push(1303289328);
 
@@ -113,16 +113,16 @@ describe('ol.format.IGC', function() {
       var geom = feature.getGeometry();
       expect(geom.getType()).to.eql('LineString');
 
-      var expectedPoint1 = _ol_proj_.transform(
+      var expectedPoint1 = transform(
           [6.851583333333333, 45.9376], 'EPSG:4326', 'EPSG:3857');
       expectedPoint1.push(1303202928);
-      var expectedPoint2 = _ol_proj_.transform(
+      var expectedPoint2 = transform(
           [6.850183333333334, 45.93395], 'EPSG:4326', 'EPSG:3857');
       expectedPoint2.push(1303203353);
-      var expectedPoint3 = _ol_proj_.transform(
+      var expectedPoint3 = transform(
           [6.800816666666667, 45.916066666666666], 'EPSG:4326', 'EPSG:3857');
       expectedPoint3.push(1303203815);
-      var expectedPoint4 = _ol_proj_.transform(
+      var expectedPoint4 = transform(
           [6.851583333333333, 45.9376], 'EPSG:4326', 'EPSG:3857');
       expectedPoint4.push(1303289328);
 

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -10,7 +10,7 @@ import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {addProjection, addCoordinateTransforms, transform, get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_proj_transforms_ from '../../../../src/ol/proj/transforms.js';
 import _ol_style_Circle_ from '../../../../src/ol/style/Circle.js';
@@ -80,12 +80,12 @@ describe('ol.format.KML', function() {
     describe('#readProjection', function() {
       it('returns the default projection from document', function() {
         var projection = format.readProjectionFromDocument();
-        expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+        expect(projection).to.eql(getProjection('EPSG:4326'));
       });
 
       it('returns the default projection from node', function() {
         var projection = format.readProjectionFromNode();
-        expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+        expect(projection).to.eql(getProjection('EPSG:4326'));
       });
     });
 
@@ -266,7 +266,7 @@ describe('ol.format.KML', function() {
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
           expect(g).to.be.an(_ol_geom_Point_);
-          var expectedPoint = _ol_proj_.transform([1, 2], 'EPSG:4326', 'EPSG:3857');
+          var expectedPoint = transform([1, 2], 'EPSG:4326', 'EPSG:3857');
           expectedPoint.push(3);
           expect(g.getCoordinates()).to.eql(expectedPoint);
         });
@@ -310,7 +310,7 @@ describe('ol.format.KML', function() {
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
           expect(g).to.be.an(_ol_geom_Point_);
-          var expectedPoint = _ol_proj_.transform([1, 2], 'EPSG:4326', 'EPSG:3857');
+          var expectedPoint = transform([1, 2], 'EPSG:4326', 'EPSG:3857');
           expectedPoint.push(3);
           expect(g.getCoordinates()).to.eql(expectedPoint);
         });
@@ -356,8 +356,8 @@ describe('ol.format.KML', function() {
         });
 
         it('can transform and write XYZ Point geometries', function() {
-          _ol_proj_.addProjection(new _ol_proj_Projection_({code: 'double'}));
-          _ol_proj_.addCoordinateTransforms('EPSG:4326', 'double',
+          addProjection(new _ol_proj_Projection_({code: 'double'}));
+          addCoordinateTransforms('EPSG:4326', 'double',
               function(coordinate) {
                 return [2 * coordinate[0], 2 * coordinate[1]];
               },
@@ -387,9 +387,9 @@ describe('ol.format.KML', function() {
           expect(node).to.xmleql(_ol_xml_.parse(text));
 
           _ol_proj_transforms_.remove(
-              _ol_proj_.get('EPSG:4326'), _ol_proj_.get('double'));
+              getProjection('EPSG:4326'), getProjection('double'));
           _ol_proj_transforms_.remove(
-              _ol_proj_.get('double'), _ol_proj_.get('EPSG:4326'));
+              getProjection('double'), getProjection('EPSG:4326'));
         });
 
         it('can write XYM Point geometries', function() {
@@ -2849,7 +2849,7 @@ describe('ol.format.KML', function() {
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
           expect(g).to.be.an(_ol_geom_Point_);
-          var expectedPoint = _ol_proj_.transform([1, 2], 'EPSG:4326', 'EPSG:3857');
+          var expectedPoint = transform([1, 2], 'EPSG:4326', 'EPSG:3857');
           expectedPoint.push(3);
           expect(g.getCoordinates()).to.eql(expectedPoint);
         });

--- a/test/spec/ol/format/osmxml.test.js
+++ b/test/spec/ol/format/osmxml.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_OSMXML_ from '../../../../src/ol/format/OSMXML.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 
 describe('ol.format.OSMXML', function() {
@@ -15,12 +15,12 @@ describe('ol.format.OSMXML', function() {
   describe('#readProjection', function() {
     it('returns the default projection from document', function() {
       var projection = format.readProjectionFromDocument();
-      expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.eql(getProjection('EPSG:4326'));
     });
 
     it('returns the default projection from node', function() {
       var projection = format.readProjectionFromNode();
-      expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.eql(getProjection('EPSG:4326'));
     });
   });
 
@@ -132,7 +132,7 @@ describe('ol.format.OSMXML', function() {
       var g = f.getGeometry();
       expect(g).to.be.an(_ol_geom_Point_);
       expect(g.getCoordinates()).to.eql(
-          _ol_proj_.transform([2, 1], 'EPSG:4326', 'EPSG:3857'));
+          transform([2, 1], 'EPSG:4326', 'EPSG:3857'));
     });
 
   });

--- a/test/spec/ol/format/polyline.test.js
+++ b/test/spec/ol/format/polyline.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_Polyline_ from '../../../../src/ol/format/Polyline.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 describe('ol.format.Polyline', function() {
 
@@ -32,9 +32,9 @@ describe('ol.format.Polyline', function() {
     ];
     encodedFlatPoints = '_p~iF~ps|U_ulLnnqC_mqNvxq`@';
     points3857 = [
-      _ol_proj_.transform([-120.20000, 38.50000], 'EPSG:4326', 'EPSG:3857'),
-      _ol_proj_.transform([-120.95000, 40.70000], 'EPSG:4326', 'EPSG:3857'),
-      _ol_proj_.transform([-126.45300, 43.25200], 'EPSG:4326', 'EPSG:3857')
+      transform([-120.20000, 38.50000], 'EPSG:4326', 'EPSG:3857'),
+      transform([-120.95000, 40.70000], 'EPSG:4326', 'EPSG:3857'),
+      transform([-126.45300, 43.25200], 'EPSG:4326', 'EPSG:3857')
     ];
 
     floats = [0.00, 0.15, -0.01, -0.16, 0.16, 0.01];
@@ -54,7 +54,7 @@ describe('ol.format.Polyline', function() {
   describe('#readProjectionFromText', function() {
     it('returns the default projection', function() {
       var projection = format.readProjectionFromText(encodedFlatPoints);
-      expect(projection).to.eql(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.eql(getProjection('EPSG:4326'));
     });
   });
 
@@ -352,7 +352,7 @@ describe('ol.format.Polyline', function() {
 
     it('returns the expected projection', function() {
       var projection = format.readProjection(encodedFlatPoints);
-      expect(projection).to.be(_ol_proj_.get('EPSG:4326'));
+      expect(projection).to.be(getProjection('EPSG:4326'));
     });
 
   });

--- a/test/spec/ol/format/topojson.test.js
+++ b/test/spec/ol/format/topojson.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_format_Feature_ from '../../../../src/ol/format/Feature.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {transform} from '../../../../src/ol/proj.js';
 import _ol_format_TopoJSON_ from '../../../../src/ol/format/TopoJSON.js';
 
 var aruba = {
@@ -123,25 +123,25 @@ describe('ol.format.TopoJSON', function() {
         var point = features[0].getGeometry();
         expect(point.getType()).to.be('Point');
         expect(features[0].getGeometry().getCoordinates()).to.eql(
-            _ol_proj_.transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
+            transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
 
         var line = features[1].getGeometry();
         expect(line.getType()).to.be('LineString');
         expect(line.getCoordinates()).to.eql([
-          _ol_proj_.transform([102.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([103.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([104.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([105.0, 1.0], 'EPSG:4326', 'EPSG:3857')
+          transform([102.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([103.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([104.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([105.0, 1.0], 'EPSG:4326', 'EPSG:3857')
         ]);
 
         var polygon = features[2].getGeometry();
         expect(polygon.getType()).to.be('Polygon');
         expect(polygon.getCoordinates()).to.eql([[
-          _ol_proj_.transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([100.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([101.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([101.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
-          _ol_proj_.transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857')
+          transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([100.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([101.0, 1.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([101.0, 0.0], 'EPSG:4326', 'EPSG:3857'),
+          transform([100.0, 0.0], 'EPSG:4326', 'EPSG:3857')
         ]]);
 
         done();

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -7,7 +7,7 @@ import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.j
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
 describe('ol.format.WFS', function() {
@@ -67,7 +67,7 @@ describe('ol.format.WFS', function() {
       expect(feature.get('STATE_NAME')).to.equal('Illinois');
       var geom = feature.getGeometry();
       expect(geom).to.be.an(_ol_geom_MultiPolygon_);
-      var p = _ol_proj_.transform([-88.071, 37.511], 'EPSG:4326', 'EPSG:3857');
+      var p = transform([-88.071, 37.511], 'EPSG:4326', 'EPSG:3857');
       p.push(0);
       expect(geom.getFirstCoordinate()).to.eql(p);
     });

--- a/test/spec/ol/format/wkt.test.js
+++ b/test/spec/ol/format/wkt.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_format_WKT_ from '../../../../src/ol/format/WKT.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {transform} from '../../../../src/ol/proj.js';
 
 
 describe('ol.format.WKT', function() {
@@ -24,7 +24,7 @@ describe('ol.format.WKT', function() {
         featureProjection: 'EPSG:3857'
       });
       expect(geom.getCoordinates()).to.eql(
-          _ol_proj_.transform([1, 2], 'EPSG:4326', 'EPSG:3857'));
+          transform([1, 2], 'EPSG:4326', 'EPSG:3857'));
     });
 
   });
@@ -54,7 +54,7 @@ describe('ol.format.WKT', function() {
       });
       var geom = feature.getGeometry();
       expect(geom.getCoordinates()).to.eql(
-          _ol_proj_.transform([1, 2], 'EPSG:4326', 'EPSG:3857'));
+          transform([1, 2], 'EPSG:4326', 'EPSG:3857'));
     });
 
   });
@@ -91,9 +91,9 @@ describe('ol.format.WKT', function() {
       expect(point1.getType()).to.eql('Point');
       expect(point2.getType()).to.eql('Point');
       expect(point1.getCoordinates()).to.eql(
-          _ol_proj_.transform([1, 2], 'EPSG:4326', 'EPSG:3857'));
+          transform([1, 2], 'EPSG:4326', 'EPSG:3857'));
       expect(point2.getCoordinates()).to.eql(
-          _ol_proj_.transform([4, 5], 'EPSG:4326', 'EPSG:3857'));
+          transform([4, 5], 'EPSG:4326', 'EPSG:3857'));
     });
   });
 

--- a/test/spec/ol/graticule.test.js
+++ b/test/spec/ol/graticule.test.js
@@ -1,6 +1,6 @@
 import _ol_Graticule_ from '../../../src/ol/Graticule.js';
 import _ol_Map_ from '../../../src/ol/Map.js';
-import _ol_proj_ from '../../../src/ol/proj.js';
+import {get as getProjection} from '../../../src/ol/proj.js';
 import _ol_style_Stroke_ from '../../../src/ol/style/Stroke.js';
 import _ol_style_Text_ from '../../../src/ol/style/Text.js';
 
@@ -18,7 +18,7 @@ describe('ol.Graticule', function() {
       createGraticule();
       var extent = [-25614353.926475704, -7827151.696402049,
         25614353.926475704, 7827151.696402049];
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var resolution = 39135.75848201024;
       var squaredTolerance = resolution * resolution / 4.0;
       graticule.updateProjectionInfo_(projection);
@@ -36,7 +36,7 @@ describe('ol.Graticule', function() {
       });
       var extent = [-25614353.926475704, -7827151.696402049,
         25614353.926475704, 7827151.696402049];
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var resolution = 39135.75848201024;
       var squaredTolerance = resolution * resolution / 4.0;
       graticule.updateProjectionInfo_(projection);
@@ -91,7 +91,7 @@ describe('ol.Graticule', function() {
       });
       var extent = [-25614353.926475704, -7827151.696402049,
         25614353.926475704, 7827151.696402049];
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var resolution = 39135.75848201024;
       var squaredTolerance = resolution * resolution / 4.0;
       graticule.updateProjectionInfo_(projection);

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -1,7 +1,7 @@
 import {getUid} from '../../../../src/ol/index.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_layer_Layer_ from '../../../../src/ol/layer/Layer.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_render_Event_ from '../../../../src/ol/render/Event.js';
 import _ol_source_Source_ from '../../../../src/ol/source/Source.js';
 
@@ -15,7 +15,7 @@ describe('ol.layer.Layer', function() {
     beforeEach(function() {
       layer = new _ol_layer_Layer_({
         source: new _ol_source_Source_({
-          projection: _ol_proj_.get('EPSG:4326')
+          projection: getProjection('EPSG:4326')
         })
       });
     });
@@ -65,7 +65,7 @@ describe('ol.layer.Layer', function() {
     it('accepts options', function() {
       var layer = new _ol_layer_Layer_({
         source: new _ol_source_Source_({
-          projection: _ol_proj_.get('EPSG:4326')
+          projection: getProjection('EPSG:4326')
         }),
         opacity: 0.5,
         visible: false,
@@ -103,7 +103,7 @@ describe('ol.layer.Layer', function() {
     beforeEach(function() {
       layer = new _ol_layer_Layer_({
         source: new _ol_source_Source_({
-          projection: _ol_proj_.get('EPSG:4326')
+          projection: getProjection('EPSG:4326')
         })
       });
     });
@@ -153,7 +153,7 @@ describe('ol.layer.Layer', function() {
     beforeEach(function() {
       layer = new _ol_layer_Layer_({
         source: new _ol_source_Source_({
-          projection: _ol_proj_.get('EPSG:4326')
+          projection: getProjection('EPSG:4326')
         })
       });
     });
@@ -216,7 +216,7 @@ describe('ol.layer.Layer', function() {
   describe('#getSource', function() {
 
     it('gets the layer source', function() {
-      var source = new _ol_source_Source_({projection: _ol_proj_.get('EPSG:4326')});
+      var source = new _ol_source_Source_({projection: getProjection('EPSG:4326')});
       var layer = new _ol_layer_Layer_({source: source});
       expect(layer.getSource()).to.be(source);
     });
@@ -224,7 +224,7 @@ describe('ol.layer.Layer', function() {
   });
 
   describe('#set("source", source)', function() {
-    var projection = _ol_proj_.get('EPSG:4326');
+    var projection = getProjection('EPSG:4326');
 
     it('sets the layer source', function() {
       var layer = new _ol_layer_Layer_({
@@ -270,7 +270,7 @@ describe('ol.layer.Layer', function() {
   });
 
   describe('#setSource()', function() {
-    var projection = _ol_proj_.get('EPSG:4326');
+    var projection = getProjection('EPSG:4326');
 
     it('sets the layer source', function() {
       var layer = new _ol_layer_Layer_({
@@ -323,7 +323,7 @@ describe('ol.layer.Layer', function() {
     beforeEach(function() {
       layer = new _ol_layer_Layer_({
         source: new _ol_source_Source_({
-          projection: _ol_proj_.get('EPSG:4326')
+          projection: getProjection('EPSG:4326')
         })
       });
     });
@@ -353,7 +353,7 @@ describe('ol.layer.Layer', function() {
     beforeEach(function() {
       layer = new _ol_layer_Layer_({
         source: new _ol_source_Source_({
-          projection: _ol_proj_.get('EPSG:4326')
+          projection: getProjection('EPSG:4326')
         })
       });
     });

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -1,4 +1,17 @@
-import _ol_proj_ from '../../../src/ol/proj.js';
+import {
+  addCommon,
+  setProj4,
+  clearAllProjections,
+  equivalent,
+  get as getProjection,
+  transform,
+  transformExtent,
+  fromLonLat,
+  toLonLat,
+  getTransform,
+  getPointResolution,
+  getTransformFromProjections
+} from '../../../src/ol/proj.js';
 import _ol_proj_EPSG3857_ from '../../../src/ol/proj/EPSG3857.js';
 import _ol_proj_EPSG4326_ from '../../../src/ol/proj/EPSG4326.js';
 import _ol_proj_Projection_ from '../../../src/ol/proj/Projection.js';
@@ -7,8 +20,8 @@ import _ol_proj_Projection_ from '../../../src/ol/proj/Projection.js';
 describe('ol.proj', function() {
 
   afterEach(function() {
-    _ol_proj_.clearAllProjections();
-    _ol_proj_.addCommon();
+    clearAllProjections();
+    addCommon();
   });
 
   describe('toLonLat()', function() {
@@ -28,7 +41,7 @@ describe('ol.proj', function() {
 
     cases.forEach(function(c) {
       it('works for ' + c.from.join(', '), function() {
-        var lonLat = _ol_proj_.toLonLat(c.from);
+        var lonLat = toLonLat(c.from);
         expect(lonLat[0]).to.roughlyEqual(c.to[0], 1e-9);
         expect(lonLat[1]).to.roughlyEqual(c.to[1], 1e-9);
       });
@@ -38,10 +51,10 @@ describe('ol.proj', function() {
   describe('projection equivalence', function() {
 
     function _testAllEquivalent(codes) {
-      var projections = codes.map(_ol_proj_.get);
+      var projections = codes.map(getProjection);
       projections.forEach(function(source) {
         projections.forEach(function(destination) {
-          expect(_ol_proj_.equivalent(source, destination)).to.be.ok();
+          expect(equivalent(source, destination)).to.be.ok();
         });
       });
     }
@@ -66,7 +79,7 @@ describe('ol.proj', function() {
         code: code
       });
 
-      expect(_ol_proj_.equivalent(source, destination)).to.be.ok();
+      expect(equivalent(source, destination)).to.be.ok();
     });
 
     it('gives that default 3857 is equivalent to self', function() {
@@ -96,7 +109,7 @@ describe('ol.proj', function() {
             code: 'EPSG:3857',
             units: 'tile-pixels'
           });
-          expect(_ol_proj_.equivalent(proj1, proj2)).to.not.be.ok();
+          expect(equivalent(proj1, proj2)).to.not.be.ok();
         });
 
   });
@@ -104,10 +117,10 @@ describe('ol.proj', function() {
   describe('identify transform', function() {
 
     it('returns a new object, with same coord values', function() {
-      var epsg4326 = _ol_proj_.get('EPSG:4326');
+      var epsg4326 = getProjection('EPSG:4326');
       var uniqueObject = {};
       var sourcePoint = [uniqueObject, uniqueObject];
-      var destinationPoint = _ol_proj_.transform(
+      var destinationPoint = transform(
           sourcePoint, epsg4326, epsg4326);
       expect(sourcePoint === destinationPoint).to.not.be();
       expect(destinationPoint[0] === sourcePoint[0]).to.be.ok();
@@ -118,7 +131,7 @@ describe('ol.proj', function() {
   describe('transform 0,0 from 4326 to 3857', function() {
 
     it('returns expected value', function() {
-      var point = _ol_proj_.transform([0, 0], 'EPSG:4326', 'EPSG:3857');
+      var point = transform([0, 0], 'EPSG:4326', 'EPSG:3857');
       expect(point).not.to.be(undefined);
       expect(point).not.to.be(null);
       expect(point[1]).to.roughlyEqual(0, 1e-9);
@@ -128,7 +141,7 @@ describe('ol.proj', function() {
   describe('transform 0,0 from 3857 to 4326', function() {
 
     it('returns expected value', function() {
-      var point = _ol_proj_.transform([0, 0], 'EPSG:3857', 'EPSG:4326');
+      var point = transform([0, 0], 'EPSG:3857', 'EPSG:4326');
       expect(point).not.to.be(undefined);
       expect(point).not.to.be(null);
       expect(point[0]).to.eql(0);
@@ -140,7 +153,7 @@ describe('ol.proj', function() {
     // http://alastaira.wordpress.com/2011/01/23/the-google-maps-bing-maps-spherical-mercator-projection/
 
     it('returns expected value using ol.proj.transform', function() {
-      var point = _ol_proj_.transform(
+      var point = transform(
           [-5.625, 52.4827802220782], 'EPSG:4326', 'EPSG:900913');
       expect(point).not.to.be(undefined);
       expect(point).not.to.be(null);
@@ -149,7 +162,7 @@ describe('ol.proj', function() {
     });
 
     it('returns expected value using ol.proj.fromLonLat', function() {
-      var point = _ol_proj_.fromLonLat([-5.625, 52.4827802220782]);
+      var point = fromLonLat([-5.625, 52.4827802220782]);
       expect(point).not.to.be(undefined);
       expect(point).not.to.be(null);
       expect(point[0]).to.roughlyEqual(-626172.13571216376, 1e-9);
@@ -161,7 +174,7 @@ describe('ol.proj', function() {
     // http://alastaira.wordpress.com/2011/01/23/the-google-maps-bing-maps-spherical-mercator-projection/
 
     it('returns expected value using ol.proj.transform', function() {
-      var point = _ol_proj_.transform([-626172.13571216376, 6887893.4928337997],
+      var point = transform([-626172.13571216376, 6887893.4928337997],
           'EPSG:900913', 'EPSG:4326');
       expect(point).not.to.be(undefined);
       expect(point).not.to.be(null);
@@ -170,7 +183,7 @@ describe('ol.proj', function() {
     });
 
     it('returns expected value using ol.proj.toLonLat', function() {
-      var point = _ol_proj_.toLonLat([-626172.13571216376, 6887893.4928337997]);
+      var point = toLonLat([-626172.13571216376, 6887893.4928337997]);
       expect(point).not.to.be(undefined);
       expect(point).not.to.be(null);
       expect(point[0]).to.roughlyEqual(-5.625, 1e-9);
@@ -222,7 +235,7 @@ describe('ol.proj', function() {
 
     it('transforms an extent given projection identifiers', function() {
       var sourceExtent = [-15, -30, 45, 60];
-      var destinationExtent = _ol_proj_.transformExtent(
+      var destinationExtent = transformExtent(
           sourceExtent, 'EPSG:4326', 'EPSG:3857');
       expect(destinationExtent).not.to.be(undefined);
       expect(destinationExtent).not.to.be(null);
@@ -237,27 +250,27 @@ describe('ol.proj', function() {
 
   describe('getPointResolution()', function() {
     it('returns the correct point resolution for EPSG:4326', function() {
-      var pointResolution = _ol_proj_.getPointResolution('EPSG:4326', 1, [0, 0]);
+      var pointResolution = getPointResolution('EPSG:4326', 1, [0, 0]);
       expect (pointResolution).to.be(1);
-      pointResolution = _ol_proj_.getPointResolution('EPSG:4326', 1, [0, 52]);
+      pointResolution = getPointResolution('EPSG:4326', 1, [0, 52]);
       expect (pointResolution).to.be(1);
     });
     it('returns the correct point resolution for EPSG:4326 with custom units', function() {
-      var pointResolution = _ol_proj_.getPointResolution('EPSG:4326', 1, [0, 0], 'm');
+      var pointResolution = getPointResolution('EPSG:4326', 1, [0, 0], 'm');
       expect(pointResolution).to.roughlyEqual(111195.0802335329, 1e-5);
-      pointResolution = _ol_proj_.getPointResolution('EPSG:4326', 1, [0, 52], 'm');
+      pointResolution = getPointResolution('EPSG:4326', 1, [0, 52], 'm');
       expect(pointResolution).to.roughlyEqual(89826.53390979706, 1e-5);
     });
     it('returns the correct point resolution for EPSG:3857', function() {
-      var pointResolution = _ol_proj_.getPointResolution('EPSG:3857', 1, [0, 0]);
+      var pointResolution = getPointResolution('EPSG:3857', 1, [0, 0]);
       expect(pointResolution).to.be(1);
-      pointResolution = _ol_proj_.getPointResolution('EPSG:3857', 1, _ol_proj_.fromLonLat([0, 52]));
+      pointResolution = getPointResolution('EPSG:3857', 1, fromLonLat([0, 52]));
       expect(pointResolution).to.roughlyEqual(0.615661, 1e-5);
     });
     it('returns the correct point resolution for EPSG:3857 with custom units', function() {
-      var pointResolution = _ol_proj_.getPointResolution('EPSG:3857', 1, [0, 0], 'degrees');
+      var pointResolution = getPointResolution('EPSG:3857', 1, [0, 0], 'degrees');
       expect(pointResolution).to.be(1);
-      pointResolution = _ol_proj_.getPointResolution('EPSG:4326', 1, _ol_proj_.fromLonLat([0, 52]), 'degrees');
+      pointResolution = getPointResolution('EPSG:4326', 1, fromLonLat([0, 52]), 'degrees');
       expect(pointResolution).to.be(1);
     });
   });
@@ -269,7 +282,7 @@ describe('ol.proj', function() {
     afterEach(function() {
       delete proj4.defs['EPSG:21781'];
       window.proj4 = proj4;
-      _ol_proj_.setProj4(window.proj4);
+      setProj4(window.proj4);
     });
 
     it('creates ol.proj.Projection instance from EPSG:21781', function() {
@@ -277,7 +290,7 @@ describe('ol.proj', function() {
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
-      var proj = _ol_proj_.get('EPSG:21781');
+      var proj = getProjection('EPSG:21781');
       expect(proj.getCode()).to.eql('EPSG:21781');
       expect(proj.getUnits()).to.eql('m');
       expect(proj.getMetersPerUnit()).to.eql(1);
@@ -287,12 +300,12 @@ describe('ol.proj', function() {
       var proj4 = window.proj4;
       var proj4new = proj4;
       delete window.proj4;
-      _ol_proj_.setProj4(proj4new);
+      setProj4(proj4new);
       proj4new.defs('EPSG:21781',
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
-      var proj = _ol_proj_.get('EPSG:21781');
+      var proj = getProjection('EPSG:21781');
       expect(proj.getCode()).to.eql('EPSG:21781');
       expect(proj.getUnits()).to.eql('m');
       expect(proj.getMetersPerUnit()).to.eql(1);
@@ -303,7 +316,7 @@ describe('ol.proj', function() {
           '+proj=tmerc +lat_0=40.5 +lon_0=-110.0833333333333 +k=0.9999375 ' +
           '+x_0=800000.0000101599 +y_0=99999.99998983997 +ellps=GRS80 ' +
           '+towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs');
-      var proj = _ol_proj_.get('EPSG:3739');
+      var proj = getProjection('EPSG:3739');
       expect(proj.getCode()).to.eql('EPSG:3739');
       expect(proj.getUnits()).to.eql('us-ft');
       expect(proj.getMetersPerUnit()).to.eql(1200 / 3937);
@@ -312,7 +325,7 @@ describe('ol.proj', function() {
     });
 
     it('allows Proj4js projections to be used transparently', function() {
-      var point = _ol_proj_.transform(
+      var point = transform(
           [-626172.13571216376, 6887893.4928337997], 'GOOGLE', 'WGS84');
       expect(point[0]).to.roughlyEqual(-5.625, 1e-9);
       expect(point[1]).to.roughlyEqual(52.4827802220782, 1e-9);
@@ -323,7 +336,7 @@ describe('ol.proj', function() {
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
-      var point = _ol_proj_.transform([7.439583333333333, 46.95240555555556],
+      var point = transform([7.439583333333333, 46.95240555555556],
           'EPSG:4326', 'EPSG:21781');
       expect(point[0]).to.roughlyEqual(600072.300, 1);
       expect(point[1]).to.roughlyEqual(200146.976, 1);
@@ -335,10 +348,10 @@ describe('ol.proj', function() {
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
       var lonLat = [7.439583333333333, 46.95240555555556];
-      var point = _ol_proj_.fromLonLat(lonLat, 'EPSG:21781');
+      var point = fromLonLat(lonLat, 'EPSG:21781');
       expect(point[0]).to.roughlyEqual(600072.300, 1);
       expect(point[1]).to.roughlyEqual(200146.976, 1);
-      point = _ol_proj_.toLonLat(point, 'EPSG:21781');
+      point = toLonLat(point, 'EPSG:21781');
       expect(point[0]).to.roughlyEqual(lonLat[0], 1);
       expect(point[1]).to.roughlyEqual(lonLat[1], 1);
     });
@@ -351,50 +364,50 @@ describe('ol.proj', function() {
       var code = 'urn:ogc:def:crs:EPSG:21781';
       var srsCode = 'EPSG:21781';
       proj4.defs(code, proj4.defs(srsCode));
-      var proj = _ol_proj_.get(code);
-      var proj2 = _ol_proj_.get(srsCode);
-      expect(_ol_proj_.equivalent(proj2, proj)).to.be(true);
+      var proj = getProjection(code);
+      var proj2 = getProjection(srsCode);
+      expect(equivalent(proj2, proj)).to.be(true);
       delete proj4.defs[code];
     });
 
     it('numerically estimates point scale at the equator', function() {
-      var googleProjection = _ol_proj_.get('GOOGLE');
-      expect(_ol_proj_.getPointResolution(googleProjection, 1, [0, 0])).
+      var googleProjection = getProjection('GOOGLE');
+      expect(getPointResolution(googleProjection, 1, [0, 0])).
           to.roughlyEqual(1, 1e-1);
     });
 
     it('numerically estimates point scale at various latitudes', function() {
-      var epsg3857Projection = _ol_proj_.get('EPSG:3857');
-      var googleProjection = _ol_proj_.get('GOOGLE');
+      var epsg3857Projection = getProjection('EPSG:3857');
+      var googleProjection = getProjection('GOOGLE');
       var point, y;
       for (y = -20; y <= 20; ++y) {
         point = [0, 1000000 * y];
-        expect(_ol_proj_.getPointResolution(googleProjection, 1, point)).to.roughlyEqual(
-            _ol_proj_.getPointResolution(epsg3857Projection, 1, point), 1e-1);
+        expect(getPointResolution(googleProjection, 1, point)).to.roughlyEqual(
+            getPointResolution(epsg3857Projection, 1, point), 1e-1);
       }
     });
 
     it('numerically estimates point scale at various points', function() {
-      var epsg3857Projection = _ol_proj_.get('EPSG:3857');
-      var googleProjection = _ol_proj_.get('GOOGLE');
+      var epsg3857Projection = getProjection('EPSG:3857');
+      var googleProjection = getProjection('GOOGLE');
       var point, x, y;
       for (x = -20; x <= 20; x += 2) {
         for (y = -20; y <= 20; y += 2) {
           point = [1000000 * x, 1000000 * y];
-          expect(_ol_proj_.getPointResolution(googleProjection, 1, point)).to.roughlyEqual(
-              _ol_proj_.getPointResolution(epsg3857Projection, 1, point), 1e-1);
+          expect(getPointResolution(googleProjection, 1, point)).to.roughlyEqual(
+              getPointResolution(epsg3857Projection, 1, point), 1e-1);
         }
       }
     });
 
     it('does not overwrite existing projections in the registry', function() {
-      var epsg4326 = _ol_proj_.get('EPSG:4326');
+      var epsg4326 = getProjection('EPSG:4326');
       new _ol_proj_Projection_({
         code: 'EPSG:4326',
         units: 'degrees',
         extent: [-45, -45, 45, 45]
       });
-      expect(_ol_proj_.get('EPSG:4326')).to.equal(epsg4326);
+      expect(getProjection('EPSG:4326')).to.equal(epsg4326);
     });
 
   });
@@ -402,8 +415,8 @@ describe('ol.proj', function() {
   describe('ol.proj.getTransformFromProjections()', function() {
 
     it('returns a transform function', function() {
-      var transform = _ol_proj_.getTransformFromProjections(_ol_proj_.get('GOOGLE'),
-          _ol_proj_.get('EPSG:4326'));
+      var transform = getTransformFromProjections(getProjection('GOOGLE'),
+          getProjection('EPSG:4326'));
       expect(typeof transform).to.be('function');
 
       var output = transform([-12000000, 5000000]);
@@ -413,8 +426,8 @@ describe('ol.proj', function() {
     });
 
     it('works for longer arrays', function() {
-      var transform = _ol_proj_.getTransformFromProjections(_ol_proj_.get('GOOGLE'),
-          _ol_proj_.get('EPSG:4326'));
+      var transform = getTransformFromProjections(getProjection('GOOGLE'),
+          getProjection('EPSG:4326'));
       expect(typeof transform).to.be('function');
 
       var output = transform([-12000000, 5000000, -12000000, 5000000]);
@@ -430,12 +443,12 @@ describe('ol.proj', function() {
   describe('ol.proj.getTransform()', function() {
 
     it('returns a function', function() {
-      var transform = _ol_proj_.getTransform('GOOGLE', 'EPSG:4326');
+      var transform = getTransform('GOOGLE', 'EPSG:4326');
       expect(typeof transform).to.be('function');
     });
 
     it('returns a transform function', function() {
-      var transform = _ol_proj_.getTransform('GOOGLE', 'EPSG:4326');
+      var transform = getTransform('GOOGLE', 'EPSG:4326');
       expect(typeof transform).to.be('function');
 
       var output = transform([-626172.13571216376, 6887893.4928337997]);
@@ -446,7 +459,7 @@ describe('ol.proj', function() {
     });
 
     it('works for longer arrays of coordinate values', function() {
-      var transform = _ol_proj_.getTransform('GOOGLE', 'EPSG:4326');
+      var transform = getTransform('GOOGLE', 'EPSG:4326');
       expect(typeof transform).to.be('function');
 
       var output = transform([
@@ -464,7 +477,7 @@ describe('ol.proj', function() {
     });
 
     it('accepts an optional destination array', function() {
-      var transform = _ol_proj_.getTransform('EPSG:3857', 'EPSG:4326');
+      var transform = getTransform('EPSG:3857', 'EPSG:4326');
       var input = [-12000000, 5000000];
       var output = [];
 
@@ -478,7 +491,7 @@ describe('ol.proj', function() {
     });
 
     it('accepts a dimension', function() {
-      var transform = _ol_proj_.getTransform('GOOGLE', 'EPSG:4326');
+      var transform = getTransform('GOOGLE', 'EPSG:4326');
       expect(typeof transform).to.be('function');
 
       var dimension = 3;
@@ -503,14 +516,14 @@ describe('ol.proj', function() {
   describe('ol.proj.transform()', function() {
 
     it('transforms a 2d coordinate', function() {
-      var got = _ol_proj_.transform([-10, -20], 'EPSG:4326', 'EPSG:3857');
+      var got = transform([-10, -20], 'EPSG:4326', 'EPSG:3857');
       expect(got).to.have.length(2);
       expect(got[0]).to.roughlyEqual(-1113194.9079327357, 1e-3);
       expect(got[1]).to.roughlyEqual(-2273030.92698769, 1e-3);
     });
 
     it('transforms a 3d coordinate', function() {
-      var got = _ol_proj_.transform([-10, -20, 3], 'EPSG:4326', 'EPSG:3857');
+      var got = transform([-10, -20, 3], 'EPSG:4326', 'EPSG:3857');
       expect(got).to.have.length(3);
       expect(got[0]).to.roughlyEqual(-1113194.9079327357, 1e-3);
       expect(got[1]).to.roughlyEqual(-2273030.92698769, 1e-3);
@@ -518,7 +531,7 @@ describe('ol.proj', function() {
     });
 
     it('transforms a 4d coordinate', function() {
-      var got = _ol_proj_.transform([-10, -20, 3, 4], 'EPSG:4326', 'EPSG:3857');
+      var got = transform([-10, -20, 3, 4], 'EPSG:4326', 'EPSG:3857');
       expect(got).to.have.length(4);
       expect(got[0]).to.roughlyEqual(-1113194.9079327357, 1e-3);
       expect(got[1]).to.roughlyEqual(-2273030.92698769, 1e-3);
@@ -532,7 +545,7 @@ describe('ol.proj', function() {
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
 
-      var got = _ol_proj_.transform([-111, 45.5, 123], 'EPSG:4326', 'custom');
+      var got = transform([-111, 45.5, 123], 'EPSG:4326', 'custom');
       expect(got).to.have.length(3);
       expect(got[0]).to.roughlyEqual(-6601512.194209638, 1);
       expect(got[1]).to.roughlyEqual(6145843.802742112, 1);
@@ -579,26 +592,26 @@ describe('ol.proj', function() {
     });
 
     it('returns value in meters', function() {
-      var epsg4326 = _ol_proj_.get('EPSG:4326');
+      var epsg4326 = getProjection('EPSG:4326');
       expect(epsg4326.getMetersPerUnit()).to.eql(
           _ol_proj_EPSG4326_.METERS_PER_UNIT);
     });
 
     it('works for proj4js projections without units', function() {
-      var epsg26782 = _ol_proj_.get('EPSG:26782');
+      var epsg26782 = getProjection('EPSG:26782');
       expect(epsg26782.getMetersPerUnit()).to.eql(0.3048006096012192);
     });
 
     it('works for proj4js projections with units other than m', function() {
-      var epsg3739 = _ol_proj_.get('EPSG:3739');
+      var epsg3739 = getProjection('EPSG:3739');
       expect(epsg3739.getMetersPerUnit()).to.eql(1200 / 3937);
     });
 
     it('works for proj4js OGC WKT GEOGCS projections', function() {
-      var epsg4269 = _ol_proj_.get('EPSG:4269');
+      var epsg4269 = getProjection('EPSG:4269');
       expect(epsg4269.getMetersPerUnit()).to.eql(
           6378137 * 0.01745329251994328);
-      var epsg4279 = _ol_proj_.get('EPSG:4279');
+      var epsg4279 = getProjection('EPSG:4279');
       expect(epsg4279.getMetersPerUnit()).to.eql(
           6377563.396 * 0.01745329251994328);
     });

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -1,11 +1,11 @@
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {getPointResolution, transform, get as getProjection, clearAllProjections, addCommon} from '../../../../src/ol/proj.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
 
 describe('ol.proj.EPSG3857', function() {
 
   afterEach(function() {
-    _ol_proj_.clearAllProjections();
-    _ol_proj_.addCommon();
+    clearAllProjections();
+    addCommon();
   });
 
   describe('fromEPSG4326()', function() {
@@ -44,33 +44,33 @@ describe('ol.proj.EPSG3857', function() {
 
     it('returns the correct point scale at the equator', function() {
       // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
-      var epsg3857 = _ol_proj_.get('EPSG:3857');
+      var epsg3857 = getProjection('EPSG:3857');
       var resolution = 19.11;
       var point = [0, 0];
-      expect(_ol_proj_.getPointResolution(epsg3857, resolution, point)).
+      expect(getPointResolution(epsg3857, resolution, point)).
           to.roughlyEqual(19.11, 1e-1);
     });
 
     it('returns the correct point scale at the latitude of Toronto',
         function() {
           // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
-          var epsg3857 = _ol_proj_.get('EPSG:3857');
-          var epsg4326 = _ol_proj_.get('EPSG:4326');
+          var epsg3857 = getProjection('EPSG:3857');
+          var epsg4326 = getProjection('EPSG:4326');
           var resolution = 19.11;
-          var point = _ol_proj_.transform([0, 43.65], epsg4326, epsg3857);
-          expect(_ol_proj_.getPointResolution(epsg3857, resolution, point)).
+          var point = transform([0, 43.65], epsg4326, epsg3857);
+          expect(getPointResolution(epsg3857, resolution, point)).
               to.roughlyEqual(19.11 * Math.cos(Math.PI * 43.65 / 180), 1e-9);
         });
 
     it('returns the correct point scale at various latitudes', function() {
       // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
-      var epsg3857 = _ol_proj_.get('EPSG:3857');
-      var epsg4326 = _ol_proj_.get('EPSG:4326');
+      var epsg3857 = getProjection('EPSG:3857');
+      var epsg4326 = getProjection('EPSG:4326');
       var resolution = 19.11;
       var latitude;
       for (latitude = 0; latitude <= 85; ++latitude) {
-        var point = _ol_proj_.transform([0, latitude], epsg4326, epsg3857);
-        expect(_ol_proj_.getPointResolution(epsg3857, resolution, point)).
+        var point = transform([0, latitude], epsg4326, epsg3857);
+        expect(getPointResolution(epsg3857, resolution, point)).
             to.roughlyEqual(19.11 * Math.cos(Math.PI * latitude / 180), 1e-9);
       }
     });

--- a/test/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/tilelayer.test.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../../src/ol/View.js';
 import _ol_layer_Tile_ from '../../../../../src/ol/layer/Tile.js';
-import _ol_proj_ from '../../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../../src/ol/proj.js';
 import _ol_renderer_Map_ from '../../../../../src/ol/renderer/Map.js';
 import _ol_renderer_canvas_TileLayer_ from '../../../../../src/ol/renderer/canvas/TileLayer.js';
 import _ol_source_TileWMS_ from '../../../../../src/ol/source/TileWMS.js';
@@ -82,7 +82,7 @@ describe('ol.renderer.canvas.TileLayer', function() {
         time: Date.now(),
         viewState: {
           center: [10, 5],
-          projection: _ol_proj_.get('EPSG:3857'),
+          projection: getProjection('EPSG:3857'),
           resolution: 1,
           rotation: Math.PI
         },

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -6,7 +6,7 @@ import * as _ol_extent_ from '../../../../../src/ol/extent.js';
 import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../../../../../src/ol/layer/Vector.js';
 import _ol_obj_ from '../../../../../src/ol/obj.js';
-import _ol_proj_ from '../../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../../src/ol/proj.js';
 import _ol_render_canvas_ from '../../../../../src/ol/render/canvas.js';
 import _ol_renderer_canvas_VectorLayer_ from '../../../../../src/ol/renderer/canvas/VectorLayer.js';
 import _ol_source_Vector_ from '../../../../../src/ol/source/Vector.js';
@@ -226,7 +226,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
         source: new _ol_source_Vector_({wrapX: true})
       });
       renderer = new _ol_renderer_canvas_VectorLayer_(layer);
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       projExtent = projection.getExtent();
       worldWidth = _ol_extent_.getWidth(projExtent);
       buffer = layer.getRenderBuffer();

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -10,7 +10,7 @@ import * as _ol_extent_ from '../../../../../src/ol/extent.js';
 import _ol_format_MVT_ from '../../../../../src/ol/format/MVT.js';
 import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
 import _ol_layer_VectorTile_ from '../../../../../src/ol/layer/VectorTile.js';
-import _ol_proj_ from '../../../../../src/ol/proj.js';
+import {get as getProjection, fromLonLat} from '../../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../../src/ol/proj/Projection.js';
 import _ol_render_canvas_ from '../../../../../src/ol/render/canvas.js';
 import _ol_render_Feature_ from '../../../../../src/ol/render/Feature.js';
@@ -63,7 +63,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         _ol_VectorTile_.apply(this, arguments);
         this.setState('loaded');
         this.setFeatures([feature1, feature2, feature3]);
-        this.setProjection(_ol_proj_.get('EPSG:4326'));
+        this.setProjection(getProjection('EPSG:4326'));
         tileCallback(this);
       };
       inherits(TileClass, _ol_VectorTile_);
@@ -196,9 +196,8 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         tile = t;
       };
       map.renderSync();
-      expect(tile.getProjection()).to.equal(_ol_proj_.get('EPSG:3857'));
-      expect(feature1.getGeometry().getCoordinates()).to.eql(
-          _ol_proj_.fromLonLat([1, -1]));
+      expect(tile.getProjection()).to.equal(getProjection('EPSG:3857'));
+      expect(feature1.getGeometry().getCoordinates()).to.eql(fromLonLat([1, -1]));
     });
 
     it('Geometries are transformed from tile-pixels', function() {
@@ -209,7 +208,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         tile = t;
       };
       map.renderSync();
-      expect(tile.getProjection()).to.equal(_ol_proj_.get('EPSG:3857'));
+      expect(tile.getProjection()).to.equal(getProjection('EPSG:3857'));
       expect(feature1.getGeometry().getCoordinates()).to.eql([-20027724.40316874, 20047292.282409746]);
       expect(feature3.flatCoordinates_).to.eql([-20027724.40316874, 20047292.282409746]);
     });
@@ -247,7 +246,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         })
       });
       var sourceTile = new _ol_VectorTile_([0, 0, 0], 2);
-      sourceTile.setProjection(_ol_proj_.get('EPSG:3857'));
+      sourceTile.setProjection(getProjection('EPSG:3857'));
       sourceTile.features_ = [];
       sourceTile.getImage = function() {
         return document.createElement('canvas');
@@ -264,7 +263,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       };
       var renderer = new _ol_renderer_canvas_VectorTileLayer_(layer);
       renderer.renderTileImage_ = sinon.spy();
-      var proj = _ol_proj_.get('EPSG:3857');
+      var proj = getProjection('EPSG:3857');
       var frameState = {
         extent: proj.getExtent(),
         pixelRatio: 1,
@@ -295,7 +294,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       _ol_VectorImageTile_.apply(this, arguments);
       this.setState('loaded');
       var sourceTile = new _ol_VectorTile_([0, 0, 0]);
-      sourceTile.setProjection(_ol_proj_.get('EPSG:3857'));
+      sourceTile.setProjection(getProjection('EPSG:3857'));
       sourceTile.getReplayGroup = function() {
         return replayGroup;
       };
@@ -331,7 +330,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         layerStates: {},
         skippedFeatureUids: {},
         viewState: {
-          projection: _ol_proj_.get('EPSG:3857'),
+          projection: getProjection('EPSG:3857'),
           resolution: 1,
           rotation: 0
         }

--- a/test/spec/ol/reproj/image.test.js
+++ b/test/spec/ol/reproj/image.test.js
@@ -1,13 +1,13 @@
 import _ol_Image_ from '../../../../src/ol/Image.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_reproj_Image_ from '../../../../src/ol/reproj/Image.js';
 
 
 describe('ol.reproj.Image', function() {
   function createImage(pixelRatio) {
     return new _ol_reproj_Image_(
-        _ol_proj_.get('EPSG:3857'), _ol_proj_.get('EPSG:4326'),
+        getProjection('EPSG:3857'), getProjection('EPSG:4326'),
         [-180, -85, 180, 85], 10, pixelRatio,
         function(extent, resolution, pixelRatio) {
           return new _ol_Image_(extent, resolution, pixelRatio,

--- a/test/spec/ol/reproj/reproj.test.js
+++ b/test/spec/ol/reproj/reproj.test.js
@@ -1,15 +1,15 @@
 import _ol_reproj_ from '../../../../src/ol/reproj.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 
 describe('ol.reproj', function() {
 
   describe('#calculateSourceResolution', function() {
-    var proj3857 = _ol_proj_.get('EPSG:3857');
-    var proj4326 = _ol_proj_.get('EPSG:4326');
+    var proj3857 = getProjection('EPSG:3857');
+    var proj4326 = getProjection('EPSG:4326');
     var origin = [0, 0];
     var point3857 = [50, 40];
-    var point4326 = _ol_proj_.transform(point3857, proj3857, proj4326);
+    var point4326 = transform(point3857, proj3857, proj4326);
 
     it('is identity for identical projection', function() {
       var result;

--- a/test/spec/ol/reproj/tile.test.js
+++ b/test/spec/ol/reproj/tile.test.js
@@ -1,6 +1,6 @@
 import _ol_ImageTile_ from '../../../../src/ol/ImageTile.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_reproj_Tile_ from '../../../../src/ol/reproj/Tile.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
 
@@ -11,7 +11,7 @@ describe('ol.reproj.Tile', function() {
         '+k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy ' +
         '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
         '+units=m +no_defs');
-    var proj27700 = _ol_proj_.get('EPSG:27700');
+    var proj27700 = getProjection('EPSG:27700');
     proj27700.setExtent([0, 0, 700000, 1300000]);
   });
 
@@ -21,8 +21,8 @@ describe('ol.reproj.Tile', function() {
 
 
   function createTile(pixelRatio, opt_tileSize) {
-    var proj4326 = _ol_proj_.get('EPSG:4326');
-    var proj3857 = _ol_proj_.get('EPSG:3857');
+    var proj4326 = getProjection('EPSG:4326');
+    var proj3857 = getProjection('EPSG:3857');
     return new _ol_reproj_Tile_(
         proj3857, _ol_tilegrid_.createForProjection(proj3857), proj4326,
         _ol_tilegrid_.createForProjection(proj4326, 3, opt_tileSize),
@@ -48,8 +48,8 @@ describe('ol.reproj.Tile', function() {
   });
 
   it('is empty when outside target tile grid', function() {
-    var proj4326 = _ol_proj_.get('EPSG:4326');
-    var proj3857 = _ol_proj_.get('EPSG:3857');
+    var proj4326 = getProjection('EPSG:4326');
+    var proj3857 = getProjection('EPSG:3857');
     var tile = new _ol_reproj_Tile_(
         proj3857, _ol_tilegrid_.createForProjection(proj3857),
         proj4326, _ol_tilegrid_.createForProjection(proj4326),
@@ -60,8 +60,8 @@ describe('ol.reproj.Tile', function() {
   });
 
   it('is empty when outside source tile grid', function() {
-    var proj4326 = _ol_proj_.get('EPSG:4326');
-    var proj27700 = _ol_proj_.get('EPSG:27700');
+    var proj4326 = getProjection('EPSG:4326');
+    var proj27700 = getProjection('EPSG:27700');
     var tile = new _ol_reproj_Tile_(
         proj27700, _ol_tilegrid_.createForProjection(proj27700),
         proj4326, _ol_tilegrid_.createForProjection(proj4326),

--- a/test/spec/ol/reproj/triangulation.test.js
+++ b/test/spec/ol/reproj/triangulation.test.js
@@ -1,4 +1,4 @@
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_reproj_Triangulation_ from '../../../../src/ol/reproj/Triangulation.js';
 
 
@@ -8,7 +8,7 @@ describe('ol.reproj.Triangulation', function() {
         '+k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy ' +
         '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
         '+units=m +no_defs');
-    var proj27700 = _ol_proj_.get('EPSG:27700');
+    var proj27700 = getProjection('EPSG:27700');
     proj27700.setExtent([0, 0, 700000, 1300000]);
   });
 
@@ -18,22 +18,22 @@ describe('ol.reproj.Triangulation', function() {
 
   describe('constructor', function() {
     it('is trivial for identity', function() {
-      var proj4326 = _ol_proj_.get('EPSG:4326');
+      var proj4326 = getProjection('EPSG:4326');
       var triangulation = new _ol_reproj_Triangulation_(proj4326, proj4326,
           [20, 20, 30, 30], [-180, -90, 180, 90], 0);
       expect(triangulation.getTriangles().length).to.be(2);
     });
 
     it('is empty when outside source extent', function() {
-      var proj4326 = _ol_proj_.get('EPSG:4326');
-      var proj27700 = _ol_proj_.get('EPSG:27700');
+      var proj4326 = getProjection('EPSG:4326');
+      var proj27700 = getProjection('EPSG:27700');
       var triangulation = new _ol_reproj_Triangulation_(proj27700, proj4326,
           [0, 0, 10, 10], proj27700.getExtent(), 0);
       expect(triangulation.getTriangles().length).to.be(0);
     });
 
     it('can handle null source extent', function() {
-      var proj4326 = _ol_proj_.get('EPSG:4326');
+      var proj4326 = getProjection('EPSG:4326');
       var triangulation = new _ol_reproj_Triangulation_(proj4326, proj4326,
           [20, 20, 30, 30], null, 0);
       expect(triangulation.getTriangles().length).to.be(2);

--- a/test/spec/ol/source/cluster.test.js
+++ b/test/spec/ol/source/cluster.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_Cluster_ from '../../../../src/ol/source/Cluster.js';
 import _ol_source_Source_ from '../../../../src/ol/source/Source.js';
 import _ol_source_Vector_ from '../../../../src/ol/source/Vector.js';
@@ -12,7 +12,7 @@ describe('ol.source.Cluster', function() {
   describe('constructor', function() {
     it('returns a cluster source', function() {
       var source = new _ol_source_Cluster_({
-        projection: _ol_proj_.get('EPSG:4326'),
+        projection: getProjection('EPSG:4326'),
         source: new _ol_source_Vector_()
       });
       expect(source).to.be.a(_ol_source_Source_);
@@ -23,7 +23,7 @@ describe('ol.source.Cluster', function() {
 
   describe('#loadFeatures', function() {
     var extent = [-1, -1, 1, 1];
-    var projection = _ol_proj_.get('EPSG:3857');
+    var projection = getProjection('EPSG:3857');
     it('clusters a source with point features', function() {
       var source = new _ol_source_Cluster_({
         source: new _ol_source_Vector_({

--- a/test/spec/ol/source/imagearcgisrest.test.js
+++ b/test/spec/ol/source/imagearcgisrest.test.js
@@ -1,5 +1,5 @@
 import _ol_source_ImageArcGISRest_ from '../../../../src/ol/source/ImageArcGISRest.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 
 
 describe('ol.source.ImageArcGISRest', function() {
@@ -7,8 +7,8 @@ describe('ol.source.ImageArcGISRest', function() {
   var pixelRatio, options, projection, proj3857, resolution;
   beforeEach(function() {
     pixelRatio = 1;
-    projection = _ol_proj_.get('EPSG:4326');
-    proj3857 = _ol_proj_.get('EPSG:3857');
+    projection = getProjection('EPSG:4326');
+    proj3857 = getProjection('EPSG:3857');
     resolution = 0.1;
     options = {
       params: {},

--- a/test/spec/ol/source/imagestatic.test.js
+++ b/test/spec/ol/source/imagestatic.test.js
@@ -1,5 +1,5 @@
 import _ol_source_ImageStatic_ from '../../../../src/ol/source/ImageStatic.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 
 
 describe('ol.source.ImageStatic', function() {
@@ -10,7 +10,7 @@ describe('ol.source.ImageStatic', function() {
       -13637278.73946974, 4543799.13271362,
       -13617443.330629736, 4553927.038961405];
     pixelRatio = 1;
-    projection = _ol_proj_.get('EPSG:3857');
+    projection = getProjection('EPSG:3857');
     resolution = 38;
   });
 

--- a/test/spec/ol/source/imagewms.test.js
+++ b/test/spec/ol/source/imagewms.test.js
@@ -1,5 +1,5 @@
 import _ol_source_ImageWMS_ from '../../../../src/ol/source/ImageWMS.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 
 
 describe('ol.source.ImageWMS', function() {
@@ -8,7 +8,7 @@ describe('ol.source.ImageWMS', function() {
   beforeEach(function() {
     extent = [10, 20, 30, 40];
     pixelRatio = 1;
-    projection = _ol_proj_.get('EPSG:4326');
+    projection = getProjection('EPSG:4326');
     resolution = 0.1;
     options = {
       params: {
@@ -121,7 +121,7 @@ describe('ol.source.ImageWMS', function() {
 
     it('changes the BBOX order for EN axis orientations', function() {
       var source = new _ol_source_ImageWMS_(options);
-      projection = _ol_proj_.get('CRS:84');
+      projection = getProjection('CRS:84');
       var image = source.getImage(extent, resolution, pixelRatio, projection);
       var uri = new URL(image.src_);
       var queryData = uri.searchParams;

--- a/test/spec/ol/source/source.test.js
+++ b/test/spec/ol/source/source.test.js
@@ -1,4 +1,4 @@
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_Source_ from '../../../../src/ol/source/Source.js';
 
 
@@ -7,7 +7,7 @@ describe('ol.source.Source', function() {
   describe('constructor', function() {
     it('returns a source', function() {
       var source = new _ol_source_Source_({
-        projection: _ol_proj_.get('EPSG:4326')
+        projection: getProjection('EPSG:4326')
       });
       expect(source).to.be.a(_ol_source_Source_);
     });
@@ -68,7 +68,7 @@ describe('ol.source.Source', function() {
   describe('#refresh()', function() {
     it('dispatches the change event', function() {
       var source = new _ol_source_Source_({
-        projection: _ol_proj_.get('EPSG:4326')
+        projection: getProjection('EPSG:4326')
       });
       var changedSpy = sinon.spy();
       source.on('change', changedSpy);

--- a/test/spec/ol/source/tile.test.js
+++ b/test/spec/ol/source/tile.test.js
@@ -1,7 +1,7 @@
 import {inherits} from '../../../../src/ol/index.js';
 import _ol_Tile_ from '../../../../src/ol/Tile.js';
 import _ol_TileRange_ from '../../../../src/ol/TileRange.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_source_Source_ from '../../../../src/ol/source/Source.js';
 import _ol_source_Tile_ from '../../../../src/ol/source/Tile.js';
@@ -26,7 +26,7 @@ var MockTile = function(tileStates) {
   });
 
   _ol_source_Tile_.call(this, {
-    projection: _ol_proj_.get('EPSG:4326'),
+    projection: getProjection('EPSG:4326'),
     tileGrid: tileGrid
   });
 
@@ -57,13 +57,13 @@ describe('ol.source.Tile', function() {
   describe('constructor', function() {
     it('returns a tile source', function() {
       var source = new _ol_source_Tile_({
-        projection: _ol_proj_.get('EPSG:4326')
+        projection: getProjection('EPSG:4326')
       });
       expect(source).to.be.a(_ol_source_Source_);
       expect(source).to.be.a(_ol_source_Tile_);
     });
     it('sets a custom cache size', function() {
-      var projection = _ol_proj_.get('EPSG:4326');
+      var projection = getProjection('EPSG:4326');
       var source = new _ol_source_Tile_({
         projection: projection,
         cacheSize: 42

--- a/test/spec/ol/source/tilearcgisrest.test.js
+++ b/test/spec/ol/source/tilearcgisrest.test.js
@@ -1,6 +1,6 @@
 import _ol_ImageTile_ from '../../../../src/ol/ImageTile.js';
 import _ol_source_TileArcGISRest_ from '../../../../src/ol/source/TileArcGISRest.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 
 
 describe('ol.source.TileArcGISRest', function() {
@@ -17,7 +17,7 @@ describe('ol.source.TileArcGISRest', function() {
 
     it('returns a tile with the expected URL', function() {
       var source = new _ol_source_TileArcGISRest_(options);
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(_ol_ImageTile_);
       var uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -39,7 +39,7 @@ describe('ol.source.TileArcGISRest', function() {
 
     it('returns a non floating point DPI value', function() {
       var source = new _ol_source_TileArcGISRest_(options);
-      var tile = source.getTile(3, 2, -7, 1.12, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1.12, getProjection('EPSG:3857'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('DPI')).to.be('101');
@@ -48,7 +48,7 @@ describe('ol.source.TileArcGISRest', function() {
     it('takes DPI from params if specified', function() {
       options.params.DPI = 96;
       var source = new _ol_source_TileArcGISRest_(options);
-      var tile = source.getTile(3, 2, -7, 1.12, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1.12, getProjection('EPSG:3857'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('DPI')).to.be('108');
@@ -60,7 +60,7 @@ describe('ol.source.TileArcGISRest', function() {
       options.urls = ['http://test1.com/MapServer', 'http://test2.com/MapServer'];
       var source = new _ol_source_TileArcGISRest_(options);
 
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(_ol_ImageTile_);
       var uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -83,7 +83,7 @@ describe('ol.source.TileArcGISRest', function() {
     it('returns a tile with the expected URL for ImageServer', function() {
       options.url = 'http://example.com/ImageServer';
       var source = new _ol_source_TileArcGISRest_(options);
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(_ol_ImageTile_);
       var uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -106,7 +106,7 @@ describe('ol.source.TileArcGISRest', function() {
       options.params.FORMAT = 'png';
       options.params.TRANSPARENT = false;
       var source = new _ol_source_TileArcGISRest_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('EPSG:4326'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('png');
@@ -116,7 +116,7 @@ describe('ol.source.TileArcGISRest', function() {
     it('allows adding rest option', function() {
       options.params.LAYERS = 'show:1,3,4';
       var source = new _ol_source_TileArcGISRest_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('EPSG:4326'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('LAYERS')).to.be('show:1,3,4');
@@ -129,7 +129,7 @@ describe('ol.source.TileArcGISRest', function() {
       var source = new _ol_source_TileArcGISRest_(options);
       source.updateParams({'TEST': 'value'});
 
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('TEST')).to.be('value');
@@ -141,7 +141,7 @@ describe('ol.source.TileArcGISRest', function() {
       var source = new _ol_source_TileArcGISRest_(options);
       source.updateParams({'TEST': 'newValue'});
 
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('TEST')).to.be('newValue');
@@ -245,7 +245,7 @@ describe('ol.source.TileArcGISRest', function() {
 
       expect(urls).to.eql(['http://test3.com/MapServer']);
 
-      var tileUrl = source.tileUrlFunction([0, 0, 0], 1, _ol_proj_.get('EPSG:4326'));
+      var tileUrl = source.tileUrlFunction([0, 0, 0], 1, getProjection('EPSG:4326'));
       expect(tileUrl.indexOf(urls[0])).to.be(0);
     });
 

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -2,7 +2,7 @@ import _ol_ImageTile_ from '../../../../src/ol/ImageTile.js';
 import _ol_TileState_ from '../../../../src/ol/TileState.js';
 import _ol_TileUrlFunction_ from '../../../../src/ol/TileUrlFunction.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_reproj_Tile_ from '../../../../src/ol/reproj/Tile.js';
@@ -27,7 +27,7 @@ describe('ol.source.TileImage', function() {
   describe('#getTileCacheForProjection', function() {
     it('uses the cacheSize for reprojected tile caches', function() {
       var source = createSource(undefined, undefined, 42);
-      var tileCache = source.getTileCacheForProjection(_ol_proj_.get('EPSG:4326'));
+      var tileCache = source.getTileCacheForProjection(getProjection('EPSG:4326'));
       expect(tileCache.highWaterMark).to.be(42);
       expect(tileCache).to.not.equal(source.getTileCacheForProjection(source.getProjection()));
     });
@@ -38,7 +38,7 @@ describe('ol.source.TileImage', function() {
       var source = createSource();
       var tileGrid = _ol_tilegrid_.createForProjection('EPSG:4326', 3, [10, 20]);
       source.setTileGridForProjection('EPSG:4326', tileGrid);
-      var retrieved = source.getTileGridForProjection(_ol_proj_.get('EPSG:4326'));
+      var retrieved = source.getTileGridForProjection(getProjection('EPSG:4326'));
       expect(retrieved).to.be(tileGrid);
     });
   });
@@ -49,14 +49,14 @@ describe('ol.source.TileImage', function() {
     beforeEach(function() {
       source = createSource();
       expect(source.getKey()).to.be('');
-      source.getTileInternal(0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+      source.getTileInternal(0, 0, -1, 1, getProjection('EPSG:3857'));
       expect(source.tileCache.getCount()).to.be(1);
       tile = source.tileCache.get(_ol_tilecoord_.getKeyZXY(0, 0, -1));
     });
 
     it('gets the tile from the cache', function() {
       var returnedTile = source.getTileInternal(
-          0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+          0, 0, -1, 1, getProjection('EPSG:3857'));
       expect(returnedTile).to.be(tile);
     });
 
@@ -68,7 +68,7 @@ describe('ol.source.TileImage', function() {
             return 'key0';
           };
           var returnedTile = source.getTileInternal(
-              0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+              0, 0, -1, 1, getProjection('EPSG:3857'));
           expect(returnedTile).not.to.be(tile);
           expect(returnedTile.key).to.be('key0');
           expect(returnedTile.interimTile).to.be(null);
@@ -82,7 +82,7 @@ describe('ol.source.TileImage', function() {
           };
           tile.state = 2; // LOADED
           var returnedTile = source.getTileInternal(
-              0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+              0, 0, -1, 1, getProjection('EPSG:3857'));
           expect(returnedTile).not.to.be(tile);
           expect(returnedTile.key).to.be('key0');
           expect(returnedTile.interimTile).to.be(tile);
@@ -98,10 +98,10 @@ describe('ol.source.TileImage', function() {
           dynamicParamsKey = 'key0';
           tile.state = 2; // LOADED
           returnedTile = source.getTileInternal(
-              0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+              0, 0, -1, 1, getProjection('EPSG:3857'));
           dynamicParamsKey = 'key1';
           returnedTile = source.getTileInternal(
-              0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+              0, 0, -1, 1, getProjection('EPSG:3857'));
           expect(returnedTile).not.to.be(tile);
           expect(returnedTile.key).to.be('key1');
           expect(returnedTile.interimTile).to.be(tile);
@@ -115,7 +115,7 @@ describe('ol.source.TileImage', function() {
   describe('#getTile', function() {
     it('does not do reprojection for identity', function() {
       var source3857 = createSource('EPSG:3857');
-      var tile3857 = source3857.getTile(0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+      var tile3857 = source3857.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
       expect(tile3857).to.be.a(_ol_ImageTile_);
       expect(tile3857).not.to.be.a(_ol_reproj_Tile_);
 
@@ -142,7 +142,7 @@ describe('ol.source.TileImage', function() {
         extent: [-180, -90, 180, 90],
         tileSize: [2, 2]
       }));
-      var tile = source.getTile(0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.a(_ol_reproj_Tile_);
 
       _ol_events_.listen(tile, 'change', function() {
@@ -154,7 +154,7 @@ describe('ol.source.TileImage', function() {
     });
 
     it('can handle target projection without extent and units', function(done) {
-      var proj = _ol_proj_.get('4326_noextentnounits');
+      var proj = getProjection('4326_noextentnounits');
       var source = createSource();
       source.setTileGridForProjection(proj,
           _ol_tilegrid_.createXYZ({
@@ -191,7 +191,7 @@ describe('ol.source.TileImage', function() {
       source.on('tileloadstart', startSpy);
       var endSpy = sinon.spy();
       source.on('tileloadend', endSpy);
-      var tile = source.getTile(0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
       tile.load();
       expect(startSpy.callCount).to.be(1);
       expect(endSpy.callCount).to.be(1);
@@ -217,7 +217,7 @@ describe('ol.source.TileImage', function() {
         expect(errorSpy.callCount).to.be(1);
         done();
       });
-      var tile = source.getTile(0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
       tile.load();
     });
 
@@ -227,7 +227,7 @@ describe('ol.source.TileImage', function() {
       source.on('tileloadstart', startSpy);
       var endSpy = sinon.spy();
       source.on('tileloadend', endSpy);
-      var tile = source.getTile(0, 0, -1, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
       tile.load();
       tile.dispose();
       expect(startSpy.callCount).to.be(1);

--- a/test/spec/ol/source/tileutfgrid.test.js
+++ b/test/spec/ol/source/tileutfgrid.test.js
@@ -1,4 +1,4 @@
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transformExtent, fromLonLat} from '../../../../src/ol/proj.js';
 import _ol_source_Tile_ from '../../../../src/ol/source/Tile.js';
 import _ol_source_TileUTFGrid_ from '../../../../src/ol/source/TileUTFGrid.js';
 import _ol_tilegrid_TileGrid_ from '../../../../src/ol/tilegrid/TileGrid.js';
@@ -113,10 +113,10 @@ describe('ol.source.TileUTFGrid', function() {
       var tileGrid = source.getTileGrid();
       var extent = tileGrid.getExtent();
 
-      var proj4326 = _ol_proj_.get('EPSG:4326');
-      var proj3857 = _ol_proj_.get('EPSG:3857');
+      var proj4326 = getProjection('EPSG:4326');
+      var proj3857 = getProjection('EPSG:3857');
       var expectedExtent4326 = tileJson.bounds;
-      var expectedExtent3857 = _ol_proj_.transformExtent(
+      var expectedExtent3857 = transformExtent(
           expectedExtent4326, proj4326, proj3857
       );
       expect(extent).to.eql(proj3857.getExtent());
@@ -189,7 +189,7 @@ describe('ol.source.TileUTFGrid', function() {
 
   describe('#forDataAtCoordinateAndResolution', function() {
     var source = null;
-    var bonn3857 = _ol_proj_.fromLonLat([7.099814, 50.733992]);
+    var bonn3857 = fromLonLat([7.099814, 50.733992]);
     var noState3857 = [0, 0];
     var resolutionZoom1 = 78271.51696402048;
 

--- a/test/spec/ol/source/tilewms.test.js
+++ b/test/spec/ol/source/tilewms.test.js
@@ -1,5 +1,5 @@
 import _ol_ImageTile_ from '../../../../src/ol/ImageTile.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_TileWMS_ from '../../../../src/ol/source/TileWMS.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
 import _ol_tilegrid_TileGrid_ from '../../../../src/ol/tilegrid/TileGrid.js';
@@ -38,7 +38,7 @@ describe('ol.source.TileWMS', function() {
 
     it('returns a tile with the expected URL', function() {
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(_ol_ImageTile_);
       var uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -67,7 +67,7 @@ describe('ol.source.TileWMS', function() {
     it('returns a larger tile when a gutter is specified', function() {
       options.gutter = 16;
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -7, 1, _ol_proj_.get('EPSG:3857'));
+      var tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(_ol_ImageTile_);
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
@@ -84,7 +84,7 @@ describe('ol.source.TileWMS', function() {
     it('sets the SRS query value instead of CRS if version < 1.3', function() {
       options.params.VERSION = '1.2';
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('EPSG:4326'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('CRS')).to.be(null);
@@ -95,7 +95,7 @@ describe('ol.source.TileWMS', function() {
       options.params.FORMAT = 'image/jpeg';
       options.params.TRANSPARENT = false;
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('EPSG:4326'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('image/jpeg');
@@ -105,7 +105,7 @@ describe('ol.source.TileWMS', function() {
     it('does not add a STYLES= option if one is specified', function() {
       options.params.STYLES = 'foo';
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('EPSG:4326'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('STYLES')).to.be('foo');
@@ -113,7 +113,7 @@ describe('ol.source.TileWMS', function() {
 
     it('changes the BBOX order for EN axis orientations', function() {
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('EPSG:4326'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-45,-90,0,-45');
@@ -122,7 +122,7 @@ describe('ol.source.TileWMS', function() {
     it('uses EN BBOX order if version < 1.3', function() {
       options.params.VERSION = '1.1.0';
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -3, 1, _ol_proj_.get('CRS:84'));
+      var tile = source.getTile(3, 2, -3, 1, getProjection('CRS:84'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-90,-45,-45,0');
@@ -131,7 +131,7 @@ describe('ol.source.TileWMS', function() {
     it('sets FORMAT_OPTIONS when the server is GeoServer', function() {
       options.serverType = 'geoserver';
       var source = new _ol_source_TileWMS_(options);
-      var tile = source.getTile(3, 2, -3, 2, _ol_proj_.get('CRS:84'));
+      var tile = source.getTile(3, 2, -3, 2, getProjection('CRS:84'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:180');
@@ -141,7 +141,7 @@ describe('ol.source.TileWMS', function() {
       options.serverType = 'geoserver';
       var source = new _ol_source_TileWMS_(options);
       options.params.FORMAT_OPTIONS = 'param1:value1';
-      var tile = source.getTile(3, 2, -3, 2, _ol_proj_.get('CRS:84'));
+      var tile = source.getTile(3, 2, -3, 2, getProjection('CRS:84'));
       var uri = new URL(tile.src_);
       var queryData = uri.searchParams;
       expect(queryData.get('FORMAT_OPTIONS')).to.be('param1:value1;dpi:180');
@@ -151,7 +151,7 @@ describe('ol.source.TileWMS', function() {
         function() {
           options.serverType = 'geoserver';
           var source = new _ol_source_TileWMS_(options);
-          var tile = source.getTile(3, 2, -3, 1.325, _ol_proj_.get('CRS:84'));
+          var tile = source.getTile(3, 2, -3, 1.325, getProjection('CRS:84'));
           var uri = new URL(tile.src_);
           var queryData = uri.searchParams;
           expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:119');
@@ -165,7 +165,7 @@ describe('ol.source.TileWMS', function() {
       options.extent = [-80, -40, -50, -10];
       var source = new _ol_source_TileWMS_(options);
       var tileCoord = [3, 2, -3];
-      var url = source.tileUrlFunction(tileCoord, 1, _ol_proj_.get('EPSG:4326'));
+      var url = source.tileUrlFunction(tileCoord, 1, getProjection('EPSG:4326'));
       var uri = new URL(url);
       var queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-45,-90,0,-45');
@@ -175,7 +175,7 @@ describe('ol.source.TileWMS', function() {
       options.extent = [-80, -40, -40, -10];
       var source = new _ol_source_TileWMS_(options);
       var tileCoord = [3, 3, -3];
-      var url = source.tileUrlFunction(tileCoord, 1, _ol_proj_.get('EPSG:4326'));
+      var url = source.tileUrlFunction(tileCoord, 1, getProjection('EPSG:4326'));
       var uri = new URL(url);
       var queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-45,-45,0,0');
@@ -189,7 +189,7 @@ describe('ol.source.TileWMS', function() {
       });
       var source = new _ol_source_TileWMS_(options);
       var tileCoord = [3, 3, -3];
-      var url = source.tileUrlFunction(tileCoord, 1, _ol_proj_.get('EPSG:4326'));
+      var url = source.tileUrlFunction(tileCoord, 1, getProjection('EPSG:4326'));
       var uri = new URL(url);
       var queryData = uri.searchParams;
       expect(queryData.get('WIDTH')).to.be('640');
@@ -205,7 +205,7 @@ describe('ol.source.TileWMS', function() {
       source.pixelRatio_ = 1;
       var url = source.getGetFeatureInfoUrl(
           [-7000000, -12000000],
-          19567.87924100512, _ol_proj_.get('EPSG:3857'),
+          19567.87924100512, getProjection('EPSG:3857'),
           {INFO_FORMAT: 'text/plain'});
       var uri = new URL(url);
       expect(uri.protocol).to.be('http:');
@@ -239,7 +239,7 @@ describe('ol.source.TileWMS', function() {
       source.pixelRatio_ = 1;
       var url = source.getGetFeatureInfoUrl(
           [-7000000, -12000000],
-          19567.87924100512, _ol_proj_.get('EPSG:3857'),
+          19567.87924100512, getProjection('EPSG:3857'),
           {INFO_FORMAT: 'text/plain'});
       var uri = new URL(url);
       expect(uri.protocol).to.be('http:');
@@ -269,7 +269,7 @@ describe('ol.source.TileWMS', function() {
       source.pixelRatio_ = 1;
       var url = source.getGetFeatureInfoUrl(
           [-7000000, -12000000],
-          19567.87924100512, _ol_proj_.get('EPSG:3857'),
+          19567.87924100512, getProjection('EPSG:3857'),
           {INFO_FORMAT: 'text/plain', QUERY_LAYERS: 'foo,bar'});
       var uri = new URL(url);
       expect(uri.protocol).to.be('http:');
@@ -304,7 +304,7 @@ describe('ol.source.TileWMS', function() {
       var source = new _ol_source_TileWMS_(options);
       var url = 'http://foo/';
       source.setUrl(url);
-      var tileUrl = source.tileUrlFunction([0, 0, 0], 1, _ol_proj_.get('EPSG:4326'));
+      var tileUrl = source.tileUrlFunction([0, 0, 0], 1, getProjection('EPSG:4326'));
       expect(tileUrl.indexOf(url)).to.be(0);
     });
   });

--- a/test/spec/ol/source/urltile.test.js
+++ b/test/spec/ol/source/urltile.test.js
@@ -1,4 +1,4 @@
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_UrlTile_ from '../../../../src/ol/source/UrlTile.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
 
@@ -168,7 +168,7 @@ describe('ol.source.UrlTile', function() {
     beforeEach(function() {
       sourceOptions = {
         tileGrid: _ol_tilegrid_.createXYZ({
-          extent: _ol_proj_.get('EPSG:4326').getExtent()
+          extent: getProjection('EPSG:4326').getExtent()
         })
       };
     });

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -7,7 +7,7 @@ import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_loadingstrategy_ from '../../../../src/ol/loadingstrategy.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, transformExtent, fromLonLat} from '../../../../src/ol/proj.js';
 import _ol_source_Vector_ from '../../../../src/ol/source/Vector.js';
 
 
@@ -428,7 +428,7 @@ describe('ol.source.Vector', function() {
           strategy: _ol_loadingstrategy_.bbox,
           loader: function(extent) {
             setTimeout(function() {
-              var lonLatExtent = _ol_proj_.transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
+              var lonLatExtent = transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
               expect(lonLatExtent[0]).to.roughlyEqual(-99.261474609, 1e-9);
               expect(lonLatExtent[2]).to.roughlyEqual(-95.965576171, 1e-9);
               done();
@@ -446,7 +446,7 @@ describe('ol.source.Vector', function() {
             })
           ],
           view: new _ol_View_({
-            center: _ol_proj_.fromLonLat(center),
+            center: fromLonLat(center),
             zoom: 7
           })
         });
@@ -462,7 +462,7 @@ describe('ol.source.Vector', function() {
       it('stores the infinity extent in the Rtree', function() {
         var source = new _ol_source_Vector_();
         source.loadFeatures([-10000, -10000, 10000, 10000], 1,
-            _ol_proj_.get('EPSG:3857'));
+            getProjection('EPSG:3857'));
         var loadedExtents = source.loadedExtentsRtree_.getAll();
         expect(loadedExtents).to.have.length(1);
         expect(loadedExtents[0].extent).to.eql(
@@ -483,11 +483,11 @@ describe('ol.source.Vector', function() {
         };
         var source = new _ol_source_Vector_({loader: loader1});
         source.loadFeatures([-10000, -10000, 10000, 10000], 1,
-            _ol_proj_.get('EPSG:3857'));
+            getProjection('EPSG:3857'));
         source.setLoader(loader2);
         source.clear();
         source.loadFeatures([-10000, -10000, 10000, 10000], 1,
-            _ol_proj_.get('EPSG:3857'));
+            getProjection('EPSG:3857'));
         expect(count1).to.eql(1);
         expect(count2).to.eql(1);
       });
@@ -502,7 +502,7 @@ describe('ol.source.Vector', function() {
             done();
           }, 0);
         });
-        source.loadFeatures([-10000, -10000, 10000, 10000], 1, _ol_proj_.get('EPSG:3857'));
+        source.loadFeatures([-10000, -10000, 10000, 10000], 1, getProjection('EPSG:3857'));
       });
     });
 

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -4,7 +4,7 @@ import _ol_VectorImageTile_ from '../../../../src/ol/VectorImageTile.js';
 import _ol_VectorTile_ from '../../../../src/ol/VectorTile.js';
 import _ol_format_MVT_ from '../../../../src/ol/format/MVT.js';
 import _ol_layer_VectorTile_ from '../../../../src/ol/layer/VectorTile.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_VectorTile_ from '../../../../src/ol/source/VectorTile.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
 import _ol_tilegrid_TileGrid_ from '../../../../src/ol/tilegrid/TileGrid.js';
@@ -37,28 +37,28 @@ describe('ol.source.VectorTile', function() {
 
   describe('#getTile()', function() {
     it('creates a tile with the correct tile class', function() {
-      tile = source.getTile(0, 0, 0, 1, _ol_proj_.get('EPSG:3857'));
+      tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.a(_ol_VectorImageTile_);
     });
     it('sets the correct tileCoord on the created tile', function() {
       expect(tile.getTileCoord()).to.eql([0, 0, 0]);
     });
     it('fetches tile from cache when requested again', function() {
-      expect(source.getTile(0, 0, 0, 1, _ol_proj_.get('EPSG:3857')))
+      expect(source.getTile(0, 0, 0, 1, getProjection('EPSG:3857')))
           .to.equal(tile);
     });
   });
 
   describe('#getTileGridForProjection', function() {
     it('creates a tile grid with the source tile grid\'s tile size', function() {
-      var tileGrid = source.getTileGridForProjection(_ol_proj_.get('EPSG:3857'));
+      var tileGrid = source.getTileGridForProjection(getProjection('EPSG:3857'));
       expect(tileGrid.getTileSize(0)).to.be(512);
     });
   });
 
   describe('Tile load events', function() {
     it('triggers tileloadstart and tileloadend with ol.VectorTile', function(done) {
-      tile = source.getTile(14, 8938, -5681, 1, _ol_proj_.get('EPSG:3857'));
+      tile = source.getTile(14, 8938, -5681, 1, getProjection('EPSG:3857'));
       var started = false;
       source.on('tileloadstart', function() {
         started = true;

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -1,5 +1,5 @@
 import _ol_format_WMTSCapabilities_ from '../../../../src/ol/format/WMTSCapabilities.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_tilegrid_WMTS_ from '../../../../src/ol/tilegrid/WMTS.js';
 import _ol_source_WMTS_ from '../../../../src/ol/source/WMTS.js';
@@ -58,7 +58,7 @@ describe('ol.source.WMTS', function() {
           expect(options.format).to.be.eql('image/jpeg');
 
           expect(options.projection).to.be.a(_ol_proj_Projection_);
-          expect(options.projection).to.be.eql(_ol_proj_.get('EPSG:3857'));
+          expect(options.projection).to.be.eql(getProjection('EPSG:3857'));
 
           expect(options.requestEncoding).to.be.eql('KVP');
 
@@ -92,7 +92,7 @@ describe('ol.source.WMTS', function() {
           expect(options.format).to.be.eql('image/png');
 
           expect(options.projection).to.be.a(_ol_proj_Projection_);
-          expect(options.projection).to.be.eql(_ol_proj_.get('EPSG:3857'));
+          expect(options.projection).to.be.eql(getProjection('EPSG:3857'));
 
           expect(options.requestEncoding).to.be.eql('REST');
 
@@ -196,7 +196,7 @@ describe('ol.source.WMTS', function() {
             })
           });
 
-          var projection = _ol_proj_.get('EPSG:3857');
+          var projection = getProjection('EPSG:3857');
           var url = source.tileUrlFunction(
               source.getTileCoordForTileUrlFunction([1, 1, -2]), 1, projection);
           expect(url).to.be.eql('http://www.example.com/wmts/coastlines/' +
@@ -222,7 +222,7 @@ describe('ol.source.WMTS', function() {
             })
           });
 
-          var projection = _ol_proj_.get('EPSG:3857');
+          var projection = getProjection('EPSG:3857');
           var url = source.tileUrlFunction(
               source.getTileCoordForTileUrlFunction([1, 1, -2]), 1, projection);
           expect(url).to.be.eql('http://www.example.com/wmts/coastlines/' +
@@ -307,7 +307,7 @@ describe('ol.source.WMTS', function() {
     });
 
     it('generates the correct tileUrlFunction during application of setUrl()', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var source = new _ol_source_WMTS_({
         projection: projection,
         requestEncoding: 'REST',

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -1,7 +1,7 @@
 import {DEFAULT_MAX_ZOOM, DEFAULT_TILE_SIZE} from '../../../../src/ol/tilegrid/common.js';
 import _ol_TileRange_ from '../../../../src/ol/TileRange.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_proj_ from '../../../../src/ol/proj.js';
+import {get as getProjection, METERS_PER_UNIT} from '../../../../src/ol/proj.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
@@ -308,7 +308,7 @@ describe('ol.tilegrid.TileGrid', function() {
   describe('createForProjection', function() {
 
     it('allows easier creation of a tile grid', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(projection);
       expect(grid).to.be.a(_ol_tilegrid_TileGrid_);
 
@@ -317,7 +317,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('accepts a number of zoom levels', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(projection, 18);
       expect(grid).to.be.a(_ol_tilegrid_TileGrid_);
 
@@ -326,7 +326,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('accepts a big number of zoom levels', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(projection, 23);
       expect(grid).to.be.a(_ol_tilegrid_TileGrid_);
 
@@ -340,12 +340,12 @@ describe('ol.tilegrid.TileGrid', function() {
       var grid = _ol_tilegrid_.createForProjection(projection);
       var resolutions = grid.getResolutions();
       expect(resolutions[5]).to.be(
-          360 * _ol_proj_.METERS_PER_UNIT['degrees'] /
+          360 * METERS_PER_UNIT['degrees'] /
           DEFAULT_TILE_SIZE / Math.pow(2, 5));
     });
 
     it('assumes origin is top-left', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(projection);
       var origin = grid.getOrigin();
       var half = _ol_proj_EPSG3857_.HALF_SIZE;
@@ -353,7 +353,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('accepts bottom-left as corner', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(
           projection, undefined, undefined, 'bottom-left');
       var origin = grid.getOrigin();
@@ -362,7 +362,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('accepts bottom-right as corner', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(
           projection, undefined, undefined, 'bottom-right');
       var origin = grid.getOrigin();
@@ -371,7 +371,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('accepts top-left as corner', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(
           projection, undefined, undefined, 'top-left');
       var origin = grid.getOrigin();
@@ -380,7 +380,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('accepts top-right as corner', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.createForProjection(
           projection, undefined, undefined, 'top-right');
       var origin = grid.getOrigin();
@@ -395,7 +395,7 @@ describe('ol.tilegrid.TileGrid', function() {
     it('uses defaults', function() {
       var tileGrid = _ol_tilegrid_.createXYZ();
       expect(tileGrid.getExtent()).to.eql(
-          _ol_proj_.get('EPSG:3857').getExtent());
+          getProjection('EPSG:3857').getExtent());
       expect(tileGrid.getMinZoom()).to.equal(0);
       expect(tileGrid.getMaxZoom()).to.equal(DEFAULT_MAX_ZOOM);
       expect(tileGrid.getTileSize()).to.equal(DEFAULT_TILE_SIZE);
@@ -419,7 +419,7 @@ describe('ol.tilegrid.TileGrid', function() {
   describe('getForProjection', function() {
 
     it('gets the default tile grid for a projection', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.getForProjection(projection);
       expect(grid).to.be.a(_ol_tilegrid_TileGrid_);
 
@@ -429,7 +429,7 @@ describe('ol.tilegrid.TileGrid', function() {
     });
 
     it('stores the default tile grid on a projection', function() {
-      var projection = _ol_proj_.get('EPSG:3857');
+      var projection = getProjection('EPSG:3857');
       var grid = _ol_tilegrid_.getForProjection(projection);
       var gridAgain = _ol_tilegrid_.getForProjection(projection);
 
@@ -443,7 +443,7 @@ describe('ol.tilegrid.TileGrid', function() {
     var tileGrid;
     beforeEach(function() {
       tileGrid = _ol_tilegrid_.createForExtent(
-          _ol_proj_.get('EPSG:3857').getExtent(), 22);
+          getProjection('EPSG:3857').getExtent(), 22);
     });
 
     it('returns the tile range for one zoom level deeper', function() {
@@ -493,7 +493,7 @@ describe('ol.tilegrid.TileGrid', function() {
     var tileGrid;
     beforeEach(function() {
       tileGrid = _ol_tilegrid_.createForExtent(
-          _ol_proj_.get('EPSG:3857').getExtent(), 22);
+          getProjection('EPSG:3857').getExtent(), 22);
     });
 
     it('iterates as expected', function() {
@@ -552,7 +552,7 @@ describe('ol.tilegrid.TileGrid', function() {
     var tileGrid;
     beforeEach(function() {
       tileGrid = _ol_tilegrid_.createForExtent(
-          _ol_proj_.get('EPSG:3857').getExtent(), 22);
+          getProjection('EPSG:3857').getExtent(), 22);
     });
 
     it('returns the correct resolution at the equator', function() {

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -3,7 +3,7 @@ import _ol_VectorImageTile_ from '../../../src/ol/VectorImageTile.js';
 import _ol_VectorTile_ from '../../../src/ol/VectorTile.js';
 import _ol_events_ from '../../../src/ol/events.js';
 import _ol_format_GeoJSON_ from '../../../src/ol/format/GeoJSON.js';
-import _ol_proj_ from '../../../src/ol/proj.js';
+import {get as getProjection} from '../../../src/ol/proj.js';
 import _ol_tilegrid_ from '../../../src/ol/tilegrid.js';
 import _ol_tilegrid_TileGrid_ from '../../../src/ol/tilegrid/TileGrid.js';
 
@@ -17,7 +17,7 @@ describe('ol.VectorImageTile', function() {
         _ol_VectorImageTile_.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, _ol_tilegrid_.createXYZ(), _ol_tilegrid_.createXYZ(), {},
-        1, _ol_proj_.get('EPSG:3857'), _ol_VectorTile_, function() {});
+        1, getProjection('EPSG:3857'), _ol_VectorTile_, function() {});
 
     tile.load();
     var sourceTile = tile.getTile(tile.tileKeys[0]);
@@ -41,7 +41,7 @@ describe('ol.VectorImageTile', function() {
         }, [0, 0, -1], function() {
           return url;
         }, _ol_tilegrid_.createXYZ(), _ol_tilegrid_.createXYZ(), {},
-        1, _ol_proj_.get('EPSG:3857'), _ol_VectorTile_, function() {});
+        1, getProjection('EPSG:3857'), _ol_VectorTile_, function() {});
 
     tile.load();
     var calls = 0;
@@ -65,7 +65,7 @@ describe('ol.VectorImageTile', function() {
         _ol_VectorImageTile_.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, _ol_tilegrid_.createXYZ(), _ol_tilegrid_.createXYZ(), {},
-        1, _ol_proj_.get('EPSG:3857'), _ol_VectorTile_, function() {});
+        1, getProjection('EPSG:3857'), _ol_VectorTile_, function() {});
 
     tile.load();
 
@@ -81,7 +81,7 @@ describe('ol.VectorImageTile', function() {
     var tile = new _ol_VectorImageTile_([0, 0, -1], 0, url, format,
         _ol_VectorImageTile_.defaultLoadFunction, [0, 0, -1], function() {},
         _ol_tilegrid_.createXYZ(), _ol_tilegrid_.createXYZ(), {},
-        1, _ol_proj_.get('EPSG:3857'), _ol_VectorTile_, function() {});
+        1, getProjection('EPSG:3857'), _ol_VectorTile_, function() {});
 
     tile.load();
 
@@ -105,7 +105,7 @@ describe('ol.VectorImageTile', function() {
           return url;
         }, tileGrid,
         _ol_tilegrid_.createXYZ({extent: [-180, -90, 180, 90], tileSize: 512}),
-        sourceTiles, 1, _ol_proj_.get('EPSG:4326'), _ol_VectorTile_, function() {});
+        sourceTiles, 1, getProjection('EPSG:4326'), _ol_VectorTile_, function() {});
     tile.load();
     expect(tile.tileKeys.length).to.be(1);
     expect(tile.getTile(tile.tileKeys[0]).tileCoord).to.eql([0, 16, -10]);
@@ -118,7 +118,7 @@ describe('ol.VectorImageTile', function() {
         _ol_VectorImageTile_.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, _ol_tilegrid_.createXYZ(), _ol_tilegrid_.createXYZ({tileSize: 512}), {},
-        1, _ol_proj_.get('EPSG:3857'), _ol_VectorTile_, function() {});
+        1, getProjection('EPSG:3857'), _ol_VectorTile_, function() {});
 
     tile.load();
     expect(tile.loadListenerKeys_.length).to.be(4);
@@ -138,7 +138,7 @@ describe('ol.VectorImageTile', function() {
         _ol_VectorImageTile_.defaultLoadFunction, [0, 0, -1], function() {
           return url;
         }, _ol_tilegrid_.createXYZ(), _ol_tilegrid_.createXYZ({tileSize: 512}), {},
-        1, _ol_proj_.get('EPSG:3857'), _ol_VectorTile_, function() {});
+        1, getProjection('EPSG:3857'), _ol_VectorTile_, function() {});
 
     tile.load();
     _ol_events_.listenOnce(tile, 'change', function() {

--- a/test/spec/ol/vectortile.test.js
+++ b/test/spec/ol/vectortile.test.js
@@ -3,7 +3,7 @@ import _ol_VectorImageTile_ from '../../../src/ol/VectorImageTile.js';
 import _ol_VectorTile_ from '../../../src/ol/VectorTile.js';
 import _ol_events_ from '../../../src/ol/events.js';
 import _ol_format_TextFeature_ from '../../../src/ol/format/TextFeature.js';
-import _ol_proj_ from '../../../src/ol/proj.js';
+import {get as getProjection} from '../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../src/ol/proj/Projection.js';
 
 
@@ -32,7 +32,7 @@ describe('ol.VectorTile', function() {
       expect(tile.getProjection().getUnits()).to.be('tile-pixels');
       done();
     });
-    loader.call(tile, [], 1, _ol_proj_.get('EPSG:3857'));
+    loader.call(tile, [], 1, getProjection('EPSG:3857'));
   });
 
 });


### PR DESCRIPTION
This removes the default and adds named exports from the `ol/proj` module.