### PR TITLE
Rename geometry variables

### DIFF
--- a/examples/blend-modes.js
+++ b/examples/blend-modes.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -16,7 +16,7 @@ import _ol_style_Style_ from '../src/ol/style/Style.js';
 // features form the corners of an equilateral triangle and their styles overlap
 var redLayer = new _ol_layer_Vector_({
   source: new _ol_source_Vector_({
-    features: [new _ol_Feature_(new _ol_geom_Point_([0, 0]))]
+    features: [new _ol_Feature_(new Point([0, 0]))]
   }),
   style: new _ol_style_Style_({
     image: new _ol_style_Circle_({
@@ -34,7 +34,7 @@ var redLayer = new _ol_layer_Vector_({
 var greenLayer = new _ol_layer_Vector_({
   source: new _ol_source_Vector_({
     // 433.013 is roughly 250 * Math.sqrt(3)
-    features: [new _ol_Feature_(new _ol_geom_Point_([250, 433.013]))]
+    features: [new _ol_Feature_(new Point([250, 433.013]))]
   }),
   style: new _ol_style_Style_({
     image: new _ol_style_Circle_({
@@ -51,7 +51,7 @@ var greenLayer = new _ol_layer_Vector_({
 });
 var blueLayer = new _ol_layer_Vector_({
   source: new _ol_source_Vector_({
-    features: [new _ol_Feature_(new _ol_geom_Point_([500, 0]))]
+    features: [new _ol_Feature_(new Point([500, 0]))]
   }),
   style: new _ol_style_Style_({
     image: new _ol_style_Circle_({

--- a/examples/cluster.js
+++ b/examples/cluster.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Cluster_ from '../src/ol/source/Cluster.js';
@@ -21,7 +21,7 @@ var features = new Array(count);
 var e = 4500000;
 for (var i = 0; i < count; ++i) {
   var coordinates = [2 * e * Math.random() - e, 2 * e * Math.random() - e];
-  features[i] = new _ol_Feature_(new _ol_geom_Point_(coordinates));
+  features[i] = new _ol_Feature_(new Point(coordinates));
 }
 
 var source = new _ol_source_Vector_({

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -3,7 +3,7 @@ import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_interaction_ from '../src/ol/interaction.js';
 import _ol_interaction_Pointer_ from '../src/ol/interaction/Pointer.js';
@@ -134,7 +134,7 @@ app.Drag.prototype.handleUpEvent = function() {
 };
 
 
-var pointFeature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+var pointFeature = new _ol_Feature_(new Point([0, 0]));
 
 var lineFeature = new _ol_Feature_(
     new _ol_geom_LineString_([[-1e7, 1e6], [-1e6, 3e6]]));

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -4,7 +4,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import LineString from '../src/ol/geom/LineString.js';
 import Point from '../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_interaction_ from '../src/ol/interaction.js';
 import _ol_interaction_Pointer_ from '../src/ol/interaction/Pointer.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
@@ -140,7 +140,7 @@ var lineFeature = new _ol_Feature_(
     new LineString([[-1e7, 1e6], [-1e6, 3e6]]));
 
 var polygonFeature = new _ol_Feature_(
-    new _ol_geom_Polygon_([[[-3e6, -1e6], [-3e6, 1e6],
+    new Polygon([[[-3e6, -1e6], [-3e6, 1e6],
       [-1e6, 1e6], [-1e6, -1e6], [-3e6, -1e6]]]));
 
 

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -2,7 +2,7 @@ import {inherits} from '../src/ol/index.js';
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import Point from '../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_interaction_ from '../src/ol/interaction.js';
@@ -137,7 +137,7 @@ app.Drag.prototype.handleUpEvent = function() {
 var pointFeature = new _ol_Feature_(new Point([0, 0]));
 
 var lineFeature = new _ol_Feature_(
-    new _ol_geom_LineString_([[-1e7, 1e6], [-1e6, 3e6]]));
+    new LineString([[-1e7, 1e6], [-1e6, 3e6]]));
 
 var polygonFeature = new _ol_Feature_(
     new _ol_geom_Polygon_([[[-3e6, -1e6], [-3e6, 1e6],

--- a/examples/draw-shapes.js
+++ b/examples/draw-shapes.js
@@ -1,6 +1,6 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
@@ -43,7 +43,7 @@ function addInteraction() {
       value = 'Circle';
       geometryFunction = function(coordinates, geometry) {
         if (!geometry) {
-          geometry = new _ol_geom_Polygon_(null);
+          geometry = new Polygon(null);
         }
         var center = coordinates[0];
         var last = coordinates[1];

--- a/examples/dynamic-data.js
+++ b/examples/dynamic-data.js
@@ -1,6 +1,6 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_MultiPoint_ from '../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../src/ol/geom/MultiPoint.js';
 import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
@@ -66,7 +66,7 @@ map.on('postcompose', function(event) {
     coordinates.push([x, y]);
   }
   vectorContext.setStyle(imageStyle);
-  vectorContext.drawGeometry(new _ol_geom_MultiPoint_(coordinates));
+  vectorContext.drawGeometry(new MultiPoint(coordinates));
 
   var headPoint = new Point(coordinates[coordinates.length - 1]);
 

--- a/examples/dynamic-data.js
+++ b/examples/dynamic-data.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_geom_MultiPoint_ from '../src/ol/geom/MultiPoint.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -68,7 +68,7 @@ map.on('postcompose', function(event) {
   vectorContext.setStyle(imageStyle);
   vectorContext.drawGeometry(new _ol_geom_MultiPoint_(coordinates));
 
-  var headPoint = new _ol_geom_Point_(coordinates[coordinates.length - 1]);
+  var headPoint = new Point(coordinates[coordinates.length - 1]);
 
   vectorContext.setStyle(headOuterImageStyle);
   vectorContext.drawGeometry(headPoint);

--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_format_KML_ from '../src/ol/format/KML.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_render_ from '../src/ol/render.js';
@@ -39,7 +39,7 @@ var styleFunction = function(feature) {
       fill: new _ol_style_Fill_({color: 'rgba(255, 153, 0, 0.4)'}),
       stroke: new _ol_style_Stroke_({color: 'rgba(255, 204, 0, 0.2)', width: 2})
     }));
-    vectorContext.drawGeometry(new _ol_geom_Polygon_([symbol.map(scaleFunction)]));
+    vectorContext.drawGeometry(new Polygon([symbol.map(scaleFunction)]));
     style = new _ol_style_Style_({
       image: new _ol_style_Icon_({
         img: canvas,

--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -4,7 +4,7 @@ import _ol_Observable_ from '../src/ol/Observable.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import {easeOut} from '../src/ol/easing.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import {fromLonLat} from '../src/ol/proj.js';
@@ -46,7 +46,7 @@ map.addLayer(vector);
 function addRandomFeature() {
   var x = Math.random() * 360 - 180;
   var y = Math.random() * 180 - 90;
-  var geom = new _ol_geom_Point_(fromLonLat([x, y]));
+  var geom = new Point(fromLonLat([x, y]));
   var feature = new _ol_Feature_(geom);
   source.addFeature(feature);
 }

--- a/examples/feature-move-animation.js
+++ b/examples/feature-move-animation.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_format_Polyline_ from '../src/ol/format/Polyline.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_BingMaps_ from '../src/ol/source/BingMaps.js';
@@ -73,15 +73,15 @@ var routeFeature = new _ol_Feature_({
 });
 var geoMarker = new _ol_Feature_({
   type: 'geoMarker',
-  geometry: new _ol_geom_Point_(routeCoords[0])
+  geometry: new Point(routeCoords[0])
 });
 var startMarker = new _ol_Feature_({
   type: 'icon',
-  geometry: new _ol_geom_Point_(routeCoords[0])
+  geometry: new Point(routeCoords[0])
 });
 var endMarker = new _ol_Feature_({
   type: 'icon',
-  geometry: new _ol_geom_Point_(routeCoords[routeLength - 1])
+  geometry: new Point(routeCoords[routeLength - 1])
 });
 
 var styles = {
@@ -162,7 +162,7 @@ var moveFeature = function(event) {
       return;
     }
 
-    var currentPoint = new _ol_geom_Point_(routeCoords[index]);
+    var currentPoint = new Point(routeCoords[index]);
     var feature = new _ol_Feature_(currentPoint);
     vectorContext.drawFeature(feature, styles.geoMarker);
   }

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -2,7 +2,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Stamen_ from '../src/ol/source/Stamen.js';
@@ -60,7 +60,7 @@ var animateFlights = function(event) {
       }
 
       var maxIndex = Math.min(elapsedPoints, coords.length);
-      var currentLine = new _ol_geom_LineString_(coords.slice(0, maxIndex));
+      var currentLine = new LineString(coords.slice(0, maxIndex));
 
       // directly draw the line with the vector context
       vectorContext.drawGeometry(currentLine);
@@ -92,7 +92,7 @@ flightsSource = new _ol_source_Vector_({
 
         var arcLine = arcGenerator.Arc(100, {offset: 10});
         if (arcLine.geometries.length === 1) {
-          var line = new _ol_geom_LineString_(arcLine.geometries[0].coords);
+          var line = new LineString(arcLine.geometries[0].coords);
           line.transform('EPSG:4326', 'EPSG:3857');
 
           var feature = new _ol_Feature_({

--- a/examples/fractal.js
+++ b/examples/fractal.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 
@@ -11,7 +11,7 @@ var sin30 = Math.sin(Math.PI / 6);
 var rise = radius * sin30;
 var run = radius * cos30;
 
-var triangle = new _ol_geom_LineString_([
+var triangle = new LineString([
   [0, radius], [run, -rise], [-run, -rise], [0, radius]
 ]);
 

--- a/examples/geojson.js
+++ b/examples/geojson.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_format_GeoJSON_ from '../src/ol/format/GeoJSON.js';
-import _ol_geom_Circle_ from '../src/ol/geom/Circle.js';
+import Circle from '../src/ol/geom/Circle.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
@@ -164,7 +164,7 @@ var vectorSource = new _ol_source_Vector_({
   features: (new _ol_format_GeoJSON_()).readFeatures(geojsonObject)
 });
 
-vectorSource.addFeature(new _ol_Feature_(new _ol_geom_Circle_([5e6, 7e6], 1e6)));
+vectorSource.addFeature(new _ol_Feature_(new Circle([5e6, 7e6], 1e6)));
 
 var vectorLayer = new _ol_layer_Vector_({
   source: vectorSource,

--- a/examples/geolocation-orientation.js
+++ b/examples/geolocation-orientation.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_Overlay_ from '../src/ol/Overlay.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
@@ -42,7 +42,7 @@ map.addOverlay(marker);
 // LineString to store the different geolocation positions. This LineString
 // is time aware.
 // The Z dimension is actually used to store the rotation (heading).
-var positions = new _ol_geom_LineString_([],
+var positions = new LineString([],
     /** @type {ol.geom.GeometryLayout} */ ('XYZM'));
 
 // Geolocation Control

--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -3,7 +3,7 @@ import _ol_Geolocation_ from '../src/ol/Geolocation.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
@@ -83,7 +83,7 @@ positionFeature.setStyle(new _ol_style_Style_({
 geolocation.on('change:position', function() {
   var coordinates = geolocation.getPosition();
   positionFeature.setGeometry(coordinates ?
-    new _ol_geom_Point_(coordinates) : null);
+    new Point(coordinates) : null);
 });
 
 new _ol_layer_Vector_({

--- a/examples/hit-tolerance.js
+++ b/examples/hit-tolerance.js
@@ -5,7 +5,7 @@ import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_Feature_ from '../src/ol/Feature.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_style_Style_ from '../src/ol/style/Style.js';
 import _ol_style_Stroke_ from '../src/ol/style/Stroke.js';
 
@@ -20,7 +20,7 @@ var style = new _ol_style_Style_({
   })
 });
 
-var feature = new _ol_Feature_(new _ol_geom_LineString_([[-4000000, 0], [4000000, 0]]));
+var feature = new _ol_Feature_(new LineString([[-4000000, 0], [4000000, 0]]));
 
 var vector = new _ol_layer_Vector_({
   source: new _ol_source_Vector_({

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import {fromLonLat} from '../src/ol/proj.js';
@@ -12,15 +12,15 @@ import _ol_style_Style_ from '../src/ol/style/Style.js';
 
 
 var rome = new _ol_Feature_({
-  geometry: new _ol_geom_Point_(fromLonLat([12.5, 41.9]))
+  geometry: new Point(fromLonLat([12.5, 41.9]))
 });
 
 var london = new _ol_Feature_({
-  geometry: new _ol_geom_Point_(fromLonLat([-0.12755, 51.507222]))
+  geometry: new Point(fromLonLat([-0.12755, 51.507222]))
 });
 
 var madrid = new _ol_Feature_({
-  geometry: new _ol_geom_Point_(fromLonLat([-3.683333, 40.4]))
+  geometry: new Point(fromLonLat([-3.683333, 40.4]))
 });
 
 rome.setStyle(new _ol_style_Style_({

--- a/examples/icon-negative.js
+++ b/examples/icon-negative.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_interaction_Select_ from '../src/ol/interaction/Select.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
@@ -23,7 +23,7 @@ function createStyle(src, img) {
   });
 }
 
-var iconFeature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+var iconFeature = new _ol_Feature_(new Point([0, 0]));
 iconFeature.set('style', createStyle('data/icon.png', undefined));
 
 var map = new _ol_Map_({

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Icon_ from '../src/ol/style/Icon.js';
@@ -61,7 +61,7 @@ var features = new Array(featureCount);
 var feature, geometry;
 var e = 25000000;
 for (i = 0; i < featureCount; ++i) {
-  geometry = new _ol_geom_Point_(
+  geometry = new Point(
       [2 * e * Math.random() - e, 2 * e * Math.random() - e]);
   feature = new _ol_Feature_(geometry);
   feature.setStyle(

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_Overlay_ from '../src/ol/Overlay.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_TileJSON_ from '../src/ol/source/TileJSON.js';
@@ -12,7 +12,7 @@ import _ol_style_Style_ from '../src/ol/style/Style.js';
 
 
 var iconFeature = new _ol_Feature_({
-  geometry: new _ol_geom_Point_([0, 0]),
+  geometry: new Point([0, 0]),
   name: 'Null Island',
   population: 4000,
   rainfall: 500

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_format_IGC_ from '../src/ol/format/IGC.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
@@ -132,7 +132,7 @@ var displaySnap = function(coordinate) {
         closestFeature.get('PLT') + ' (' + date.toUTCString() + ')';
     var coordinates = [coordinate, [closestPoint[0], closestPoint[1]]];
     if (line === null) {
-      line = new _ol_geom_LineString_(coordinates);
+      line = new LineString(coordinates);
     } else {
       line.setCoordinates(coordinates);
     }

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -4,7 +4,7 @@ import _ol_View_ from '../src/ol/View.js';
 import _ol_control_ from '../src/ol/control.js';
 import _ol_format_IGC_ from '../src/ol/format/IGC.js';
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
@@ -123,7 +123,7 @@ var displaySnap = function(coordinate) {
     var geometry = closestFeature.getGeometry();
     var closestPoint = geometry.getClosestPoint(coordinate);
     if (point === null) {
-      point = new _ol_geom_Point_(closestPoint);
+      point = new Point(closestPoint);
     } else {
       point.setCoordinates(closestPoint);
     }
@@ -196,7 +196,7 @@ document.getElementById('time').addEventListener('input', function() {
     var coordinate = geometry.getCoordinateAtM(m, true);
     var highlight = feature.get('highlight');
     if (highlight === undefined) {
-      highlight = new _ol_Feature_(new _ol_geom_Point_(coordinate));
+      highlight = new _ol_Feature_(new Point(coordinate));
       feature.set('highlight', highlight);
       featureOverlay.getSource().addFeature(highlight);
     } else {

--- a/examples/layer-z-index.js
+++ b/examples/layer-z-index.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
@@ -46,7 +46,7 @@ var styles = {
 
 
 function createLayer(coordinates, style, zIndex) {
-  var feature = new _ol_Feature_(new _ol_geom_Point_(coordinates));
+  var feature = new _ol_Feature_(new Point(coordinates));
   feature.setStyle(style);
 
   var source = new _ol_source_Vector_({

--- a/examples/line-arrows.js
+++ b/examples/line-arrows.js
@@ -1,6 +1,6 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
@@ -34,7 +34,7 @@ var styleFunction = function(feature) {
     var rotation = Math.atan2(dy, dx);
     // arrows
     styles.push(new _ol_style_Style_({
-      geometry: new _ol_geom_Point_(end),
+      geometry: new Point(end),
       image: new _ol_style_Icon_({
         src: 'data/arrow.png',
         anchor: [0.75, 0.5],

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -3,7 +3,7 @@ import _ol_Observable_ from '../src/ol/Observable.js';
 import _ol_Overlay_ from '../src/ol/Overlay.js';
 import _ol_Sphere_ from '../src/ol/Sphere.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
@@ -106,7 +106,7 @@ var pointerMoveHandler = function(evt) {
     var geom = (sketch.getGeometry());
     if (geom instanceof _ol_geom_Polygon_) {
       helpMsg = continuePolygonMsg;
-    } else if (geom instanceof _ol_geom_LineString_) {
+    } else if (geom instanceof LineString) {
       helpMsg = continueLineMsg;
     }
   }
@@ -220,7 +220,7 @@ function addInteraction() {
           if (geom instanceof _ol_geom_Polygon_) {
             output = formatArea(geom);
             tooltipCoord = geom.getInteriorPoint().getCoordinates();
-          } else if (geom instanceof _ol_geom_LineString_) {
+          } else if (geom instanceof LineString) {
             output = formatLength(geom);
             tooltipCoord = geom.getLastCoordinate();
           }

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -4,7 +4,7 @@ import _ol_Overlay_ from '../src/ol/Overlay.js';
 import _ol_Sphere_ from '../src/ol/Sphere.js';
 import _ol_View_ from '../src/ol/View.js';
 import LineString from '../src/ol/geom/LineString.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
@@ -104,7 +104,7 @@ var pointerMoveHandler = function(evt) {
 
   if (sketch) {
     var geom = (sketch.getGeometry());
-    if (geom instanceof _ol_geom_Polygon_) {
+    if (geom instanceof Polygon) {
       helpMsg = continuePolygonMsg;
     } else if (geom instanceof LineString) {
       helpMsg = continueLineMsg;
@@ -217,7 +217,7 @@ function addInteraction() {
         listener = sketch.getGeometry().on('change', function(evt) {
           var geom = evt.target;
           var output;
-          if (geom instanceof _ol_geom_Polygon_) {
+          if (geom instanceof Polygon) {
             output = formatArea(geom);
             tooltipCoord = geom.getInteriorPoint().getCoordinates();
           } else if (geom instanceof LineString) {

--- a/examples/polygon-styles.js
+++ b/examples/polygon-styles.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_format_GeoJSON_ from '../src/ol/format/GeoJSON.js';
-import _ol_geom_MultiPoint_ from '../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../src/ol/geom/MultiPoint.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -36,7 +36,7 @@ var styles = [
     geometry: function(feature) {
       // return the coordinates of the first ring of the polygon
       var coordinates = feature.getGeometry().getCoordinates()[0];
-      return new _ol_geom_MultiPoint_(coordinates);
+      return new MultiPoint(coordinates);
     }
   })
 ];

--- a/examples/regularshape.js
+++ b/examples/regularshape.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
@@ -72,7 +72,7 @@ var features = new Array(count);
 var e = 4500000;
 for (var i = 0; i < count; ++i) {
   var coordinates = [2 * e * Math.random() - e, 2 * e * Math.random() - e];
-  features[i] = new _ol_Feature_(new _ol_geom_Point_(coordinates));
+  features[i] = new _ol_Feature_(new Point(coordinates));
   features[i].setStyle(styles[styleKeys[Math.floor(Math.random() * 5)]]);
 }
 

--- a/examples/render-geometry.js
+++ b/examples/render-geometry.js
@@ -1,5 +1,5 @@
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_render_ from '../src/ol/render.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -26,4 +26,4 @@ vectorContext.setStyle(style);
 
 vectorContext.drawGeometry(new _ol_geom_LineString_([[10, 10], [90, 90]]));
 vectorContext.drawGeometry(new _ol_geom_Polygon_([[[2, 2], [98, 2], [2, 98], [2, 2]]]));
-vectorContext.drawGeometry(new _ol_geom_Point_([88, 88]));
+vectorContext.drawGeometry(new Point([88, 88]));

--- a/examples/render-geometry.js
+++ b/examples/render-geometry.js
@@ -1,4 +1,4 @@
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import Point from '../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_render_ from '../src/ol/render.js';
@@ -24,6 +24,6 @@ var style = new _ol_style_Style_({
 });
 vectorContext.setStyle(style);
 
-vectorContext.drawGeometry(new _ol_geom_LineString_([[10, 10], [90, 90]]));
+vectorContext.drawGeometry(new LineString([[10, 10], [90, 90]]));
 vectorContext.drawGeometry(new _ol_geom_Polygon_([[[2, 2], [98, 2], [2, 98], [2, 2]]]));
 vectorContext.drawGeometry(new Point([88, 88]));

--- a/examples/render-geometry.js
+++ b/examples/render-geometry.js
@@ -1,6 +1,6 @@
 import LineString from '../src/ol/geom/LineString.js';
 import Point from '../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_render_ from '../src/ol/render.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
 import _ol_style_Fill_ from '../src/ol/style/Fill.js';
@@ -25,5 +25,5 @@ var style = new _ol_style_Style_({
 vectorContext.setStyle(style);
 
 vectorContext.drawGeometry(new LineString([[10, 10], [90, 90]]));
-vectorContext.drawGeometry(new _ol_geom_Polygon_([[[2, 2], [98, 2], [2, 98], [2, 2]]]));
+vectorContext.drawGeometry(new Polygon([[[2, 2], [98, 2], [2, 98], [2, 2]]]));
 vectorContext.drawGeometry(new Point([88, 88]));

--- a/examples/symbol-atlas-webgl.js
+++ b/examples/symbol-atlas-webgl.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_AtlasManager_ from '../src/ol/style/AtlasManager.js';
@@ -88,7 +88,7 @@ var features = new Array(featureCount);
 var feature, geometry;
 var e = 25000000;
 for (i = 0; i < featureCount; ++i) {
-  geometry = new _ol_geom_Point_(
+  geometry = new Point(
       [2 * e * Math.random() - e, 2 * e * Math.random() - e]);
   feature = new _ol_Feature_(geometry);
   feature.setStyle(

--- a/examples/synthetic-lines.js
+++ b/examples/synthetic-lines.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Stroke_ from '../src/ol/style/Stroke.js';
@@ -31,7 +31,7 @@ for (i = 0; i < count; ++i) {
   deltaY = delta * signY;
   endPoint = [startPoint[0] + deltaX, startPoint[1] + deltaY];
   features[i] = new _ol_Feature_({
-    'geometry': new _ol_geom_LineString_([startPoint, endPoint])
+    'geometry': new LineString([startPoint, endPoint])
   });
   startPoint = endPoint;
 }

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
@@ -76,7 +76,7 @@ var displaySnap = function(coordinate) {
       point.setCoordinates(closestPoint);
     }
     if (line === null) {
-      line = new _ol_geom_LineString_([coordinate, closestPoint]);
+      line = new LineString([coordinate, closestPoint]);
     } else {
       line.setCoordinates([coordinate, closestPoint]);
     }

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import _ol_style_Circle_ from '../src/ol/style/Circle.js';
@@ -16,7 +16,7 @@ var features = new Array(count);
 var e = 18000000;
 for (var i = 0; i < count; ++i) {
   features[i] = new _ol_Feature_({
-    'geometry': new _ol_geom_Point_(
+    'geometry': new Point(
         [2 * e * Math.random() - e, 2 * e * Math.random() - e]),
     'i': i,
     'size': i % 2 ? 10 : 20
@@ -71,7 +71,7 @@ var displaySnap = function(coordinate) {
     var geometry = closestFeature.getGeometry();
     var closestPoint = geometry.getClosestPoint(coordinate);
     if (point === null) {
-      point = new _ol_geom_Point_(closestPoint);
+      point = new Point(closestPoint);
     } else {
       point.setCoordinates(closestPoint);
     }

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_Sphere_ from '../src/ol/Sphere.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
@@ -63,7 +63,7 @@ var radius = 800000;
 var x, y;
 for (x = -180; x < 180; x += 30) {
   for (y = -90; y < 90; y += 30) {
-    var circle4326 = _ol_geom_Polygon_.circular(wgs84Sphere, [x, y], radius, 64);
+    var circle4326 = Polygon.circular(wgs84Sphere, [x, y], radius, 64);
     var circle3857 = circle4326.clone().transform('EPSG:4326', 'EPSG:3857');
     vectorLayer4326.getSource().addFeature(new _ol_Feature_(circle4326));
     vectorLayer3857.getSource().addFeature(new _ol_Feature_(circle3857));

--- a/examples/topolis.js
+++ b/examples/topolis.js
@@ -5,7 +5,7 @@ import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
-import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
+import LineString from '../src/ol/geom/LineString.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
 import _ol_interaction_Snap_ from '../src/ol/interaction/Snap.js';
@@ -113,7 +113,7 @@ topo.on('removenode', function(e) {
 topo.on('addedge', edgeToFeature);
 topo.on('modedge', function(e) {
   var feature = edges.getFeatureById(e.id);
-  feature.setGeometry(new _ol_geom_LineString_(e.coordinates));
+  feature.setGeometry(new LineString(e.coordinates));
 });
 topo.on('removeedge', function(e) {
   removeElementFeature(edges, e);
@@ -139,7 +139,7 @@ function nodeToFeature(node) {
 
 function edgeToFeature(edge) {
   var feature = new _ol_Feature_({
-    geometry: new _ol_geom_LineString_(edge.coordinates),
+    geometry: new LineString(edge.coordinates),
     edge: edge
   });
   feature.setId(edge.id);

--- a/examples/topolis.js
+++ b/examples/topolis.js
@@ -6,7 +6,7 @@ import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import LineString from '../src/ol/geom/LineString.js';
-import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
+import Polygon from '../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
 import _ol_interaction_Snap_ from '../src/ol/interaction/Snap.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
@@ -149,7 +149,7 @@ function edgeToFeature(edge) {
 function faceToFeature(face) {
   var coordinates = topo.getFaceGeometry(face);
   var feature = new _ol_Feature_({
-    geometry: new _ol_geom_Polygon_(coordinates),
+    geometry: new Polygon(coordinates),
     face: face
   });
   feature.setId(face.id);

--- a/examples/topolis.js
+++ b/examples/topolis.js
@@ -4,7 +4,7 @@
 import _ol_Feature_ from '../src/ol/Feature.js';
 import _ol_Map_ from '../src/ol/Map.js';
 import _ol_View_ from '../src/ol/View.js';
-import _ol_geom_Point_ from '../src/ol/geom/Point.js';
+import Point from '../src/ol/geom/Point.js';
 import _ol_geom_LineString_ from '../src/ol/geom/LineString.js';
 import _ol_geom_Polygon_ from '../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../src/ol/interaction/Draw.js';
@@ -130,7 +130,7 @@ function removeElementFeature(source, element) {
 
 function nodeToFeature(node) {
   var feature = new _ol_Feature_({
-    geometry: new _ol_geom_Point_(node.coordinate),
+    geometry: new Point(node.coordinate),
     node: node
   });
   feature.setId(node.id);

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -6,7 +6,7 @@ import _ol_events_ from './events.js';
 import _ol_events_EventType_ from './events/EventType.js';
 import {inherits} from './index.js';
 import _ol_Object_ from './Object.js';
-import _ol_geom_Geometry_ from './geom/Geometry.js';
+import Geometry from './geom/Geometry.js';
 import _ol_style_Style_ from './style/Style.js';
 
 /**
@@ -95,7 +95,7 @@ var _ol_Feature_ = function(opt_geometryOrProperties) {
       this.handleGeometryChanged_, this);
 
   if (opt_geometryOrProperties !== undefined) {
-    if (opt_geometryOrProperties instanceof _ol_geom_Geometry_ ||
+    if (opt_geometryOrProperties instanceof Geometry ||
         !opt_geometryOrProperties) {
       var geometry = opt_geometryOrProperties;
       this.setGeometry(geometry);

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -9,7 +9,7 @@ import _ol_Object_ from './Object.js';
 import _ol_Sphere_ from './Sphere.js';
 import _ol_events_ from './events.js';
 import _ol_events_EventType_ from './events/EventType.js';
-import _ol_geom_Polygon_ from './geom/Polygon.js';
+import Polygon from './geom/Polygon.js';
 import _ol_has_ from './has.js';
 import _ol_math_ from './math.js';
 import {get as getProjection, getTransformFromProjections, identityTransform} from './proj.js';
@@ -161,7 +161,7 @@ _ol_Geolocation_.prototype.positionChange_ = function(position) {
   this.set(_ol_GeolocationProperty_.POSITION, projectedPosition);
   this.set(_ol_GeolocationProperty_.SPEED,
       coords.speed === null ? undefined : coords.speed);
-  var geometry = _ol_geom_Polygon_.circular(
+  var geometry = Polygon.circular(
       this.sphere_, this.position_, coords.accuracy);
   geometry.applyTransform(this.transform_);
   this.set(_ol_GeolocationProperty_.ACCURACY_GEOMETRY, geometry);

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -5,7 +5,7 @@ import _ol_coordinate_ from './coordinate.js';
 import {intersects, getCenter} from './extent.js';
 import _ol_geom_GeometryLayout_ from './geom/GeometryLayout.js';
 import _ol_geom_LineString_ from './geom/LineString.js';
-import _ol_geom_Point_ from './geom/Point.js';
+import Point from './geom/Point.js';
 import _ol_geom_flat_geodesic_ from './geom/flat/geodesic.js';
 import _ol_math_ from './math.js';
 import {get as getProjection, equivalent as equivalentProjection, getTransform, transformExtent} from './proj.js';
@@ -283,7 +283,7 @@ _ol_Graticule_.prototype.getMeridianPoint_ = function(lineString, extent, index)
       clampedBottom, clampedTop);
   var coordinate = [flatCoordinates[0], lat];
   var point = this.meridiansLabels_[index] !== undefined ?
-    this.meridiansLabels_[index].geom : new _ol_geom_Point_(null);
+    this.meridiansLabels_[index].geom : new Point(null);
   point.setCoordinates(coordinate);
   return point;
 };
@@ -332,7 +332,7 @@ _ol_Graticule_.prototype.getParallelPoint_ = function(lineString, extent, index)
       clampedLeft, clampedRight);
   var coordinate = [lon, flatCoordinates[1]];
   var point = this.parallelsLabels_[index] !== undefined ?
-    this.parallelsLabels_[index].geom : new _ol_geom_Point_(null);
+    this.parallelsLabels_[index].geom : new Point(null);
   point.setCoordinates(coordinate);
   return point;
 };

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -4,7 +4,7 @@
 import _ol_coordinate_ from './coordinate.js';
 import {intersects, getCenter} from './extent.js';
 import _ol_geom_GeometryLayout_ from './geom/GeometryLayout.js';
-import _ol_geom_LineString_ from './geom/LineString.js';
+import LineString from './geom/LineString.js';
 import Point from './geom/Point.js';
 import _ol_geom_flat_geodesic_ from './geom/flat/geodesic.js';
 import _ol_math_ from './math.js';
@@ -491,7 +491,7 @@ _ol_Graticule_.prototype.getMeridian_ = function(lon, minLat, maxLat,
   var flatCoordinates = _ol_geom_flat_geodesic_.meridian(lon,
       minLat, maxLat, this.projection_, squaredTolerance);
   var lineString = this.meridians_[index] !== undefined ?
-    this.meridians_[index] : new _ol_geom_LineString_(null);
+    this.meridians_[index] : new LineString(null);
   lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates);
   return lineString;
 };
@@ -521,7 +521,7 @@ _ol_Graticule_.prototype.getParallel_ = function(lat, minLon, maxLon,
   var flatCoordinates = _ol_geom_flat_geodesic_.parallel(lat,
       minLon, maxLon, this.projection_, squaredTolerance);
   var lineString = this.parallels_[index] !== undefined ?
-    this.parallels_[index] : new _ol_geom_LineString_(null);
+    this.parallels_[index] : new LineString(null);
   lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates);
   return lineString;
 };

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -3,7 +3,7 @@
  */
 import _ol_coordinate_ from './coordinate.js';
 import {intersects, getCenter} from './extent.js';
-import _ol_geom_GeometryLayout_ from './geom/GeometryLayout.js';
+import GeometryLayout from './geom/GeometryLayout.js';
 import LineString from './geom/LineString.js';
 import Point from './geom/Point.js';
 import _ol_geom_flat_geodesic_ from './geom/flat/geodesic.js';
@@ -492,7 +492,7 @@ _ol_Graticule_.prototype.getMeridian_ = function(lon, minLat, maxLat,
       minLat, maxLat, this.projection_, squaredTolerance);
   var lineString = this.meridians_[index] !== undefined ?
     this.meridians_[index] : new LineString(null);
-  lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates);
+  lineString.setFlatCoordinates(GeometryLayout.XY, flatCoordinates);
   return lineString;
 };
 
@@ -522,7 +522,7 @@ _ol_Graticule_.prototype.getParallel_ = function(lat, minLon, maxLon,
       minLon, maxLon, this.projection_, squaredTolerance);
   var lineString = this.parallels_[index] !== undefined ?
     this.parallels_[index] : new LineString(null);
-  lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates);
+  lineString.setFlatCoordinates(GeometryLayout.XY, flatCoordinates);
   return lineString;
 };
 

--- a/src/ol/Sphere.js
+++ b/src/ol/Sphere.js
@@ -9,7 +9,7 @@
  */
 
 import _ol_math_ from './math.js';
-import _ol_geom_GeometryType_ from './geom/GeometryType.js';
+import GeometryType from './geom/GeometryType.js';
 
 /**
  * @classdesc
@@ -121,25 +121,25 @@ _ol_Sphere_.getLength = function(geometry, opt_options) {
   var length = 0;
   var coordinates, coords, i, ii, j, jj;
   switch (type) {
-    case _ol_geom_GeometryType_.POINT:
-    case _ol_geom_GeometryType_.MULTI_POINT: {
+    case GeometryType.POINT:
+    case GeometryType.MULTI_POINT: {
       break;
     }
-    case _ol_geom_GeometryType_.LINE_STRING:
-    case _ol_geom_GeometryType_.LINEAR_RING: {
+    case GeometryType.LINE_STRING:
+    case GeometryType.LINEAR_RING: {
       coordinates = /** @type {ol.geom.SimpleGeometry} */ (geometry).getCoordinates();
       length = _ol_Sphere_.getLength_(coordinates, radius);
       break;
     }
-    case _ol_geom_GeometryType_.MULTI_LINE_STRING:
-    case _ol_geom_GeometryType_.POLYGON: {
+    case GeometryType.MULTI_LINE_STRING:
+    case GeometryType.POLYGON: {
       coordinates = /** @type {ol.geom.SimpleGeometry} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         length += _ol_Sphere_.getLength_(coordinates[i], radius);
       }
       break;
     }
-    case _ol_geom_GeometryType_.MULTI_POLYGON: {
+    case GeometryType.MULTI_POLYGON: {
       coordinates = /** @type {ol.geom.SimpleGeometry} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         coords = coordinates[i];
@@ -149,7 +149,7 @@ _ol_Sphere_.getLength = function(geometry, opt_options) {
       }
       break;
     }
-    case _ol_geom_GeometryType_.GEOMETRY_COLLECTION: {
+    case GeometryType.GEOMETRY_COLLECTION: {
       var geometries = /** @type {ol.geom.GeometryCollection} */ (geometry).getGeometries();
       for (i = 0, ii = geometries.length; i < ii; ++i) {
         length += _ol_Sphere_.getLength(geometries[i], opt_options);
@@ -217,14 +217,14 @@ _ol_Sphere_.getArea = function(geometry, opt_options) {
   var area = 0;
   var coordinates, coords, i, ii, j, jj;
   switch (type) {
-    case _ol_geom_GeometryType_.POINT:
-    case _ol_geom_GeometryType_.MULTI_POINT:
-    case _ol_geom_GeometryType_.LINE_STRING:
-    case _ol_geom_GeometryType_.MULTI_LINE_STRING:
-    case _ol_geom_GeometryType_.LINEAR_RING: {
+    case GeometryType.POINT:
+    case GeometryType.MULTI_POINT:
+    case GeometryType.LINE_STRING:
+    case GeometryType.MULTI_LINE_STRING:
+    case GeometryType.LINEAR_RING: {
       break;
     }
-    case _ol_geom_GeometryType_.POLYGON: {
+    case GeometryType.POLYGON: {
       coordinates = /** @type {ol.geom.Polygon} */ (geometry).getCoordinates();
       area = Math.abs(_ol_Sphere_.getArea_(coordinates[0], radius));
       for (i = 1, ii = coordinates.length; i < ii; ++i) {
@@ -232,7 +232,7 @@ _ol_Sphere_.getArea = function(geometry, opt_options) {
       }
       break;
     }
-    case _ol_geom_GeometryType_.MULTI_POLYGON: {
+    case GeometryType.MULTI_POLYGON: {
       coordinates = /** @type {ol.geom.SimpleGeometry} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         coords = coordinates[i];
@@ -243,7 +243,7 @@ _ol_Sphere_.getArea = function(geometry, opt_options) {
       }
       break;
     }
-    case _ol_geom_GeometryType_.GEOMETRY_COLLECTION: {
+    case GeometryType.GEOMETRY_COLLECTION: {
       var geometries = /** @type {ol.geom.GeometryCollection} */ (geometry).getGeometries();
       for (i = 0, ii = geometries.length; i < ii; ++i) {
         area += _ol_Sphere_.getArea(geometries[i], opt_options);

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -16,7 +16,7 @@ import {inAndOut} from './easing.js';
 import {getForViewAndSize, getCenter, getHeight, getWidth, isEmpty} from './extent.js';
 import GeometryType from './geom/GeometryType.js';
 import Polygon from './geom/Polygon.js';
-import _ol_geom_SimpleGeometry_ from './geom/SimpleGeometry.js';
+import SimpleGeometry from './geom/SimpleGeometry.js';
 import _ol_math_ from './math.js';
 import _ol_obj_ from './obj.js';
 import {createProjection, METERS_PER_UNIT} from './proj.js';
@@ -879,7 +879,7 @@ _ol_View_.prototype.fit = function(geometryOrExtent, opt_options) {
   }
   /** @type {ol.geom.SimpleGeometry} */
   var geometry;
-  if (!(geometryOrExtent instanceof _ol_geom_SimpleGeometry_)) {
+  if (!(geometryOrExtent instanceof SimpleGeometry)) {
     _ol_asserts_.assert(Array.isArray(geometryOrExtent),
         24); // Invalid extent or geometry provided as `geometry`
     _ol_asserts_.assert(!isEmpty(geometryOrExtent),

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -14,7 +14,7 @@ import _ol_asserts_ from './asserts.js';
 import _ol_coordinate_ from './coordinate.js';
 import {inAndOut} from './easing.js';
 import {getForViewAndSize, getCenter, getHeight, getWidth, isEmpty} from './extent.js';
-import _ol_geom_GeometryType_ from './geom/GeometryType.js';
+import GeometryType from './geom/GeometryType.js';
 import Polygon from './geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from './geom/SimpleGeometry.js';
 import _ol_math_ from './math.js';
@@ -885,7 +885,7 @@ _ol_View_.prototype.fit = function(geometryOrExtent, opt_options) {
     _ol_asserts_.assert(!isEmpty(geometryOrExtent),
         25); // Cannot fit empty extent provided as `geometry`
     geometry = Polygon.fromExtent(geometryOrExtent);
-  } else if (geometryOrExtent.getType() === _ol_geom_GeometryType_.CIRCLE) {
+  } else if (geometryOrExtent.getType() === GeometryType.CIRCLE) {
     geometryOrExtent = geometryOrExtent.getExtent();
     geometry = Polygon.fromExtent(geometryOrExtent);
     geometry.rotate(this.getRotation(), getCenter(geometryOrExtent));

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -15,7 +15,7 @@ import _ol_coordinate_ from './coordinate.js';
 import {inAndOut} from './easing.js';
 import {getForViewAndSize, getCenter, getHeight, getWidth, isEmpty} from './extent.js';
 import _ol_geom_GeometryType_ from './geom/GeometryType.js';
-import _ol_geom_Polygon_ from './geom/Polygon.js';
+import Polygon from './geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from './geom/SimpleGeometry.js';
 import _ol_math_ from './math.js';
 import _ol_obj_ from './obj.js';
@@ -884,10 +884,10 @@ _ol_View_.prototype.fit = function(geometryOrExtent, opt_options) {
         24); // Invalid extent or geometry provided as `geometry`
     _ol_asserts_.assert(!isEmpty(geometryOrExtent),
         25); // Cannot fit empty extent provided as `geometry`
-    geometry = _ol_geom_Polygon_.fromExtent(geometryOrExtent);
+    geometry = Polygon.fromExtent(geometryOrExtent);
   } else if (geometryOrExtent.getType() === _ol_geom_GeometryType_.CIRCLE) {
     geometryOrExtent = geometryOrExtent.getExtent();
-    geometry = _ol_geom_Polygon_.fromExtent(geometryOrExtent);
+    geometry = Polygon.fromExtent(geometryOrExtent);
     geometry.rotate(this.getRotation(), getCenter(geometryOrExtent));
   } else {
     geometry = geometryOrExtent;

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -12,7 +12,7 @@ import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -214,7 +214,7 @@ _ol_format_EsriJSON_.getGeometryLayout_ = function(object) {
  */
 _ol_format_EsriJSON_.readMultiPointGeometry_ = function(object) {
   var layout = _ol_format_EsriJSON_.getGeometryLayout_(object);
-  return new _ol_geom_MultiPoint_(object.points, layout);
+  return new MultiPoint(object.points, layout);
 };
 
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -11,7 +11,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -185,7 +185,7 @@ _ol_format_EsriJSON_.readLineStringGeometry_ = function(object) {
  */
 _ol_format_EsriJSON_.readMultiLineStringGeometry_ = function(object) {
   var layout = _ol_format_EsriJSON_.getGeometryLayout_(object);
-  return new _ol_geom_MultiLineString_(object.paths, layout);
+  return new MultiLineString(object.paths, layout);
 };
 
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -9,7 +9,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -174,7 +174,7 @@ _ol_format_EsriJSON_.readPointGeometry_ = function(object) {
  */
 _ol_format_EsriJSON_.readLineStringGeometry_ = function(object) {
   var layout = _ol_format_EsriJSON_.getGeometryLayout_(object);
-  return new _ol_geom_LineString_(object.paths[0], layout);
+  return new LineString(object.paths[0], layout);
 };
 
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -7,7 +7,7 @@ import _ol_asserts_ from '../asserts.js';
 import {containsExtent} from '../extent.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
@@ -153,13 +153,13 @@ _ol_format_EsriJSON_.readPointGeometry_ = function(object) {
   var point;
   if (object.m !== undefined && object.z !== undefined) {
     point = new Point([object.x, object.y, object.z, object.m],
-        _ol_geom_GeometryLayout_.XYZM);
+        GeometryLayout.XYZM);
   } else if (object.z !== undefined) {
     point = new Point([object.x, object.y, object.z],
-        _ol_geom_GeometryLayout_.XYZ);
+        GeometryLayout.XYZ);
   } else if (object.m !== undefined) {
     point = new Point([object.x, object.y, object.m],
-        _ol_geom_GeometryLayout_.XYM);
+        GeometryLayout.XYM);
   } else {
     point = new Point([object.x, object.y]);
   }
@@ -195,13 +195,13 @@ _ol_format_EsriJSON_.readMultiLineStringGeometry_ = function(object) {
  * @return {ol.geom.GeometryLayout} The geometry layout to use.
  */
 _ol_format_EsriJSON_.getGeometryLayout_ = function(object) {
-  var layout = _ol_geom_GeometryLayout_.XY;
+  var layout = GeometryLayout.XY;
   if (object.hasZ === true && object.hasM === true) {
-    layout = _ol_geom_GeometryLayout_.XYZM;
+    layout = GeometryLayout.XYZM;
   } else if (object.hasZ === true) {
-    layout = _ol_geom_GeometryLayout_.XYZ;
+    layout = GeometryLayout.XYZ;
   } else if (object.hasM === true) {
-    layout = _ol_geom_GeometryLayout_.XYM;
+    layout = GeometryLayout.XYM;
   }
   return layout;
 };
@@ -252,26 +252,26 @@ _ol_format_EsriJSON_.writePointGeometry_ = function(geometry, opt_options) {
   var coordinates = /** @type {ol.geom.Point} */ (geometry).getCoordinates();
   var esriJSON;
   var layout = /** @type {ol.geom.Point} */ (geometry).getLayout();
-  if (layout === _ol_geom_GeometryLayout_.XYZ) {
+  if (layout === GeometryLayout.XYZ) {
     esriJSON = /** @type {EsriJSONPoint} */ ({
       x: coordinates[0],
       y: coordinates[1],
       z: coordinates[2]
     });
-  } else if (layout === _ol_geom_GeometryLayout_.XYM) {
+  } else if (layout === GeometryLayout.XYM) {
     esriJSON = /** @type {EsriJSONPoint} */ ({
       x: coordinates[0],
       y: coordinates[1],
       m: coordinates[2]
     });
-  } else if (layout === _ol_geom_GeometryLayout_.XYZM) {
+  } else if (layout === GeometryLayout.XYZM) {
     esriJSON = /** @type {EsriJSONPoint} */ ({
       x: coordinates[0],
       y: coordinates[1],
       z: coordinates[2],
       m: coordinates[3]
     });
-  } else if (layout === _ol_geom_GeometryLayout_.XY) {
+  } else if (layout === GeometryLayout.XY) {
     esriJSON = /** @type {EsriJSONPoint} */ ({
       x: coordinates[0],
       y: coordinates[1]
@@ -291,10 +291,10 @@ _ol_format_EsriJSON_.writePointGeometry_ = function(geometry, opt_options) {
 _ol_format_EsriJSON_.getHasZM_ = function(geometry) {
   var layout = geometry.getLayout();
   return {
-    hasZ: (layout === _ol_geom_GeometryLayout_.XYZ ||
-      layout === _ol_geom_GeometryLayout_.XYZM),
-    hasM: (layout === _ol_geom_GeometryLayout_.XYM ||
-      layout === _ol_geom_GeometryLayout_.XYZM)
+    hasZ: (layout === GeometryLayout.XYZ ||
+      layout === GeometryLayout.XYZM),
+    hasM: (layout === GeometryLayout.XYM ||
+      layout === GeometryLayout.XYZM)
   };
 };
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -10,7 +10,7 @@ import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
+import LinearRing from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import MultiPolygon from '../geom/MultiPolygon.js';
@@ -124,8 +124,8 @@ _ol_format_EsriJSON_.convertRings_ = function(rings, layout) {
     for (i = outerRings.length - 1; i >= 0; i--) {
       var outerRing = outerRings[i][0];
       var containsHole = containsExtent(
-          new _ol_geom_LinearRing_(outerRing).getExtent(),
-          new _ol_geom_LinearRing_(hole).getExtent()
+          new LinearRing(outerRing).getExtent(),
+          new LinearRing(hole).getExtent()
       );
       if (containsHole) {
         // the hole is contained push it into our polygon

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -14,7 +14,7 @@ import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_orient_ from '../geom/flat/orient.js';
@@ -152,16 +152,16 @@ _ol_format_EsriJSON_.convertRings_ = function(rings, layout) {
 _ol_format_EsriJSON_.readPointGeometry_ = function(object) {
   var point;
   if (object.m !== undefined && object.z !== undefined) {
-    point = new _ol_geom_Point_([object.x, object.y, object.z, object.m],
+    point = new Point([object.x, object.y, object.z, object.m],
         _ol_geom_GeometryLayout_.XYZM);
   } else if (object.z !== undefined) {
-    point = new _ol_geom_Point_([object.x, object.y, object.z],
+    point = new Point([object.x, object.y, object.z],
         _ol_geom_GeometryLayout_.XYZ);
   } else if (object.m !== undefined) {
-    point = new _ol_geom_Point_([object.x, object.y, object.m],
+    point = new Point([object.x, object.y, object.m],
         _ol_geom_GeometryLayout_.XYM);
   } else {
-    point = new _ol_geom_Point_([object.x, object.y]);
+    point = new Point([object.x, object.y]);
   }
   return point;
 };

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -8,7 +8,7 @@ import {containsExtent} from '../extent.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -61,24 +61,24 @@ _ol_format_EsriJSON_.readGeometry_ = function(object, opt_options) {
   /** @type {ol.geom.GeometryType} */
   var type;
   if (typeof object.x === 'number' && typeof object.y === 'number') {
-    type = _ol_geom_GeometryType_.POINT;
+    type = GeometryType.POINT;
   } else if (object.points) {
-    type = _ol_geom_GeometryType_.MULTI_POINT;
+    type = GeometryType.MULTI_POINT;
   } else if (object.paths) {
     if (object.paths.length === 1) {
-      type = _ol_geom_GeometryType_.LINE_STRING;
+      type = GeometryType.LINE_STRING;
     } else {
-      type = _ol_geom_GeometryType_.MULTI_LINE_STRING;
+      type = GeometryType.MULTI_LINE_STRING;
     }
   } else if (object.rings) {
     var layout = _ol_format_EsriJSON_.getGeometryLayout_(object);
     var rings = _ol_format_EsriJSON_.convertRings_(object.rings, layout);
     object = /** @type {EsriJSONGeometry} */(_ol_obj_.assign({}, object));
     if (rings.length === 1) {
-      type = _ol_geom_GeometryType_.POLYGON;
+      type = GeometryType.POLYGON;
       object.rings = rings[0];
     } else {
-      type = _ol_geom_GeometryType_.MULTI_POLYGON;
+      type = GeometryType.MULTI_POLYGON;
       object.rings = rings;
     }
   }
@@ -396,17 +396,17 @@ _ol_format_EsriJSON_.writeMultiPolygonGeometry_ = function(geometry,
  * @type {Object.<ol.geom.GeometryType, function(EsriJSONGeometry): ol.geom.Geometry>}
  */
 _ol_format_EsriJSON_.GEOMETRY_READERS_ = {};
-_ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.POINT] =
+_ol_format_EsriJSON_.GEOMETRY_READERS_[GeometryType.POINT] =
   _ol_format_EsriJSON_.readPointGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.LINE_STRING] =
+_ol_format_EsriJSON_.GEOMETRY_READERS_[GeometryType.LINE_STRING] =
   _ol_format_EsriJSON_.readLineStringGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.POLYGON] =
+_ol_format_EsriJSON_.GEOMETRY_READERS_[GeometryType.POLYGON] =
   _ol_format_EsriJSON_.readPolygonGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.MULTI_POINT] =
+_ol_format_EsriJSON_.GEOMETRY_READERS_[GeometryType.MULTI_POINT] =
   _ol_format_EsriJSON_.readMultiPointGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.MULTI_LINE_STRING] =
+_ol_format_EsriJSON_.GEOMETRY_READERS_[GeometryType.MULTI_LINE_STRING] =
   _ol_format_EsriJSON_.readMultiLineStringGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.MULTI_POLYGON] =
+_ol_format_EsriJSON_.GEOMETRY_READERS_[GeometryType.MULTI_POLYGON] =
   _ol_format_EsriJSON_.readMultiPolygonGeometry_;
 
 
@@ -416,17 +416,17 @@ _ol_format_EsriJSON_.GEOMETRY_READERS_[_ol_geom_GeometryType_.MULTI_POLYGON] =
  * @type {Object.<string, function(ol.geom.Geometry, olx.format.WriteOptions=): (EsriJSONGeometry)>}
  */
 _ol_format_EsriJSON_.GEOMETRY_WRITERS_ = {};
-_ol_format_EsriJSON_.GEOMETRY_WRITERS_[_ol_geom_GeometryType_.POINT] =
+_ol_format_EsriJSON_.GEOMETRY_WRITERS_[GeometryType.POINT] =
   _ol_format_EsriJSON_.writePointGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_WRITERS_[_ol_geom_GeometryType_.LINE_STRING] =
+_ol_format_EsriJSON_.GEOMETRY_WRITERS_[GeometryType.LINE_STRING] =
   _ol_format_EsriJSON_.writeLineStringGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_WRITERS_[_ol_geom_GeometryType_.POLYGON] =
+_ol_format_EsriJSON_.GEOMETRY_WRITERS_[GeometryType.POLYGON] =
   _ol_format_EsriJSON_.writePolygonGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_WRITERS_[_ol_geom_GeometryType_.MULTI_POINT] =
+_ol_format_EsriJSON_.GEOMETRY_WRITERS_[GeometryType.MULTI_POINT] =
   _ol_format_EsriJSON_.writeMultiPointGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_WRITERS_[_ol_geom_GeometryType_.MULTI_LINE_STRING] =
+_ol_format_EsriJSON_.GEOMETRY_WRITERS_[GeometryType.MULTI_LINE_STRING] =
   _ol_format_EsriJSON_.writeMultiLineStringGeometry_;
-_ol_format_EsriJSON_.GEOMETRY_WRITERS_[_ol_geom_GeometryType_.MULTI_POLYGON] =
+_ol_format_EsriJSON_.GEOMETRY_WRITERS_[GeometryType.MULTI_POLYGON] =
   _ol_format_EsriJSON_.writeMultiPolygonGeometry_;
 
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -15,7 +15,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_orient_ from '../geom/flat/orient.js';
 import _ol_obj_ from '../obj.js';
@@ -238,7 +238,7 @@ _ol_format_EsriJSON_.readMultiPolygonGeometry_ = function(object) {
  */
 _ol_format_EsriJSON_.readPolygonGeometry_ = function(object) {
   var layout = _ol_format_EsriJSON_.getGeometryLayout_(object);
-  return new _ol_geom_Polygon_(object.rings, layout);
+  return new Polygon(object.rings, layout);
 };
 
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -13,7 +13,7 @@ import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -225,7 +225,7 @@ _ol_format_EsriJSON_.readMultiPointGeometry_ = function(object) {
  */
 _ol_format_EsriJSON_.readMultiPolygonGeometry_ = function(object) {
   var layout = _ol_format_EsriJSON_.getGeometryLayout_(object);
-  return new _ol_geom_MultiPolygon_(
+  return new MultiPolygon(
       /** @type {Array.<Array.<Array.<Array.<number>>>>} */(object.rings),
       layout);
 };

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/format/Feature
  */
-import _ol_geom_Geometry_ from '../geom/Geometry.js';
+import Geometry from '../geom/Geometry.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection, equivalent as equivalentProjection, transformExtent} from '../proj.js';
 
@@ -184,7 +184,7 @@ _ol_format_Feature_.transformWithOptions = function(
   var transformed;
   if (featureProjection && dataProjection &&
       !equivalentProjection(featureProjection, dataProjection)) {
-    if (geometry instanceof _ol_geom_Geometry_) {
+    if (geometry instanceof Geometry) {
       transformed = (write ? geometry.clone() : geometry).transform(
           write ? featureProjection : dataProjection,
           write ? dataProjection : featureProjection);

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -6,7 +6,7 @@ import {createOrUpdate} from '../extent.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_GMLBase_ from '../format/GMLBase.js';
 import _ol_format_XSD_ from '../format/XSD.js';
-import _ol_geom_Geometry_ from '../geom/Geometry.js';
+import Geometry from '../geom/Geometry.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection, transformExtent} from '../proj.js';
 import _ol_xml_ from '../xml.js';
@@ -254,7 +254,7 @@ _ol_format_GML2_.prototype.writeFeatureElement = function(node, feature, objectS
     if (value !== null) {
       keys.push(key);
       values.push(value);
-      if (key == geometryName || value instanceof _ol_geom_Geometry_) {
+      if (key == geometryName || value instanceof Geometry) {
         if (!(key in context.serializers[featureNS])) {
           context.serializers[featureNS][key] = _ol_xml_.makeChildAppender(
               this.writeGeometryElement, this);

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -12,7 +12,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection, transformExtent} from '../proj.js';
 import _ol_xml_ from '../xml.js';
@@ -244,7 +244,7 @@ _ol_format_GML3_.prototype.readSurface_ = function(node, objectStack) {
   var flatLinearRings = _ol_xml_.pushParseAndPop([null],
       this.SURFACE_PARSERS_, node, objectStack, this);
   if (flatLinearRings && flatLinearRings[0]) {
-    var polygon = new _ol_geom_Polygon_(null);
+    var polygon = new Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
     var i, ii;

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -11,7 +11,7 @@ import _ol_geom_Geometry_ from '../geom/Geometry.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection, transformExtent} from '../proj.js';
@@ -120,7 +120,7 @@ _ol_format_GML3_.prototype.readMultiSurface_ = function(node, objectStack) {
   var polygons = _ol_xml_.pushParseAndPop([],
       this.MULTISURFACE_PARSERS_, node, objectStack, this);
   if (polygons) {
-    var multiPolygon = new _ol_geom_MultiPolygon_(null);
+    var multiPolygon = new MultiPolygon(null);
     multiPolygon.setPolygons(polygons);
     return multiPolygon;
   } else {

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -8,7 +8,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_GMLBase_ from '../format/GMLBase.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import Geometry from '../geom/Geometry.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPolygon from '../geom/MultiPolygon.js';
@@ -253,7 +253,7 @@ _ol_format_GML3_.prototype.readSurface_ = function(node, objectStack) {
       ends.push(flatCoordinates.length);
     }
     polygon.setFlatCoordinates(
-        _ol_geom_GeometryLayout_.XYZ, flatCoordinates, ends);
+        GeometryLayout.XYZ, flatCoordinates, ends);
     return polygon;
   } else {
     return undefined;
@@ -273,7 +273,7 @@ _ol_format_GML3_.prototype.readCurve_ = function(node, objectStack) {
       this.CURVE_PARSERS_, node, objectStack, this);
   if (flatCoordinates) {
     var lineString = new LineString(null);
-    lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
+    lineString.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     return lineString;
   } else {
     return undefined;

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -9,7 +9,7 @@ import _ol_format_GMLBase_ from '../format/GMLBase.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_Geometry_ from '../geom/Geometry.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -272,7 +272,7 @@ _ol_format_GML3_.prototype.readCurve_ = function(node, objectStack) {
   var flatCoordinates = _ol_xml_.pushParseAndPop([null],
       this.CURVE_PARSERS_, node, objectStack, this);
   if (flatCoordinates) {
-    var lineString = new _ol_geom_LineString_(null);
+    var lineString = new LineString(null);
     lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
     return lineString;
   } else {

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -7,7 +7,7 @@ import {createOrUpdate} from '../extent.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_GMLBase_ from '../format/GMLBase.js';
 import _ol_format_XSD_ from '../format/XSD.js';
-import _ol_geom_Geometry_ from '../geom/Geometry.js';
+import Geometry from '../geom/Geometry.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -996,7 +996,7 @@ _ol_format_GML3_.prototype.writeFeatureElement = function(node, feature, objectS
     if (value !== null) {
       keys.push(key);
       values.push(value);
-      if (key == geometryName || value instanceof _ol_geom_Geometry_) {
+      if (key == geometryName || value instanceof Geometry) {
         if (!(key in context.serializers[featureNS])) {
           context.serializers[featureNS][key] = _ol_xml_.makeChildAppender(
               this.writeGeometryElement, this);

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -10,7 +10,7 @@ import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_Geometry_ from '../geom/Geometry.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
@@ -100,7 +100,7 @@ _ol_format_GML3_.prototype.readMultiCurve_ = function(node, objectStack) {
   var lineStrings = _ol_xml_.pushParseAndPop([],
       this.MULTICURVE_PARSERS_, node, objectStack, this);
   if (lineStrings) {
-    var multiLineString = new _ol_geom_MultiLineString_(null);
+    var multiLineString = new MultiLineString(null);
     multiLineString.setLineStrings(lineStrings);
     return multiLineString;
   } else {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -10,7 +10,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -368,7 +368,7 @@ _ol_format_GMLBase_.prototype.readLineString = function(node, objectStack) {
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
-    var lineString = new _ol_geom_LineString_(null);
+    var lineString = new LineString(null);
     lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
     return lineString;
   } else {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -9,7 +9,7 @@ import _ol_array_ from '../array.js';
 import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -265,7 +265,7 @@ _ol_format_GMLBase_.prototype.readPoint = function(node, objectStack) {
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var point = new Point(null);
-    point.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
+    point.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     return point;
   }
 };
@@ -369,7 +369,7 @@ _ol_format_GMLBase_.prototype.readLineString = function(node, objectStack) {
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var lineString = new LineString(null);
-    lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
+    lineString.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     return lineString;
   } else {
     return undefined;
@@ -405,7 +405,7 @@ _ol_format_GMLBase_.prototype.readLinearRing = function(node, objectStack) {
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var ring = new _ol_geom_LinearRing_(null);
-    ring.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
+    ring.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     return ring;
   } else {
     return undefined;
@@ -432,7 +432,7 @@ _ol_format_GMLBase_.prototype.readPolygon = function(node, objectStack) {
       ends.push(flatCoordinates.length);
     }
     polygon.setFlatCoordinates(
-        _ol_geom_GeometryLayout_.XYZ, flatCoordinates, ends);
+        GeometryLayout.XYZ, flatCoordinates, ends);
     return polygon;
   } else {
     return undefined;

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -14,7 +14,7 @@ import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
@@ -317,7 +317,7 @@ _ol_format_GMLBase_.prototype.readMultiPolygon = function(node, objectStack) {
   var polygons = _ol_xml_.pushParseAndPop([],
       this.MULTIPOLYGON_PARSERS_, node, objectStack, this);
   if (polygons) {
-    var multiPolygon = new _ol_geom_MultiPolygon_(null);
+    var multiPolygon = new MultiPolygon(null);
     multiPolygon.setPolygons(polygons);
     return multiPolygon;
   } else {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -11,7 +11,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
+import LinearRing from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import MultiPolygon from '../geom/MultiPolygon.js';
@@ -404,7 +404,7 @@ _ol_format_GMLBase_.prototype.readLinearRing = function(node, objectStack) {
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
-    var ring = new _ol_geom_LinearRing_(null);
+    var ring = new LinearRing(null);
     ring.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     return ring;
   } else {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -15,7 +15,7 @@ import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
@@ -264,7 +264,7 @@ _ol_format_GMLBase_.prototype.readPoint = function(node, objectStack) {
   var flatCoordinates =
       this.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
-    var point = new _ol_geom_Point_(null);
+    var point = new Point(null);
     point.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
     return point;
   }

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -13,7 +13,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -281,7 +281,7 @@ _ol_format_GMLBase_.prototype.readMultiPoint = function(node, objectStack) {
   var coordinates = _ol_xml_.pushParseAndPop([],
       this.MULTIPOINT_PARSERS_, node, objectStack, this);
   if (coordinates) {
-    return new _ol_geom_MultiPoint_(coordinates);
+    return new MultiPoint(coordinates);
   } else {
     return undefined;
   }

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -12,7 +12,7 @@ import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -298,7 +298,7 @@ _ol_format_GMLBase_.prototype.readMultiLineString = function(node, objectStack) 
   var lineStrings = _ol_xml_.pushParseAndPop([],
       this.MULTILINESTRING_PARSERS_, node, objectStack, this);
   if (lineStrings) {
-    var multiLineString = new _ol_geom_MultiLineString_(null);
+    var multiLineString = new MultiLineString(null);
     multiLineString.setLineStrings(lineStrings);
     return multiLineString;
   } else {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -16,7 +16,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
@@ -423,7 +423,7 @@ _ol_format_GMLBase_.prototype.readPolygon = function(node, objectStack) {
   var flatLinearRings = _ol_xml_.pushParseAndPop([null],
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
   if (flatLinearRings && flatLinearRings[0]) {
-    var polygon = new _ol_geom_Polygon_(null);
+    var polygon = new Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
     var i, ii;

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -10,7 +10,7 @@ import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
 
@@ -298,7 +298,7 @@ _ol_format_GPX_.readWpt_ = function(node, objectStack) {
   var layoutOptions = /** @type {ol.LayoutOptions} */ ({});
   var coordinates = _ol_format_GPX_.appendCoordinate_([], layoutOptions, node, values);
   var layout = _ol_format_GPX_.applyLayoutOptions_(layoutOptions, coordinates);
-  var geometry = new _ol_geom_Point_(coordinates, layout);
+  var geometry = new Point(coordinates, layout);
   _ol_format_Feature_.transformWithOptions(geometry, false, options);
   var feature = new _ol_Feature_(geometry);
   feature.setProperties(values);

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -8,7 +8,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import Point from '../geom/Point.js';
 import {get as getProjection} from '../proj.js';
@@ -240,7 +240,7 @@ _ol_format_GPX_.readRte_ = function(node, objectStack) {
   var layoutOptions = /** @type {ol.LayoutOptions} */ (values['layoutOptions']);
   delete values['layoutOptions'];
   var layout = _ol_format_GPX_.applyLayoutOptions_(layoutOptions, flatCoordinates);
-  var geometry = new _ol_geom_LineString_(null);
+  var geometry = new LineString(null);
   geometry.setFlatCoordinates(layout, flatCoordinates);
   _ol_format_Feature_.transformWithOptions(geometry, false, options);
   var feature = new _ol_Feature_(geometry);

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -7,7 +7,7 @@ import _ol_array_ from '../array.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import Point from '../geom/Point.js';
@@ -105,16 +105,16 @@ _ol_format_GPX_.appendCoordinate_ = function(flatCoordinates, layoutOptions, nod
  * @return {ol.geom.GeometryLayout} Layout.
  */
 _ol_format_GPX_.applyLayoutOptions_ = function(layoutOptions, flatCoordinates, ends) {
-  var layout = _ol_geom_GeometryLayout_.XY;
+  var layout = GeometryLayout.XY;
   var stride = 2;
   if (layoutOptions.hasZ && layoutOptions.hasM) {
-    layout = _ol_geom_GeometryLayout_.XYZM;
+    layout = GeometryLayout.XYZM;
     stride = 4;
   } else if (layoutOptions.hasZ) {
-    layout = _ol_geom_GeometryLayout_.XYZ;
+    layout = GeometryLayout.XYZ;
     stride = 3;
   } else if (layoutOptions.hasM) {
-    layout = _ol_geom_GeometryLayout_.XYM;
+    layout = GeometryLayout.XYM;
     stride = 3;
   }
   if (stride !== 4) {
@@ -588,17 +588,17 @@ _ol_format_GPX_.writeWptType_ = function(node, coordinate, objectStack) {
   _ol_xml_.setAttributeNS(node, null, 'lon', coordinate[0]);
   var geometryLayout = context['geometryLayout'];
   switch (geometryLayout) {
-    case _ol_geom_GeometryLayout_.XYZM:
+    case GeometryLayout.XYZM:
       if (coordinate[3] !== 0) {
         properties['time'] = coordinate[3];
       }
       // fall through
-    case _ol_geom_GeometryLayout_.XYZ:
+    case GeometryLayout.XYZ:
       if (coordinate[2] !== 0) {
         properties['ele'] = coordinate[2];
       }
       break;
-    case _ol_geom_GeometryLayout_.XYM:
+    case GeometryLayout.XYM:
       if (coordinate[2] !== 0) {
         properties['time'] = coordinate[2];
       }

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -9,7 +9,7 @@ import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import Point from '../geom/Point.js';
 import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
@@ -273,7 +273,7 @@ _ol_format_GPX_.readTrk_ = function(node, objectStack) {
   var layoutOptions = /** @type {ol.LayoutOptions} */ (values['layoutOptions']);
   delete values['layoutOptions'];
   var layout = _ol_format_GPX_.applyLayoutOptions_(layoutOptions, flatCoordinates, ends);
-  var geometry = new _ol_geom_MultiLineString_(null);
+  var geometry = new MultiLineString(null);
   geometry.setFlatCoordinates(layout, flatCoordinates, ends);
   _ol_format_Feature_.transformWithOptions(geometry, false, options);
   var feature = new _ol_Feature_(geometry);

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -9,7 +9,7 @@ import _ol_asserts_ from '../asserts.js';
 import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
-import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
+import GeometryCollection from '../geom/GeometryCollection.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -99,7 +99,7 @@ _ol_format_GeoJSON_.readGeometryCollectionGeometry_ = function(
       function(geometry) {
         return _ol_format_GeoJSON_.readGeometry_(geometry, opt_options);
       });
-  return new _ol_geom_GeometryCollection_(geometries);
+  return new GeometryCollection(geometries);
 };
 
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -13,7 +13,7 @@ import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
@@ -149,7 +149,7 @@ _ol_format_GeoJSON_.readMultiPointGeometry_ = function(object) {
  * @return {ol.geom.MultiPolygon} MultiPolygon.
  */
 _ol_format_GeoJSON_.readMultiPolygonGeometry_ = function(object) {
-  return new _ol_geom_MultiPolygon_(object.coordinates);
+  return new MultiPolygon(object.coordinates);
 };
 
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -11,7 +11,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -129,7 +129,7 @@ _ol_format_GeoJSON_.readLineStringGeometry_ = function(object) {
  * @return {ol.geom.MultiLineString} MultiLineString.
  */
 _ol_format_GeoJSON_.readMultiLineStringGeometry_ = function(object) {
-  return new _ol_geom_MultiLineString_(object.coordinates);
+  return new MultiLineString(object.coordinates);
 };
 
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -10,7 +10,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
@@ -119,7 +119,7 @@ _ol_format_GeoJSON_.readPointGeometry_ = function(object) {
  * @return {ol.geom.LineString} LineString.
  */
 _ol_format_GeoJSON_.readLineStringGeometry_ = function(object) {
-  return new _ol_geom_LineString_(object.coordinates);
+  return new LineString(object.coordinates);
 };
 
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -12,7 +12,7 @@ import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -139,7 +139,7 @@ _ol_format_GeoJSON_.readMultiLineStringGeometry_ = function(object) {
  * @return {ol.geom.MultiPoint} MultiPoint.
  */
 _ol_format_GeoJSON_.readMultiPointGeometry_ = function(object) {
-  return new _ol_geom_MultiPoint_(object.coordinates);
+  return new MultiPoint(object.coordinates);
 };
 
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -14,7 +14,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
@@ -109,7 +109,7 @@ _ol_format_GeoJSON_.readGeometryCollectionGeometry_ = function(
  * @return {ol.geom.Point} Point.
  */
 _ol_format_GeoJSON_.readPointGeometry_ = function(object) {
-  return new _ol_geom_Point_(object.coordinates);
+  return new Point(object.coordinates);
 };
 
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -15,7 +15,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
 
@@ -159,7 +159,7 @@ _ol_format_GeoJSON_.readMultiPolygonGeometry_ = function(object) {
  * @return {ol.geom.Polygon} Polygon.
  */
 _ol_format_GeoJSON_.readPolygonGeometry_ = function(object) {
-  return new _ol_geom_Polygon_(object.coordinates);
+  return new Polygon(object.coordinates);
 };
 
 

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -6,7 +6,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_IGCZ_ from '../format/IGCZ.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import {get as getProjection} from '../proj.js';
 
@@ -159,7 +159,7 @@ _ol_format_IGC_.prototype.readFeatureFromText = function(text, opt_options) {
   }
   var lineString = new LineString(null);
   var layout = altitudeMode == _ol_format_IGCZ_.NONE ?
-    _ol_geom_GeometryLayout_.XYM : _ol_geom_GeometryLayout_.XYZM;
+    GeometryLayout.XYM : GeometryLayout.XYZM;
   lineString.setFlatCoordinates(layout, flatCoordinates);
   var feature = new _ol_Feature_(_ol_format_Feature_.transformWithOptions(
       lineString, false, opt_options));

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -7,7 +7,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_IGCZ_ from '../format/IGCZ.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import {get as getProjection} from '../proj.js';
 
 /**
@@ -157,7 +157,7 @@ _ol_format_IGC_.prototype.readFeatureFromText = function(text, opt_options) {
   if (flatCoordinates.length === 0) {
     return null;
   }
-  var lineString = new _ol_geom_LineString_(null);
+  var lineString = new LineString(null);
   var layout = altitudeMode == _ol_format_IGCZ_.NONE ?
     _ol_geom_GeometryLayout_.XYM : _ol_geom_GeometryLayout_.XYZM;
   lineString.setFlatCoordinates(layout, flatCoordinates);

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -15,7 +15,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import GeometryCollection from '../geom/GeometryCollection.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -817,7 +817,7 @@ _ol_format_KML_.readGxTrack_ = function(node, objectStack) {
     flatCoordinates[4 * i + 3] = whens[i];
   }
   var lineString = new LineString(null);
-  lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZM, flatCoordinates);
+  lineString.setFlatCoordinates(GeometryLayout.XYZM, flatCoordinates);
   return lineString;
 };
 
@@ -865,7 +865,7 @@ _ol_format_KML_.readLineString_ = function(node, objectStack) {
       _ol_format_KML_.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var lineString = new LineString(null);
-    lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
+    lineString.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     lineString.setProperties(properties);
     return lineString;
   } else {
@@ -888,7 +888,7 @@ _ol_format_KML_.readLinearRing_ = function(node, objectStack) {
       _ol_format_KML_.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var polygon = new Polygon(null);
-    polygon.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates,
+    polygon.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates,
         [flatCoordinates.length]);
     polygon.setProperties(properties);
     return polygon;
@@ -973,7 +973,7 @@ _ol_format_KML_.readPoint_ = function(node, objectStack) {
       _ol_format_KML_.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
     var point = new Point(null);
-    point.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
+    point.setFlatCoordinates(GeometryLayout.XYZ, flatCoordinates);
     point.setProperties(properties);
     return point;
   } else {
@@ -1004,7 +1004,7 @@ _ol_format_KML_.readPolygon_ = function(node, objectStack) {
       ends.push(flatCoordinates.length);
     }
     polygon.setFlatCoordinates(
-        _ol_geom_GeometryLayout_.XYZ, flatCoordinates, ends);
+        GeometryLayout.XYZ, flatCoordinates, ends);
     polygon.setProperties(properties);
     return polygon;
   } else {
@@ -2122,11 +2122,11 @@ _ol_format_KML_.writeCoordinatesTextNode_ = function(node, coordinates, objectSt
   var stride = context['stride'];
 
   var dimension;
-  if (layout == _ol_geom_GeometryLayout_.XY ||
-      layout == _ol_geom_GeometryLayout_.XYM) {
+  if (layout == GeometryLayout.XY ||
+      layout == GeometryLayout.XYM) {
     dimension = 2;
-  } else if (layout == _ol_geom_GeometryLayout_.XYZ ||
-      layout == _ol_geom_GeometryLayout_.XYZM) {
+  } else if (layout == GeometryLayout.XYZ ||
+      layout == GeometryLayout.XYZM) {
     dimension = 3;
   } else {
     _ol_asserts_.assert(false, 34); // Invalid geometry layout

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -22,7 +22,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_math_ from '../math.js';
 import {get as getProjection} from '../proj.js';
 import _ol_style_Fill_ from '../style/Fill.js';
@@ -887,7 +887,7 @@ _ol_format_KML_.readLinearRing_ = function(node, objectStack) {
   var flatCoordinates =
       _ol_format_KML_.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
-    var polygon = new _ol_geom_Polygon_(null);
+    var polygon = new Polygon(null);
     polygon.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates,
         [flatCoordinates.length]);
     polygon.setProperties(properties);
@@ -995,7 +995,7 @@ _ol_format_KML_.readPolygon_ = function(node, objectStack) {
   var flatLinearRings = _ol_xml_.pushParseAndPop([null],
       _ol_format_KML_.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack);
   if (flatLinearRings && flatLinearRings[0]) {
-    var polygon = new _ol_geom_Polygon_(null);
+    var polygon = new Polygon(null);
     var flatCoordinates = flatLinearRings[0];
     var ends = [flatCoordinates.length];
     var i, ii;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -19,7 +19,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -936,7 +936,7 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
         geometry = geometries[i];
         _ol_array_.extend(flatCoordinates, geometry.getFlatCoordinates());
       }
-      multiGeometry = new _ol_geom_MultiPoint_(null);
+      multiGeometry = new MultiPoint(null);
       multiGeometry.setFlatCoordinates(layout, flatCoordinates);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
     } else if (type == _ol_geom_GeometryType_.LINE_STRING) {

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -14,7 +14,7 @@ import _ol_color_ from '../color.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
-import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
+import GeometryCollection from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
@@ -911,7 +911,7 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
     return null;
   }
   if (geometries.length === 0) {
-    return new _ol_geom_GeometryCollection_(geometries);
+    return new GeometryCollection(geometries);
   }
   /** @type {ol.geom.Geometry} */
   var multiGeometry;
@@ -948,12 +948,12 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
       multiGeometry.setPolygons(geometries);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
     } else if (type == _ol_geom_GeometryType_.GEOMETRY_COLLECTION) {
-      multiGeometry = new _ol_geom_GeometryCollection_(geometries);
+      multiGeometry = new GeometryCollection(geometries);
     } else {
       _ol_asserts_.assert(false, 37); // Unknown geometry type found
     }
   } else {
-    multiGeometry = new _ol_geom_GeometryCollection_(geometries);
+    multiGeometry = new GeometryCollection(geometries);
   }
   return /** @type {ol.geom.Geometry} */ (multiGeometry);
 };

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -18,7 +18,7 @@ import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -788,7 +788,7 @@ _ol_format_KML_.readGxMultiTrack_ = function(node, objectStack) {
   if (!lineStrings) {
     return undefined;
   }
-  var multiLineString = new _ol_geom_MultiLineString_(null);
+  var multiLineString = new MultiLineString(null);
   multiLineString.setLineStrings(lineStrings);
   return multiLineString;
 };
@@ -940,7 +940,7 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
       multiGeometry.setFlatCoordinates(layout, flatCoordinates);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
     } else if (type == _ol_geom_GeometryType_.LINE_STRING) {
-      multiGeometry = new _ol_geom_MultiLineString_(null);
+      multiGeometry = new MultiLineString(null);
       multiGeometry.setLineStrings(geometries);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
     } else if (type == _ol_geom_GeometryType_.POLYGON) {

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -17,7 +17,7 @@ import _ol_format_XSD_ from '../format/XSD.js';
 import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
@@ -816,7 +816,7 @@ _ol_format_KML_.readGxTrack_ = function(node, objectStack) {
     ++i) {
     flatCoordinates[4 * i + 3] = whens[i];
   }
-  var lineString = new _ol_geom_LineString_(null);
+  var lineString = new LineString(null);
   lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZM, flatCoordinates);
   return lineString;
 };
@@ -864,7 +864,7 @@ _ol_format_KML_.readLineString_ = function(node, objectStack) {
   var flatCoordinates =
       _ol_format_KML_.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
-    var lineString = new _ol_geom_LineString_(null);
+    var lineString = new LineString(null);
     lineString.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
     lineString.setProperties(properties);
     return lineString;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -21,7 +21,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_math_ from '../math.js';
 import {get as getProjection} from '../proj.js';
@@ -972,7 +972,7 @@ _ol_format_KML_.readPoint_ = function(node, objectStack) {
   var flatCoordinates =
       _ol_format_KML_.readFlatCoordinatesFromNode_(node, objectStack);
   if (flatCoordinates) {
-    var point = new _ol_geom_Point_(null);
+    var point = new Point(null);
     point.setFlatCoordinates(_ol_geom_GeometryLayout_.XYZ, flatCoordinates);
     point.setProperties(properties);
     return point;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -16,7 +16,7 @@ import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
 import GeometryCollection from '../geom/GeometryCollection.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -367,7 +367,7 @@ _ol_format_KML_.createFeatureStyleFunction_ = function(style, styleUrl,
       if (drawName) {
         if (this.getGeometry()) {
           drawName = (this.getGeometry().getType() ===
-                        _ol_geom_GeometryType_.POINT);
+                        GeometryType.POINT);
         }
       }
 
@@ -928,7 +928,7 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
   if (homogeneous) {
     var layout;
     var flatCoordinates;
-    if (type == _ol_geom_GeometryType_.POINT) {
+    if (type == GeometryType.POINT) {
       var point = geometries[0];
       layout = point.getLayout();
       flatCoordinates = point.getFlatCoordinates();
@@ -939,15 +939,15 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
       multiGeometry = new MultiPoint(null);
       multiGeometry.setFlatCoordinates(layout, flatCoordinates);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
-    } else if (type == _ol_geom_GeometryType_.LINE_STRING) {
+    } else if (type == GeometryType.LINE_STRING) {
       multiGeometry = new MultiLineString(null);
       multiGeometry.setLineStrings(geometries);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
-    } else if (type == _ol_geom_GeometryType_.POLYGON) {
+    } else if (type == GeometryType.POLYGON) {
       multiGeometry = new MultiPolygon(null);
       multiGeometry.setPolygons(geometries);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
-    } else if (type == _ol_geom_GeometryType_.GEOMETRY_COLLECTION) {
+    } else if (type == GeometryType.GEOMETRY_COLLECTION) {
       multiGeometry = new GeometryCollection(geometries);
     } else {
       _ol_asserts_.assert(false, 37); // Unknown geometry type found
@@ -2372,17 +2372,17 @@ _ol_format_KML_.writeMultiGeometry_ = function(node, geometry, objectStack) {
   var geometries;
   /** @type {function(*, Array.<*>, string=): (Node|undefined)} */
   var factory;
-  if (type == _ol_geom_GeometryType_.GEOMETRY_COLLECTION) {
+  if (type == GeometryType.GEOMETRY_COLLECTION) {
     geometries = /** @type {ol.geom.GeometryCollection} */ (geometry).getGeometries();
     factory = _ol_format_KML_.GEOMETRY_NODE_FACTORY_;
-  } else if (type == _ol_geom_GeometryType_.MULTI_POINT) {
+  } else if (type == GeometryType.MULTI_POINT) {
     geometries = /** @type {ol.geom.MultiPoint} */ (geometry).getPoints();
     factory = _ol_format_KML_.POINT_NODE_FACTORY_;
-  } else if (type == _ol_geom_GeometryType_.MULTI_LINE_STRING) {
+  } else if (type == GeometryType.MULTI_LINE_STRING) {
     geometries =
         (/** @type {ol.geom.MultiLineString} */ (geometry)).getLineStrings();
     factory = _ol_format_KML_.LINE_STRING_NODE_FACTORY_;
-  } else if (type == _ol_geom_GeometryType_.MULTI_POLYGON) {
+  } else if (type == GeometryType.MULTI_POLYGON) {
     geometries =
         (/** @type {ol.geom.MultiPolygon} */ (geometry)).getPolygons();
     factory = _ol_format_KML_.POLYGON_NODE_FACTORY_;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -20,7 +20,7 @@ import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_math_ from '../math.js';
@@ -944,7 +944,7 @@ _ol_format_KML_.readMultiGeometry_ = function(node, objectStack) {
       multiGeometry.setLineStrings(geometries);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
     } else if (type == _ol_geom_GeometryType_.POLYGON) {
-      multiGeometry = new _ol_geom_MultiPolygon_(null);
+      multiGeometry = new MultiPolygon(null);
       multiGeometry.setPolygons(geometries);
       _ol_format_KML_.setCommonGeometryProperties_(multiGeometry, geometries);
     } else if (type == _ol_geom_GeometryType_.GEOMETRY_COLLECTION) {

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -14,7 +14,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_geom_flat_orient_ from '../geom/flat/orient.js';
 import _ol_proj_Projection_ from '../proj/Projection.js';
@@ -310,7 +310,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
         geom = new _ol_geom_Polygon_(null);
       }
     } else {
-      geom = geometryType === _ol_geom_GeometryType_.POINT ? new _ol_geom_Point_(null) :
+      geom = geometryType === _ol_geom_GeometryType_.POINT ? new Point(null) :
         geometryType === _ol_geom_GeometryType_.LINE_STRING ? new _ol_geom_LineString_(null) :
           geometryType === _ol_geom_GeometryType_.POLYGON ? new _ol_geom_Polygon_(null) :
             geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new _ol_geom_MultiPoint_ (null) :

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -10,7 +10,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_FormatType_ from '../format/FormatType.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
@@ -311,7 +311,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
       }
     } else {
       geom = geometryType === _ol_geom_GeometryType_.POINT ? new Point(null) :
-        geometryType === _ol_geom_GeometryType_.LINE_STRING ? new _ol_geom_LineString_(null) :
+        geometryType === _ol_geom_GeometryType_.LINE_STRING ? new LineString(null) :
           geometryType === _ol_geom_GeometryType_.POLYGON ? new _ol_geom_Polygon_(null) :
             geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new MultiPoint (null) :
               geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new _ol_geom_MultiLineString_(null) :

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -13,7 +13,7 @@ import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_geom_flat_orient_ from '../geom/flat/orient.js';
@@ -305,7 +305,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
       }
       if (endss.length > 1) {
         ends = endss;
-        geom = new _ol_geom_MultiPolygon_(null);
+        geom = new MultiPolygon(null);
       } else {
         geom = new Polygon(null);
       }

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -8,7 +8,7 @@ import _ol_asserts_ from '../asserts.js';
 import _ol_ext_PBF_ from 'pbf';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_FormatType_ from '../format/FormatType.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -317,7 +317,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
               geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new MultiLineString(null) :
                 null;
     }
-    geom.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates, ends);
+    geom.setFlatCoordinates(GeometryLayout.XY, flatCoordinates, ends);
     feature = new this.featureClass_();
     if (this.geometryName_) {
       feature.setGeometryName(this.geometryName_);

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -12,7 +12,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -313,7 +313,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
       geom = geometryType === _ol_geom_GeometryType_.POINT ? new Point(null) :
         geometryType === _ol_geom_GeometryType_.LINE_STRING ? new _ol_geom_LineString_(null) :
           geometryType === _ol_geom_GeometryType_.POLYGON ? new _ol_geom_Polygon_(null) :
-            geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new _ol_geom_MultiPoint_ (null) :
+            geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new MultiPoint (null) :
               geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new _ol_geom_MultiLineString_(null) :
                 null;
     }

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -15,7 +15,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_geom_flat_orient_ from '../geom/flat/orient.js';
 import _ol_proj_Projection_ from '../proj/Projection.js';
 import _ol_proj_Units_ from '../proj/Units.js';
@@ -307,12 +307,12 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
         ends = endss;
         geom = new _ol_geom_MultiPolygon_(null);
       } else {
-        geom = new _ol_geom_Polygon_(null);
+        geom = new Polygon(null);
       }
     } else {
       geom = geometryType === _ol_geom_GeometryType_.POINT ? new Point(null) :
         geometryType === _ol_geom_GeometryType_.LINE_STRING ? new LineString(null) :
-          geometryType === _ol_geom_GeometryType_.POLYGON ? new _ol_geom_Polygon_(null) :
+          geometryType === _ol_geom_GeometryType_.POLYGON ? new Polygon(null) :
             geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new MultiPoint (null) :
               geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new MultiLineString(null) :
                 null;

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -11,7 +11,7 @@ import _ol_format_FormatType_ from '../format/FormatType.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -314,7 +314,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
         geometryType === _ol_geom_GeometryType_.LINE_STRING ? new LineString(null) :
           geometryType === _ol_geom_GeometryType_.POLYGON ? new _ol_geom_Polygon_(null) :
             geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new MultiPoint (null) :
-              geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new _ol_geom_MultiLineString_(null) :
+              geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new MultiLineString(null) :
                 null;
     }
     geom.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates, ends);

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -9,7 +9,7 @@ import _ol_ext_PBF_ from 'pbf';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_FormatType_ from '../format/FormatType.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -250,13 +250,13 @@ _ol_format_MVT_.getGeometryType_ = function(type, numEnds) {
   var geometryType;
   if (type === 1) {
     geometryType = numEnds === 1 ?
-      _ol_geom_GeometryType_.POINT : _ol_geom_GeometryType_.MULTI_POINT;
+      GeometryType.POINT : GeometryType.MULTI_POINT;
   } else if (type === 2) {
     geometryType = numEnds === 1 ?
-      _ol_geom_GeometryType_.LINE_STRING :
-      _ol_geom_GeometryType_.MULTI_LINE_STRING;
+      GeometryType.LINE_STRING :
+      GeometryType.MULTI_LINE_STRING;
   } else if (type === 3) {
-    geometryType = _ol_geom_GeometryType_.POLYGON;
+    geometryType = GeometryType.POLYGON;
     // MultiPolygon not relevant for rendering - winding order determines
     // outer rings of polygons.
   }
@@ -291,7 +291,7 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
     feature = new this.featureClass_(geometryType, flatCoordinates, ends, values, id);
   } else {
     var geom;
-    if (geometryType == _ol_geom_GeometryType_.POLYGON) {
+    if (geometryType == GeometryType.POLYGON) {
       var endss = [];
       var offset = 0;
       var prevEndIndex = 0;
@@ -310,11 +310,11 @@ _ol_format_MVT_.prototype.createFeature_ = function(pbf, rawFeature, opt_options
         geom = new Polygon(null);
       }
     } else {
-      geom = geometryType === _ol_geom_GeometryType_.POINT ? new Point(null) :
-        geometryType === _ol_geom_GeometryType_.LINE_STRING ? new LineString(null) :
-          geometryType === _ol_geom_GeometryType_.POLYGON ? new Polygon(null) :
-            geometryType === _ol_geom_GeometryType_.MULTI_POINT ? new MultiPoint (null) :
-              geometryType === _ol_geom_GeometryType_.MULTI_LINE_STRING ? new MultiLineString(null) :
+      geom = geometryType === GeometryType.POINT ? new Point(null) :
+        geometryType === GeometryType.LINE_STRING ? new LineString(null) :
+          geometryType === GeometryType.POLYGON ? new Polygon(null) :
+            geometryType === GeometryType.MULTI_POINT ? new MultiPoint (null) :
+              geometryType === GeometryType.MULTI_LINE_STRING ? new MultiLineString(null) :
                 null;
     }
     geom.setFlatCoordinates(GeometryLayout.XY, flatCoordinates, ends);

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -7,7 +7,7 @@ import _ol_array_ from '../array.js';
 import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
@@ -186,11 +186,11 @@ _ol_format_OSMXML_.prototype.readFeaturesFromNode = function(node, opt_options) 
       if (values.ndrefs[0] == values.ndrefs[values.ndrefs.length - 1]) {
         // closed way
         geometry = new Polygon(null);
-        geometry.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates,
+        geometry.setFlatCoordinates(GeometryLayout.XY, flatCoordinates,
             [flatCoordinates.length]);
       } else {
         geometry = new LineString(null);
-        geometry.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates);
+        geometry.setFlatCoordinates(GeometryLayout.XY, flatCoordinates);
       }
       _ol_format_Feature_.transformWithOptions(geometry, false, options);
       var feature = new _ol_Feature_(geometry);

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -9,7 +9,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
@@ -56,7 +56,7 @@ _ol_format_OSMXML_.readNode_ = function(node, objectStack) {
     tags: {}
   }, _ol_format_OSMXML_.NODE_PARSERS_, node, objectStack);
   if (!_ol_obj_.isEmpty(values.tags)) {
-    var geometry = new _ol_geom_Point_(coordinates);
+    var geometry = new Point(coordinates);
     _ol_format_Feature_.transformWithOptions(geometry, false, options);
     var feature = new _ol_Feature_(geometry);
     feature.setId(id);

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -10,7 +10,7 @@ import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
@@ -185,7 +185,7 @@ _ol_format_OSMXML_.prototype.readFeaturesFromNode = function(node, opt_options) 
       var geometry;
       if (values.ndrefs[0] == values.ndrefs[values.ndrefs.length - 1]) {
         // closed way
-        geometry = new _ol_geom_Polygon_(null);
+        geometry = new Polygon(null);
         geometry.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates,
             [flatCoordinates.length]);
       } else {

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -8,7 +8,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_obj_ from '../obj.js';
@@ -189,7 +189,7 @@ _ol_format_OSMXML_.prototype.readFeaturesFromNode = function(node, opt_options) 
         geometry.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates,
             [flatCoordinates.length]);
       } else {
-        geometry = new _ol_geom_LineString_(null);
+        geometry = new LineString(null);
         geometry.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, flatCoordinates);
       }
       _ol_format_Feature_.transformWithOptions(geometry, false, options);

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -6,7 +6,7 @@ import _ol_asserts_ from '../asserts.js';
 import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_flip_ from '../geom/flat/flip.js';
@@ -46,7 +46,7 @@ var _ol_format_Polyline_ = function(opt_options) {
    * @type {ol.geom.GeometryLayout}
    */
   this.geometryLayout_ = options.geometryLayout ?
-    options.geometryLayout : _ol_geom_GeometryLayout_.XY;
+    options.geometryLayout : GeometryLayout.XY;
 };
 
 inherits(_ol_format_Polyline_, _ol_format_TextFeature_);

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -7,7 +7,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_flip_ from '../geom/flat/flip.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
@@ -334,7 +334,7 @@ _ol_format_Polyline_.prototype.readGeometryFromText = function(text, opt_options
 
   return (
     /** @type {ol.geom.Geometry} */ _ol_format_Feature_.transformWithOptions(
-        new _ol_geom_LineString_(coordinates, this.geometryLayout_), false,
+        new LineString(coordinates, this.geometryLayout_), false,
         this.adaptOptions(opt_options))
   );
 };

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -8,7 +8,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_flip_ from '../geom/flat/flip.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
 import {get as getProjection} from '../proj.js';
@@ -324,7 +324,7 @@ _ol_format_Polyline_.prototype.readGeometry;
  * @inheritDoc
  */
 _ol_format_Polyline_.prototype.readGeometryFromText = function(text, opt_options) {
-  var stride = _ol_geom_SimpleGeometry_.getStrideForLayout(this.geometryLayout_);
+  var stride = SimpleGeometry.getStrideForLayout(this.geometryLayout_);
   var flatCoordinates = _ol_format_Polyline_.decodeDeltas(
       text, stride, this.factor_);
   _ol_geom_flat_flip_.flipXY(

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -9,7 +9,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import {get as getProjection} from '../proj.js';
 
@@ -104,7 +104,7 @@ _ol_format_TopoJSON_.readPointGeometry_ = function(object, scale, translate) {
   if (scale && translate) {
     _ol_format_TopoJSON_.transformVertex_(coordinates, scale, translate);
   }
-  return new _ol_geom_Point_(coordinates);
+  return new Point(coordinates);
 };
 
 

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -7,7 +7,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -126,7 +126,7 @@ _ol_format_TopoJSON_.readMultiPointGeometry_ = function(object, scale,
       _ol_format_TopoJSON_.transformVertex_(coordinates[i], scale, translate);
     }
   }
-  return new _ol_geom_MultiPoint_(coordinates);
+  return new MultiPoint(coordinates);
 };
 
 

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -10,7 +10,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import {get as getProjection} from '../proj.js';
 
 /**
@@ -176,7 +176,7 @@ _ol_format_TopoJSON_.readPolygonGeometry_ = function(object, arcs) {
   for (i = 0, ii = object.arcs.length; i < ii; ++i) {
     coordinates[i] = _ol_format_TopoJSON_.concatenateArcs_(object.arcs[i], arcs);
   }
-  return new _ol_geom_Polygon_(coordinates);
+  return new Polygon(coordinates);
 };
 
 

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -8,7 +8,7 @@ import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import {get as getProjection} from '../proj.js';
@@ -202,7 +202,7 @@ _ol_format_TopoJSON_.readMultiPolygonGeometry_ = function(object, arcs) {
     }
     coordinates[i] = ringCoords;
   }
-  return new _ol_geom_MultiPolygon_(coordinates);
+  return new MultiPolygon(coordinates);
 };
 
 

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -6,7 +6,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -158,7 +158,7 @@ _ol_format_TopoJSON_.readMultiLineStringGeometry_ = function(object, arcs) {
   for (i = 0, ii = object.arcs.length; i < ii; ++i) {
     coordinates[i] = _ol_format_TopoJSON_.concatenateArcs_(object.arcs[i], arcs);
   }
-  return new _ol_geom_MultiLineString_(coordinates);
+  return new MultiLineString(coordinates);
 };
 
 

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_JSONFeature_ from '../format/JSONFeature.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
@@ -140,7 +140,7 @@ _ol_format_TopoJSON_.readMultiPointGeometry_ = function(object, scale,
  */
 _ol_format_TopoJSON_.readLineStringGeometry_ = function(object, arcs) {
   var coordinates = _ol_format_TopoJSON_.concatenateArcs_(object.arcs, arcs);
-  return new _ol_geom_LineString_(coordinates);
+  return new LineString(coordinates);
 };
 
 

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -9,7 +9,7 @@ import _ol_format_GMLBase_ from '../format/GMLBase.js';
 import _ol_format_filter_ from '../format/filter.js';
 import _ol_format_XMLFeature_ from '../format/XMLFeature.js';
 import _ol_format_XSD_ from '../format/XSD.js';
-import _ol_geom_Geometry_ from '../geom/Geometry.js';
+import Geometry from '../geom/Geometry.js';
 import _ol_obj_ from '../obj.js';
 import {get as getProjection} from '../proj.js';
 import _ol_xml_ from '../xml.js';
@@ -490,7 +490,7 @@ _ol_format_WFS_.writeUpdate_ = function(node, feature, objectStack) {
       var value = feature.get(keys[i]);
       if (value !== undefined) {
         var name = keys[i];
-        if (value instanceof _ol_geom_Geometry_) {
+        if (value instanceof Geometry) {
           name = geometryName;
         }
         values.push({name: name, value: value});
@@ -522,7 +522,7 @@ _ol_format_WFS_.writeProperty_ = function(node, pair, objectStack) {
   if (pair.value !== undefined && pair.value !== null) {
     var value = _ol_xml_.createElementNS(_ol_format_WFS_.WFSNS, 'Value');
     node.appendChild(value);
-    if (pair.value instanceof _ol_geom_Geometry_) {
+    if (pair.value instanceof Geometry) {
       if (gmlVersion === 2) {
         _ol_format_GML2_.prototype.writeGeometryElement(value,
             pair.value, objectStack);

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -14,7 +14,7 @@ import MultiPoint from '../geom/MultiPoint.js';
 import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 
 /**
  * @classdesc
@@ -208,7 +208,7 @@ _ol_format_WKT_.encode_ = function(geom) {
   var geometryEncoder = _ol_format_WKT_.GeometryEncoder_[type];
   var enc = geometryEncoder(geom);
   type = type.toUpperCase();
-  if (geom instanceof _ol_geom_SimpleGeometry_) {
+  if (geom instanceof SimpleGeometry) {
     var dimInfo = _ol_format_WKT_.encodeGeometryLayout_(geom);
     if (dimInfo.length > 0) {
       type += ' ' + dimInfo;

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
-import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
+import GeometryCollection from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
@@ -386,7 +386,7 @@ _ol_format_WKT_.prototype.writeFeaturesText = function(features, opt_options) {
   for (var i = 0, ii = features.length; i < ii; ++i) {
     geometries.push(features[i].getGeometry());
   }
-  var collection = new _ol_geom_GeometryCollection_(geometries);
+  var collection = new GeometryCollection(geometries);
   return this.writeGeometryText(collection, opt_options);
 };
 
@@ -671,7 +671,7 @@ _ol_format_WKT_.Parser.prototype.parseGeometry_ = function() {
     this.layout_ = this.parseGeometryLayout_();
     if (geomType == _ol_geom_GeometryType_.GEOMETRY_COLLECTION.toUpperCase()) {
       var geometries = this.parseGeometryCollectionText_();
-      return new _ol_geom_GeometryCollection_(geometries);
+      return new GeometryCollection(geometries);
     } else {
       var parser = _ol_format_WKT_.Parser.GeometryParser_[geomType];
       var ctor = _ol_format_WKT_.Parser.GeometryConstructor_[geomType];

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -10,7 +10,7 @@ import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -921,7 +921,7 @@ _ol_format_WKT_.Parser.GeometryConstructor_ = {
   'POINT': Point,
   'LINESTRING': _ol_geom_LineString_,
   'POLYGON': _ol_geom_Polygon_,
-  'MULTIPOINT': _ol_geom_MultiPoint_,
+  'MULTIPOINT': MultiPoint,
   'MULTILINESTRING': _ol_geom_MultiLineString_,
   'MULTIPOLYGON': _ol_geom_MultiPolygon_
 };

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -13,7 +13,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 
 /**
@@ -920,7 +920,7 @@ _ol_format_WKT_.Parser.prototype.formatErrorMessage_ = function() {
 _ol_format_WKT_.Parser.GeometryConstructor_ = {
   'POINT': Point,
   'LINESTRING': LineString,
-  'POLYGON': _ol_geom_Polygon_,
+  'POLYGON': Polygon,
   'MULTIPOINT': MultiPoint,
   'MULTILINESTRING': MultiLineString,
   'MULTIPOLYGON': _ol_geom_MultiPolygon_

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -8,7 +8,7 @@ import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
@@ -919,7 +919,7 @@ _ol_format_WKT_.Parser.prototype.formatErrorMessage_ = function() {
  */
 _ol_format_WKT_.Parser.GeometryConstructor_ = {
   'POINT': Point,
-  'LINESTRING': _ol_geom_LineString_,
+  'LINESTRING': LineString,
   'POLYGON': _ol_geom_Polygon_,
   'MULTIPOINT': MultiPoint,
   'MULTILINESTRING': _ol_geom_MultiLineString_,

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -7,7 +7,7 @@ import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import GeometryCollection from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -187,10 +187,10 @@ _ol_format_WKT_.encodeMultiPolygonGeometry_ = function(geom) {
 _ol_format_WKT_.encodeGeometryLayout_ = function(geom) {
   var layout = geom.getLayout();
   var dimInfo = '';
-  if (layout === _ol_geom_GeometryLayout_.XYZ || layout === _ol_geom_GeometryLayout_.XYZM) {
+  if (layout === GeometryLayout.XYZ || layout === GeometryLayout.XYZM) {
     dimInfo += _ol_format_WKT_.Z;
   }
-  if (layout === _ol_geom_GeometryLayout_.XYM || layout === _ol_geom_GeometryLayout_.XYZM) {
+  if (layout === GeometryLayout.XYM || layout === GeometryLayout.XYZM) {
     dimInfo += _ol_format_WKT_.M;
   }
   return dimInfo;
@@ -587,7 +587,7 @@ _ol_format_WKT_.Parser = function(lexer) {
    * @type {ol.geom.GeometryLayout}
    * @private
    */
-  this.layout_ = _ol_geom_GeometryLayout_.XY;
+  this.layout_ = GeometryLayout.XY;
 };
 
 
@@ -641,18 +641,18 @@ _ol_format_WKT_.Parser.prototype.parse = function() {
  * @private
  */
 _ol_format_WKT_.Parser.prototype.parseGeometryLayout_ = function() {
-  var layout = _ol_geom_GeometryLayout_.XY;
+  var layout = GeometryLayout.XY;
   var dimToken = this.token_;
   if (this.isTokenType(_ol_format_WKT_.TokenType_.TEXT)) {
     var dimInfo = dimToken.value;
     if (dimInfo === _ol_format_WKT_.Z) {
-      layout = _ol_geom_GeometryLayout_.XYZ;
+      layout = GeometryLayout.XYZ;
     } else if (dimInfo === _ol_format_WKT_.M) {
-      layout = _ol_geom_GeometryLayout_.XYM;
+      layout = GeometryLayout.XYM;
     } else if (dimInfo === _ol_format_WKT_.ZM) {
-      layout = _ol_geom_GeometryLayout_.XYZM;
+      layout = GeometryLayout.XYZM;
     }
-    if (layout !== _ol_geom_GeometryLayout_.XY) {
+    if (layout !== GeometryLayout.XY) {
       this.consume_();
     }
   }

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -6,7 +6,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_format_Feature_ from '../format/Feature.js';
 import _ol_format_TextFeature_ from '../format/TextFeature.js';
 import GeometryCollection from '../geom/GeometryCollection.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -296,7 +296,7 @@ _ol_format_WKT_.prototype.readFeaturesFromText = function(text, opt_options) {
   var geometries = [];
   var geometry = this.readGeometryFromText(text, opt_options);
   if (this.splitCollection_ &&
-      geometry.getType() == _ol_geom_GeometryType_.GEOMETRY_COLLECTION) {
+      geometry.getType() == GeometryType.GEOMETRY_COLLECTION) {
     geometries = (/** @type {ol.geom.GeometryCollection} */ (geometry))
         .getGeometriesArray();
   } else {
@@ -669,7 +669,7 @@ _ol_format_WKT_.Parser.prototype.parseGeometry_ = function() {
   if (this.match(_ol_format_WKT_.TokenType_.TEXT)) {
     var geomType = token.value;
     this.layout_ = this.parseGeometryLayout_();
-    if (geomType == _ol_geom_GeometryType_.GEOMETRY_COLLECTION.toUpperCase()) {
+    if (geomType == GeometryType.GEOMETRY_COLLECTION.toUpperCase()) {
       var geometries = this.parseGeometryCollectionText_();
       return new GeometryCollection(geometries);
     } else {

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -12,7 +12,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 
@@ -918,7 +918,7 @@ _ol_format_WKT_.Parser.prototype.formatErrorMessage_ = function() {
  * @private
  */
 _ol_format_WKT_.Parser.GeometryConstructor_ = {
-  'POINT': _ol_geom_Point_,
+  'POINT': Point,
   'LINESTRING': _ol_geom_LineString_,
   'POLYGON': _ol_geom_Polygon_,
   'MULTIPOINT': _ol_geom_MultiPoint_,

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -11,7 +11,7 @@ import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
@@ -923,7 +923,7 @@ _ol_format_WKT_.Parser.GeometryConstructor_ = {
   'POLYGON': Polygon,
   'MULTIPOINT': MultiPoint,
   'MULTILINESTRING': MultiLineString,
-  'MULTIPOLYGON': _ol_geom_MultiPolygon_
+  'MULTIPOLYGON': MultiPolygon
 };
 
 

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -9,7 +9,7 @@ import _ol_geom_GeometryCollection_ from '../geom/GeometryCollection.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -922,7 +922,7 @@ _ol_format_WKT_.Parser.GeometryConstructor_ = {
   'LINESTRING': LineString,
   'POLYGON': _ol_geom_Polygon_,
   'MULTIPOINT': MultiPoint,
-  'MULTILINESTRING': _ol_geom_MultiLineString_,
+  'MULTILINESTRING': MultiLineString,
   'MULTIPOLYGON': _ol_geom_MultiPolygon_
 };
 

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import {createOrUpdate, forEachCorner, intersects} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 
 /**
@@ -20,12 +20,12 @@ import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
  * @api
  */
 var Circle = function(center, opt_radius, opt_layout) {
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
   var radius = opt_radius ? opt_radius : 0;
   this.setCenterAndRadius(center, radius, opt_layout);
 };
 
-inherits(Circle, _ol_geom_SimpleGeometry_);
+inherits(Circle, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import {createOrUpdate, forEachCorner, intersects} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 
@@ -131,7 +131,7 @@ Circle.prototype.getRadiusSquared_ = function() {
  * @api
  */
 Circle.prototype.getType = function() {
-  return _ol_geom_GeometryType_.CIRCLE;
+  return GeometryType.CIRCLE;
 };
 
 

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -19,13 +19,13 @@ import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_Circle_ = function(center, opt_radius, opt_layout) {
+var Circle = function(center, opt_radius, opt_layout) {
   _ol_geom_SimpleGeometry_.call(this);
   var radius = opt_radius ? opt_radius : 0;
   this.setCenterAndRadius(center, radius, opt_layout);
 };
 
-inherits(_ol_geom_Circle_, _ol_geom_SimpleGeometry_);
+inherits(Circle, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -34,8 +34,8 @@ inherits(_ol_geom_Circle_, _ol_geom_SimpleGeometry_);
  * @override
  * @api
  */
-_ol_geom_Circle_.prototype.clone = function() {
-  var circle = new _ol_geom_Circle_(null);
+Circle.prototype.clone = function() {
+  var circle = new Circle(null);
   circle.setFlatCoordinates(this.layout, this.flatCoordinates.slice());
   return circle;
 };
@@ -44,7 +44,7 @@ _ol_geom_Circle_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_Circle_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+Circle.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   var flatCoordinates = this.flatCoordinates;
   var dx = x - flatCoordinates[0];
   var dy = y - flatCoordinates[1];
@@ -74,7 +74,7 @@ _ol_geom_Circle_.prototype.closestPointXY = function(x, y, closestPoint, minSqua
 /**
  * @inheritDoc
  */
-_ol_geom_Circle_.prototype.containsXY = function(x, y) {
+Circle.prototype.containsXY = function(x, y) {
   var flatCoordinates = this.flatCoordinates;
   var dx = x - flatCoordinates[0];
   var dy = y - flatCoordinates[1];
@@ -87,7 +87,7 @@ _ol_geom_Circle_.prototype.containsXY = function(x, y) {
  * @return {ol.Coordinate} Center.
  * @api
  */
-_ol_geom_Circle_.prototype.getCenter = function() {
+Circle.prototype.getCenter = function() {
   return this.flatCoordinates.slice(0, this.stride);
 };
 
@@ -95,7 +95,7 @@ _ol_geom_Circle_.prototype.getCenter = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_Circle_.prototype.computeExtent = function(extent) {
+Circle.prototype.computeExtent = function(extent) {
   var flatCoordinates = this.flatCoordinates;
   var radius = flatCoordinates[this.stride] - flatCoordinates[0];
   return createOrUpdate(
@@ -110,7 +110,7 @@ _ol_geom_Circle_.prototype.computeExtent = function(extent) {
  * @return {number} Radius.
  * @api
  */
-_ol_geom_Circle_.prototype.getRadius = function() {
+Circle.prototype.getRadius = function() {
   return Math.sqrt(this.getRadiusSquared_());
 };
 
@@ -119,7 +119,7 @@ _ol_geom_Circle_.prototype.getRadius = function() {
  * @private
  * @return {number} Radius squared.
  */
-_ol_geom_Circle_.prototype.getRadiusSquared_ = function() {
+Circle.prototype.getRadiusSquared_ = function() {
   var dx = this.flatCoordinates[this.stride] - this.flatCoordinates[0];
   var dy = this.flatCoordinates[this.stride + 1] - this.flatCoordinates[1];
   return dx * dx + dy * dy;
@@ -130,7 +130,7 @@ _ol_geom_Circle_.prototype.getRadiusSquared_ = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_Circle_.prototype.getType = function() {
+Circle.prototype.getType = function() {
   return _ol_geom_GeometryType_.CIRCLE;
 };
 
@@ -139,7 +139,7 @@ _ol_geom_Circle_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_Circle_.prototype.intersectsExtent = function(extent) {
+Circle.prototype.intersectsExtent = function(extent) {
   var circleExtent = this.getExtent();
   if (intersects(extent, circleExtent)) {
     var center = this.getCenter();
@@ -163,7 +163,7 @@ _ol_geom_Circle_.prototype.intersectsExtent = function(extent) {
  * @param {ol.Coordinate} center Center.
  * @api
  */
-_ol_geom_Circle_.prototype.setCenter = function(center) {
+Circle.prototype.setCenter = function(center) {
   var stride = this.stride;
   var radius = this.flatCoordinates[stride] - this.flatCoordinates[0];
   var flatCoordinates = center.slice();
@@ -184,7 +184,7 @@ _ol_geom_Circle_.prototype.setCenter = function(center) {
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-_ol_geom_Circle_.prototype.setCenterAndRadius = function(center, radius, opt_layout) {
+Circle.prototype.setCenterAndRadius = function(center, radius, opt_layout) {
   if (!center) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
   } else {
@@ -210,20 +210,20 @@ _ol_geom_Circle_.prototype.setCenterAndRadius = function(center, radius, opt_lay
 /**
  * @inheritDoc
  */
-_ol_geom_Circle_.prototype.getCoordinates = function() {};
+Circle.prototype.getCoordinates = function() {};
 
 
 /**
  * @inheritDoc
  */
-_ol_geom_Circle_.prototype.setCoordinates = function(coordinates, opt_layout) {};
+Circle.prototype.setCoordinates = function(coordinates, opt_layout) {};
 
 
 /**
  * @param {ol.geom.GeometryLayout} layout Layout.
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  */
-_ol_geom_Circle_.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
+Circle.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.changed();
 };
@@ -234,7 +234,7 @@ _ol_geom_Circle_.prototype.setFlatCoordinates = function(layout, flatCoordinates
  * @param {number} radius Radius.
  * @api
  */
-_ol_geom_Circle_.prototype.setRadius = function(radius) {
+Circle.prototype.setRadius = function(radius) {
   this.flatCoordinates[this.stride] = this.flatCoordinates[0] + radius;
   this.changed();
 };
@@ -262,5 +262,5 @@ _ol_geom_Circle_.prototype.setRadius = function(radius) {
  * @function
  * @api
  */
-_ol_geom_Circle_.prototype.transform;
-export default _ol_geom_Circle_;
+Circle.prototype.transform;
+export default Circle;

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../index.js';
 import {createOrUpdate, forEachCorner, intersects} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -186,7 +186,7 @@ Circle.prototype.setCenter = function(center) {
  */
 Circle.prototype.setCenterAndRadius = function(center, radius, opt_layout) {
   if (!center) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
+    this.setFlatCoordinates(GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, center, 0);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -24,7 +24,7 @@ import _ol_transform_ from '../transform.js';
  * @extends {ol.Object}
  * @api
  */
-var _ol_geom_Geometry_ = function() {
+var Geometry = function() {
 
   _ol_Object_.call(this);
 
@@ -66,7 +66,7 @@ var _ol_geom_Geometry_ = function() {
 
 };
 
-inherits(_ol_geom_Geometry_, _ol_Object_);
+inherits(Geometry, _ol_Object_);
 
 
 /**
@@ -74,7 +74,7 @@ inherits(_ol_geom_Geometry_, _ol_Object_);
  * @abstract
  * @return {!ol.geom.Geometry} Clone.
  */
-_ol_geom_Geometry_.prototype.clone = function() {};
+Geometry.prototype.clone = function() {};
 
 
 /**
@@ -85,7 +85,7 @@ _ol_geom_Geometry_.prototype.clone = function() {};
  * @param {number} minSquaredDistance Minimum squared distance.
  * @return {number} Minimum squared distance.
  */
-_ol_geom_Geometry_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {};
+Geometry.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {};
 
 
 /**
@@ -96,7 +96,7 @@ _ol_geom_Geometry_.prototype.closestPointXY = function(x, y, closestPoint, minSq
  * @return {ol.Coordinate} Closest point.
  * @api
  */
-_ol_geom_Geometry_.prototype.getClosestPoint = function(point, opt_closestPoint) {
+Geometry.prototype.getClosestPoint = function(point, opt_closestPoint) {
   var closestPoint = opt_closestPoint ? opt_closestPoint : [NaN, NaN];
   this.closestPointXY(point[0], point[1], closestPoint, Infinity);
   return closestPoint;
@@ -110,7 +110,7 @@ _ol_geom_Geometry_.prototype.getClosestPoint = function(point, opt_closestPoint)
  * @return {boolean} Contains coordinate.
  * @api
  */
-_ol_geom_Geometry_.prototype.intersectsCoordinate = function(coordinate) {
+Geometry.prototype.intersectsCoordinate = function(coordinate) {
   return this.containsXY(coordinate[0], coordinate[1]);
 };
 
@@ -121,7 +121,7 @@ _ol_geom_Geometry_.prototype.intersectsCoordinate = function(coordinate) {
  * @protected
  * @return {ol.Extent} extent Extent.
  */
-_ol_geom_Geometry_.prototype.computeExtent = function(extent) {};
+Geometry.prototype.computeExtent = function(extent) {};
 
 
 /**
@@ -129,7 +129,7 @@ _ol_geom_Geometry_.prototype.computeExtent = function(extent) {};
  * @param {number} y Y.
  * @return {boolean} Contains (x, y).
  */
-_ol_geom_Geometry_.prototype.containsXY = _ol_functions_.FALSE;
+Geometry.prototype.containsXY = _ol_functions_.FALSE;
 
 
 /**
@@ -138,7 +138,7 @@ _ol_geom_Geometry_.prototype.containsXY = _ol_functions_.FALSE;
  * @return {ol.Extent} extent Extent.
  * @api
  */
-_ol_geom_Geometry_.prototype.getExtent = function(opt_extent) {
+Geometry.prototype.getExtent = function(opt_extent) {
   if (this.extentRevision_ != this.getRevision()) {
     this.extent_ = this.computeExtent(this.extent_);
     this.extentRevision_ = this.getRevision();
@@ -155,7 +155,7 @@ _ol_geom_Geometry_.prototype.getExtent = function(opt_extent) {
  * @param {ol.Coordinate} anchor The rotation center.
  * @api
  */
-_ol_geom_Geometry_.prototype.rotate = function(angle, anchor) {};
+Geometry.prototype.rotate = function(angle, anchor) {};
 
 
 /**
@@ -169,7 +169,7 @@ _ol_geom_Geometry_.prototype.rotate = function(angle, anchor) {};
  *     of the geometry extent).
  * @api
  */
-_ol_geom_Geometry_.prototype.scale = function(sx, opt_sy, opt_anchor) {};
+Geometry.prototype.scale = function(sx, opt_sy, opt_anchor) {};
 
 
 /**
@@ -184,7 +184,7 @@ _ol_geom_Geometry_.prototype.scale = function(sx, opt_sy, opt_anchor) {};
  *     geometry.
  * @api
  */
-_ol_geom_Geometry_.prototype.simplify = function(tolerance) {
+Geometry.prototype.simplify = function(tolerance) {
   return this.getSimplifiedGeometry(tolerance * tolerance);
 };
 
@@ -197,7 +197,7 @@ _ol_geom_Geometry_.prototype.simplify = function(tolerance) {
  * @param {number} squaredTolerance Squared tolerance.
  * @return {ol.geom.Geometry} Simplified geometry.
  */
-_ol_geom_Geometry_.prototype.getSimplifiedGeometry = function(squaredTolerance) {};
+Geometry.prototype.getSimplifiedGeometry = function(squaredTolerance) {};
 
 
 /**
@@ -205,7 +205,7 @@ _ol_geom_Geometry_.prototype.getSimplifiedGeometry = function(squaredTolerance) 
  * @abstract
  * @return {ol.geom.GeometryType} Geometry type.
  */
-_ol_geom_Geometry_.prototype.getType = function() {};
+Geometry.prototype.getType = function() {};
 
 
 /**
@@ -216,7 +216,7 @@ _ol_geom_Geometry_.prototype.getType = function() {};
  * @abstract
  * @param {ol.TransformFunction} transformFn Transform.
  */
-_ol_geom_Geometry_.prototype.applyTransform = function(transformFn) {};
+Geometry.prototype.applyTransform = function(transformFn) {};
 
 
 /**
@@ -225,7 +225,7 @@ _ol_geom_Geometry_.prototype.applyTransform = function(transformFn) {};
  * @param {ol.Extent} extent Extent.
  * @return {boolean} `true` if the geometry and the extent intersect.
  */
-_ol_geom_Geometry_.prototype.intersectsExtent = function(extent) {};
+Geometry.prototype.intersectsExtent = function(extent) {};
 
 
 /**
@@ -235,7 +235,7 @@ _ol_geom_Geometry_.prototype.intersectsExtent = function(extent) {};
  * @param {number} deltaX Delta X.
  * @param {number} deltaY Delta Y.
  */
-_ol_geom_Geometry_.prototype.translate = function(deltaX, deltaY) {};
+Geometry.prototype.translate = function(deltaX, deltaY) {};
 
 
 /**
@@ -253,7 +253,7 @@ _ol_geom_Geometry_.prototype.translate = function(deltaX, deltaY) {};
  *     modified in place.
  * @api
  */
-_ol_geom_Geometry_.prototype.transform = function(source, destination) {
+Geometry.prototype.transform = function(source, destination) {
   var tmpTransform = this.tmpTransform_;
   source = getProjection(source);
   var transformFn = source.getUnits() == _ol_proj_Units_.TILE_PIXELS ?
@@ -273,4 +273,4 @@ _ol_geom_Geometry_.prototype.transform = function(source, destination) {
   this.applyTransform(transformFn);
   return this;
 };
-export default _ol_geom_Geometry_;
+export default Geometry;

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {createOrUpdateEmpty, closestSquaredDistanceXY, extend, getCenter} from '../extent.js';
-import _ol_geom_Geometry_ from '../geom/Geometry.js';
+import Geometry from '../geom/Geometry.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_obj_ from '../obj.js';
 
@@ -20,7 +20,7 @@ import _ol_obj_ from '../obj.js';
  */
 var _ol_geom_GeometryCollection_ = function(opt_geometries) {
 
-  _ol_geom_Geometry_.call(this);
+  Geometry.call(this);
 
   /**
    * @private
@@ -31,7 +31,7 @@ var _ol_geom_GeometryCollection_ = function(opt_geometries) {
   this.listenGeometriesChange_();
 };
 
-inherits(_ol_geom_GeometryCollection_, _ol_geom_Geometry_);
+inherits(_ol_geom_GeometryCollection_, Geometry);
 
 
 /**
@@ -321,6 +321,6 @@ _ol_geom_GeometryCollection_.prototype.translate = function(deltaX, deltaY) {
  */
 _ol_geom_GeometryCollection_.prototype.disposeInternal = function() {
   this.unlistenGeometriesChange_();
-  _ol_geom_Geometry_.prototype.disposeInternal.call(this);
+  Geometry.prototype.disposeInternal.call(this);
 };
 export default _ol_geom_GeometryCollection_;

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -18,7 +18,7 @@ import _ol_obj_ from '../obj.js';
  * @param {Array.<ol.geom.Geometry>=} opt_geometries Geometries.
  * @api
  */
-var _ol_geom_GeometryCollection_ = function(opt_geometries) {
+var GeometryCollection = function(opt_geometries) {
 
   Geometry.call(this);
 
@@ -31,7 +31,7 @@ var _ol_geom_GeometryCollection_ = function(opt_geometries) {
   this.listenGeometriesChange_();
 };
 
-inherits(_ol_geom_GeometryCollection_, Geometry);
+inherits(GeometryCollection, Geometry);
 
 
 /**
@@ -39,7 +39,7 @@ inherits(_ol_geom_GeometryCollection_, Geometry);
  * @private
  * @return {Array.<ol.geom.Geometry>} Cloned geometries.
  */
-_ol_geom_GeometryCollection_.cloneGeometries_ = function(geometries) {
+GeometryCollection.cloneGeometries_ = function(geometries) {
   var clonedGeometries = [];
   var i, ii;
   for (i = 0, ii = geometries.length; i < ii; ++i) {
@@ -52,7 +52,7 @@ _ol_geom_GeometryCollection_.cloneGeometries_ = function(geometries) {
 /**
  * @private
  */
-_ol_geom_GeometryCollection_.prototype.unlistenGeometriesChange_ = function() {
+GeometryCollection.prototype.unlistenGeometriesChange_ = function() {
   var i, ii;
   if (!this.geometries_) {
     return;
@@ -68,7 +68,7 @@ _ol_geom_GeometryCollection_.prototype.unlistenGeometriesChange_ = function() {
 /**
  * @private
  */
-_ol_geom_GeometryCollection_.prototype.listenGeometriesChange_ = function() {
+GeometryCollection.prototype.listenGeometriesChange_ = function() {
   var i, ii;
   if (!this.geometries_) {
     return;
@@ -87,8 +87,8 @@ _ol_geom_GeometryCollection_.prototype.listenGeometriesChange_ = function() {
  * @override
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.clone = function() {
-  var geometryCollection = new _ol_geom_GeometryCollection_(null);
+GeometryCollection.prototype.clone = function() {
+  var geometryCollection = new GeometryCollection(null);
   geometryCollection.setGeometries(this.geometries_);
   return geometryCollection;
 };
@@ -97,7 +97,7 @@ _ol_geom_GeometryCollection_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_GeometryCollection_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+GeometryCollection.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -114,7 +114,7 @@ _ol_geom_GeometryCollection_.prototype.closestPointXY = function(x, y, closestPo
 /**
  * @inheritDoc
  */
-_ol_geom_GeometryCollection_.prototype.containsXY = function(x, y) {
+GeometryCollection.prototype.containsXY = function(x, y) {
   var geometries = this.geometries_;
   var i, ii;
   for (i = 0, ii = geometries.length; i < ii; ++i) {
@@ -129,7 +129,7 @@ _ol_geom_GeometryCollection_.prototype.containsXY = function(x, y) {
 /**
  * @inheritDoc
  */
-_ol_geom_GeometryCollection_.prototype.computeExtent = function(extent) {
+GeometryCollection.prototype.computeExtent = function(extent) {
   createOrUpdateEmpty(extent);
   var geometries = this.geometries_;
   for (var i = 0, ii = geometries.length; i < ii; ++i) {
@@ -144,15 +144,15 @@ _ol_geom_GeometryCollection_.prototype.computeExtent = function(extent) {
  * @return {Array.<ol.geom.Geometry>} Geometries.
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.getGeometries = function() {
-  return _ol_geom_GeometryCollection_.cloneGeometries_(this.geometries_);
+GeometryCollection.prototype.getGeometries = function() {
+  return GeometryCollection.cloneGeometries_(this.geometries_);
 };
 
 
 /**
  * @return {Array.<ol.geom.Geometry>} Geometries.
  */
-_ol_geom_GeometryCollection_.prototype.getGeometriesArray = function() {
+GeometryCollection.prototype.getGeometriesArray = function() {
   return this.geometries_;
 };
 
@@ -160,7 +160,7 @@ _ol_geom_GeometryCollection_.prototype.getGeometriesArray = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_GeometryCollection_.prototype.getSimplifiedGeometry = function(squaredTolerance) {
+GeometryCollection.prototype.getSimplifiedGeometry = function(squaredTolerance) {
   if (this.simplifiedGeometryRevision != this.getRevision()) {
     _ol_obj_.clear(this.simplifiedGeometryCache);
     this.simplifiedGeometryMaxMinSquaredTolerance = 0;
@@ -188,7 +188,7 @@ _ol_geom_GeometryCollection_.prototype.getSimplifiedGeometry = function(squaredT
       }
     }
     if (simplified) {
-      var simplifiedGeometryCollection = new _ol_geom_GeometryCollection_(null);
+      var simplifiedGeometryCollection = new GeometryCollection(null);
       simplifiedGeometryCollection.setGeometriesArray(simplifiedGeometries);
       this.simplifiedGeometryCache[key] = simplifiedGeometryCollection;
       return simplifiedGeometryCollection;
@@ -204,7 +204,7 @@ _ol_geom_GeometryCollection_.prototype.getSimplifiedGeometry = function(squaredT
  * @inheritDoc
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.getType = function() {
+GeometryCollection.prototype.getType = function() {
   return _ol_geom_GeometryType_.GEOMETRY_COLLECTION;
 };
 
@@ -213,7 +213,7 @@ _ol_geom_GeometryCollection_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.intersectsExtent = function(extent) {
+GeometryCollection.prototype.intersectsExtent = function(extent) {
   var geometries = this.geometries_;
   var i, ii;
   for (i = 0, ii = geometries.length; i < ii; ++i) {
@@ -228,7 +228,7 @@ _ol_geom_GeometryCollection_.prototype.intersectsExtent = function(extent) {
 /**
  * @return {boolean} Is empty.
  */
-_ol_geom_GeometryCollection_.prototype.isEmpty = function() {
+GeometryCollection.prototype.isEmpty = function() {
   return this.geometries_.length === 0;
 };
 
@@ -237,7 +237,7 @@ _ol_geom_GeometryCollection_.prototype.isEmpty = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.rotate = function(angle, anchor) {
+GeometryCollection.prototype.rotate = function(angle, anchor) {
   var geometries = this.geometries_;
   for (var i = 0, ii = geometries.length; i < ii; ++i) {
     geometries[i].rotate(angle, anchor);
@@ -250,7 +250,7 @@ _ol_geom_GeometryCollection_.prototype.rotate = function(angle, anchor) {
  * @inheritDoc
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.scale = function(sx, opt_sy, opt_anchor) {
+GeometryCollection.prototype.scale = function(sx, opt_sy, opt_anchor) {
   var anchor = opt_anchor;
   if (!anchor) {
     anchor = getCenter(this.getExtent());
@@ -268,16 +268,16 @@ _ol_geom_GeometryCollection_.prototype.scale = function(sx, opt_sy, opt_anchor) 
  * @param {Array.<ol.geom.Geometry>} geometries Geometries.
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.setGeometries = function(geometries) {
+GeometryCollection.prototype.setGeometries = function(geometries) {
   this.setGeometriesArray(
-      _ol_geom_GeometryCollection_.cloneGeometries_(geometries));
+      GeometryCollection.cloneGeometries_(geometries));
 };
 
 
 /**
  * @param {Array.<ol.geom.Geometry>} geometries Geometries.
  */
-_ol_geom_GeometryCollection_.prototype.setGeometriesArray = function(geometries) {
+GeometryCollection.prototype.setGeometriesArray = function(geometries) {
   this.unlistenGeometriesChange_();
   this.geometries_ = geometries;
   this.listenGeometriesChange_();
@@ -289,7 +289,7 @@ _ol_geom_GeometryCollection_.prototype.setGeometriesArray = function(geometries)
  * @inheritDoc
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.applyTransform = function(transformFn) {
+GeometryCollection.prototype.applyTransform = function(transformFn) {
   var geometries = this.geometries_;
   var i, ii;
   for (i = 0, ii = geometries.length; i < ii; ++i) {
@@ -306,7 +306,7 @@ _ol_geom_GeometryCollection_.prototype.applyTransform = function(transformFn) {
  * @override
  * @api
  */
-_ol_geom_GeometryCollection_.prototype.translate = function(deltaX, deltaY) {
+GeometryCollection.prototype.translate = function(deltaX, deltaY) {
   var geometries = this.geometries_;
   var i, ii;
   for (i = 0, ii = geometries.length; i < ii; ++i) {
@@ -319,8 +319,8 @@ _ol_geom_GeometryCollection_.prototype.translate = function(deltaX, deltaY) {
 /**
  * @inheritDoc
  */
-_ol_geom_GeometryCollection_.prototype.disposeInternal = function() {
+GeometryCollection.prototype.disposeInternal = function() {
   this.unlistenGeometriesChange_();
   Geometry.prototype.disposeInternal.call(this);
 };
-export default _ol_geom_GeometryCollection_;
+export default GeometryCollection;

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -6,7 +6,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {createOrUpdateEmpty, closestSquaredDistanceXY, extend, getCenter} from '../extent.js';
 import Geometry from '../geom/Geometry.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_obj_ from '../obj.js';
 
 /**
@@ -205,7 +205,7 @@ GeometryCollection.prototype.getSimplifiedGeometry = function(squaredTolerance) 
  * @api
  */
 GeometryCollection.prototype.getType = function() {
-  return _ol_geom_GeometryType_.GEOMETRY_COLLECTION;
+  return GeometryType.GEOMETRY_COLLECTION;
 };
 
 

--- a/src/ol/geom/GeometryLayout.js
+++ b/src/ol/geom/GeometryLayout.js
@@ -7,11 +7,11 @@
  * `'XYZ'`, `'XYM'`, `'XYZM'`.
  * @enum {string}
  */
-var _ol_geom_GeometryLayout_ = {
+var GeometryLayout = {
   XY: 'XY',
   XYZ: 'XYZ',
   XYM: 'XYM',
   XYZM: 'XYZM'
 };
 
-export default _ol_geom_GeometryLayout_;
+export default GeometryLayout;

--- a/src/ol/geom/GeometryType.js
+++ b/src/ol/geom/GeometryType.js
@@ -7,7 +7,7 @@
  * `'GeometryCollection'`, `'Circle'`.
  * @enum {string}
  */
-var _ol_geom_GeometryType_ = {
+var GeometryType = {
   POINT: 'Point',
   LINE_STRING: 'LineString',
   LINEAR_RING: 'LinearRing',
@@ -19,4 +19,4 @@ var _ol_geom_GeometryType_ = {
   CIRCLE: 'Circle'
 };
 
-export default _ol_geom_GeometryType_;
+export default GeometryType;

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -223,7 +223,7 @@ LineString.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) 
  * @api
  */
 LineString.prototype.getType = function() {
-  return _ol_geom_GeometryType_.LINE_STRING;
+  return GeometryType.LINE_STRING;
 };
 
 

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -6,7 +6,7 @@ import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
@@ -28,7 +28,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  */
 var LineString = function(coordinates, opt_layout) {
 
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
 
   /**
    * @private
@@ -58,7 +58,7 @@ var LineString = function(coordinates, opt_layout) {
 
 };
 
-inherits(LineString, _ol_geom_SimpleGeometry_);
+inherits(LineString, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
@@ -141,8 +141,8 @@ LineString.prototype.forEachSegment = function(callback, opt_this) {
  * @api
  */
 LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
-  if (this.layout != _ol_geom_GeometryLayout_.XYM &&
-      this.layout != _ol_geom_GeometryLayout_.XYZM) {
+  if (this.layout != GeometryLayout.XYM &&
+      this.layout != GeometryLayout.XYZM) {
     return null;
   }
   var extrapolate = opt_extrapolate !== undefined ? opt_extrapolate : false;
@@ -213,7 +213,7 @@ LineString.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) 
       squaredTolerance, simplifiedFlatCoordinates, 0);
   var simplifiedLineString = new LineString(null);
   simplifiedLineString.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates);
+      GeometryLayout.XY, simplifiedFlatCoordinates);
   return simplifiedLineString;
 };
 
@@ -247,7 +247,7 @@ LineString.prototype.intersectsExtent = function(extent) {
  */
 LineString.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
+    this.setFlatCoordinates(GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 1);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -26,7 +26,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_LineString_ = function(coordinates, opt_layout) {
+var LineString = function(coordinates, opt_layout) {
 
   _ol_geom_SimpleGeometry_.call(this);
 
@@ -58,7 +58,7 @@ var _ol_geom_LineString_ = function(coordinates, opt_layout) {
 
 };
 
-inherits(_ol_geom_LineString_, _ol_geom_SimpleGeometry_);
+inherits(LineString, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -66,7 +66,7 @@ inherits(_ol_geom_LineString_, _ol_geom_SimpleGeometry_);
  * @param {ol.Coordinate} coordinate Coordinate.
  * @api
  */
-_ol_geom_LineString_.prototype.appendCoordinate = function(coordinate) {
+LineString.prototype.appendCoordinate = function(coordinate) {
   if (!this.flatCoordinates) {
     this.flatCoordinates = coordinate.slice();
   } else {
@@ -82,8 +82,8 @@ _ol_geom_LineString_.prototype.appendCoordinate = function(coordinate) {
  * @override
  * @api
  */
-_ol_geom_LineString_.prototype.clone = function() {
-  var lineString = new _ol_geom_LineString_(null);
+LineString.prototype.clone = function() {
+  var lineString = new LineString(null);
   lineString.setFlatCoordinates(this.layout, this.flatCoordinates.slice());
   return lineString;
 };
@@ -92,7 +92,7 @@ _ol_geom_LineString_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_LineString_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+LineString.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -120,7 +120,7 @@ _ol_geom_LineString_.prototype.closestPointXY = function(x, y, closestPoint, min
  * @template T,S
  * @api
  */
-_ol_geom_LineString_.prototype.forEachSegment = function(callback, opt_this) {
+LineString.prototype.forEachSegment = function(callback, opt_this) {
   return _ol_geom_flat_segments_.forEach(this.flatCoordinates, 0,
       this.flatCoordinates.length, this.stride, callback, opt_this);
 };
@@ -140,7 +140,7 @@ _ol_geom_LineString_.prototype.forEachSegment = function(callback, opt_this) {
  * @return {ol.Coordinate} Coordinate.
  * @api
  */
-_ol_geom_LineString_.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
+LineString.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
   if (this.layout != _ol_geom_GeometryLayout_.XYM &&
       this.layout != _ol_geom_GeometryLayout_.XYZM) {
     return null;
@@ -157,7 +157,7 @@ _ol_geom_LineString_.prototype.getCoordinateAtM = function(m, opt_extrapolate) {
  * @override
  * @api
  */
-_ol_geom_LineString_.prototype.getCoordinates = function() {
+LineString.prototype.getCoordinates = function() {
   return _ol_geom_flat_inflate_.coordinates(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride);
 };
@@ -173,7 +173,7 @@ _ol_geom_LineString_.prototype.getCoordinates = function() {
  * @return {ol.Coordinate} Coordinate of the interpolated point.
  * @api
  */
-_ol_geom_LineString_.prototype.getCoordinateAt = function(fraction, opt_dest) {
+LineString.prototype.getCoordinateAt = function(fraction, opt_dest) {
   return _ol_geom_flat_interpolate_.lineString(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride,
       fraction, opt_dest);
@@ -185,7 +185,7 @@ _ol_geom_LineString_.prototype.getCoordinateAt = function(fraction, opt_dest) {
  * @return {number} Length (on projected plane).
  * @api
  */
-_ol_geom_LineString_.prototype.getLength = function() {
+LineString.prototype.getLength = function() {
   return _ol_geom_flat_length_.lineString(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride);
 };
@@ -194,7 +194,7 @@ _ol_geom_LineString_.prototype.getLength = function() {
 /**
  * @return {Array.<number>} Flat midpoint.
  */
-_ol_geom_LineString_.prototype.getFlatMidpoint = function() {
+LineString.prototype.getFlatMidpoint = function() {
   if (this.flatMidpointRevision_ != this.getRevision()) {
     this.flatMidpoint_ = this.getCoordinateAt(0.5, this.flatMidpoint_);
     this.flatMidpointRevision_ = this.getRevision();
@@ -206,12 +206,12 @@ _ol_geom_LineString_.prototype.getFlatMidpoint = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_LineString_.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
+LineString.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
   var simplifiedFlatCoordinates = [];
   simplifiedFlatCoordinates.length = _ol_geom_flat_simplify_.douglasPeucker(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride,
       squaredTolerance, simplifiedFlatCoordinates, 0);
-  var simplifiedLineString = new _ol_geom_LineString_(null);
+  var simplifiedLineString = new LineString(null);
   simplifiedLineString.setFlatCoordinates(
       _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates);
   return simplifiedLineString;
@@ -222,7 +222,7 @@ _ol_geom_LineString_.prototype.getSimplifiedGeometryInternal = function(squaredT
  * @inheritDoc
  * @api
  */
-_ol_geom_LineString_.prototype.getType = function() {
+LineString.prototype.getType = function() {
   return _ol_geom_GeometryType_.LINE_STRING;
 };
 
@@ -231,7 +231,7 @@ _ol_geom_LineString_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_LineString_.prototype.intersectsExtent = function(extent) {
+LineString.prototype.intersectsExtent = function(extent) {
   return _ol_geom_flat_intersectsextent_.lineString(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride,
       extent);
@@ -245,7 +245,7 @@ _ol_geom_LineString_.prototype.intersectsExtent = function(extent) {
  * @override
  * @api
  */
-_ol_geom_LineString_.prototype.setCoordinates = function(coordinates, opt_layout) {
+LineString.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
   } else {
@@ -264,8 +264,8 @@ _ol_geom_LineString_.prototype.setCoordinates = function(coordinates, opt_layout
  * @param {ol.geom.GeometryLayout} layout Layout.
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  */
-_ol_geom_LineString_.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
+LineString.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.changed();
 };
-export default _ol_geom_LineString_;
+export default LineString;

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../index.js';
 import {closestSquaredDistanceXY} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
@@ -110,7 +110,7 @@ _ol_geom_LinearRing_.prototype.getSimplifiedGeometryInternal = function(squaredT
       squaredTolerance, simplifiedFlatCoordinates, 0);
   var simplifiedLinearRing = new _ol_geom_LinearRing_(null);
   simplifiedLinearRing.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates);
+      GeometryLayout.XY, simplifiedFlatCoordinates);
   return simplifiedLinearRing;
 };
 
@@ -139,7 +139,7 @@ _ol_geom_LinearRing_.prototype.intersectsExtent = function(extent) {};
  */
 _ol_geom_LinearRing_.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
+    this.setFlatCoordinates(GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 1);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -25,7 +25,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  */
 var LinearRing = function(coordinates, opt_layout) {
 
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
 
   /**
    * @private
@@ -43,7 +43,7 @@ var LinearRing = function(coordinates, opt_layout) {
 
 };
 
-inherits(LinearRing, _ol_geom_SimpleGeometry_);
+inherits(LinearRing, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
@@ -120,7 +120,7 @@ _ol_geom_LinearRing_.prototype.getSimplifiedGeometryInternal = function(squaredT
  * @api
  */
 _ol_geom_LinearRing_.prototype.getType = function() {
-  return _ol_geom_GeometryType_.LINEAR_RING;
+  return GeometryType.LINEAR_RING;
 };
 
 

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -23,7 +23,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_LinearRing_ = function(coordinates, opt_layout) {
+var LinearRing = function(coordinates, opt_layout) {
 
   _ol_geom_SimpleGeometry_.call(this);
 
@@ -43,7 +43,7 @@ var _ol_geom_LinearRing_ = function(coordinates, opt_layout) {
 
 };
 
-inherits(_ol_geom_LinearRing_, _ol_geom_SimpleGeometry_);
+inherits(LinearRing, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -52,8 +52,8 @@ inherits(_ol_geom_LinearRing_, _ol_geom_SimpleGeometry_);
  * @override
  * @api
  */
-_ol_geom_LinearRing_.prototype.clone = function() {
-  var linearRing = new _ol_geom_LinearRing_(null);
+LinearRing.prototype.clone = function() {
+  var linearRing = new LinearRing(null);
   linearRing.setFlatCoordinates(this.layout, this.flatCoordinates.slice());
   return linearRing;
 };
@@ -62,7 +62,7 @@ _ol_geom_LinearRing_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_LinearRing_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+LinearRing.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -82,7 +82,7 @@ _ol_geom_LinearRing_.prototype.closestPointXY = function(x, y, closestPoint, min
  * @return {number} Area (on projected plane).
  * @api
  */
-_ol_geom_LinearRing_.prototype.getArea = function() {
+LinearRing.prototype.getArea = function() {
   return _ol_geom_flat_area_.linearRing(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride);
 };
@@ -94,7 +94,7 @@ _ol_geom_LinearRing_.prototype.getArea = function() {
  * @override
  * @api
  */
-_ol_geom_LinearRing_.prototype.getCoordinates = function() {
+LinearRing.prototype.getCoordinates = function() {
   return _ol_geom_flat_inflate_.coordinates(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride);
 };
@@ -103,12 +103,12 @@ _ol_geom_LinearRing_.prototype.getCoordinates = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_LinearRing_.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
+LinearRing.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
   var simplifiedFlatCoordinates = [];
   simplifiedFlatCoordinates.length = _ol_geom_flat_simplify_.douglasPeucker(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride,
       squaredTolerance, simplifiedFlatCoordinates, 0);
-  var simplifiedLinearRing = new _ol_geom_LinearRing_(null);
+  var simplifiedLinearRing = new LinearRing(null);
   simplifiedLinearRing.setFlatCoordinates(
       GeometryLayout.XY, simplifiedFlatCoordinates);
   return simplifiedLinearRing;
@@ -119,7 +119,7 @@ _ol_geom_LinearRing_.prototype.getSimplifiedGeometryInternal = function(squaredT
  * @inheritDoc
  * @api
  */
-_ol_geom_LinearRing_.prototype.getType = function() {
+LinearRing.prototype.getType = function() {
   return GeometryType.LINEAR_RING;
 };
 
@@ -127,7 +127,7 @@ _ol_geom_LinearRing_.prototype.getType = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_LinearRing_.prototype.intersectsExtent = function(extent) {};
+LinearRing.prototype.intersectsExtent = function(extent) {};
 
 
 /**
@@ -137,7 +137,7 @@ _ol_geom_LinearRing_.prototype.intersectsExtent = function(extent) {};
  * @override
  * @api
  */
-_ol_geom_LinearRing_.prototype.setCoordinates = function(coordinates, opt_layout) {
+LinearRing.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(GeometryLayout.XY, null);
   } else {
@@ -156,8 +156,8 @@ _ol_geom_LinearRing_.prototype.setCoordinates = function(coordinates, opt_layout
  * @param {ol.geom.GeometryLayout} layout Layout.
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  */
-_ol_geom_LinearRing_.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
+LinearRing.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.changed();
 };
-export default _ol_geom_LinearRing_;
+export default LinearRing;

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
@@ -241,7 +241,7 @@ MultiLineString.prototype.getSimplifiedGeometryInternal = function(squaredTolera
  * @api
  */
 MultiLineString.prototype.getType = function() {
-  return _ol_geom_GeometryType_.MULTI_LINE_STRING;
+  return GeometryType.MULTI_LINE_STRING;
 };
 
 

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -7,7 +7,7 @@ import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
@@ -27,7 +27,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  */
 var MultiLineString = function(coordinates, opt_layout) {
 
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
 
   /**
    * @type {Array.<number>}
@@ -51,7 +51,7 @@ var MultiLineString = function(coordinates, opt_layout) {
 
 };
 
-inherits(MultiLineString, _ol_geom_SimpleGeometry_);
+inherits(MultiLineString, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -25,7 +25,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_MultiLineString_ = function(coordinates, opt_layout) {
+var MultiLineString = function(coordinates, opt_layout) {
 
   _ol_geom_SimpleGeometry_.call(this);
 
@@ -51,7 +51,7 @@ var _ol_geom_MultiLineString_ = function(coordinates, opt_layout) {
 
 };
 
-inherits(_ol_geom_MultiLineString_, _ol_geom_SimpleGeometry_);
+inherits(MultiLineString, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -59,7 +59,7 @@ inherits(_ol_geom_MultiLineString_, _ol_geom_SimpleGeometry_);
  * @param {ol.geom.LineString} lineString LineString.
  * @api
  */
-_ol_geom_MultiLineString_.prototype.appendLineString = function(lineString) {
+MultiLineString.prototype.appendLineString = function(lineString) {
   if (!this.flatCoordinates) {
     this.flatCoordinates = lineString.getFlatCoordinates().slice();
   } else {
@@ -77,8 +77,8 @@ _ol_geom_MultiLineString_.prototype.appendLineString = function(lineString) {
  * @override
  * @api
  */
-_ol_geom_MultiLineString_.prototype.clone = function() {
-  var multiLineString = new _ol_geom_MultiLineString_(null);
+MultiLineString.prototype.clone = function() {
+  var multiLineString = new MultiLineString(null);
   multiLineString.setFlatCoordinates(
       this.layout, this.flatCoordinates.slice(), this.ends_.slice());
   return multiLineString;
@@ -88,7 +88,7 @@ _ol_geom_MultiLineString_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_MultiLineString_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+MultiLineString.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -125,7 +125,7 @@ _ol_geom_MultiLineString_.prototype.closestPointXY = function(x, y, closestPoint
  * @return {ol.Coordinate} Coordinate.
  * @api
  */
-_ol_geom_MultiLineString_.prototype.getCoordinateAtM = function(m, opt_extrapolate, opt_interpolate) {
+MultiLineString.prototype.getCoordinateAtM = function(m, opt_extrapolate, opt_interpolate) {
   if ((this.layout != _ol_geom_GeometryLayout_.XYM &&
        this.layout != _ol_geom_GeometryLayout_.XYZM) ||
       this.flatCoordinates.length === 0) {
@@ -144,7 +144,7 @@ _ol_geom_MultiLineString_.prototype.getCoordinateAtM = function(m, opt_extrapola
  * @override
  * @api
  */
-_ol_geom_MultiLineString_.prototype.getCoordinates = function() {
+MultiLineString.prototype.getCoordinates = function() {
   return _ol_geom_flat_inflate_.coordinatess(
       this.flatCoordinates, 0, this.ends_, this.stride);
 };
@@ -153,7 +153,7 @@ _ol_geom_MultiLineString_.prototype.getCoordinates = function() {
 /**
  * @return {Array.<number>} Ends.
  */
-_ol_geom_MultiLineString_.prototype.getEnds = function() {
+MultiLineString.prototype.getEnds = function() {
   return this.ends_;
 };
 
@@ -164,7 +164,7 @@ _ol_geom_MultiLineString_.prototype.getEnds = function() {
  * @return {ol.geom.LineString} LineString.
  * @api
  */
-_ol_geom_MultiLineString_.prototype.getLineString = function(index) {
+MultiLineString.prototype.getLineString = function(index) {
   if (index < 0 || this.ends_.length <= index) {
     return null;
   }
@@ -180,7 +180,7 @@ _ol_geom_MultiLineString_.prototype.getLineString = function(index) {
  * @return {Array.<ol.geom.LineString>} LineStrings.
  * @api
  */
-_ol_geom_MultiLineString_.prototype.getLineStrings = function() {
+MultiLineString.prototype.getLineStrings = function() {
   var flatCoordinates = this.flatCoordinates;
   var ends = this.ends_;
   var layout = this.layout;
@@ -202,7 +202,7 @@ _ol_geom_MultiLineString_.prototype.getLineStrings = function() {
 /**
  * @return {Array.<number>} Flat midpoints.
  */
-_ol_geom_MultiLineString_.prototype.getFlatMidpoints = function() {
+MultiLineString.prototype.getFlatMidpoints = function() {
   var midpoints = [];
   var flatCoordinates = this.flatCoordinates;
   var offset = 0;
@@ -223,13 +223,13 @@ _ol_geom_MultiLineString_.prototype.getFlatMidpoints = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_MultiLineString_.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
+MultiLineString.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
   var simplifiedFlatCoordinates = [];
   var simplifiedEnds = [];
   simplifiedFlatCoordinates.length = _ol_geom_flat_simplify_.douglasPeuckers(
       this.flatCoordinates, 0, this.ends_, this.stride, squaredTolerance,
       simplifiedFlatCoordinates, 0, simplifiedEnds);
-  var simplifiedMultiLineString = new _ol_geom_MultiLineString_(null);
+  var simplifiedMultiLineString = new MultiLineString(null);
   simplifiedMultiLineString.setFlatCoordinates(
       _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates, simplifiedEnds);
   return simplifiedMultiLineString;
@@ -240,7 +240,7 @@ _ol_geom_MultiLineString_.prototype.getSimplifiedGeometryInternal = function(squ
  * @inheritDoc
  * @api
  */
-_ol_geom_MultiLineString_.prototype.getType = function() {
+MultiLineString.prototype.getType = function() {
   return _ol_geom_GeometryType_.MULTI_LINE_STRING;
 };
 
@@ -249,7 +249,7 @@ _ol_geom_MultiLineString_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_MultiLineString_.prototype.intersectsExtent = function(extent) {
+MultiLineString.prototype.intersectsExtent = function(extent) {
   return _ol_geom_flat_intersectsextent_.lineStrings(
       this.flatCoordinates, 0, this.ends_, this.stride, extent);
 };
@@ -262,7 +262,7 @@ _ol_geom_MultiLineString_.prototype.intersectsExtent = function(extent) {
  * @override
  * @api
  */
-_ol_geom_MultiLineString_.prototype.setCoordinates = function(coordinates, opt_layout) {
+MultiLineString.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null, this.ends_);
   } else {
@@ -283,7 +283,7 @@ _ol_geom_MultiLineString_.prototype.setCoordinates = function(coordinates, opt_l
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  * @param {Array.<number>} ends Ends.
  */
-_ol_geom_MultiLineString_.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
+MultiLineString.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.ends_ = ends;
   this.changed();
@@ -293,7 +293,7 @@ _ol_geom_MultiLineString_.prototype.setFlatCoordinates = function(layout, flatCo
 /**
  * @param {Array.<ol.geom.LineString>} lineStrings LineStrings.
  */
-_ol_geom_MultiLineString_.prototype.setLineStrings = function(lineStrings) {
+MultiLineString.prototype.setLineStrings = function(lineStrings) {
   var layout = this.getLayout();
   var flatCoordinates = [];
   var ends = [];
@@ -308,4 +308,4 @@ _ol_geom_MultiLineString_.prototype.setLineStrings = function(lineStrings) {
   }
   this.setFlatCoordinates(layout, flatCoordinates, ends);
 };
-export default _ol_geom_MultiLineString_;
+export default MultiLineString;

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
@@ -126,8 +126,8 @@ MultiLineString.prototype.closestPointXY = function(x, y, closestPoint, minSquar
  * @api
  */
 MultiLineString.prototype.getCoordinateAtM = function(m, opt_extrapolate, opt_interpolate) {
-  if ((this.layout != _ol_geom_GeometryLayout_.XYM &&
-       this.layout != _ol_geom_GeometryLayout_.XYZM) ||
+  if ((this.layout != GeometryLayout.XYM &&
+       this.layout != GeometryLayout.XYZM) ||
       this.flatCoordinates.length === 0) {
     return null;
   }
@@ -231,7 +231,7 @@ MultiLineString.prototype.getSimplifiedGeometryInternal = function(squaredTolera
       simplifiedFlatCoordinates, 0, simplifiedEnds);
   var simplifiedMultiLineString = new MultiLineString(null);
   simplifiedMultiLineString.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates, simplifiedEnds);
+      GeometryLayout.XY, simplifiedFlatCoordinates, simplifiedEnds);
   return simplifiedMultiLineString;
 };
 
@@ -264,7 +264,7 @@ MultiLineString.prototype.intersectsExtent = function(extent) {
  */
 MultiLineString.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null, this.ends_);
+    this.setFlatCoordinates(GeometryLayout.XY, null, this.ends_);
   } else {
     this.setLayout(opt_layout, coordinates, 2);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -6,7 +6,7 @@ import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -168,7 +168,7 @@ _ol_geom_MultiLineString_.prototype.getLineString = function(index) {
   if (index < 0 || this.ends_.length <= index) {
     return null;
   }
-  var lineString = new _ol_geom_LineString_(null);
+  var lineString = new LineString(null);
   lineString.setFlatCoordinates(this.layout, this.flatCoordinates.slice(
       index === 0 ? 0 : this.ends_[index - 1], this.ends_[index]));
   return lineString;
@@ -190,7 +190,7 @@ _ol_geom_MultiLineString_.prototype.getLineStrings = function() {
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];
-    var lineString = new _ol_geom_LineString_(null);
+    var lineString = new LineString(null);
     lineString.setFlatCoordinates(layout, flatCoordinates.slice(offset, end));
     lineStrings.push(lineString);
     offset = end;

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY, containsXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -140,7 +140,7 @@ MultiPoint.prototype.getPoints = function() {
  * @api
  */
 MultiPoint.prototype.getType = function() {
-  return _ol_geom_GeometryType_.MULTI_POINT;
+  return GeometryType.MULTI_POINT;
 };
 
 

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -7,7 +7,7 @@ import {closestSquaredDistanceXY, containsXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
 import _ol_math_ from '../math.js';
@@ -23,11 +23,11 @@ import _ol_math_ from '../math.js';
  * @api
  */
 var MultiPoint = function(coordinates, opt_layout) {
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
   this.setCoordinates(coordinates, opt_layout);
 };
 
-inherits(MultiPoint, _ol_geom_SimpleGeometry_);
+inherits(MultiPoint, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -22,12 +22,12 @@ import _ol_math_ from '../math.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_MultiPoint_ = function(coordinates, opt_layout) {
+var MultiPoint = function(coordinates, opt_layout) {
   _ol_geom_SimpleGeometry_.call(this);
   this.setCoordinates(coordinates, opt_layout);
 };
 
-inherits(_ol_geom_MultiPoint_, _ol_geom_SimpleGeometry_);
+inherits(MultiPoint, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -35,7 +35,7 @@ inherits(_ol_geom_MultiPoint_, _ol_geom_SimpleGeometry_);
  * @param {ol.geom.Point} point Point.
  * @api
  */
-_ol_geom_MultiPoint_.prototype.appendPoint = function(point) {
+MultiPoint.prototype.appendPoint = function(point) {
   if (!this.flatCoordinates) {
     this.flatCoordinates = point.getFlatCoordinates().slice();
   } else {
@@ -51,8 +51,8 @@ _ol_geom_MultiPoint_.prototype.appendPoint = function(point) {
  * @override
  * @api
  */
-_ol_geom_MultiPoint_.prototype.clone = function() {
-  var multiPoint = new _ol_geom_MultiPoint_(null);
+MultiPoint.prototype.clone = function() {
+  var multiPoint = new MultiPoint(null);
   multiPoint.setFlatCoordinates(this.layout, this.flatCoordinates.slice());
   return multiPoint;
 };
@@ -61,7 +61,7 @@ _ol_geom_MultiPoint_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_MultiPoint_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+MultiPoint.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -89,7 +89,7 @@ _ol_geom_MultiPoint_.prototype.closestPointXY = function(x, y, closestPoint, min
  * @override
  * @api
  */
-_ol_geom_MultiPoint_.prototype.getCoordinates = function() {
+MultiPoint.prototype.getCoordinates = function() {
   return _ol_geom_flat_inflate_.coordinates(
       this.flatCoordinates, 0, this.flatCoordinates.length, this.stride);
 };
@@ -101,7 +101,7 @@ _ol_geom_MultiPoint_.prototype.getCoordinates = function() {
  * @return {ol.geom.Point} Point.
  * @api
  */
-_ol_geom_MultiPoint_.prototype.getPoint = function(index) {
+MultiPoint.prototype.getPoint = function(index) {
   var n = !this.flatCoordinates ?
     0 : this.flatCoordinates.length / this.stride;
   if (index < 0 || n <= index) {
@@ -119,7 +119,7 @@ _ol_geom_MultiPoint_.prototype.getPoint = function(index) {
  * @return {Array.<ol.geom.Point>} Points.
  * @api
  */
-_ol_geom_MultiPoint_.prototype.getPoints = function() {
+MultiPoint.prototype.getPoints = function() {
   var flatCoordinates = this.flatCoordinates;
   var layout = this.layout;
   var stride = this.stride;
@@ -139,7 +139,7 @@ _ol_geom_MultiPoint_.prototype.getPoints = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_MultiPoint_.prototype.getType = function() {
+MultiPoint.prototype.getType = function() {
   return _ol_geom_GeometryType_.MULTI_POINT;
 };
 
@@ -148,7 +148,7 @@ _ol_geom_MultiPoint_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_MultiPoint_.prototype.intersectsExtent = function(extent) {
+MultiPoint.prototype.intersectsExtent = function(extent) {
   var flatCoordinates = this.flatCoordinates;
   var stride = this.stride;
   var i, ii, x, y;
@@ -170,7 +170,7 @@ _ol_geom_MultiPoint_.prototype.intersectsExtent = function(extent) {
  * @override
  * @api
  */
-_ol_geom_MultiPoint_.prototype.setCoordinates = function(coordinates, opt_layout) {
+MultiPoint.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
   } else {
@@ -189,8 +189,8 @@ _ol_geom_MultiPoint_.prototype.setCoordinates = function(coordinates, opt_layout
  * @param {ol.geom.GeometryLayout} layout Layout.
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  */
-_ol_geom_MultiPoint_.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
+MultiPoint.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.changed();
 };
-export default _ol_geom_MultiPoint_;
+export default MultiPoint;

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -6,7 +6,7 @@ import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY, containsXY} from '../extent.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_geom_flat_inflate_ from '../geom/flat/inflate.js';
@@ -107,7 +107,7 @@ _ol_geom_MultiPoint_.prototype.getPoint = function(index) {
   if (index < 0 || n <= index) {
     return null;
   }
-  var point = new _ol_geom_Point_(null);
+  var point = new Point(null);
   point.setFlatCoordinates(this.layout, this.flatCoordinates.slice(
       index * this.stride, (index + 1) * this.stride));
   return point;
@@ -127,7 +127,7 @@ _ol_geom_MultiPoint_.prototype.getPoints = function() {
   var points = [];
   var i, ii;
   for (i = 0, ii = flatCoordinates.length; i < ii; i += stride) {
-    var point = new _ol_geom_Point_(null);
+    var point = new Point(null);
     point.setFlatCoordinates(layout, flatCoordinates.slice(i, i + stride));
     points.push(point);
   }

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY, containsXY} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
@@ -172,7 +172,7 @@ MultiPoint.prototype.intersectsExtent = function(extent) {
  */
 MultiPoint.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
+    this.setFlatCoordinates(GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 1);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -7,7 +7,7 @@ import {closestSquaredDistanceXY} from '../extent.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
 import _ol_geom_flat_center_ from '../geom/flat/center.js';
@@ -298,7 +298,7 @@ _ol_geom_MultiPolygon_.prototype.getPolygon = function(index) {
       ends[i] -= offset;
     }
   }
-  var polygon = new _ol_geom_Polygon_(null);
+  var polygon = new Polygon(null);
   polygon.setFlatCoordinates(
       this.layout, this.flatCoordinates.slice(offset, end), ends);
   return polygon;
@@ -325,7 +325,7 @@ _ol_geom_MultiPolygon_.prototype.getPolygons = function() {
         ends[j] -= offset;
       }
     }
-    var polygon = new _ol_geom_Polygon_(null);
+    var polygon = new Polygon(null);
     polygon.setFlatCoordinates(
         layout, flatCoordinates.slice(offset, end), ends);
     polygons.push(polygon);

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -6,7 +6,7 @@ import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
@@ -228,7 +228,7 @@ _ol_geom_MultiPolygon_.prototype.getFlatInteriorPoints = function() {
  * @api
  */
 _ol_geom_MultiPolygon_.prototype.getInteriorPoints = function() {
-  var interiorPoints = new _ol_geom_MultiPoint_(null);
+  var interiorPoints = new MultiPoint(null);
   interiorPoints.setFlatCoordinates(_ol_geom_GeometryLayout_.XYM,
       this.getFlatInteriorPoints().slice());
   return interiorPoints;

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
@@ -340,7 +340,7 @@ MultiPolygon.prototype.getPolygons = function() {
  * @api
  */
 MultiPolygon.prototype.getType = function() {
-  return _ol_geom_GeometryType_.MULTI_POLYGON;
+  return GeometryType.MULTI_POLYGON;
 };
 
 

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -8,7 +8,7 @@ import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import Polygon from '../geom/Polygon.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
 import _ol_geom_flat_center_ from '../geom/flat/center.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
@@ -32,7 +32,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  */
 var MultiPolygon = function(coordinates, opt_layout) {
 
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
 
   /**
    * @type {Array.<Array.<number>>}
@@ -80,7 +80,7 @@ var MultiPolygon = function(coordinates, opt_layout) {
 
 };
 
-inherits(MultiPolygon, _ol_geom_SimpleGeometry_);
+inherits(MultiPolygon, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -30,7 +30,7 @@ import _ol_geom_flat_simplify_ from '../geom/flat/simplify.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_MultiPolygon_ = function(coordinates, opt_layout) {
+var MultiPolygon = function(coordinates, opt_layout) {
 
   _ol_geom_SimpleGeometry_.call(this);
 
@@ -80,7 +80,7 @@ var _ol_geom_MultiPolygon_ = function(coordinates, opt_layout) {
 
 };
 
-inherits(_ol_geom_MultiPolygon_, _ol_geom_SimpleGeometry_);
+inherits(MultiPolygon, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -88,7 +88,7 @@ inherits(_ol_geom_MultiPolygon_, _ol_geom_SimpleGeometry_);
  * @param {ol.geom.Polygon} polygon Polygon.
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.appendPolygon = function(polygon) {
+MultiPolygon.prototype.appendPolygon = function(polygon) {
   /** @type {Array.<number>} */
   var ends;
   if (!this.flatCoordinates) {
@@ -115,8 +115,8 @@ _ol_geom_MultiPolygon_.prototype.appendPolygon = function(polygon) {
  * @override
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.clone = function() {
-  var multiPolygon = new _ol_geom_MultiPolygon_(null);
+MultiPolygon.prototype.clone = function() {
+  var multiPolygon = new MultiPolygon(null);
 
   var len = this.endss_.length;
   var newEndss = new Array(len);
@@ -133,7 +133,7 @@ _ol_geom_MultiPolygon_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_MultiPolygon_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+MultiPolygon.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -151,7 +151,7 @@ _ol_geom_MultiPolygon_.prototype.closestPointXY = function(x, y, closestPoint, m
 /**
  * @inheritDoc
  */
-_ol_geom_MultiPolygon_.prototype.containsXY = function(x, y) {
+MultiPolygon.prototype.containsXY = function(x, y) {
   return _ol_geom_flat_contains_.linearRingssContainsXY(
       this.getOrientedFlatCoordinates(), 0, this.endss_, this.stride, x, y);
 };
@@ -162,7 +162,7 @@ _ol_geom_MultiPolygon_.prototype.containsXY = function(x, y) {
  * @return {number} Area (on projected plane).
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.getArea = function() {
+MultiPolygon.prototype.getArea = function() {
   return _ol_geom_flat_area_.linearRingss(
       this.getOrientedFlatCoordinates(), 0, this.endss_, this.stride);
 };
@@ -182,7 +182,7 @@ _ol_geom_MultiPolygon_.prototype.getArea = function() {
  * @override
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.getCoordinates = function(opt_right) {
+MultiPolygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
   if (opt_right !== undefined) {
     flatCoordinates = this.getOrientedFlatCoordinates().slice();
@@ -200,7 +200,7 @@ _ol_geom_MultiPolygon_.prototype.getCoordinates = function(opt_right) {
 /**
  * @return {Array.<Array.<number>>} Endss.
  */
-_ol_geom_MultiPolygon_.prototype.getEndss = function() {
+MultiPolygon.prototype.getEndss = function() {
   return this.endss_;
 };
 
@@ -208,7 +208,7 @@ _ol_geom_MultiPolygon_.prototype.getEndss = function() {
 /**
  * @return {Array.<number>} Flat interior points.
  */
-_ol_geom_MultiPolygon_.prototype.getFlatInteriorPoints = function() {
+MultiPolygon.prototype.getFlatInteriorPoints = function() {
   if (this.flatInteriorPointsRevision_ != this.getRevision()) {
     var flatCenters = _ol_geom_flat_center_.linearRingss(
         this.flatCoordinates, 0, this.endss_, this.stride);
@@ -227,7 +227,7 @@ _ol_geom_MultiPolygon_.prototype.getFlatInteriorPoints = function() {
  * the length of the horizontal intersection that the point belongs to.
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.getInteriorPoints = function() {
+MultiPolygon.prototype.getInteriorPoints = function() {
   var interiorPoints = new MultiPoint(null);
   interiorPoints.setFlatCoordinates(_ol_geom_GeometryLayout_.XYM,
       this.getFlatInteriorPoints().slice());
@@ -238,7 +238,7 @@ _ol_geom_MultiPolygon_.prototype.getInteriorPoints = function() {
 /**
  * @return {Array.<number>} Oriented flat coordinates.
  */
-_ol_geom_MultiPolygon_.prototype.getOrientedFlatCoordinates = function() {
+MultiPolygon.prototype.getOrientedFlatCoordinates = function() {
   if (this.orientedRevision_ != this.getRevision()) {
     var flatCoordinates = this.flatCoordinates;
     if (_ol_geom_flat_orient_.linearRingssAreOriented(
@@ -259,14 +259,14 @@ _ol_geom_MultiPolygon_.prototype.getOrientedFlatCoordinates = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_MultiPolygon_.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
+MultiPolygon.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
   var simplifiedFlatCoordinates = [];
   var simplifiedEndss = [];
   simplifiedFlatCoordinates.length = _ol_geom_flat_simplify_.quantizess(
       this.flatCoordinates, 0, this.endss_, this.stride,
       Math.sqrt(squaredTolerance),
       simplifiedFlatCoordinates, 0, simplifiedEndss);
-  var simplifiedMultiPolygon = new _ol_geom_MultiPolygon_(null);
+  var simplifiedMultiPolygon = new MultiPolygon(null);
   simplifiedMultiPolygon.setFlatCoordinates(
       _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates, simplifiedEndss);
   return simplifiedMultiPolygon;
@@ -279,7 +279,7 @@ _ol_geom_MultiPolygon_.prototype.getSimplifiedGeometryInternal = function(square
  * @return {ol.geom.Polygon} Polygon.
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.getPolygon = function(index) {
+MultiPolygon.prototype.getPolygon = function(index) {
   if (index < 0 || this.endss_.length <= index) {
     return null;
   }
@@ -310,7 +310,7 @@ _ol_geom_MultiPolygon_.prototype.getPolygon = function(index) {
  * @return {Array.<ol.geom.Polygon>} Polygons.
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.getPolygons = function() {
+MultiPolygon.prototype.getPolygons = function() {
   var layout = this.layout;
   var flatCoordinates = this.flatCoordinates;
   var endss = this.endss_;
@@ -339,7 +339,7 @@ _ol_geom_MultiPolygon_.prototype.getPolygons = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.getType = function() {
+MultiPolygon.prototype.getType = function() {
   return _ol_geom_GeometryType_.MULTI_POLYGON;
 };
 
@@ -348,7 +348,7 @@ _ol_geom_MultiPolygon_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.intersectsExtent = function(extent) {
+MultiPolygon.prototype.intersectsExtent = function(extent) {
   return _ol_geom_flat_intersectsextent_.linearRingss(
       this.getOrientedFlatCoordinates(), 0, this.endss_, this.stride, extent);
 };
@@ -361,7 +361,7 @@ _ol_geom_MultiPolygon_.prototype.intersectsExtent = function(extent) {
  * @override
  * @api
  */
-_ol_geom_MultiPolygon_.prototype.setCoordinates = function(coordinates, opt_layout) {
+MultiPolygon.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null, this.endss_);
   } else {
@@ -388,7 +388,7 @@ _ol_geom_MultiPolygon_.prototype.setCoordinates = function(coordinates, opt_layo
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  * @param {Array.<Array.<number>>} endss Endss.
  */
-_ol_geom_MultiPolygon_.prototype.setFlatCoordinates = function(layout, flatCoordinates, endss) {
+MultiPolygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, endss) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.endss_ = endss;
   this.changed();
@@ -398,7 +398,7 @@ _ol_geom_MultiPolygon_.prototype.setFlatCoordinates = function(layout, flatCoord
 /**
  * @param {Array.<ol.geom.Polygon>} polygons Polygons.
  */
-_ol_geom_MultiPolygon_.prototype.setPolygons = function(polygons) {
+MultiPolygon.prototype.setPolygons = function(polygons) {
   var layout = this.getLayout();
   var flatCoordinates = [];
   var endss = [];
@@ -419,4 +419,4 @@ _ol_geom_MultiPolygon_.prototype.setPolygons = function(polygons) {
   }
   this.setFlatCoordinates(layout, flatCoordinates, endss);
 };
-export default _ol_geom_MultiPolygon_;
+export default MultiPolygon;

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import Polygon from '../geom/Polygon.js';
@@ -229,7 +229,7 @@ MultiPolygon.prototype.getFlatInteriorPoints = function() {
  */
 MultiPolygon.prototype.getInteriorPoints = function() {
   var interiorPoints = new MultiPoint(null);
-  interiorPoints.setFlatCoordinates(_ol_geom_GeometryLayout_.XYM,
+  interiorPoints.setFlatCoordinates(GeometryLayout.XYM,
       this.getFlatInteriorPoints().slice());
   return interiorPoints;
 };
@@ -268,7 +268,7 @@ MultiPolygon.prototype.getSimplifiedGeometryInternal = function(squaredTolerance
       simplifiedFlatCoordinates, 0, simplifiedEndss);
   var simplifiedMultiPolygon = new MultiPolygon(null);
   simplifiedMultiPolygon.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates, simplifiedEndss);
+      GeometryLayout.XY, simplifiedFlatCoordinates, simplifiedEndss);
   return simplifiedMultiPolygon;
 };
 
@@ -363,7 +363,7 @@ MultiPolygon.prototype.intersectsExtent = function(extent) {
  */
 MultiPolygon.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null, this.endss_);
+    this.setFlatCoordinates(GeometryLayout.XY, null, this.endss_);
   } else {
     this.setLayout(opt_layout, coordinates, 3);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../index.js';
 import {createOrUpdateFromCoordinate, containsXY} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
@@ -104,7 +104,7 @@ Point.prototype.intersectsExtent = function(extent) {
  */
 Point.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
+    this.setFlatCoordinates(GeometryLayout.XY, null);
   } else {
     this.setLayout(opt_layout, coordinates, 0);
     if (!this.flatCoordinates) {

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import {createOrUpdateFromCoordinate, containsXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_math_ from '../math.js';
 
@@ -20,11 +20,11 @@ import _ol_math_ from '../math.js';
  * @api
  */
 var Point = function(coordinates, opt_layout) {
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
   this.setCoordinates(coordinates, opt_layout);
 };
 
-inherits(Point, _ol_geom_SimpleGeometry_);
+inherits(Point, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import {createOrUpdateFromCoordinate, containsXY} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_deflate_ from '../geom/flat/deflate.js';
 import _ol_math_ from '../math.js';
@@ -85,7 +85,7 @@ Point.prototype.computeExtent = function(extent) {
  * @api
  */
 Point.prototype.getType = function() {
-  return _ol_geom_GeometryType_.POINT;
+  return GeometryType.POINT;
 };
 
 

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -19,12 +19,12 @@ import _ol_math_ from '../math.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_Point_ = function(coordinates, opt_layout) {
+var Point = function(coordinates, opt_layout) {
   _ol_geom_SimpleGeometry_.call(this);
   this.setCoordinates(coordinates, opt_layout);
 };
 
-inherits(_ol_geom_Point_, _ol_geom_SimpleGeometry_);
+inherits(Point, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -33,8 +33,8 @@ inherits(_ol_geom_Point_, _ol_geom_SimpleGeometry_);
  * @override
  * @api
  */
-_ol_geom_Point_.prototype.clone = function() {
-  var point = new _ol_geom_Point_(null);
+Point.prototype.clone = function() {
+  var point = new Point(null);
   point.setFlatCoordinates(this.layout, this.flatCoordinates.slice());
   return point;
 };
@@ -43,7 +43,7 @@ _ol_geom_Point_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_Point_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+Point.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   var flatCoordinates = this.flatCoordinates;
   var squaredDistance = _ol_math_.squaredDistance(
       x, y, flatCoordinates[0], flatCoordinates[1]);
@@ -67,7 +67,7 @@ _ol_geom_Point_.prototype.closestPointXY = function(x, y, closestPoint, minSquar
  * @override
  * @api
  */
-_ol_geom_Point_.prototype.getCoordinates = function() {
+Point.prototype.getCoordinates = function() {
   return !this.flatCoordinates ? [] : this.flatCoordinates.slice();
 };
 
@@ -75,7 +75,7 @@ _ol_geom_Point_.prototype.getCoordinates = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_Point_.prototype.computeExtent = function(extent) {
+Point.prototype.computeExtent = function(extent) {
   return createOrUpdateFromCoordinate(this.flatCoordinates, extent);
 };
 
@@ -84,7 +84,7 @@ _ol_geom_Point_.prototype.computeExtent = function(extent) {
  * @inheritDoc
  * @api
  */
-_ol_geom_Point_.prototype.getType = function() {
+Point.prototype.getType = function() {
   return _ol_geom_GeometryType_.POINT;
 };
 
@@ -93,7 +93,7 @@ _ol_geom_Point_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_Point_.prototype.intersectsExtent = function(extent) {
+Point.prototype.intersectsExtent = function(extent) {
   return containsXY(extent, this.flatCoordinates[0], this.flatCoordinates[1]);
 };
 
@@ -102,7 +102,7 @@ _ol_geom_Point_.prototype.intersectsExtent = function(extent) {
  * @inheritDoc
  * @api
  */
-_ol_geom_Point_.prototype.setCoordinates = function(coordinates, opt_layout) {
+Point.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null);
   } else {
@@ -121,8 +121,8 @@ _ol_geom_Point_.prototype.setCoordinates = function(coordinates, opt_layout) {
  * @param {ol.geom.GeometryLayout} layout Layout.
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  */
-_ol_geom_Point_.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
+Point.prototype.setFlatCoordinates = function(layout, flatCoordinates) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.changed();
 };
-export default _ol_geom_Point_;
+export default Point;

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY, getCenter} from '../extent.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import Point from '../geom/Point.js';
@@ -215,7 +215,7 @@ Polygon.prototype.getFlatInteriorPoint = function() {
  * @api
  */
 Polygon.prototype.getInteriorPoint = function() {
-  return new Point(this.getFlatInteriorPoint(), _ol_geom_GeometryLayout_.XYM);
+  return new Point(this.getFlatInteriorPoint(), GeometryLayout.XYM);
 };
 
 
@@ -308,7 +308,7 @@ Polygon.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
       simplifiedFlatCoordinates, 0, simplifiedEnds);
   var simplifiedPolygon = new Polygon(null);
   simplifiedPolygon.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates, simplifiedEnds);
+      GeometryLayout.XY, simplifiedFlatCoordinates, simplifiedEnds);
   return simplifiedPolygon;
 };
 
@@ -341,7 +341,7 @@ Polygon.prototype.intersectsExtent = function(extent) {
  */
 Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
-    this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null, this.ends_);
+    this.setFlatCoordinates(GeometryLayout.XY, null, this.ends_);
   } else {
     this.setLayout(opt_layout, coordinates, 2);
     if (!this.flatCoordinates) {
@@ -390,7 +390,7 @@ Polygon.circular = function(sphere, center, radius, opt_n) {
   flatCoordinates.push(flatCoordinates[0], flatCoordinates[1]);
   var polygon = new Polygon(null);
   polygon.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, flatCoordinates, [flatCoordinates.length]);
+      GeometryLayout.XY, flatCoordinates, [flatCoordinates.length]);
   return polygon;
 };
 
@@ -410,7 +410,7 @@ Polygon.fromExtent = function(extent) {
       [minX, minY, minX, maxY, maxX, maxY, maxX, minY, minX, minY];
   var polygon = new Polygon(null);
   polygon.setFlatCoordinates(
-      _ol_geom_GeometryLayout_.XY, flatCoordinates, [flatCoordinates.length]);
+      GeometryLayout.XY, flatCoordinates, [flatCoordinates.length]);
   return polygon;
 };
 

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -6,7 +6,7 @@ import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY, getCenter} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
-import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
+import LinearRing from '../geom/LinearRing.js';
 import Point from '../geom/Point.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
@@ -245,7 +245,7 @@ Polygon.prototype.getLinearRing = function(index) {
   if (index < 0 || this.ends_.length <= index) {
     return null;
   }
-  var linearRing = new _ol_geom_LinearRing_(null);
+  var linearRing = new LinearRing(null);
   linearRing.setFlatCoordinates(this.layout, this.flatCoordinates.slice(
       index === 0 ? 0 : this.ends_[index - 1], this.ends_[index]));
   return linearRing;
@@ -266,7 +266,7 @@ Polygon.prototype.getLinearRings = function() {
   var i, ii;
   for (i = 0, ii = ends.length; i < ii; ++i) {
     var end = ends[i];
-    var linearRing = new _ol_geom_LinearRing_(null);
+    var linearRing = new LinearRing(null);
     linearRing.setFlatCoordinates(layout, flatCoordinates.slice(offset, end));
     linearRings.push(linearRing);
     offset = end;

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -7,7 +7,7 @@ import {closestSquaredDistanceXY, getCenter} from '../extent.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
@@ -215,7 +215,7 @@ _ol_geom_Polygon_.prototype.getFlatInteriorPoint = function() {
  * @api
  */
 _ol_geom_Polygon_.prototype.getInteriorPoint = function() {
-  return new _ol_geom_Point_(this.getFlatInteriorPoint(), _ol_geom_GeometryLayout_.XYM);
+  return new Point(this.getFlatInteriorPoint(), _ol_geom_GeometryLayout_.XYM);
 };
 
 

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_array_ from '../array.js';
 import {closestSquaredDistanceXY, getCenter} from '../extent.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_geom_LinearRing_ from '../geom/LinearRing.js';
 import Point from '../geom/Point.js';
 import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
@@ -318,7 +318,7 @@ Polygon.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
  * @api
  */
 Polygon.prototype.getType = function() {
-  return _ol_geom_GeometryType_.POLYGON;
+  return GeometryType.POLYGON;
 };
 
 

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -8,7 +8,7 @@ import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
 import LinearRing from '../geom/LinearRing.js';
 import Point from '../geom/Point.js';
-import _ol_geom_SimpleGeometry_ from '../geom/SimpleGeometry.js';
+import SimpleGeometry from '../geom/SimpleGeometry.js';
 import _ol_geom_flat_area_ from '../geom/flat/area.js';
 import _ol_geom_flat_closest_ from '../geom/flat/closest.js';
 import _ol_geom_flat_contains_ from '../geom/flat/contains.js';
@@ -37,7 +37,7 @@ import _ol_math_ from '../math.js';
  */
 var Polygon = function(coordinates, opt_layout) {
 
-  _ol_geom_SimpleGeometry_.call(this);
+  SimpleGeometry.call(this);
 
   /**
    * @type {Array.<number>}
@@ -85,7 +85,7 @@ var Polygon = function(coordinates, opt_layout) {
 
 };
 
-inherits(Polygon, _ol_geom_SimpleGeometry_);
+inherits(Polygon, SimpleGeometry);
 
 
 /**

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -35,7 +35,7 @@ import _ol_math_ from '../math.js';
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  * @api
  */
-var _ol_geom_Polygon_ = function(coordinates, opt_layout) {
+var Polygon = function(coordinates, opt_layout) {
 
   _ol_geom_SimpleGeometry_.call(this);
 
@@ -85,7 +85,7 @@ var _ol_geom_Polygon_ = function(coordinates, opt_layout) {
 
 };
 
-inherits(_ol_geom_Polygon_, _ol_geom_SimpleGeometry_);
+inherits(Polygon, _ol_geom_SimpleGeometry_);
 
 
 /**
@@ -93,7 +93,7 @@ inherits(_ol_geom_Polygon_, _ol_geom_SimpleGeometry_);
  * @param {ol.geom.LinearRing} linearRing Linear ring.
  * @api
  */
-_ol_geom_Polygon_.prototype.appendLinearRing = function(linearRing) {
+Polygon.prototype.appendLinearRing = function(linearRing) {
   if (!this.flatCoordinates) {
     this.flatCoordinates = linearRing.getFlatCoordinates().slice();
   } else {
@@ -110,8 +110,8 @@ _ol_geom_Polygon_.prototype.appendLinearRing = function(linearRing) {
  * @override
  * @api
  */
-_ol_geom_Polygon_.prototype.clone = function() {
-  var polygon = new _ol_geom_Polygon_(null);
+Polygon.prototype.clone = function() {
+  var polygon = new Polygon(null);
   polygon.setFlatCoordinates(
       this.layout, this.flatCoordinates.slice(), this.ends_.slice());
   return polygon;
@@ -121,7 +121,7 @@ _ol_geom_Polygon_.prototype.clone = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_Polygon_.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
+Polygon.prototype.closestPointXY = function(x, y, closestPoint, minSquaredDistance) {
   if (minSquaredDistance < closestSquaredDistanceXY(this.getExtent(), x, y)) {
     return minSquaredDistance;
   }
@@ -139,7 +139,7 @@ _ol_geom_Polygon_.prototype.closestPointXY = function(x, y, closestPoint, minSqu
 /**
  * @inheritDoc
  */
-_ol_geom_Polygon_.prototype.containsXY = function(x, y) {
+Polygon.prototype.containsXY = function(x, y) {
   return _ol_geom_flat_contains_.linearRingsContainsXY(
       this.getOrientedFlatCoordinates(), 0, this.ends_, this.stride, x, y);
 };
@@ -150,7 +150,7 @@ _ol_geom_Polygon_.prototype.containsXY = function(x, y) {
  * @return {number} Area (on projected plane).
  * @api
  */
-_ol_geom_Polygon_.prototype.getArea = function() {
+Polygon.prototype.getArea = function() {
   return _ol_geom_flat_area_.linearRings(
       this.getOrientedFlatCoordinates(), 0, this.ends_, this.stride);
 };
@@ -170,7 +170,7 @@ _ol_geom_Polygon_.prototype.getArea = function() {
  * @override
  * @api
  */
-_ol_geom_Polygon_.prototype.getCoordinates = function(opt_right) {
+Polygon.prototype.getCoordinates = function(opt_right) {
   var flatCoordinates;
   if (opt_right !== undefined) {
     flatCoordinates = this.getOrientedFlatCoordinates().slice();
@@ -188,7 +188,7 @@ _ol_geom_Polygon_.prototype.getCoordinates = function(opt_right) {
 /**
  * @return {Array.<number>} Ends.
  */
-_ol_geom_Polygon_.prototype.getEnds = function() {
+Polygon.prototype.getEnds = function() {
   return this.ends_;
 };
 
@@ -196,7 +196,7 @@ _ol_geom_Polygon_.prototype.getEnds = function() {
 /**
  * @return {Array.<number>} Interior point.
  */
-_ol_geom_Polygon_.prototype.getFlatInteriorPoint = function() {
+Polygon.prototype.getFlatInteriorPoint = function() {
   if (this.flatInteriorPointRevision_ != this.getRevision()) {
     var flatCenter = getCenter(this.getExtent());
     this.flatInteriorPoint_ = _ol_geom_flat_interiorpoint_.linearRings(
@@ -214,7 +214,7 @@ _ol_geom_Polygon_.prototype.getFlatInteriorPoint = function() {
  * length of the horizontal intersection that the point belongs to.
  * @api
  */
-_ol_geom_Polygon_.prototype.getInteriorPoint = function() {
+Polygon.prototype.getInteriorPoint = function() {
   return new Point(this.getFlatInteriorPoint(), _ol_geom_GeometryLayout_.XYM);
 };
 
@@ -226,7 +226,7 @@ _ol_geom_Polygon_.prototype.getInteriorPoint = function() {
  * @return {number} Number of rings.
  * @api
  */
-_ol_geom_Polygon_.prototype.getLinearRingCount = function() {
+Polygon.prototype.getLinearRingCount = function() {
   return this.ends_.length;
 };
 
@@ -241,7 +241,7 @@ _ol_geom_Polygon_.prototype.getLinearRingCount = function() {
  * @return {ol.geom.LinearRing} Linear ring.
  * @api
  */
-_ol_geom_Polygon_.prototype.getLinearRing = function(index) {
+Polygon.prototype.getLinearRing = function(index) {
   if (index < 0 || this.ends_.length <= index) {
     return null;
   }
@@ -257,7 +257,7 @@ _ol_geom_Polygon_.prototype.getLinearRing = function(index) {
  * @return {Array.<ol.geom.LinearRing>} Linear rings.
  * @api
  */
-_ol_geom_Polygon_.prototype.getLinearRings = function() {
+Polygon.prototype.getLinearRings = function() {
   var layout = this.layout;
   var flatCoordinates = this.flatCoordinates;
   var ends = this.ends_;
@@ -278,7 +278,7 @@ _ol_geom_Polygon_.prototype.getLinearRings = function() {
 /**
  * @return {Array.<number>} Oriented flat coordinates.
  */
-_ol_geom_Polygon_.prototype.getOrientedFlatCoordinates = function() {
+Polygon.prototype.getOrientedFlatCoordinates = function() {
   if (this.orientedRevision_ != this.getRevision()) {
     var flatCoordinates = this.flatCoordinates;
     if (_ol_geom_flat_orient_.linearRingsAreOriented(
@@ -299,14 +299,14 @@ _ol_geom_Polygon_.prototype.getOrientedFlatCoordinates = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_Polygon_.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
+Polygon.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
   var simplifiedFlatCoordinates = [];
   var simplifiedEnds = [];
   simplifiedFlatCoordinates.length = _ol_geom_flat_simplify_.quantizes(
       this.flatCoordinates, 0, this.ends_, this.stride,
       Math.sqrt(squaredTolerance),
       simplifiedFlatCoordinates, 0, simplifiedEnds);
-  var simplifiedPolygon = new _ol_geom_Polygon_(null);
+  var simplifiedPolygon = new Polygon(null);
   simplifiedPolygon.setFlatCoordinates(
       _ol_geom_GeometryLayout_.XY, simplifiedFlatCoordinates, simplifiedEnds);
   return simplifiedPolygon;
@@ -317,7 +317,7 @@ _ol_geom_Polygon_.prototype.getSimplifiedGeometryInternal = function(squaredTole
  * @inheritDoc
  * @api
  */
-_ol_geom_Polygon_.prototype.getType = function() {
+Polygon.prototype.getType = function() {
   return _ol_geom_GeometryType_.POLYGON;
 };
 
@@ -326,7 +326,7 @@ _ol_geom_Polygon_.prototype.getType = function() {
  * @inheritDoc
  * @api
  */
-_ol_geom_Polygon_.prototype.intersectsExtent = function(extent) {
+Polygon.prototype.intersectsExtent = function(extent) {
   return _ol_geom_flat_intersectsextent_.linearRings(
       this.getOrientedFlatCoordinates(), 0, this.ends_, this.stride, extent);
 };
@@ -339,7 +339,7 @@ _ol_geom_Polygon_.prototype.intersectsExtent = function(extent) {
  * @override
  * @api
  */
-_ol_geom_Polygon_.prototype.setCoordinates = function(coordinates, opt_layout) {
+Polygon.prototype.setCoordinates = function(coordinates, opt_layout) {
   if (!coordinates) {
     this.setFlatCoordinates(_ol_geom_GeometryLayout_.XY, null, this.ends_);
   } else {
@@ -360,7 +360,7 @@ _ol_geom_Polygon_.prototype.setCoordinates = function(coordinates, opt_layout) {
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  * @param {Array.<number>} ends Ends.
  */
-_ol_geom_Polygon_.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
+Polygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, ends) {
   this.setFlatCoordinatesInternal(layout, flatCoordinates);
   this.ends_ = ends;
   this.changed();
@@ -378,7 +378,7 @@ _ol_geom_Polygon_.prototype.setFlatCoordinates = function(layout, flatCoordinate
  * @return {ol.geom.Polygon} The "circular" polygon.
  * @api
  */
-_ol_geom_Polygon_.circular = function(sphere, center, radius, opt_n) {
+Polygon.circular = function(sphere, center, radius, opt_n) {
   var n = opt_n ? opt_n : 32;
   /** @type {Array.<number>} */
   var flatCoordinates = [];
@@ -388,7 +388,7 @@ _ol_geom_Polygon_.circular = function(sphere, center, radius, opt_n) {
         flatCoordinates, sphere.offset(center, radius, 2 * Math.PI * i / n));
   }
   flatCoordinates.push(flatCoordinates[0], flatCoordinates[1]);
-  var polygon = new _ol_geom_Polygon_(null);
+  var polygon = new Polygon(null);
   polygon.setFlatCoordinates(
       _ol_geom_GeometryLayout_.XY, flatCoordinates, [flatCoordinates.length]);
   return polygon;
@@ -401,14 +401,14 @@ _ol_geom_Polygon_.circular = function(sphere, center, radius, opt_n) {
  * @return {ol.geom.Polygon} The polygon.
  * @api
  */
-_ol_geom_Polygon_.fromExtent = function(extent) {
+Polygon.fromExtent = function(extent) {
   var minX = extent[0];
   var minY = extent[1];
   var maxX = extent[2];
   var maxY = extent[3];
   var flatCoordinates =
       [minX, minY, minX, maxY, maxX, maxY, maxX, minY, minX, minY];
-  var polygon = new _ol_geom_Polygon_(null);
+  var polygon = new Polygon(null);
   polygon.setFlatCoordinates(
       _ol_geom_GeometryLayout_.XY, flatCoordinates, [flatCoordinates.length]);
   return polygon;
@@ -424,11 +424,11 @@ _ol_geom_Polygon_.fromExtent = function(extent) {
  * @return {ol.geom.Polygon} Polygon geometry.
  * @api
  */
-_ol_geom_Polygon_.fromCircle = function(circle, opt_sides, opt_angle) {
+Polygon.fromCircle = function(circle, opt_sides, opt_angle) {
   var sides = opt_sides ? opt_sides : 32;
   var stride = circle.getStride();
   var layout = circle.getLayout();
-  var polygon = new _ol_geom_Polygon_(null, layout);
+  var polygon = new Polygon(null, layout);
   var arrayLength = stride * (sides + 1);
   var flatCoordinates = new Array(arrayLength);
   for (var i = 0; i < arrayLength; i++) {
@@ -436,7 +436,7 @@ _ol_geom_Polygon_.fromCircle = function(circle, opt_sides, opt_angle) {
   }
   var ends = [flatCoordinates.length];
   polygon.setFlatCoordinates(layout, flatCoordinates, ends);
-  _ol_geom_Polygon_.makeRegular(
+  Polygon.makeRegular(
       polygon, circle.getCenter(), circle.getRadius(), opt_angle);
   return polygon;
 };
@@ -450,7 +450,7 @@ _ol_geom_Polygon_.fromCircle = function(circle, opt_sides, opt_angle) {
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in
  *     radians. Default is 0.
  */
-_ol_geom_Polygon_.makeRegular = function(polygon, center, radius, opt_angle) {
+Polygon.makeRegular = function(polygon, center, radius, opt_angle) {
   var flatCoordinates = polygon.getFlatCoordinates();
   var layout = polygon.getLayout();
   var stride = polygon.getStride();
@@ -466,4 +466,4 @@ _ol_geom_Polygon_.makeRegular = function(polygon, center, radius, opt_angle) {
   }
   polygon.setFlatCoordinates(layout, flatCoordinates, ends);
 };
-export default _ol_geom_Polygon_;
+export default Polygon;

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_functions_ from '../functions.js';
 import {createOrUpdateFromFlatCoordinates, getCenter} from '../extent.js';
 import Geometry from '../geom/Geometry.js';
-import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
 import _ol_geom_flat_transform_ from '../geom/flat/transform.js';
 import _ol_obj_ from '../obj.js';
 
@@ -27,7 +27,7 @@ var _ol_geom_SimpleGeometry_ = function() {
    * @protected
    * @type {ol.geom.GeometryLayout}
    */
-  this.layout = _ol_geom_GeometryLayout_.XY;
+  this.layout = GeometryLayout.XY;
 
   /**
    * @protected
@@ -54,11 +54,11 @@ inherits(_ol_geom_SimpleGeometry_, Geometry);
 _ol_geom_SimpleGeometry_.getLayoutForStride_ = function(stride) {
   var layout;
   if (stride == 2) {
-    layout = _ol_geom_GeometryLayout_.XY;
+    layout = GeometryLayout.XY;
   } else if (stride == 3) {
-    layout = _ol_geom_GeometryLayout_.XYZ;
+    layout = GeometryLayout.XYZ;
   } else if (stride == 4) {
-    layout = _ol_geom_GeometryLayout_.XYZM;
+    layout = GeometryLayout.XYZM;
   }
   return /** @type {ol.geom.GeometryLayout} */ (layout);
 };
@@ -70,11 +70,11 @@ _ol_geom_SimpleGeometry_.getLayoutForStride_ = function(stride) {
  */
 _ol_geom_SimpleGeometry_.getStrideForLayout = function(layout) {
   var stride;
-  if (layout == _ol_geom_GeometryLayout_.XY) {
+  if (layout == GeometryLayout.XY) {
     stride = 2;
-  } else if (layout == _ol_geom_GeometryLayout_.XYZ || layout == _ol_geom_GeometryLayout_.XYM) {
+  } else if (layout == GeometryLayout.XYZ || layout == GeometryLayout.XYM) {
     stride = 3;
-  } else if (layout == _ol_geom_GeometryLayout_.XYZM) {
+  } else if (layout == GeometryLayout.XYZM) {
     stride = 4;
   }
   return /** @type {number} */ (stride);
@@ -234,7 +234,7 @@ _ol_geom_SimpleGeometry_.prototype.setLayout = function(layout, coordinates, nes
     var i;
     for (i = 0; i < nesting; ++i) {
       if (coordinates.length === 0) {
-        this.layout = _ol_geom_GeometryLayout_.XY;
+        this.layout = GeometryLayout.XY;
         this.stride = 2;
         return;
       } else {

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -19,7 +19,7 @@ import _ol_obj_ from '../obj.js';
  * @extends {ol.geom.Geometry}
  * @api
  */
-var _ol_geom_SimpleGeometry_ = function() {
+var SimpleGeometry = function() {
 
   Geometry.call(this);
 
@@ -43,7 +43,7 @@ var _ol_geom_SimpleGeometry_ = function() {
 
 };
 
-inherits(_ol_geom_SimpleGeometry_, Geometry);
+inherits(SimpleGeometry, Geometry);
 
 
 /**
@@ -51,7 +51,7 @@ inherits(_ol_geom_SimpleGeometry_, Geometry);
  * @private
  * @return {ol.geom.GeometryLayout} layout Layout.
  */
-_ol_geom_SimpleGeometry_.getLayoutForStride_ = function(stride) {
+SimpleGeometry.getLayoutForStride_ = function(stride) {
   var layout;
   if (stride == 2) {
     layout = GeometryLayout.XY;
@@ -68,7 +68,7 @@ _ol_geom_SimpleGeometry_.getLayoutForStride_ = function(stride) {
  * @param {ol.geom.GeometryLayout} layout Layout.
  * @return {number} Stride.
  */
-_ol_geom_SimpleGeometry_.getStrideForLayout = function(layout) {
+SimpleGeometry.getStrideForLayout = function(layout) {
   var stride;
   if (layout == GeometryLayout.XY) {
     stride = 2;
@@ -84,13 +84,13 @@ _ol_geom_SimpleGeometry_.getStrideForLayout = function(layout) {
 /**
  * @inheritDoc
  */
-_ol_geom_SimpleGeometry_.prototype.containsXY = _ol_functions_.FALSE;
+SimpleGeometry.prototype.containsXY = _ol_functions_.FALSE;
 
 
 /**
  * @inheritDoc
  */
-_ol_geom_SimpleGeometry_.prototype.computeExtent = function(extent) {
+SimpleGeometry.prototype.computeExtent = function(extent) {
   return createOrUpdateFromFlatCoordinates(this.flatCoordinates,
       0, this.flatCoordinates.length, this.stride, extent);
 };
@@ -100,7 +100,7 @@ _ol_geom_SimpleGeometry_.prototype.computeExtent = function(extent) {
  * @abstract
  * @return {Array} Coordinates.
  */
-_ol_geom_SimpleGeometry_.prototype.getCoordinates = function() {};
+SimpleGeometry.prototype.getCoordinates = function() {};
 
 
 /**
@@ -108,7 +108,7 @@ _ol_geom_SimpleGeometry_.prototype.getCoordinates = function() {};
  * @return {ol.Coordinate} First coordinate.
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.getFirstCoordinate = function() {
+SimpleGeometry.prototype.getFirstCoordinate = function() {
   return this.flatCoordinates.slice(0, this.stride);
 };
 
@@ -116,7 +116,7 @@ _ol_geom_SimpleGeometry_.prototype.getFirstCoordinate = function() {
 /**
  * @return {Array.<number>} Flat coordinates.
  */
-_ol_geom_SimpleGeometry_.prototype.getFlatCoordinates = function() {
+SimpleGeometry.prototype.getFlatCoordinates = function() {
   return this.flatCoordinates;
 };
 
@@ -126,7 +126,7 @@ _ol_geom_SimpleGeometry_.prototype.getFlatCoordinates = function() {
  * @return {ol.Coordinate} Last point.
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.getLastCoordinate = function() {
+SimpleGeometry.prototype.getLastCoordinate = function() {
   return this.flatCoordinates.slice(this.flatCoordinates.length - this.stride);
 };
 
@@ -136,7 +136,7 @@ _ol_geom_SimpleGeometry_.prototype.getLastCoordinate = function() {
  * @return {ol.geom.GeometryLayout} Layout.
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.getLayout = function() {
+SimpleGeometry.prototype.getLayout = function() {
   return this.layout;
 };
 
@@ -144,7 +144,7 @@ _ol_geom_SimpleGeometry_.prototype.getLayout = function() {
 /**
  * @inheritDoc
  */
-_ol_geom_SimpleGeometry_.prototype.getSimplifiedGeometry = function(squaredTolerance) {
+SimpleGeometry.prototype.getSimplifiedGeometry = function(squaredTolerance) {
   if (this.simplifiedGeometryRevision != this.getRevision()) {
     _ol_obj_.clear(this.simplifiedGeometryCache);
     this.simplifiedGeometryMaxMinSquaredTolerance = 0;
@@ -186,7 +186,7 @@ _ol_geom_SimpleGeometry_.prototype.getSimplifiedGeometry = function(squaredToler
  * @return {ol.geom.SimpleGeometry} Simplified geometry.
  * @protected
  */
-_ol_geom_SimpleGeometry_.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
+SimpleGeometry.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
   return this;
 };
 
@@ -194,7 +194,7 @@ _ol_geom_SimpleGeometry_.prototype.getSimplifiedGeometryInternal = function(squa
 /**
  * @return {number} Stride.
  */
-_ol_geom_SimpleGeometry_.prototype.getStride = function() {
+SimpleGeometry.prototype.getStride = function() {
   return this.stride;
 };
 
@@ -204,8 +204,8 @@ _ol_geom_SimpleGeometry_.prototype.getStride = function() {
  * @param {Array.<number>} flatCoordinates Flat coordinates.
  * @protected
  */
-_ol_geom_SimpleGeometry_.prototype.setFlatCoordinatesInternal = function(layout, flatCoordinates) {
-  this.stride = _ol_geom_SimpleGeometry_.getStrideForLayout(layout);
+SimpleGeometry.prototype.setFlatCoordinatesInternal = function(layout, flatCoordinates) {
+  this.stride = SimpleGeometry.getStrideForLayout(layout);
   this.layout = layout;
   this.flatCoordinates = flatCoordinates;
 };
@@ -216,7 +216,7 @@ _ol_geom_SimpleGeometry_.prototype.setFlatCoordinatesInternal = function(layout,
  * @param {Array} coordinates Coordinates.
  * @param {ol.geom.GeometryLayout=} opt_layout Layout.
  */
-_ol_geom_SimpleGeometry_.prototype.setCoordinates = function(coordinates, opt_layout) {};
+SimpleGeometry.prototype.setCoordinates = function(coordinates, opt_layout) {};
 
 
 /**
@@ -225,11 +225,11 @@ _ol_geom_SimpleGeometry_.prototype.setCoordinates = function(coordinates, opt_la
  * @param {number} nesting Nesting.
  * @protected
  */
-_ol_geom_SimpleGeometry_.prototype.setLayout = function(layout, coordinates, nesting) {
+SimpleGeometry.prototype.setLayout = function(layout, coordinates, nesting) {
   /** @type {number} */
   var stride;
   if (layout) {
-    stride = _ol_geom_SimpleGeometry_.getStrideForLayout(layout);
+    stride = SimpleGeometry.getStrideForLayout(layout);
   } else {
     var i;
     for (i = 0; i < nesting; ++i) {
@@ -242,7 +242,7 @@ _ol_geom_SimpleGeometry_.prototype.setLayout = function(layout, coordinates, nes
       }
     }
     stride = coordinates.length;
-    layout = _ol_geom_SimpleGeometry_.getLayoutForStride_(stride);
+    layout = SimpleGeometry.getLayoutForStride_(stride);
   }
   this.layout = layout;
   this.stride = stride;
@@ -253,7 +253,7 @@ _ol_geom_SimpleGeometry_.prototype.setLayout = function(layout, coordinates, nes
  * @inheritDoc
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.applyTransform = function(transformFn) {
+SimpleGeometry.prototype.applyTransform = function(transformFn) {
   if (this.flatCoordinates) {
     transformFn(this.flatCoordinates, this.flatCoordinates, this.stride);
     this.changed();
@@ -265,7 +265,7 @@ _ol_geom_SimpleGeometry_.prototype.applyTransform = function(transformFn) {
  * @inheritDoc
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.rotate = function(angle, anchor) {
+SimpleGeometry.prototype.rotate = function(angle, anchor) {
   var flatCoordinates = this.getFlatCoordinates();
   if (flatCoordinates) {
     var stride = this.getStride();
@@ -281,7 +281,7 @@ _ol_geom_SimpleGeometry_.prototype.rotate = function(angle, anchor) {
  * @inheritDoc
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.scale = function(sx, opt_sy, opt_anchor) {
+SimpleGeometry.prototype.scale = function(sx, opt_sy, opt_anchor) {
   var sy = opt_sy;
   if (sy === undefined) {
     sy = sx;
@@ -305,7 +305,7 @@ _ol_geom_SimpleGeometry_.prototype.scale = function(sx, opt_sy, opt_anchor) {
  * @inheritDoc
  * @api
  */
-_ol_geom_SimpleGeometry_.prototype.translate = function(deltaX, deltaY) {
+SimpleGeometry.prototype.translate = function(deltaX, deltaY) {
   var flatCoordinates = this.getFlatCoordinates();
   if (flatCoordinates) {
     var stride = this.getStride();
@@ -323,7 +323,7 @@ _ol_geom_SimpleGeometry_.prototype.translate = function(deltaX, deltaY) {
  * @param {Array.<number>=} opt_dest Destination.
  * @return {Array.<number>} Transformed flat coordinates.
  */
-_ol_geom_SimpleGeometry_.transform2D = function(simpleGeometry, transform, opt_dest) {
+SimpleGeometry.transform2D = function(simpleGeometry, transform, opt_dest) {
   var flatCoordinates = simpleGeometry.getFlatCoordinates();
   if (!flatCoordinates) {
     return null;
@@ -334,4 +334,4 @@ _ol_geom_SimpleGeometry_.transform2D = function(simpleGeometry, transform, opt_d
         transform, opt_dest);
   }
 };
-export default _ol_geom_SimpleGeometry_;
+export default SimpleGeometry;

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_functions_ from '../functions.js';
 import {createOrUpdateFromFlatCoordinates, getCenter} from '../extent.js';
-import _ol_geom_Geometry_ from '../geom/Geometry.js';
+import Geometry from '../geom/Geometry.js';
 import _ol_geom_GeometryLayout_ from '../geom/GeometryLayout.js';
 import _ol_geom_flat_transform_ from '../geom/flat/transform.js';
 import _ol_obj_ from '../obj.js';
@@ -21,7 +21,7 @@ import _ol_obj_ from '../obj.js';
  */
 var _ol_geom_SimpleGeometry_ = function() {
 
-  _ol_geom_Geometry_.call(this);
+  Geometry.call(this);
 
   /**
    * @protected
@@ -43,7 +43,7 @@ var _ol_geom_SimpleGeometry_ = function() {
 
 };
 
-inherits(_ol_geom_SimpleGeometry_, _ol_geom_Geometry_);
+inherits(_ol_geom_SimpleGeometry_, Geometry);
 
 
 /**

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -16,7 +16,7 @@ import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
+import MultiPolygon from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_interaction_DrawEventType_ from '../interaction/DrawEventType.js';
@@ -676,7 +676,7 @@ _ol_interaction_Draw_.prototype.finishDrawing = function() {
   } else if (this.type_ === _ol_geom_GeometryType_.MULTI_LINE_STRING) {
     sketchFeature.setGeometry(new MultiLineString([coordinates]));
   } else if (this.type_ === _ol_geom_GeometryType_.MULTI_POLYGON) {
-    sketchFeature.setGeometry(new _ol_geom_MultiPolygon_([coordinates]));
+    sketchFeature.setGeometry(new MultiPolygon([coordinates]));
   }
 
   // First dispatch event to allow full set up of feature

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -17,7 +17,7 @@ import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_interaction_DrawEventType_ from '../interaction/DrawEventType.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
@@ -152,7 +152,7 @@ var _ol_interaction_Draw_ = function(options) {
       var Constructor;
       var mode = this.mode_;
       if (mode === _ol_interaction_Draw_.Mode_.POINT) {
-        Constructor = _ol_geom_Point_;
+        Constructor = Point;
       } else if (mode === _ol_interaction_Draw_.Mode_.LINE_STRING) {
         Constructor = _ol_geom_LineString_;
       } else if (mode === _ol_interaction_Draw_.Mode_.POLYGON) {
@@ -481,7 +481,7 @@ _ol_interaction_Draw_.prototype.atFinish_ = function(event) {
 _ol_interaction_Draw_.prototype.createOrUpdateSketchPoint_ = function(event) {
   var coordinates = event.coordinate.slice();
   if (!this.sketchPoint_) {
-    this.sketchPoint_ = new _ol_Feature_(new _ol_geom_Point_(coordinates));
+    this.sketchPoint_ = new _ol_Feature_(new Point(coordinates));
     this.updateSketchFeatures_();
   } else {
     var sketchPointGeom = /** @type {ol.geom.Point} */ (this.sketchPoint_.getGeometry());

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -14,7 +14,7 @@ import _ol_functions_ from '../functions.js';
 import _ol_geom_Circle_ from '../geom/Circle.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
+import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
@@ -674,7 +674,7 @@ _ol_interaction_Draw_.prototype.finishDrawing = function() {
   if (this.type_ === _ol_geom_GeometryType_.MULTI_POINT) {
     sketchFeature.setGeometry(new MultiPoint([coordinates]));
   } else if (this.type_ === _ol_geom_GeometryType_.MULTI_LINE_STRING) {
-    sketchFeature.setGeometry(new _ol_geom_MultiLineString_([coordinates]));
+    sketchFeature.setGeometry(new MultiLineString([coordinates]));
   } else if (this.type_ === _ol_geom_GeometryType_.MULTI_POLYGON) {
     sketchFeature.setGeometry(new _ol_geom_MultiPolygon_([coordinates]));
   }

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -18,7 +18,7 @@ import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_interaction_DrawEventType_ from '../interaction/DrawEventType.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
 import _ol_interaction_Property_ from '../interaction/Property.js';
@@ -156,7 +156,7 @@ var _ol_interaction_Draw_ = function(options) {
       } else if (mode === _ol_interaction_Draw_.Mode_.LINE_STRING) {
         Constructor = LineString;
       } else if (mode === _ol_interaction_Draw_.Mode_.POLYGON) {
-        Constructor = _ol_geom_Polygon_;
+        Constructor = Polygon;
       }
       /**
        * @param {!Array.<ol.Coordinate>} coordinates
@@ -555,7 +555,7 @@ _ol_interaction_Draw_.prototype.modifyDrawing_ = function(event) {
     sketchPointGeom.setCoordinates(coordinate);
   }
   var sketchLineGeom;
-  if (geometry instanceof _ol_geom_Polygon_ &&
+  if (geometry instanceof Polygon &&
       this.mode_ !== _ol_interaction_Draw_.Mode_.POLYGON) {
     if (!this.sketchLine_) {
       this.sketchLine_ = new _ol_Feature_(new LineString(null));
@@ -798,10 +798,10 @@ _ol_interaction_Draw_.createRegularPolygon = function(opt_sides, opt_angle) {
       var radius = Math.sqrt(
           _ol_coordinate_.squaredDistance(center, end));
       var geometry = opt_geometry ? /** @type {ol.geom.Polygon} */ (opt_geometry) :
-        _ol_geom_Polygon_.fromCircle(new _ol_geom_Circle_(center), opt_sides);
+        Polygon.fromCircle(new _ol_geom_Circle_(center), opt_sides);
       var angle = opt_angle ? opt_angle :
         Math.atan((end[1] - center[1]) / (end[0] - center[0]));
-      _ol_geom_Polygon_.makeRegular(geometry, center, radius, angle);
+      Polygon.makeRegular(geometry, center, radius, angle);
       return geometry;
     }
   );
@@ -824,7 +824,7 @@ _ol_interaction_Draw_.createBox = function() {
      */
     function(coordinates, opt_geometry) {
       var extent = boundingExtent(coordinates);
-      var geometry = opt_geometry || new _ol_geom_Polygon_(null);
+      var geometry = opt_geometry || new Polygon(null);
       geometry.setCoordinates([[
         getBottomLeft(extent),
         getBottomRight(extent),

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -15,7 +15,7 @@ import _ol_geom_Circle_ from '../geom/Circle.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import _ol_geom_LineString_ from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../geom/MultiPoint.js';
+import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
 import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
@@ -672,7 +672,7 @@ _ol_interaction_Draw_.prototype.finishDrawing = function() {
 
   // cast multi-part geometries
   if (this.type_ === _ol_geom_GeometryType_.MULTI_POINT) {
-    sketchFeature.setGeometry(new _ol_geom_MultiPoint_([coordinates]));
+    sketchFeature.setGeometry(new MultiPoint([coordinates]));
   } else if (this.type_ === _ol_geom_GeometryType_.MULTI_LINE_STRING) {
     sketchFeature.setGeometry(new _ol_geom_MultiLineString_([coordinates]));
   } else if (this.type_ === _ol_geom_GeometryType_.MULTI_POLYGON) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -11,7 +11,7 @@ import _ol_events_Event_ from '../events/Event.js';
 import _ol_events_condition_ from '../events/condition.js';
 import {boundingExtent, getBottomLeft, getBottomRight, getTopLeft, getTopRight} from '../extent.js';
 import _ol_functions_ from '../functions.js';
-import _ol_geom_Circle_ from '../geom/Circle.js';
+import Circle from '../geom/Circle.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -142,7 +142,7 @@ var _ol_interaction_Draw_ = function(options) {
        */
       geometryFunction = function(coordinates, opt_geometry) {
         var circle = opt_geometry ? /** @type {ol.geom.Circle} */ (opt_geometry) :
-          new _ol_geom_Circle_([NaN, NaN]);
+          new Circle([NaN, NaN]);
         var squaredLength = _ol_coordinate_.squaredDistance(
             coordinates[0], coordinates[1]);
         circle.setCenterAndRadius(coordinates[0], Math.sqrt(squaredLength));
@@ -798,7 +798,7 @@ _ol_interaction_Draw_.createRegularPolygon = function(opt_sides, opt_angle) {
       var radius = Math.sqrt(
           _ol_coordinate_.squaredDistance(center, end));
       var geometry = opt_geometry ? /** @type {ol.geom.Polygon} */ (opt_geometry) :
-        Polygon.fromCircle(new _ol_geom_Circle_(center), opt_sides);
+        Polygon.fromCircle(new Circle(center), opt_sides);
       var angle = opt_angle ? opt_angle :
         Math.atan((end[1] - center[1]) / (end[0] - center[0]));
       Polygon.makeRegular(geometry, center, radius, angle);

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -13,7 +13,7 @@ import {boundingExtent, getBottomLeft, getBottomRight, getTopLeft, getTopRight} 
 import _ol_functions_ from '../functions.js';
 import _ol_geom_Circle_ from '../geom/Circle.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_LineString_ from '../geom/LineString.js';
+import LineString from '../geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../geom/MultiPolygon.js';
@@ -154,7 +154,7 @@ var _ol_interaction_Draw_ = function(options) {
       if (mode === _ol_interaction_Draw_.Mode_.POINT) {
         Constructor = Point;
       } else if (mode === _ol_interaction_Draw_.Mode_.LINE_STRING) {
-        Constructor = _ol_geom_LineString_;
+        Constructor = LineString;
       } else if (mode === _ol_interaction_Draw_.Mode_.POLYGON) {
         Constructor = _ol_geom_Polygon_;
       }
@@ -511,7 +511,7 @@ _ol_interaction_Draw_.prototype.startDrawing_ = function(event) {
   }
   if (this.sketchLineCoords_) {
     this.sketchLine_ = new _ol_Feature_(
-        new _ol_geom_LineString_(this.sketchLineCoords_));
+        new LineString(this.sketchLineCoords_));
   }
   var geometry = this.geometryFunction_(this.sketchCoords_);
   this.sketchFeature_ = new _ol_Feature_();
@@ -558,7 +558,7 @@ _ol_interaction_Draw_.prototype.modifyDrawing_ = function(event) {
   if (geometry instanceof _ol_geom_Polygon_ &&
       this.mode_ !== _ol_interaction_Draw_.Mode_.POLYGON) {
     if (!this.sketchLine_) {
-      this.sketchLine_ = new _ol_Feature_(new _ol_geom_LineString_(null));
+      this.sketchLine_ = new _ol_Feature_(new LineString(null));
     }
     var ring = geometry.getLinearRing(0);
     sketchLineGeom = /** @type {ol.geom.LineString} */ (this.sketchLine_.getGeometry());

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -12,7 +12,7 @@ import _ol_events_condition_ from '../events/condition.js';
 import {boundingExtent, getBottomLeft, getBottomRight, getTopLeft, getTopRight} from '../extent.js';
 import _ol_functions_ from '../functions.js';
 import Circle from '../geom/Circle.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -133,7 +133,7 @@ var _ol_interaction_Draw_ = function(options) {
 
   var geometryFunction = options.geometryFunction;
   if (!geometryFunction) {
-    if (this.type_ === _ol_geom_GeometryType_.CIRCLE) {
+    if (this.type_ === GeometryType.CIRCLE) {
       /**
        * @param {!Array.<ol.Coordinate>} coordinates
        *     The coordinates.
@@ -671,11 +671,11 @@ _ol_interaction_Draw_.prototype.finishDrawing = function() {
   }
 
   // cast multi-part geometries
-  if (this.type_ === _ol_geom_GeometryType_.MULTI_POINT) {
+  if (this.type_ === GeometryType.MULTI_POINT) {
     sketchFeature.setGeometry(new MultiPoint([coordinates]));
-  } else if (this.type_ === _ol_geom_GeometryType_.MULTI_LINE_STRING) {
+  } else if (this.type_ === GeometryType.MULTI_LINE_STRING) {
     sketchFeature.setGeometry(new MultiLineString([coordinates]));
-  } else if (this.type_ === _ol_geom_GeometryType_.MULTI_POLYGON) {
+  } else if (this.type_ === GeometryType.MULTI_POLYGON) {
     sketchFeature.setGeometry(new MultiPolygon([coordinates]));
   }
 
@@ -847,16 +847,16 @@ _ol_interaction_Draw_.createBox = function() {
  */
 _ol_interaction_Draw_.getMode_ = function(type) {
   var mode;
-  if (type === _ol_geom_GeometryType_.POINT ||
-      type === _ol_geom_GeometryType_.MULTI_POINT) {
+  if (type === GeometryType.POINT ||
+      type === GeometryType.MULTI_POINT) {
     mode = _ol_interaction_Draw_.Mode_.POINT;
-  } else if (type === _ol_geom_GeometryType_.LINE_STRING ||
-      type === _ol_geom_GeometryType_.MULTI_LINE_STRING) {
+  } else if (type === GeometryType.LINE_STRING ||
+      type === GeometryType.MULTI_LINE_STRING) {
     mode = _ol_interaction_Draw_.Mode_.LINE_STRING;
-  } else if (type === _ol_geom_GeometryType_.POLYGON ||
-      type === _ol_geom_GeometryType_.MULTI_POLYGON) {
+  } else if (type === GeometryType.POLYGON ||
+      type === GeometryType.MULTI_POLYGON) {
     mode = _ol_interaction_Draw_.Mode_.POLYGON;
-  } else if (type === _ol_geom_GeometryType_.CIRCLE) {
+  } else if (type === GeometryType.CIRCLE) {
     mode = _ol_interaction_Draw_.Mode_.CIRCLE;
   }
   return /** @type {!ol.interaction.Draw.Mode_} */ (mode);

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -9,7 +9,7 @@ import _ol_coordinate_ from '../coordinate.js';
 import _ol_events_Event_ from '../events/Event.js';
 import {boundingExtent, getArea} from '../extent.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_geom_Polygon_ from '../geom/Polygon.js';
 import _ol_interaction_ExtentEventType_ from '../interaction/ExtentEventType.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
@@ -399,7 +399,7 @@ _ol_interaction_Extent_.prototype.createOrUpdateExtentFeature_ = function(extent
 _ol_interaction_Extent_.prototype.createOrUpdatePointerFeature_ = function(vertex) {
   var vertexFeature = this.vertexFeature_;
   if (!vertexFeature) {
-    vertexFeature = new _ol_Feature_(new _ol_geom_Point_(vertex));
+    vertexFeature = new _ol_Feature_(new Point(vertex));
     this.vertexFeature_ = vertexFeature;
     this.vertexOverlay_.getSource().addFeature(vertexFeature);
   } else {

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -8,7 +8,7 @@ import _ol_MapBrowserPointerEvent_ from '../MapBrowserPointerEvent.js';
 import _ol_coordinate_ from '../coordinate.js';
 import _ol_events_Event_ from '../events/Event.js';
 import {boundingExtent, getArea} from '../extent.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_interaction_ExtentEventType_ from '../interaction/ExtentEventType.js';
@@ -245,7 +245,7 @@ _ol_interaction_Extent_.handleUpEvent_ = function(mapBrowserEvent) {
 _ol_interaction_Extent_.getDefaultExtentStyleFunction_ = function() {
   var style = _ol_style_Style_.createDefaultEditing();
   return function(feature, resolution) {
-    return style[_ol_geom_GeometryType_.POLYGON];
+    return style[GeometryType.POLYGON];
   };
 };
 
@@ -258,7 +258,7 @@ _ol_interaction_Extent_.getDefaultExtentStyleFunction_ = function() {
 _ol_interaction_Extent_.getDefaultPointerStyleFunction_ = function() {
   var style = _ol_style_Style_.createDefaultEditing();
   return function(feature, resolution) {
-    return style[_ol_geom_GeometryType_.POINT];
+    return style[GeometryType.POINT];
   };
 };
 

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -10,7 +10,7 @@ import _ol_events_Event_ from '../events/Event.js';
 import {boundingExtent, getArea} from '../extent.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_interaction_ExtentEventType_ from '../interaction/ExtentEventType.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
 import _ol_layer_Vector_ from '../layer/Vector.js';
@@ -376,7 +376,7 @@ _ol_interaction_Extent_.prototype.createOrUpdateExtentFeature_ = function(extent
     if (!extent) {
       extentFeature = new _ol_Feature_({});
     } else {
-      extentFeature = new _ol_Feature_(_ol_geom_Polygon_.fromExtent(extent));
+      extentFeature = new _ol_Feature_(Polygon.fromExtent(extent));
     }
     this.extentFeature_ = extentFeature;
     this.extentOverlay_.getSource().addFeature(extentFeature);
@@ -384,7 +384,7 @@ _ol_interaction_Extent_.prototype.createOrUpdateExtentFeature_ = function(extent
     if (!extent) {
       extentFeature.setGeometry(undefined);
     } else {
-      extentFeature.setGeometry(_ol_geom_Polygon_.fromExtent(extent));
+      extentFeature.setGeometry(Polygon.fromExtent(extent));
     }
   }
   return extentFeature;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -15,7 +15,7 @@ import _ol_events_EventType_ from '../events/EventType.js';
 import _ol_events_condition_ from '../events/condition.js';
 import {boundingExtent, buffer, createOrUpdateFromCoordinate} from '../extent.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_interaction_ModifyEventType_ from '../interaction/ModifyEventType.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
 import _ol_layer_Vector_ from '../layer/Vector.js';
@@ -579,7 +579,7 @@ _ol_interaction_Modify_.prototype.writeGeometryCollectionGeometry_ = function(fe
 _ol_interaction_Modify_.prototype.createOrUpdateVertexFeature_ = function(coordinates) {
   var vertexFeature = this.vertexFeature_;
   if (!vertexFeature) {
-    vertexFeature = new _ol_Feature_(new _ol_geom_Point_(coordinates));
+    vertexFeature = new _ol_Feature_(new Point(coordinates));
     this.vertexFeature_ = vertexFeature;
     this.overlay_.getSource().addFeature(vertexFeature);
   } else {

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -14,7 +14,7 @@ import _ol_events_Event_ from '../events/Event.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import _ol_events_condition_ from '../events/condition.js';
 import {boundingExtent, buffer, createOrUpdateFromCoordinate} from '../extent.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
 import _ol_interaction_ModifyEventType_ from '../interaction/ModifyEventType.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
@@ -635,7 +635,7 @@ _ol_interaction_Modify_.handleDownEvent_ = function(evt) {
       if (!componentSegments[uid]) {
         componentSegments[uid] = new Array(2);
       }
-      if (segmentDataMatch.geometry.getType() === _ol_geom_GeometryType_.CIRCLE &&
+      if (segmentDataMatch.geometry.getType() === GeometryType.CIRCLE &&
       segmentDataMatch.index === _ol_interaction_Modify_.MODIFY_SEGMENT_CIRCLE_CIRCUMFERENCE_INDEX) {
 
         var closestVertex = _ol_interaction_Modify_.closestOnSegmentData_(pixelCoordinate, segmentDataMatch);
@@ -652,9 +652,9 @@ _ol_interaction_Modify_.handleDownEvent_ = function(evt) {
 
         // prevent dragging closed linestrings by the connecting node
         if ((segmentDataMatch.geometry.getType() ===
-            _ol_geom_GeometryType_.LINE_STRING ||
+            GeometryType.LINE_STRING ||
             segmentDataMatch.geometry.getType() ===
-            _ol_geom_GeometryType_.MULTI_LINE_STRING) &&
+            GeometryType.MULTI_LINE_STRING) &&
             componentSegments[uid][0] &&
             componentSegments[uid][0].index === 0) {
           continue;
@@ -702,36 +702,36 @@ _ol_interaction_Modify_.handleDragEvent_ = function(evt) {
     }
 
     switch (geometry.getType()) {
-      case _ol_geom_GeometryType_.POINT:
+      case GeometryType.POINT:
         coordinates = vertex;
         segment[0] = segment[1] = vertex;
         break;
-      case _ol_geom_GeometryType_.MULTI_POINT:
+      case GeometryType.MULTI_POINT:
         coordinates = geometry.getCoordinates();
         coordinates[segmentData.index] = vertex;
         segment[0] = segment[1] = vertex;
         break;
-      case _ol_geom_GeometryType_.LINE_STRING:
+      case GeometryType.LINE_STRING:
         coordinates = geometry.getCoordinates();
         coordinates[segmentData.index + index] = vertex;
         segment[index] = vertex;
         break;
-      case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+      case GeometryType.MULTI_LINE_STRING:
         coordinates = geometry.getCoordinates();
         coordinates[depth[0]][segmentData.index + index] = vertex;
         segment[index] = vertex;
         break;
-      case _ol_geom_GeometryType_.POLYGON:
+      case GeometryType.POLYGON:
         coordinates = geometry.getCoordinates();
         coordinates[depth[0]][segmentData.index + index] = vertex;
         segment[index] = vertex;
         break;
-      case _ol_geom_GeometryType_.MULTI_POLYGON:
+      case GeometryType.MULTI_POLYGON:
         coordinates = geometry.getCoordinates();
         coordinates[depth[1]][depth[0]][segmentData.index + index] = vertex;
         segment[index] = vertex;
         break;
-      case _ol_geom_GeometryType_.CIRCLE:
+      case GeometryType.CIRCLE:
         segment[0] = segment[1] = vertex;
         if (segmentData.index === _ol_interaction_Modify_.MODIFY_SEGMENT_CIRCLE_CENTER_INDEX) {
           this.changingFeature_ = true;
@@ -767,7 +767,7 @@ _ol_interaction_Modify_.handleUpEvent_ = function(evt) {
   for (var i = this.dragSegments_.length - 1; i >= 0; --i) {
     segmentData = this.dragSegments_[i][0];
     geometry = segmentData.geometry;
-    if (geometry.getType() === _ol_geom_GeometryType_.CIRCLE) {
+    if (geometry.getType() === GeometryType.CIRCLE) {
       // Update a circle object in the R* bush:
       var coordinates = geometry.getCenter();
       var centerSegmentData = segmentData.featureSegments[0];
@@ -865,7 +865,7 @@ _ol_interaction_Modify_.prototype.handlePointerAtPixel_ = function(pixel, map) {
     if (dist <= this.pixelTolerance_) {
       var vertexSegments = {};
 
-      if (node.geometry.getType() === _ol_geom_GeometryType_.CIRCLE &&
+      if (node.geometry.getType() === GeometryType.CIRCLE &&
       node.index === _ol_interaction_Modify_.MODIFY_SEGMENT_CIRCLE_CIRCUMFERENCE_INDEX) {
 
         this.snappedToVertex_ = true;
@@ -920,7 +920,7 @@ _ol_interaction_Modify_.prototype.handlePointerAtPixel_ = function(pixel, map) {
 _ol_interaction_Modify_.pointDistanceToSegmentDataSquared_ = function(pointCoordinates, segmentData) {
   var geometry = segmentData.geometry;
 
-  if (geometry.getType() === _ol_geom_GeometryType_.CIRCLE) {
+  if (geometry.getType() === GeometryType.CIRCLE) {
     var circleGeometry = /** @type {ol.geom.Circle} */ (geometry);
 
     if (segmentData.index === _ol_interaction_Modify_.MODIFY_SEGMENT_CIRCLE_CIRCUMFERENCE_INDEX) {
@@ -946,7 +946,7 @@ _ol_interaction_Modify_.pointDistanceToSegmentDataSquared_ = function(pointCoord
 _ol_interaction_Modify_.closestOnSegmentData_ = function(pointCoordinates, segmentData) {
   var geometry = segmentData.geometry;
 
-  if (geometry.getType() === _ol_geom_GeometryType_.CIRCLE &&
+  if (geometry.getType() === GeometryType.CIRCLE &&
   segmentData.index === _ol_interaction_Modify_.MODIFY_SEGMENT_CIRCLE_CIRCUMFERENCE_INDEX) {
     return geometry.getClosestPoint(pointCoordinates);
   }
@@ -972,19 +972,19 @@ _ol_interaction_Modify_.prototype.insertVertex_ = function(segmentData, vertex) 
   }
 
   switch (geometry.getType()) {
-    case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+    case GeometryType.MULTI_LINE_STRING:
       coordinates = geometry.getCoordinates();
       coordinates[depth[0]].splice(index + 1, 0, vertex);
       break;
-    case _ol_geom_GeometryType_.POLYGON:
+    case GeometryType.POLYGON:
       coordinates = geometry.getCoordinates();
       coordinates[depth[0]].splice(index + 1, 0, vertex);
       break;
-    case _ol_geom_GeometryType_.MULTI_POLYGON:
+    case GeometryType.MULTI_POLYGON:
       coordinates = geometry.getCoordinates();
       coordinates[depth[1]][depth[0]].splice(index + 1, 0, vertex);
       break;
-    case _ol_geom_GeometryType_.LINE_STRING:
+    case GeometryType.LINE_STRING:
       coordinates = geometry.getCoordinates();
       coordinates.splice(index + 1, 0, vertex);
       break;
@@ -1087,22 +1087,22 @@ _ol_interaction_Modify_.prototype.removeVertex_ = function() {
     component = coordinates;
     deleted = false;
     switch (geometry.getType()) {
-      case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+      case GeometryType.MULTI_LINE_STRING:
         if (coordinates[segmentData.depth[0]].length > 2) {
           coordinates[segmentData.depth[0]].splice(index, 1);
           deleted = true;
         }
         break;
-      case _ol_geom_GeometryType_.LINE_STRING:
+      case GeometryType.LINE_STRING:
         if (coordinates.length > 2) {
           coordinates.splice(index, 1);
           deleted = true;
         }
         break;
-      case _ol_geom_GeometryType_.MULTI_POLYGON:
+      case GeometryType.MULTI_POLYGON:
         component = component[segmentData.depth[1]];
         /* falls through */
-      case _ol_geom_GeometryType_.POLYGON:
+      case GeometryType.POLYGON:
         component = component[segmentData.depth[0]];
         if (component.length > 4) {
           if (index == component.length - 1) {
@@ -1195,7 +1195,7 @@ _ol_interaction_Modify_.prototype.updateSegmentIndices_ = function(
 _ol_interaction_Modify_.getDefaultStyleFunction = function() {
   var style = _ol_style_Style_.createDefaultEditing();
   return function(feature, resolution) {
-    return style[_ol_geom_GeometryType_.POINT];
+    return style[GeometryType.POINT];
   };
 };
 

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -8,7 +8,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_Event_ from '../events/Event.js';
 import _ol_events_condition_ from '../events/condition.js';
 import _ol_functions_ from '../functions.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_interaction_Interaction_ from '../interaction/Interaction.js';
 import _ol_layer_Vector_ from '../layer/Vector.js';
 import _ol_obj_ from '../obj.js';
@@ -329,10 +329,10 @@ _ol_interaction_Select_.prototype.setMap = function(map) {
  */
 _ol_interaction_Select_.getDefaultStyleFunction = function() {
   var styles = _ol_style_Style_.createDefaultEditing();
-  _ol_array_.extend(styles[_ol_geom_GeometryType_.POLYGON],
-      styles[_ol_geom_GeometryType_.LINE_STRING]);
-  _ol_array_.extend(styles[_ol_geom_GeometryType_.GEOMETRY_COLLECTION],
-      styles[_ol_geom_GeometryType_.LINE_STRING]);
+  _ol_array_.extend(styles[GeometryType.POLYGON],
+      styles[GeometryType.LINE_STRING]);
+  _ol_array_.extend(styles[GeometryType.GEOMETRY_COLLECTION],
+      styles[GeometryType.LINE_STRING]);
 
   return function(feature, resolution) {
     if (!feature.getGeometry()) {

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -10,7 +10,7 @@ import _ol_events_EventType_ from '../events/EventType.js';
 import {boundingExtent, createEmpty} from '../extent.js';
 import _ol_functions_ from '../functions.js';
 import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
 import _ol_obj_ from '../obj.js';
 import _ol_source_Vector_ from '../source/Vector.js';
@@ -435,7 +435,7 @@ _ol_interaction_Snap_.prototype.updateFeature_ = function(feature) {
  * @private
  */
 _ol_interaction_Snap_.prototype.writeCircleGeometry_ = function(feature, geometry) {
-  var polygon = _ol_geom_Polygon_.fromCircle(geometry);
+  var polygon = Polygon.fromCircle(geometry);
   var coordinates = polygon.getCoordinates()[0];
   var i, ii, segment, segmentData;
   for (i = 0, ii = coordinates.length - 1; i < ii; ++i) {

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -9,7 +9,7 @@ import _ol_events_ from '../events.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {boundingExtent, createEmpty} from '../extent.js';
 import _ol_functions_ from '../functions.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import Polygon from '../geom/Polygon.js';
 import _ol_interaction_Pointer_ from '../interaction/Pointer.js';
 import _ol_obj_ from '../obj.js';
@@ -353,7 +353,7 @@ _ol_interaction_Snap_.prototype.snapTo = function(pixel, pixelCoordinate, map) {
   if (this.vertex_ && !this.edge_) {
     segments = segments.filter(function(segment) {
       return segment.feature.getGeometry().getType() !==
-          _ol_geom_GeometryType_.CIRCLE;
+          GeometryType.CIRCLE;
     });
   }
 
@@ -367,7 +367,7 @@ _ol_interaction_Snap_.prototype.snapTo = function(pixel, pixelCoordinate, map) {
     segments.sort(this.sortByDistance_);
     var closestSegment = segments[0].segment;
     var isCircle = segments[0].feature.getGeometry().getType() ===
-        _ol_geom_GeometryType_.CIRCLE;
+        GeometryType.CIRCLE;
     if (this.vertex_ && !this.edge_) {
       pixel1 = map.getPixelFromCoordinate(closestSegment[0]);
       pixel2 = map.getPixelFromCoordinate(closestSegment[1]);

--- a/src/ol/render/Box.js
+++ b/src/ol/render/Box.js
@@ -5,7 +5,7 @@
 
 import {inherits} from '../index.js';
 import _ol_Disposable_ from '../Disposable.js';
-import _ol_geom_Polygon_ from '../geom/Polygon.js';
+import Polygon from '../geom/Polygon.js';
 
 /**
  * @constructor
@@ -118,7 +118,7 @@ _ol_render_Box_.prototype.createOrUpdateGeometry = function() {
   // close the polygon
   coordinates[4] = coordinates[0].slice();
   if (!this.geometry_) {
-    this.geometry_ = new _ol_geom_Polygon_([coordinates]);
+    this.geometry_ = new Polygon([coordinates]);
   } else {
     this.geometry_.setCoordinates([coordinates]);
   }

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -4,7 +4,7 @@
 import {nullFunction} from '../index.js';
 import _ol_array_ from '../array.js';
 import {createOrUpdateFromCoordinate, createOrUpdateFromFlatCoordinates, getCenter, getHeight} from '../extent.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_geom_flat_center_ from '../geom/flat/center.js';
 import _ol_geom_flat_interiorpoint_ from '../geom/flat/interiorpoint.js';
 import _ol_geom_flat_interpolate_ from '../geom/flat/interpolate.js';
@@ -109,7 +109,7 @@ _ol_render_Feature_.prototype.getEndss = function() {
  */
 _ol_render_Feature_.prototype.getExtent = function() {
   if (!this.extent_) {
-    this.extent_ = this.type_ === _ol_geom_GeometryType_.POINT ?
+    this.extent_ = this.type_ === GeometryType.POINT ?
       createOrUpdateFromCoordinate(this.flatCoordinates_) :
       createOrUpdateFromFlatCoordinates(
           this.flatCoordinates_, 0, this.flatCoordinates_.length, 2);

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -9,7 +9,7 @@ import {inherits} from '../../index.js';
 import _ol_array_ from '../../array.js';
 import _ol_colorlike_ from '../../colorlike.js';
 import {intersects} from '../../extent.js';
-import _ol_geom_GeometryType_ from '../../geom/GeometryType.js';
+import GeometryType from '../../geom/GeometryType.js';
 import _ol_geom_SimpleGeometry_ from '../../geom/SimpleGeometry.js';
 import _ol_geom_flat_transform_ from '../../geom/flat/transform.js';
 import _ol_has_ from '../../has.js';
@@ -460,28 +460,28 @@ _ol_render_canvas_Immediate_.prototype.setStyle = function(style) {
 _ol_render_canvas_Immediate_.prototype.drawGeometry = function(geometry) {
   var type = geometry.getType();
   switch (type) {
-    case _ol_geom_GeometryType_.POINT:
+    case GeometryType.POINT:
       this.drawPoint(/** @type {ol.geom.Point} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.LINE_STRING:
+    case GeometryType.LINE_STRING:
       this.drawLineString(/** @type {ol.geom.LineString} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.POLYGON:
+    case GeometryType.POLYGON:
       this.drawPolygon(/** @type {ol.geom.Polygon} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.MULTI_POINT:
+    case GeometryType.MULTI_POINT:
       this.drawMultiPoint(/** @type {ol.geom.MultiPoint} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+    case GeometryType.MULTI_LINE_STRING:
       this.drawMultiLineString(/** @type {ol.geom.MultiLineString} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.MULTI_POLYGON:
+    case GeometryType.MULTI_POLYGON:
       this.drawMultiPolygon(/** @type {ol.geom.MultiPolygon} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.GEOMETRY_COLLECTION:
+    case GeometryType.GEOMETRY_COLLECTION:
       this.drawGeometryCollection(/** @type {ol.geom.GeometryCollection} */ (geometry));
       break;
-    case _ol_geom_GeometryType_.CIRCLE:
+    case GeometryType.CIRCLE:
       this.drawCircle(/** @type {ol.geom.Circle} */ (geometry));
       break;
     default:

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -10,7 +10,7 @@ import _ol_array_ from '../../array.js';
 import _ol_colorlike_ from '../../colorlike.js';
 import {intersects} from '../../extent.js';
 import GeometryType from '../../geom/GeometryType.js';
-import _ol_geom_SimpleGeometry_ from '../../geom/SimpleGeometry.js';
+import SimpleGeometry from '../../geom/SimpleGeometry.js';
 import _ol_geom_flat_transform_ from '../../geom/flat/transform.js';
 import _ol_has_ from '../../has.js';
 import _ol_render_VectorContext_ from '../VectorContext.js';
@@ -412,7 +412,7 @@ _ol_render_canvas_Immediate_.prototype.drawCircle = function(geometry) {
     if (this.strokeState_) {
       this.setContextStrokeState_(this.strokeState_);
     }
-    var pixelCoordinates = _ol_geom_SimpleGeometry_.transform2D(
+    var pixelCoordinates = SimpleGeometry.transform2D(
         geometry, this.transform_, this.pixelCoordinates_);
     var dx = pixelCoordinates[2] - pixelCoordinates[0];
     var dy = pixelCoordinates[3] - pixelCoordinates[1];

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -7,7 +7,7 @@ import _ol_colorlike_ from '../../colorlike.js';
 import {buffer, clone, coordinateRelationship, createEmpty, createOrUpdate,
   createOrUpdateEmpty, extend, extendCoordinate, intersects} from '../../extent.js';
 import Relationship from '../../extent/Relationship.js';
-import _ol_geom_GeometryType_ from '../../geom/GeometryType.js';
+import GeometryType from '../../geom/GeometryType.js';
 import _ol_geom_flat_inflate_ from '../../geom/flat/inflate.js';
 import _ol_geom_flat_length_ from '../../geom/flat/length.js';
 import _ol_geom_flat_textpath_ from '../../geom/flat/textpath.js';
@@ -395,7 +395,7 @@ _ol_render_canvas_Replay_.prototype.drawCustom = function(geometry, feature, ren
   var replayBegin = this.coordinates.length;
   var flatCoordinates, replayEnd, replayEnds, replayEndss;
   var offset;
-  if (type == _ol_geom_GeometryType_.MULTI_POLYGON) {
+  if (type == GeometryType.MULTI_POLYGON) {
     geometry = /** @type {ol.geom.MultiPolygon} */ (geometry);
     flatCoordinates = geometry.getOrientedFlatCoordinates();
     replayEndss = [];
@@ -408,9 +408,9 @@ _ol_render_canvas_Replay_.prototype.drawCustom = function(geometry, feature, ren
     }
     this.instructions.push([_ol_render_canvas_Instruction_.CUSTOM,
       replayBegin, replayEndss, geometry, renderer, _ol_geom_flat_inflate_.coordinatesss]);
-  } else if (type == _ol_geom_GeometryType_.POLYGON || type == _ol_geom_GeometryType_.MULTI_LINE_STRING) {
+  } else if (type == GeometryType.POLYGON || type == GeometryType.MULTI_LINE_STRING) {
     replayEnds = [];
-    flatCoordinates = (type == _ol_geom_GeometryType_.POLYGON) ?
+    flatCoordinates = (type == GeometryType.POLYGON) ?
       /** @type {ol.geom.Polygon} */ (geometry).getOrientedFlatCoordinates() :
       geometry.getFlatCoordinates();
     offset = this.drawCustomCoordinates_(flatCoordinates, 0,
@@ -418,13 +418,13 @@ _ol_render_canvas_Replay_.prototype.drawCustom = function(geometry, feature, ren
         stride, replayEnds);
     this.instructions.push([_ol_render_canvas_Instruction_.CUSTOM,
       replayBegin, replayEnds, geometry, renderer, _ol_geom_flat_inflate_.coordinatess]);
-  } else if (type == _ol_geom_GeometryType_.LINE_STRING || type == _ol_geom_GeometryType_.MULTI_POINT) {
+  } else if (type == GeometryType.LINE_STRING || type == GeometryType.MULTI_POINT) {
     flatCoordinates = geometry.getFlatCoordinates();
     replayEnd = this.appendFlatCoordinates(
         flatCoordinates, 0, flatCoordinates.length, stride, false, false);
     this.instructions.push([_ol_render_canvas_Instruction_.CUSTOM,
       replayBegin, replayEnd, geometry, renderer, _ol_geom_flat_inflate_.coordinates]);
-  } else if (type == _ol_geom_GeometryType_.POINT) {
+  } else if (type == GeometryType.POINT) {
     flatCoordinates = geometry.getFlatCoordinates();
     this.coordinates.push(flatCoordinates[0], flatCoordinates[1]);
     replayEnd = this.coordinates.length;

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -6,7 +6,7 @@ import _ol_colorlike_ from '../../colorlike.js';
 import {createCanvasContext2D} from '../../dom.js';
 import {intersects} from '../../extent.js';
 import _ol_geom_flat_straightchunk_ from '../../geom/flat/straightchunk.js';
-import _ol_geom_GeometryType_ from '../../geom/GeometryType.js';
+import GeometryType from '../../geom/GeometryType.js';
 import _ol_has_ from '../../has.js';
 import _ol_render_canvas_ from '../canvas.js';
 import _ol_render_canvas_Instruction_ from '../canvas/Instruction.js';
@@ -183,13 +183,13 @@ _ol_render_canvas_TextReplay_.prototype.drawText = function(geometry, feature) {
     var ends;
     flatCoordinates = geometry.getFlatCoordinates();
     stride = geometry.getStride();
-    if (geometryType == _ol_geom_GeometryType_.LINE_STRING) {
+    if (geometryType == GeometryType.LINE_STRING) {
       ends = [flatCoordinates.length];
-    } else if (geometryType == _ol_geom_GeometryType_.MULTI_LINE_STRING) {
+    } else if (geometryType == GeometryType.MULTI_LINE_STRING) {
       ends = geometry.getEnds();
-    } else if (geometryType == _ol_geom_GeometryType_.POLYGON) {
+    } else if (geometryType == GeometryType.POLYGON) {
       ends = geometry.getEnds().slice(0, 1);
-    } else if (geometryType == _ol_geom_GeometryType_.MULTI_POLYGON) {
+    } else if (geometryType == GeometryType.MULTI_POLYGON) {
       var endss = geometry.getEndss();
       ends = [];
       for (i = 0, ii = endss.length; i < ii; ++i) {
@@ -223,29 +223,29 @@ _ol_render_canvas_TextReplay_.prototype.drawText = function(geometry, feature) {
     var label = this.getImage(this.text_, this.textKey_, this.fillKey_, this.strokeKey_);
     var width = label.width / this.pixelRatio;
     switch (geometryType) {
-      case _ol_geom_GeometryType_.POINT:
-      case _ol_geom_GeometryType_.MULTI_POINT:
+      case GeometryType.POINT:
+      case GeometryType.MULTI_POINT:
         flatCoordinates = geometry.getFlatCoordinates();
         end = flatCoordinates.length;
         break;
-      case _ol_geom_GeometryType_.LINE_STRING:
+      case GeometryType.LINE_STRING:
         flatCoordinates = /** @type {ol.geom.LineString} */ (geometry).getFlatMidpoint();
         break;
-      case _ol_geom_GeometryType_.CIRCLE:
+      case GeometryType.CIRCLE:
         flatCoordinates = /** @type {ol.geom.Circle} */ (geometry).getCenter();
         break;
-      case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+      case GeometryType.MULTI_LINE_STRING:
         flatCoordinates = /** @type {ol.geom.MultiLineString} */ (geometry).getFlatMidpoints();
         end = flatCoordinates.length;
         break;
-      case _ol_geom_GeometryType_.POLYGON:
+      case GeometryType.POLYGON:
         flatCoordinates = /** @type {ol.geom.Polygon} */ (geometry).getFlatInteriorPoint();
         if (!textState.overflow && flatCoordinates[2] / this.resolution < width) {
           return;
         }
         stride = 3;
         break;
-      case _ol_geom_GeometryType_.MULTI_POLYGON:
+      case GeometryType.MULTI_POLYGON:
         var interiorPoints = /** @type {ol.geom.MultiPolygon} */ (geometry).getFlatInteriorPoints();
         flatCoordinates = [];
         for (i = 0, ii = interiorPoints.length; i < ii; i += 3) {

--- a/src/ol/render/webgl/Immediate.js
+++ b/src/ol/render/webgl/Immediate.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../../index.js';
 import {intersects} from '../../extent.js';
-import _ol_geom_GeometryType_ from '../../geom/GeometryType.js';
+import GeometryType from '../../geom/GeometryType.js';
 import _ol_render_ReplayType_ from '../ReplayType.js';
 import _ol_render_VectorContext_ from '../VectorContext.js';
 import _ol_render_webgl_ReplayGroup_ from '../webgl/ReplayGroup.js';
@@ -137,28 +137,28 @@ _ol_render_webgl_Immediate_.prototype.setStyle = function(style) {
 _ol_render_webgl_Immediate_.prototype.drawGeometry = function(geometry) {
   var type = geometry.getType();
   switch (type) {
-    case _ol_geom_GeometryType_.POINT:
+    case GeometryType.POINT:
       this.drawPoint(/** @type {ol.geom.Point} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.LINE_STRING:
+    case GeometryType.LINE_STRING:
       this.drawLineString(/** @type {ol.geom.LineString} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.POLYGON:
+    case GeometryType.POLYGON:
       this.drawPolygon(/** @type {ol.geom.Polygon} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.MULTI_POINT:
+    case GeometryType.MULTI_POINT:
       this.drawMultiPoint(/** @type {ol.geom.MultiPoint} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+    case GeometryType.MULTI_LINE_STRING:
       this.drawMultiLineString(/** @type {ol.geom.MultiLineString} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.MULTI_POLYGON:
+    case GeometryType.MULTI_POLYGON:
       this.drawMultiPolygon(/** @type {ol.geom.MultiPolygon} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.GEOMETRY_COLLECTION:
+    case GeometryType.GEOMETRY_COLLECTION:
       this.drawGeometryCollection(/** @type {ol.geom.GeometryCollection} */ (geometry), null);
       break;
-    case _ol_geom_GeometryType_.CIRCLE:
+    case GeometryType.CIRCLE:
       this.drawCircle(/** @type {ol.geom.Circle} */ (geometry), null);
       break;
     default:

--- a/src/ol/render/webgl/TextReplay.js
+++ b/src/ol/render/webgl/TextReplay.js
@@ -4,7 +4,7 @@
 import {getUid, inherits} from '../../index.js';
 import _ol_colorlike_ from '../../colorlike.js';
 import {createCanvasContext2D} from '../../dom.js';
-import _ol_geom_GeometryType_ from '../../geom/GeometryType.js';
+import GeometryType from '../../geom/GeometryType.js';
 import _ol_has_ from '../../has.js';
 import _ol_render_replay_ from '../replay.js';
 import _ol_render_webgl_ from '../webgl.js';
@@ -127,26 +127,26 @@ _ol_render_webgl_TextReplay_.prototype.drawText = function(geometry, feature) {
     var end = 2;
     var stride = 2;
     switch (geometry.getType()) {
-      case _ol_geom_GeometryType_.POINT:
-      case _ol_geom_GeometryType_.MULTI_POINT:
+      case GeometryType.POINT:
+      case GeometryType.MULTI_POINT:
         flatCoordinates = geometry.getFlatCoordinates();
         end = flatCoordinates.length;
         stride = geometry.getStride();
         break;
-      case _ol_geom_GeometryType_.CIRCLE:
+      case GeometryType.CIRCLE:
         flatCoordinates = /** @type {ol.geom.Circle} */ (geometry).getCenter();
         break;
-      case _ol_geom_GeometryType_.LINE_STRING:
+      case GeometryType.LINE_STRING:
         flatCoordinates = /** @type {ol.geom.LineString} */ (geometry).getFlatMidpoint();
         break;
-      case _ol_geom_GeometryType_.MULTI_LINE_STRING:
+      case GeometryType.MULTI_LINE_STRING:
         flatCoordinates = /** @type {ol.geom.MultiLineString} */ (geometry).getFlatMidpoints();
         end = flatCoordinates.length;
         break;
-      case _ol_geom_GeometryType_.POLYGON:
+      case GeometryType.POLYGON:
         flatCoordinates = /** @type {ol.geom.Polygon} */ (geometry).getFlatInteriorPoint();
         break;
-      case _ol_geom_GeometryType_.MULTI_POLYGON:
+      case GeometryType.MULTI_POLYGON:
         flatCoordinates = /** @type {ol.geom.MultiPolygon} */ (geometry).getFlatInteriorPoints();
         end = flatCoordinates.length;
         break;

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -3,7 +3,7 @@
  */
 import {getUid} from '../index.js';
 import _ol_ImageState_ from '../ImageState.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_render_ReplayType_ from '../render/ReplayType.js';
 var _ol_renderer_vector_ = {};
 
@@ -140,7 +140,7 @@ _ol_renderer_vector_.renderFeature_ = function(
  * @private
  */
 _ol_renderer_vector_.renderGeometry_ = function(replayGroup, geometry, style, feature) {
-  if (geometry.getType() == _ol_geom_GeometryType_.GEOMETRY_COLLECTION) {
+  if (geometry.getType() == GeometryType.GEOMETRY_COLLECTION) {
     var geometries = /** @type {ol.geom.GeometryCollection} */ (geometry).getGeometries();
     for (var i = 0, ii = geometries.length; i < ii; ++i) {
       _ol_renderer_vector_.renderGeometry_(replayGroup, geometries[i], style, feature);

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -8,7 +8,7 @@ import _ol_Feature_ from '../Feature.js';
 import _ol_coordinate_ from '../coordinate.js';
 import _ol_events_EventType_ from '../events/EventType.js';
 import {buffer, createEmpty, createOrUpdateFromCoordinate} from '../extent.js';
-import _ol_geom_Point_ from '../geom/Point.js';
+import Point from '../geom/Point.js';
 import _ol_source_Vector_ from '../source/Vector.js';
 
 /**
@@ -56,7 +56,7 @@ var _ol_source_Cluster_ = function(options) {
    */
   this.geometryFunction = options.geometryFunction || function(feature) {
     var geometry = /** @type {ol.geom.Point} */ (feature.getGeometry());
-    _ol_asserts_.assert(geometry instanceof _ol_geom_Point_,
+    _ol_asserts_.assert(geometry instanceof Point,
         10); // The default `geometryFunction` can only handle `ol.geom.Point` geometries
     return geometry;
   };
@@ -192,7 +192,7 @@ _ol_source_Cluster_.prototype.createCluster = function(features) {
   }
   _ol_coordinate_.scale(centroid, 1 / features.length);
 
-  var cluster = new _ol_Feature_(new _ol_geom_Point_(centroid));
+  var cluster = new _ol_Feature_(new Point(centroid));
   cluster.set('features', features);
   return cluster;
 };

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -2,7 +2,7 @@
  * @module ol/style/Style
  */
 import _ol_asserts_ from '../asserts.js';
-import _ol_geom_GeometryType_ from '../geom/GeometryType.js';
+import GeometryType from '../geom/GeometryType.js';
 import _ol_style_Circle_ from '../style/Circle.js';
 import _ol_style_Fill_ from '../style/Fill.js';
 import _ol_style_Stroke_ from '../style/Stroke.js';
@@ -355,17 +355,17 @@ _ol_style_Style_.createDefaultEditing = function() {
   var white = [255, 255, 255, 1];
   var blue = [0, 153, 255, 1];
   var width = 3;
-  styles[_ol_geom_GeometryType_.POLYGON] = [
+  styles[GeometryType.POLYGON] = [
     new _ol_style_Style_({
       fill: new _ol_style_Fill_({
         color: [255, 255, 255, 0.5]
       })
     })
   ];
-  styles[_ol_geom_GeometryType_.MULTI_POLYGON] =
-      styles[_ol_geom_GeometryType_.POLYGON];
+  styles[GeometryType.MULTI_POLYGON] =
+      styles[GeometryType.POLYGON];
 
-  styles[_ol_geom_GeometryType_.LINE_STRING] = [
+  styles[GeometryType.LINE_STRING] = [
     new _ol_style_Style_({
       stroke: new _ol_style_Stroke_({
         color: white,
@@ -379,16 +379,16 @@ _ol_style_Style_.createDefaultEditing = function() {
       })
     })
   ];
-  styles[_ol_geom_GeometryType_.MULTI_LINE_STRING] =
-      styles[_ol_geom_GeometryType_.LINE_STRING];
+  styles[GeometryType.MULTI_LINE_STRING] =
+      styles[GeometryType.LINE_STRING];
 
-  styles[_ol_geom_GeometryType_.CIRCLE] =
-      styles[_ol_geom_GeometryType_.POLYGON].concat(
-          styles[_ol_geom_GeometryType_.LINE_STRING]
+  styles[GeometryType.CIRCLE] =
+      styles[GeometryType.POLYGON].concat(
+          styles[GeometryType.LINE_STRING]
       );
 
 
-  styles[_ol_geom_GeometryType_.POINT] = [
+  styles[GeometryType.POINT] = [
     new _ol_style_Style_({
       image: new _ol_style_Circle_({
         radius: width * 2,
@@ -403,13 +403,13 @@ _ol_style_Style_.createDefaultEditing = function() {
       zIndex: Infinity
     })
   ];
-  styles[_ol_geom_GeometryType_.MULTI_POINT] =
-      styles[_ol_geom_GeometryType_.POINT];
+  styles[GeometryType.MULTI_POINT] =
+      styles[GeometryType.POINT];
 
-  styles[_ol_geom_GeometryType_.GEOMETRY_COLLECTION] =
-      styles[_ol_geom_GeometryType_.POLYGON].concat(
-          styles[_ol_geom_GeometryType_.LINE_STRING],
-          styles[_ol_geom_GeometryType_.POINT]
+  styles[GeometryType.GEOMETRY_COLLECTION] =
+      styles[GeometryType.POLYGON].concat(
+          styles[GeometryType.LINE_STRING],
+          styles[GeometryType.POINT]
       );
 
   return styles;

--- a/test/rendering/ol/layer/clip.test.js
+++ b/test/rendering/ol/layer/clip.test.js
@@ -1,6 +1,6 @@
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_layer_Tile_ from '../../../../src/ol/layer/Tile.js';
 import _ol_source_XYZ_ from '../../../../src/ol/source/XYZ.js';
 import _ol_style_Stroke_ from '../../../../src/ol/style/Stroke.js';
@@ -64,7 +64,7 @@ describe('layer clipping', function() {
         source: source
       });
 
-      var geometry = new _ol_geom_MultiPolygon_([
+      var geometry = new MultiPolygon([
         [[[-80, -40], [-40, 0], [-80, 40], [-120, 0], [-80, -40]]],
         [[[80, -40], [120, 0], [80, 40], [40, 0], [80, -40]]]
       ]).transform('EPSG:4326', 'EPSG:3857');

--- a/test/rendering/ol/layer/tile.test.js
+++ b/test/rendering/ol/layer/tile.test.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../../../../src/ol/layer/Tile.js';
 import _ol_obj_ from '../../../../src/ol/obj.js';
 import {transform} from '../../../../src/ol/proj.js';
@@ -284,7 +284,7 @@ describe('ol.rendering.layer.Tile', function() {
             fill: new _ol_style_Fill_({color: 'yellow'}),
             stroke: new _ol_style_Stroke_({color: 'red', width: 1})
           }));
-          e.vectorContext.drawPoint(new _ol_geom_Point_(
+          e.vectorContext.drawPoint(new Point(
               transform([-123, 38], 'EPSG:4326', 'EPSG:3857')));
         });
       };

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -58,7 +58,7 @@ describe('ol.rendering.layer.Vector', function() {
   }
 
   function addLineString(r) {
-    source.addFeature(new _ol_Feature_(new _ol_geom_LineString_([
+    source.addFeature(new _ol_Feature_(new LineString([
       [center[0] - r, center[1] - r],
       [center[0] + r, center[1] - r],
       [center[0] + r, center[1] + r],
@@ -75,7 +75,7 @@ describe('ol.rendering.layer.Vector', function() {
 
     it('renders opacity correctly with the canvas renderer', function(done) {
       createMap('canvas');
-      var smallLine = new _ol_Feature_(new _ol_geom_LineString_([
+      var smallLine = new _ol_Feature_(new LineString([
         [center[0], center[1] - 1],
         [center[0], center[1] + 1]
       ]));
@@ -101,7 +101,7 @@ describe('ol.rendering.layer.Vector', function() {
 
     it('renders opacity correctly with renderMode: \'image\'', function(done) {
       createMap('canvas');
-      var smallLine = new _ol_Feature_(new _ol_geom_LineString_([
+      var smallLine = new _ol_Feature_(new LineString([
         [center[0], center[1] - 1],
         [center[0], center[1] + 1]
       ]));
@@ -128,7 +128,7 @@ describe('ol.rendering.layer.Vector', function() {
 
     it('renders transparent layers correctly with the canvas renderer', function(done) {
       createMap('canvas');
-      var smallLine = new _ol_Feature_(new _ol_geom_LineString_([
+      var smallLine = new _ol_Feature_(new LineString([
         [center[0], center[1] - 1],
         [center[0], center[1] + 1]
       ]));
@@ -141,7 +141,7 @@ describe('ol.rendering.layer.Vector', function() {
         })
       ]);
       source.addFeature(smallLine);
-      var smallLine2 = new _ol_Feature_(new _ol_geom_LineString_([
+      var smallLine2 = new _ol_Feature_(new LineString([
         [center[0], center[1] - 1000],
         [center[0], center[1] + 1000]
       ]));
@@ -167,7 +167,7 @@ describe('ol.rendering.layer.Vector', function() {
 
     it('renders transparent layers correctly with renderMode: \'image\'', function(done) {
       createMap('canvas');
-      var smallLine = new _ol_Feature_(new _ol_geom_LineString_([
+      var smallLine = new _ol_Feature_(new LineString([
         [center[0], center[1] - 1],
         [center[0], center[1] + 1]
       ]));
@@ -180,7 +180,7 @@ describe('ol.rendering.layer.Vector', function() {
         })
       ]);
       source.addFeature(smallLine);
-      var smallLine2 = new _ol_Feature_(new _ol_geom_LineString_([
+      var smallLine2 = new _ol_Feature_(new LineString([
         [center[0], center[1] - 1000],
         [center[0], center[1] + 1000]
       ]));
@@ -881,7 +881,7 @@ describe('ol.rendering.layer.Vector', function() {
           })
         })
       }));
-      var line = new _ol_Feature_(new _ol_geom_LineString_([
+      var line = new _ol_Feature_(new LineString([
         [center[0] - 650, center[1] - 200],
         [center[0] + 650, center[1] - 200]
       ]));
@@ -924,7 +924,7 @@ describe('ol.rendering.layer.Vector', function() {
           })
         })
       }));
-      var line = new _ol_Feature_(new _ol_geom_LineString_([
+      var line = new _ol_Feature_(new LineString([
         [center[0] - 650, center[1] - 200],
         [center[0] + 650, center[1] - 200]
       ]));
@@ -968,7 +968,7 @@ describe('ol.rendering.layer.Vector', function() {
           })
         })
       }));
-      var line = new _ol_Feature_(new _ol_geom_LineString_([
+      var line = new _ol_Feature_(new LineString([
         [center[0] - 650, center[1] - 200],
         [center[0] + 650, center[1] - 200]
       ]));

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -4,7 +4,7 @@ import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../../../../src/ol/source/Vector.js';
@@ -590,16 +590,16 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       var centerFeature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center),
+        geometry: new Point(center),
         text: 'center'
       });
       source.addFeature(centerFeature);
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]]),
+        geometry: new Point([center[0] - 540, center[1]]),
         text: 'west'
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]]),
+        geometry: new Point([center[0] + 540, center[1]]),
         text: 'east'
       }));
 
@@ -631,16 +631,16 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       var centerFeature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center),
+        geometry: new Point(center),
         text: 'center'
       });
       source.addFeature(centerFeature);
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]]),
+        geometry: new Point([center[0] - 540, center[1]]),
         text: 'west'
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]]),
+        geometry: new Point([center[0] + 540, center[1]]),
         text: 'east'
       }));
 
@@ -671,17 +671,17 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center),
+        geometry: new Point(center),
         text: 'center',
         zIndex: 2
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]]),
+        geometry: new Point([center[0] - 540, center[1]]),
         text: 'west',
         zIndex: 3
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]]),
+        geometry: new Point([center[0] + 540, center[1]]),
         text: 'east',
         zIndex: 1
       }));
@@ -711,14 +711,14 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       var centerFeature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center)
+        geometry: new Point(center)
       });
       source.addFeature(centerFeature);
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]])
+        geometry: new Point([center[0] - 540, center[1]])
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]])
+        geometry: new Point([center[0] + 540, center[1]])
       }));
 
       layer.setDeclutter(true);
@@ -751,14 +751,14 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       var centerFeature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center)
+        geometry: new Point(center)
       });
       source.addFeature(centerFeature);
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]])
+        geometry: new Point([center[0] - 540, center[1]])
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]])
+        geometry: new Point([center[0] + 540, center[1]])
       }));
 
       layer.setDeclutter(true);
@@ -790,15 +790,15 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center),
+        geometry: new Point(center),
         zIndex: 2
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]]),
+        geometry: new Point([center[0] - 540, center[1]]),
         zIndex: 3
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]]),
+        geometry: new Point([center[0] + 540, center[1]]),
         zIndex: 1
       }));
 
@@ -829,15 +829,15 @@ describe('ol.rendering.layer.Vector', function() {
       map.addLayer(layer);
 
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_(center),
+        geometry: new Point(center),
         text: 'center'
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] - 540, center[1]]),
+        geometry: new Point([center[0] - 540, center[1]]),
         text: 'west'
       }));
       source.addFeature(new _ol_Feature_({
-        geometry: new _ol_geom_Point_([center[0] + 540, center[1]]),
+        geometry: new Point([center[0] + 540, center[1]]),
         text: 'east'
       }));
 
@@ -872,7 +872,7 @@ describe('ol.rendering.layer.Vector', function() {
       });
       map.addLayer(layer);
 
-      var point = new _ol_Feature_(new _ol_geom_Point_(center));
+      var point = new _ol_Feature_(new Point(center));
       point.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
           radius: 8,
@@ -915,7 +915,7 @@ describe('ol.rendering.layer.Vector', function() {
       });
       map.addLayer(layer);
 
-      var point = new _ol_Feature_(new _ol_geom_Point_(center));
+      var point = new _ol_Feature_(new Point(center));
       point.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
           radius: 8,
@@ -958,7 +958,7 @@ describe('ol.rendering.layer.Vector', function() {
       });
       map.addLayer(layer);
 
-      var point = new _ol_Feature_(new _ol_geom_Point_(center));
+      var point = new _ol_Feature_(new Point(center));
       point.setStyle(new _ol_style_Style_({
         zIndex: 2,
         image: new _ol_style_Circle_({

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -5,7 +5,7 @@ import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_source_Vector_ from '../../../../src/ol/source/Vector.js';
 import _ol_style_Circle_ from '../../../../src/ol/style/Circle.js';
@@ -46,7 +46,7 @@ describe('ol.rendering.layer.Vector', function() {
   }
 
   function addPolygon(r) {
-    source.addFeature(new _ol_Feature_(new _ol_geom_Polygon_([
+    source.addFeature(new _ol_Feature_(new Polygon([
       [
         [center[0] - r, center[1] - r],
         [center[0] + r, center[1] - r],
@@ -494,14 +494,14 @@ describe('ol.rendering.layer.Vector', function() {
     beforeEach(function() {
       var src = new _ol_source_Vector_({
         features: [
-          new _ol_Feature_(new _ol_geom_Polygon_([[
+          new _ol_Feature_(new Polygon([[
             [-22, 58],
             [-22, 78],
             [-9, 78],
             [-9, 58],
             [-22, 58]
           ]])),
-          new _ol_Feature_(new _ol_geom_Polygon_([[
+          new _ol_Feature_(new Polygon([[
             [-9, 58],
             [-9, 78],
             [4, 78],

--- a/test/rendering/ol/layer/vector.test.js
+++ b/test/rendering/ol/layer/vector.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
@@ -42,7 +42,7 @@ describe('ol.rendering.layer.Vector', function() {
   var source;
 
   function addCircle(r) {
-    source.addFeature(new _ol_Feature_(new _ol_geom_Circle_(center, r)));
+    source.addFeature(new _ol_Feature_(new Circle(center, r)));
   }
 
   function addPolygon(r) {

--- a/test/rendering/ol/layer/vectortile.test.js
+++ b/test/rendering/ol/layer/vectortile.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_format_MVT_ from '../../../../src/ol/format/MVT.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_layer_VectorTile_ from '../../../../src/ol/layer/VectorTile.js';
 import _ol_obj_ from '../../../../src/ol/obj.js';
@@ -98,7 +98,7 @@ describe('ol.rendering.layer.VectorTile', function() {
       createMap('canvas');
       var vectorSource = new _ol_source_Vector_({
         features: [
-          new _ol_Feature_(new _ol_geom_Point_([1825727.7316762917, 6143091.089223046]))
+          new _ol_Feature_(new Point([1825727.7316762917, 6143091.089223046]))
         ]
       });
       map.addLayer(new _ol_layer_Vector_({

--- a/test/rendering/ol/map.test.js
+++ b/test/rendering/ol/map.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../src/ol/geom/Point.js';
+import Point from '../../../src/ol/geom/Point.js';
 import _ol_Map_ from '../../../src/ol/Map.js';
 import _ol_View_ from '../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../src/ol/layer/Vector.js';
@@ -13,7 +13,7 @@ describe('ol.rendering.Map', function() {
     var vectorLayer = new _ol_layer_Vector_({
       source: new _ol_source_Vector_({
         features: [new _ol_Feature_({
-          geometry: new _ol_geom_Point_([0, 0])
+          geometry: new Point([0, 0])
         })]
       })
     });

--- a/test/rendering/ol/render.test.js
+++ b/test/rendering/ol/render.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
+import LineString from '../../../src/ol/geom/LineString.js';
 import Point from '../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../src/ol/geom/Polygon.js';
 import _ol_render_ from '../../../src/ol/render.js';
@@ -65,7 +65,7 @@ describe('ol.render', function() {
       });
 
       vectorContext.setStyle(style);
-      vectorContext.drawGeometry(new _ol_geom_LineString_([
+      vectorContext.drawGeometry(new LineString([
         [10, 60], [30, 40], [50, 60], [70, 40], [90, 60]
       ]));
 
@@ -90,7 +90,7 @@ describe('ol.render', function() {
       });
 
       vectorContext.setStyle(style);
-      vectorContext.drawGeometry(new _ol_geom_LineString_([
+      vectorContext.drawGeometry(new LineString([
         [10, 60], [30, 40], [50, 60], [70, 40], [90, 60]
       ]));
 
@@ -115,7 +115,7 @@ describe('ol.render', function() {
       });
 
       vectorContext.setStyle(style);
-      vectorContext.drawGeometry(new _ol_geom_LineString_([
+      vectorContext.drawGeometry(new LineString([
         [10, 60], [30, 40], [50, 60], [70, 40], [90, 60]
       ]));
 

--- a/test/rendering/ol/render.test.js
+++ b/test/rendering/ol/render.test.js
@@ -1,6 +1,6 @@
 import LineString from '../../../src/ol/geom/LineString.js';
 import Point from '../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../src/ol/geom/Polygon.js';
 import _ol_render_ from '../../../src/ol/render.js';
 import _ol_render_VectorContext_ from '../../../src/ol/render/VectorContext.js';
 import _ol_render_canvas_Immediate_ from '../../../src/ol/render/canvas/Immediate.js';
@@ -143,7 +143,7 @@ describe('ol.render', function() {
 
       vectorContext.setStyle(style);
 
-      vectorContext.drawGeometry(new _ol_geom_Polygon_([
+      vectorContext.drawGeometry(new Polygon([
         [[25, 25], [75, 25], [75, 75], [25, 75], [25, 25]],
         [[40, 40], [40, 60], [60, 60], [60, 40], [40, 40]]
       ]));
@@ -168,7 +168,7 @@ describe('ol.render', function() {
 
       vectorContext.setStyle(style);
 
-      vectorContext.drawGeometry(new _ol_geom_Polygon_([
+      vectorContext.drawGeometry(new Polygon([
         [[25, 25], [75, 25], [75, 75], [25, 75], [25, 25]],
         [[40, 40], [40, 60], [60, 60], [60, 40], [40, 40]]
       ]));
@@ -194,7 +194,7 @@ describe('ol.render', function() {
 
       vectorContext.setStyle(style);
 
-      vectorContext.drawGeometry(new _ol_geom_Polygon_([
+      vectorContext.drawGeometry(new Polygon([
         [[25, 25], [75, 25], [75, 75], [25, 75], [25, 25]],
         [[40, 40], [40, 60], [60, 60], [60, 40], [40, 40]]
       ]));

--- a/test/rendering/ol/render.test.js
+++ b/test/rendering/ol/render.test.js
@@ -1,5 +1,5 @@
 import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../src/ol/geom/Point.js';
+import Point from '../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../src/ol/geom/Polygon.js';
 import _ol_render_ from '../../../src/ol/render.js';
 import _ol_render_VectorContext_ from '../../../src/ol/render/VectorContext.js';
@@ -43,7 +43,7 @@ describe('ol.render', function() {
       });
 
       vectorContext.setStyle(style);
-      vectorContext.drawGeometry(new _ol_geom_Point_([50, 50]));
+      vectorContext.drawGeometry(new Point([50, 50]));
 
       resembleCanvas(context.canvas,
           'rendering/ol/expected/render-point.png', IMAGE_TOLERANCE, done);

--- a/test/rendering/ol/style/circle.test.js
+++ b/test/rendering/ol/style/circle.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -46,7 +46,7 @@ describe('ol.rendering.style.Circle', function() {
     function createFeatures(multi) {
       var feature;
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-20, 18]]) : new Point([-20, 18])
+        geometry: multi ? new MultiPoint([[-20, 18]]) : new Point([-20, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -59,7 +59,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-10, 18]]) : new Point([-10, 18])
+        geometry: multi ? new MultiPoint([[-10, 18]]) : new Point([-10, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -72,7 +72,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[4, 18]]) : new Point([4, 18])
+        geometry: multi ? new MultiPoint([[4, 18]]) : new Point([4, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -85,7 +85,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-20, 3]]) : new Point([-20, 3])
+        geometry: multi ? new MultiPoint([[-20, 3]]) : new Point([-20, 3])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -102,7 +102,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-10, 3]]) : new Point([-10, 3])
+        geometry: multi ? new MultiPoint([[-10, 3]]) : new Point([-10, 3])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -119,7 +119,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[4, 3]]) : new Point([4, 3])
+        geometry: multi ? new MultiPoint([[4, 3]]) : new Point([4, 3])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -136,7 +136,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-20, -15]]) : new Point([-20, -15])
+        geometry: multi ? new MultiPoint([[-20, -15]]) : new Point([-20, -15])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -150,7 +150,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-10, -15]]) : new Point([-10, -15])
+        geometry: multi ? new MultiPoint([[-10, -15]]) : new Point([-10, -15])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -167,7 +167,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[4, -15]]) : new Point([4, -15])
+        geometry: multi ? new MultiPoint([[4, -15]]) : new Point([4, -15])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({

--- a/test/rendering/ol/style/circle.test.js
+++ b/test/rendering/ol/style/circle.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
@@ -46,7 +46,7 @@ describe('ol.rendering.style.Circle', function() {
     function createFeatures(multi) {
       var feature;
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-20, 18]]) : new _ol_geom_Point_([-20, 18])
+        geometry: multi ? new _ol_geom_MultiPoint_([[-20, 18]]) : new Point([-20, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -59,7 +59,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-10, 18]]) : new _ol_geom_Point_([-10, 18])
+        geometry: multi ? new _ol_geom_MultiPoint_([[-10, 18]]) : new Point([-10, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -72,7 +72,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[4, 18]]) : new _ol_geom_Point_([4, 18])
+        geometry: multi ? new _ol_geom_MultiPoint_([[4, 18]]) : new Point([4, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -85,7 +85,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-20, 3]]) : new _ol_geom_Point_([-20, 3])
+        geometry: multi ? new _ol_geom_MultiPoint_([[-20, 3]]) : new Point([-20, 3])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -102,7 +102,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-10, 3]]) : new _ol_geom_Point_([-10, 3])
+        geometry: multi ? new _ol_geom_MultiPoint_([[-10, 3]]) : new Point([-10, 3])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -119,7 +119,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[4, 3]]) : new _ol_geom_Point_([4, 3])
+        geometry: multi ? new _ol_geom_MultiPoint_([[4, 3]]) : new Point([4, 3])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -136,7 +136,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-20, -15]]) : new _ol_geom_Point_([-20, -15])
+        geometry: multi ? new _ol_geom_MultiPoint_([[-20, -15]]) : new Point([-20, -15])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -150,7 +150,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[-10, -15]]) : new _ol_geom_Point_([-10, -15])
+        geometry: multi ? new _ol_geom_MultiPoint_([[-10, -15]]) : new Point([-10, -15])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({
@@ -167,7 +167,7 @@ describe('ol.rendering.style.Circle', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: multi ? new _ol_geom_MultiPoint_([[4, -15]]) : new _ol_geom_Point_([4, -15])
+        geometry: multi ? new _ol_geom_MultiPoint_([[4, -15]]) : new Point([4, -15])
       });
       feature.setStyle(new _ol_style_Style_({
         image: new _ol_style_Circle_({

--- a/test/rendering/ol/style/icon.test.js
+++ b/test/rendering/ol/style/icon.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -52,7 +52,7 @@ describe('ol.rendering.style.Icon', function() {
     function createFeatures(src, imgInfo, callback) {
       var feature;
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([0, 0])
+        geometry: new Point([0, 0])
       });
 
       var img = new Image();

--- a/test/rendering/ol/style/linestring.test.js
+++ b/test/rendering/ol/style/linestring.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -44,7 +44,7 @@ describe('ol.rendering.style.LineString', function() {
       var feature;
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[-20, 20], [15, 20]]
         )
       });
@@ -54,7 +54,7 @@ describe('ol.rendering.style.LineString', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[-20, 15], [15, 15]]
         )
       });
@@ -64,7 +64,7 @@ describe('ol.rendering.style.LineString', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[-20, 10], [15, 10]]
         )
       });
@@ -76,7 +76,7 @@ describe('ol.rendering.style.LineString', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[-20, -20], [-2, 0], [15, -20]]
         )
       });
@@ -92,7 +92,7 @@ describe('ol.rendering.style.LineString', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[-20, -15], [-2, 5], [15, -15]]
         )
       });

--- a/test/rendering/ol/style/polygon.test.js
+++ b/test/rendering/ol/style/polygon.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -49,7 +49,7 @@ describe('ol.rendering.style.Polygon', function() {
       var feature;
       // rectangle
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, 10], [-20, 20], [-5, 20], [-5, 10], [-20, 10]]
         ])
       });
@@ -60,7 +60,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with 1 hole
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[0, 10], [0, 20], [15, 20], [15, 10], [0, 10]],
           [[5, 13], [10, 13], [10, 17], [5, 17], [5, 13]]
 
@@ -73,7 +73,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with 2 holes
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, -20], [-20, 5], [15, 5], [15, -20], [-20, -20]],
           [[-18, -18], [-12, -18], [-12, -12], [-18, -12], [-18, -18]],
           [[5, -18], [12, -18], [12, -12], [5, -12], [5, -18]]
@@ -114,7 +114,7 @@ describe('ol.rendering.style.Polygon', function() {
       var feature;
       // rectangle
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, 10], [-20, 20], [-5, 20], [-5, 10], [-20, 10]]
         ])
       });
@@ -125,7 +125,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with 1 hole
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[0, 10], [0, 20], [20, 20], [20, 10], [0, 10]],
           [[5, 13], [10, 13], [10, 17], [5, 17], [5, 13]]
 
@@ -138,7 +138,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with 2 holes
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, -20], [-20, 5], [20, 5], [20, -20], [-20, -20]],
           [[-12, -3], [-12, -12], [-8, -12], [-8, -3], [-12, -3]],
           [[0, -12], [13, -12], [13, -3], [0, -3], [0, -12]]
@@ -174,7 +174,7 @@ describe('ol.rendering.style.Polygon', function() {
       var feature;
       // rectangle with z-index 2
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, 10], [-20, 20], [-0, 20], [-0, 10], [-20, 10]]
         ])
       });
@@ -186,7 +186,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with z-index 3
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-15, 5], [-15, 15], [5, 15], [5, 5], [-15, 5]]
         ])
       });
@@ -198,7 +198,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with z-index 1
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-10, 0], [-10, 10], [10, 10], [10, 0], [-10, 0]]
         ])
       });
@@ -231,7 +231,7 @@ describe('ol.rendering.style.Polygon', function() {
       var feature;
       // rectangle
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, 10], [-20, 20], [-5, 20], [-5, 10], [-20, 10]]
         ])
       });
@@ -243,7 +243,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with 1 hole
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[0, 10], [0, 20], [15, 20], [15, 10], [0, 10]]
         ])
       });
@@ -255,7 +255,7 @@ describe('ol.rendering.style.Polygon', function() {
 
       // rectangle with 2 holes
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, -20], [-20, 5], [15, 5], [15, -20], [-20, -20]]
         ])
       });
@@ -317,7 +317,7 @@ describe('ol.rendering.style.Polygon', function() {
 
     function createFeatures() {
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[-20, -20], [-20, 20], [18, 20], [-20, -20]]
         ])
       });

--- a/test/rendering/ol/style/regularshape.test.js
+++ b/test/rendering/ol/style/regularshape.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -43,7 +43,7 @@ describe('ol.rendering.style.RegularShape', function() {
   function createFeatures(stroke, fill) {
     var feature;
     feature = new _ol_Feature_({
-      geometry: new _ol_geom_Point_([-15, 15])
+      geometry: new Point([-15, 15])
     });
     // square
     feature.setStyle(new _ol_style_Style_({
@@ -58,7 +58,7 @@ describe('ol.rendering.style.RegularShape', function() {
     vectorSource.addFeature(feature);
 
     feature = new _ol_Feature_({
-      geometry: new _ol_geom_Point_([8, 15])
+      geometry: new Point([8, 15])
     });
     // triangle
     feature.setStyle(new _ol_style_Style_({
@@ -74,7 +74,7 @@ describe('ol.rendering.style.RegularShape', function() {
     vectorSource.addFeature(feature);
 
     feature = new _ol_Feature_({
-      geometry: new _ol_geom_Point_([-10, -8])
+      geometry: new Point([-10, -8])
     });
     // star
     feature.setStyle(new _ol_style_Style_({
@@ -90,7 +90,7 @@ describe('ol.rendering.style.RegularShape', function() {
     vectorSource.addFeature(feature);
 
     feature = new _ol_Feature_({
-      geometry: new _ol_geom_Point_([12, -8])
+      geometry: new Point([12, -8])
     });
     // cross
     feature.setStyle(new _ol_style_Style_({

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -3,7 +3,7 @@ import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -287,7 +287,7 @@ describe('ol.rendering.style.Text', function() {
 
     it('renders text along a Polygon', function(done) {
       createMap('canvas');
-      var geom = new _ol_geom_Polygon_(null);
+      var geom = new Polygon(null);
       geom.setFlatCoordinates('XY', polygon, [polygon.length]);
       var feature = new _ol_Feature_(geom);
       feature.setStyle(new _ol_style_Style_({
@@ -305,7 +305,7 @@ describe('ol.rendering.style.Text', function() {
 
     it('renders text along a MultiPolygon', function(done) {
       createMap('canvas');
-      var geom = new _ol_geom_Polygon_(null);
+      var geom = new Polygon(null);
       geom.setFlatCoordinates('XY', polygon, [polygon.length]);
       var multiPolygon = new _ol_geom_MultiPolygon_(null);
       multiPolygon.appendPolygon(geom);

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
@@ -307,7 +307,7 @@ describe('ol.rendering.style.Text', function() {
       createMap('canvas');
       var geom = new Polygon(null);
       geom.setFlatCoordinates('XY', polygon, [polygon.length]);
-      var multiPolygon = new _ol_geom_MultiPolygon_(null);
+      var multiPolygon = new MultiPolygon(null);
       multiPolygon.appendPolygon(geom);
       geom = geom.clone();
       geom.translate(0, 30);

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
@@ -50,7 +50,7 @@ describe('ol.rendering.style.Text', function() {
       var scale = opt_scale || 1;
       var feature;
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([-20, 18])
+        geometry: new Point([-20, 18])
       });
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
@@ -62,7 +62,7 @@ describe('ol.rendering.style.Text', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([-10, 0])
+        geometry: new Point([-10, 0])
       });
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
@@ -81,7 +81,7 @@ describe('ol.rendering.style.Text', function() {
       vectorSource.addFeature(feature);
 
       feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([20, 10])
+        geometry: new Point([20, 10])
       });
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
@@ -175,7 +175,7 @@ describe('ol.rendering.style.Text', function() {
     it('renders multiline text with alignment options', function(done) {
       createMap('canvas');
       var feature;
-      feature = new _ol_Feature_(new _ol_geom_Point_([25, 0]));
+      feature = new _ol_Feature_(new Point([25, 0]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'Hello world\nleft',
@@ -184,7 +184,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      feature = new _ol_Feature_(new _ol_geom_Point_([-25, 0]));
+      feature = new _ol_Feature_(new Point([-25, 0]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'Hello world\nright',
@@ -193,7 +193,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      feature = new _ol_Feature_(new _ol_geom_Point_([0, 25]));
+      feature = new _ol_Feature_(new Point([0, 25]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'Hello world\nbottom',
@@ -202,7 +202,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      feature = new _ol_Feature_(new _ol_geom_Point_([0, -25]));
+      feature = new _ol_Feature_(new Point([0, -25]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'top\nHello world',
@@ -217,7 +217,7 @@ describe('ol.rendering.style.Text', function() {
     it('renders multiline text with positioning options', function(done) {
       createMap('canvas');
       var feature;
-      feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      feature = new _ol_Feature_(new Point([0, 0]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'Hello world\nleft',
@@ -227,7 +227,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      feature = new _ol_Feature_(new Point([0, 0]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'Hello world\nright',
@@ -237,7 +237,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      feature = new _ol_Feature_(new Point([0, 0]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'Hello world\nbottom',
@@ -247,7 +247,7 @@ describe('ol.rendering.style.Text', function() {
         })
       }));
       vectorSource.addFeature(feature);
-      feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      feature = new _ol_Feature_(new Point([0, 0]));
       feature.setStyle(new _ol_style_Style_({
         text: new _ol_style_Text_({
           text: 'top\nHello world',

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -105,7 +105,7 @@ describe('ol.rendering.style.Text', function() {
     var polygon = [151, 17, 163, 22, 159, 30, 150, 30, 143, 24, 151, 17];
 
     function createLineString(coords, textAlign, maxAngle, strokeColor, strokeWidth, scale) {
-      var geom = new _ol_geom_LineString_();
+      var geom = new LineString();
       geom.setFlatCoordinates('XY', coords);
       var style = new _ol_style_Style_({
         stroke: new _ol_style_Stroke_({
@@ -262,7 +262,7 @@ describe('ol.rendering.style.Text', function() {
 
     it('renders text along a MultiLineString', function(done) {
       createMap('canvas');
-      var line = new _ol_geom_LineString_();
+      var line = new LineString();
       line.setFlatCoordinates('XY', nicePath);
       var geom = new _ol_geom_MultiLineString_(null);
       geom.appendLineString(line);

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -264,7 +264,7 @@ describe('ol.rendering.style.Text', function() {
       createMap('canvas');
       var line = new LineString();
       line.setFlatCoordinates('XY', nicePath);
-      var geom = new _ol_geom_MultiLineString_(null);
+      var geom = new MultiLineString(null);
       geom.appendLineString(line);
       line = line.clone();
       line.translate(0, 50);

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -1,5 +1,5 @@
 import _ol_coordinate_ from '../../../src/ol/coordinate.js';
-import _ol_geom_Circle_ from '../../../src/ol/geom/Circle.js';
+import Circle from '../../../src/ol/geom/Circle.js';
 
 
 describe('ol.coordinate', function() {
@@ -90,7 +90,7 @@ describe('ol.coordinate', function() {
 
   describe('#closestOnCircle', function() {
     var center = [5, 10];
-    var circle = new _ol_geom_Circle_(center, 10);
+    var circle = new Circle(center, 10);
     it('can find the closest point on circle', function() {
       expect(_ol_coordinate_.closestOnCircle([-20, 10], circle))
           .to.eql([-5, 10]);

--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../src/ol/geom/Point.js';
+import Point from '../../../src/ol/geom/Point.js';
 import _ol_obj_ from '../../../src/ol/obj.js';
 import _ol_style_Style_ from '../../../src/ol/style/Style.js';
 
@@ -28,11 +28,11 @@ describe('ol.Feature', function() {
 
     it('will set the default geometry', function() {
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([10, 20]),
+        geometry: new Point([10, 20]),
         foo: 'bar'
       });
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Point_);
+      expect(geometry).to.be.a(Point);
       expect(feature.get('geometry')).to.be(geometry);
     });
 
@@ -65,7 +65,7 @@ describe('ol.Feature', function() {
   describe('#getProperties()', function() {
 
     it('returns an object with all attributes', function() {
-      var point = new _ol_geom_Point_([15, 30]);
+      var point = new Point([15, 30]);
       var feature = new _ol_Feature_({
         foo: 'bar',
         ten: 10,
@@ -93,7 +93,7 @@ describe('ol.Feature', function() {
 
   describe('#getGeometry()', function() {
 
-    var point = new _ol_geom_Point_([15, 30]);
+    var point = new Point([15, 30]);
 
     it('returns undefined for unset geometry', function() {
       var feature = new _ol_Feature_();
@@ -123,7 +123,7 @@ describe('ol.Feature', function() {
       feature.setGeometry(point);
       expect(feature.getGeometry()).to.be(point);
 
-      var point2 = new _ol_geom_Point_([1, 2]);
+      var point2 = new Point([1, 2]);
       feature.setGeometry(point2);
       expect(feature.getGeometry()).to.be(point2);
     });
@@ -142,9 +142,9 @@ describe('ol.Feature', function() {
     });
 
     it('can be used to set the geometry', function() {
-      var point = new _ol_geom_Point_([3, 4]);
+      var point = new Point([3, 4]);
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([1, 2])
+        geometry: new Point([1, 2])
       });
       feature.set('geometry', point);
       expect(feature.get('geometry')).to.be(point);
@@ -162,8 +162,8 @@ describe('ol.Feature', function() {
       feature.set('getGeometry', 'x');
       expect(feature.get('getGeometry')).to.be('x');
 
-      feature.set('geometry', new _ol_geom_Point_([1, 2]));
-      expect(feature.getGeometry()).to.be.a(_ol_geom_Point_);
+      feature.set('geometry', new Point([1, 2]));
+      expect(feature.getGeometry()).to.be.a(Point);
 
     });
 
@@ -171,7 +171,7 @@ describe('ol.Feature', function() {
 
   describe('#setGeometry()', function() {
 
-    var point = new _ol_geom_Point_([15, 30]);
+    var point = new Point([15, 30]);
 
     it('sets the default geometry', function() {
       var feature = new _ol_Feature_();
@@ -185,7 +185,7 @@ describe('ol.Feature', function() {
       });
       expect(feature.getGeometry()).to.be(point);
 
-      var point2 = new _ol_geom_Point_([1, 2]);
+      var point2 = new Point([1, 2]);
       feature.setGeometry(point2);
       expect(feature.getGeometry()).to.be(point2);
     });
@@ -194,14 +194,14 @@ describe('ol.Feature', function() {
 
   describe('#setGeometryName()', function() {
 
-    var point = new _ol_geom_Point_([15, 30]);
+    var point = new Point([15, 30]);
 
     it('sets property where to to look at geometry', function() {
       var feature = new _ol_Feature_();
       feature.setGeometry(point);
       expect(feature.getGeometry()).to.be(point);
 
-      var point2 = new _ol_geom_Point_([1, 2]);
+      var point2 = new Point([1, 2]);
       feature.set('altGeometry', point2);
       expect(feature.getGeometry()).to.be(point);
       feature.setGeometryName('altGeometry');
@@ -216,7 +216,7 @@ describe('ol.Feature', function() {
     it('changes property listener', function() {
       var feature = new _ol_Feature_();
       feature.setGeometry(point);
-      var point2 = new _ol_geom_Point_([1, 2]);
+      var point2 = new Point([1, 2]);
       feature.set('altGeometry', point2);
       feature.setGeometryName('altGeometry');
 
@@ -229,7 +229,7 @@ describe('ol.Feature', function() {
     it('can use a different geometry name', function() {
       var feature = new _ol_Feature_();
       feature.setGeometryName('foo');
-      var point = new _ol_geom_Point_([10, 20]);
+      var point = new Point([10, 20]);
       feature.setGeometry(point);
       expect(feature.getGeometry()).to.be(point);
     });
@@ -401,7 +401,7 @@ describe('ol.Feature', function() {
       feature.setProperties({'fookey': 'fooval'});
       feature.setId(1);
       feature.setGeometryName('geom');
-      var geometry = new _ol_geom_Point_([1, 2]);
+      var geometry = new Point([1, 2]);
       feature.setGeometry(geometry);
       var style = new _ol_style_Style_({});
       feature.setStyle(style);
@@ -436,7 +436,7 @@ describe('ol.Feature', function() {
     it('dispatches a change event when geometry is set to null',
         function() {
           var feature = new _ol_Feature_({
-            geometry: new _ol_geom_Point_([0, 0])
+            geometry: new Point([0, 0])
           });
           var spy = sinon.spy();
           feature.on('change', spy);

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -5,7 +5,7 @@ import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
@@ -217,7 +217,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = format.readFeature(multiPolygonEsriJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_MultiPolygon_);
+      expect(geometry).to.be.an(MultiPolygon);
       expect(geometry.getCoordinates()).to.eql([
         [[[0, 1], [1, 4], [4, 3], [3, 0]], [[2, 2], [3, 2], [3, 3], [2, 3]]],
         [[[10, 1], [11, 5], [14, 3], [13, 0]]]
@@ -644,7 +644,7 @@ describe('ol.format.EsriJSON', function() {
         ]
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPolygon_);
+      expect(obj).to.be.a(MultiPolygon);
       expect(obj.getLayout()).to.eql('XY');
       expect(obj.getCoordinates()).to.eql([
         [[[0, 1], [1, 4], [4, 3], [3, 0]], [[2, 2], [3, 2],
@@ -663,7 +663,7 @@ describe('ol.format.EsriJSON', function() {
         hasZ: true
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPolygon_);
+      expect(obj).to.be.a(MultiPolygon);
       expect(obj.getLayout()).to.eql('XYZ');
       expect(obj.getCoordinates()).to.eql([
         [[[0, 1, 0], [1, 4, 0], [4, 3, 0], [3, 0, 0]], [[2, 2, 0], [3, 2, 0],
@@ -682,7 +682,7 @@ describe('ol.format.EsriJSON', function() {
         hasM: true
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPolygon_);
+      expect(obj).to.be.a(MultiPolygon);
       expect(obj.getLayout()).to.eql('XYM');
       expect(obj.getCoordinates()).to.eql([
         [[[0, 1, 0], [1, 4, 0], [4, 3, 0], [3, 0, 0]], [[2, 2, 0], [3, 2, 0],
@@ -702,7 +702,7 @@ describe('ol.format.EsriJSON', function() {
         hasM: true
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPolygon_);
+      expect(obj).to.be.a(MultiPolygon);
       expect(obj.getLayout()).to.eql('XYZM');
       expect(obj.getCoordinates()).to.eql([
         [[[0, 1, 0, 1], [1, 4, 0, 1], [4, 3, 0, 1], [3, 0, 0, 1]],
@@ -945,7 +945,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes multipolygon', function() {
-      var multipolygon = new _ol_geom_MultiPolygon_([
+      var multipolygon = new MultiPolygon([
         [[[0, 1], [1, 4], [4, 3], [3, 0]], [[2, 2], [3, 2], [3, 3], [2, 3]]],
         [[[10, 1], [11, 5], [14, 3], [13, 0]]]
       ]);
@@ -955,7 +955,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYZ multipolygon', function() {
-      var multipolygon = new _ol_geom_MultiPolygon_([
+      var multipolygon = new MultiPolygon([
         [[[0, 1, 0], [1, 4, 0], [4, 3, 0], [3, 0, 0]], [[2, 2, 0], [3, 2, 0],
           [3, 3, 0], [2, 3, 0]]],
         [[[10, 1, 0], [11, 5, 0], [14, 3, 0], [13, 0, 0]]]
@@ -966,7 +966,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYM multipolygon', function() {
-      var multipolygon = new _ol_geom_MultiPolygon_([
+      var multipolygon = new MultiPolygon([
         [[[0, 1, 0], [1, 4, 0], [4, 3, 0], [3, 0, 0]], [[2, 2, 0], [3, 2, 0],
           [3, 3, 0], [2, 3, 0]]],
         [[[10, 1, 0], [11, 5, 0], [14, 3, 0], [13, 0, 0]]]
@@ -977,7 +977,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYZM multipolygon', function() {
-      var multipolygon = new _ol_geom_MultiPolygon_([
+      var multipolygon = new MultiPolygon([
         [[[0, 1, 0, 1], [1, 4, 0, 1], [4, 3, 0, 3], [3, 0, 0, 3]],
           [[2, 2, 0, 3], [3, 2, 0, 4],
             [3, 3, 0, 1], [2, 3, 0, 1]]],

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -7,7 +7,7 @@ import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 
@@ -205,7 +205,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = format.readFeature(polygonEsriJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_Polygon_);
+      expect(geometry).to.be.an(Polygon);
       expect(geometry.getCoordinates()).to.eql([[
         [100.0, 0.0], [100.0, 1.0], [101.0, 1.0], [101.0, 0.0]
       ]]);
@@ -229,7 +229,7 @@ describe('ol.format.EsriJSON', function() {
       expect(features).to.have.length(3);
       expect(features[0].getGeometry()).to.be.an(Point);
       expect(features[1].getGeometry()).to.be.an(LineString);
-      expect(features[2].getGeometry()).to.be.an(_ol_geom_Polygon_);
+      expect(features[2].getGeometry()).to.be.an(Polygon);
     });
 
     it('can read and transform a point', function() {
@@ -304,7 +304,7 @@ describe('ol.format.EsriJSON', function() {
         expect(first.get('field_name')).to.be('EUDORA');
         expect(first.getId()).to.be(6406);
         var firstGeom = first.getGeometry();
-        expect(firstGeom).to.be.a(_ol_geom_Polygon_);
+        expect(firstGeom).to.be.a(Polygon);
         expect(_ol_extent_.equals(firstGeom.getExtent(), [
           -10585772.743554419, 4712365.161160459,
           -10579560.16462974, 4716567.373073828
@@ -315,7 +315,7 @@ describe('ol.format.EsriJSON', function() {
         expect(last.get('field_name')).to.be('FEAGINS');
         expect(last.getId()).to.be(6030);
         var lastGeom = last.getGeometry();
-        expect(lastGeom).to.be.a(_ol_geom_Polygon_);
+        expect(lastGeom).to.be.a(Polygon);
         expect(_ol_extent_.equals(lastGeom.getExtent(), [
           -10555714.026858449, 4576511.565880965,
           -10553671.199322715, 4578554.9934867555
@@ -558,7 +558,7 @@ describe('ol.format.EsriJSON', function() {
         rings: [outer, inner1, inner2]
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Polygon_);
+      expect(obj).to.be.a(Polygon);
       expect(obj.getLayout()).to.eql('XY');
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
@@ -577,7 +577,7 @@ describe('ol.format.EsriJSON', function() {
         hasZ: true
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Polygon_);
+      expect(obj).to.be.a(Polygon);
       expect(obj.getLayout()).to.eql('XYZ');
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
@@ -596,7 +596,7 @@ describe('ol.format.EsriJSON', function() {
         hasM: true
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Polygon_);
+      expect(obj).to.be.a(Polygon);
       expect(obj.getLayout()).to.eql('XYM');
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
@@ -625,7 +625,7 @@ describe('ol.format.EsriJSON', function() {
         hasM: true
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Polygon_);
+      expect(obj).to.be.a(Polygon);
       expect(obj.getLayout()).to.eql('XYZM');
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
@@ -826,7 +826,7 @@ describe('ol.format.EsriJSON', function() {
       var outer = [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]];
       var inner1 = [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]];
       var inner2 = [[8, 8], [9, 8], [9, 9], [8, 9], [8, 8]];
-      var polygon = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      var polygon = new Polygon([outer, inner1, inner2]);
       var esrijson = format.writeGeometry(polygon);
       expect(polygon.getCoordinates(false)).to.eql(
           format.readGeometry(esrijson).getCoordinates());
@@ -836,7 +836,7 @@ describe('ol.format.EsriJSON', function() {
       var outer = [[0, 0, 5], [0, 10, 5], [10, 10, 5], [10, 0, 5], [0, 0, 5]];
       var inner1 = [[1, 1, 3], [2, 1, 3], [2, 2, 3], [1, 2, 3], [1, 1, 3]];
       var inner2 = [[8, 8, 2], [9, 8, 2], [9, 9, 2], [8, 9, 2], [8, 8, 2]];
-      var polygon = new _ol_geom_Polygon_([outer, inner1, inner2],
+      var polygon = new Polygon([outer, inner1, inner2],
           'XYZ');
       var esrijson = format.writeGeometry(polygon);
       expect(polygon.getCoordinates(false)).to.eql(
@@ -847,7 +847,7 @@ describe('ol.format.EsriJSON', function() {
       var outer = [[0, 0, 5], [0, 10, 5], [10, 10, 5], [10, 0, 5], [0, 0, 5]];
       var inner1 = [[1, 1, 3], [2, 1, 3], [2, 2, 3], [1, 2, 3], [1, 1, 3]];
       var inner2 = [[8, 8, 2], [9, 8, 2], [9, 9, 2], [8, 9, 2], [8, 8, 2]];
-      var polygon = new _ol_geom_Polygon_([outer, inner1, inner2],
+      var polygon = new Polygon([outer, inner1, inner2],
           'XYM');
       var esrijson = format.writeGeometry(polygon);
       expect(polygon.getCoordinates(false)).to.eql(
@@ -864,7 +864,7 @@ describe('ol.format.EsriJSON', function() {
       var inner2 = [
         [8, 8, 2, 1], [9, 8, 2, 2], [9, 9, 2, 1], [8, 9, 2, 1], [8, 8, 2, 1]
       ];
-      var polygon = new _ol_geom_Polygon_([outer, inner1, inner2],
+      var polygon = new Polygon([outer, inner1, inner2],
           'XYZM');
       var esrijson = format.writeGeometry(polygon);
       expect(polygon.getCoordinates(false)).to.eql(

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -4,7 +4,7 @@ import _ol_format_EsriJSON_ from '../../../../src/ol/format/EsriJSON.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -172,7 +172,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = format.readFeature(multiPointEsriJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_MultiPoint_);
+      expect(geometry).to.be.an(MultiPoint);
       expect(geometry.getCoordinates()).to.eql([[102.0, 0.0], [103.0, 1.0]]);
       expect(feature.get('prop0')).to.be('value0');
     });
@@ -387,7 +387,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPoint_);
+      expect(obj).to.be.a(MultiPoint);
       expect(obj.getCoordinates()).to.eql([[10, 20], [20, 30]]);
       expect(obj.getLayout()).to.eql('XY');
     });
@@ -399,7 +399,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPoint_);
+      expect(obj).to.be.a(MultiPoint);
       expect(obj.getCoordinates()).to.eql([[10, 20, 0], [20, 30, 0]]);
       expect(obj.getLayout()).to.eql('XYZ');
     });
@@ -411,7 +411,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPoint_);
+      expect(obj).to.be.a(MultiPoint);
       expect(obj.getCoordinates()).to.eql([[10, 20, 0], [20, 30, 0]]);
       expect(obj.getLayout()).to.eql('XYM');
     });
@@ -424,7 +424,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiPoint_);
+      expect(obj).to.be.a(MultiPoint);
       expect(obj.getCoordinates()).to.eql([[10, 20, 0, 1], [20, 30, 0, 1]]);
       expect(obj.getLayout()).to.eql('XYZM');
     });
@@ -872,14 +872,14 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes multipoint', function() {
-      var multipoint = new _ol_geom_MultiPoint_([[102.0, 0.0], [103.0, 1.0]]);
+      var multipoint = new MultiPoint([[102.0, 0.0], [103.0, 1.0]]);
       var esrijson = format.writeGeometry(multipoint);
       expect(multipoint.getCoordinates()).to.eql(
           format.readGeometry(esrijson).getCoordinates());
     });
 
     it('encodes XYZ multipoint', function() {
-      var multipoint = new _ol_geom_MultiPoint_([[102.0, 0.0, 3],
+      var multipoint = new MultiPoint([[102.0, 0.0, 3],
         [103.0, 1.0, 4]], 'XYZ');
       var esrijson = format.writeGeometry(multipoint);
       expect(multipoint.getCoordinates()).to.eql(
@@ -887,7 +887,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYM multipoint', function() {
-      var multipoint = new _ol_geom_MultiPoint_([[102.0, 0.0, 3],
+      var multipoint = new MultiPoint([[102.0, 0.0, 3],
         [103.0, 1.0, 4]], 'XYM');
       var esrijson = format.writeGeometry(multipoint);
       expect(multipoint.getCoordinates()).to.eql(
@@ -895,7 +895,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYZM multipoint', function() {
-      var multipoint = new _ol_geom_MultiPoint_([[102.0, 0.0, 3, 1],
+      var multipoint = new MultiPoint([[102.0, 0.0, 3, 1],
         [103.0, 1.0, 4, 1]], 'XYZM');
       var esrijson = format.writeGeometry(multipoint);
       expect(multipoint.getCoordinates()).to.eql(

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -3,7 +3,7 @@ import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_EsriJSON_ from '../../../../src/ol/format/EsriJSON.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -192,7 +192,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = format.readFeature(multiLineStringEsriJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_MultiLineString_);
+      expect(geometry).to.be.an(MultiLineString);
       expect(geometry.getCoordinates()).to.eql([
         [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]],
         [[105.0, 3.0], [106.0, 4.0], [107.0, 3.0], [108.0, 4.0]]
@@ -487,7 +487,7 @@ describe('ol.format.EsriJSON', function() {
         ]]
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiLineString_);
+      expect(obj).to.be.a(MultiLineString);
       expect(obj.getCoordinates()).to.eql([
         [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]],
         [[105.0, 3.0], [106.0, 4.0], [107.0, 3.0], [108.0, 4.0]]
@@ -505,7 +505,7 @@ describe('ol.format.EsriJSON', function() {
         ]]
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiLineString_);
+      expect(obj).to.be.a(MultiLineString);
       expect(obj.getCoordinates()).to.eql([
         [[102.0, 0.0, 1], [103.0, 1.0, 1], [104.0, 0.0, 1], [105.0, 1.0, 1]],
         [[105.0, 3.0, 1], [106.0, 4.0, 1], [107.0, 3.0, 1], [108.0, 4.0, 1]]
@@ -523,7 +523,7 @@ describe('ol.format.EsriJSON', function() {
         ]]
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiLineString_);
+      expect(obj).to.be.a(MultiLineString);
       expect(obj.getCoordinates()).to.eql([
         [[102.0, 0.0, 1], [103.0, 1.0, 1], [104.0, 0.0, 1], [105.0, 1.0, 1]],
         [[105.0, 3.0, 1], [106.0, 4.0, 1], [107.0, 3.0, 1], [108.0, 4.0, 1]]
@@ -542,7 +542,7 @@ describe('ol.format.EsriJSON', function() {
         ]]
       });
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_MultiLineString_);
+      expect(obj).to.be.a(MultiLineString);
       expect(obj.getCoordinates()).to.eql([
         [[102, 0, 1, 2], [103, 1, 1, 2], [104, 0, 1, 2], [105, 1, 1, 2]],
         [[105, 3, 1, 2], [106, 4, 1, 2], [107, 3, 1, 2], [108, 4, 1, 2]]
@@ -903,7 +903,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes multilinestring', function() {
-      var multilinestring = new _ol_geom_MultiLineString_([
+      var multilinestring = new MultiLineString([
         [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]],
         [[105.0, 3.0], [106.0, 4.0], [107.0, 3.0], [108.0, 4.0]]
       ]);
@@ -913,7 +913,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYZ multilinestring', function() {
-      var multilinestring = new _ol_geom_MultiLineString_([
+      var multilinestring = new MultiLineString([
         [[102.0, 0.0, 1], [103.0, 1.0, 2], [104.0, 0.0, 3], [105.0, 1.0, 4]],
         [[105.0, 3.0, 1], [106.0, 4.0, 2], [107.0, 3.0, 3], [108.0, 4.0, 4]]
       ], 'XYZ');
@@ -923,7 +923,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYM multilinestring', function() {
-      var multilinestring = new _ol_geom_MultiLineString_([
+      var multilinestring = new MultiLineString([
         [[102.0, 0.0, 1], [103.0, 1.0, 2], [104.0, 0.0, 3], [105.0, 1.0, 4]],
         [[105.0, 3.0, 1], [106.0, 4.0, 2], [107.0, 3.0, 3], [108.0, 4.0, 4]]
       ], 'XYM');
@@ -933,7 +933,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYZM multilinestring', function() {
-      var multilinestring = new _ol_geom_MultiLineString_([
+      var multilinestring = new MultiLineString([
         [[102.0, 0.0, 1, 0], [103.0, 1.0, 2, 2], [104.0, 0.0, 3, 1],
           [105.0, 1.0, 4, 2]],
         [[105.0, 3.0, 1, 0], [106.0, 4.0, 2, 1], [107.0, 3.0, 3, 1],

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_EsriJSON_ from '../../../../src/ol/format/EsriJSON.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
@@ -181,7 +181,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = format.readFeature(lineStringEsriJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getCoordinates()).to.eql(
           [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]]);
       expect(feature.get('prop0')).to.be('value0');
@@ -228,7 +228,7 @@ describe('ol.format.EsriJSON', function() {
       var features = format.readFeatures(featureCollectionEsriJSON);
       expect(features).to.have.length(3);
       expect(features[0].getGeometry()).to.be.an(Point);
-      expect(features[1].getGeometry()).to.be.an(_ol_geom_LineString_);
+      expect(features[1].getGeometry()).to.be.an(LineString);
       expect(features[2].getGeometry()).to.be.an(_ol_geom_Polygon_);
     });
 
@@ -285,13 +285,13 @@ describe('ol.format.EsriJSON', function() {
       expect(first).to.be.a(_ol_Feature_);
       expect(first.get('LINK_ID')).to.be(573730499);
       var firstGeom = first.getGeometry();
-      expect(firstGeom).to.be.a(_ol_geom_LineString_);
+      expect(firstGeom).to.be.a(LineString);
 
       var second = array[1];
       expect(second).to.be.a(_ol_Feature_);
       expect(second.get('ST_NAME')).to.be('BRUNNSGATAN');
       var secondGeom = second.getGeometry();
-      expect(secondGeom).to.be.a(_ol_geom_LineString_);
+      expect(secondGeom).to.be.a(LineString);
     });
 
     it('parses ksfields.geojson', function(done) {
@@ -435,7 +435,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_LineString_);
+      expect(obj).to.be.a(LineString);
       expect(obj.getCoordinates()).to.eql([[10, 20], [30, 40]]);
       expect(obj.getLayout()).to.eql('XY');
     });
@@ -447,7 +447,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_LineString_);
+      expect(obj).to.be.a(LineString);
       expect(obj.getLayout()).to.eql('XYZ');
       expect(obj.getCoordinates()).to.eql([[10, 20, 1534], [30, 40, 1420]]);
     });
@@ -459,7 +459,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_LineString_);
+      expect(obj).to.be.a(LineString);
       expect(obj.getLayout()).to.eql('XYM');
       expect(obj.getCoordinates()).to.eql([[10, 20, 1534], [30, 40, 1420]]);
     });
@@ -472,7 +472,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_LineString_);
+      expect(obj).to.be.a(LineString);
       expect(obj.getLayout()).to.eql('XYZM');
       expect(obj.getCoordinates()).to.eql([[10, 20, 1534, 1],
         [30, 40, 1420, 2]]);
@@ -751,7 +751,7 @@ describe('ol.format.EsriJSON', function() {
       var second = features[1];
       expect(second).to.be.a(_ol_Feature_);
       expect(second.get('bam')).to.be('baz');
-      expect(second.getGeometry()).to.be.a(_ol_geom_LineString_);
+      expect(second.getGeometry()).to.be.a(LineString);
 
       expect(format.readProjection(json)).to.be(getProjection('EPSG:3857'));
 
@@ -791,14 +791,14 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes linestring', function() {
-      var linestring = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      var linestring = new LineString([[10, 20], [30, 40]]);
       var esrijson = format.writeGeometry(linestring);
       expect(linestring.getCoordinates()).to.eql(
           format.readGeometry(esrijson).getCoordinates());
     });
 
     it('encodes XYZ linestring', function() {
-      var linestring = new _ol_geom_LineString_([[10, 20, 1534], [30, 40, 1420]],
+      var linestring = new LineString([[10, 20, 1534], [30, 40, 1420]],
           'XYZ');
       var esrijson = format.writeGeometry(linestring);
       expect(linestring.getCoordinates()).to.eql(
@@ -806,7 +806,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYM linestring', function() {
-      var linestring = new _ol_geom_LineString_([[10, 20, 1534], [30, 40, 1420]],
+      var linestring = new LineString([[10, 20, 1534], [30, 40, 1420]],
           'XYM');
       var esrijson = format.writeGeometry(linestring);
       expect(linestring.getCoordinates()).to.eql(
@@ -814,7 +814,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('encodes XYZM linestring', function() {
-      var linestring = new _ol_geom_LineString_([[10, 20, 1534, 1],
+      var linestring = new LineString([[10, 20, 1534, 1],
         [30, 40, 1420, 1]],
       'XYZM');
       var esrijson = format.writeGeometry(linestring);

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_EsriJSON_ from '../../../../src/ol/format/EsriJSON.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
+import LinearRing from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
@@ -563,9 +563,9 @@ describe('ol.format.EsriJSON', function() {
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
       expect(rings[0].getCoordinates()[0].length).to.equal(2);
-      expect(rings[0]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[1]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[2]).to.be.a(_ol_geom_LinearRing_);
+      expect(rings[0]).to.be.a(LinearRing);
+      expect(rings[1]).to.be.a(LinearRing);
+      expect(rings[2]).to.be.a(LinearRing);
     });
 
     it('parses XYZ polygon', function() {
@@ -582,9 +582,9 @@ describe('ol.format.EsriJSON', function() {
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
       expect(rings[0].getCoordinates()[0].length).to.equal(3);
-      expect(rings[0]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[1]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[2]).to.be.a(_ol_geom_LinearRing_);
+      expect(rings[0]).to.be.a(LinearRing);
+      expect(rings[1]).to.be.a(LinearRing);
+      expect(rings[2]).to.be.a(LinearRing);
     });
 
     it('parses XYM polygon', function() {
@@ -601,9 +601,9 @@ describe('ol.format.EsriJSON', function() {
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
       expect(rings[0].getCoordinates()[0].length).to.equal(3);
-      expect(rings[0]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[1]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[2]).to.be.a(_ol_geom_LinearRing_);
+      expect(rings[0]).to.be.a(LinearRing);
+      expect(rings[1]).to.be.a(LinearRing);
+      expect(rings[2]).to.be.a(LinearRing);
     });
 
     it('parses XYZM polygon', function() {
@@ -630,9 +630,9 @@ describe('ol.format.EsriJSON', function() {
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
       expect(rings[0].getCoordinates()[0].length).to.equal(4);
-      expect(rings[0]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[1]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[2]).to.be.a(_ol_geom_LinearRing_);
+      expect(rings[0]).to.be.a(LinearRing);
+      expect(rings[1]).to.be.a(LinearRing);
+      expect(rings[2]).to.be.a(LinearRing);
     });
 
     it('parses XY multipolygon', function() {

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -6,7 +6,7 @@ import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
@@ -163,7 +163,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = format.readFeature(pointEsriJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_Point_);
+      expect(geometry).to.be.an(Point);
       expect(geometry.getCoordinates()).to.eql([102.0, 0.5]);
       expect(feature.get('prop0')).to.be('value0');
     });
@@ -227,7 +227,7 @@ describe('ol.format.EsriJSON', function() {
     it('can read a feature collection', function() {
       var features = format.readFeatures(featureCollectionEsriJSON);
       expect(features).to.have.length(3);
-      expect(features[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(features[0].getGeometry()).to.be.an(Point);
       expect(features[1].getGeometry()).to.be.an(_ol_geom_LineString_);
       expect(features[2].getGeometry()).to.be.an(_ol_geom_Polygon_);
     });
@@ -237,7 +237,7 @@ describe('ol.format.EsriJSON', function() {
         featureProjection: 'EPSG:3857',
         dataProjection: 'EPSG:4326'
       });
-      expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature[0].getGeometry()).to.be.an(Point);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
           transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
@@ -247,7 +247,7 @@ describe('ol.format.EsriJSON', function() {
         featureProjection: 'EPSG:3857',
         dataProjection: 'EPSG:4326'
       });
-      expect(features[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(features[0].getGeometry()).to.be.an(Point);
       expect(features[0].getGeometry().getCoordinates()).to.eql(
           transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
       expect(features[1].getGeometry().getCoordinates()).to.eql([
@@ -268,7 +268,7 @@ describe('ol.format.EsriJSON', function() {
       var feature = new _ol_format_EsriJSON_({geometryName: 'the_geom'}).
           readFeature(pointEsriJSON);
       expect(feature.getGeometryName()).to.be('the_geom');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature.getGeometry()).to.be.an(Point);
     });
 
   });
@@ -336,7 +336,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Point_);
+      expect(obj).to.be.a(Point);
       expect(obj.getCoordinates()).to.eql([10, 20]);
       expect(obj.getLayout()).to.eql('XY');
     });
@@ -349,7 +349,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Point_);
+      expect(obj).to.be.a(Point);
       expect(obj.getCoordinates()).to.eql([10, 20, 10]);
       expect(obj.getLayout()).to.eql('XYZ');
     });
@@ -362,7 +362,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Point_);
+      expect(obj).to.be.a(Point);
       expect(obj.getCoordinates()).to.eql([10, 20, 10]);
       expect(obj.getLayout()).to.eql('XYM');
     });
@@ -376,7 +376,7 @@ describe('ol.format.EsriJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Point_);
+      expect(obj).to.be.a(Point);
       expect(obj.getCoordinates()).to.eql([10, 20, 0, 10]);
       expect(obj.getLayout()).to.eql('XYZM');
     });
@@ -746,7 +746,7 @@ describe('ol.format.EsriJSON', function() {
       var first = features[0];
       expect(first).to.be.a(_ol_Feature_);
       expect(first.get('foo')).to.be('bar');
-      expect(first.getGeometry()).to.be.a(_ol_geom_Point_);
+      expect(first.getGeometry()).to.be.a(Point);
 
       var second = features[1];
       expect(second).to.be.a(_ol_Feature_);
@@ -762,28 +762,28 @@ describe('ol.format.EsriJSON', function() {
   describe('#writeGeometry', function() {
 
     it('encodes point', function() {
-      var point = new _ol_geom_Point_([10, 20]);
+      var point = new Point([10, 20]);
       var esrijson = format.writeGeometry(point);
       expect(point.getCoordinates()).to.eql(
           format.readGeometry(esrijson).getCoordinates());
     });
 
     it('encodes XYZ point', function() {
-      var point = new _ol_geom_Point_([10, 20, 0], 'XYZ');
+      var point = new Point([10, 20, 0], 'XYZ');
       var esrijson = format.writeGeometry(point);
       expect(point.getCoordinates()).to.eql(
           format.readGeometry(esrijson).getCoordinates());
     });
 
     it('encodes XYM point', function() {
-      var point = new _ol_geom_Point_([10, 20, 0], 'XYM');
+      var point = new Point([10, 20, 0], 'XYM');
       var esrijson = format.writeGeometry(point);
       expect(point.getCoordinates()).to.eql(
           format.readGeometry(esrijson).getCoordinates());
     });
 
     it('encodes XYZM point', function() {
-      var point = new _ol_geom_Point_([10, 20, 5, 0],
+      var point = new Point([10, 20, 5, 0],
           'XYZM');
       var esrijson = format.writeGeometry(point);
       expect(point.getCoordinates()).to.eql(
@@ -989,7 +989,7 @@ describe('ol.format.EsriJSON', function() {
     });
 
     it('transforms and encodes a point', function() {
-      var point = new _ol_geom_Point_([2, 3]);
+      var point = new Point([2, 3]);
       var esrijson = format.writeGeometry(point, {
         dataProjection: 'EPSG:4326',
         featureProjection: 'EPSG:3857'
@@ -1050,13 +1050,13 @@ describe('ol.format.EsriJSON', function() {
         function() {
           var feature = new _ol_Feature_({'foo': 'bar'});
           feature.setGeometryName('mygeom');
-          feature.setGeometry(new _ol_geom_Point_([5, 10]));
+          feature.setGeometry(new Point([5, 10]));
           var esrijson = format.writeFeaturesObject([feature]);
           expect(esrijson.features[0].attributes.mygeom).to.eql(undefined);
         });
 
     it('writes out a feature without properties correctly', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Point_([5, 10]));
+      var feature = new _ol_Feature_(new Point([5, 10]));
       var esrijson = format.writeFeatureObject(feature);
       expect(esrijson.attributes).to.eql({});
     });

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -3,7 +3,7 @@ import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -164,7 +164,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeature(lineStringGeoJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getCoordinates()).to.eql(
           [[102.0, 0.0], [103.0, 1.0], [104.0, 0.0], [105.0, 1.0]]);
       expect(feature.get('prop0')).to.be('value0');
@@ -201,7 +201,7 @@ describe('ol.format.GeoJSON', function() {
       var features = format.readFeatures(featureCollectionGeoJSON);
       expect(features).to.have.length(3);
       expect(features[0].getGeometry()).to.be.an(Point);
-      expect(features[1].getGeometry()).to.be.an(_ol_geom_LineString_);
+      expect(features[1].getGeometry()).to.be.an(LineString);
       expect(features[2].getGeometry()).to.be.an(_ol_geom_Polygon_);
     });
 
@@ -274,13 +274,13 @@ describe('ol.format.GeoJSON', function() {
       expect(first).to.be.a(_ol_Feature_);
       expect(first.get('LINK_ID')).to.be(573730499);
       var firstGeom = first.getGeometry();
-      expect(firstGeom).to.be.a(_ol_geom_LineString_);
+      expect(firstGeom).to.be.a(LineString);
 
       var second = array[1];
       expect(second).to.be.a(_ol_Feature_);
       expect(second.get('ST_NAME')).to.be('BRUNNSGATAN');
       var secondGeom = second.getGeometry();
-      expect(secondGeom).to.be.a(_ol_geom_LineString_);
+      expect(secondGeom).to.be.a(LineString);
     });
 
     it('can parse a polygon geometry as an array of one feature', function() {
@@ -340,7 +340,7 @@ describe('ol.format.GeoJSON', function() {
       var first = features[0];
       expect(first).to.be.a(_ol_Feature_);
       expect(first.get('bam')).to.be('baz');
-      expect(first.getGeometry()).to.be.a(_ol_geom_LineString_);
+      expect(first.getGeometry()).to.be.a(LineString);
 
       expect(format.readProjection(json)).to.be(getProjection('EPSG:4326'));
     });
@@ -368,7 +368,7 @@ describe('ol.format.GeoJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_LineString_);
+      expect(obj).to.be.a(LineString);
       expect(obj.getCoordinates()).to.eql([[10, 20], [30, 40]]);
       expect(obj.getLayout()).to.eql('XY');
     });
@@ -380,7 +380,7 @@ describe('ol.format.GeoJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_LineString_);
+      expect(obj).to.be.a(LineString);
       expect(obj.getLayout()).to.eql('XYZ');
       expect(obj.getCoordinates()).to.eql([[10, 20, 1534], [30, 40, 1420]]);
     });
@@ -419,7 +419,7 @@ describe('ol.format.GeoJSON', function() {
       expect(array.length).to.be(2);
       expect(array[0]).to.be.a(Point);
       expect(array[0].getLayout()).to.eql('XY');
-      expect(array[1]).to.be.a(_ol_geom_LineString_);
+      expect(array[1]).to.be.a(LineString);
       expect(array[1].getLayout()).to.eql('XY');
     });
 
@@ -469,7 +469,7 @@ describe('ol.format.GeoJSON', function() {
       var second = features[1];
       expect(second).to.be.a(_ol_Feature_);
       expect(second.get('bam')).to.be('baz');
-      expect(second.getGeometry()).to.be.a(_ol_geom_LineString_);
+      expect(second.getGeometry()).to.be.a(LineString);
 
       expect(format.readProjection(json)).to.be(getProjection('EPSG:3857'));
 
@@ -512,7 +512,7 @@ describe('ol.format.GeoJSON', function() {
       var second = features[1];
       expect(second).to.be.a(_ol_Feature_);
       expect(second.get('bam')).to.be('baz');
-      expect(second.getGeometry()).to.be.a(_ol_geom_LineString_);
+      expect(second.getGeometry()).to.be.a(LineString);
 
       expect(format.readProjection(json)).to.be(getProjection('EPSG:4326'));
 
@@ -612,7 +612,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('encodes linestring', function() {
-      var linestring = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      var linestring = new LineString([[10, 20], [30, 40]]);
       var geojson = format.writeGeometry(linestring);
       expect(linestring.getCoordinates()).to.eql(
           format.readGeometry(geojson).getCoordinates());
@@ -731,7 +731,7 @@ describe('ol.format.GeoJSON', function() {
     it('encodes geometry collection', function() {
       var collection = new _ol_geom_GeometryCollection_([
         new Point([10, 20]),
-        new _ol_geom_LineString_([[30, 40], [50, 60]])
+        new LineString([[30, 40], [50, 60]])
       ]);
       var geojson = format.writeGeometry(collection);
       var got = format.readGeometry(geojson);
@@ -772,7 +772,7 @@ describe('ol.format.GeoJSON', function() {
     it('transforms and encodes geometry collection', function() {
       var collection = new _ol_geom_GeometryCollection_([
         new Point([2, 3]),
-        new _ol_geom_LineString_([[3, 2], [2, 1]])
+        new LineString([[3, 2], [2, 1]])
       ]);
       var geojson = format.writeGeometry(collection, {
         featureProjection: 'EPSG:3857'
@@ -803,7 +803,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('truncates a linestring with decimals option', function() {
-      var linestring = new _ol_geom_LineString_([[42.123456789, 38.987654321],
+      var linestring = new LineString([[42.123456789, 38.987654321],
         [43, 39]]);
       var geojson = format.writeGeometry(linestring, {
         decimals: 6
@@ -815,7 +815,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('rounds a linestring with decimals option = 0', function() {
-      var linestring = new _ol_geom_LineString_([[42.123456789, 38.987654321],
+      var linestring = new LineString([[42.123456789, 38.987654321],
         [43, 39]]);
       var geojson = format.writeGeometry(linestring, {
         decimals: 0

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -5,7 +5,7 @@ import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {fromLonLat, get as getProjection, toLonLat, transform} from '../../../../src/ol/proj.js';
@@ -634,9 +634,9 @@ describe('ol.format.GeoJSON', function() {
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
 
       var right = new Polygon([ccw, cw]);
-      var rightMulti = new _ol_geom_MultiPolygon_([[ccw, cw]]);
+      var rightMulti = new MultiPolygon([[ccw, cw]]);
       var left = new Polygon([cw, ccw]);
-      var leftMulti = new _ol_geom_MultiPolygon_([[cw, ccw]]);
+      var leftMulti = new MultiPolygon([[cw, ccw]]);
 
       var rightObj = {
         type: 'Polygon',
@@ -671,9 +671,9 @@ describe('ol.format.GeoJSON', function() {
       var cw = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
       var right = new Polygon([ccw, cw]);
-      var rightMulti = new _ol_geom_MultiPolygon_([[ccw, cw]]);
+      var rightMulti = new MultiPolygon([[ccw, cw]]);
       var left = new Polygon([cw, ccw]);
-      var leftMulti = new _ol_geom_MultiPolygon_([[cw, ccw]]);
+      var leftMulti = new MultiPolygon([[cw, ccw]]);
 
       var rightObj = {
         type: 'Polygon',
@@ -702,9 +702,9 @@ describe('ol.format.GeoJSON', function() {
       var cw = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
       var right = new Polygon([ccw, cw]);
-      var rightMulti = new _ol_geom_MultiPolygon_([[ccw, cw]]);
+      var rightMulti = new MultiPolygon([[ccw, cw]]);
       var left = new Polygon([cw, ccw]);
-      var leftMulti = new _ol_geom_MultiPolygon_([[cw, ccw]]);
+      var leftMulti = new MultiPolygon([[cw, ccw]]);
 
       var leftObj = {
         type: 'Polygon',

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
-import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
@@ -414,7 +414,7 @@ describe('ol.format.GeoJSON', function() {
       });
 
       var geometryCollection = format.readGeometry(str);
-      expect(geometryCollection).to.be.an(_ol_geom_GeometryCollection_);
+      expect(geometryCollection).to.be.an(GeometryCollection);
       var array = geometryCollection.getGeometries();
       expect(array.length).to.be(2);
       expect(array[0]).to.be.a(Point);
@@ -729,13 +729,13 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('encodes geometry collection', function() {
-      var collection = new _ol_geom_GeometryCollection_([
+      var collection = new GeometryCollection([
         new Point([10, 20]),
         new LineString([[30, 40], [50, 60]])
       ]);
       var geojson = format.writeGeometry(collection);
       var got = format.readGeometry(geojson);
-      expect(got).to.be.an(_ol_geom_GeometryCollection_);
+      expect(got).to.be.an(GeometryCollection);
       var gotGeometries = got.getGeometries();
       var geometries = collection.getGeometries();
       expect(geometries.length).to.equal(gotGeometries.length);
@@ -770,7 +770,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('transforms and encodes geometry collection', function() {
-      var collection = new _ol_geom_GeometryCollection_([
+      var collection = new GeometryCollection([
         new Point([2, 3]),
         new LineString([[3, 2], [2, 1]])
       ]);

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -7,7 +7,7 @@ import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {fromLonLat, get as getProjection, toLonLat, transform} from '../../../../src/ol/proj.js';
 
 
@@ -175,7 +175,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeature(polygonGeoJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_Polygon_);
+      expect(geometry).to.be.an(Polygon);
       expect(geometry.getCoordinates()).to.eql([[
         [100.0, 0.0], [100.0, 1.0], [101.0, 1.0], [101.0, 0.0]
       ]]);
@@ -202,7 +202,7 @@ describe('ol.format.GeoJSON', function() {
       expect(features).to.have.length(3);
       expect(features[0].getGeometry()).to.be.an(Point);
       expect(features[1].getGeometry()).to.be.an(LineString);
-      expect(features[2].getGeometry()).to.be.an(_ol_geom_Polygon_);
+      expect(features[2].getGeometry()).to.be.an(Polygon);
     });
 
     it('can read and transform a point', function() {
@@ -288,7 +288,7 @@ describe('ol.format.GeoJSON', function() {
       expect(features).to.be.an(Array);
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.an(_ol_geom_Polygon_);
+      expect(geometry).to.be.an(Polygon);
     });
 
     it('parses countries.geojson', function(done) {
@@ -301,7 +301,7 @@ describe('ol.format.GeoJSON', function() {
         expect(first.get('name')).to.be('Afghanistan');
         expect(first.getId()).to.be('AFG');
         var firstGeom = first.getGeometry();
-        expect(firstGeom).to.be.a(_ol_geom_Polygon_);
+        expect(firstGeom).to.be.a(Polygon);
         expect(_ol_extent_.equals(firstGeom.getExtent(),
             [60.52843, 29.318572, 75.158028, 38.486282]))
             .to.be(true);
@@ -311,7 +311,7 @@ describe('ol.format.GeoJSON', function() {
         expect(last.get('name')).to.be('Zimbabwe');
         expect(last.getId()).to.be('ZWE');
         var lastGeom = last.getGeometry();
-        expect(lastGeom).to.be.a(_ol_geom_Polygon_);
+        expect(lastGeom).to.be.a(Polygon);
         expect(_ol_extent_.equals(lastGeom.getExtent(),
             [25.264226, -22.271612, 32.849861, -15.507787]))
             .to.be(true);
@@ -395,7 +395,7 @@ describe('ol.format.GeoJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Polygon_);
+      expect(obj).to.be.a(Polygon);
       expect(obj.getLayout()).to.eql('XY');
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
@@ -622,7 +622,7 @@ describe('ol.format.GeoJSON', function() {
       var outer = [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]];
       var inner1 = [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]];
       var inner2 = [[8, 8], [9, 8], [9, 9], [8, 9], [8, 8]];
-      var polygon = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      var polygon = new Polygon([outer, inner1, inner2]);
       var geojson = format.writeGeometry(polygon);
       expect(polygon.getCoordinates()).to.eql(
           format.readGeometry(geojson).getCoordinates());
@@ -633,9 +633,9 @@ describe('ol.format.GeoJSON', function() {
       var cw = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
 
-      var right = new _ol_geom_Polygon_([ccw, cw]);
+      var right = new Polygon([ccw, cw]);
       var rightMulti = new _ol_geom_MultiPolygon_([[ccw, cw]]);
-      var left = new _ol_geom_Polygon_([cw, ccw]);
+      var left = new Polygon([cw, ccw]);
       var leftMulti = new _ol_geom_MultiPolygon_([[cw, ccw]]);
 
       var rightObj = {
@@ -670,9 +670,9 @@ describe('ol.format.GeoJSON', function() {
 
       var cw = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
-      var right = new _ol_geom_Polygon_([ccw, cw]);
+      var right = new Polygon([ccw, cw]);
       var rightMulti = new _ol_geom_MultiPolygon_([[ccw, cw]]);
-      var left = new _ol_geom_Polygon_([cw, ccw]);
+      var left = new Polygon([cw, ccw]);
       var leftMulti = new _ol_geom_MultiPolygon_([[cw, ccw]]);
 
       var rightObj = {
@@ -701,9 +701,9 @@ describe('ol.format.GeoJSON', function() {
 
       var cw = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
-      var right = new _ol_geom_Polygon_([ccw, cw]);
+      var right = new Polygon([ccw, cw]);
       var rightMulti = new _ol_geom_MultiPolygon_([[ccw, cw]]);
-      var left = new _ol_geom_Polygon_([cw, ccw]);
+      var left = new Polygon([cw, ccw]);
       var leftMulti = new _ol_geom_MultiPolygon_([[cw, ccw]]);
 
       var leftObj = {

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -6,7 +6,7 @@ import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollec
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {fromLonLat, get as getProjection, toLonLat, transform} from '../../../../src/ol/proj.js';
 
@@ -147,7 +147,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeature(pointGeoJSON);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_Point_);
+      expect(geometry).to.be.an(Point);
       expect(geometry.getCoordinates()).to.eql([102.0, 0.5]);
       expect(feature.get('prop0')).to.be('value0');
     });
@@ -156,7 +156,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeature(pointGeoJSON.geometry);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_Point_);
+      expect(geometry).to.be.an(Point);
       expect(geometry.getCoordinates()).to.eql([102.0, 0.5]);
     });
 
@@ -200,7 +200,7 @@ describe('ol.format.GeoJSON', function() {
     it('can read a feature collection', function() {
       var features = format.readFeatures(featureCollectionGeoJSON);
       expect(features).to.have.length(3);
-      expect(features[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(features[0].getGeometry()).to.be.an(Point);
       expect(features[1].getGeometry()).to.be.an(_ol_geom_LineString_);
       expect(features[2].getGeometry()).to.be.an(_ol_geom_Polygon_);
     });
@@ -209,7 +209,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeatures(pointGeoJSON, {
         featureProjection: 'EPSG:3857'
       });
-      expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature[0].getGeometry()).to.be.an(Point);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
           transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
@@ -217,7 +217,7 @@ describe('ol.format.GeoJSON', function() {
     it('uses featureProjection passed to the constructor', function() {
       var format = new _ol_format_GeoJSON_({featureProjection: 'EPSG:3857'});
       var feature = format.readFeatures(pointGeoJSON);
-      expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature[0].getGeometry()).to.be.an(Point);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
           transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
@@ -227,7 +227,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = format.readFeatures(pointGeoJSON, {
         featureProjection: 'EPSG:3857'
       });
-      expect(feature[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature[0].getGeometry()).to.be.an(Point);
       expect(feature[0].getGeometry().getCoordinates()).to.eql(
           transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
     });
@@ -236,7 +236,7 @@ describe('ol.format.GeoJSON', function() {
       var features = format.readFeatures(featureCollectionGeoJSON, {
         featureProjection: 'EPSG:3857'
       });
-      expect(features[0].getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(features[0].getGeometry()).to.be.an(Point);
       expect(features[0].getGeometry().getCoordinates()).to.eql(
           transform([102.0, 0.5], 'EPSG:4326', 'EPSG:3857'));
       expect(features[1].getGeometry().getCoordinates()).to.eql([
@@ -257,7 +257,7 @@ describe('ol.format.GeoJSON', function() {
       var feature = new _ol_format_GeoJSON_({geometryName: 'the_geom'}).
           readFeature(pointGeoJSON);
       expect(feature.getGeometryName()).to.be('the_geom');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature.getGeometry()).to.be.an(Point);
     });
 
   });
@@ -356,7 +356,7 @@ describe('ol.format.GeoJSON', function() {
       });
 
       var obj = format.readGeometry(str);
-      expect(obj).to.be.a(_ol_geom_Point_);
+      expect(obj).to.be.a(Point);
       expect(obj.getCoordinates()).to.eql([10, 20]);
       expect(obj.getLayout()).to.eql('XY');
     });
@@ -417,7 +417,7 @@ describe('ol.format.GeoJSON', function() {
       expect(geometryCollection).to.be.an(_ol_geom_GeometryCollection_);
       var array = geometryCollection.getGeometries();
       expect(array.length).to.be(2);
-      expect(array[0]).to.be.a(_ol_geom_Point_);
+      expect(array[0]).to.be.a(Point);
       expect(array[0].getLayout()).to.eql('XY');
       expect(array[1]).to.be.a(_ol_geom_LineString_);
       expect(array[1].getLayout()).to.eql('XY');
@@ -464,7 +464,7 @@ describe('ol.format.GeoJSON', function() {
       var first = features[0];
       expect(first).to.be.a(_ol_Feature_);
       expect(first.get('foo')).to.be('bar');
-      expect(first.getGeometry()).to.be.a(_ol_geom_Point_);
+      expect(first.getGeometry()).to.be.a(Point);
 
       var second = features[1];
       expect(second).to.be.a(_ol_Feature_);
@@ -507,7 +507,7 @@ describe('ol.format.GeoJSON', function() {
       var first = features[0];
       expect(first).to.be.a(_ol_Feature_);
       expect(first.get('foo')).to.be('bar');
-      expect(first.getGeometry()).to.be.a(_ol_geom_Point_);
+      expect(first.getGeometry()).to.be.a(Point);
 
       var second = features[1];
       expect(second).to.be.a(_ol_Feature_);
@@ -562,13 +562,13 @@ describe('ol.format.GeoJSON', function() {
         function() {
           var feature = new _ol_Feature_({'foo': 'bar'});
           feature.setGeometryName('mygeom');
-          feature.setGeometry(new _ol_geom_Point_([5, 10]));
+          feature.setGeometry(new Point([5, 10]));
           var geojson = format.writeFeaturesObject([feature]);
           expect(geojson.features[0].properties.mygeom).to.eql(undefined);
         });
 
     it('writes out a feature without properties correctly', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Point_([5, 10]));
+      var feature = new _ol_Feature_(new Point([5, 10]));
       var geojson = format.writeFeatureObject(feature);
       expect(geojson.properties).to.eql(null);
     });
@@ -590,14 +590,14 @@ describe('ol.format.GeoJSON', function() {
   describe('#writeGeometry', function() {
 
     it('encodes point', function() {
-      var point = new _ol_geom_Point_([10, 20]);
+      var point = new Point([10, 20]);
       var geojson = format.writeGeometry(point);
       expect(point.getCoordinates()).to.eql(
           format.readGeometry(geojson).getCoordinates());
     });
 
     it('accepts featureProjection', function() {
-      var point = new _ol_geom_Point_(fromLonLat([10, 20]));
+      var point = new Point(fromLonLat([10, 20]));
       var geojson = format.writeGeometry(point, {featureProjection: 'EPSG:3857'});
       var obj = JSON.parse(geojson);
       expect(obj.coordinates).to.eql(toLonLat(point.getCoordinates()));
@@ -605,7 +605,7 @@ describe('ol.format.GeoJSON', function() {
 
     it('respects featureProjection passed to constructor', function() {
       var format = new _ol_format_GeoJSON_({featureProjection: 'EPSG:3857'});
-      var point = new _ol_geom_Point_(fromLonLat([10, 20]));
+      var point = new Point(fromLonLat([10, 20]));
       var geojson = format.writeGeometry(point);
       var obj = JSON.parse(geojson);
       expect(obj.coordinates).to.eql(toLonLat(point.getCoordinates()));
@@ -730,7 +730,7 @@ describe('ol.format.GeoJSON', function() {
 
     it('encodes geometry collection', function() {
       var collection = new _ol_geom_GeometryCollection_([
-        new _ol_geom_Point_([10, 20]),
+        new Point([10, 20]),
         new _ol_geom_LineString_([[30, 40], [50, 60]])
       ]);
       var geojson = format.writeGeometry(collection);
@@ -756,7 +756,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('transforms and encodes a point', function() {
-      var point = new _ol_geom_Point_([2, 3]);
+      var point = new Point([2, 3]);
       var geojson = format.writeGeometry(point, {
         featureProjection: 'EPSG:3857'
       });
@@ -771,7 +771,7 @@ describe('ol.format.GeoJSON', function() {
 
     it('transforms and encodes geometry collection', function() {
       var collection = new _ol_geom_GeometryCollection_([
-        new _ol_geom_Point_([2, 3]),
+        new Point([2, 3]),
         new _ol_geom_LineString_([[3, 2], [2, 1]])
       ]);
       var geojson = format.writeGeometry(collection, {
@@ -793,7 +793,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('truncates transformed point with decimals option', function() {
-      var point = new _ol_geom_Point_([2, 3]).transform('EPSG:4326', 'EPSG:3857');
+      var point = new Point([2, 3]).transform('EPSG:4326', 'EPSG:3857');
       var geojson = format.writeGeometry(point, {
         featureProjection: 'EPSG:3857',
         decimals: 2

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -4,7 +4,7 @@ import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
 import GeometryCollection from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
+import LinearRing from '../../../../src/ol/geom/LinearRing.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
@@ -399,9 +399,9 @@ describe('ol.format.GeoJSON', function() {
       expect(obj.getLayout()).to.eql('XY');
       var rings = obj.getLinearRings();
       expect(rings.length).to.be(3);
-      expect(rings[0]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[1]).to.be.a(_ol_geom_LinearRing_);
-      expect(rings[2]).to.be.a(_ol_geom_LinearRing_);
+      expect(rings[0]).to.be.a(LinearRing);
+      expect(rings[1]).to.be.a(LinearRing);
+      expect(rings[2]).to.be.a(LinearRing);
     });
 
     it('parses geometry collection', function() {

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
@@ -747,7 +747,7 @@ describe('ol.format.GeoJSON', function() {
     });
 
     it('encodes a circle as an empty geometry collection', function() {
-      var circle = new _ol_geom_Circle_([0, 0], 1);
+      var circle = new Circle([0, 0], 1);
       var geojson = format.writeGeometryObject(circle);
       expect(geojson).to.eql({
         'type': 'GeometryCollection',

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_GML_ from '../../../../src/ol/format/GML.js';
 import _ol_format_GML2_ from '../../../../src/ol/format/GML2.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
@@ -164,7 +164,7 @@ describe('ol.format.GML2', function() {
         '  </layer>';
 
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_([[1.1, 2], [3, 4.2]])
+        geometry: new LineString([[1.1, 2], [3, 4.2]])
       });
       feature.setId(1);
       var objectStack = [{
@@ -442,7 +442,7 @@ describe('ol.format.GML3', function() {
             '  <gml:posList srsDimension="2">1 2 3 4</gml:posList>' +
             '</gml:LineString>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_LineString_);
+        expect(g).to.be.an(LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [3, 4, 0]]);
         var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -459,7 +459,7 @@ describe('ol.format.GML3', function() {
             '  <gml:posList>1 2 3 4</gml:posList>' +
             '</gml:LineString>';
         var g = readGeometry(format, text, config);
-        expect(g).to.be.an(_ol_geom_LineString_);
+        expect(g).to.be.an(LineString);
         var coordinates = g.getCoordinates();
         expect(coordinates[0].slice(0, 2)).to.eql(
             transform([1, 2], 'CRS:84', 'EPSG:3857'));
@@ -481,7 +481,7 @@ describe('ol.format.GML3', function() {
             '  <gml:posList srsDimension="2">2 1 4 3</gml:posList>' +
             '</gml:LineString>';
         var g = readGeometry(formatWGS84, text);
-        expect(g).to.be.an(_ol_geom_LineString_);
+        expect(g).to.be.an(LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [3, 4, 0]]);
         var serialized = formatWGS84.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -500,7 +500,7 @@ describe('ol.format.GML3', function() {
                 ' <gml:posList srsDimension="2">-90 -180 90 180</gml:posList>' +
                 '</gml:LineString>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_LineString_);
+        expect(g).to.be.an(LineString);
         expect(g.getCoordinates()).to.eql([[-180, -90, 0], [180, 90, 0]]);
         var serialized = formatWGS84.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -563,7 +563,7 @@ describe('ol.format.GML3', function() {
             '  <gml:posList>1 2 3 4 5 6</gml:posList>' +
             '</gml:LineString>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_LineString_);
+        expect(g).to.be.an(LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
       });
 
@@ -677,7 +677,7 @@ describe('ol.format.GML3', function() {
             '  </gml:segments>' +
             '</gml:Curve>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_LineString_);
+        expect(g).to.be.an(LineString);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [3, 4, 0]]);
         format = new _ol_format_GML_({srsName: 'CRS:84', curve: true});
         var serialized = format.writeGeometryNode(g);
@@ -1522,7 +1522,7 @@ describe('ol.format.GML3', function() {
     it('creates a LineString', function() {
       feature = features[0];
       expect(feature.getId()).to.equal('geoserver_layer.1');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_LineString_);
+      expect(feature.getGeometry()).to.be.an(LineString);
     });
 
     it('creates a Polygon', function() {

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -7,7 +7,7 @@ import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
@@ -195,7 +195,7 @@ describe('ol.format.GML2', function() {
         '  </layer>';
 
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([[[1.1, 2], [3, 4.2], [5.2, 6]]])
+        geometry: new Polygon([[[1.1, 2], [3, 4.2], [5.2, 6]]])
       });
       feature.setId(1);
       var objectStack = [{
@@ -610,7 +610,7 @@ describe('ol.format.GML3', function() {
             '  </gml:interior>' +
             '</gml:Polygon>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Polygon_);
+        expect(g).to.be.an(Polygon);
         expect(g.getCoordinates()).to.eql([[[1, 2, 0], [3, 2, 0], [3, 4, 0],
           [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
         [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]]);
@@ -653,7 +653,7 @@ describe('ol.format.GML3', function() {
             '  </gml:patches>' +
             '</gml:Surface>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Polygon_);
+        expect(g).to.be.an(Polygon);
         expect(g.getCoordinates()).to.eql([[[1, 2, 0], [3, 2, 0], [3, 4, 0],
           [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
         [[3, 4, 0], [3, 6, 0], [5, 6, 0], [3, 4, 0]]]);
@@ -1528,7 +1528,7 @@ describe('ol.format.GML3', function() {
     it('creates a Polygon', function() {
       feature = features[1];
       expect(feature.getId()).to.equal('geoserver_layer.2');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_Polygon_);
+      expect(feature.getGeometry()).to.be.an(Polygon);
     });
 
     it('creates a Point', function() {

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -4,7 +4,7 @@ import _ol_format_GML2_ from '../../../../src/ol/format/GML2.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -253,7 +253,7 @@ describe('ol.format.GML2', function() {
         '  </layer>';
 
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_MultiPoint_([[1.1, 2]])
+        geometry: new MultiPoint([[1.1, 2]])
       });
       feature.setId(1);
       var objectStack = [{
@@ -724,7 +724,7 @@ describe('ol.format.GML3', function() {
             '  </gml:pointMember>' +
             '</gml:MultiPoint>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPoint_);
+        expect(g).to.be.an(MultiPoint);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [2, 3, 0], [3, 4, 0]]);
         var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -747,7 +747,7 @@ describe('ol.format.GML3', function() {
             '  </gml:pointMembers>' +
             '</gml:MultiPoint>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPoint_);
+        expect(g).to.be.an(MultiPoint);
         expect(g.getCoordinates()).to.eql([[1, 2, 0], [2, 3, 0], [3, 4, 0]]);
       });
 

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -6,7 +6,7 @@ import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
@@ -57,7 +57,7 @@ describe('ol.format.GML2', function() {
             '</gml:Point>';
 
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         expect(g.getCoordinates()).to.eql([-180, -90, 0]);
       });
 
@@ -68,7 +68,7 @@ describe('ol.format.GML2', function() {
             '</gml:Point>';
 
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         expect(g.getCoordinates()).to.eql([-180, -90, 42]);
       });
 
@@ -222,7 +222,7 @@ describe('ol.format.GML2', function() {
         '  </layer>';
 
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_Point_([1.1, 2])
+        geometry: new Point([1.1, 2])
       });
       feature.setId(1);
       var objectStack = [{
@@ -355,7 +355,7 @@ describe('ol.format.GML3', function() {
             '  <gml:pos srsDimension="2">1 2</gml:pos>' +
             '</gml:Point>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         expect(g.getCoordinates()).to.eql([1, 2, 0]);
         var serialized = format.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -368,7 +368,7 @@ describe('ol.format.GML3', function() {
             '  <gml:pos>1E7 2</gml:pos>' +
             '</gml:Point>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         expect(g.getCoordinates()).to.eql([10000000, 2, 0]);
         text =
             '<gml:Point xmlns:gml="http://www.opengis.net/gml" ' +
@@ -376,7 +376,7 @@ describe('ol.format.GML3', function() {
             '  <gml:pos>1e7 2</gml:pos>' +
             '</gml:Point>';
         g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         expect(g.getCoordinates()).to.eql([10000000, 2, 0]);
       });
 
@@ -390,7 +390,7 @@ describe('ol.format.GML3', function() {
             '  <gml:pos>1 2</gml:pos>' +
             '</gml:Point>';
         var g = readGeometry(format, text, config);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         var coordinates = g.getCoordinates();
         expect(coordinates.splice(0, 2)).to.eql(
             transform([1, 2], 'CRS:84', 'EPSG:3857'));
@@ -412,7 +412,7 @@ describe('ol.format.GML3', function() {
             '  <gml:pos>1 2</gml:pos>' +
             '</gml:Point>';
         var g = readGeometry(formatNoSrs, text, config);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         var coordinates = g.getCoordinates();
         expect(coordinates.splice(0, 2)).to.eql(
             transform([1, 2], 'CRS:84', 'EPSG:3857'));
@@ -425,7 +425,7 @@ describe('ol.format.GML3', function() {
             '  <gml:pos srsDimension="2">2 1</gml:pos>' +
             '</gml:Point>';
         var g = readGeometry(formatWGS84, text);
-        expect(g).to.be.an(_ol_geom_Point_);
+        expect(g).to.be.an(Point);
         expect(g.getCoordinates()).to.eql([1, 2, 0]);
         var serialized = formatWGS84.writeGeometryNode(g);
         expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -514,7 +514,7 @@ describe('ol.format.GML3', function() {
                 '  <gml:pos srsDimension="2">-90 -180</gml:pos>' +
                 '</gml:Point>';
             var g = readGeometry(format, text);
-            expect(g).to.be.an(_ol_geom_Point_);
+            expect(g).to.be.an(Point);
             expect(g.getCoordinates()).to.eql([-180, -90, 0]);
             var serialized = formatWGS84.writeGeometryNode(g);
             expect(serialized.firstElementChild).to.xmleql(_ol_xml_.parse(text));
@@ -1333,7 +1333,7 @@ describe('ol.format.GML3', function() {
 
     it('creates 2 geometries', function() {
       var feature = features[0];
-      expect(feature.get('center')).to.be.a(_ol_geom_Point_);
+      expect(feature.get('center')).to.be.a(Point);
       expect(feature.get('the_geom')).to.be.a(_ol_geom_MultiPolygon_);
     });
 
@@ -1534,7 +1534,7 @@ describe('ol.format.GML3', function() {
     it('creates a Point', function() {
       feature = features[2];
       expect(feature.getId()).to.equal('geoserver_layer.3');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_Point_);
+      expect(feature.getGeometry()).to.be.an(Point);
     });
 
 

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -5,7 +5,7 @@ import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {transform} from '../../../../src/ol/proj.js';
@@ -118,7 +118,7 @@ describe('ol.format.GML2', function() {
             '</gml:MultiPolygon>';
 
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPolygon_);
+        expect(g).to.be.an(MultiPolygon);
         expect(g.getCoordinates()).to.eql([
           [
             [
@@ -319,7 +319,7 @@ describe('ol.format.GML2', function() {
         '  </layer>';
 
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_MultiPolygon_([[[[1.1, 2], [3, 4.2], [5.2, 6]]]])
+        geometry: new MultiPolygon([[[[1.1, 2], [3, 4.2], [5.2, 6]]]])
       });
       feature.setId(1);
       var objectStack = [{
@@ -844,7 +844,7 @@ describe('ol.format.GML3', function() {
             '  </gml:polygonMember>' +
             '</gml:MultiPolygon>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPolygon_);
+        expect(g).to.be.an(MultiPolygon);
         expect(g.getCoordinates()).to.eql([
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0],
             [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
@@ -887,7 +887,7 @@ describe('ol.format.GML3', function() {
             '  </gml:polygonMembers>' +
             '</gml:MultiPolygon>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPolygon_);
+        expect(g).to.be.an(MultiPolygon);
         expect(g.getCoordinates()).to.eql([
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0],
             [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
@@ -1001,7 +1001,7 @@ describe('ol.format.GML3', function() {
             '  </gml:surfaceMember>' +
             '</gml:MultiSurface>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPolygon_);
+        expect(g).to.be.an(MultiPolygon);
         expect(g.getCoordinates()).to.eql([
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0],
             [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
@@ -1045,7 +1045,7 @@ describe('ol.format.GML3', function() {
             '  </gml:surfaceMembers>' +
             '</gml:MultiSurface>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPolygon_);
+        expect(g).to.be.an(MultiPolygon);
         expect(g.getCoordinates()).to.eql([
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0],
             [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
@@ -1103,7 +1103,7 @@ describe('ol.format.GML3', function() {
             '  </gml:surfaceMember>' +
             '</gml:MultiSurface>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiPolygon_);
+        expect(g).to.be.an(MultiPolygon);
         expect(g.getCoordinates()).to.eql([
           [[[1, 2, 0], [3, 2, 0], [3, 4, 0],
             [1, 2, 0]], [[2, 3, 0], [2, 5, 0], [4, 5, 0], [2, 3, 0]],
@@ -1308,7 +1308,7 @@ describe('ol.format.GML3', function() {
       feature = features[0];
       expect(feature.getId()).to.equal('states.1');
       expect(feature.get('STATE_NAME')).to.equal('Illinois');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_MultiPolygon_);
+      expect(feature.getGeometry()).to.be.an(MultiPolygon);
     });
 
   });
@@ -1334,7 +1334,7 @@ describe('ol.format.GML3', function() {
     it('creates 2 geometries', function() {
       var feature = features[0];
       expect(feature.get('center')).to.be.a(Point);
-      expect(feature.get('the_geom')).to.be.a(_ol_geom_MultiPolygon_);
+      expect(feature.get('the_geom')).to.be.a(MultiPolygon);
     });
 
   });

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_GML_ from '../../../../src/ol/format/GML.js';
 import _ol_format_GML2_ from '../../../../src/ol/format/GML2.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
+import LinearRing from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
@@ -578,7 +578,7 @@ describe('ol.format.GML3', function() {
             '  <gml:posList srsDimension="2">1 2 3 4 5 6 1 2</gml:posList>' +
             '</gml:LinearRing>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_LinearRing_);
+        expect(g).to.be.an(LinearRing);
         expect(g.getCoordinates()).to.eql(
             [[1, 2, 0], [3, 4, 0], [5, 6, 0], [1, 2, 0]]);
         var serialized = format.writeGeometryNode(g);

--- a/test/spec/ol/format/gml.test.js
+++ b/test/spec/ol/format/gml.test.js
@@ -3,7 +3,7 @@ import _ol_format_GML_ from '../../../../src/ol/format/GML.js';
 import _ol_format_GML2_ from '../../../../src/ol/format/GML2.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -284,7 +284,7 @@ describe('ol.format.GML2', function() {
         '  </layer>';
 
       var feature = new _ol_Feature_({
-        geometry: new _ol_geom_MultiLineString_([[[1.1, 2], [3, 4.2]]])
+        geometry: new MultiLineString([[[1.1, 2], [3, 4.2]]])
       });
       feature.setId(1);
       var objectStack = [{
@@ -771,7 +771,7 @@ describe('ol.format.GML3', function() {
             '  </gml:lineStringMember>' +
             '</gml:MultiLineString>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiLineString_);
+        expect(g).to.be.an(MultiLineString);
         expect(g.getCoordinates()).to.eql(
             [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
         format = new _ol_format_GML_({srsName: 'CRS:84', multiCurve: false});
@@ -793,7 +793,7 @@ describe('ol.format.GML3', function() {
             '  </gml:lineStringMembers>' +
             '</gml:MultiLineString>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiLineString_);
+        expect(g).to.be.an(MultiLineString);
         expect(g.getCoordinates()).to.eql(
             [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
       });
@@ -916,7 +916,7 @@ describe('ol.format.GML3', function() {
                 '  </gml:curveMember>' +
                 '</gml:MultiCurve>';
             var g = readGeometry(format, text);
-            expect(g).to.be.an(_ol_geom_MultiLineString_);
+            expect(g).to.be.an(MultiLineString);
             expect(g.getCoordinates()).to.eql(
                 [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
             var serialized = format.writeGeometryNode(g);
@@ -947,7 +947,7 @@ describe('ol.format.GML3', function() {
             '  </gml:curveMember>' +
             '</gml:MultiCurve>';
         var g = readGeometry(format, text);
-        expect(g).to.be.an(_ol_geom_MultiLineString_);
+        expect(g).to.be.an(MultiLineString);
         expect(g.getCoordinates()).to.eql(
             [[[1, 2, 0], [2, 3, 0]], [[3, 4, 0], [4, 5, 0]]]);
         format = new _ol_format_GML_({srsName: 'CRS:84', curve: true});

--- a/test/spec/ol/format/gpx.test.js
+++ b/test/spec/ol/format/gpx.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_GPX_ from '../../../../src/ol/format/GPX.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -38,7 +38,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_LineString_);
+      expect(g).to.be.an(LineString);
       expect(g.getCoordinates()).to.eql([]);
       expect(g.getLayout()).to.be('XY');
     });
@@ -95,7 +95,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_LineString_);
+      expect(g).to.be.an(LineString);
       expect(g.getCoordinates()).to.eql([[2, 1], [4, 3]]);
       expect(g.getLayout()).to.be('XY');
       var serialized = format.writeFeaturesNode(fs);
@@ -120,7 +120,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_LineString_);
+      expect(g).to.be.an(LineString);
       var p1 = transform([2, 1], 'EPSG:4326', 'EPSG:3857');
       var p2 = transform([6, 5], 'EPSG:4326', 'EPSG:3857');
       expect(g.getCoordinates()).to.eql([p1, p2]);

--- a/test/spec/ol/format/gpx.test.js
+++ b/test/spec/ol/format/gpx.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_GPX_ from '../../../../src/ol/format/GPX.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
@@ -393,7 +393,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql([2, 1]);
       expect(g.getLayout()).to.be('XY');
       var serialized = format.writeFeaturesNode(fs);
@@ -415,7 +415,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       var expectedPoint = transform([2, 1], 'EPSG:4326', 'EPSG:3857');
       expect(g.getCoordinates()).to.eql(expectedPoint);
       expect(g.getLayout()).to.be('XY');
@@ -440,7 +440,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql([2, 1, 3]);
       expect(g.getLayout()).to.be('XYZ');
       var serialized = format.writeFeaturesNode(fs);
@@ -462,7 +462,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql([2, 1, 1263115752]);
       expect(g.getLayout()).to.be('XYM');
       var serialized = format.writeFeaturesNode(fs);
@@ -485,7 +485,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql([2, 1, 3, 1263115752]);
       expect(g.getLayout()).to.be('XYZM');
       var serialized = format.writeFeaturesNode(fs);

--- a/test/spec/ol/format/gpx.test.js
+++ b/test/spec/ol/format/gpx.test.js
@@ -3,7 +3,7 @@ import _ol_format_GPX_ from '../../../../src/ol/format/GPX.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
@@ -661,7 +661,7 @@ describe('ol.format.GPX', function() {
     });
 
     it('does not fail', function() {
-      var polygon = new _ol_geom_Polygon_(
+      var polygon = new Polygon(
           [[[0, 0], [2, 2], [4, 0], [0, 0]]]);
       var feature = new _ol_Feature_(polygon);
       var features = [feature];

--- a/test/spec/ol/format/gpx.test.js
+++ b/test/spec/ol/format/gpx.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_GPX_ from '../../../../src/ol/format/GPX.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
@@ -162,7 +162,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_MultiLineString_);
+      expect(g).to.be.an(MultiLineString);
       expect(g.getCoordinates()).to.eql([]);
       expect(g.getLayout()).to.be('XY');
     });
@@ -218,7 +218,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_MultiLineString_);
+      expect(g).to.be.an(MultiLineString);
       expect(g.getCoordinates()).to.eql([[]]);
       expect(g.getLayout()).to.be('XY');
       var serialized = format.writeFeaturesNode(fs);
@@ -249,7 +249,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_MultiLineString_);
+      expect(g).to.be.an(MultiLineString);
       expect(g.getCoordinates()).to.eql([
         [[2, 1, 3, 1263115752], [6, 5, 7, 1263115812]]
       ]);
@@ -284,7 +284,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_MultiLineString_);
+      expect(g).to.be.an(MultiLineString);
       var p1 = transform([2, 1], 'EPSG:4326', 'EPSG:3857');
       p1.push(3, 1263115752);
       var p2 = transform([6, 5], 'EPSG:4326', 'EPSG:3857');
@@ -331,7 +331,7 @@ describe('ol.format.GPX', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_MultiLineString_);
+      expect(g).to.be.an(MultiLineString);
       expect(g.getCoordinates()).to.eql([
         [[2, 1, 3, 1263115752], [6, 5, 7, 1263115812]],
         [[9, 8, 10, 1263115872], [12, 11, 13, 1263115932]]

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -8,7 +8,7 @@ import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {addProjection, addCoordinateTransforms, transform, get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
@@ -239,7 +239,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Point_);
+          expect(g).to.be.an(Point);
           expect(g.getCoordinates()).to.eql([1, 2, 3]);
           expect(g.get('extrude')).to.be(false);
           expect(g.get('altitudeMode')).to.be('absolute');
@@ -265,7 +265,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Point_);
+          expect(g).to.be.an(Point);
           var expectedPoint = transform([1, 2], 'EPSG:4326', 'EPSG:3857');
           expectedPoint.push(3);
           expect(g.getCoordinates()).to.eql(expectedPoint);
@@ -287,7 +287,7 @@ describe('ol.format.KML', function() {
           var f = format.readFeature(text);
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Point_);
+          expect(g).to.be.an(Point);
           expect(g.getCoordinates()).to.eql([1, 2, 3]);
         });
 
@@ -309,7 +309,7 @@ describe('ol.format.KML', function() {
           });
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Point_);
+          expect(g).to.be.an(Point);
           var expectedPoint = transform([1, 2], 'EPSG:4326', 'EPSG:3857');
           expectedPoint.push(3);
           expect(g.getCoordinates()).to.eql(expectedPoint);
@@ -317,7 +317,7 @@ describe('ol.format.KML', function() {
 
         it('can write XY Point geometries', function() {
           var layout = 'XY';
-          var point = new _ol_geom_Point_([1, 2], layout);
+          var point = new Point([1, 2], layout);
           var features = [new _ol_Feature_(point)];
           var node = format.writeFeaturesNode(features);
           var text =
@@ -337,7 +337,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZ Point geometries', function() {
           var layout = 'XYZ';
-          var point = new _ol_geom_Point_([1, 2, 3], layout);
+          var point = new Point([1, 2, 3], layout);
           var features = [new _ol_Feature_(point)];
           var node = format.writeFeaturesNode(features);
           var text =
@@ -366,7 +366,7 @@ describe('ol.format.KML', function() {
               });
 
           var layout = 'XYZ';
-          var point = new _ol_geom_Point_([1, 2, 3], layout).transform(
+          var point = new Point([1, 2, 3], layout).transform(
               'EPSG:4326', 'double');
           var features = [new _ol_Feature_(point)];
           var node = format.writeFeaturesNode(features, {
@@ -394,7 +394,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYM Point geometries', function() {
           var layout = 'XYM';
-          var point = new _ol_geom_Point_([1, 2, 100], layout);
+          var point = new Point([1, 2, 100], layout);
           var features = [new _ol_Feature_(point)];
           var node = format.writeFeaturesNode(features);
           var text =
@@ -414,7 +414,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZM Point geometries', function() {
           var layout = 'XYZM';
-          var point = new _ol_geom_Point_([1, 2, 3, 100], layout);
+          var point = new Point([1, 2, 3, 100], layout);
           var features = [new _ol_Feature_(point)];
           var node = format.writeFeaturesNode(features);
           var text =
@@ -1180,7 +1180,7 @@ describe('ol.format.KML', function() {
           expect(g).to.be.an(_ol_geom_GeometryCollection_);
           var gs = g.getGeometries();
           expect(gs).to.have.length(4);
-          expect(gs[0]).to.be.an(_ol_geom_Point_);
+          expect(gs[0]).to.be.an(Point);
           expect(gs[1]).to.be.an(_ol_geom_LineString_);
           expect(gs[2]).to.be.an(_ol_geom_Polygon_);
           expect(gs[3]).to.be.an(_ol_geom_Polygon_);
@@ -1209,7 +1209,7 @@ describe('ol.format.KML', function() {
 
         it('can write GeometryCollection geometries', function() {
           var collection = new _ol_geom_GeometryCollection_([
-            new _ol_geom_Point_([1, 2]),
+            new Point([1, 2]),
             new _ol_geom_LineString_([[1, 2], [3, 4]]),
             new _ol_geom_Polygon_([[[1, 2], [3, 4], [3, 2], [1, 2]]])
           ]);
@@ -2848,7 +2848,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Point_);
+          expect(g).to.be.an(Point);
           var expectedPoint = transform([1, 2], 'EPSG:4326', 'EPSG:3857');
           expectedPoint.push(3);
           expect(g.getCoordinates()).to.eql(expectedPoint);
@@ -3198,7 +3198,7 @@ describe('ol.format.KML', function() {
         expect(geometry).to.be.an(_ol_geom_GeometryCollection_);
         var components = geometry.getGeometries();
         expect(components).to.have.length(2);
-        expect(components[0]).to.be.an(_ol_geom_Point_);
+        expect(components[0]).to.be.an(Point);
         expect(components[1]).to.be.an(_ol_geom_MultiPolygon_);
       });
 

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -7,7 +7,7 @@ import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {addProjection, addCoordinateTransforms, transform, get as getProjection} from '../../../../src/ol/proj.js';
@@ -876,7 +876,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_MultiPolygon_);
+          expect(g).to.be.an(MultiPolygon);
           expect(g.getCoordinates()).to.eql(
               [[[[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]],
                 [[[3, 0, 0], [3, 1, 0], [4, 1, 0], [4, 0, 0]]]]);
@@ -892,7 +892,7 @@ describe('ol.format.KML', function() {
 
         it('can write MultiPolygon geometries', function() {
           var layout = 'XYZ';
-          var multiPolygon = new _ol_geom_MultiPolygon_(
+          var multiPolygon = new MultiPolygon(
               [[[[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]],
                 [[[3, 0, 0], [3, 1, 0], [4, 1, 0], [4, 0, 0]]]], layout);
           var features = [new _ol_Feature_(multiPolygon)];
@@ -1080,7 +1080,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_MultiPolygon_);
+          expect(g).to.be.an(MultiPolygon);
           expect(g.getCoordinates()).to.eql([
             [[[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]],
             [[[3, 0, 0], [3, 1, 0], [4, 1, 0], [4, 0, 0]]]
@@ -1097,7 +1097,7 @@ describe('ol.format.KML', function() {
 
         it('can write MultiPolygon geometries', function() {
           var layout = 'XYZ';
-          var multiPolygon = new _ol_geom_MultiPolygon_([
+          var multiPolygon = new MultiPolygon([
             [[[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 0, 0]]],
             [[[3, 0, 0], [3, 1, 0], [4, 1, 0], [4, 0, 0]]]
           ], layout);
@@ -3199,7 +3199,7 @@ describe('ol.format.KML', function() {
         var components = geometry.getGeometries();
         expect(components).to.have.length(2);
         expect(components[0]).to.be.an(Point);
-        expect(components[1]).to.be.an(_ol_geom_MultiPolygon_);
+        expect(components[1]).to.be.an(MultiPolygon);
       });
 
       it('reads style and icon', function() {

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -3,7 +3,7 @@ import _ol_array_ from '../../../../src/ol/array.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_format_KML_ from '../../../../src/ol/format/KML.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
@@ -194,7 +194,7 @@ describe('ol.format.KML', function() {
 
 
         it('can write properties', function() {
-          var lineString = new _ol_geom_LineString_([[1, 2], [3, 4]]);
+          var lineString = new LineString([[1, 2], [3, 4]]);
           lineString.set('extrude', false);
           lineString.set('tessellate', true);
           lineString.set('altitudeMode', 'clampToGround');
@@ -449,7 +449,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_LineString_);
+          expect(g).to.be.an(LineString);
           expect(g.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
           expect(g.get('extrude')).to.be(false);
           expect(g.get('tessellate')).to.be(true);
@@ -458,7 +458,7 @@ describe('ol.format.KML', function() {
 
         it('can write XY LineString geometries', function() {
           var layout = 'XY';
-          var lineString = new _ol_geom_LineString_([[1, 2], [3, 4]], layout);
+          var lineString = new LineString([[1, 2], [3, 4]], layout);
           var features = [new _ol_Feature_(lineString)];
           var node = format.writeFeaturesNode(features);
           var text =
@@ -478,7 +478,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZ LineString geometries', function() {
           var layout = 'XYZ';
-          var lineString = new _ol_geom_LineString_(
+          var lineString = new LineString(
               [[1, 2, 3], [4, 5, 6]], layout);
           var features = [new _ol_Feature_(lineString)];
           var node = format.writeFeaturesNode(features);
@@ -499,7 +499,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYM LineString geometries', function() {
           var layout = 'XYM';
-          var lineString = new _ol_geom_LineString_(
+          var lineString = new LineString(
               [[1, 2, 100], [3, 4, 200]], layout);
           var features = [new _ol_Feature_(lineString)];
           var node = format.writeFeaturesNode(features);
@@ -520,7 +520,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZM LineString geometries', function() {
           var layout = 'XYZM';
-          var lineString = new _ol_geom_LineString_(
+          var lineString = new LineString(
               [[1, 2, 3, 100], [4, 5, 6, 200]], layout);
           var features = [new _ol_Feature_(lineString)];
           var node = format.writeFeaturesNode(features);
@@ -1181,7 +1181,7 @@ describe('ol.format.KML', function() {
           var gs = g.getGeometries();
           expect(gs).to.have.length(4);
           expect(gs[0]).to.be.an(Point);
-          expect(gs[1]).to.be.an(_ol_geom_LineString_);
+          expect(gs[1]).to.be.an(LineString);
           expect(gs[2]).to.be.an(_ol_geom_Polygon_);
           expect(gs[3]).to.be.an(_ol_geom_Polygon_);
         });
@@ -1210,7 +1210,7 @@ describe('ol.format.KML', function() {
         it('can write GeometryCollection geometries', function() {
           var collection = new _ol_geom_GeometryCollection_([
             new Point([1, 2]),
-            new _ol_geom_LineString_([[1, 2], [3, 4]]),
+            new LineString([[1, 2], [3, 4]]),
             new _ol_geom_Polygon_([[[1, 2], [3, 4], [3, 2], [1, 2]]])
           ]);
           var features = [new _ol_Feature_(collection)];
@@ -1262,7 +1262,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_LineString_);
+          expect(g).to.be.an(LineString);
         });
 
         it('can read gx:MultiTrack', function() {
@@ -1292,7 +1292,7 @@ describe('ol.format.KML', function() {
           expect(g).to.be.an(_ol_geom_MultiLineString_);
           var gs = g.getLineStrings();
           expect(gs).to.have.length(2);
-          expect(gs[0]).to.be.an(_ol_geom_LineString_);
+          expect(gs[0]).to.be.an(LineString);
         });
 
         it('can read dateTime', function() {

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -4,7 +4,7 @@ import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_format_KML_ from '../../../../src/ol/format/KML.js';
 import GeometryCollection from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
+import LinearRing from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
@@ -559,7 +559,7 @@ describe('ol.format.KML', function() {
 
         it('can write XY LinearRing geometries', function() {
           var layout = 'XY';
-          var linearRing = new _ol_geom_LinearRing_(
+          var linearRing = new LinearRing(
               [[1, 2], [3, 4], [1, 2]], layout);
           var features = [new _ol_Feature_(linearRing)];
           var node = format.writeFeaturesNode(features);
@@ -580,7 +580,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZ LinearRing geometries', function() {
           var layout = 'XYZ';
-          var linearRing = new _ol_geom_LinearRing_(
+          var linearRing = new LinearRing(
               [[1, 2, 3], [4, 5, 6], [1, 2, 3]], layout);
           var features = [new _ol_Feature_(linearRing)];
           var node = format.writeFeaturesNode(features);
@@ -601,7 +601,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYM LinearRing geometries', function() {
           var layout = 'XYM';
-          var linearRing = new _ol_geom_LinearRing_(
+          var linearRing = new LinearRing(
               [[1, 2, 100], [3, 4, 200], [1, 2, 100]], layout);
           var features = [new _ol_Feature_(linearRing)];
           var node = format.writeFeaturesNode(features);
@@ -622,7 +622,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZM LinearRing geometries', function() {
           var layout = 'XYZM';
-          var linearRing = new _ol_geom_LinearRing_(
+          var linearRing = new LinearRing(
               [[1, 2, 3, 100], [4, 5, 6, 200], [1, 2, 3, 100]], layout);
           var features = [new _ol_Feature_(linearRing)];
           var node = format.writeFeaturesNode(features);

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -9,7 +9,7 @@ import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {addProjection, addCoordinateTransforms, transform, get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_proj_transforms_ from '../../../../src/ol/proj/transforms.js';
@@ -553,7 +553,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Polygon_);
+          expect(g).to.be.an(Polygon);
           expect(g.getCoordinates()).to.eql([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]);
         });
 
@@ -661,7 +661,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Polygon_);
+          expect(g).to.be.an(Polygon);
           expect(g.getCoordinates()).to.eql(
               [[[0, 0, 1], [0, 5, 1], [5, 5, 2], [5, 0, 3]]]);
           expect(g.get('extrude')).to.be(false);
@@ -670,7 +670,7 @@ describe('ol.format.KML', function() {
 
         it('can write XY Polygon geometries', function() {
           var layout = 'XY';
-          var polygon = new _ol_geom_Polygon_(
+          var polygon = new Polygon(
               [[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]], layout);
           var features = [new _ol_Feature_(polygon)];
           var node = format.writeFeaturesNode(features);
@@ -695,7 +695,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZ Polygon geometries', function() {
           var layout = 'XYZ';
-          var polygon = new _ol_geom_Polygon_(
+          var polygon = new Polygon(
               [[[0, 0, 1], [0, 2, 2], [2, 2, 3], [2, 0, 4], [0, 0, 5]]], layout);
           var features = [new _ol_Feature_(polygon)];
           var node = format.writeFeaturesNode(features);
@@ -722,7 +722,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYM Polygon geometries', function() {
           var layout = 'XYM';
-          var polygon = new _ol_geom_Polygon_(
+          var polygon = new Polygon(
               [[[0, 0, 1], [0, 2, 1], [2, 2, 1], [2, 0, 1], [0, 0, 1]]], layout);
           var features = [new _ol_Feature_(polygon)];
           var node = format.writeFeaturesNode(features);
@@ -749,7 +749,7 @@ describe('ol.format.KML', function() {
 
         it('can write XYZM Polygon geometries', function() {
           var layout = 'XYZM';
-          var polygon = new _ol_geom_Polygon_([
+          var polygon = new Polygon([
             [[0, 0, 1, 1], [0, 2, 2, 1], [2, 2, 3, 1], [2, 0, 4, 1], [0, 0, 5, 1]]
           ], layout);
           var features = [new _ol_Feature_(polygon)];
@@ -801,7 +801,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_Polygon_);
+          expect(g).to.be.an(Polygon);
           expect(g.getCoordinates()).to.eql([
             [[0, 0, 1], [0, 5, 1], [5, 5, 2], [5, 0, 3]],
             [[1, 1, 0], [1, 2, 0], [2, 2, 0], [2, 1, 0]],
@@ -811,7 +811,7 @@ describe('ol.format.KML', function() {
 
         it('can write complex Polygon geometries', function() {
           var layout = 'XYZ';
-          var polygon = new _ol_geom_Polygon_([
+          var polygon = new Polygon([
             [[0, 0, 1], [0, 5, 1], [5, 5, 2], [5, 0, 3]],
             [[1, 1, 0], [1, 2, 0], [2, 2, 0], [2, 1, 0]],
             [[3, 3, 0], [3, 4, 0], [4, 4, 0], [4, 3, 0]]
@@ -1182,8 +1182,8 @@ describe('ol.format.KML', function() {
           expect(gs).to.have.length(4);
           expect(gs[0]).to.be.an(Point);
           expect(gs[1]).to.be.an(LineString);
-          expect(gs[2]).to.be.an(_ol_geom_Polygon_);
-          expect(gs[3]).to.be.an(_ol_geom_Polygon_);
+          expect(gs[2]).to.be.an(Polygon);
+          expect(gs[3]).to.be.an(Polygon);
         });
 
         it('can read nested GeometryCollection geometries', function() {
@@ -1211,7 +1211,7 @@ describe('ol.format.KML', function() {
           var collection = new _ol_geom_GeometryCollection_([
             new Point([1, 2]),
             new LineString([[1, 2], [3, 4]]),
-            new _ol_geom_Polygon_([[[1, 2], [3, 4], [3, 2], [1, 2]]])
+            new Polygon([[[1, 2], [3, 4], [3, 2], [1, 2]]])
           ]);
           var features = [new _ol_Feature_(collection)];
           var node = format.writeFeaturesNode(features);

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -5,7 +5,7 @@ import _ol_format_KML_ from '../../../../src/ol/format/KML.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -1008,7 +1008,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_MultiLineString_);
+          expect(g).to.be.an(MultiLineString);
           expect(g.getCoordinates()).to.eql(
               [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]);
           expect(g.get('extrude')).to.be.an('array');
@@ -1027,7 +1027,7 @@ describe('ol.format.KML', function() {
 
         it('can write MultiLineString geometries', function() {
           var layout = 'XYZ';
-          var multiLineString = new _ol_geom_MultiLineString_(
+          var multiLineString = new MultiLineString(
               [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], layout);
           var features = [new _ol_Feature_(multiLineString)];
           var node = format.writeFeaturesNode(features);
@@ -1289,7 +1289,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_MultiLineString_);
+          expect(g).to.be.an(MultiLineString);
           var gs = g.getLineStrings();
           expect(gs).to.have.length(2);
           expect(gs[0]).to.be.an(LineString);

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -6,7 +6,7 @@ import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollec
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -948,7 +948,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_MultiPoint_);
+          expect(g).to.be.an(MultiPoint);
           expect(g.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
           expect(g.get('extrude')).to.be.an('array');
           expect(g.get('extrude')).to.have.length(2);
@@ -962,7 +962,7 @@ describe('ol.format.KML', function() {
 
         it('can write MultiPoint geometries', function() {
           var layout = 'XYZ';
-          var multiPoint = new _ol_geom_MultiPoint_(
+          var multiPoint = new MultiPoint(
               [[1, 2, 3], [4, 5, 6]], layout);
           var features = [new _ol_Feature_(multiPoint)];
           var node = format.writeFeaturesNode(features);

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_array_ from '../../../../src/ol/array.js';
 import _ol_format_GeoJSON_ from '../../../../src/ol/format/GeoJSON.js';
 import _ol_format_KML_ from '../../../../src/ol/format/KML.js';
-import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
@@ -1144,7 +1144,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_GeometryCollection_);
+          expect(g).to.be.an(GeometryCollection);
           expect(g.getGeometries()).to.be.empty();
         });
 
@@ -1177,7 +1177,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_GeometryCollection_);
+          expect(g).to.be.an(GeometryCollection);
           var gs = g.getGeometries();
           expect(gs).to.have.length(4);
           expect(gs[0]).to.be.an(Point);
@@ -1201,14 +1201,14 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_GeometryCollection_);
+          expect(g).to.be.an(GeometryCollection);
           var gs = g.getGeometries();
           expect(gs).to.have.length(1);
-          expect(gs[0]).to.be.an(_ol_geom_GeometryCollection_);
+          expect(gs[0]).to.be.an(GeometryCollection);
         });
 
         it('can write GeometryCollection geometries', function() {
-          var collection = new _ol_geom_GeometryCollection_([
+          var collection = new GeometryCollection([
             new Point([1, 2]),
             new LineString([[1, 2], [3, 4]]),
             new Polygon([[[1, 2], [3, 4], [3, 2], [1, 2]]])
@@ -3112,7 +3112,7 @@ describe('ol.format.KML', function() {
           var f = fs[0];
           expect(f).to.be.an(_ol_Feature_);
           var g = f.getGeometry();
-          expect(g).to.be.an(_ol_geom_GeometryCollection_);
+          expect(g).to.be.an(GeometryCollection);
           expect(g.getGeometries()).to.be.empty();
         });
 
@@ -3186,7 +3186,7 @@ describe('ol.format.KML', function() {
         var feature = features[0];
         expect(feature).to.be.an(_ol_Feature_);
         var geometry = feature.getGeometry();
-        expect(geometry).to.be.an(_ol_geom_GeometryCollection_);
+        expect(geometry).to.be.an(GeometryCollection);
       });
 
       it('creates a Point and a MultiPolygon for Alaska', function() {
@@ -3195,7 +3195,7 @@ describe('ol.format.KML', function() {
         });
         expect(alaska).to.be.an(_ol_Feature_);
         var geometry = alaska.getGeometry();
-        expect(geometry).to.be.an(_ol_geom_GeometryCollection_);
+        expect(geometry).to.be.an(GeometryCollection);
         var components = geometry.getGeometries();
         expect(components).to.have.length(2);
         expect(components[0]).to.be.an(Point);

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -3,7 +3,7 @@ import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_MVT_ from '../../../../src/ol/format/MVT.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_render_Feature_ from '../../../../src/ol/render/Feature.js';
 
 where('ArrayBuffer.isView').describe('ol.format.MVT', function() {
@@ -159,7 +159,7 @@ describe('ol.format.MVT', function() {
       var feature = format.createFeature_({}, rawFeature);
       _ol_format_MVT_.readRawGeometry_ = readRawGeometry_;
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.a(_ol_geom_MultiPolygon_);
+      expect(geometry).to.be.a(MultiPolygon);
     });
 
     it('creates ol.render.Feature instances', function() {

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_MVT_ from '../../../../src/ol/format/MVT.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_render_Feature_ from '../../../../src/ol/render/Feature.js';
@@ -111,7 +111,7 @@ describe('ol.format.MVT', function() {
       var feature = format.createFeature_({}, rawFeature);
       _ol_format_MVT_.readRawGeometry_ = readRawGeometry_;
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Point_);
+      expect(geometry).to.be.a(Point);
       expect(feature.get('myGeom')).to.equal(geometry);
       expect(feature.get('geometry')).to.be('foo');
     });

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_format_MVT_ from '../../../../src/ol/format/MVT.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_render_Feature_ from '../../../../src/ol/render/Feature.js';
 
@@ -136,7 +136,7 @@ describe('ol.format.MVT', function() {
       var feature = format.createFeature_({}, rawFeature);
       _ol_format_MVT_.readRawGeometry_ = readRawGeometry_;
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
     });
 
     it('detects a MultiPolygon', function() {

--- a/test/spec/ol/format/osmxml.test.js
+++ b/test/spec/ol/format/osmxml.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_OSMXML_ from '../../../../src/ol/format/OSMXML.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 
@@ -81,7 +81,7 @@ describe('ol.format.OSMXML', function() {
       var line = fs[2];
       expect(line).to.be.an(_ol_Feature_);
       g = line.getGeometry();
-      expect(g).to.be.an(_ol_geom_LineString_);
+      expect(g).to.be.an(LineString);
       expect(g.getCoordinates()).to.eql([[2, 1], [4, 3]]);
     });
 
@@ -107,7 +107,7 @@ describe('ol.format.OSMXML', function() {
       var line = fs[2];
       expect(line).to.be.an(_ol_Feature_);
       var g = line.getGeometry();
-      expect(g).to.be.an(_ol_geom_LineString_);
+      expect(g).to.be.an(LineString);
       expect(g.getCoordinates()).to.eql([[2, 1], [4, 3]]);
     });
 

--- a/test/spec/ol/format/osmxml.test.js
+++ b/test/spec/ol/format/osmxml.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_OSMXML_ from '../../../../src/ol/format/OSMXML.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
@@ -51,7 +51,7 @@ describe('ol.format.OSMXML', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql([2, 1]);
     });
 
@@ -76,7 +76,7 @@ describe('ol.format.OSMXML', function() {
       var point = fs[0];
       expect(point).to.be.an(_ol_Feature_);
       var g = point.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql([2, 1]);
       var line = fs[2];
       expect(line).to.be.an(_ol_Feature_);
@@ -130,7 +130,7 @@ describe('ol.format.OSMXML', function() {
       var f = fs[0];
       expect(f).to.be.an(_ol_Feature_);
       var g = f.getGeometry();
-      expect(g).to.be.an(_ol_geom_Point_);
+      expect(g).to.be.an(Point);
       expect(g.getCoordinates()).to.eql(
           transform([2, 1], 'EPSG:4326', 'EPSG:3857'));
     });

--- a/test/spec/ol/format/polyline.test.js
+++ b/test/spec/ol/format/polyline.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_Polyline_ from '../../../../src/ol/format/Polyline.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import {get as getProjection, transform} from '../../../../src/ol/proj.js';
 
 describe('ol.format.Polyline', function() {
@@ -267,7 +267,7 @@ describe('ol.format.Polyline', function() {
       var feature = format.readFeature(encodedFlatPoints);
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getFlatCoordinates()).to.eql(flatPoints);
     });
 
@@ -277,7 +277,7 @@ describe('ol.format.Polyline', function() {
       });
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getCoordinates()).to.eql(points3857);
     });
 
@@ -292,7 +292,7 @@ describe('ol.format.Polyline', function() {
       var feature = features[0];
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getFlatCoordinates()).to.eql(flatPoints);
     });
 
@@ -305,7 +305,7 @@ describe('ol.format.Polyline', function() {
       var feature = features[0];
       expect(feature).to.be.an(_ol_Feature_);
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getCoordinates()).to.eql(points3857);
     });
 
@@ -315,7 +315,7 @@ describe('ol.format.Polyline', function() {
 
     it('returns the expected geometry', function() {
       var geometry = format.readGeometry(encodedFlatPoints);
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getFlatCoordinates()).to.eql(flatPoints);
     });
 
@@ -342,7 +342,7 @@ describe('ol.format.Polyline', function() {
       var geometry = format.readGeometry(encodedFlatPoints, {
         featureProjection: 'EPSG:3857'
       });
-      expect(geometry).to.be.an(_ol_geom_LineString_);
+      expect(geometry).to.be.an(LineString);
       expect(geometry.getCoordinates()).to.eql(points3857);
     });
 
@@ -360,12 +360,12 @@ describe('ol.format.Polyline', function() {
   describe('#writeFeature', function() {
 
     it('returns the expected text', function() {
-      var feature = new _ol_Feature_(new _ol_geom_LineString_(points));
+      var feature = new _ol_Feature_(new LineString(points));
       expect(format.writeFeature(feature)).to.be(encodedFlatPoints);
     });
 
     it('transforms and returns the expected text', function() {
-      var feature = new _ol_Feature_(new _ol_geom_LineString_(points3857));
+      var feature = new _ol_Feature_(new LineString(points3857));
       expect(format.writeFeature(feature, {
         featureProjection: 'EPSG:3857'
       })).to.be(encodedFlatPoints);
@@ -376,12 +376,12 @@ describe('ol.format.Polyline', function() {
   describe('#writeFeature', function() {
 
     it('returns the expected text', function() {
-      var features = [new _ol_Feature_(new _ol_geom_LineString_(points))];
+      var features = [new _ol_Feature_(new LineString(points))];
       expect(format.writeFeatures(features)).to.be(encodedFlatPoints);
     });
 
     it('transforms and returns the expected text', function() {
-      var features = [new _ol_Feature_(new _ol_geom_LineString_(points3857))];
+      var features = [new _ol_Feature_(new LineString(points3857))];
       expect(format.writeFeatures(features, {
         featureProjection: 'EPSG:3857'
       })).to.be(encodedFlatPoints);
@@ -392,12 +392,12 @@ describe('ol.format.Polyline', function() {
   describe('#writeGeometry', function() {
 
     it('returns the expected text', function() {
-      var geometry = new _ol_geom_LineString_(points);
+      var geometry = new LineString(points);
       expect(format.writeGeometry(geometry)).to.be(encodedFlatPoints);
     });
 
     it('transforms and returns the expected text', function() {
-      var geometry = new _ol_geom_LineString_(points3857);
+      var geometry = new LineString(points3857);
       expect(format.writeGeometry(geometry, {
         featureProjection: 'EPSG:3857'
       })).to.be(encodedFlatPoints);

--- a/test/spec/ol/format/topojson.test.js
+++ b/test/spec/ol/format/topojson.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_format_Feature_ from '../../../../src/ol/format/Feature.js';
 import {transform} from '../../../../src/ol/proj.js';
@@ -157,7 +157,7 @@ describe('ol.format.TopoJSON', function() {
         var first = features[0];
         expect(first).to.be.a(_ol_Feature_);
         var firstGeom = first.getGeometry();
-        expect(firstGeom).to.be.a(_ol_geom_MultiPolygon_);
+        expect(firstGeom).to.be.a(MultiPolygon);
         expect(firstGeom.getExtent()).to.eql(
             [-180, -85.60903777459777, 180, 83.64513000000002]);
 

--- a/test/spec/ol/format/topojson.test.js
+++ b/test/spec/ol/format/topojson.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_format_Feature_ from '../../../../src/ol/format/Feature.js';
 import {transform} from '../../../../src/ol/proj.js';
 import _ol_format_TopoJSON_ from '../../../../src/ol/format/TopoJSON.js';
@@ -62,7 +62,7 @@ describe('ol.format.TopoJSON', function() {
       expect(feature).to.be.a(_ol_Feature_);
 
       var geometry = feature.getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
 
       // Parses identifier
       expect(feature.getId()).to.be(533);
@@ -164,7 +164,7 @@ describe('ol.format.TopoJSON', function() {
         var last = features[177];
         expect(last).to.be.a(_ol_Feature_);
         var lastGeom = last.getGeometry();
-        expect(lastGeom).to.be.a(_ol_geom_Polygon_);
+        expect(lastGeom).to.be.a(Polygon);
         expect(lastGeom.getExtent()).to.eql([
           25.26325263252633, -22.271802279310577,
           32.848528485284874, -15.50833810039586

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -4,7 +4,7 @@ import _ol_format_WFS_ from '../../../../src/ol/format/WFS.js';
 import _ol_format_filter_ from '../../../../src/ol/format/filter.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {transform} from '../../../../src/ol/proj.js';
@@ -864,14 +864,14 @@ describe('ol.format.WFS', function() {
     it('creates the correct transaction body', function() {
       var format = new _ol_format_WFS_();
       var insertFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiPoint_([[1, 2]]),
+        the_geom: new MultiPoint([[1, 2]]),
         foo: 'bar',
         nul: null
       });
       insertFeature.setGeometryName('the_geom');
       var inserts = [insertFeature];
       var updateFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiPoint_([[1, 2]]),
+        the_geom: new MultiPoint([[1, 2]]),
         foo: 'bar',
         // null value gets Property element with no Value
         nul: null,
@@ -978,14 +978,14 @@ describe('ol.format.WFS', function() {
     it('do not add feature prefix twice', function() {
       var format = new _ol_format_WFS_();
       var insertFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiPoint_([[1, 2]]),
+        the_geom: new MultiPoint([[1, 2]]),
         foo: 'bar',
         nul: null
       });
       insertFeature.setGeometryName('the_geom');
       var inserts = [insertFeature];
       var updateFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiPoint_([[1, 2]]),
+        the_geom: new MultiPoint([[1, 2]]),
         foo: 'bar',
         // null value gets Property element with no Value
         nul: null,
@@ -1063,14 +1063,14 @@ describe('ol.format.WFS', function() {
     it('handles 3D in WFS 1.1.0', function() {
       var format = new _ol_format_WFS_();
       var insertFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiPoint_([[1, 2, 3]]),
+        the_geom: new MultiPoint([[1, 2, 3]]),
         foo: 'bar',
         nul: null
       });
       insertFeature.setGeometryName('the_geom');
       var inserts = [insertFeature];
       var updateFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiPoint_([[1, 2, 3]]),
+        the_geom: new MultiPoint([[1, 2, 3]]),
         foo: 'bar',
         // null value gets Property element with no Value
         nul: null,

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -6,7 +6,7 @@ import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
@@ -551,7 +551,7 @@ describe('ol.format.WFS', function() {
         featureTypes: ['area'],
         filter: _ol_format_filter_.contains(
             'the_geom',
-            new _ol_geom_Polygon_([[
+            new Polygon([[
               [10, 20],
               [10, 25],
               [15, 25],
@@ -588,7 +588,7 @@ describe('ol.format.WFS', function() {
         featureTypes: ['area'],
         filter: _ol_format_filter_.intersects(
             'the_geom',
-            new _ol_geom_Polygon_([[
+            new Polygon([[
               [10, 20],
               [10, 25],
               [15, 25],
@@ -625,7 +625,7 @@ describe('ol.format.WFS', function() {
         featureTypes: ['area'],
         filter: _ol_format_filter_.within(
             'the_geom',
-            new _ol_geom_Polygon_([[
+            new Polygon([[
               [10, 20],
               [10, 25],
               [15, 25],
@@ -1138,7 +1138,7 @@ describe('ol.format.WFS', function() {
       var fid = 'Historische_Messtischblaetter_WFS.71055885';
       expect(feature.getId()).to.equal(fid);
       expect(feature.get('titel')).to.equal('Arnstadt');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_Polygon_);
+      expect(feature.getGeometry()).to.be.an(Polygon);
     });
 
   });

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -3,7 +3,7 @@ import _ol_format_GML2_ from '../../../../src/ol/format/GML2.js';
 import _ol_format_WFS_ from '../../../../src/ol/format/WFS.js';
 import _ol_format_filter_ from '../../../../src/ol/format/filter.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -697,7 +697,7 @@ describe('ol.format.WFS', function() {
     it('creates the correct srsName', function() {
       var format = new _ol_format_WFS_();
       var insertFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_MultiLineString_([[
+        the_geom: new MultiLineString([[
           [-5178372.1885436, 1992365.7775042],
           [-4434792.7774889, 1601008.1927386],
           [-4043435.1927233, 2148908.8114105]
@@ -729,7 +729,7 @@ describe('ol.format.WFS', function() {
       var format = new _ol_format_WFS_();
       var updateFeature = new _ol_Feature_();
       updateFeature.setGeometryName('the_geom');
-      updateFeature.setGeometry(new _ol_geom_MultiLineString_([[
+      updateFeature.setGeometry(new MultiLineString([[
         [-12279454, 6741885],
         [-12064207, 6732101],
         [-11941908, 6595126],
@@ -748,7 +748,7 @@ describe('ol.format.WFS', function() {
 
     it('creates the correct update if geometry name is alias', function() {
       var format = new _ol_format_WFS_();
-      var updateFeature = new _ol_Feature_(new _ol_geom_MultiLineString_([[
+      var updateFeature = new _ol_Feature_(new MultiLineString([[
         [-12279454, 6741885],
         [-12064207, 6732101],
         [-11941908, 6595126],
@@ -774,7 +774,7 @@ describe('ol.format.WFS', function() {
       var format = new _ol_format_WFS_();
       var updateFeature = new _ol_Feature_();
       updateFeature.setGeometryName('the_geom');
-      updateFeature.setGeometry(new _ol_geom_MultiLineString_([[
+      updateFeature.setGeometry(new MultiLineString([[
         [-12279454, 6741885],
         [-12064207, 6732101],
         [-11941908, 6595126],
@@ -797,7 +797,7 @@ describe('ol.format.WFS', function() {
       var format = new _ol_format_WFS_();
       var updateFeature = new _ol_Feature_();
       updateFeature.setGeometryName('the_geom');
-      updateFeature.setGeometry(new _ol_geom_MultiLineString_([[
+      updateFeature.setGeometry(new MultiLineString([[
         [-12279454, 6741885],
         [-12064207, 6732101],
         [-11941908, 6595126],
@@ -830,14 +830,14 @@ describe('ol.format.WFS', function() {
       var format = new _ol_format_WFS_();
       var updateFeature = new _ol_Feature_();
       updateFeature.setGeometryName('the_geom');
-      updateFeature.setGeometry(new _ol_geom_MultiLineString_([[
+      updateFeature.setGeometry(new MultiLineString([[
         [-12279454, 6741885],
         [-12064207, 6732101],
         [-11941908, 6595126],
         [-12240318, 6507071],
         [-12416429, 6604910]
       ]]));
-      updateFeature.set('geom2', new _ol_geom_MultiLineString_([[
+      updateFeature.set('geom2', new MultiLineString([[
         [-12000000, 6700000],
         [-12000001, 6700001],
         [-12000002, 6700002]

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_format_GML2_ from '../../../../src/ol/format/GML2.js';
 import _ol_format_WFS_ from '../../../../src/ol/format/WFS.js';
 import _ol_format_filter_ from '../../../../src/ol/format/filter.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
@@ -934,14 +934,14 @@ describe('ol.format.WFS', function() {
     it('handles the WFS version', function() {
       var format = new _ol_format_WFS_();
       var insertFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_LineString_([[1.1, 2], [3, 4.2]]),
+        the_geom: new LineString([[1.1, 2], [3, 4.2]]),
         foo: 'bar',
         nul: null
       });
       insertFeature.setGeometryName('the_geom');
       var inserts = [insertFeature];
       var updateFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_LineString_([[1.1, 2], [3, 4.2]]),
+        the_geom: new LineString([[1.1, 2], [3, 4.2]]),
         foo: 'bar',
         // null value gets Property element with no Value
         nul: null,
@@ -1021,14 +1021,14 @@ describe('ol.format.WFS', function() {
     it('handles 3D in WFS 1.0.0', function() {
       var format = new _ol_format_WFS_();
       var insertFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_LineString_([[1.1, 2, 4], [3, 4.2, 5]]),
+        the_geom: new LineString([[1.1, 2, 4], [3, 4.2, 5]]),
         foo: 'bar',
         nul: null
       });
       insertFeature.setGeometryName('the_geom');
       var inserts = [insertFeature];
       var updateFeature = new _ol_Feature_({
-        the_geom: new _ol_geom_LineString_([[1.1, 2, 6], [3, 4.2, 7]]),
+        the_geom: new LineString([[1.1, 2, 6], [3, 4.2, 7]]),
         foo: 'bar',
         // null value gets Property element with no Value
         nul: null,

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -5,7 +5,7 @@ import _ol_format_filter_ from '../../../../src/ol/format/filter.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {transform} from '../../../../src/ol/proj.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
@@ -55,7 +55,7 @@ describe('ol.format.WFS', function() {
       feature = features[0];
       expect(feature.getId()).to.equal('states.1');
       expect(feature.get('STATE_NAME')).to.equal('Illinois');
-      expect(feature.getGeometry()).to.be.an(_ol_geom_MultiPolygon_);
+      expect(feature.getGeometry()).to.be.an(MultiPolygon);
     });
 
     it('transforms and creates a polygon for Illinois', function() {
@@ -66,7 +66,7 @@ describe('ol.format.WFS', function() {
       expect(feature.getId()).to.equal('states.1');
       expect(feature.get('STATE_NAME')).to.equal('Illinois');
       var geom = feature.getGeometry();
-      expect(geom).to.be.an(_ol_geom_MultiPolygon_);
+      expect(geom).to.be.an(MultiPolygon);
       var p = transform([-88.071, 37.511], 'EPSG:4326', 'EPSG:3857');
       p.push(0);
       expect(geom.getFirstCoordinate()).to.eql(p);
@@ -106,7 +106,7 @@ describe('ol.format.WFS', function() {
       expect(feature.get('name')).to.equal('My Polygon with hole');
       expect(feature.get('boundedBy')).to.eql(
           [47.003018, -0.768746, 47.925567, 0.532597]);
-      expect(feature.getGeometry()).to.be.an(_ol_geom_MultiPolygon_);
+      expect(feature.getGeometry()).to.be.an(MultiPolygon);
       expect(feature.getGeometry().getFlatCoordinates()).
           to.have.length(60);
     });

--- a/test/spec/ol/format/wkt.test.js
+++ b/test/spec/ol/format/wkt.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_format_WKT_ from '../../../../src/ol/format/WKT.js';
 import {transform} from '../../../../src/ol/proj.js';
 
@@ -32,7 +32,7 @@ describe('ol.format.WKT', function() {
   describe('#writeGeometry()', function() {
 
     it('transforms with dataProjection and featureProjection', function() {
-      var geom = new _ol_geom_Point_([1, 2]).transform('EPSG:4326', 'EPSG:3857');
+      var geom = new Point([1, 2]).transform('EPSG:4326', 'EPSG:3857');
       var wkt = format.writeGeometry(geom, {
         dataProjection: 'EPSG:4326',
         featureProjection: 'EPSG:3857'
@@ -63,7 +63,7 @@ describe('ol.format.WKT', function() {
 
     it('transforms with dataProjection and featureProjection', function() {
       var feature = new _ol_Feature_(
-          new _ol_geom_Point_([1, 2]).transform('EPSG:4326', 'EPSG:3857'));
+          new Point([1, 2]).transform('EPSG:4326', 'EPSG:3857'));
       var wkt = format.writeFeature(feature, {
         dataProjection: 'EPSG:4326',
         featureProjection: 'EPSG:3857'
@@ -102,9 +102,9 @@ describe('ol.format.WKT', function() {
     it('transforms with dataProjection and featureProjection', function() {
       var features = [
         new _ol_Feature_(
-            new _ol_geom_Point_([1, 2]).transform('EPSG:4326', 'EPSG:3857')),
+            new Point([1, 2]).transform('EPSG:4326', 'EPSG:3857')),
         new _ol_Feature_(
-            new _ol_geom_Point_([4, 5]).transform('EPSG:4326', 'EPSG:3857'))
+            new Point([4, 5]).transform('EPSG:4326', 'EPSG:3857'))
       ];
       var wkt = format.writeFeatures(features, {
         dataProjection: 'EPSG:4326',

--- a/test/spec/ol/geom/circle.test.js
+++ b/test/spec/ol/geom/circle.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 
 
 describe('ol.geom.Circle', function() {
@@ -7,14 +7,14 @@ describe('ol.geom.Circle', function() {
 
     var circle;
     beforeEach(function() {
-      circle = new _ol_geom_Circle_([0, 0], 1);
+      circle = new Circle([0, 0], 1);
     });
 
     describe('#clone', function() {
 
       it('returns a clone', function() {
         var clone = circle.clone();
-        expect(clone).to.be.an(_ol_geom_Circle_);
+        expect(clone).to.be.an(Circle);
         expect(clone.getCenter()).to.eql(circle.getCenter());
         expect(clone.getCenter()).not.to.be(circle.getCenter());
         expect(clone.getRadius()).to.be(circle.getRadius());
@@ -90,7 +90,7 @@ describe('ol.geom.Circle', function() {
       });
 
       it('maintains Z coordinates', function() {
-        var circle = new _ol_geom_Circle_([0, 0, 1], 1);
+        var circle = new Circle([0, 0, 1], 1);
         expect(circle.getLayout()).to.be('XYZ');
         var closestPoint = circle.getClosestPoint([2, 0]);
         expect(closestPoint).to.have.length(3);
@@ -100,7 +100,7 @@ describe('ol.geom.Circle', function() {
       });
 
       it('maintains M coordinates', function() {
-        var circle = new _ol_geom_Circle_([0, 0, 2], 1,
+        var circle = new Circle([0, 0, 2], 1,
             'XYM');
         var closestPoint = circle.getClosestPoint([2, 0]);
         expect(closestPoint).to.have.length(3);
@@ -110,7 +110,7 @@ describe('ol.geom.Circle', function() {
       });
 
       it('maintains Z and M coordinates', function() {
-        var circle = new _ol_geom_Circle_([0, 0, 1, 2], 1);
+        var circle = new Circle([0, 0, 1, 2], 1);
         expect(circle.getLayout()).to.be('XYZM');
         var closestPoint = circle.getClosestPoint([2, 0]);
         expect(closestPoint).to.have.length(4);

--- a/test/spec/ol/geom/flat/center.test.js
+++ b/test/spec/ol/geom/flat/center.test.js
@@ -1,5 +1,5 @@
 import _ol_geom_flat_center_ from '../../../../../src/ol/geom/flat/center.js';
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 
 
 describe('ol.geom.flat.center', function() {
@@ -7,7 +7,7 @@ describe('ol.geom.flat.center', function() {
   describe('ol.geom.flat.center.linearRingss', function() {
 
     it('calculates the center of a square', function() {
-      var squareMultiPoly = new _ol_geom_MultiPolygon_([[
+      var squareMultiPoly = new MultiPolygon([[
         [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]
       ]]);
       var got = _ol_geom_flat_center_.linearRingss(
@@ -20,7 +20,7 @@ describe('ol.geom.flat.center', function() {
     });
 
     it('calculates the centers of two squares', function() {
-      var squareMultiPoly = new _ol_geom_MultiPolygon_([
+      var squareMultiPoly = new MultiPolygon([
         [
           [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]
         ],
@@ -38,7 +38,7 @@ describe('ol.geom.flat.center', function() {
     });
 
     it('does not care about holes', function() {
-      var polywithHole = new _ol_geom_MultiPolygon_([[
+      var polywithHole = new MultiPolygon([[
         [[0, 0], [0, 5], [5, 5], [5, 0], [0, 0]],
         [[1, 1], [1, 4], [4, 4], [4, 1], [1, 1]]
       ]]);

--- a/test/spec/ol/geom/flat/transform.test.js
+++ b/test/spec/ol/geom/flat/transform.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_SimpleGeometry_ from '../../../../../src/ol/geom/SimpleGeometry.js';
 import _ol_geom_flat_transform_ from '../../../../../src/ol/geom/flat/transform.js';
 
@@ -9,7 +9,7 @@ describe('ol.geom.flat.transform', function() {
 
     it('transforms a Simple Geometry to 2D', function() {
 
-      var multiPolygonGeometry = new _ol_geom_MultiPolygon_([
+      var multiPolygonGeometry = new MultiPolygon([
         [[[-80.736061, 28.788576000000006, 0],
           [-80.763557, 28.821799999999996, 0],
           [-80.817406, 28.895123999999996, 0],
@@ -69,7 +69,7 @@ describe('ol.geom.flat.transform', function() {
 
   describe('ol.geom.flat.transform.translate', function() {
     it('translates the coordinates array', function() {
-      var multiPolygon = new _ol_geom_MultiPolygon_([
+      var multiPolygon = new MultiPolygon([
         [[[0, 0, 2], [0, 1, 2], [1, 1, 2], [1, 0, 2], [0, 0, 2]]],
         [[[2, 2, 3], [2, 3, 3], [3, 3, 3], [3, 2, 3], [2, 2, 3]]]]);
       var flatCoordinates = multiPolygon.getFlatCoordinates();
@@ -86,7 +86,7 @@ describe('ol.geom.flat.transform', function() {
 
   describe('ol.geom.flat.transform.rotate', function() {
     it('rotates the coordinates array', function() {
-      var multiPolygon = new _ol_geom_MultiPolygon_([
+      var multiPolygon = new MultiPolygon([
         [[[0, 0, 2], [0, 1, 2], [1, 1, 2], [1, 0, 2], [0, 0, 2]]],
         [[[2, 2, 3], [2, 3, 3], [3, 3, 3], [3, 2, 3], [2, 2, 3]]]]);
       var flatCoordinates = multiPolygon.getFlatCoordinates();

--- a/test/spec/ol/geom/flat/transform.test.js
+++ b/test/spec/ol/geom/flat/transform.test.js
@@ -1,5 +1,5 @@
 import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_SimpleGeometry_ from '../../../../../src/ol/geom/SimpleGeometry.js';
+import SimpleGeometry from '../../../../../src/ol/geom/SimpleGeometry.js';
 import _ol_geom_flat_transform_ from '../../../../../src/ol/geom/flat/transform.js';
 
 
@@ -31,7 +31,7 @@ describe('ol.geom.flat.transform', function() {
         0, -0.0004088332670837288,
         4480.991370439071, 1529.5752568707105
       ];
-      var pixelCoordinates = _ol_geom_SimpleGeometry_.transform2D(
+      var pixelCoordinates = SimpleGeometry.transform2D(
           multiPolygonGeometry, transform, []);
       expect(pixelCoordinates[0]).to.roughlyEqual(806.6035275946265, 1e-9);
       expect(pixelCoordinates[1]).to.roughlyEqual(160.48916296287916, 1e-9);

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -1,5 +1,5 @@
 import Geometry from '../../../../src/ol/geom/Geometry.js';
-import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
@@ -17,11 +17,11 @@ describe('ol.geom.GeometryCollection', function() {
       point = new Point([10, 20]);
       line = new LineString([[10, 20], [30, 40]]);
       poly = new Polygon([outer, inner1, inner2]);
-      multi = new _ol_geom_GeometryCollection_([point, line, poly]);
+      multi = new GeometryCollection([point, line, poly]);
     });
 
     it('creates a geometry collection from an array of geometries', function() {
-      expect(multi).to.be.a(_ol_geom_GeometryCollection_);
+      expect(multi).to.be.a(GeometryCollection);
       expect(multi).to.be.a(Geometry);
     });
 
@@ -59,7 +59,7 @@ describe('ol.geom.GeometryCollection', function() {
       var point = new Point([10, 20]);
       var line = new LineString([[10, 20], [30, 40]]);
       var poly = new Polygon([outer, inner1, inner2]);
-      var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
+      var multi = new GeometryCollection([point, line, poly]);
 
       var geometries = multi.getGeometries();
       expect(geometries).to.be.an(Array);
@@ -77,7 +77,7 @@ describe('ol.geom.GeometryCollection', function() {
       var point = new Point([10, 20]);
       var line = new LineString([[10, 20], [30, 40]]);
       var poly = new Polygon([outer, inner1, inner2]);
-      var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
+      var multi = new GeometryCollection([point, line, poly]);
       var clone = multi.clone();
       expect(clone).to.not.be(multi);
       var geometries = clone.getGeometries();
@@ -89,7 +89,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('does a deep clone', function() {
       var point = new Point([30, 40]);
       var originalGeometries = [point];
-      var multi = new _ol_geom_GeometryCollection_(originalGeometries);
+      var multi = new GeometryCollection(originalGeometries);
       var clone = multi.clone();
       var clonedGeometries = clone.getGeometries();
       expect(clonedGeometries).not.to.be(originalGeometries);
@@ -107,7 +107,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('returns the bounding extent', function() {
       var point = new Point([10, 2]);
       var line = new LineString([[1, 20], [30, 40]]);
-      var multi = new _ol_geom_GeometryCollection_([point, line]);
+      var multi = new GeometryCollection([point, line]);
       var extent = multi.getExtent();
       expect(extent[0]).to.be(1);
       expect(extent[2]).to.be(30);
@@ -125,7 +125,7 @@ describe('ol.geom.GeometryCollection', function() {
       point = new Point([5, 20]);
       line = new LineString([[10, 20], [30, 40]]);
       poly = new Polygon([outer, inner1, inner2]);
-      multi = new _ol_geom_GeometryCollection_([point, line, poly]);
+      multi = new GeometryCollection([point, line, poly]);
     });
 
     it('returns true for intersecting point', function() {
@@ -154,7 +154,7 @@ describe('ol.geom.GeometryCollection', function() {
       point = new Point([10, 20]);
       line = new LineString([[10, 20], [30, 40]]);
       poly = new Polygon([outer, inner1, inner2]);
-      multi = new _ol_geom_GeometryCollection_([point, line, poly]);
+      multi = new GeometryCollection([point, line, poly]);
     });
 
     it('fires a change event', function() {
@@ -175,7 +175,7 @@ describe('ol.geom.GeometryCollection', function() {
   describe('#scale()', function() {
 
     it('scales a collection', function() {
-      var geom = new _ol_geom_GeometryCollection_([
+      var geom = new GeometryCollection([
         new Point([-1, -2]),
         new LineString([[0, 0], [1, 2]])
       ]);
@@ -186,7 +186,7 @@ describe('ol.geom.GeometryCollection', function() {
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_GeometryCollection_([
+      var geom = new GeometryCollection([
         new Point([-1, -2]),
         new LineString([[0, 0], [1, 2]])
       ]);
@@ -197,7 +197,7 @@ describe('ol.geom.GeometryCollection', function() {
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_GeometryCollection_([
+      var geom = new GeometryCollection([
         new Point([-1, -2]),
         new LineString([[0, 0], [1, 2]])
       ]);
@@ -215,7 +215,7 @@ describe('ol.geom.GeometryCollection', function() {
     beforeEach(function() {
       point = new Point([10, 20]);
       line = new LineString([[10, 20], [30, 40]]);
-      multi = new _ol_geom_GeometryCollection_([point, line]);
+      multi = new GeometryCollection([point, line]);
     });
 
     it('transforms all geometries', function() {

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_Geometry_ from '../../../../src/ol/geom/Geometry.js';
+import Geometry from '../../../../src/ol/geom/Geometry.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -22,7 +22,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('creates a geometry collection from an array of geometries', function() {
       expect(multi).to.be.a(_ol_geom_GeometryCollection_);
-      expect(multi).to.be.a(_ol_geom_Geometry_);
+      expect(multi).to.be.a(Geometry);
     });
 
     it('fires a change event when one of its component changes',

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -1,6 +1,6 @@
 import _ol_geom_Geometry_ from '../../../../src/ol/geom/Geometry.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 
@@ -15,7 +15,7 @@ describe('ol.geom.GeometryCollection', function() {
     var line, multi, point, poly;
     beforeEach(function() {
       point = new Point([10, 20]);
-      line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      line = new LineString([[10, 20], [30, 40]]);
       poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
     });
@@ -57,7 +57,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('returns a collection of geometries', function() {
       var point = new Point([10, 20]);
-      var line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      var line = new LineString([[10, 20], [30, 40]]);
       var poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
 
@@ -65,7 +65,7 @@ describe('ol.geom.GeometryCollection', function() {
       expect(geometries).to.be.an(Array);
       expect(geometries).to.have.length(3);
       expect(geometries[0]).to.be.a(Point);
-      expect(geometries[1]).to.be.a(_ol_geom_LineString_);
+      expect(geometries[1]).to.be.a(LineString);
       expect(geometries[2]).to.be.a(_ol_geom_Polygon_);
     });
 
@@ -75,7 +75,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('has a working clone method', function() {
       var point = new Point([10, 20]);
-      var line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      var line = new LineString([[10, 20], [30, 40]]);
       var poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
       var clone = multi.clone();
@@ -106,7 +106,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('returns the bounding extent', function() {
       var point = new Point([10, 2]);
-      var line = new _ol_geom_LineString_([[1, 20], [30, 40]]);
+      var line = new LineString([[1, 20], [30, 40]]);
       var multi = new _ol_geom_GeometryCollection_([point, line]);
       var extent = multi.getExtent();
       expect(extent[0]).to.be(1);
@@ -123,7 +123,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     beforeEach(function() {
       point = new Point([5, 20]);
-      line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      line = new LineString([[10, 20], [30, 40]]);
       poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
     });
@@ -152,7 +152,7 @@ describe('ol.geom.GeometryCollection', function() {
     var line, multi, point, poly;
     beforeEach(function() {
       point = new Point([10, 20]);
-      line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      line = new LineString([[10, 20], [30, 40]]);
       poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
     });
@@ -177,7 +177,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('scales a collection', function() {
       var geom = new _ol_geom_GeometryCollection_([
         new Point([-1, -2]),
-        new _ol_geom_LineString_([[0, 0], [1, 2]])
+        new LineString([[0, 0], [1, 2]])
       ]);
       geom.scale(10);
       var geometries = geom.getGeometries();
@@ -188,7 +188,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('accepts sx and sy', function() {
       var geom = new _ol_geom_GeometryCollection_([
         new Point([-1, -2]),
-        new _ol_geom_LineString_([[0, 0], [1, 2]])
+        new LineString([[0, 0], [1, 2]])
       ]);
       geom.scale(2, 3);
       var geometries = geom.getGeometries();
@@ -199,7 +199,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('accepts an anchor', function() {
       var geom = new _ol_geom_GeometryCollection_([
         new Point([-1, -2]),
-        new _ol_geom_LineString_([[0, 0], [1, 2]])
+        new LineString([[0, 0], [1, 2]])
       ]);
       geom.scale(10, 15, [-1, -2]);
       var geometries = geom.getGeometries();
@@ -214,7 +214,7 @@ describe('ol.geom.GeometryCollection', function() {
     var line, multi, point;
     beforeEach(function() {
       point = new Point([10, 20]);
-      line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
+      line = new LineString([[10, 20], [30, 40]]);
       multi = new _ol_geom_GeometryCollection_([point, line]);
     });
 
@@ -223,7 +223,7 @@ describe('ol.geom.GeometryCollection', function() {
 
       var geometries = multi.getGeometries();
       expect(geometries[0]).to.be.a(Point);
-      expect(geometries[1]).to.be.a(_ol_geom_LineString_);
+      expect(geometries[1]).to.be.a(LineString);
 
       var coords = geometries[0].getCoordinates();
       expect(coords[0]).to.roughlyEqual(1113194.90, 1e-2);

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -2,7 +2,7 @@ import _ol_geom_Geometry_ from '../../../../src/ol/geom/Geometry.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 
 describe('ol.geom.GeometryCollection', function() {
 
@@ -16,7 +16,7 @@ describe('ol.geom.GeometryCollection', function() {
     beforeEach(function() {
       point = new Point([10, 20]);
       line = new LineString([[10, 20], [30, 40]]);
-      poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      poly = new Polygon([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
     });
 
@@ -58,7 +58,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('returns a collection of geometries', function() {
       var point = new Point([10, 20]);
       var line = new LineString([[10, 20], [30, 40]]);
-      var poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      var poly = new Polygon([outer, inner1, inner2]);
       var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
 
       var geometries = multi.getGeometries();
@@ -66,7 +66,7 @@ describe('ol.geom.GeometryCollection', function() {
       expect(geometries).to.have.length(3);
       expect(geometries[0]).to.be.a(Point);
       expect(geometries[1]).to.be.a(LineString);
-      expect(geometries[2]).to.be.a(_ol_geom_Polygon_);
+      expect(geometries[2]).to.be.a(Polygon);
     });
 
   });
@@ -76,7 +76,7 @@ describe('ol.geom.GeometryCollection', function() {
     it('has a working clone method', function() {
       var point = new Point([10, 20]);
       var line = new LineString([[10, 20], [30, 40]]);
-      var poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      var poly = new Polygon([outer, inner1, inner2]);
       var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
       var clone = multi.clone();
       expect(clone).to.not.be(multi);
@@ -124,7 +124,7 @@ describe('ol.geom.GeometryCollection', function() {
     beforeEach(function() {
       point = new Point([5, 20]);
       line = new LineString([[10, 20], [30, 40]]);
-      poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      poly = new Polygon([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
     });
 
@@ -153,7 +153,7 @@ describe('ol.geom.GeometryCollection', function() {
     beforeEach(function() {
       point = new Point([10, 20]);
       line = new LineString([[10, 20], [30, 40]]);
-      poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
+      poly = new Polygon([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
     });
 

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -1,7 +1,7 @@
 import _ol_geom_Geometry_ from '../../../../src/ol/geom/Geometry.js';
 import _ol_geom_GeometryCollection_ from '../../../../src/ol/geom/GeometryCollection.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 
 describe('ol.geom.GeometryCollection', function() {
@@ -14,7 +14,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     var line, multi, point, poly;
     beforeEach(function() {
-      point = new _ol_geom_Point_([10, 20]);
+      point = new Point([10, 20]);
       line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
       poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
@@ -43,7 +43,7 @@ describe('ol.geom.GeometryCollection', function() {
     });
 
     it('register new components', function(done) {
-      var point2 = new _ol_geom_Point_([10, 20]);
+      var point2 = new Point([10, 20]);
       multi.setGeometriesArray([point2]);
       multi.on('change', function() {
         done();
@@ -56,7 +56,7 @@ describe('ol.geom.GeometryCollection', function() {
   describe('#getGeometries', function() {
 
     it('returns a collection of geometries', function() {
-      var point = new _ol_geom_Point_([10, 20]);
+      var point = new Point([10, 20]);
       var line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
       var poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
@@ -64,7 +64,7 @@ describe('ol.geom.GeometryCollection', function() {
       var geometries = multi.getGeometries();
       expect(geometries).to.be.an(Array);
       expect(geometries).to.have.length(3);
-      expect(geometries[0]).to.be.a(_ol_geom_Point_);
+      expect(geometries[0]).to.be.a(Point);
       expect(geometries[1]).to.be.a(_ol_geom_LineString_);
       expect(geometries[2]).to.be.a(_ol_geom_Polygon_);
     });
@@ -74,7 +74,7 @@ describe('ol.geom.GeometryCollection', function() {
   describe('#clone()', function() {
 
     it('has a working clone method', function() {
-      var point = new _ol_geom_Point_([10, 20]);
+      var point = new Point([10, 20]);
       var line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
       var poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       var multi = new _ol_geom_GeometryCollection_([point, line, poly]);
@@ -87,7 +87,7 @@ describe('ol.geom.GeometryCollection', function() {
     });
 
     it('does a deep clone', function() {
-      var point = new _ol_geom_Point_([30, 40]);
+      var point = new Point([30, 40]);
       var originalGeometries = [point];
       var multi = new _ol_geom_GeometryCollection_(originalGeometries);
       var clone = multi.clone();
@@ -105,7 +105,7 @@ describe('ol.geom.GeometryCollection', function() {
   describe('#getExtent()', function() {
 
     it('returns the bounding extent', function() {
-      var point = new _ol_geom_Point_([10, 2]);
+      var point = new Point([10, 2]);
       var line = new _ol_geom_LineString_([[1, 20], [30, 40]]);
       var multi = new _ol_geom_GeometryCollection_([point, line]);
       var extent = multi.getExtent();
@@ -122,7 +122,7 @@ describe('ol.geom.GeometryCollection', function() {
     var point, line, poly, multi;
 
     beforeEach(function() {
-      point = new _ol_geom_Point_([5, 20]);
+      point = new Point([5, 20]);
       line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
       poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
@@ -151,7 +151,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     var line, multi, point, poly;
     beforeEach(function() {
-      point = new _ol_geom_Point_([10, 20]);
+      point = new Point([10, 20]);
       line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
       poly = new _ol_geom_Polygon_([outer, inner1, inner2]);
       multi = new _ol_geom_GeometryCollection_([point, line, poly]);
@@ -176,7 +176,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('scales a collection', function() {
       var geom = new _ol_geom_GeometryCollection_([
-        new _ol_geom_Point_([-1, -2]),
+        new Point([-1, -2]),
         new _ol_geom_LineString_([[0, 0], [1, 2]])
       ]);
       geom.scale(10);
@@ -187,7 +187,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('accepts sx and sy', function() {
       var geom = new _ol_geom_GeometryCollection_([
-        new _ol_geom_Point_([-1, -2]),
+        new Point([-1, -2]),
         new _ol_geom_LineString_([[0, 0], [1, 2]])
       ]);
       geom.scale(2, 3);
@@ -198,7 +198,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     it('accepts an anchor', function() {
       var geom = new _ol_geom_GeometryCollection_([
-        new _ol_geom_Point_([-1, -2]),
+        new Point([-1, -2]),
         new _ol_geom_LineString_([[0, 0], [1, 2]])
       ]);
       geom.scale(10, 15, [-1, -2]);
@@ -213,7 +213,7 @@ describe('ol.geom.GeometryCollection', function() {
 
     var line, multi, point;
     beforeEach(function() {
-      point = new _ol_geom_Point_([10, 20]);
+      point = new Point([10, 20]);
       line = new _ol_geom_LineString_([[10, 20], [30, 40]]);
       multi = new _ol_geom_GeometryCollection_([point, line]);
     });
@@ -222,7 +222,7 @@ describe('ol.geom.GeometryCollection', function() {
       multi.transform('EPSG:4326', 'EPSG:3857');
 
       var geometries = multi.getGeometries();
-      expect(geometries[0]).to.be.a(_ol_geom_Point_);
+      expect(geometries[0]).to.be.a(Point);
       expect(geometries[1]).to.be.a(_ol_geom_LineString_);
 
       var coords = geometries[0].getCoordinates();

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -1,12 +1,12 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 
 
 describe('ol.geom.LineString', function() {
 
   it('can be constructed with a null geometry', function() {
     expect(function() {
-      return new _ol_geom_LineString_(null);
+      return new LineString(null);
     }).not.to.throwException();
   });
 
@@ -14,7 +14,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_([]);
+      lineString = new LineString([]);
     });
 
     it('defaults to layout XY', function() {
@@ -50,7 +50,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_([[1, 2], [3, 4]]);
+      lineString = new LineString([[1, 2], [3, 4]]);
     });
 
     it('has the expected layout', function() {
@@ -111,7 +111,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_([[1, 2, 3], [4, 5, 6]]);
+      lineString = new LineString([[1, 2, 3], [4, 5, 6]]);
     });
 
     it('has the expected layout', function() {
@@ -156,7 +156,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_(
+      lineString = new LineString(
           [[1, 2, 3], [4, 5, 6]], 'XYM');
     });
 
@@ -202,7 +202,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_([[1, 2, 3, 4], [5, 6, 7, 8]]);
+      lineString = new LineString([[1, 2, 3, 4], [5, 6, 7, 8]]);
     });
 
     it('has the expected layout', function() {
@@ -246,21 +246,21 @@ describe('ol.geom.LineString', function() {
   describe('#scale()', function() {
 
     it('scales a linestring', function() {
-      var geom = new _ol_geom_LineString_([[-10, -20], [10, 20]]);
+      var geom = new LineString([[-10, -20], [10, 20]]);
       geom.scale(10);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[-100, -200], [100, 200]]);
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_LineString_([[-10, -20], [10, 20]]);
+      var geom = new LineString([[-10, -20], [10, 20]]);
       geom.scale(2, 3);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[-20, -60], [20, 60]]);
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_LineString_([[-10, -20], [10, 20]]);
+      var geom = new LineString([[-10, -20], [10, 20]]);
       geom.scale(3, 2, [10, 20]);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[-50, -60], [10, 20]]);
@@ -272,7 +272,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_(
+      lineString = new LineString(
           [[0, 0], [1.5, 1], [3, 3], [5, 1], [6, 3.5], [7, 5]]);
     });
 
@@ -308,7 +308,7 @@ describe('ol.geom.LineString', function() {
 
       it('returns a simplified geometry', function() {
         var simplified = lineString.simplify(1);
-        expect(simplified).to.be.an(_ol_geom_LineString_);
+        expect(simplified).to.be.an(LineString);
         expect(simplified.getCoordinates()).to.eql(
             [[0, 0], [3, 3], [5, 1], [7, 5]]);
       });
@@ -331,7 +331,7 @@ describe('ol.geom.LineString', function() {
 
       it('returns the expectedResult', function() {
         var simplifiedGeometry = lineString.getSimplifiedGeometry(1);
-        expect(simplifiedGeometry).to.be.an(_ol_geom_LineString_);
+        expect(simplifiedGeometry).to.be.an(LineString);
         expect(simplifiedGeometry.getCoordinates()).to.eql(
             [[0, 0], [3, 3], [5, 1], [7, 5]]);
       });
@@ -384,7 +384,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_(
+      lineString = new LineString(
           [[1, 2, 3], [4, 5, 6]], 'XYM');
     });
 
@@ -413,7 +413,7 @@ describe('ol.geom.LineString', function() {
 
     var lineString;
     beforeEach(function() {
-      lineString = new _ol_geom_LineString_([
+      lineString = new LineString([
         [0, 0, 0, 0],
         [1, -1, 2, 1],
         [2, -2, 4, 2],

--- a/test/spec/ol/geom/multilinestring.test.js
+++ b/test/spec/ol/geom/multilinestring.test.js
@@ -1,5 +1,5 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 
 
@@ -40,11 +40,11 @@ describe('ol.geom.MultiLineString', function() {
 
     it('can append line strings', function() {
       multiLineString.appendLineString(
-          new _ol_geom_LineString_([[1, 2], [3, 4]]));
+          new LineString([[1, 2], [3, 4]]));
       expect(multiLineString.getCoordinates()).to.eql(
           [[[1, 2], [3, 4]]]);
       multiLineString.appendLineString(
-          new _ol_geom_LineString_([[5, 6], [7, 8]]));
+          new LineString([[5, 6], [7, 8]]));
       expect(multiLineString.getCoordinates()).to.eql(
           [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
     });
@@ -168,11 +168,11 @@ describe('ol.geom.MultiLineString', function() {
 
     it('can return individual line strings', function() {
       var lineString0 = multiLineString.getLineString(0);
-      expect(lineString0).to.be.an(_ol_geom_LineString_);
+      expect(lineString0).to.be.an(LineString);
       expect(lineString0.getLayout()).to.be('XYM');
       expect(lineString0.getCoordinates()).to.eql([[1, 2, 3], [4, 5, 6]]);
       var lineString1 = multiLineString.getLineString(1);
-      expect(lineString1).to.be.an(_ol_geom_LineString_);
+      expect(lineString1).to.be.an(LineString);
       expect(lineString1.getLayout()).to.be('XYM');
       expect(lineString1.getCoordinates()).to.eql([[7, 8, 9], [10, 11, 12]]);
     });
@@ -344,8 +344,8 @@ describe('ol.geom.MultiLineString', function() {
 
     it('sets the line strings', function() {
       var multiLineString = new _ol_geom_MultiLineString_(null);
-      var lineString1 = new _ol_geom_LineString_([[1, 2], [3, 4]]);
-      var lineString2 = new _ol_geom_LineString_([[5, 6], [7, 8]]);
+      var lineString1 = new LineString([[1, 2], [3, 4]]);
+      var lineString2 = new LineString([[5, 6], [7, 8]]);
       multiLineString.setLineStrings([lineString1, lineString2]);
       expect(multiLineString.getFlatCoordinates()).to.eql(
           [1, 2, 3, 4, 5, 6, 7, 8]);

--- a/test/spec/ol/geom/multilinestring.test.js
+++ b/test/spec/ol/geom/multilinestring.test.js
@@ -1,13 +1,13 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 
 
 describe('ol.geom.MultiLineString', function() {
 
   it('can be constructed with a null geometry', function() {
     expect(function() {
-      return new _ol_geom_MultiLineString_(null);
+      return new MultiLineString(null);
     }).not.to.throwException();
   });
 
@@ -15,7 +15,7 @@ describe('ol.geom.MultiLineString', function() {
 
     var multiLineString;
     beforeEach(function() {
-      multiLineString = new _ol_geom_MultiLineString_([]);
+      multiLineString = new MultiLineString([]);
     });
 
     it('defaults to layout XY', function() {
@@ -55,7 +55,7 @@ describe('ol.geom.MultiLineString', function() {
 
     var multiLineString;
     beforeEach(function() {
-      multiLineString = new _ol_geom_MultiLineString_(
+      multiLineString = new MultiLineString(
           [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]);
     });
 
@@ -107,7 +107,7 @@ describe('ol.geom.MultiLineString', function() {
 
     var multiLineString;
     beforeEach(function() {
-      multiLineString = new _ol_geom_MultiLineString_(
+      multiLineString = new MultiLineString(
           [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]);
     });
 
@@ -139,7 +139,7 @@ describe('ol.geom.MultiLineString', function() {
 
     var multiLineString;
     beforeEach(function() {
-      multiLineString = new _ol_geom_MultiLineString_(
+      multiLineString = new MultiLineString(
           [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
           'XYM');
     });
@@ -287,7 +287,7 @@ describe('ol.geom.MultiLineString', function() {
 
     var multiLineString;
     beforeEach(function() {
-      multiLineString = new _ol_geom_MultiLineString_(
+      multiLineString = new MultiLineString(
           [[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]]]);
     });
 
@@ -318,21 +318,21 @@ describe('ol.geom.MultiLineString', function() {
   describe('#scale()', function() {
 
     it('scales a multi-linestring', function() {
-      var geom = new _ol_geom_MultiLineString_([[[-10, -20], [10, 20]], [[5, -10], [-5, 10]]]);
+      var geom = new MultiLineString([[[-10, -20], [10, 20]], [[5, -10], [-5, 10]]]);
       geom.scale(10);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[[-100, -200], [100, 200]], [[50, -100], [-50, 100]]]);
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_MultiLineString_([[[-10, -20], [10, 20]], [[5, -10], [-5, 10]]]);
+      var geom = new MultiLineString([[[-10, -20], [10, 20]], [[5, -10], [-5, 10]]]);
       geom.scale(2, 3);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[[-20, -60], [20, 60]], [[10, -30], [-10, 30]]]);
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_MultiLineString_([[[-10, -20], [10, 20]], [[5, -10], [-5, 10]]]);
+      var geom = new MultiLineString([[[-10, -20], [10, 20]], [[5, -10], [-5, 10]]]);
       geom.scale(3, 2, [10, 20]);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[[-50, -60], [10, 20]], [[-5, -40], [-35, 0]]]);
@@ -343,7 +343,7 @@ describe('ol.geom.MultiLineString', function() {
   describe('#setLineStrings', function() {
 
     it('sets the line strings', function() {
-      var multiLineString = new _ol_geom_MultiLineString_(null);
+      var multiLineString = new MultiLineString(null);
       var lineString1 = new LineString([[1, 2], [3, 4]]);
       var lineString2 = new LineString([[5, 6], [7, 8]]);
       multiLineString.setLineStrings([lineString1, lineString2]);

--- a/test/spec/ol/geom/multipoint.test.js
+++ b/test/spec/ol/geom/multipoint.test.js
@@ -1,5 +1,5 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../../src/ol/geom/Point.js';
 
 
@@ -7,7 +7,7 @@ describe('ol.geom.MultiPoint', function() {
 
   it('can be constructed with a null geometry', function() {
     expect(function() {
-      return new _ol_geom_MultiPoint_(null);
+      return new MultiPoint(null);
     }).not.to.throwException();
   });
 
@@ -15,7 +15,7 @@ describe('ol.geom.MultiPoint', function() {
 
     var multiPoint;
     beforeEach(function() {
-      multiPoint = new _ol_geom_MultiPoint_([]);
+      multiPoint = new MultiPoint([]);
     });
 
     it('defaults to layout XY', function() {
@@ -51,7 +51,7 @@ describe('ol.geom.MultiPoint', function() {
 
     var multiPoint;
     beforeEach(function() {
-      multiPoint = new _ol_geom_MultiPoint_([[1, 2], [3, 4]]);
+      multiPoint = new MultiPoint([[1, 2], [3, 4]]);
     });
 
     it('has the expected layout', function() {
@@ -92,7 +92,7 @@ describe('ol.geom.MultiPoint', function() {
 
     var multiPoint;
     beforeEach(function() {
-      multiPoint = new _ol_geom_MultiPoint_([[1, 2, 3], [4, 5, 6]]);
+      multiPoint = new MultiPoint([[1, 2, 3], [4, 5, 6]]);
     });
 
     it('has the expected layout', function() {
@@ -121,7 +121,7 @@ describe('ol.geom.MultiPoint', function() {
 
     var multiPoint;
     beforeEach(function() {
-      multiPoint = new _ol_geom_MultiPoint_(
+      multiPoint = new MultiPoint(
           [[1, 2, 3], [4, 5, 6]], 'XYM');
     });
 
@@ -171,7 +171,7 @@ describe('ol.geom.MultiPoint', function() {
 
     var multiPoint;
     beforeEach(function() {
-      multiPoint = new _ol_geom_MultiPoint_([[1, 2, 3, 4], [5, 6, 7, 8]]);
+      multiPoint = new MultiPoint([[1, 2, 3, 4], [5, 6, 7, 8]]);
     });
 
     it('has the expected layout', function() {
@@ -208,21 +208,21 @@ describe('ol.geom.MultiPoint', function() {
   describe('#scale()', function() {
 
     it('scales a multi-point', function() {
-      var geom = new _ol_geom_MultiPoint_([[-10, -20], [10, 20]]);
+      var geom = new MultiPoint([[-10, -20], [10, 20]]);
       geom.scale(10);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[-100, -200], [100, 200]]);
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_MultiPoint_([[-10, -20], [10, 20]]);
+      var geom = new MultiPoint([[-10, -20], [10, 20]]);
       geom.scale(2, 3);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[-20, -60], [20, 60]]);
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_MultiPoint_([[-10, -20], [10, 20]]);
+      var geom = new MultiPoint([[-10, -20], [10, 20]]);
       geom.scale(3, 2, [-10, -20]);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([[-10, -20], [50, 60]]);
@@ -234,7 +234,7 @@ describe('ol.geom.MultiPoint', function() {
 
     var multi, transform;
     beforeEach(function() {
-      multi = new _ol_geom_MultiPoint_([[1, 2], [3, 4]]);
+      multi = new MultiPoint([[1, 2], [3, 4]]);
       transform = sinon.spy();
     });
 
@@ -271,10 +271,10 @@ describe('ol.geom.MultiPoint', function() {
   describe('#transform()', function() {
 
     it('transforms a geometry given CRS identifiers', function() {
-      var multi = new _ol_geom_MultiPoint_([[-111, 45], [111, -45]]).transform(
+      var multi = new MultiPoint([[-111, 45], [111, -45]]).transform(
           'EPSG:4326', 'EPSG:3857');
 
-      expect(multi).to.be.a(_ol_geom_MultiPoint_);
+      expect(multi).to.be.a(MultiPoint);
 
       var coords = multi.getCoordinates();
 

--- a/test/spec/ol/geom/multipoint.test.js
+++ b/test/spec/ol/geom/multipoint.test.js
@@ -1,6 +1,6 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 
 
 describe('ol.geom.MultiPoint', function() {
@@ -39,9 +39,9 @@ describe('ol.geom.MultiPoint', function() {
     });
 
     it('can append points', function() {
-      multiPoint.appendPoint(new _ol_geom_Point_([1, 2]));
+      multiPoint.appendPoint(new Point([1, 2]));
       expect(multiPoint.getCoordinates()).to.eql([[1, 2]]);
-      multiPoint.appendPoint(new _ol_geom_Point_([3, 4]));
+      multiPoint.appendPoint(new Point([3, 4]));
       expect(multiPoint.getCoordinates()).to.eql([[1, 2], [3, 4]]);
     });
 
@@ -157,10 +157,10 @@ describe('ol.geom.MultiPoint', function() {
     it('can return all points', function() {
       var points = multiPoint.getPoints();
       expect(points).to.have.length(2);
-      expect(points[0]).to.be.an(_ol_geom_Point_);
+      expect(points[0]).to.be.an(Point);
       expect(points[0].getLayout()).to.be('XYM');
       expect(points[0].getCoordinates()).to.eql([1, 2, 3]);
-      expect(points[1]).to.be.an(_ol_geom_Point_);
+      expect(points[1]).to.be.an(Point);
       expect(points[1].getLayout()).to.be('XYM');
       expect(points[1].getCoordinates()).to.eql([4, 5, 6]);
     });

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -1,5 +1,5 @@
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 
 
 describe('ol.geom.MultiPolygon', function() {
@@ -19,11 +19,11 @@ describe('ol.geom.MultiPolygon', function() {
 
     it('can append polygons', function() {
       multiPolygon.appendPolygon(
-          new _ol_geom_Polygon_([[[0, 0], [0, 2], [1, 1], [2, 0]]]));
+          new Polygon([[[0, 0], [0, 2], [1, 1], [2, 0]]]));
       expect(multiPolygon.getCoordinates()).to.eql(
           [[[[0, 0], [0, 2], [1, 1], [2, 0]]]]);
       multiPolygon.appendPolygon(
-          new _ol_geom_Polygon_([[[3, 0], [4, 1], [5, 2], [5, 0]]]));
+          new Polygon([[[3, 0], [4, 1], [5, 2], [5, 0]]]));
       expect(multiPolygon.getCoordinates()).to.eql([
         [[[0, 0], [0, 2], [1, 1], [2, 0]]],
         [[[3, 0], [4, 1], [5, 2], [5, 0]]]
@@ -42,11 +42,11 @@ describe('ol.geom.MultiPolygon', function() {
 
     it('can append polygons', function() {
       multiPolygon.appendPolygon(
-          new _ol_geom_Polygon_([[[0, 0], [0, 2], [1, 1], [2, 0]]]));
+          new Polygon([[[0, 0], [0, 2], [1, 1], [2, 0]]]));
       expect(multiPolygon.getCoordinates()).to.eql(
           [[[[0, 0], [0, 2], [1, 1], [2, 0]]]]);
       multiPolygon.appendPolygon(
-          new _ol_geom_Polygon_([[[3, 0], [4, 1], [5, 2], [5, 0]]]));
+          new Polygon([[[3, 0], [4, 1], [5, 2], [5, 0]]]));
       expect(multiPolygon.getCoordinates()).to.eql([
         [[[0, 0], [0, 2], [1, 1], [2, 0]]],
         [[[3, 0], [4, 1], [5, 2], [5, 0]]]
@@ -99,11 +99,11 @@ describe('ol.geom.MultiPolygon', function() {
 
     it('can return individual polygons', function() {
       var polygon0 = multiPolygon.getPolygon(0);
-      expect(polygon0).to.be.an(_ol_geom_Polygon_);
+      expect(polygon0).to.be.an(Polygon);
       expect(polygon0.getCoordinates()).to.eql(
           [[[0, 0], [0, 2], [1, 1], [2, 0]]]);
       var polygon1 = multiPolygon.getPolygon(1);
-      expect(polygon1).to.be.an(_ol_geom_Polygon_);
+      expect(polygon1).to.be.an(Polygon);
       expect(polygon1.getCoordinates()).to.eql(
           [[[3, 0], [4, 1], [5, 2], [5, 0]]]);
     });
@@ -112,10 +112,10 @@ describe('ol.geom.MultiPolygon', function() {
       var polygons = multiPolygon.getPolygons();
       expect(polygons).to.be.an(Array);
       expect(polygons).to.have.length(2);
-      expect(polygons[0]).to.be.an(_ol_geom_Polygon_);
+      expect(polygons[0]).to.be.an(Polygon);
       expect(polygons[0].getCoordinates()).to.eql(
           [[[0, 0], [0, 2], [1, 1], [2, 0]]]);
-      expect(polygons[1]).to.be.an(_ol_geom_Polygon_);
+      expect(polygons[1]).to.be.an(Polygon);
       expect(polygons[1].getCoordinates()).to.eql(
           [[[3, 0], [4, 1], [5, 2], [5, 0]]]);
     });

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 
 
@@ -6,7 +6,7 @@ describe('ol.geom.MultiPolygon', function() {
 
   it('can be constructed with a null geometry', function() {
     expect(function() {
-      return new _ol_geom_MultiPolygon_(null);
+      return new MultiPolygon(null);
     }).not.to.throwException();
   });
 
@@ -14,7 +14,7 @@ describe('ol.geom.MultiPolygon', function() {
 
     var multiPolygon;
     beforeEach(function() {
-      multiPolygon = new _ol_geom_MultiPolygon_(null);
+      multiPolygon = new MultiPolygon(null);
     });
 
     it('can append polygons', function() {
@@ -37,7 +37,7 @@ describe('ol.geom.MultiPolygon', function() {
 
     var multiPolygon;
     beforeEach(function() {
-      multiPolygon = new _ol_geom_MultiPolygon_([]);
+      multiPolygon = new MultiPolygon([]);
     });
 
     it('can append polygons', function() {
@@ -59,7 +59,7 @@ describe('ol.geom.MultiPolygon', function() {
   describe('#scale()', function() {
 
     it('scales a multi-polygon', function() {
-      var geom = new _ol_geom_MultiPolygon_([[
+      var geom = new MultiPolygon([[
         [[-1, -2], [1, -2], [1, 2], [-1, 2], [-1, -2]]
       ]]);
       geom.scale(10);
@@ -68,7 +68,7 @@ describe('ol.geom.MultiPolygon', function() {
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_MultiPolygon_([[
+      var geom = new MultiPolygon([[
         [[-1, -2], [1, -2], [1, 2], [-1, 2], [-1, -2]]
       ]]);
       geom.scale(2, 3);
@@ -77,7 +77,7 @@ describe('ol.geom.MultiPolygon', function() {
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_MultiPolygon_([[
+      var geom = new MultiPolygon([[
         [[-1, -2], [1, -2], [1, 2], [-1, 2], [-1, -2]]
       ]]);
       geom.scale(3, 2, [-1, -2]);
@@ -91,7 +91,7 @@ describe('ol.geom.MultiPolygon', function() {
 
     var multiPolygon;
     beforeEach(function() {
-      multiPolygon = new _ol_geom_MultiPolygon_([
+      multiPolygon = new MultiPolygon([
         [[[0, 0], [0, 2], [1, 1], [2, 0]]],
         [[[3, 0], [4, 1], [5, 2], [5, 0]]]
       ]);
@@ -135,8 +135,8 @@ describe('ol.geom.MultiPolygon', function() {
       var cw2 = [[-140, -60], [-140, 60], [140, 60], [140, -60], [-140, -60]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
       var ccw2 = [[-140, -60], [140, -60], [140, 60], [-140, 60], [-140, -60]];
-      var right = new _ol_geom_MultiPolygon_([[ccw, cw], [ccw2, cw2]]);
-      var left = new _ol_geom_MultiPolygon_([[cw, ccw], [cw2, ccw2]]);
+      var right = new MultiPolygon([[ccw, cw], [ccw2, cw2]]);
+      var left = new MultiPolygon([[cw, ccw], [cw2, ccw2]]);
 
       it('returns coordinates as they were constructed', function() {
         expect(right.getCoordinates()).to.eql([[ccw, cw], [ccw2, cw2]]);
@@ -167,7 +167,7 @@ describe('ol.geom.MultiPolygon', function() {
 
       it('returns the expected result', function() {
         var simplifiedGeometry = multiPolygon.getSimplifiedGeometry(1);
-        expect(simplifiedGeometry).to.be.an(_ol_geom_MultiPolygon_);
+        expect(simplifiedGeometry).to.be.an(MultiPolygon);
         expect(simplifiedGeometry.getCoordinates()).to.eql([
           [[[0, 0], [0, 2], [2, 0]]],
           [[[3, 0], [5, 2], [5, 0]]]
@@ -196,7 +196,7 @@ describe('ol.geom.MultiPolygon', function() {
   describe('#getInteriorPoints', function() {
 
     it('returns XYM multipoint with intersection width as M', function() {
-      var geom = new _ol_geom_MultiPolygon_([
+      var geom = new MultiPolygon([
         [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
         [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
       ]);

--- a/test/spec/ol/geom/point.test.js
+++ b/test/spec/ol/geom/point.test.js
@@ -1,11 +1,11 @@
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 
 
 describe('ol.geom.Point', function() {
 
   it('can be constructed with a null geometry', function() {
     expect(function() {
-      return new _ol_geom_Point_(null);
+      return new Point(null);
     }).not.to.throwException();
   });
 
@@ -13,7 +13,7 @@ describe('ol.geom.Point', function() {
 
     var point;
     beforeEach(function() {
-      point = new _ol_geom_Point_([1, 2]);
+      point = new Point([1, 2]);
     });
 
     it('has the expected layout', function() {
@@ -50,7 +50,7 @@ describe('ol.geom.Point', function() {
 
     var point;
     beforeEach(function() {
-      point = new _ol_geom_Point_([1, 2, 3], 'XYM');
+      point = new Point([1, 2, 3], 'XYM');
     });
 
     it('has the expected layout', function() {
@@ -87,7 +87,7 @@ describe('ol.geom.Point', function() {
 
     var point;
     beforeEach(function() {
-      point = new _ol_geom_Point_([1, 2, 3, 4]);
+      point = new Point([1, 2, 3, 4]);
     });
 
     it('has the expected layout', function() {
@@ -132,21 +132,21 @@ describe('ol.geom.Point', function() {
   describe('#scale()', function() {
 
     it('scales a point', function() {
-      var geom = new _ol_geom_Point_([1, 2]);
+      var geom = new Point([1, 2]);
       geom.scale(10e6);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([1, 2]);
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_Point_([1, 2]);
+      var geom = new Point([1, 2]);
       geom.scale(1e6, -42);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([1, 2]);
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_Point_([1, 2]);
+      var geom = new Point([1, 2]);
       geom.scale(10, 15, [0, 0]);
       var coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([10, 30]);
@@ -158,7 +158,7 @@ describe('ol.geom.Point', function() {
 
     var point, transform;
     beforeEach(function() {
-      point = new _ol_geom_Point_([1, 2]);
+      point = new Point([1, 2]);
       transform = sinon.spy();
     });
 
@@ -193,10 +193,10 @@ describe('ol.geom.Point', function() {
   describe('#transform()', function() {
 
     it('transforms a geometry given CRS identifiers', function() {
-      var point = new _ol_geom_Point_([-111, 45]).transform(
+      var point = new Point([-111, 45]).transform(
           'EPSG:4326', 'EPSG:3857');
 
-      expect(point).to.be.a(_ol_geom_Point_);
+      expect(point).to.be.a(Point);
 
       var coords = point.getCoordinates();
 
@@ -205,7 +205,7 @@ describe('ol.geom.Point', function() {
     });
 
     it('modifies the original', function() {
-      var point = new _ol_geom_Point_([-111, 45]);
+      var point = new Point([-111, 45]);
       point.transform('EPSG:4326', 'EPSG:3857');
       var coords = point.getCoordinates();
 

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -1,5 +1,5 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 
@@ -577,7 +577,7 @@ describe('ol.geom.Polygon', function() {
   describe('ol.geom.Polygon.fromCircle', function() {
 
     it('creates a regular polygon', function() {
-      var circle = new _ol_geom_Circle_([0, 0, 0], 1, 'XYZ');
+      var circle = new Circle([0, 0, 0], 1, 'XYZ');
       var polygon = Polygon.fromCircle(circle);
       var coordinates = polygon.getLinearRing(0).getCoordinates();
       expect(coordinates[0].length).to.eql(3);
@@ -598,7 +598,7 @@ describe('ol.geom.Polygon', function() {
     });
 
     it('creates a regular polygon with custom sides and angle', function() {
-      var circle = new _ol_geom_Circle_([0, 0], 1);
+      var circle = new Circle([0, 0], 1);
       var polygon = Polygon.fromCircle(circle, 4, Math.PI / 2);
       var coordinates = polygon.getLinearRing(0).getCoordinates();
       expect(coordinates[4]).to.eql(coordinates[0]);

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -1,14 +1,14 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 
 
 describe('ol.geom.Polygon', function() {
 
   it('can be constructed with a null geometry', function() {
     expect(function() {
-      return new _ol_geom_Polygon_(null);
+      return new Polygon(null);
     }).not.to.throwException();
   });
 
@@ -16,7 +16,7 @@ describe('ol.geom.Polygon', function() {
 
     var polygon;
     beforeEach(function() {
-      polygon = new _ol_geom_Polygon_([]);
+      polygon = new Polygon([]);
     });
 
     it('defaults to layout XY', function() {
@@ -59,7 +59,7 @@ describe('ol.geom.Polygon', function() {
     beforeEach(function() {
       outerRing = [[0, 1], [1, 4], [4, 3], [3, 0]];
       innerRing = [[2, 2], [3, 2], [3, 3], [2, 3]];
-      polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+      polygon = new Polygon([outerRing, innerRing]);
       flatCoordinates = [0, 1, 1, 4, 4, 3, 3, 0, 2, 2, 3, 2, 3, 3, 2, 3];
       outsideOuter = [0, 4];
       inside = [1.5, 1.5];
@@ -104,7 +104,7 @@ describe('ol.geom.Polygon', function() {
     it('does not reverse any rings', function() {
       outerRing.reverse();
       innerRing.reverse();
-      polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+      polygon = new Polygon([outerRing, innerRing]);
       var coordinates = polygon.getCoordinates();
       expect(coordinates[0]).to.eql(outerRing);
       expect(coordinates[1]).to.eql(innerRing);
@@ -126,8 +126,8 @@ describe('ol.geom.Polygon', function() {
 
       var cw = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]];
       var ccw = [[-180, -90], [180, -90], [180, 90], [-180, 90], [-180, -90]];
-      var right = new _ol_geom_Polygon_([ccw, cw]);
-      var left = new _ol_geom_Polygon_([cw, ccw]);
+      var right = new Polygon([ccw, cw]);
+      var left = new Polygon([cw, ccw]);
 
       it('returns coordinates as they were constructed', function() {
         expect(right.getCoordinates()).to.eql([ccw, cw]);
@@ -150,20 +150,20 @@ describe('ol.geom.Polygon', function() {
 
       it('reverses the outer ring if necessary', function() {
         outerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses inner rings if necessary', function() {
         innerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses all rings if necessary', function() {
         outerRing.reverse();
         innerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
@@ -178,7 +178,7 @@ describe('ol.geom.Polygon', function() {
     beforeEach(function() {
       outerRing = [[0, 0, 1], [4, 4, 2], [4, 0, 3]];
       innerRing = [[2, 1, 4], [3, 1, 5], [3, 2, 6]];
-      polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+      polygon = new Polygon([outerRing, innerRing]);
       flatCoordinates = [0, 0, 1, 4, 4, 2, 4, 0, 3, 2, 1, 4, 3, 1, 5, 3, 2, 6];
       outsideOuter = [1, 3];
       inside = [3.5, 0.5];
@@ -248,20 +248,20 @@ describe('ol.geom.Polygon', function() {
 
       it('reverses the outer ring if necessary', function() {
         outerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses inner rings if necessary', function() {
         innerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses all rings if necessary', function() {
         outerRing.reverse();
         innerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
@@ -276,7 +276,7 @@ describe('ol.geom.Polygon', function() {
     beforeEach(function() {
       outerRing = [[0, 0, 1], [4, 4, 2], [4, 0, 3]];
       innerRing = [[2, 1, 4], [3, 1, 5], [3, 2, 6]];
-      polygon = new _ol_geom_Polygon_(
+      polygon = new Polygon(
           [outerRing, innerRing], 'XYM');
       flatCoordinates = [0, 0, 1, 4, 4, 2, 4, 0, 3, 2, 1, 4, 3, 1, 5, 3, 2, 6];
       outsideOuter = [1, 3];
@@ -347,20 +347,20 @@ describe('ol.geom.Polygon', function() {
 
       it('reverses the outer ring if necessary', function() {
         outerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses inner rings if necessary', function() {
         innerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses all rings if necessary', function() {
         outerRing.reverse();
         innerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing]);
+        polygon = new Polygon([outerRing, innerRing]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
@@ -377,7 +377,7 @@ describe('ol.geom.Polygon', function() {
       innerRing1 =
           [[2, 4, 7, 8], [4, 4, 9, 10], [4, 5, 11, 12], [2, 5, 13, 14]];
       innerRing2 = [[3, 2, 15, 16], [4, 3, 17, 18], [2, 3, 19, 20]];
-      polygon = new _ol_geom_Polygon_([outerRing, innerRing1, innerRing2]);
+      polygon = new Polygon([outerRing, innerRing1, innerRing2]);
       flatCoordinates = [
         0, 6, 1, 2, 6, 6, 3, 4, 3, 0, 5, 6,
         2, 4, 7, 8, 4, 4, 9, 10, 4, 5, 11, 12, 2, 5, 13, 14,
@@ -456,14 +456,14 @@ describe('ol.geom.Polygon', function() {
 
       it('reverses the outer ring if necessary', function() {
         outerRing.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing1, innerRing2]);
+        polygon = new Polygon([outerRing, innerRing1, innerRing2]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
       it('reverses inner rings if necessary', function() {
         innerRing1.reverse();
         innerRing2.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing1, innerRing2]);
+        polygon = new Polygon([outerRing, innerRing1, innerRing2]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
@@ -471,7 +471,7 @@ describe('ol.geom.Polygon', function() {
         outerRing.reverse();
         innerRing1.reverse();
         innerRing2.reverse();
-        polygon = new _ol_geom_Polygon_([outerRing, innerRing1, innerRing2]);
+        polygon = new Polygon([outerRing, innerRing1, innerRing2]);
         expect(polygon.getOrientedFlatCoordinates()).to.eql(flatCoordinates);
       });
 
@@ -483,7 +483,7 @@ describe('ol.geom.Polygon', function() {
 
     var polygon;
     beforeEach(function() {
-      polygon = new _ol_geom_Polygon_(
+      polygon = new Polygon(
           [[[3, 0], [1, 3], [0, 6], [2, 6], [3, 7], [4, 6], [6, 6], [4, 3]]]);
     });
 
@@ -491,7 +491,7 @@ describe('ol.geom.Polygon', function() {
 
       it('returns the expected result', function() {
         var simplifiedGeometry = polygon.getSimplifiedGeometry(9);
-        expect(simplifiedGeometry).to.be.an(_ol_geom_Polygon_);
+        expect(simplifiedGeometry).to.be.an(Polygon);
         expect(simplifiedGeometry.getCoordinates()).to.eql(
             [[[3, 0], [0, 3], [0, 6], [6, 6], [3, 3]]]);
       });
@@ -511,7 +511,7 @@ describe('ol.geom.Polygon', function() {
   describe('#scale()', function() {
 
     it('scales a polygon', function() {
-      var geom = new _ol_geom_Polygon_([
+      var geom = new Polygon([
         [[-1, -2], [1, -2], [1, 2], [-1, 2], [-1, -2]]
       ]);
       geom.scale(10);
@@ -520,7 +520,7 @@ describe('ol.geom.Polygon', function() {
     });
 
     it('accepts sx and sy', function() {
-      var geom = new _ol_geom_Polygon_([
+      var geom = new Polygon([
         [[-1, -2], [1, -2], [1, 2], [-1, 2], [-1, -2]]
       ]);
       geom.scale(2, 3);
@@ -529,7 +529,7 @@ describe('ol.geom.Polygon', function() {
     });
 
     it('accepts an anchor', function() {
-      var geom = new _ol_geom_Polygon_([
+      var geom = new Polygon([
         [[-1, -2], [1, -2], [1, 2], [-1, 2], [-1, -2]]
       ]);
       geom.scale(3, 2, [-1, -2]);
@@ -542,7 +542,7 @@ describe('ol.geom.Polygon', function() {
   describe('#getInteriorPoint', function() {
 
     it('returns XYM point with intersection width as M', function() {
-      var geom = new _ol_geom_Polygon_([[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]);
+      var geom = new Polygon([[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]);
       var interiorPoint = geom.getInteriorPoint();
       expect(interiorPoint.getType()).to.be('Point');
       expect(interiorPoint.layout).to.be('XYM');
@@ -550,7 +550,7 @@ describe('ol.geom.Polygon', function() {
     });
 
     it('returns XYM point for donut polygons', function() {
-      var geom = new _ol_geom_Polygon_([
+      var geom = new Polygon([
         [[0.5, 0.5], [0.5, 2.5], [2.5, 2.5], [2.5, 0.5], [0.5, 0.5]],
         [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]
       ]);
@@ -564,7 +564,7 @@ describe('ol.geom.Polygon', function() {
   describe('ol.geom.Polygon.fromExtent', function() {
     it('creates the correct polygon', function() {
       var extent = [1, 2, 3, 5];
-      var polygon = _ol_geom_Polygon_.fromExtent(extent);
+      var polygon = Polygon.fromExtent(extent);
       var flatCoordinates = polygon.getFlatCoordinates();
       expect(flatCoordinates).to.eql(
           [1, 2, 1, 5, 3, 5, 3, 2, 1, 2]);
@@ -578,7 +578,7 @@ describe('ol.geom.Polygon', function() {
 
     it('creates a regular polygon', function() {
       var circle = new _ol_geom_Circle_([0, 0, 0], 1, 'XYZ');
-      var polygon = _ol_geom_Polygon_.fromCircle(circle);
+      var polygon = Polygon.fromCircle(circle);
       var coordinates = polygon.getLinearRing(0).getCoordinates();
       expect(coordinates[0].length).to.eql(3);
       expect(coordinates[0][2]).to.eql(0);
@@ -599,7 +599,7 @@ describe('ol.geom.Polygon', function() {
 
     it('creates a regular polygon with custom sides and angle', function() {
       var circle = new _ol_geom_Circle_([0, 0], 1);
-      var polygon = _ol_geom_Polygon_.fromCircle(circle, 4, Math.PI / 2);
+      var polygon = Polygon.fromCircle(circle, 4, Math.PI / 2);
       var coordinates = polygon.getLinearRing(0).getCoordinates();
       expect(coordinates[4]).to.eql(coordinates[0]);
       expect(coordinates[0][0]).to.roughlyEqual(0, 1e-9);

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -1,6 +1,6 @@
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
-import _ol_geom_LinearRing_ from '../../../../src/ol/geom/LinearRing.js';
+import LinearRing from '../../../../src/ol/geom/LinearRing.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 
 
@@ -41,11 +41,11 @@ describe('ol.geom.Polygon', function() {
 
     it('can append linear rings', function() {
       polygon.appendLinearRing(
-          new _ol_geom_LinearRing_([[1, 2], [3, 4], [5, 6]]));
+          new LinearRing([[1, 2], [3, 4], [5, 6]]));
       expect(polygon.getCoordinates()).to.eql(
           [[[1, 2], [3, 4], [5, 6]]]);
       polygon.appendLinearRing(
-          new _ol_geom_LinearRing_([[7, 8], [9, 10], [11, 12]]));
+          new LinearRing([[7, 8], [9, 10], [11, 12]]));
       expect(polygon.getCoordinates()).to.eql(
           [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]);
     });
@@ -95,9 +95,9 @@ describe('ol.geom.Polygon', function() {
       var linearRings = polygon.getLinearRings();
       expect(linearRings).to.be.an(Array);
       expect(linearRings).to.have.length(2);
-      expect(linearRings[0]).to.be.an(_ol_geom_LinearRing_);
+      expect(linearRings[0]).to.be.an(LinearRing);
       expect(linearRings[0].getCoordinates()).to.eql(outerRing);
-      expect(linearRings[1]).to.be.an(_ol_geom_LinearRing_);
+      expect(linearRings[1]).to.be.an(LinearRing);
       expect(linearRings[1].getCoordinates()).to.eql(innerRing);
     });
 

--- a/test/spec/ol/interaction/dragzoom.test.js
+++ b/test/spec/ol/interaction/dragzoom.test.js
@@ -1,7 +1,7 @@
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import * as _ol_extent_ from '../../../../src/ol/extent.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_DragZoom_ from '../../../../src/ol/interaction/DragZoom.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_render_Box_ from '../../../../src/ol/render/Box.js';
@@ -72,7 +72,7 @@ describe('ol.interaction.DragZoom', function() {
 
       var box = new _ol_render_Box_();
       var extent = [-110, 40, -90, 60];
-      box.geometry_ = _ol_geom_Polygon_.fromExtent(extent);
+      box.geometry_ = Polygon.fromExtent(extent);
       interaction.box_ = box;
 
       interaction.onBoxEnd();
@@ -94,7 +94,7 @@ describe('ol.interaction.DragZoom', function() {
 
       var box = new _ol_render_Box_();
       var extent = [-11.25, -11.25, 11.25, 11.25];
-      box.geometry_ = _ol_geom_Polygon_.fromExtent(extent);
+      box.geometry_ = Polygon.fromExtent(extent);
       interaction.box_ = box;
 
       map.getView().setResolution(0.25);

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -6,7 +6,7 @@ import _ol_array_ from '../../../../src/ol/array.js';
 import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
@@ -284,7 +284,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_LineString_);
+      expect(geometry).to.be.a(LineString);
       expect(geometry.getCoordinates()).to.eql([[10, -20], [30, -20]]);
     });
 
@@ -326,7 +326,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_LineString_);
+      expect(geometry).to.be.a(LineString);
       expect(geometry.getCoordinates()).to.eql(
           [[10, -20], [20, -30], [20, -40]]);
     });
@@ -363,7 +363,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       // expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_LineString_);
+      expect(geometry).to.be.a(LineString);
       expect(geometry.getCoordinates()).to.eql(
           [[10, -20], [20, -30], [30, -40], [40, -50], [50, -60], [60, -70]]);
     });
@@ -392,7 +392,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_LineString_);
+      expect(geometry).to.be.a(LineString);
       expect(geometry.getCoordinates()).to.eql([[10, -20], [30, -20]]);
     });
 
@@ -1036,7 +1036,7 @@ describe('ol.interaction.Draw', function() {
       });
       map.addInteraction(draw);
       feature = new _ol_Feature_(
-          new _ol_geom_LineString_([[0, 0], [1, 1], [2, 0]]));
+          new LineString([[0, 0], [1, 1], [2, 0]]));
     });
 
     it('sets the initial state', function() {

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -11,7 +11,7 @@ import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../../../../src/ol/interaction/Draw.js';
 import _ol_interaction_Interaction_ from '../../../../src/ol/interaction/Interaction.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -551,7 +551,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
 
       expect(geometry.getCoordinates()).to.eql([
         [[10, -20], [30, -20], [40, -10], [10, -20]]
@@ -629,7 +629,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
 
       expect(geometry.getCoordinates()).to.eql([
         [[10, -20], [30, -20], [40, -10], [10, -20]]
@@ -653,7 +653,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
 
       expect(geometry.getCoordinates()).to.eql([
         [[10, -20], [30, -20], [40, -10], [10, -20]]
@@ -988,7 +988,7 @@ describe('ol.interaction.Draw', function() {
 
       var features = source.getFeatures();
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
       var coordinates = geometry.getCoordinates();
       expect(coordinates[0].length).to.eql(5);
       expect(coordinates[0][0][0]).to.roughlyEqual(20, 1e-9);
@@ -1017,7 +1017,7 @@ describe('ol.interaction.Draw', function() {
 
       var features = source.getFeatures();
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Polygon_);
+      expect(geometry).to.be.a(Polygon);
       var coordinates = geometry.getCoordinates();
       expect(coordinates[0]).to.have.length(5);
       expect(geometry.getArea()).to.equal(400);

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -5,7 +5,7 @@ import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_array_ from '../../../../src/ol/array.js';
 import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
@@ -795,7 +795,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Circle_);
+      expect(geometry).to.be.a(Circle);
       expect(geometry.getCenter()).to.eql([10, -20]);
       expect(geometry.getRadius()).to.eql(20);
     });

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -10,7 +10,7 @@ import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../../../../src/ol/interaction/Draw.js';
 import _ol_interaction_Interaction_ from '../../../../src/ol/interaction/Interaction.js';
@@ -123,7 +123,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       var geometry = features[0].getGeometry();
       expect(features[0].getGeometryName()).to.equal('the_geom');
-      expect(geometry).to.be.a(_ol_geom_Point_);
+      expect(geometry).to.be.a(Point);
     });
   });
 
@@ -172,7 +172,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Point_);
+      expect(geometry).to.be.a(Point);
       expect(geometry.getCoordinates()).to.eql([10, -20]);
     });
 

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -7,7 +7,7 @@ import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -501,7 +501,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_MultiLineString_);
+      expect(geometry).to.be.a(MultiLineString);
       expect(geometry.getCoordinates()).to.eql([[[10, -20], [30, -20]]]);
     });
 

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -9,7 +9,7 @@ import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Draw_ from '../../../../src/ol/interaction/Draw.js';
@@ -727,7 +727,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_MultiPolygon_);
+      expect(geometry).to.be.a(MultiPolygon);
       var coordinates = geometry.getCoordinates();
       expect(coordinates).to.have.length(1);
 
@@ -759,7 +759,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_MultiPolygon_);
+      expect(geometry).to.be.a(MultiPolygon);
       var coordinates = geometry.getCoordinates();
       expect(coordinates).to.have.length(1);
 

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -8,7 +8,7 @@ import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -249,7 +249,7 @@ describe('ol.interaction.Draw', function() {
       var features = source.getFeatures();
       expect(features).to.have.length(1);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_MultiPoint_);
+      expect(geometry).to.be.a(MultiPoint);
       expect(geometry.getCoordinates()).to.eql([[30, -15]]);
     });
 

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -8,7 +8,7 @@ import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Modify_ from '../../../../src/ol/interaction/Modify.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_pointer_PointerEvent_ from '../../../../src/ol/pointer/PointerEvent.js';
@@ -35,7 +35,7 @@ describe('ol.interaction.Modify', function() {
 
     features = [
       new _ol_Feature_({
-        geometry: new _ol_geom_Polygon_([
+        geometry: new Polygon([
           [[0, 0], [10, 20], [0, 40], [40, 40], [40, 0]]
         ])
       })

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -6,7 +6,7 @@ import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Modify_ from '../../../../src/ol/interaction/Modify.js';
@@ -226,7 +226,7 @@ describe('ol.interaction.Modify', function() {
 
     it('deletes first vertex of a LineString', function() {
       var lineFeature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[0, 0], [10, 20], [0, 40], [40, 40], [40, 0]]
         )
       });
@@ -262,7 +262,7 @@ describe('ol.interaction.Modify', function() {
 
     it('deletes last vertex of a LineString', function() {
       var lineFeature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[0, 0], [10, 20], [0, 40], [40, 40], [40, 0]]
         )
       });
@@ -298,7 +298,7 @@ describe('ol.interaction.Modify', function() {
 
     it('deletes vertex of a LineString programmatically', function() {
       var lineFeature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[0, 0], [10, 20], [0, 40], [40, 40], [40, 0]]
         )
       });
@@ -340,7 +340,7 @@ describe('ol.interaction.Modify', function() {
 
     it('keeps the third dimension', function() {
       var lineFeature = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_(
+        geometry: new LineString(
             [[0, 0, 10], [10, 20, 20], [0, 40, 30], [40, 40, 40], [40, 0, 50]]
         )
       });

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -5,7 +5,7 @@ import _ol_MapBrowserPointerEvent_ from '../../../../src/ol/MapBrowserPointerEve
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
@@ -382,7 +382,7 @@ describe('ol.interaction.Modify', function() {
 
   describe('circle modification', function() {
     it('changes the circle radius and center', function() {
-      var circleFeature = new _ol_Feature_(new _ol_geom_Circle_([10, 10], 20));
+      var circleFeature = new _ol_Feature_(new Circle([10, 10], 20));
       features.length = 0;
       features.push(circleFeature);
 
@@ -617,7 +617,7 @@ describe('ol.interaction.Modify', function() {
     });
 
     it('updates circle segment data', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Circle_([10, 10], 20));
+      var feature = new _ol_Feature_(new Circle([10, 10], 20));
       features.length = 0;
       features.push(feature);
 

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -7,7 +7,7 @@ import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Modify_ from '../../../../src/ol/interaction/Modify.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -152,7 +152,7 @@ describe('ol.interaction.Modify', function() {
   describe('constructor', function() {
     it('adds features to the RTree', function() {
       var feature = new _ol_Feature_(
-          new _ol_geom_Point_([0, 0]));
+          new Point([0, 0]));
       var features = new _ol_Collection_([feature]);
       var modify = new _ol_interaction_Modify_({
         features: features
@@ -171,7 +171,7 @@ describe('ol.interaction.Modify', function() {
       var rbushEntries = modify.rBush_.getAll();
       expect(rbushEntries.length).to.be(0);
 
-      feature.setGeometry(new _ol_geom_Point_([0, 10]));
+      feature.setGeometry(new Point([0, 10]));
       rbushEntries = modify.rBush_.getAll();
       expect(rbushEntries.length).to.be(1);
       expect(rbushEntries[0].feature).to.be(feature);
@@ -179,7 +179,7 @@ describe('ol.interaction.Modify', function() {
 
     it('accepts a source', function() {
       var feature = new _ol_Feature_(
-          new _ol_geom_Point_([0, 0]));
+          new Point([0, 0]));
       var source = new _ol_source_Vector_({features: [feature]});
       var modify = new _ol_interaction_Modify_({source: source});
       var rbushEntries = modify.rBush_.getAll();

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -4,7 +4,7 @@ import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_MapBrowserEventType_ from '../../../../src/ol/MapBrowserEventType.js';
 import _ol_MapBrowserPointerEvent_ from '../../../../src/ol/MapBrowserPointerEvent.js';
 import _ol_View_ from '../../../../src/ol/View.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_interaction_Interaction_ from '../../../../src/ol/interaction/Interaction.js';
 import _ol_interaction_Select_ from '../../../../src/ol/interaction/Select.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -29,7 +29,7 @@ describe('ol.interaction.Select', function() {
     style.height = height + 'px';
     document.body.appendChild(target);
 
-    var geometry = new _ol_geom_Polygon_([[[0, 0], [0, 40], [40, 40], [40, 0]]]);
+    var geometry = new Polygon([[[0, 0], [0, 40], [40, 40], [40, 0]]]);
 
     // Four overlapping features, two features of type "foo" and two features
     // of type "bar". The rendering order is, from top to bottom, foo -> bar

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -3,7 +3,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_interaction_Snap_ from '../../../../src/ol/interaction/Snap.js';
 
@@ -56,7 +56,7 @@ describe('ol.interaction.Snap', function() {
     });
 
     it('can handle XYZ coordinates', function() {
-      var point = new _ol_Feature_(new _ol_geom_Point_([0, 0, 123]));
+      var point = new _ol_Feature_(new Point([0, 0, 123]));
       var snapInteraction = new _ol_interaction_Snap_({
         features: new _ol_Collection_([point])
       });

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -2,7 +2,7 @@ import _ol_Collection_ from '../../../../src/ol/Collection.js';
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
-import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../src/ol/geom/Circle.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_interaction_Snap_ from '../../../../src/ol/interaction/Snap.js';
@@ -109,7 +109,7 @@ describe('ol.interaction.Snap', function() {
     });
 
     it('snaps to circle', function() {
-      var circle = new _ol_Feature_(new _ol_geom_Circle_([0, 0], 10));
+      var circle = new _ol_Feature_(new Circle([0, 0], 10));
       var snapInteraction = new _ol_interaction_Snap_({
         features: new _ol_Collection_([circle]),
         pixelTolerance: 5

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -4,7 +4,7 @@ import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import _ol_geom_Circle_ from '../../../../src/ol/geom/Circle.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_interaction_Snap_ from '../../../../src/ol/interaction/Snap.js';
 
 
@@ -73,7 +73,7 @@ describe('ol.interaction.Snap', function() {
     });
 
     it('snaps to edges only', function() {
-      var point = new _ol_Feature_(new _ol_geom_LineString_([[-10, 0], [10, 0]]));
+      var point = new _ol_Feature_(new LineString([[-10, 0], [10, 0]]));
       var snapInteraction = new _ol_interaction_Snap_({
         features: new _ol_Collection_([point]),
         pixelTolerance: 5,
@@ -91,7 +91,7 @@ describe('ol.interaction.Snap', function() {
     });
 
     it('snaps to vertices only', function() {
-      var point = new _ol_Feature_(new _ol_geom_LineString_([[-10, 0], [10, 0]]));
+      var point = new _ol_Feature_(new LineString([[-10, 0], [10, 0]]));
       var snapInteraction = new _ol_interaction_Snap_({
         features: new _ol_Collection_([point]),
         pixelTolerance: 5,
@@ -136,7 +136,7 @@ describe('ol.interaction.Snap', function() {
       });
       snapInteraction.setMap(map);
 
-      feature.setGeometry(new _ol_geom_LineString_([[-10, 0], [10, 0]]));
+      feature.setGeometry(new LineString([[-10, 0], [10, 0]]));
 
       var event = {
         pixel: [7 + width / 2, height / 2 - 4],
@@ -148,7 +148,7 @@ describe('ol.interaction.Snap', function() {
     });
 
     it('handle geometry changes', function() {
-      var line = new _ol_Feature_(new _ol_geom_LineString_([[-10, 0], [0, 0]]));
+      var line = new _ol_Feature_(new LineString([[-10, 0], [0, 0]]));
       var snapInteraction = new _ol_interaction_Snap_({
         features: new _ol_Collection_([line]),
         pixelTolerance: 5,
@@ -169,8 +169,8 @@ describe('ol.interaction.Snap', function() {
 
     it('handle geometry name changes', function() {
       var line = new _ol_Feature_({
-        geometry: new _ol_geom_LineString_([[-10, 0], [0, 0]]),
-        alt_geometry: new _ol_geom_LineString_([[-10, 0], [10, 0]])
+        geometry: new LineString([[-10, 0], [0, 0]]),
+        alt_geometry: new LineString([[-10, 0], [10, 0]])
       });
       var snapInteraction = new _ol_interaction_Snap_({
         features: new _ol_Collection_([line]),

--- a/test/spec/ol/interaction/translate.test.js
+++ b/test/spec/ol/interaction/translate.test.js
@@ -3,7 +3,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_MapBrowserPointerEvent_ from '../../../../src/ol/MapBrowserPointerEvent.js';
 import _ol_View_ from '../../../../src/ol/View.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_interaction_Translate_ from '../../../../src/ol/interaction/Translate.js';
 import _ol_interaction_Interaction_ from '../../../../src/ol/interaction/Interaction.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
@@ -28,9 +28,9 @@ describe('ol.interaction.Translate', function() {
     document.body.appendChild(target);
     source = new _ol_source_Vector_();
     features = [new _ol_Feature_({
-      geometry: new _ol_geom_Point_([10, -20])
+      geometry: new Point([10, -20])
     }), new _ol_Feature_({
-      geometry: new _ol_geom_Point_([20, -30])
+      geometry: new Point([20, -30])
     })];
     source.addFeatures(features);
     var layer = new _ol_layer_Vector_({source: source});
@@ -172,7 +172,7 @@ describe('ol.interaction.Translate', function() {
       simulateEvent('pointerdrag', 50, -40);
       simulateEvent('pointerup', 50, -40);
       var geometry = features[0].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Point_);
+      expect(geometry).to.be.a(Point);
       expect(geometry.getCoordinates()).to.eql([50, 40]);
 
       validateEvents(events, [features[0]]);
@@ -186,7 +186,7 @@ describe('ol.interaction.Translate', function() {
       simulateEvent('pointerdrag', 50, -40);
       simulateEvent('pointerup', 50, -40);
       var geometry = features[1].getGeometry();
-      expect(geometry).to.be.a(_ol_geom_Point_);
+      expect(geometry).to.be.a(Point);
       expect(geometry.getCoordinates()).to.eql([20, -30]);
 
       expect(events).to.be.empty();

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -3,7 +3,7 @@ import _ol_Map_ from '../../../src/ol/Map.js';
 import _ol_MapEvent_ from '../../../src/ol/MapEvent.js';
 import _ol_Overlay_ from '../../../src/ol/Overlay.js';
 import _ol_View_ from '../../../src/ol/View.js';
-import _ol_geom_Point_ from '../../../src/ol/geom/Point.js';
+import Point from '../../../src/ol/geom/Point.js';
 import _ol_has_ from '../../../src/ol/has.js';
 import _ol_interaction_ from '../../../src/ol/interaction.js';
 import _ol_interaction_DoubleClickZoom_ from '../../../src/ol/interaction/DoubleClickZoom.js';
@@ -197,7 +197,7 @@ describe('ol.Map', function() {
         target: target,
         layers: [new _ol_layer_Vector_({
           source: new _ol_source_Vector_({
-            features: [new _ol_Feature_(new _ol_geom_Point_([0, 0]))]
+            features: [new _ol_Feature_(new Point([0, 0]))]
           })
         })],
         view: new _ol_View_({

--- a/test/spec/ol/render/box.test.js
+++ b/test/spec/ol/render/box.test.js
@@ -1,7 +1,7 @@
 import _ol_Disposable_ from '../../../../src/ol/Disposable.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_render_Box_ from '../../../../src/ol/render/Box.js';
 
 
@@ -67,7 +67,7 @@ describe('ol.render.Box', function() {
     it('creates a polygon geometry', function() {
       expect(box.getGeometry()).to.be(null);
       box.setPixels([1, 2], [3, 4]);
-      expect(box.getGeometry()).to.be.a(_ol_geom_Polygon_);
+      expect(box.getGeometry()).to.be.a(Polygon);
     });
   });
 

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
@@ -154,7 +154,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawCircle');
 
-      var geometry = new _ol_geom_Circle_([0, 0]);
+      var geometry = new Circle([0, 0]);
       context.drawGeometry(geometry);
 
       expect(context.drawCircle.calledOnce).to.be(true);

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -1,7 +1,7 @@
 import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
@@ -111,7 +111,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawMultiLineString');
 
-      var geometry = new _ol_geom_MultiLineString_([[[1, 2], [3, 4]]]);
+      var geometry = new MultiLineString([[[1, 2], [3, 4]]]);
       context.drawGeometry(geometry);
       expect(context.drawMultiLineString.calledOnce).to.be(true);
       expect(context.drawMultiLineString.firstCall.calledWithExactly(geometry)).to.be(true);

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -4,7 +4,7 @@ import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_VectorContext_ from '../../../../../src/ol/render/VectorContext.js';
 import _ol_render_canvas_Immediate_ from '../../../../../src/ol/render/canvas/Immediate.js';
@@ -71,7 +71,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawPoint');
 
-      var geometry = new _ol_geom_Point_([1, 2]);
+      var geometry = new Point([1, 2]);
       context.drawGeometry(geometry);
       expect(context.drawPoint.calledOnce).to.be(true);
       expect(context.drawPoint.firstCall.calledWithExactly(geometry)).to.be(true);
@@ -134,7 +134,7 @@ describe('ol.render.canvas.Immediate', function() {
       sinon.spy(context, 'drawLineString');
       sinon.spy(context, 'drawPolygon');
 
-      var point = new _ol_geom_Point_([1, 2]);
+      var point = new Point([1, 2]);
       var linestring = new _ol_geom_LineString_([[1, 2], [3, 4]]);
       var polygon = new _ol_geom_Polygon_([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
 

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -3,7 +3,7 @@ import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCol
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_VectorContext_ from '../../../../../src/ol/render/VectorContext.js';
@@ -121,7 +121,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawMultiPolygon');
 
-      var geometry = new _ol_geom_MultiPolygon_([[[[1, 2], [3, 4], [5, 6], [1, 2]]]]);
+      var geometry = new MultiPolygon([[[[1, 2], [3, 4], [5, 6], [1, 2]]]]);
       context.drawGeometry(geometry);
       expect(context.drawMultiPolygon.calledOnce).to.be(true);
       expect(context.drawMultiPolygon.firstCall.calledWithExactly(geometry)).to.be(true);
@@ -234,7 +234,7 @@ describe('ol.render.canvas.Immediate', function() {
         strokeStyle: '#00FFFF'
       };
 
-      var multiPolygonGeometry = new _ol_geom_MultiPolygon_([[[
+      var multiPolygonGeometry = new MultiPolygon([[[
         // first polygon
         [-80.736061, 28.788576000000006, 0], // moveTo()
         [-80.763557, 28.821799999999996, 0], // lineTo()

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -5,7 +5,7 @@ import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_VectorContext_ from '../../../../../src/ol/render/VectorContext.js';
 import _ol_render_canvas_Immediate_ from '../../../../../src/ol/render/canvas/Immediate.js';
 import _ol_style_Circle_ from '../../../../../src/ol/style/Circle.js';
@@ -91,7 +91,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawPolygon');
 
-      var geometry = new _ol_geom_Polygon_([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
+      var geometry = new Polygon([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
       context.drawGeometry(geometry);
       expect(context.drawPolygon.calledOnce).to.be(true);
       expect(context.drawPolygon.firstCall.calledWithExactly(geometry)).to.be(true);
@@ -136,7 +136,7 @@ describe('ol.render.canvas.Immediate', function() {
 
       var point = new Point([1, 2]);
       var linestring = new LineString([[1, 2], [3, 4]]);
-      var polygon = new _ol_geom_Polygon_([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
+      var polygon = new Polygon([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
 
       var geometry = new _ol_geom_GeometryCollection_([point, linestring, polygon]);
       context.drawGeometry(geometry);

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -1,5 +1,5 @@
 import Circle from '../../../../../src/ol/geom/Circle.js';
-import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
@@ -138,7 +138,7 @@ describe('ol.render.canvas.Immediate', function() {
       var linestring = new LineString([[1, 2], [3, 4]]);
       var polygon = new Polygon([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
 
-      var geometry = new _ol_geom_GeometryCollection_([point, linestring, polygon]);
+      var geometry = new GeometryCollection([point, linestring, polygon]);
       context.drawGeometry(geometry);
 
       expect(context.drawGeometryCollection.calledOnce).to.be(true);

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -2,7 +2,7 @@ import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
@@ -101,7 +101,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawMultiPoint');
 
-      var geometry = new _ol_geom_MultiPoint_([[1, 2], [3, 4]]);
+      var geometry = new MultiPoint([[1, 2], [3, 4]]);
       context.drawGeometry(geometry);
       expect(context.drawMultiPoint.calledOnce).to.be(true);
       expect(context.drawMultiPoint.firstCall.calledWithExactly(geometry)).to.be(true);

--- a/test/spec/ol/render/canvas/immediate.test.js
+++ b/test/spec/ol/render/canvas/immediate.test.js
@@ -1,6 +1,6 @@
 import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
@@ -81,7 +81,7 @@ describe('ol.render.canvas.Immediate', function() {
       var context = new _ol_render_canvas_Immediate_(getMockContext(), 1, extent);
       sinon.spy(context, 'drawLineString');
 
-      var geometry = new _ol_geom_LineString_([[1, 2], [3, 4]]);
+      var geometry = new LineString([[1, 2], [3, 4]]);
       context.drawGeometry(geometry);
       expect(context.drawLineString.calledOnce).to.be(true);
       expect(context.drawLineString.firstCall.calledWithExactly(geometry)).to.be(true);
@@ -135,7 +135,7 @@ describe('ol.render.canvas.Immediate', function() {
       sinon.spy(context, 'drawPolygon');
 
       var point = new Point([1, 2]);
-      var linestring = new _ol_geom_LineString_([[1, 2], [3, 4]]);
+      var linestring = new LineString([[1, 2], [3, 4]]);
       var polygon = new _ol_geom_Polygon_([[[1, 2], [3, 4], [5, 6], [1, 2]]]);
 
       var geometry = new _ol_geom_GeometryCollection_([point, linestring, polygon]);

--- a/test/spec/ol/render/canvas/textreplay.test.js
+++ b/test/spec/ol/render/canvas/textreplay.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_canvas_TextReplay_ from '../../../../../src/ol/render/canvas/TextReplay.js';
 import _ol_style_Text_ from '../../../../../src/ol/style/Text.js';
@@ -26,7 +26,7 @@ describe('ol.render.canvas.TextReplay', function() {
 
   it('renders multipolygon labels only when they fit', function() {
     var replay = new _ol_render_canvas_TextReplay_(1, [-180, -90, 180, 90], 0.02, 1, true);
-    var geometry = new _ol_geom_MultiPolygon_([
+    var geometry = new MultiPolygon([
       [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
       [[[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]]]
     ]);

--- a/test/spec/ol/render/canvas/textreplay.test.js
+++ b/test/spec/ol/render/canvas/textreplay.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_canvas_TextReplay_ from '../../../../../src/ol/render/canvas/TextReplay.js';
 import _ol_style_Text_ from '../../../../../src/ol/style/Text.js';
 
@@ -8,7 +8,7 @@ describe('ol.render.canvas.TextReplay', function() {
 
   it('renders polygon labels only when they fit', function() {
     var replay = new _ol_render_canvas_TextReplay_(1, [-180, -90, 180, 90], 0.02, 1, true);
-    var geometry = new _ol_geom_Polygon_([[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]);
+    var geometry = new Polygon([[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]);
     var feature = new _ol_Feature_(geometry);
 
     replay.setTextStyle(new _ol_style_Text_({

--- a/test/spec/ol/render/feature.test.js
+++ b/test/spec/ol/render/feature.test.js
@@ -1,5 +1,5 @@
 import LineString from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_render_Feature_ from '../../../../src/ol/render/Feature.js';
@@ -87,7 +87,7 @@ describe('ol.render.Feature', function() {
 
   describe('#getFlatMidpoints()', function() {
     it('returns correct points and caches them', function() {
-      var line = new _ol_geom_MultiLineString_([
+      var line = new MultiLineString([
         [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]],
         [[10, 0], [10, 10], [20, 10], [20, 0], [10, 0]]
       ]);

--- a/test/spec/ol/render/feature.test.js
+++ b/test/spec/ol/render/feature.test.js
@@ -1,6 +1,6 @@
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_render_Feature_ from '../../../../src/ol/render/Feature.js';
 
@@ -65,7 +65,7 @@ describe('ol.render.Feature', function() {
 
   describe('#getFlatInteriorPoints()', function() {
     it('returns correct points and caches them', function() {
-      var polygon = new _ol_geom_MultiPolygon_([
+      var polygon = new MultiPolygon([
         [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]],
         [[[10, 0], [10, 10], [20, 10], [20, 0], [10, 0]]]
       ]);

--- a/test/spec/ol/render/feature.test.js
+++ b/test/spec/ol/render/feature.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
@@ -78,7 +78,7 @@ describe('ol.render.Feature', function() {
 
   describe('#getFlatMidpoint()', function() {
     it('returns correct point', function() {
-      var line = new _ol_geom_LineString_([[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]);
+      var line = new LineString([[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]);
       var feature = new _ol_render_Feature_('LineString', line.getFlatCoordinates());
       expect(feature.getFlatMidpoint()).to.eql([10, 10]);
       expect(feature.getFlatMidpoint()).to.eql(feature.flatMidpoints_);

--- a/test/spec/ol/render/feature.test.js
+++ b/test/spec/ol/render/feature.test.js
@@ -1,7 +1,7 @@
 import LineString from '../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import _ol_render_Feature_ from '../../../../src/ol/render/Feature.js';
 
 
@@ -55,7 +55,7 @@ describe('ol.render.Feature', function() {
 
   describe('#getFlatInteriorPoint()', function() {
     it('returns correct point and caches it', function() {
-      var polygon = new _ol_geom_Polygon_([[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]);
+      var polygon = new Polygon([[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]]);
       var feature = new _ol_render_Feature_('Polygon', polygon.getOrientedFlatCoordinates(),
           polygon.getEnds());
       expect(feature.getFlatInteriorPoint()).to.eql([5, 5, 10]);

--- a/test/spec/ol/render/webgl/circlereplay.test.js
+++ b/test/spec/ol/render/webgl/circlereplay.test.js
@@ -1,6 +1,6 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
-import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../../src/ol/geom/Circle.js';
 import _ol_render_webgl_CircleReplay_ from '../../../../../src/ol/render/webgl/CircleReplay.js';
 import _ol_render_webgl_circlereplay_defaultshader_ from '../../../../../src/ol/render/webgl/circlereplay/defaultshader.js';
 import _ol_render_webgl_circlereplay_defaultshader_Locations_ from '../../../../../src/ol/render/webgl/circlereplay/defaultshader/Locations.js';
@@ -48,7 +48,7 @@ describe('ol.render.webgl.CircleReplay', function() {
 
   describe('#drawCircle', function() {
     it('sets the buffer data', function() {
-      var circle = new _ol_geom_Circle_([0, 0], 5000);
+      var circle = new Circle([0, 0], 5000);
 
       replay.setFillStrokeStyle(fillStyle, strokeStyle);
       replay.drawCircle(circle, null);
@@ -61,7 +61,7 @@ describe('ol.render.webgl.CircleReplay', function() {
     });
 
     it('does not draw if radius is zero', function() {
-      var circle = new _ol_geom_Circle_([0, 0], 0);
+      var circle = new Circle([0, 0], 0);
 
       replay.drawCircle(circle, null);
       expect(replay.vertices).to.have.length(0);
@@ -71,7 +71,7 @@ describe('ol.render.webgl.CircleReplay', function() {
     });
 
     it('resets state and removes style if it belongs to a zero radius circle', function() {
-      var circle = new _ol_geom_Circle_([0, 0], 0);
+      var circle = new Circle([0, 0], 0);
 
       replay.setFillStrokeStyle(fillStyle, strokeStyle);
       replay.setFillStrokeStyle(null, strokeStyle);
@@ -174,13 +174,13 @@ describe('ol.render.webgl.CircleReplay', function() {
   describe('#drawReplay', function() {
     var gl, context;
     var feature1 = new _ol_Feature_({
-      geometry: new _ol_geom_Circle_([0, 0], 5000)
+      geometry: new Circle([0, 0], 5000)
     });
     var feature2 = new _ol_Feature_({
-      geometry: new _ol_geom_Circle_([10, 10], 5000)
+      geometry: new Circle([10, 10], 5000)
     });
     var feature3 = new _ol_Feature_({
-      geometry: new _ol_geom_Circle_([20, 20], 5000)
+      geometry: new Circle([20, 20], 5000)
     });
     beforeEach(function() {
       gl = {};

--- a/test/spec/ol/render/webgl/imagereplay.test.js
+++ b/test/spec/ol/render/webgl/imagereplay.test.js
@@ -1,4 +1,4 @@
-import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_render_webgl_ImageReplay_ from '../../../../../src/ol/render/webgl/ImageReplay.js';
 import _ol_style_Image_ from '../../../../../src/ol/style/Image.js';
@@ -127,7 +127,7 @@ describe('ol.render.webgl.ImageReplay', function() {
     it('sets the buffer data', function() {
       var multiPoint;
 
-      multiPoint = new _ol_geom_MultiPoint_(
+      multiPoint = new MultiPoint(
           [[1000, 2000], [2000, 3000]]);
       replay.drawMultiPoint(multiPoint, null);
       expect(replay.vertices).to.have.length(64);
@@ -145,7 +145,7 @@ describe('ol.render.webgl.ImageReplay', function() {
       expect(replay.indices[10]).to.be(6);
       expect(replay.indices[11]).to.be(7);
 
-      multiPoint = new _ol_geom_MultiPoint_(
+      multiPoint = new MultiPoint(
           [[3000, 4000], [4000, 5000]]);
       replay.drawMultiPoint(multiPoint, null);
       expect(replay.vertices).to.have.length(128);

--- a/test/spec/ol/render/webgl/imagereplay.test.js
+++ b/test/spec/ol/render/webgl/imagereplay.test.js
@@ -1,5 +1,5 @@
 import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_render_webgl_ImageReplay_ from '../../../../../src/ol/render/webgl/ImageReplay.js';
 import _ol_style_Image_ from '../../../../../src/ol/style/Image.js';
 
@@ -94,7 +94,7 @@ describe('ol.render.webgl.ImageReplay', function() {
     it('sets the buffer data', function() {
       var point;
 
-      point = new _ol_geom_Point_([1000, 2000]);
+      point = new Point([1000, 2000]);
       replay.drawPoint(point, null);
       expect(replay.vertices).to.have.length(32);
       expect(replay.indices).to.have.length(6);
@@ -105,7 +105,7 @@ describe('ol.render.webgl.ImageReplay', function() {
       expect(replay.indices[4]).to.be(2);
       expect(replay.indices[5]).to.be(3);
 
-      point = new _ol_geom_Point_([2000, 3000]);
+      point = new Point([2000, 3000]);
       replay.drawPoint(point, null);
       expect(replay.vertices).to.have.length(64);
       expect(replay.indices).to.have.length(12);

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -6,7 +6,7 @@ import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_webgl_CircleReplay_ from '../../../../../src/ol/render/webgl/CircleReplay.js';
 import _ol_render_webgl_ImageReplay_ from '../../../../../src/ol/render/webgl/ImageReplay.js';
 import _ol_render_webgl_Immediate_ from '../../../../../src/ol/render/webgl/Immediate.js';
@@ -31,7 +31,7 @@ describe('ol.render.webgl.Immediate', function() {
     multiLine = new MultiLineString([[[0, 0], [5, 5]]]);
     point = new Point([0, 0]);
     multiPoint = new MultiPoint([[0, 0]]);
-    polygon = new _ol_geom_Polygon_([[[0, 0], [5, 5], [5, 0], [0, 0]]]);
+    polygon = new Polygon([[[0, 0], [5, 5], [5, 0], [0, 0]]]);
     multiPolygon = new _ol_geom_MultiPolygon_([[[[0, 0], [5, 5], [5, 0], [0, 0]]]]);
   });
 

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -5,7 +5,7 @@ import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_webgl_CircleReplay_ from '../../../../../src/ol/render/webgl/CircleReplay.js';
 import _ol_render_webgl_ImageReplay_ from '../../../../../src/ol/render/webgl/ImageReplay.js';
@@ -29,7 +29,7 @@ describe('ol.render.webgl.Immediate', function() {
     circle = new _ol_geom_Circle_([0, 0], 5);
     line = new _ol_geom_LineString_([[0, 0], [5, 5]]);
     multiLine = new _ol_geom_MultiLineString_([[[0, 0], [5, 5]]]);
-    point = new _ol_geom_Point_([0, 0]);
+    point = new Point([0, 0]);
     multiPoint = new _ol_geom_MultiPoint_([[0, 0]]);
     polygon = new _ol_geom_Polygon_([[[0, 0], [5, 5], [5, 0], [0, 0]]]);
     multiPolygon = new _ol_geom_MultiPolygon_([[[[0, 0], [5, 5], [5, 0], [0, 0]]]]);

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -4,7 +4,7 @@ import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCol
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_webgl_CircleReplay_ from '../../../../../src/ol/render/webgl/CircleReplay.js';
@@ -32,7 +32,7 @@ describe('ol.render.webgl.Immediate', function() {
     point = new Point([0, 0]);
     multiPoint = new MultiPoint([[0, 0]]);
     polygon = new Polygon([[[0, 0], [5, 5], [5, 0], [0, 0]]]);
-    multiPolygon = new _ol_geom_MultiPolygon_([[[[0, 0], [5, 5], [5, 0], [0, 0]]]]);
+    multiPolygon = new MultiPolygon([[[[0, 0], [5, 5], [5, 0], [0, 0]]]]);
   });
 
   describe('#setStyle', function() {

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -3,7 +3,7 @@ import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
@@ -30,7 +30,7 @@ describe('ol.render.webgl.Immediate', function() {
     line = new _ol_geom_LineString_([[0, 0], [5, 5]]);
     multiLine = new _ol_geom_MultiLineString_([[[0, 0], [5, 5]]]);
     point = new Point([0, 0]);
-    multiPoint = new _ol_geom_MultiPoint_([[0, 0]]);
+    multiPoint = new MultiPoint([[0, 0]]);
     polygon = new _ol_geom_Polygon_([[[0, 0], [5, 5], [5, 0], [0, 0]]]);
     multiPolygon = new _ol_geom_MultiPolygon_([[[[0, 0], [5, 5], [5, 0], [0, 0]]]]);
   });

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
@@ -27,7 +27,7 @@ describe('ol.render.webgl.Immediate', function() {
       stroke: new _ol_style_Stroke_()
     });
     circle = new _ol_geom_Circle_([0, 0], 5);
-    line = new _ol_geom_LineString_([[0, 0], [5, 5]]);
+    line = new LineString([[0, 0], [5, 5]]);
     multiLine = new _ol_geom_MultiLineString_([[[0, 0], [5, 5]]]);
     point = new Point([0, 0]);
     multiPoint = new MultiPoint([[0, 0]]);

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
-import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
+import Circle from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
@@ -26,7 +26,7 @@ describe('ol.render.webgl.Immediate', function() {
       fill: new _ol_style_Fill_(),
       stroke: new _ol_style_Stroke_()
     });
-    circle = new _ol_geom_Circle_([0, 0], 5);
+    circle = new Circle([0, 0], 5);
     line = new LineString([[0, 0], [5, 5]]);
     multiLine = new MultiLineString([[[0, 0], [5, 5]]]);
     point = new Point([0, 0]);
@@ -75,7 +75,7 @@ describe('ol.render.webgl.Immediate', function() {
 
     it('does nothing if geometry is out of bounds', function() {
       feat = new _ol_Feature_({
-        geometry: new _ol_geom_Circle_([540, 540], 1)
+        geometry: new Circle([540, 540], 1)
       });
       context.drawFeature(feat, style);
       expect(context.setStyle.called).to.be(false);

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -2,7 +2,7 @@ import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_Circle_ from '../../../../../src/ol/geom/Circle.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
@@ -28,7 +28,7 @@ describe('ol.render.webgl.Immediate', function() {
     });
     circle = new _ol_geom_Circle_([0, 0], 5);
     line = new LineString([[0, 0], [5, 5]]);
-    multiLine = new _ol_geom_MultiLineString_([[[0, 0], [5, 5]]]);
+    multiLine = new MultiLineString([[[0, 0], [5, 5]]]);
     point = new Point([0, 0]);
     multiPoint = new MultiPoint([[0, 0]]);
     polygon = new _ol_geom_Polygon_([[[0, 0], [5, 5], [5, 0], [0, 0]]]);

--- a/test/spec/ol/render/webgl/immediate.test.js
+++ b/test/spec/ol/render/webgl/immediate.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import Circle from '../../../../../src/ol/geom/Circle.js';
-import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
@@ -86,7 +86,7 @@ describe('ol.render.webgl.Immediate', function() {
   describe('#drawGeometryCollection', function() {
     var geomColl;
     beforeEach(function() {
-      geomColl = new _ol_geom_GeometryCollection_([circle, point, multiPoint,
+      geomColl = new GeometryCollection([circle, point, multiPoint,
         line, multiLine, polygon, multiPolygon]);
     });
 

--- a/test/spec/ol/render/webgl/linestringreplay.test.js
+++ b/test/spec/ol/render/webgl/linestringreplay.test.js
@@ -1,6 +1,6 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
-import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import _ol_render_webgl_LineStringReplay_ from '../../../../../src/ol/render/webgl/LineStringReplay.js';
 import _ol_render_webgl_linestringreplay_defaultshader_ from '../../../../../src/ol/render/webgl/linestringreplay/defaultshader.js';
@@ -56,7 +56,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
     it('sets the buffer data', function() {
       var linestring;
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 2000], [2000, 3000]]);
       replay.setFillStrokeStyle(null, strokeStyle1);
       replay.drawLineString(linestring, null);
@@ -66,7 +66,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
       expect(replay.startIndices).to.have.length(1);
       expect(replay.startIndicesFeature).to.have.length(1);
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 3000], [2000, 4000], [3000, 3000]]);
       replay.drawLineString(linestring, null);
       expect(replay.vertices).to.have.length(140);
@@ -106,7 +106,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
         lineJoin: 'bevel'
       });
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 3000], [2000, 4000], [3000, 3000]]);
       var flatCoordinates = linestring.getFlatCoordinates();
       replay.setFillStrokeStyle(null, stroke);
@@ -126,7 +126,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
         lineCap: 'butt'
       });
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 3000], [2000, 4000], [3000, 3000]]);
       var flatCoordinates = linestring.getFlatCoordinates();
       replay.setFillStrokeStyle(null, stroke);
@@ -145,7 +145,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
         color: [0, 255, 0, 1]
       });
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 3000], [2000, 4000], [3000, 3000]]);
       var flatCoordinates = linestring.getFlatCoordinates();
       replay.setFillStrokeStyle(null, stroke);
@@ -168,7 +168,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
         lineJoin: 'bevel'
       });
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 3000], [2000, 2000], [3000, 3000]]);
       var flatCoordinates = linestring.getFlatCoordinates();
       replay.setFillStrokeStyle(null, stroke);
@@ -189,7 +189,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
         lineJoin: 'bevel'
       });
 
-      linestring = new _ol_geom_LineString_(
+      linestring = new LineString(
           [[1000, 3000], [2000, 4000], [3000, 3000], [1000, 3000]]);
       var flatCoordinates = linestring.getFlatCoordinates();
       replay.setFillStrokeStyle(null, stroke);
@@ -287,13 +287,13 @@ describe('ol.render.webgl.LineStringReplay', function() {
   describe('#drawReplay', function() {
     var gl, context;
     var feature1 = new _ol_Feature_({
-      geometry: new _ol_geom_LineString_([[0, 0], [500, 500]])
+      geometry: new LineString([[0, 0], [500, 500]])
     });
     var feature2 = new _ol_Feature_({
-      geometry: new _ol_geom_LineString_([[0, 0], [500, 500]])
+      geometry: new LineString([[0, 0], [500, 500]])
     });
     var feature3 = new _ol_Feature_({
-      geometry: new _ol_geom_LineString_([[0, 0], [500, 500]])
+      geometry: new LineString([[0, 0], [500, 500]])
     });
     beforeEach(function() {
       gl = {

--- a/test/spec/ol/render/webgl/linestringreplay.test.js
+++ b/test/spec/ol/render/webgl/linestringreplay.test.js
@@ -1,7 +1,7 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import _ol_render_webgl_LineStringReplay_ from '../../../../../src/ol/render/webgl/LineStringReplay.js';
 import _ol_render_webgl_linestringreplay_defaultshader_ from '../../../../../src/ol/render/webgl/linestringreplay/defaultshader.js';
 import _ol_render_webgl_linestringreplay_defaultshader_Locations_ from '../../../../../src/ol/render/webgl/linestringreplay/defaultshader/Locations.js';
@@ -82,7 +82,7 @@ describe('ol.render.webgl.LineStringReplay', function() {
     it('sets the buffer data', function() {
       var multilinestring;
 
-      multilinestring = new _ol_geom_MultiLineString_(
+      multilinestring = new MultiLineString(
           [[[1000, 2000], [2000, 3000]],
             [[1000, 3000], [2000, 4000], [3000, 3000]]]);
       replay.setFillStrokeStyle(null, strokeStyle1);

--- a/test/spec/ol/render/webgl/polygonreplay.test.js
+++ b/test/spec/ol/render/webgl/polygonreplay.test.js
@@ -1,7 +1,7 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_webgl_PolygonReplay_ from '../../../../../src/ol/render/webgl/PolygonReplay.js';
 import _ol_render_webgl_polygonreplay_defaultshader_ from '../../../../../src/ol/render/webgl/polygonreplay/defaultshader.js';
 import _ol_render_webgl_polygonreplay_defaultshader_Locations_ from '../../../../../src/ol/render/webgl/polygonreplay/defaultshader/Locations.js';
@@ -32,7 +32,7 @@ describe('ol.render.webgl.PolygonReplay', function() {
     });
 
     it('sets the buffer data', function() {
-      var polygon1 = new _ol_geom_Polygon_(
+      var polygon1 = new Polygon(
           [[[1000, 2000], [1200, 2000], [1200, 3000]]]
       );
       replay.drawPolygon(polygon1, null);
@@ -43,7 +43,7 @@ describe('ol.render.webgl.PolygonReplay', function() {
         1000, 2000, 1200, 3000, 1200, 2000, 1000, 2000]);
       expect(replay.indices).to.eql([2, 0, 1]);
 
-      var polygon2 = new _ol_geom_Polygon_(
+      var polygon2 = new Polygon(
           [[[4000, 2000], [4200, 2000], [4200, 3000]]]
       );
       replay.drawPolygon(polygon2, null);
@@ -396,13 +396,13 @@ describe('ol.render.webgl.PolygonReplay', function() {
   describe('#drawReplay', function() {
     var gl, context;
     var feature1 = new _ol_Feature_({
-      geometry: new _ol_geom_Polygon_([[[0, 0], [500, 500], [500, 0], [0, 0]]])
+      geometry: new Polygon([[[0, 0], [500, 500], [500, 0], [0, 0]]])
     });
     var feature2 = new _ol_Feature_({
-      geometry: new _ol_geom_Polygon_([[[0, 0], [500, 500], [500, 0], [0, 0]]])
+      geometry: new Polygon([[[0, 0], [500, 500], [500, 0], [0, 0]]])
     });
     var feature3 = new _ol_Feature_({
-      geometry: new _ol_geom_Polygon_([[[0, 0], [500, 500], [500, 0], [0, 0]]])
+      geometry: new Polygon([[[0, 0], [500, 500], [500, 0], [0, 0]]])
     });
     beforeEach(function() {
       gl = {

--- a/test/spec/ol/render/webgl/polygonreplay.test.js
+++ b/test/spec/ol/render/webgl/polygonreplay.test.js
@@ -1,6 +1,6 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_webgl_PolygonReplay_ from '../../../../../src/ol/render/webgl/PolygonReplay.js';
 import _ol_render_webgl_polygonreplay_defaultshader_ from '../../../../../src/ol/render/webgl/polygonreplay/defaultshader.js';
@@ -64,7 +64,7 @@ describe('ol.render.webgl.PolygonReplay', function() {
     });
 
     it('sets the buffer data', function() {
-      var multiPolygon = new _ol_geom_MultiPolygon_([
+      var multiPolygon = new MultiPolygon([
         [[[1000, 2000], [1200, 2000], [1200, 3000]]],
         [[[4000, 2000], [4200, 2000], [4200, 3000]]]
       ]);

--- a/test/spec/ol/render/webgl/textreplay.test.js
+++ b/test/spec/ol/render/webgl/textreplay.test.js
@@ -1,5 +1,5 @@
 import {createCanvasContext2D} from '../../../../../src/ol/dom.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_render_webgl_TextReplay_ from '../../../../../src/ol/render/webgl/TextReplay.js';
 import _ol_style_Fill_ from '../../../../../src/ol/style/Fill.js';
 import _ol_style_Stroke_ from '../../../../../src/ol/style/Stroke.js';
@@ -126,19 +126,19 @@ describe('ol.render.webgl.TextReplay', function() {
       var point;
 
       point = [1000, 2000];
-      replay.drawText(new _ol_geom_Point_(point), null);
+      replay.drawText(new Point(point), null);
       expect(replay.vertices).to.have.length(256);
       expect(replay.indices).to.have.length(48);
 
       point = [2000, 3000];
-      replay.drawText(new _ol_geom_Point_(point), null);
+      replay.drawText(new Point(point), null);
       expect(replay.vertices).to.have.length(512);
       expect(replay.indices).to.have.length(96);
     });
 
     it('sets part of its state during drawing', function() {
       var point = [1000, 2000];
-      replay.drawText(new _ol_geom_Point_(point), null);
+      replay.drawText(new Point(point), null);
 
       var height = replay.currAtlas_.height;
       var widths = replay.currAtlas_.width;
@@ -162,7 +162,7 @@ describe('ol.render.webgl.TextReplay', function() {
       var point;
 
       point = [1000, 2000];
-      replay.drawText(new _ol_geom_Point_(point), null);
+      replay.drawText(new Point(point), null);
       expect(replay.vertices).to.have.length(0);
       expect(replay.indices).to.have.length(0);
     });

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -2,7 +2,7 @@ import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../../src/ol/View.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_layer_Tile_ from '../../../../../src/ol/layer/Tile.js';
 import _ol_layer_Vector_ from '../../../../../src/ol/layer/Vector.js';
 import _ol_renderer_canvas_Layer_ from '../../../../../src/ol/renderer/canvas/Layer.js';
@@ -54,7 +54,7 @@ describe('ol.renderer.canvas.Map', function() {
         source: new _ol_source_Vector_({
           features: [
             new _ol_Feature_({
-              geometry: new _ol_geom_Point_([0, 0])
+              geometry: new Point([0, 0])
             })
           ]
         }),

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -2,7 +2,7 @@ import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
@@ -234,7 +234,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
           [[45, 90], [90, 45]]));
       var linestring = new _ol_Feature_(new LineString(
           [[45, 90], [45, 45], [90, 45]]));
-      var multilinestring = new _ol_Feature_(new _ol_geom_MultiLineString_(
+      var multilinestring = new _ol_Feature_(new MultiLineString(
           [linestring.getGeometry().getCoordinates(), linestring.getGeometry().getCoordinates()]));
       var polygon = feature1;
       var multipolygon = new _ol_Feature_(new _ol_geom_MultiPolygon_(

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -3,7 +3,7 @@ import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
 import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
@@ -230,7 +230,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
         }
       });
       var point = new _ol_Feature_(new Point([45, 90]));
-      var multipoint = new _ol_Feature_(new _ol_geom_MultiPoint_(
+      var multipoint = new _ol_Feature_(new MultiPoint(
           [[45, 90], [90, 45]]));
       var linestring = new _ol_Feature_(new _ol_geom_LineString_(
           [[45, 90], [45, 45], [90, 45]]));

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -4,7 +4,7 @@ import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCol
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_canvas_LineStringReplay_ from '../../../../../src/ol/render/canvas/LineStringReplay.js';
@@ -237,7 +237,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
       var multilinestring = new _ol_Feature_(new MultiLineString(
           [linestring.getGeometry().getCoordinates(), linestring.getGeometry().getCoordinates()]));
       var polygon = feature1;
-      var multipolygon = new _ol_Feature_(new _ol_geom_MultiPolygon_(
+      var multipolygon = new _ol_Feature_(new MultiPolygon(
           [polygon.getGeometry().getCoordinates(), polygon.getGeometry().getCoordinates()]));
       var geometrycollection = new _ol_Feature_(new _ol_geom_GeometryCollection_(
           [point.getGeometry(), linestring.getGeometry(), polygon.getGeometry()]));

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -5,7 +5,7 @@ import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_canvas_LineStringReplay_ from '../../../../../src/ol/render/canvas/LineStringReplay.js';
 import _ol_render_canvas_PolygonReplay_ from '../../../../../src/ol/render/canvas/PolygonReplay.js';
@@ -229,7 +229,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
           });
         }
       });
-      var point = new _ol_Feature_(new _ol_geom_Point_([45, 90]));
+      var point = new _ol_Feature_(new Point([45, 90]));
       var multipoint = new _ol_Feature_(new _ol_geom_MultiPoint_(
           [[45, 90], [90, 45]]));
       var linestring = new _ol_Feature_(new _ol_geom_LineString_(

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -6,7 +6,7 @@ import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import _ol_render_canvas_LineStringReplay_ from '../../../../../src/ol/render/canvas/LineStringReplay.js';
 import _ol_render_canvas_PolygonReplay_ from '../../../../../src/ol/render/canvas/PolygonReplay.js';
 import _ol_render_canvas_Replay_ from '../../../../../src/ol/render/canvas/Replay.js';
@@ -29,13 +29,13 @@ describe('ol.render.canvas.ReplayGroup', function() {
     beforeEach(function() {
       transform = _ol_transform_.create();
       replay = new _ol_render_canvas_ReplayGroup_(1, [-180, -90, 180, 90], 1, 1, false);
-      feature0 = new _ol_Feature_(new _ol_geom_Polygon_(
+      feature0 = new _ol_Feature_(new Polygon(
           [[[-90, 0], [-45, 45], [0, 0], [1, 1], [0, -45], [-90, 0]]]));
-      feature1 = new _ol_Feature_(new _ol_geom_Polygon_(
+      feature1 = new _ol_Feature_(new Polygon(
           [[[-90, -45], [-90, 0], [0, 0], [0, -45], [-90, -45]]]));
-      feature2 = new _ol_Feature_(new _ol_geom_Polygon_(
+      feature2 = new _ol_Feature_(new Polygon(
           [[[90, 45], [90, 0], [0, 0], [0, 45], [90, 45]]]));
-      feature3 = new _ol_Feature_(new _ol_geom_Polygon_(
+      feature3 = new _ol_Feature_(new Polygon(
           [[[-90, -45], [-90, 45], [90, 45], [90, -45], [-90, -45]]]));
       fill0 = new _ol_style_Style_({
         fill: new _ol_style_Fill_({color: 'black'})

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -1,6 +1,6 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
-import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
@@ -239,7 +239,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
       var polygon = feature1;
       var multipolygon = new _ol_Feature_(new MultiPolygon(
           [polygon.getGeometry().getCoordinates(), polygon.getGeometry().getCoordinates()]));
-      var geometrycollection = new _ol_Feature_(new _ol_geom_GeometryCollection_(
+      var geometrycollection = new _ol_Feature_(new GeometryCollection(
           [point.getGeometry(), linestring.getGeometry(), polygon.getGeometry()]));
       replay = new _ol_render_canvas_ReplayGroup_(1, [-180, -90, 180, 90], 1, 1, true);
       _ol_renderer_vector_.renderFeature(replay, point, style, 1);

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -1,7 +1,7 @@
 import {getUid} from '../../../../../src/ol/index.js';
 import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_geom_GeometryCollection_ from '../../../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../../src/ol/geom/MultiPolygon.js';
@@ -232,7 +232,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
       var point = new _ol_Feature_(new Point([45, 90]));
       var multipoint = new _ol_Feature_(new MultiPoint(
           [[45, 90], [90, 45]]));
-      var linestring = new _ol_Feature_(new _ol_geom_LineString_(
+      var linestring = new _ol_Feature_(new LineString(
           [[45, 90], [45, 45], [90, 45]]));
       var multilinestring = new _ol_Feature_(new _ol_geom_MultiLineString_(
           [linestring.getGeometry().getCoordinates(), linestring.getGeometry().getCoordinates()]));

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -3,7 +3,7 @@ import _ol_Feature_ from '../../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../../src/ol/View.js';
 import * as _ol_extent_ from '../../../../../src/ol/extent.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_layer_Vector_ from '../../../../../src/ol/layer/Vector.js';
 import _ol_obj_ from '../../../../../src/ol/obj.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
@@ -66,8 +66,8 @@ describe('ol.renderer.canvas.VectorLayer', function() {
           text: 'feature'
         })
       })];
-      var feature1 = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
-      var feature2 = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      var feature1 = new _ol_Feature_(new Point([0, 0]));
+      var feature2 = new _ol_Feature_(new Point([0, 0]));
       feature2.setStyle(featureStyle);
       var layer = new _ol_layer_Vector_({
         source: new _ol_source_Vector_({
@@ -100,7 +100,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
         })
       });
 
-      var feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      var feature = new _ol_Feature_(new Point([0, 0]));
       var layer = new _ol_layer_Vector_({
         source: new _ol_source_Vector_({
           features: [feature]
@@ -131,7 +131,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
         })
       });
 
-      var feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      var feature = new _ol_Feature_(new Point([0, 0]));
       var layer = new _ol_layer_Vector_({
         source: new _ol_source_Vector_({
           features: [feature]
@@ -163,7 +163,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
         })
       });
 
-      var feature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      var feature = new _ol_Feature_(new Point([0, 0]));
       var layer = new _ol_layer_Vector_({
         source: new _ol_source_Vector_({
           features: [feature]

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -8,7 +8,7 @@ import _ol_VectorTile_ from '../../../../../src/ol/VectorTile.js';
 import _ol_View_ from '../../../../../src/ol/View.js';
 import * as _ol_extent_ from '../../../../../src/ol/extent.js';
 import _ol_format_MVT_ from '../../../../../src/ol/format/MVT.js';
-import _ol_geom_Point_ from '../../../../../src/ol/geom/Point.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import _ol_layer_VectorTile_ from '../../../../../src/ol/layer/VectorTile.js';
 import {get as getProjection, fromLonLat} from '../../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../../src/ol/proj/Projection.js';
@@ -55,8 +55,8 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
           text: 'feature'
         })
       })];
-      feature1 = new _ol_Feature_(new _ol_geom_Point_([1, -1]));
-      feature2 = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+      feature1 = new _ol_Feature_(new Point([1, -1]));
+      feature2 = new _ol_Feature_(new Point([0, 0]));
       feature3 = new _ol_render_Feature_('Point', [1, -1], []);
       feature2.setStyle(featureStyle);
       var TileClass = function() {

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -1,6 +1,6 @@
 import {nullFunction} from '../../../../src/ol/index.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
@@ -99,7 +99,7 @@ describe('ol.renderer.vector', function() {
       });
 
       it('does render the linestring', function() {
-        feature.setGeometry(new _ol_geom_LineString_([[0, 0], [1, 1]]));
+        feature.setGeometry(new LineString([[0, 0], [1, 1]]));
         var lineStringReplay = replayGroup.getReplay(
             style.getZIndex(), 'LineString');
         var setFillStrokeStyleSpy = sinon.spy(lineStringReplay,

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -4,7 +4,7 @@ import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_render_canvas_ReplayGroup_ from '../../../../src/ol/render/canvas/ReplayGroup.js';
 import _ol_renderer_vector_ from '../../../../src/ol/renderer/vector.js';
@@ -86,7 +86,7 @@ describe('ol.renderer.vector', function() {
       });
 
       it('does not render the multipoint', function() {
-        feature.setGeometry(new _ol_geom_MultiPoint_([[0, 0], [1, 1]]));
+        feature.setGeometry(new MultiPoint([[0, 0], [1, 1]]));
         var imageReplay = replayGroup.getReplay(
             style.getZIndex(), 'Image');
         var setImageStyleSpy = sinon.spy(imageReplay, 'setImageStyle');

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -1,7 +1,7 @@
 import {nullFunction} from '../../../../src/ol/index.js';
 import _ol_events_ from '../../../../src/ol/events.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../../src/ol/geom/MultiPoint.js';
@@ -73,7 +73,7 @@ describe('ol.renderer.vector', function() {
     describe('call renderFeature with a loading icon', function() {
 
       it('does not render the point', function() {
-        feature.setGeometry(new _ol_geom_Point_([0, 0]));
+        feature.setGeometry(new Point([0, 0]));
         var imageReplay = replayGroup.getReplay(
             style.getZIndex(), 'Image');
         var setImageStyleSpy = sinon.spy(imageReplay, 'setImageStyle');

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -5,7 +5,7 @@ import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
+import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_render_canvas_ReplayGroup_ from '../../../../src/ol/render/canvas/ReplayGroup.js';
 import _ol_renderer_vector_ from '../../../../src/ol/renderer/vector.js';
 import _ol_style_Fill_ from '../../../../src/ol/style/Fill.js';
@@ -145,7 +145,7 @@ describe('ol.renderer.vector', function() {
       });
 
       it('does render the multipolygon', function() {
-        feature.setGeometry(new _ol_geom_MultiPolygon_(
+        feature.setGeometry(new MultiPolygon(
             [[[[0, 0], [1, 1], [1, 0], [0, 0]]]]));
         var polygonReplay = replayGroup.getReplay(
             style.getZIndex(), 'Polygon');

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -2,7 +2,7 @@ import {nullFunction} from '../../../../src/ol/index.js';
 import _ol_events_ from '../../../../src/ol/events.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
@@ -129,7 +129,7 @@ describe('ol.renderer.vector', function() {
       });
 
       it('does render the polygon', function() {
-        feature.setGeometry(new _ol_geom_Polygon_(
+        feature.setGeometry(new Polygon(
             [[[0, 0], [1, 1], [1, 0], [0, 0]]]));
         var polygonReplay = replayGroup.getReplay(
             style.getZIndex(), 'Polygon');

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -3,7 +3,7 @@ import _ol_events_ from '../../../../src/ol/events.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
-import _ol_geom_MultiLineString_ from '../../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import _ol_geom_MultiPolygon_ from '../../../../src/ol/geom/MultiPolygon.js';
 import _ol_render_canvas_ReplayGroup_ from '../../../../src/ol/render/canvas/ReplayGroup.js';
@@ -114,7 +114,7 @@ describe('ol.renderer.vector', function() {
       });
 
       it('does render the multilinestring', function() {
-        feature.setGeometry(new _ol_geom_MultiLineString_([[[0, 0], [1, 1]]]));
+        feature.setGeometry(new MultiLineString([[[0, 0], [1, 1]]]));
         var lineStringReplay = replayGroup.getReplay(
             style.getZIndex(), 'LineString');
         var setFillStrokeStyleSpy = sinon.spy(lineStringReplay,

--- a/test/spec/ol/source/cluster.test.js
+++ b/test/spec/ol/source/cluster.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
@@ -51,7 +51,7 @@ describe('ol.source.Cluster', function() {
         source: new _ol_source_Vector_({
           features: [
             new _ol_Feature_(new Point([0, 0])),
-            new _ol_Feature_(new _ol_geom_LineString_([[0, 0], [1, 1]])),
+            new _ol_Feature_(new LineString([[0, 0], [1, 1]])),
             new _ol_Feature_(new _ol_geom_Polygon_(
                 [[[-1, -1], [-1, 1], [1, 1], [1, -1], [-1, -1]]]))
           ]

--- a/test/spec/ol/source/cluster.test.js
+++ b/test/spec/ol/source/cluster.test.js
@@ -1,7 +1,7 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_Cluster_ from '../../../../src/ol/source/Cluster.js';
 import _ol_source_Source_ from '../../../../src/ol/source/Source.js';
@@ -52,7 +52,7 @@ describe('ol.source.Cluster', function() {
           features: [
             new _ol_Feature_(new Point([0, 0])),
             new _ol_Feature_(new LineString([[0, 0], [1, 1]])),
-            new _ol_Feature_(new _ol_geom_Polygon_(
+            new _ol_Feature_(new Polygon(
                 [[[-1, -1], [-1, 1], [1, 1], [1, -1], [-1, -1]]]))
           ]
         })

--- a/test/spec/ol/source/cluster.test.js
+++ b/test/spec/ol/source/cluster.test.js
@@ -1,6 +1,6 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_Polygon_ from '../../../../src/ol/geom/Polygon.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_source_Cluster_ from '../../../../src/ol/source/Cluster.js';
@@ -28,8 +28,8 @@ describe('ol.source.Cluster', function() {
       var source = new _ol_source_Cluster_({
         source: new _ol_source_Vector_({
           features: [
-            new _ol_Feature_(new _ol_geom_Point_([0, 0])),
-            new _ol_Feature_(new _ol_geom_Point_([0, 0]))
+            new _ol_Feature_(new Point([0, 0])),
+            new _ol_Feature_(new Point([0, 0]))
           ]
         })
       });
@@ -50,7 +50,7 @@ describe('ol.source.Cluster', function() {
         },
         source: new _ol_source_Vector_({
           features: [
-            new _ol_Feature_(new _ol_geom_Point_([0, 0])),
+            new _ol_Feature_(new Point([0, 0])),
             new _ol_Feature_(new _ol_geom_LineString_([[0, 0], [1, 1]])),
             new _ol_Feature_(new _ol_geom_Polygon_(
                 [[[-1, -1], [-1, 1], [1, 1], [1, -1], [-1, -1]]]))

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -4,7 +4,7 @@ import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
 import Point from '../../../../src/ol/geom/Point.js';
-import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
+import LineString from '../../../../src/ol/geom/LineString.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_loadingstrategy_ from '../../../../src/ol/loadingstrategy.js';
 import {get as getProjection, transformExtent, fromLonLat} from '../../../../src/ol/proj.js';
@@ -92,7 +92,7 @@ describe('ol.source.Vector', function() {
     var features = [];
     var vectorSource;
     beforeEach(function() {
-      features.push(new _ol_Feature_(new _ol_geom_LineString_([[0, 0], [10, 10]])));
+      features.push(new _ol_Feature_(new LineString([[0, 0], [10, 10]])));
       features.push(new _ol_Feature_(new Point([0, 10])));
       features.push(new _ol_Feature_(new Point([10, 5])));
       vectorSource = new _ol_source_Vector_({

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -3,7 +3,7 @@ import _ol_Collection_ from '../../../../src/ol/Collection.js';
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
 import _ol_Map_ from '../../../../src/ol/Map.js';
 import _ol_View_ from '../../../../src/ol/View.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_geom_LineString_ from '../../../../src/ol/geom/LineString.js';
 import _ol_layer_Vector_ from '../../../../src/ol/layer/Vector.js';
 import _ol_loadingstrategy_ from '../../../../src/ol/loadingstrategy.js';
@@ -16,7 +16,7 @@ describe('ol.source.Vector', function() {
   var pointFeature;
   var infiniteExtent;
   beforeEach(function() {
-    pointFeature = new _ol_Feature_(new _ol_geom_Point_([0, 0]));
+    pointFeature = new _ol_Feature_(new Point([0, 0]));
     infiniteExtent = [-Infinity, -Infinity, Infinity, Infinity];
   });
 
@@ -93,8 +93,8 @@ describe('ol.source.Vector', function() {
     var vectorSource;
     beforeEach(function() {
       features.push(new _ol_Feature_(new _ol_geom_LineString_([[0, 0], [10, 10]])));
-      features.push(new _ol_Feature_(new _ol_geom_Point_([0, 10])));
-      features.push(new _ol_Feature_(new _ol_geom_Point_([10, 5])));
+      features.push(new _ol_Feature_(new Point([0, 10])));
+      features.push(new _ol_Feature_(new Point([10, 5])));
       vectorSource = new _ol_source_Vector_({
         features: features
       });
@@ -127,7 +127,7 @@ describe('ol.source.Vector', function() {
       var i;
       for (i = 0; i < 10; ++i) {
         features[i] =
-            new _ol_Feature_(new _ol_geom_Point_([Math.random(), Math.random()]));
+            new _ol_Feature_(new Point([Math.random(), Math.random()]));
       }
       features.push(new _ol_Feature_(null));
       vectorSource = new _ol_source_Vector_({
@@ -252,7 +252,7 @@ describe('ol.source.Vector', function() {
       it('keeps the R-Tree index up to date', function() {
         expect(vectorSource.getFeaturesInExtent([0, 0, 1, 1])).
             to.have.length(10);
-        features[0].setGeometry(new _ol_geom_Point_([100, 100]));
+        features[0].setGeometry(new Point([100, 100]));
         expect(vectorSource.getFeaturesInExtent([0, 0, 1, 1])).
             to.have.length(9);
       });
@@ -269,7 +269,7 @@ describe('ol.source.Vector', function() {
     });
 
     it('keeps its index up-to-date', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Point_([1, 1]));
+      var feature = new _ol_Feature_(new Point([1, 1]));
       vectorSource.addFeature(feature);
       expect(vectorSource.getFeaturesInExtent([0, 0, 2, 2])).
           to.eql([feature]);
@@ -290,14 +290,14 @@ describe('ol.source.Vector', function() {
       var feature = new _ol_Feature_(null);
       vectorSource.addFeature(feature);
       expect(vectorSource.getFeatures()).to.eql([feature]);
-      feature.setGeometry(new _ol_geom_Point_([1, 1]));
+      feature.setGeometry(new Point([1, 1]));
       expect(vectorSource.getFeaturesInExtent([0, 0, 2, 2])).
           to.eql([feature]);
       expect(vectorSource.getFeatures()).to.eql([feature]);
     });
 
     it('handles features with geometries changing to null', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Point_([1, 1]));
+      var feature = new _ol_Feature_(new Point([1, 1]));
       vectorSource.addFeature(feature);
       expect(vectorSource.getFeatures()).to.eql([feature]);
       expect(vectorSource.getFeaturesInExtent([0, 0, 2, 2])).
@@ -308,7 +308,7 @@ describe('ol.source.Vector', function() {
     });
 
     it('fires a change event when setting a feature\'s property', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Point_([1, 1]));
+      var feature = new _ol_Feature_(new Point([1, 1]));
       vectorSource.addFeature(feature);
       var listener = sinon.spy();
       _ol_events_.listen(vectorSource, 'change', listener);
@@ -317,7 +317,7 @@ describe('ol.source.Vector', function() {
     });
 
     it('fires a changefeature event when updating a feature', function() {
-      var feature = new _ol_Feature_(new _ol_geom_Point_([1, 1]));
+      var feature = new _ol_Feature_(new Point([1, 1]));
       vectorSource.addFeature(feature);
       var listener = sinon.spy(function(event) {
         expect(event.feature).to.be(feature);

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -4,7 +4,7 @@
 
 import _ol_Sphere_ from '../../../src/ol/Sphere.js';
 import _ol_format_WKT_ from '../../../src/ol/format/WKT.js';
-import _ol_geom_GeometryCollection_ from '../../../src/ol/geom/GeometryCollection.js';
+import GeometryCollection from '../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../src/ol/geom/MultiPoint.js';
@@ -154,7 +154,7 @@ describe('ol.Sphere.getLength()', function() {
     options: {projection: 'EPSG:4326'},
     length: 2 * 4407939.124914191
   }, {
-    geometry: new _ol_geom_GeometryCollection_([
+    geometry: new GeometryCollection([
       new LineString([
         [115, -32],
         [131, -22],

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -8,7 +8,7 @@ import _ol_geom_GeometryCollection_ from '../../../src/ol/geom/GeometryCollectio
 import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../src/ol/geom/MultiLineString.js';
 import _ol_geom_MultiPoint_ from '../../../src/ol/geom/MultiPoint.js';
-import _ol_geom_Point_ from '../../../src/ol/geom/Point.js';
+import Point from '../../../src/ol/geom/Point.js';
 import _ol_proj_EPSG4326_ from '../../../src/ol/proj/EPSG4326.js';
 
 
@@ -115,7 +115,7 @@ describe('ol.Sphere', function() {
 
 describe('ol.Sphere.getLength()', function() {
   var cases = [{
-    geometry: new _ol_geom_Point_([0, 0]),
+    geometry: new Point([0, 0]),
     length: 0
   }, {
     geometry: new _ol_geom_MultiPoint_([[0, 0], [1, 1]]),

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -5,7 +5,7 @@
 import _ol_Sphere_ from '../../../src/ol/Sphere.js';
 import _ol_format_WKT_ from '../../../src/ol/format/WKT.js';
 import _ol_geom_GeometryCollection_ from '../../../src/ol/geom/GeometryCollection.js';
-import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
+import LineString from '../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../src/ol/geom/Point.js';
@@ -121,7 +121,7 @@ describe('ol.Sphere.getLength()', function() {
     geometry: new MultiPoint([[0, 0], [1, 1]]),
     length: 0
   }, {
-    geometry: new _ol_geom_LineString_([
+    geometry: new LineString([
       [12801741.441226462, -3763310.627144653],
       [14582853.293918837, -2511525.2348457114],
       [15918687.18343812, -2875744.624352243],
@@ -129,7 +129,7 @@ describe('ol.Sphere.getLength()', function() {
     ]),
     length: 4407939.124914191
   }, {
-    geometry: new _ol_geom_LineString_([
+    geometry: new LineString([
       [115, -32],
       [131, -22],
       [143, -25],
@@ -155,13 +155,13 @@ describe('ol.Sphere.getLength()', function() {
     length: 2 * 4407939.124914191
   }, {
     geometry: new _ol_geom_GeometryCollection_([
-      new _ol_geom_LineString_([
+      new LineString([
         [115, -32],
         [131, -22],
         [143, -25],
         [150, -34]
       ]),
-      new _ol_geom_LineString_([
+      new LineString([
         [115, -32],
         [131, -22],
         [143, -25],

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -7,7 +7,7 @@ import _ol_format_WKT_ from '../../../src/ol/format/WKT.js';
 import _ol_geom_GeometryCollection_ from '../../../src/ol/geom/GeometryCollection.js';
 import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
 import _ol_geom_MultiLineString_ from '../../../src/ol/geom/MultiLineString.js';
-import _ol_geom_MultiPoint_ from '../../../src/ol/geom/MultiPoint.js';
+import MultiPoint from '../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../src/ol/geom/Point.js';
 import _ol_proj_EPSG4326_ from '../../../src/ol/proj/EPSG4326.js';
 
@@ -118,7 +118,7 @@ describe('ol.Sphere.getLength()', function() {
     geometry: new Point([0, 0]),
     length: 0
   }, {
-    geometry: new _ol_geom_MultiPoint_([[0, 0], [1, 1]]),
+    geometry: new MultiPoint([[0, 0], [1, 1]]),
     length: 0
   }, {
     geometry: new _ol_geom_LineString_([

--- a/test/spec/ol/sphere.test.js
+++ b/test/spec/ol/sphere.test.js
@@ -6,7 +6,7 @@ import _ol_Sphere_ from '../../../src/ol/Sphere.js';
 import _ol_format_WKT_ from '../../../src/ol/format/WKT.js';
 import _ol_geom_GeometryCollection_ from '../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../src/ol/geom/LineString.js';
-import _ol_geom_MultiLineString_ from '../../../src/ol/geom/MultiLineString.js';
+import MultiLineString from '../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../src/ol/geom/Point.js';
 import _ol_proj_EPSG4326_ from '../../../src/ol/proj/EPSG4326.js';
@@ -138,7 +138,7 @@ describe('ol.Sphere.getLength()', function() {
     options: {projection: 'EPSG:4326'},
     length: 4407939.124914191
   }, {
-    geometry: new _ol_geom_MultiLineString_([
+    geometry: new MultiLineString([
       [
         [115, -32],
         [131, -22],

--- a/test/spec/ol/style/style.test.js
+++ b/test/spec/ol/style/style.test.js
@@ -1,5 +1,5 @@
 import _ol_Feature_ from '../../../../src/ol/Feature.js';
-import _ol_geom_Point_ from '../../../../src/ol/geom/Point.js';
+import Point from '../../../../src/ol/geom/Point.js';
 import _ol_style_Style_ from '../../../../src/ol/style/Style.js';
 import _ol_style_Fill_ from '../../../../src/ol/style/Fill.js';
 import _ol_style_Circle_ from '../../../../src/ol/style/Circle.js';
@@ -44,7 +44,7 @@ describe('ol.style.Style', function() {
 
     it('copies all values', function() {
       var original = new _ol_style_Style_({
-        geometry: new _ol_geom_Point_([0, 0, 0]),
+        geometry: new Point([0, 0, 0]),
         fill: new _ol_style_Fill_({
           color: '#319FD3'
         }),
@@ -70,7 +70,7 @@ describe('ol.style.Style', function() {
 
     it('the clone does not reference the same objects as the original', function() {
       var original = new _ol_style_Style_({
-        geometry: new _ol_geom_Point_([0, 0, 0]),
+        geometry: new Point([0, 0, 0]),
         fill: new _ol_style_Fill_({
           color: '#319FD3'
         }),
@@ -195,21 +195,21 @@ describe('ol.style.Style', function() {
 
     it('creates a geometry function from a string', function() {
       var feature = new _ol_Feature_();
-      feature.set('myGeom', new _ol_geom_Point_([0, 0]));
+      feature.set('myGeom', new Point([0, 0]));
       style.setGeometry('myGeom');
       expect(style.getGeometryFunction()(feature))
           .to.eql(feature.get('myGeom'));
     });
 
     it('creates a geometry function from a geometry', function() {
-      var geom = new _ol_geom_Point_([0, 0]);
+      var geom = new Point([0, 0]);
       style.setGeometry(geom);
       expect(style.getGeometryFunction()())
           .to.eql(geom);
     });
 
     it('returns the configured geometry function', function() {
-      var geom = new _ol_geom_Point_([0, 0]);
+      var geom = new Point([0, 0]);
       style.setGeometry(function() {
         return geom;
       });
@@ -224,7 +224,7 @@ describe('ol.style.Style', function() {
       var style = new _ol_style_Style_();
       style.setGeometry('foo');
       expect(style.getGeometry()).to.eql('foo');
-      var geom = new _ol_geom_Point_([1, 2]);
+      var geom = new Point([1, 2]);
       style.setGeometry(geom);
       expect(style.getGeometry()).to.eql(geom);
       var fn = function() {

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -3,7 +3,7 @@ import _ol_View_ from '../../../src/ol/View.js';
 import _ol_ViewHint_ from '../../../src/ol/ViewHint.js';
 import * as _ol_extent_ from '../../../src/ol/extent.js';
 import _ol_geom_Circle_ from '../../../src/ol/geom/Circle.js';
-import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
+import LineString from '../../../src/ol/geom/LineString.js';
 import Point from '../../../src/ol/geom/Point.js';
 
 describe('ol.View', function() {
@@ -1252,21 +1252,21 @@ describe('ol.View', function() {
     });
     it('fits correctly to the geometry', function() {
       view.fit(
-          new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           {size: [200, 200], padding: [100, 0, 0, 100], constrainResolution: false});
       expect(view.getResolution()).to.be(11);
       expect(view.getCenter()[0]).to.be(5950);
       expect(view.getCenter()[1]).to.be(47100);
 
       view.fit(
-          new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           {size: [200, 200], padding: [100, 0, 0, 100]});
       expect(view.getResolution()).to.be(20);
       expect(view.getCenter()[0]).to.be(5500);
       expect(view.getCenter()[1]).to.be(47550);
 
       view.fit(
-          new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           {size: [200, 200], padding: [100, 0, 0, 100], nearest: true});
       expect(view.getResolution()).to.be(10);
       expect(view.getCenter()[0]).to.be(6000);
@@ -1304,7 +1304,7 @@ describe('ol.View', function() {
 
       view.setRotation(Math.PI / 4);
       view.fit(
-          new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           {size: [200, 200], padding: [100, 0, 0, 100], constrainResolution: false});
       expect(view.getResolution()).to.roughlyEqual(14.849242404917458, 1e-9);
       expect(view.getCenter()[0]).to.roughlyEqual(5200, 1e-9);
@@ -1328,7 +1328,7 @@ describe('ol.View', function() {
     });
     it('animates when duration is defined', function(done) {
       view.fit(
-          new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]),
+          new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]),
           {
             size: [200, 200],
             padding: [100, 0, 0, 100],
@@ -1348,7 +1348,7 @@ describe('ol.View', function() {
 
     });
     it('calls a callback when duration is not defined', function(done) {
-      view.fit(new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]), {
+      view.fit(new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]), {
         callback: function(complete) {
           expect(complete).to.be(true);
           done();
@@ -1356,7 +1356,7 @@ describe('ol.View', function() {
       });
     });
     it('calls a callback when animation completes', function(done) {
-      view.fit(new _ol_geom_LineString_([[6000, 46000], [6000, 47100], [7000, 46000]]), {
+      view.fit(new LineString([[6000, 46000], [6000, 47100], [7000, 46000]]), {
         duration: 25,
         callback: function(complete) {
           expect(complete).to.be(true);

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -4,7 +4,7 @@ import _ol_ViewHint_ from '../../../src/ol/ViewHint.js';
 import * as _ol_extent_ from '../../../src/ol/extent.js';
 import _ol_geom_Circle_ from '../../../src/ol/geom/Circle.js';
 import _ol_geom_LineString_ from '../../../src/ol/geom/LineString.js';
-import _ol_geom_Point_ from '../../../src/ol/geom/Point.js';
+import Point from '../../../src/ol/geom/Point.js';
 
 describe('ol.View', function() {
 
@@ -1273,14 +1273,14 @@ describe('ol.View', function() {
       expect(view.getCenter()[1]).to.be(47050);
 
       view.fit(
-          new _ol_geom_Point_([6000, 46000]),
+          new Point([6000, 46000]),
           {size: [200, 200], padding: [100, 0, 0, 100], minResolution: 2});
       expect(view.getResolution()).to.be(2);
       expect(view.getCenter()[0]).to.be(5900);
       expect(view.getCenter()[1]).to.be(46100);
 
       view.fit(
-          new _ol_geom_Point_([6000, 46000]),
+          new Point([6000, 46000]),
           {size: [200, 200], padding: [100, 0, 0, 100], maxZoom: 6});
       expect(view.getResolution()).to.be(2);
       expect(view.getZoom()).to.be(6);

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -2,7 +2,7 @@ import _ol_Map_ from '../../../src/ol/Map.js';
 import _ol_View_ from '../../../src/ol/View.js';
 import _ol_ViewHint_ from '../../../src/ol/ViewHint.js';
 import * as _ol_extent_ from '../../../src/ol/extent.js';
-import _ol_geom_Circle_ from '../../../src/ol/geom/Circle.js';
+import Circle from '../../../src/ol/geom/Circle.js';
 import LineString from '../../../src/ol/geom/LineString.js';
 import Point from '../../../src/ol/geom/Point.js';
 
@@ -1288,7 +1288,7 @@ describe('ol.View', function() {
       expect(view.getCenter()[1]).to.be(46100);
 
       view.fit(
-          new _ol_geom_Circle_([6000, 46000], 1000),
+          new Circle([6000, 46000], 1000),
           {size: [200, 200], constrainResolution: false});
       expect(view.getResolution()).to.be(10);
       expect(view.getCenter()[0]).to.be(6000);
@@ -1296,7 +1296,7 @@ describe('ol.View', function() {
 
       view.setRotation(Math.PI / 8);
       view.fit(
-          new _ol_geom_Circle_([6000, 46000], 1000),
+          new Circle([6000, 46000], 1000),
           {size: [200, 200], constrainResolution: false});
       expect(view.getResolution()).to.roughlyEqual(10, 1e-9);
       expect(view.getCenter()[0]).to.roughlyEqual(6000, 1e-9);


### PR DESCRIPTION
This renames the auto-generated (ugly) geometry constructor names to ones that look nicer.