### PR TITLE
Simplify default export

### DIFF
--- a/src/ol/CollectionEventType.js
+++ b/src/ol/CollectionEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/CollectionEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_CollectionEventType_ = {
+export default {
   /**
    * Triggered when an item is added to the collection.
    * @event ol.Collection.Event#add
@@ -18,5 +19,3 @@ var _ol_CollectionEventType_ = {
    */
   REMOVE: 'remove'
 };
-
-export default _ol_CollectionEventType_;

--- a/src/ol/LayerType.js
+++ b/src/ol/LayerType.js
@@ -1,15 +1,14 @@
 /**
  * @module ol/LayerType
  */
+
 /**
  * A layer type used when creating layer renderers.
  * @enum {string}
  */
-var _ol_LayerType_ = {
+export default {
   IMAGE: 'IMAGE',
   TILE: 'TILE',
   VECTOR_TILE: 'VECTOR_TILE',
   VECTOR: 'VECTOR'
 };
-
-export default _ol_LayerType_;

--- a/src/ol/MapBrowserEventType.js
+++ b/src/ol/MapBrowserEventType.js
@@ -1,13 +1,13 @@
 /**
  * @module ol/MapBrowserEventType
  */
-import _ol_events_EventType_ from './events/EventType.js';
+import EventType from './events/EventType.js';
 
 /**
  * Constants for event names.
  * @enum {string}
  */
-var _ol_MapBrowserEventType_ = {
+export default {
 
   /**
    * A true single click with no dragging and no double click. Note that this
@@ -22,14 +22,14 @@ var _ol_MapBrowserEventType_ = {
    * @event ol.MapBrowserEvent#click
    * @api
    */
-  CLICK: _ol_events_EventType_.CLICK,
+  CLICK: EventType.CLICK,
 
   /**
    * A true double click, with no dragging.
    * @event ol.MapBrowserEvent#dblclick
    * @api
    */
-  DBLCLICK: _ol_events_EventType_.DBLCLICK,
+  DBLCLICK: EventType.DBLCLICK,
 
   /**
    * Triggered when a pointer is dragged.
@@ -54,5 +54,3 @@ var _ol_MapBrowserEventType_ = {
   POINTERLEAVE: 'pointerleave',
   POINTERCANCEL: 'pointercancel'
 };
-
-export default _ol_MapBrowserEventType_;

--- a/src/ol/MapEventType.js
+++ b/src/ol/MapEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/MapEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_MapEventType_ = {
+export default {
 
   /**
    * Triggered after a map frame is rendered.
@@ -28,5 +29,3 @@ var _ol_MapEventType_ = {
   MOVEEND: 'moveend'
 
 };
-
-export default _ol_MapEventType_;

--- a/src/ol/ObjectEventType.js
+++ b/src/ol/ObjectEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/ObjectEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_ObjectEventType_ = {
+export default {
   /**
    * Triggered when a property is changed.
    * @event ol.Object.Event#propertychange
@@ -12,5 +13,3 @@ var _ol_ObjectEventType_ = {
    */
   PROPERTYCHANGE: 'propertychange'
 };
-
-export default _ol_ObjectEventType_;

--- a/src/ol/PluginType.js
+++ b/src/ol/PluginType.js
@@ -1,14 +1,13 @@
 /**
  * @module ol/PluginType
  */
+
 /**
  * A plugin type used when registering a plugin.  The supported plugin types are
  * 'MAP_RENDERER', and 'LAYER_RENDERER'.
  * @enum {string}
  */
-var _ol_PluginType_ = {
+export default {
   MAP_RENDERER: 'MAP_RENDERER',
   LAYER_RENDERER: 'LAYER_RENDERER'
 };
-
-export default _ol_PluginType_;

--- a/src/ol/events/EventType.js
+++ b/src/ol/events/EventType.js
@@ -1,11 +1,12 @@
 /**
  * @module ol/events/EventType
  */
+
 /**
  * @enum {string}
  * @const
  */
-var _ol_events_EventType_ = {
+export default {
   /**
    * Generic change event. Triggered when the revision counter is increased.
    * @event ol.events.Event#change
@@ -35,5 +36,3 @@ var _ol_events_EventType_ = {
   TOUCHEND: 'touchend',
   WHEEL: 'wheel'
 };
-
-export default _ol_events_EventType_;

--- a/src/ol/format/FormatType.js
+++ b/src/ol/format/FormatType.js
@@ -1,14 +1,13 @@
 /**
  * @module ol/format/FormatType
  */
+
 /**
  * @enum {string}
  */
-var _ol_format_FormatType_ = {
+export default {
   ARRAY_BUFFER: 'arraybuffer',
   JSON: 'json',
   TEXT: 'text',
   XML: 'xml'
 };
-
-export default _ol_format_FormatType_;

--- a/src/ol/geom/GeometryType.js
+++ b/src/ol/geom/GeometryType.js
@@ -1,13 +1,14 @@
 /**
  * @module ol/geom/GeometryType
  */
+
 /**
  * The geometry type. One of `'Point'`, `'LineString'`, `'LinearRing'`,
  * `'Polygon'`, `'MultiPoint'`, `'MultiLineString'`, `'MultiPolygon'`,
  * `'GeometryCollection'`, `'Circle'`.
  * @enum {string}
  */
-var GeometryType = {
+export default {
   POINT: 'Point',
   LINE_STRING: 'LineString',
   LINEAR_RING: 'LinearRing',
@@ -18,5 +19,3 @@ var GeometryType = {
   GEOMETRY_COLLECTION: 'GeometryCollection',
   CIRCLE: 'Circle'
 };
-
-export default GeometryType;

--- a/src/ol/interaction/DrawEventType.js
+++ b/src/ol/interaction/DrawEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/interaction/DrawEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_interaction_DrawEventType_ = {
+export default {
   /**
    * Triggered upon feature draw start
    * @event ol.interaction.Draw.Event#drawstart
@@ -18,5 +19,3 @@ var _ol_interaction_DrawEventType_ = {
    */
   DRAWEND: 'drawend'
 };
-
-export default _ol_interaction_DrawEventType_;

--- a/src/ol/interaction/ExtentEventType.js
+++ b/src/ol/interaction/ExtentEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/interaction/ExtentEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_interaction_ExtentEventType_ = {
+export default {
   /**
    * Triggered after the extent is changed
    * @event ol.interaction.Extent.Event#extentchanged
@@ -12,5 +13,3 @@ var _ol_interaction_ExtentEventType_ = {
    */
   EXTENTCHANGED: 'extentchanged'
 };
-
-export default _ol_interaction_ExtentEventType_;

--- a/src/ol/interaction/ModifyEventType.js
+++ b/src/ol/interaction/ModifyEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/interaction/ModifyEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_interaction_ModifyEventType_ = {
+export default {
   /**
    * Triggered upon feature modification start
    * @event ol.interaction.Modify.Event#modifystart
@@ -18,5 +19,3 @@ var _ol_interaction_ModifyEventType_ = {
    */
   MODIFYEND: 'modifyend'
 };
-
-export default _ol_interaction_ModifyEventType_;

--- a/src/ol/interaction/TranslateEventType.js
+++ b/src/ol/interaction/TranslateEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/interaction/TranslateEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_interaction_TranslateEventType_ = {
+export default {
   /**
    * Triggered upon feature translation start.
    * @event ol.interaction.Translate.Event#translatestart
@@ -24,5 +25,3 @@ var _ol_interaction_TranslateEventType_ = {
    */
   TRANSLATEEND: 'translateend'
 };
-
-export default _ol_interaction_TranslateEventType_;

--- a/src/ol/layer/VectorRenderType.js
+++ b/src/ol/layer/VectorRenderType.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/layer/VectorRenderType
  */
+
 /**
  * @enum {string}
  * Render mode for vector layers:
@@ -11,9 +12,7 @@
  *    even during animations, but slower performance.
  * @api
  */
-var _ol_layer_VectorRenderType_ = {
+export default {
   IMAGE: 'image',
   VECTOR: 'vector'
 };
-
-export default _ol_layer_VectorRenderType_;

--- a/src/ol/layer/VectorTileRenderType.js
+++ b/src/ol/layer/VectorTileRenderType.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/layer/VectorTileRenderType
  */
+
 /**
  * @enum {string}
  * Render mode for vector tiles:
@@ -14,10 +15,8 @@
  *    even during animations, but slower performance than the other options.
  * @api
  */
-var _ol_layer_VectorTileRenderType_ = {
+export default {
   IMAGE: 'image',
   HYBRID: 'hybrid',
   VECTOR: 'vector'
 };
-
-export default _ol_layer_VectorTileRenderType_;

--- a/src/ol/pointer/EventType.js
+++ b/src/ol/pointer/EventType.js
@@ -1,11 +1,12 @@
 /**
  * @module ol/pointer/EventType
  */
+
 /**
  * Constants for event names.
  * @enum {string}
  */
-var _ol_pointer_EventType_ = {
+export default {
   POINTERMOVE: 'pointermove',
   POINTERDOWN: 'pointerdown',
   POINTERUP: 'pointerup',
@@ -15,5 +16,3 @@ var _ol_pointer_EventType_ = {
   POINTERLEAVE: 'pointerleave',
   POINTERCANCEL: 'pointercancel'
 };
-
-export default _ol_pointer_EventType_;

--- a/src/ol/render/EventType.js
+++ b/src/ol/render/EventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/render/EventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_render_EventType_ = {
+export default {
   /**
    * @event ol.render.Event#postcompose
    * @api
@@ -21,5 +22,3 @@ var _ol_render_EventType_ = {
    */
   RENDER: 'render'
 };
-
-export default _ol_render_EventType_;

--- a/src/ol/render/ReplayType.js
+++ b/src/ol/render/ReplayType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/render/ReplayType
  */
+
 /**
  * @enum {string}
  */
-var _ol_render_ReplayType_ = {
+export default {
   CIRCLE: 'Circle',
   DEFAULT: 'Default',
   IMAGE: 'Image',
@@ -12,5 +13,3 @@ var _ol_render_ReplayType_ = {
   POLYGON: 'Polygon',
   TEXT: 'Text'
 };
-
-export default _ol_render_ReplayType_;

--- a/src/ol/renderer/Type.js
+++ b/src/ol/renderer/Type.js
@@ -1,13 +1,12 @@
 /**
  * @module ol/renderer/Type
  */
+
 /**
  * Available renderers: `'canvas'` or `'webgl'`.
  * @enum {string}
  */
-var _ol_renderer_Type_ = {
+export default {
   CANVAS: 'canvas',
   WEBGL: 'webgl'
 };
-
-export default _ol_renderer_Type_;

--- a/src/ol/source/RasterOperationType.js
+++ b/src/ol/source/RasterOperationType.js
@@ -1,13 +1,12 @@
 /**
  * @module ol/source/RasterOperationType
  */
+
 /**
  * Raster operation type. Supported values are `'pixel'` and `'image'`.
  * @enum {string}
  */
-var _ol_source_RasterOperationType_ = {
+export default {
   PIXEL: 'pixel',
   IMAGE: 'image'
 };
-
-export default _ol_source_RasterOperationType_;

--- a/src/ol/source/TileEventType.js
+++ b/src/ol/source/TileEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/source/TileEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_source_TileEventType_ = {
+export default {
 
   /**
    * Triggered when a tile starts loading.
@@ -29,5 +30,3 @@ var _ol_source_TileEventType_ = {
   TILELOADERROR: 'tileloaderror'
 
 };
-
-export default _ol_source_TileEventType_;

--- a/src/ol/source/VectorEventType.js
+++ b/src/ol/source/VectorEventType.js
@@ -1,10 +1,11 @@
 /**
  * @module ol/source/VectorEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_source_VectorEventType_ = {
+export default {
   /**
    * Triggered when a feature is added to the source.
    * @event ol.source.Vector.Event#addfeature
@@ -34,5 +35,3 @@ var _ol_source_VectorEventType_ = {
    */
   REMOVEFEATURE: 'removefeature'
 };
-
-export default _ol_source_VectorEventType_;

--- a/src/ol/source/WMSServerType.js
+++ b/src/ol/source/WMSServerType.js
@@ -1,17 +1,16 @@
 /**
  * @module ol/source/WMSServerType
  */
+
 /**
  * Available server types: `'carmentaserver'`, `'geoserver'`, `'mapserver'`,
  *     `'qgis'`. These are servers that have vendor parameters beyond the WMS
  *     specification that OpenLayers can make use of.
  * @enum {string}
  */
-var _ol_source_WMSServerType_ = {
+export default {
   CARMENTA_SERVER: 'carmentaserver',
   GEOSERVER: 'geoserver',
   MAPSERVER: 'mapserver',
   QGIS: 'qgis'
 };
-
-export default _ol_source_WMSServerType_;

--- a/src/ol/webgl/ContextEventType.js
+++ b/src/ol/webgl/ContextEventType.js
@@ -1,12 +1,11 @@
 /**
  * @module ol/webgl/ContextEventType
  */
+
 /**
  * @enum {string}
  */
-var _ol_webgl_ContextEventType_ = {
+export default {
   LOST: 'webglcontextlost',
   RESTORED: 'webglcontextrestored'
 };
-
-export default _ol_webgl_ContextEventType_;


### PR DESCRIPTION
This removes unnecessary variable declarations where the default object is an object.

(This is a rebased version of #7590 with conflicts removed.)