### PR TITLE
Modular proj4 integration

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,36 @@
 ## Upgrade notes
 
+### Next release
+
+#### Changes in proj4 integration
+
+Because relying on a globally available proj4 is not practical with ES modules, we have made a change to the way we integrate proj4:
+
+ * The `setProj4()` function from the `ol/proj` module was removed.
+ * A new `ol/proj/proj4` module with a `register()` function was added. Regardless of whether the application imports `proj4` or uses a global `proj4`, this function needs to be called with the proj4 instance as argument whenever projection definitions were added to proj4's registry with (`proj4.defs`).
+
+It is also recommended to no longer use a global `proj4`. Instead,
+
+    npm install proj4
+
+and import it:
+
+```js
+import proj4 from 'proj4';
+```
+
+Applications can be updated by importing the `register` function from the `ol/proj/proj4` module
+
+```js
+import {register} from 'ol/proj/proj4'
+```
+
+and calling it before using projections, and any time the proj4 registry was changed by `proj4.defs()` calls:
+
+```js
+register(proj4);
+```
+
 ### v4.6.0
 
 #### Renamed `exceedLength` option of `ol.style.Text` to `overflow`

--- a/examples/reprojection-by-code.html
+++ b/examples/reprojection-by-code.html
@@ -7,8 +7,6 @@ docs: >
   OSM (EPSG:3857) to arbitrary projection by searching
   in <a href="https://epsg.io/">EPSG.io</a> database.
 tags: "reprojection, projection, proj4js, epsg.io"
-resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -6,6 +6,7 @@ import {get as getProjection, getTransform} from '../src/ol/proj.js';
 import {register} from '../src/ol/proj/proj4.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileImage_ from '../src/ol/source/TileImage.js';
+import proj4 from 'proj4';
 
 
 var map = new _ol_Map_({

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -3,6 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import {get as getProjection, getTransform} from '../src/ol/proj.js';
+import {register} from '../src/ol/proj/proj4.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileImage_ from '../src/ol/source/TileImage.js';
 
@@ -42,6 +43,7 @@ function setProjection(code, name, proj4def, bbox) {
 
   var newProjCode = 'EPSG:' + code;
   proj4.defs(newProjCode, proj4def);
+  register(proj4);
   var newProj = getProjection(newProjCode);
   var fromLonLat = getTransform('EPSG:4326', newProj);
 

--- a/examples/reprojection-image.html
+++ b/examples/reprojection-image.html
@@ -5,7 +5,5 @@ shortdesc: Demonstrates client-side reprojection of single image source.
 docs: >
   This example shows client-side reprojection of single image source.
 tags: "reprojection, projection, proj4js, image, imagestatic"
-resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/reprojection-image.js
+++ b/examples/reprojection-image.js
@@ -6,12 +6,15 @@ import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import {transform} from '../src/ol/proj.js';
 import _ol_source_ImageStatic_ from '../src/ol/source/ImageStatic.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
-
+import {register} from '../src/ol/proj/proj4.js';
+import proj4 from 'proj4';
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 ' +
     '+x_0=400000 +y_0=-100000 +ellps=airy ' +
     '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
     '+units=m +no_defs');
+register(proj4);
+
 var imageExtent = [0, 0, 700000, 1300000];
 
 var map = new _ol_Map_({

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -5,8 +5,6 @@ shortdesc: Demonstrates client-side raster reprojection between various projecti
 docs: >
   This example shows client-side raster reprojection between various projections.
 tags: "reprojection, projection, proj4js, osm, wms, wmts, hidpi"
-resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -11,6 +11,7 @@ import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
 import _ol_source_WMTS_ from '../src/ol/source/WMTS.js';
 import _ol_source_XYZ_ from '../src/ol/source/XYZ.js';
 import _ol_tilegrid_TileGrid_ from '../src/ol/tilegrid/TileGrid.js';
+import proj4 from 'proj4';
 
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 ' +

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -4,6 +4,7 @@ import * as _ol_extent_ from '../src/ol/extent.js';
 import _ol_format_WMTSCapabilities_ from '../src/ol/format/WMTSCapabilities.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import {get as getProjection} from '../src/ol/proj.js';
+import {register} from '../src/ol/proj/proj4.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 import _ol_source_TileImage_ from '../src/ol/source/TileImage.js';
 import _ol_source_TileWMS_ from '../src/ol/source/TileWMS.js';
@@ -16,38 +17,40 @@ proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 ' +
     '+x_0=400000 +y_0=-100000 +ellps=airy ' +
     '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
     '+units=m +no_defs');
-var proj27700 = getProjection('EPSG:27700');
-proj27700.setExtent([0, 0, 700000, 1300000]);
-
 proj4.defs('EPSG:23032', '+proj=utm +zone=32 +ellps=intl ' +
     '+towgs84=-87,-98,-121,0,0,0,0 +units=m +no_defs');
-var proj23032 = getProjection('EPSG:23032');
-proj23032.setExtent([-1206118.71, 4021309.92, 1295389.00, 8051813.28]);
-
 proj4.defs('EPSG:5479', '+proj=lcc +lat_1=-76.66666666666667 +lat_2=' +
     '-79.33333333333333 +lat_0=-78 +lon_0=163 +x_0=7000000 +y_0=5000000 ' +
     '+ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-var proj5479 = getProjection('EPSG:5479');
-proj5479.setExtent([6825737.53, 4189159.80, 9633741.96, 5782472.71]);
-
 proj4.defs('EPSG:21781', '+proj=somerc +lat_0=46.95240555555556 ' +
     '+lon_0=7.439583333333333 +k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
     '+towgs84=674.4,15.1,405.3,0,0,0,0 +units=m +no_defs');
+proj4.defs('EPSG:3413', '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 ' +
+    '+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
+proj4.defs('EPSG:2163', '+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 ' +
+    '+a=6370997 +b=6370997 +units=m +no_defs');
+proj4.defs('ESRI:54009', '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 ' +
+    '+units=m +no_defs');
+register(proj4);
+
+var proj27700 = getProjection('EPSG:27700');
+proj27700.setExtent([0, 0, 700000, 1300000]);
+
+var proj23032 = getProjection('EPSG:23032');
+proj23032.setExtent([-1206118.71, 4021309.92, 1295389.00, 8051813.28]);
+
+var proj5479 = getProjection('EPSG:5479');
+proj5479.setExtent([6825737.53, 4189159.80, 9633741.96, 5782472.71]);
+
 var proj21781 = getProjection('EPSG:21781');
 proj21781.setExtent([485071.54, 75346.36, 828515.78, 299941.84]);
 
-proj4.defs('EPSG:3413', '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 ' +
-    '+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
 var proj3413 = getProjection('EPSG:3413');
 proj3413.setExtent([-4194304, -4194304, 4194304, 4194304]);
 
-proj4.defs('EPSG:2163', '+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 ' +
-    '+a=6370997 +b=6370997 +units=m +no_defs');
 var proj2163 = getProjection('EPSG:2163');
 proj2163.setExtent([-8040784.5135, -2577524.9210, 3668901.4484, 4785105.1096]);
 
-proj4.defs('ESRI:54009', '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 ' +
-    '+units=m +no_defs');
 var proj54009 = getProjection('ESRI:54009');
 proj54009.setExtent([-18e6, -9e6, 18e6, 9e6]);
 

--- a/examples/scaleline-indiana-east.html
+++ b/examples/scaleline-indiana-east.html
@@ -5,7 +5,5 @@ shortdesc: Demonstrates client-side reprojection of OpenStreetMap to NAD83 India
 docs: >
   This example shows client-side reprojection of OpenStreetMap to NAD83 Indiana East, including a ScaleLine control with US units.
 tags: "reprojection, projection, openstreetmap, nad83, tile, scaleline"
-resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/scaleline-indiana-east.js
+++ b/examples/scaleline-indiana-east.js
@@ -3,6 +3,7 @@ import _ol_View_ from '../src/ol/View.js';
 import ScaleLine from '../src/ol/control/ScaleLine.js';
 import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import {fromLonLat, transformExtent} from '../src/ol/proj.js';
+import {register} from '../src/ol/proj/proj4.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
 
 proj4.defs('Indiana-East', 'PROJCS["IN83-EF",GEOGCS["LL83",DATUM["NAD83",' +
@@ -14,6 +15,7 @@ proj4.defs('Indiana-East', 'PROJCS["IN83-EF",GEOGCS["LL83",DATUM["NAD83",' +
     'PARAMETER["central_meridian",-85.66666666666670],' +
     'PARAMETER["latitude_of_origin",37.50000000000000],' +
     'UNIT["Foot_US",0.30480060960122]]');
+register(proj4);
 
 var map = new _ol_Map_({
   layers: [

--- a/examples/scaleline-indiana-east.js
+++ b/examples/scaleline-indiana-east.js
@@ -5,6 +5,7 @@ import _ol_layer_Tile_ from '../src/ol/layer/Tile.js';
 import {fromLonLat, transformExtent} from '../src/ol/proj.js';
 import {register} from '../src/ol/proj/proj4.js';
 import _ol_source_OSM_ from '../src/ol/source/OSM.js';
+import proj4 from 'proj4';
 
 proj4.defs('Indiana-East', 'PROJCS["IN83-EF",GEOGCS["LL83",DATUM["NAD83",' +
     'SPHEROID["GRS1980",6378137.000,298.25722210]],PRIMEM["Greenwich",0],' +

--- a/examples/sphere-mollweide.html
+++ b/examples/sphere-mollweide.html
@@ -5,7 +5,5 @@ shortdesc: Example of a Sphere Mollweide map with a Graticule component.
 docs: >
   Example of a Sphere Mollweide map with a Graticule component.
 tags: "graticule, Mollweide, projection, proj4js"
-resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js
 ---
 <div id="map" class="map"></div>

--- a/examples/sphere-mollweide.js
+++ b/examples/sphere-mollweide.js
@@ -5,10 +5,12 @@ import _ol_format_GeoJSON_ from '../src/ol/format/GeoJSON.js';
 import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_proj_Projection_ from '../src/ol/proj/Projection.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
+import {register} from '../src/ol/proj/proj4.js';
 
 
 proj4.defs('ESRI:53009', '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 ' +
     '+b=6371000 +units=m +no_defs');
+register(proj4);
 
 // Configure the Sphere Mollweide projection object with an extent,
 // and a world extent. These are required for the Graticule.

--- a/examples/sphere-mollweide.js
+++ b/examples/sphere-mollweide.js
@@ -6,6 +6,7 @@ import _ol_layer_Vector_ from '../src/ol/layer/Vector.js';
 import _ol_proj_Projection_ from '../src/ol/proj/Projection.js';
 import _ol_source_Vector_ from '../src/ol/source/Vector.js';
 import {register} from '../src/ol/proj/proj4.js';
+import proj4 from 'proj4';
 
 
 proj4.defs('ESRI:53009', '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 ' +

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -141,7 +141,15 @@ ExampleBuilder.prototype.render = async function(dir, chunk) {
 
   // add in script tag
   const jsName = `${name}.js`;
-  let jsSource = chunk.modules[0].source;
+  const jsPath = path.join(dir, jsName);
+  let jsSource;
+  for (let i = 0, ii = chunk.modules.length; i < ii; ++i) {
+    const module = chunk.modules[i];
+    if (module.identifier == jsPath) {
+      jsSource = module.source;
+      break;
+    }
+  }
   if (data.cloak) {
     for (const key in data.cloak) {
       jsSource = jsSource.replace(new RegExp(key, 'g'), data.cloak[key]);

--- a/examples/wms-image-custom-proj.html
+++ b/examples/wms-image-custom-proj.html
@@ -5,8 +5,5 @@ shortdesc: Example of integrating Proj4js for coordinate transforms.
 docs: >
   With [Proj4js](http://proj4js.org/) integration, OpenLayers can transform coordinates between arbitrary projections.
 tags: "wms, single image, proj4js, projection"
-resources:
-  - https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.4.4/proj4.js
-  - https://epsg.io/21781-1753.js
 ---
 <div id="map" class="map"></div>

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -7,23 +7,26 @@ import {fromLonLat} from '../src/ol/proj.js';
 import _ol_proj_Projection_ from '../src/ol/proj/Projection.js';
 import _ol_source_ImageWMS_ from '../src/ol/source/ImageWMS.js';
 import {register} from '../src/ol/proj/proj4.js';
+import proj4 from 'proj4';
 
 
 // Transparent Proj4js support:
 //
-// EPSG:21781 is known to Proj4js because its definition was loaded in the html.
-// Now when we create an ol.proj.Projection instance with the 'EPSG:21781' code,
-// OpenLayers will pick up parameters like units and transform functions from
-// Proj4js.
+// EPSG:21781 is known to Proj4js because its definition is registered by
+// calling proj4.defs(). Now when we create an ol/proj/Projection instance with
+// the 'EPSG:21781' code, OpenLayers will pick up the transform functions from
+// Proj4js. To get the registered ol/proj/Projection instance with other
+// parameters like units and axis orientation applied from Proj4js, use
+// `ol/proj#get('EPSG:21781')`.
 //
 // Note that we are setting the projection's extent here, which is used to
 // determine the view resolution for zoom level 0. Recommended values for a
 // projection's validity extent can be found at https://epsg.io/.
-//
-// If you use Proj4js only to transform coordinates, you don't even need to
-// create an ol.proj.Projection instance. ol.proj.get() will take care of it
-// internally.
 
+proj4.defs('EPSG:21781',
+    '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 ' +
+    '+x_0=600000 +y_0=200000 +ellps=bessel ' +
+    '+towgs84=660.077,13.551,369.344,2.484,1.783,2.939,5.66 +units=m +no_defs');
 register(proj4);
 
 var projection = new _ol_proj_Projection_({

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -6,6 +6,7 @@ import _ol_layer_Image_ from '../src/ol/layer/Image.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import _ol_proj_Projection_ from '../src/ol/proj/Projection.js';
 import _ol_source_ImageWMS_ from '../src/ol/source/ImageWMS.js';
+import {register} from '../src/ol/proj/proj4.js';
 
 
 // Transparent Proj4js support:
@@ -22,6 +23,8 @@ import _ol_source_ImageWMS_ from '../src/ol/source/ImageWMS.js';
 // If you use Proj4js only to transform coordinates, you don't even need to
 // create an ol.proj.Projection instance. ol.proj.get() will take care of it
 // internally.
+
+register(proj4);
 
 var projection = new _ol_proj_Projection_({
   code: 'EPSG:21781',

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -8,7 +8,6 @@ import EPSG3857 from './proj/EPSG3857.js';
 import EPSG4326 from './proj/EPSG4326.js';
 import Projection from './proj/Projection.js';
 import Units from './proj/Units.js';
-import _ol_proj_proj4_ from './proj/proj4.js';
 import _ol_proj_projections_ from './proj/projections.js';
 import {add as addTransformFunc, clear as clearTransformFuncs, get as getTransformFunc} from './proj/transforms.js';
 
@@ -27,23 +26,6 @@ export var METERS_PER_UNIT = Units.METERS_PER_UNIT;
  * @type {ol.Sphere}
  */
 var SPHERE = new Sphere(Sphere.DEFAULT_RADIUS);
-
-
-/**
- * Register proj4. If not explicitly registered, it will be assumed that
- * proj4js will be loaded in the global namespace. For example in a
- * browserify ES6 environment you could use:
- *
- *     import ol from 'openlayers';
- *     import proj4 from 'proj4';
- *     ol.proj.setProj4(proj4);
- *
- * @param {Proj4} proj4 Proj4.
- * @api
- */
-export function setProj4(proj4) {
-  _ol_proj_proj4_.set(proj4);
-}
 
 
 /**
@@ -121,13 +103,6 @@ export function get(projectionLike) {
   } else if (typeof projectionLike === 'string') {
     var code = projectionLike;
     projection = _ol_proj_projections_.get(code);
-    if (!projection) {
-      var proj4js = _ol_proj_proj4_.get();
-      if (typeof proj4js == 'function' && proj4js.defs(code) !== undefined) {
-        projection = new Projection({code: code});
-        addProjection(projection);
-      }
-    }
   }
   return projection;
 }
@@ -390,24 +365,6 @@ export function equivalent(projection1, projection2) {
 export function getTransformFromProjections(sourceProjection, destinationProjection) {
   var sourceCode = sourceProjection.getCode();
   var destinationCode = destinationProjection.getCode();
-  if (!transformFunc) {
-    var proj4js = _ol_proj_proj4_.get();
-    if (typeof proj4js == 'function') {
-      var sourceDef = proj4js.defs(sourceCode);
-      var destinationDef = proj4js.defs(destinationCode);
-
-      if (sourceDef !== undefined && destinationDef !== undefined) {
-        if (sourceDef === destinationDef) {
-          addEquivalentProjections([destinationProjection, sourceProjection]);
-        } else {
-          var proj4Transform = proj4js(destinationCode, sourceCode);
-          addCoordinateTransforms(destinationProjection, sourceProjection,
-              proj4Transform.forward, proj4Transform.inverse);
-        }
-        transformFunc = _ol_proj_transforms_.get(sourceCode, destinationCode);
-      }
-    }
-  }
   var transformFunc = getTransformFunc(sourceCode, destinationCode);
   if (!transformFunc) {
     transformFunc = identityTransform;

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -2,7 +2,6 @@
  * @module ol/proj/Projection
  */
 import _ol_proj_Units_ from '../proj/Units.js';
-import _ol_proj_proj4_ from '../proj/proj4.js';
 
 /**
  * @classdesc
@@ -105,23 +104,6 @@ var _ol_proj_Projection_ = function(options) {
    * @type {number|undefined}
    */
   this.metersPerUnit_ = options.metersPerUnit;
-
-  var code = options.code;
-  var proj4js = _ol_proj_proj4_.get();
-  if (typeof proj4js == 'function') {
-    var def = proj4js.defs(code);
-    if (def !== undefined) {
-      if (def.axis !== undefined && options.axisOrientation === undefined) {
-        this.axisOrientation_ = def.axis;
-      }
-      if (options.metersPerUnit === undefined) {
-        this.metersPerUnit_ = def.to_meter;
-      }
-      if (options.units === undefined) {
-        this.units_ = def.units;
-      }
-    }
-  }
 };
 
 

--- a/src/ol/proj/index.jsdoc
+++ b/src/ol/proj/index.jsdoc
@@ -21,15 +21,14 @@
  * for the required projections. These definitions can be obtained from
  * {@link https://epsg.io/}, and are a JS function, so can be loaded in a script
  * tag (as in the examples) or pasted into your application.
- * The first time there is a request for a projection, either with a
- * {@link ol.proj.projectionLike} or directly with {@link ol.proj.get}, the
- * code will check if the Proj4js library and the necessary definition are
- * loaded; if so, it will register the appropriate {@link ol.proj.Projection}
- * object and add transform functions between the new projection and all the
- * existing ones. See examples/wms-image-custom-proj for an example of this.
- * Because the check for presence of the Proj4js library and the definition only
- * takes place on the first request for them, this means they can be loaded
- * dynamically as needed; for example, with user-supplied data where you don't
+ *
+ * After all required projection definitions are added to proj4's registry (by
+ * using `proj4.defs()`), simply call `register(proj4)` from the `ol/proj/proj4`
+ * package. Existing transforms are not changed by this function. See
+ * examples/wms-image-custom-proj for an example of this.
+ *
+ * Additional projection definitions can be registered with `proj4.defs()` any
+ * time. Just make sure to call `register(proj4)` again; for example, with user-supplied data where you don't
  * know in advance what projections are needed, you can initially load minimal
  * support and then load whichever are requested.
  *

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -1,30 +1,51 @@
 /**
  * @module ol/proj/proj4
  */
-var _ol_proj_proj4_ = {};
-
-
-/**
- * @private
- * @type {Proj4}
- */
-_ol_proj_proj4_.cache_ = null;
-
+import {addCoordinateTransforms, addProjection, addEquivalentProjections, get} from '../proj.js';
+import {get as getTransform} from './transforms.js';
+import Projection from './Projection.js';
 
 /**
- * Store the proj4 function.
- * @param {Proj4} proj4 The proj4 function.
+ * Make projections defined in proj4 (with `proj4.defs()`) available in
+ * OpenLayers.
+ *
+ * This function should be called whenever changes are made to the proj4
+ * registry, e.g. after calling `proj4.defs()`. Existing transforms will not be
+ * modified by this function.
+ *
+ * @param {?} proj4 Proj4.
+ * @api
  */
-_ol_proj_proj4_.set = function(proj4) {
-  _ol_proj_proj4_.cache_ = proj4;
-};
-
-
-/**
- * Get proj4.
- * @return {Proj4} The proj4 function set above or available globally.
- */
-_ol_proj_proj4_.get = function() {
-  return _ol_proj_proj4_.cache_ || window['proj4'];
-};
-export default _ol_proj_proj4_;
+export function register(proj4) {
+  var projCodes = Object.keys(proj4.defs);
+  var len = projCodes.length;
+  var i, j;
+  for (i = 0; i < len; ++i) {
+    var code = projCodes[i];
+    if (!get(code)) {
+      var def = proj4.defs(code);
+      addProjection(new Projection({
+        code: code,
+        axisOrientation: def.axis,
+        metersPerUnit: def.to_meter,
+        units: def.units
+      }));
+    }
+  }
+  for (i = 0; i < len; ++i) {
+    var code1 = projCodes[i];
+    var proj1 = get(code1);
+    for (j = 0; j < len; ++j) {
+      var code2 = projCodes[j];
+      var proj2 = get(code2);
+      if (!getTransform(code1, code2)) {
+        if (proj4.defs[code1] === proj4.defs[code2]) {
+          addEquivalentProjections([proj1, proj2]);
+        } else {
+          var transform = proj4(code1, code2);
+          addCoordinateTransforms(proj1, proj2, transform.forward, transform.inverse);
+        }
+      }
+    }
+  }
+}

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -2,22 +2,21 @@
  * @module ol/proj/transforms
  */
 import _ol_obj_ from '../obj.js';
-var _ol_proj_transforms_ = {};
 
 
 /**
  * @private
  * @type {Object.<string, Object.<string, ol.TransformFunction>>}
  */
-_ol_proj_transforms_.cache_ = {};
+var transforms = {};
 
 
 /**
  * Clear the transform cache.
  */
-_ol_proj_transforms_.clear = function() {
-  _ol_proj_transforms_.cache_ = {};
-};
+export function clear() {
+  transforms = {};
+}
 
 
 /**
@@ -28,15 +27,14 @@ _ol_proj_transforms_.clear = function() {
  * @param {ol.proj.Projection} destination Destination.
  * @param {ol.TransformFunction} transformFn Transform.
  */
-_ol_proj_transforms_.add = function(source, destination, transformFn) {
+export function add(source, destination, transformFn) {
   var sourceCode = source.getCode();
   var destinationCode = destination.getCode();
-  var transforms = _ol_proj_transforms_.cache_;
   if (!(sourceCode in transforms)) {
     transforms[sourceCode] = {};
   }
   transforms[sourceCode][destinationCode] = transformFn;
-};
+}
 
 
 /**
@@ -48,17 +46,16 @@ _ol_proj_transforms_.add = function(source, destination, transformFn) {
  * @param {ol.proj.Projection} destination Destination projection.
  * @return {ol.TransformFunction} transformFn The unregistered transform.
  */
-_ol_proj_transforms_.remove = function(source, destination) {
+export function remove(source, destination) {
   var sourceCode = source.getCode();
   var destinationCode = destination.getCode();
-  var transforms = _ol_proj_transforms_.cache_;
   var transform = transforms[sourceCode][destinationCode];
   delete transforms[sourceCode][destinationCode];
   if (_ol_obj_.isEmpty(transforms[sourceCode])) {
     delete transforms[sourceCode];
   }
   return transform;
-};
+}
 
 
 /**
@@ -67,12 +64,10 @@ _ol_proj_transforms_.remove = function(source, destination) {
  * @param {string} destinationCode The code for the destination projection.
  * @return {ol.TransformFunction|undefined} The transform function (if found).
  */
-_ol_proj_transforms_.get = function(sourceCode, destinationCode) {
+export function get(sourceCode, destinationCode) {
   var transform;
-  var transforms = _ol_proj_transforms_.cache_;
   if (sourceCode in transforms && destinationCode in transforms[sourceCode]) {
     transform = transforms[sourceCode][destinationCode];
   }
   return transform;
-};
-export default _ol_proj_transforms_;
+}

--- a/test/rendering/ol/reproj/tile.test.js
+++ b/test/rendering/ol/reproj/tile.test.js
@@ -4,6 +4,7 @@ import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_reproj_Tile_ from '../../../../src/ol/reproj/Tile.js';
 import _ol_source_XYZ_ from '../../../../src/ol/source/XYZ.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
+import {register} from '../../../../src/ol/proj/proj4.js';
 
 
 describe('ol.rendering.reproj.Tile', function() {
@@ -58,6 +59,7 @@ describe('ol.rendering.reproj.Tile', function() {
       proj4.defs('EPSG:5070',
           '+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +x_0=0 ' +
           '+y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
+      register(proj4);
       var proj5070 = getProjection('EPSG:5070');
       proj5070.setExtent([-6e6, 0, 4e6, 6e6]);
 
@@ -69,6 +71,7 @@ describe('ol.rendering.reproj.Tile', function() {
     it('to ESRI:54009', function(done) {
       proj4.defs('ESRI:54009',
           '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
+      register(proj4);
       var proj54009 = getProjection('ESRI:54009');
       proj54009.setExtent([-18e6, -9e6, 18e6, 9e6]);
 
@@ -96,6 +99,7 @@ describe('ol.rendering.reproj.Tile', function() {
       proj4.defs('EPSG:3740',
           '+proj=utm +zone=10 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 ' +
           '+units=m +no_defs');
+      register(proj4);
       var proj3740 = getProjection('EPSG:3740');
       proj3740.setExtent([318499.05, 2700792.39, 4359164.89, 7149336.98]);
 
@@ -158,6 +162,7 @@ describe('ol.rendering.reproj.Tile', function() {
 
     it('wraps X when prime meridian is shifted', function(done) {
       proj4.defs('merc_180', '+proj=merc +lon_0=180 +units=m +no_defs');
+      register(proj4);
       var proj_ = getProjection('merc_180');
       proj_.setExtent([-20026376.39, -20048966.10, 20026376.39, 20048966.10]);
 
@@ -169,6 +174,7 @@ describe('ol.rendering.reproj.Tile', function() {
     it('displays north pole correctly (EPSG:3413)', function(done) {
       proj4.defs('EPSG:3413', '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 ' +
           '+k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs');
+      register(proj4);
       var proj3413 = getProjection('EPSG:3413');
       proj3413.setExtent([-4194304, -4194304, 4194304, 4194304]);
 

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -12,7 +12,7 @@ import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import {addProjection, addCoordinateTransforms, transform, get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
-import _ol_proj_transforms_ from '../../../../src/ol/proj/transforms.js';
+import {remove as removeTransform} from '../../../../src/ol/proj/transforms.js';
 import _ol_style_Circle_ from '../../../../src/ol/style/Circle.js';
 import _ol_style_Fill_ from '../../../../src/ol/style/Fill.js';
 import _ol_style_Icon_ from '../../../../src/ol/style/Icon.js';
@@ -386,10 +386,8 @@ describe('ol.format.KML', function() {
               '</kml>';
           expect(node).to.xmleql(_ol_xml_.parse(text));
 
-          _ol_proj_transforms_.remove(
-              getProjection('EPSG:4326'), getProjection('double'));
-          _ol_proj_transforms_.remove(
-              getProjection('double'), getProjection('EPSG:4326'));
+          removeTransform(getProjection('EPSG:4326'), getProjection('double'));
+          removeTransform(getProjection('double'), getProjection('EPSG:4326'));
         });
 
         it('can write XYM Point geometries', function() {

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -7,7 +7,8 @@ import MultiLineString from '../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../src/ol/geom/MultiPoint.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
-import {transform} from '../../../../src/ol/proj.js';
+import {addCommon, clearAllProjections, transform} from '../../../../src/ol/proj.js';
+import {register} from '../../../../src/ol/proj/proj4.js';
 import _ol_xml_ from '../../../../src/ol/xml.js';
 
 describe('ol.format.WFS', function() {
@@ -36,6 +37,7 @@ describe('ol.format.WFS', function() {
 
     before(function(done) {
       proj4.defs('urn:x-ogc:def:crs:EPSG:4326', proj4.defs('EPSG:4326'));
+      register(proj4);
       afterLoadText('spec/ol/format/wfs/topp-states-wfs.xml', function(data) {
         try {
           xml = data;
@@ -45,6 +47,12 @@ describe('ol.format.WFS', function() {
         }
         done();
       });
+    });
+
+    after(function() {
+      delete proj4.defs['urn:x-ogc:def:crs:EPSG:4326'];
+      clearAllProjections();
+      addCommon();
     });
 
     it('creates 3 features', function() {
@@ -85,6 +93,7 @@ describe('ol.format.WFS', function() {
 
     before(function(done) {
       proj4.defs('urn:x-ogc:def:crs:EPSG:4326', proj4.defs('EPSG:4326'));
+      register(proj4);
       afterLoadText('spec/ol/format/wfs/polygonv2.xml', function(data) {
         try {
           xml = data;
@@ -94,6 +103,12 @@ describe('ol.format.WFS', function() {
         }
         done();
       });
+    });
+
+    after(function() {
+      delete proj4.defs['urn:x-ogc:def:crs:EPSG:4326'];
+      clearAllProjections();
+      addCommon();
     });
 
     it('creates 3 features', function() {
@@ -153,6 +168,7 @@ describe('ol.format.WFS', function() {
           '+lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 ' +
           '+ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,' +
           '-1.8774,4.0725 +units=m +no_defs');
+      register(proj4);
       afterLoadText('spec/ol/format/wfs/boundedBy.xml',
           function(xml) {
             try {

--- a/test/spec/ol/format/wmsgetfeatureinfo.test.js
+++ b/test/spec/ol/format/wmsgetfeatureinfo.test.js
@@ -1,4 +1,6 @@
 import _ol_format_WMSGetFeatureInfo_ from '../../../../src/ol/format/WMSGetFeatureInfo.js';
+import {addCommon, clearAllProjections} from '../../../../src/ol/proj.js';
+import {register} from '../../../../src/ol/proj/proj4.js';
 
 
 describe('ol.format.WMSGetFeatureInfo', function() {
@@ -27,6 +29,7 @@ describe('ol.format.WMSGetFeatureInfo', function() {
 
       before(function(done) {
         proj4.defs('urn:x-ogc:def:crs:EPSG:4326', proj4.defs('EPSG:4326'));
+        register(proj4);
         afterLoadText('spec/ol/format/wms/getfeatureinfo.xml', function(data) {
           try {
             features = new _ol_format_WMSGetFeatureInfo_().readFeatures(data);
@@ -38,7 +41,9 @@ describe('ol.format.WMSGetFeatureInfo', function() {
       });
 
       after(function() {
-        proj4.defs('urn:x-ogc:def:crs:EPSG:4326', undefined);
+        delete proj4.defs['urn:x-ogc:def:crs:EPSG:4326'];
+        clearAllProjections();
+        addCommon();
       });
 
       it('creates 3 features', function() {

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -1,6 +1,5 @@
 import {
   addCommon,
-  setProj4,
   clearAllProjections,
   equivalent,
   get as getProjection,
@@ -12,6 +11,7 @@ import {
   getPointResolution,
   getTransformFromProjections
 } from '../../../src/ol/proj.js';
+import {register} from '../../../src/ol/proj/proj4.js';
 import _ol_proj_EPSG3857_ from '../../../src/ol/proj/EPSG3857.js';
 import _ol_proj_EPSG4326_ from '../../../src/ol/proj/EPSG4326.js';
 import _ol_proj_Projection_ from '../../../src/ol/proj/Projection.js';
@@ -277,12 +277,10 @@ describe('ol.proj', function() {
 
   describe('Proj4js integration', function() {
 
-    var proj4 = window.proj4;
-
     afterEach(function() {
       delete proj4.defs['EPSG:21781'];
-      window.proj4 = proj4;
-      setProj4(window.proj4);
+      clearAllProjections();
+      addCommon();
     });
 
     it('creates ol.proj.Projection instance from EPSG:21781', function() {
@@ -290,21 +288,7 @@ describe('ol.proj', function() {
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
-      var proj = getProjection('EPSG:21781');
-      expect(proj.getCode()).to.eql('EPSG:21781');
-      expect(proj.getUnits()).to.eql('m');
-      expect(proj.getMetersPerUnit()).to.eql(1);
-    });
-
-    it('can use an alternative namespace for proj4', function() {
-      var proj4 = window.proj4;
-      var proj4new = proj4;
-      delete window.proj4;
-      setProj4(proj4new);
-      proj4new.defs('EPSG:21781',
-          '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
-          '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
-          '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
+      register(proj4);
       var proj = getProjection('EPSG:21781');
       expect(proj.getCode()).to.eql('EPSG:21781');
       expect(proj.getUnits()).to.eql('m');
@@ -316,6 +300,7 @@ describe('ol.proj', function() {
           '+proj=tmerc +lat_0=40.5 +lon_0=-110.0833333333333 +k=0.9999375 ' +
           '+x_0=800000.0000101599 +y_0=99999.99998983997 +ellps=GRS80 ' +
           '+towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs');
+      register(proj4);
       var proj = getProjection('EPSG:3739');
       expect(proj.getCode()).to.eql('EPSG:3739');
       expect(proj.getUnits()).to.eql('us-ft');
@@ -325,6 +310,7 @@ describe('ol.proj', function() {
     });
 
     it('allows Proj4js projections to be used transparently', function() {
+      register(proj4);
       var point = transform(
           [-626172.13571216376, 6887893.4928337997], 'GOOGLE', 'WGS84');
       expect(point[0]).to.roughlyEqual(-5.625, 1e-9);
@@ -336,6 +322,7 @@ describe('ol.proj', function() {
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
+      register(proj4);
       var point = transform([7.439583333333333, 46.95240555555556],
           'EPSG:4326', 'EPSG:21781');
       expect(point[0]).to.roughlyEqual(600072.300, 1);
@@ -347,6 +334,7 @@ describe('ol.proj', function() {
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
+      register(proj4);
       var lonLat = [7.439583333333333, 46.95240555555556];
       var point = fromLonLat(lonLat, 'EPSG:21781');
       expect(point[0]).to.roughlyEqual(600072.300, 1);
@@ -364,6 +352,7 @@ describe('ol.proj', function() {
       var code = 'urn:ogc:def:crs:EPSG:21781';
       var srsCode = 'EPSG:21781';
       proj4.defs(code, proj4.defs(srsCode));
+      register(proj4);
       var proj = getProjection(code);
       var proj2 = getProjection(srsCode);
       expect(equivalent(proj2, proj)).to.be(true);
@@ -371,12 +360,14 @@ describe('ol.proj', function() {
     });
 
     it('numerically estimates point scale at the equator', function() {
+      register(proj4);
       var googleProjection = getProjection('GOOGLE');
       expect(getPointResolution(googleProjection, 1, [0, 0])).
           to.roughlyEqual(1, 1e-1);
     });
 
     it('numerically estimates point scale at various latitudes', function() {
+      register(proj4);
       var epsg3857Projection = getProjection('EPSG:3857');
       var googleProjection = getProjection('GOOGLE');
       var point, y;
@@ -388,6 +379,7 @@ describe('ol.proj', function() {
     });
 
     it('numerically estimates point scale at various points', function() {
+      register(proj4);
       var epsg3857Projection = getProjection('EPSG:3857');
       var googleProjection = getProjection('GOOGLE');
       var point, x, y;
@@ -401,6 +393,7 @@ describe('ol.proj', function() {
     });
 
     it('does not overwrite existing projections in the registry', function() {
+      register(proj4);
       var epsg4326 = getProjection('EPSG:4326');
       new _ol_proj_Projection_({
         code: 'EPSG:4326',
@@ -413,6 +406,10 @@ describe('ol.proj', function() {
   });
 
   describe('ol.proj.getTransformFromProjections()', function() {
+
+    beforeEach(function() {
+      register(proj4);
+    });
 
     it('returns a transform function', function() {
       var transform = getTransformFromProjections(getProjection('GOOGLE'),
@@ -441,6 +438,10 @@ describe('ol.proj', function() {
   });
 
   describe('ol.proj.getTransform()', function() {
+
+    beforeEach(function() {
+      register(proj4);
+    });
 
     it('returns a function', function() {
       var transform = getTransform('GOOGLE', 'EPSG:4326');
@@ -544,6 +545,7 @@ describe('ol.proj', function() {
           '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 ' +
           '+k_0=1 +x_0=600000 +y_0=200000 +ellps=bessel ' +
           '+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs');
+      register(proj4);
 
       var got = transform([-111, 45.5, 123], 'EPSG:4326', 'custom');
       expect(got).to.have.length(3);
@@ -552,6 +554,8 @@ describe('ol.proj', function() {
       expect(got[2]).to.be(123);
 
       delete proj4.defs.custom;
+      clearAllProjections();
+      addCommon();
     });
 
   });
@@ -582,6 +586,7 @@ describe('ol.proj', function() {
           'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],' +
           'UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],' +
           'AUTHORITY["EPSG","4279"]]');
+      register(proj4);
     });
 
     afterEach(function() {
@@ -589,6 +594,8 @@ describe('ol.proj', function() {
       delete proj4.defs['EPSG:3739'];
       delete proj4.defs['EPSG:4269'];
       delete proj4.defs['EPSG:4279'];
+      clearAllProjections();
+      addCommon();
     });
 
     it('returns value in meters', function() {

--- a/test/spec/ol/proj/transforms.test.js
+++ b/test/spec/ol/proj/transforms.test.js
@@ -1,13 +1,13 @@
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
-import _ol_proj_transforms_ from '../../../../src/ol/proj/transforms.js';
+import * as transforms from '../../../../src/ol/proj/transforms.js';
 
 
-describe('ol.proj.transforms.remove()', function() {
+describe('transforms.remove()', function() {
 
   var extent = [180, -90, 180, 90];
   var units = 'degrees';
 
-  it('removes functions cached by ol.proj.transforms.add()', function() {
+  it('removes functions cached by transforms.add()', function() {
     var foo = new _ol_proj_Projection_({
       code: 'foo',
       units: units,
@@ -21,15 +21,12 @@ describe('ol.proj.transforms.remove()', function() {
     var transform = function(input, output, dimension) {
       return input;
     };
-    _ol_proj_transforms_.add(foo, bar, transform);
-    var cache = _ol_proj_transforms_.cache_;
-    expect(cache).not.to.be(undefined);
-    expect(cache.foo).not.to.be(undefined);
-    expect(cache.foo.bar).to.be(transform);
+    transforms.add(foo, bar, transform);
+    expect(transforms.get('foo', 'bar')).to.be(transform);
 
-    var removed = _ol_proj_transforms_.remove(foo, bar);
+    var removed = transforms.remove(foo, bar);
     expect(removed).to.be(transform);
-    expect(cache.foo).to.be(undefined);
+    expect(transforms.get('foo', 'bar')).to.be(undefined);
   });
 
 });

--- a/test/spec/ol/reproj/tile.test.js
+++ b/test/spec/ol/reproj/tile.test.js
@@ -1,6 +1,7 @@
 import _ol_ImageTile_ from '../../../../src/ol/ImageTile.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import {get as getProjection} from '../../../../src/ol/proj.js';
+import {addCommon, clearAllProjections, get as getProjection} from '../../../../src/ol/proj.js';
+import {register} from '../../../../src/ol/proj/proj4.js';
 import _ol_reproj_Tile_ from '../../../../src/ol/reproj/Tile.js';
 import _ol_tilegrid_ from '../../../../src/ol/tilegrid.js';
 
@@ -11,12 +12,15 @@ describe('ol.reproj.Tile', function() {
         '+k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy ' +
         '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
         '+units=m +no_defs');
+    register(proj4);
     var proj27700 = getProjection('EPSG:27700');
     proj27700.setExtent([0, 0, 700000, 1300000]);
   });
 
   afterEach(function() {
     delete proj4.defs['EPSG:27700'];
+    clearAllProjections();
+    addCommon();
   });
 
 

--- a/test/spec/ol/reproj/triangulation.test.js
+++ b/test/spec/ol/reproj/triangulation.test.js
@@ -1,4 +1,5 @@
-import {get as getProjection} from '../../../../src/ol/proj.js';
+import {addCommon, clearAllProjections, get as getProjection} from '../../../../src/ol/proj.js';
+import {register} from '../../../../src/ol/proj/proj4.js';
 import _ol_reproj_Triangulation_ from '../../../../src/ol/reproj/Triangulation.js';
 
 
@@ -8,12 +9,15 @@ describe('ol.reproj.Triangulation', function() {
         '+k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy ' +
         '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 ' +
         '+units=m +no_defs');
+    register(proj4);
     var proj27700 = getProjection('EPSG:27700');
     proj27700.setExtent([0, 0, 700000, 1300000]);
   });
 
   afterEach(function() {
     delete proj4.defs['EPSG:27700'];
+    clearAllProjections();
+    addCommon();
   });
 
   describe('constructor', function() {

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -2,7 +2,8 @@ import _ol_ImageTile_ from '../../../../src/ol/ImageTile.js';
 import _ol_TileState_ from '../../../../src/ol/TileState.js';
 import _ol_TileUrlFunction_ from '../../../../src/ol/TileUrlFunction.js';
 import _ol_events_ from '../../../../src/ol/events.js';
-import {get as getProjection} from '../../../../src/ol/proj.js';
+import {addCommon, clearAllProjections, get as getProjection} from '../../../../src/ol/proj.js';
+import {register} from '../../../../src/ol/proj/proj4.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
 import _ol_proj_Projection_ from '../../../../src/ol/proj/Projection.js';
 import _ol_reproj_Tile_ from '../../../../src/ol/reproj/Tile.js';
@@ -131,10 +132,13 @@ describe('ol.source.TileImage', function() {
 
     beforeEach(function() {
       proj4.defs('4326_noextentnounits', '+proj=longlat +datum=WGS84 +no_defs');
+      register(proj4);
     });
 
     afterEach(function() {
       delete proj4.defs['4326_noextentnounits'];
+      clearAllProjections();
+      addCommon();
     });
 
     it('can handle source projection without extent and units', function(done) {


### PR DESCRIPTION
This pull request changes the API for proj4 integration a bit, so proj4 related code is only added to the build when the users requests so. The braking change is that the `ol.proj.setProj4()` function is gone, and instead there is a `ol/proj/proj4` module with a `register()` function. This function should be called whenever changes are made to the proj4 registry, e.g.
```js
import proj4 from `proj4`;
import {register} from 'ol/proj/proj4';

proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs');
register(proj4);
```
From here on, everything is the same as previously.

This pul request also changes exports to named exports for `ol/proj/transforms`.

Fixes #5628.