### PR TITLE
Facilitate the removal of externs/olx.js

### DIFF
--- a/externs/xol.js
+++ b/externs/xol.js
@@ -1,0 +1,4359 @@
+
+/**
+ * @typedef {{unique: (boolean|undefined)}}
+ */
+export var CollectionOptions;
+
+/**
+ * @param {CollectionOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.unique Disallow the same item from being added to the collection twice.  Default is
+ * false.
+ *
+ */
+
+
+/**
+ * @typedef {{tracking: (boolean|undefined),
+ *     trackingOptions: (GeolocationPositionOptions|undefined),
+ *     projection: ol.ProjectionLike}}
+ */
+export var GeolocationOptions;
+
+/**
+ * @param {GeolocationOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.tracking Start Tracking. Default is `false`.
+ *
+ * @param {GeolocationPositionOptions|undefined} options.trackingOptions Tracking options. See
+ * {@link http://www.w3.org/TR/geolocation-API/#position_options_interface}.
+ *
+ * @param {ol.ProjectionLike} options.projection The projection the position is reported in.
+ *
+ */
+
+
+/**
+ * Object literal with config options for the map logo.
+ * @typedef {{href: (string), src: (string)}}
+ */
+export var LogoOptions;
+
+/**
+ * @param {LogoOptions} options TODO: repace this
+ *
+ * @param {string} options.href Link url for the logo. Will be followed when the logo is clicked.
+ *
+ * @param {string} options.src Image src for the logo.
+ *
+ */
+
+
+/**
+ * @typedef {{map: (ol.PluggableMap|undefined),
+ *     maxLines: (number|undefined),
+ *     strokeStyle: (ol.style.Stroke|undefined),
+ *     targetSize: (number|undefined),
+ *     showLabels: (boolean|undefined),
+ *     lonLabelFormatter: (undefined|function(number):string),
+ *     latLabelFormatter: (undefined|function(number):string),
+ *     lonLabelPosition: (number|undefined),
+ *     latLabelPosition: (number|undefined),
+ *     lonLabelStyle: (ol.style.Text|undefined),
+ *     latLabelStyle: (ol.style.Text|undefined)}}
+ */
+export var GraticuleOptions;
+
+/**
+ * @param {GraticuleOptions} options TODO: repace this
+ *
+ * @param {ol.PluggableMap|undefined} options.map Reference to an `ol.Map` object.
+ *
+ * @param {number|undefined} options.maxLines The maximum number of meridians and parallels from the center of the
+ * map. The default value is 100, which means that at most 200 meridians
+ * and 200 parallels will be displayed. The default value is appropriate
+ * for conformal projections like Spherical Mercator. If you increase
+ * the value more lines will be drawn and the drawing performance will
+ * decrease.
+ *
+ * @param {ol.style.Stroke|undefined} options.strokeStyle The stroke style to use for drawing the graticule. If not provided, the
+ * lines will be drawn with `rgba(0,0,0,0.2)`, a not fully opaque black.
+ *
+ *
+ * @param {number|undefined} options.targetSize The target size of the graticule cells, in pixels. Default
+ * value is 100 pixels.
+ *
+ * @param {boolean|undefined} options.showLabels Render a label with the respective latitude/longitude for each graticule
+ * line. Default is false.
+ *
+ *
+ * @param {undefined|function(number):string} options.lonLabelFormatter Label formatter for longitudes. This function is called with the longitude as
+ * argument, and should return a formatted string representing the longitude.
+ * By default, labels are formatted as degrees, minutes, seconds and hemisphere.
+ *
+ *
+ * @param {undefined|function(number):string} options.latLabelFormatter Label formatter for latitudes. This function is called with the latitude as
+ * argument, and should return a formatted string representing the latitude.
+ * By default, labels are formatted as degrees, minutes, seconds and hemisphere.
+ *
+ *
+ * @param {number|undefined} options.lonLabelPosition Longitude label position in fractions (0..1) of view extent. 0 means at the
+ * bottom of the viewport, 1 means at the top. Default is 0.
+ *
+ * @param {number|undefined} options.latLabelPosition Latitude label position in fractions (0..1) of view extent. 0 means at the
+ * left of the viewport, 1 means at the right. Default is 1.
+ *
+ * @param {ol.style.Text|undefined} options.lonLabelStyle Longitude label text style. The default is
+ * ```js
+ * new ol.style.Text({
+ *   font: '12px Calibri,sans-serif',
+ *   textBaseline: 'bottom',
+ *   fill: new ol.style.Fill({
+ *     color: 'rgba(0,0,0,1)'
+ *   }),
+ *   stroke: new ol.style.Stroke({
+ *     color: 'rgba(255,255,255,1)',
+ *     width: 3
+ *   })
+ * });
+ * ```
+ * Note that the default's `textBaseline` configuration will not work well for
+ * `lonLabelPosition` configurations that position labels close to the top of
+ * the viewport.
+ *
+ *
+ * @param {ol.style.Text|undefined} options.latLabelStyle Latitude label text style. The default is
+ * ```js
+ * new ol.style.Text({
+ *   font: '12px Calibri,sans-serif',
+ *   textAlign: 'end',
+ *   fill: new ol.style.Fill({
+ *     color: 'rgba(0,0,0,1)'
+ *   }),
+ *   stroke: new ol.style.Stroke({
+ *     color: 'rgba(255,255,255,1)',
+ *     width: 3
+ *   })
+ * });
+ * ```
+ * Note that the default's `textAlign` configuration will not work well for
+ * `latLabelPosition` configurations that position labels close to the left of
+ * the viewport.
+ *
+ *
+ */
+
+
+/**
+ * Object literal with config options for interactions.
+ * @typedef {{handleEvent: function(ol.MapBrowserEvent):boolean}}
+ */
+export var interaction_InteractionOptions;
+
+/**
+ * @param {interaction_InteractionOptions} options TODO: repace this
+ *
+ * @param {function(ol.MapBrowserEvent):boolean} options.handleEvent Method called by the map to notify the interaction that a browser event was
+ * dispatched to the map. If the function returns a falsy value,
+ * propagation of the event to other interactions in the map's interactions
+ * chain will be prevented (this includes functions with no explicit return). See
+ * {@link https://developer.mozilla.org/en-US/docs/Glossary/Falsy}
+ *
+ */
+
+
+/**
+ * Object literal with config options for the map.
+ * @typedef {{controls: (ol.Collection.<ol.control.Control>|Array.<ol.control.Control>|undefined),
+ *     pixelRatio: (number|undefined),
+ *     interactions: (ol.Collection.<ol.interaction.Interaction>|Array.<ol.interaction.Interaction>|undefined),
+ *     keyboardEventTarget: (Element|Document|string|undefined),
+ *     layers: (Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined),
+ *     loadTilesWhileAnimating: (boolean|undefined),
+ *     loadTilesWhileInteracting: (boolean|undefined),
+ *     logo: (boolean|string|olx.LogoOptions|Element|undefined),
+ *     moveTolerance: (number|undefined),
+ *     overlays: (ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined),
+ *     renderer: (ol.renderer.Type|Array.<ol.renderer.Type>|undefined),
+ *     target: (Element|string|undefined),
+ *     view: (ol.View|undefined)}}
+ */
+export var MapOptions;
+
+/**
+ * @param {MapOptions} options TODO: repace this
+ *
+ * @param {ol.Collection.<ol.control.Control>|Array.<ol.control.Control>|undefined} options.controls Controls initially added to the map. If not specified,
+ * {@link ol.control.defaults ol.control.defaults()} is used.
+ *
+ * @param {number|undefined} options.pixelRatio The ratio between physical pixels and device-independent pixels (dips) on the
+ * device. If `undefined` then it gets set by using `window.devicePixelRatio`.
+ *
+ * @param {ol.Collection.<ol.interaction.Interaction>|Array.<ol.interaction.Interaction>|undefined} options.interactions Interactions that are initially added to the map. If not specified,
+ * {@link ol.interaction.defaults ol.interaction.defaults()} is used.
+ *
+ * @param {Element|Document|string|undefined} options.keyboardEventTarget The element to listen to keyboard events on. This determines when the
+ * `KeyboardPan` and `KeyboardZoom` interactions trigger. For example, if this
+ * option is set to `document` the keyboard interactions will always trigger. If
+ * this option is not specified, the element the library listens to keyboard
+ * events on is the map target (i.e. the user-provided div for the map). If this
+ * is not `document` the target element needs to be focused for key events to be
+ * emitted, requiring that the target element has a `tabindex` attribute.
+ *
+ * @param {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} options.layers Layers. If this is not defined, a map with no layers will be rendered. Note
+ * that layers are rendered in the order supplied, so if you want, for example,
+ * a vector layer to appear on top of a tile layer, it must come after the tile
+ * layer.
+ *
+ * @param {boolean|undefined} options.loadTilesWhileAnimating When set to true, tiles will be loaded during animations. This may improve
+ * the user experience, but can also make animations stutter on devices with
+ * slow memory. Default is `false`.
+ *
+ * @param {boolean|undefined} options.loadTilesWhileInteracting When set to true, tiles will be loaded while interacting with the map. This
+ * may improve the user experience, but can also make map panning and zooming
+ * choppy on devices with slow memory. Default is `false`.
+ *
+ * @param {boolean|string|olx.LogoOptions|Element|undefined} options.logo The map logo. A logo to be displayed on the map at all times. If a string is
+ * provided, it will be set as the image source of the logo. If an object is
+ * provided, the `src` property should be the URL for an image and the `href`
+ * property should be a URL for creating a link. If an element is provided,
+ * the element will be used. To disable the map logo, set the option to
+ * `false`. By default, the OpenLayers logo is shown.
+ *
+ * @param {number|undefined} options.moveTolerance The minimum distance in pixels the cursor must move to be detected
+ * as a map move event instead of a click. Increasing this value can make it
+ * easier to click on the map.
+ * Default is `1`.
+ *
+ * @param {ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined} options.overlays Overlays initially added to the map. By default, no overlays are added.
+ *
+ * @param {ol.renderer.Type|Array.<ol.renderer.Type>|undefined} options.renderer Renderer. By default, Canvas and WebGL renderers are tested for support
+ * in that order, and the first supported used. Specify a
+ * {@link ol.renderer.Type} here to use a specific renderer.
+ * Note that the Canvas renderer fully supports vector data, but WebGL can only
+ * render Point geometries.
+ *
+ * @param {Element|string|undefined} options.target The container for the map, either the element itself or the `id` of the
+ * element. If not specified at construction time, {@link ol.Map#setTarget}
+ * must be called for the map to be rendered.
+ *
+ * @param {ol.View|undefined} options.view The map's view.  No layer sources will be fetched unless this is specified at
+ * construction time or through {@link ol.Map#setView}.
+ *
+ */
+
+
+/**
+ * Object literal with options for the {@link ol.Sphere.getLength} or
+ * {@link ol.Sphere.getArea} functions.
+ * @typedef {{projection: (ol.ProjectionLike|undefined),
+ *    radius: (number|undefined)}}
+ */
+export var SphereMetricOptions;
+
+/**
+ * @param {SphereMetricOptions} options TODO: repace this
+ *
+ * @param {(ol.ProjectionLike|undefined)} options.projection Projection of the geometry.  By default, the geometry is assumed to be in
+ * EPSG:3857 (Web Mercator).
+ *
+ * @param {(number|undefined)} options.radius Sphere radius.  By default, the radius of the earth is used (Clarke 1866
+ * Authalic Sphere).
+ *
+ */
+
+
+/**
+ * Options for tile constructors.
+ * @typedef {{transition: (number|undefined)}}
+ */
+export var TileOptions;
+
+/**
+ * @param {TileOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.transition A duration for tile opacity transitions.  By default, tiles will render with
+ * an opacity transition that lasts 250 ms.  To change the duration, pass a
+ * number in milliseconds.  A duration of 0 disables the opacity transition.
+ *
+ */
+
+
+/**
+ * Object literal with options for the {@link ol.Map#forEachFeatureAtPixel} and
+ * {@link ol.Map#hasFeatureAtPixel} methods.
+ * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
+ *    hitTolerance: (number|undefined)}}
+ */
+export var AtPixelOptions;
+
+/**
+ * @param {AtPixelOptions} options TODO: repace this
+ *
+ * @param {((function(ol.layer.Layer): boolean)|undefined)} options.layerFilter Layer filter function. The filter function will receive one argument, the
+ * {@link ol.layer.Layer layer-candidate} and it should return a boolean value.
+ * Only layers which are visible and for which this function returns `true`
+ * will be tested for features. By default, all visible layers will be tested.
+ *
+ * @param {number|undefined} options.hitTolerance Hit-detection tolerance in pixels. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL. Default is `0`.
+ *
+ */
+
+
+/**
+ * Object literal with config options for the overlay.
+ * @typedef {{id: (number|string|undefined),
+ *     element: (Element|undefined),
+ *     offset: (Array.<number>|undefined),
+ *     position: (ol.Coordinate|undefined),
+ *     positioning: (ol.OverlayPositioning|string|undefined),
+ *     stopEvent: (boolean|undefined),
+ *     insertFirst: (boolean|undefined),
+ *     autoPan: (boolean|undefined),
+ *     autoPanAnimation: (olx.OverlayPanOptions|undefined),
+ *     autoPanMargin: (number|undefined),
+ *     className: (string|undefined)}}
+ */
+export var OverlayOptions;
+
+/**
+ * @param {OverlayOptions} options TODO: repace this
+ *
+ * @param {number|string|undefined} options.id Set the overlay id. The overlay id can be used with the
+ * {@link ol.Map#getOverlayById} method.
+ *
+ * @param {Element|undefined} options.element The overlay element.
+ *
+ * @param {Array.<number>|undefined} options.offset Offsets in pixels used when positioning the overlay. The first element in the
+ * array is the horizontal offset. A positive value shifts the overlay right.
+ * The second element in the array is the vertical offset. A positive value
+ * shifts the overlay down. Default is `[0, 0]`.
+ *
+ * @param {ol.Coordinate|undefined} options.position The overlay position in map projection.
+ *
+ * @param {ol.OverlayPositioning|string|undefined} options.positioning Defines how the overlay is actually positioned with respect to its `position`
+ * property. Possible values are `'bottom-left'`, `'bottom-center'`,
+ * `'bottom-right'`, `'center-left'`, `'center-center'`, `'center-right'`,
+ * `'top-left'`, `'top-center'`, and `'top-right'`. Default is `'top-left'`.
+ *
+ * @param {boolean|undefined} options.stopEvent Whether event propagation to the map viewport should be stopped. Default is
+ * `true`. If `true` the overlay is placed in the same container as that of the
+ * controls (CSS class name `ol-overlaycontainer-stopevent`); if `false` it is
+ * placed in the container with CSS class name `ol-overlaycontainer`.
+ *
+ * @param {boolean|undefined} options.insertFirst Whether the overlay is inserted first in the overlay container, or appended.
+ * Default is `true`. If the overlay is placed in the same container as that of
+ * the controls (see the `stopEvent` option) you will probably set `insertFirst`
+ * to `true` so the overlay is displayed below the controls.
+ *
+ * @param {boolean|undefined} options.autoPan If set to `true` the map is panned when calling `setPosition`, so that the
+ * overlay is entirely visible in the current viewport.
+ * The default is `false`.
+ *
+ * @param {olx.OverlayPanOptions|undefined} options.autoPanAnimation The animation options used to pan the overlay into view. This animation
+ * is only used when `autoPan` is enabled. A `duration` and `easing` may be
+ * provided to customize the animation.
+ *
+ * @param {number|undefined} options.autoPanMargin The margin (in pixels) between the overlay and the borders of the map when
+ * autopanning. The default is `20`.
+ *
+ * @param {string|undefined} options.className CSS class name. Default is `ol-overlay-container ol-selectable`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *   duration: (number|undefined),
+ *   easing: (undefined|function(number):number)
+ * }}
+ */
+export var OverlayPanOptions;
+
+/**
+ * @param {OverlayPanOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration The duration of the animation in milliseconds. Default is `1000`.
+ *
+ * @param {undefined|function(number):number} options.easing The easing function to use. Can be an {@link ol.easing} or a custom function.
+ * Default is {@link ol.easing.inAndOut}.
+ *
+ */
+
+
+/**
+ * Object literal with config options for the projection.
+ * @typedef {{code: string,
+ *     units: (ol.proj.Units|string|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     axisOrientation: (string|undefined),
+ *     global: (boolean|undefined),
+ *     metersPerUnit: (number|undefined),
+ *     worldExtent: (ol.Extent|undefined),
+ *     getPointResolution: (function(number, ol.Coordinate):number|undefined) }}
+ */
+export var ProjectionOptions;
+
+/**
+ * @param {ProjectionOptions} options TODO: repace this
+ *
+ * @param {string} options.code The SRS identifier code, e.g. `EPSG:4326`.
+ *
+ * @param {ol.proj.Units|string|undefined} options.units Units. Required unless a proj4 projection is defined for `code`.
+ *
+ * @param {ol.Extent|undefined} options.extent The validity extent for the SRS.
+ *
+ * @param {string|undefined} options.axisOrientation The axis orientation as specified in Proj4. The default is `enu`.
+ *
+ * @param {boolean|undefined} options.global Whether the projection is valid for the whole globe. Default is `false`.
+ *
+ * @param {number|undefined} options.metersPerUnit The meters per unit for the SRS. If not provided, the `units` are used to get
+ * the meters per unit from the {@link ol.proj.METERS_PER_UNIT} lookup table.
+ *
+ * @param {ol.Extent|undefined} options.worldExtent The world extent for the SRS.
+ *
+ * @param {(function(number, ol.Coordinate):number|undefined)} options.getPointResolution Function to determine resolution at a point. The function is called with a
+ * `{number}` view resolution and an `{ol.Coordinate}` as arguments, and returns
+ * the `{number}` resolution at the passed coordinate. If this is `undefined`,
+ * the default {@link ol.proj#getPointResolution} function will be used.
+ *
+ */
+
+
+/**
+ * Object literal with config options for the view.
+ * @typedef {{center: (ol.Coordinate|undefined),
+ *     constrainRotation: (boolean|number|undefined),
+ *     enableRotation: (boolean|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     minZoom: (number|undefined),
+ *     maxZoom: (number|undefined),
+ *     projection: ol.ProjectionLike,
+ *     resolution: (number|undefined),
+ *     resolutions: (Array.<number>|undefined),
+ *     rotation: (number|undefined),
+ *     zoom: (number|undefined),
+ *     zoomFactor: (number|undefined)}}
+ */
+export var ViewOptions;
+
+/**
+ * @param {ViewOptions} options TODO: repace this
+ *
+ * @param {ol.Coordinate|undefined} options.center The initial center for the view. The coordinate system for the center is
+ * specified with the `projection` option. Default is `undefined`, and layer
+ * sources will not be fetched if this is not set.
+ *
+ * @param {boolean|number|undefined} options.constrainRotation Rotation constraint. `false` means no constraint. `true` means no constraint,
+ * but snap to zero near zero. A number constrains the rotation to that number
+ * of values. For example, `4` will constrain the rotation to 0, 90, 180, and
+ * 270 degrees. The default is `true`.
+ *
+ * @param {boolean|undefined} options.enableRotation Enable rotation. Default is `true`. If `false` a rotation constraint that
+ * always sets the rotation to zero is used. The `constrainRotation` option
+ * has no effect if `enableRotation` is `false`.
+ *
+ * @param {ol.Extent|undefined} options.extent The extent that constrains the center, in other words, center cannot be set
+ * outside this extent. Default is `undefined`.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution used to determine the resolution constraint. It is
+ * used together with `minResolution` (or `maxZoom`) and `zoomFactor`. If
+ * unspecified it is calculated in such a way that the projection's validity
+ * extent fits in a 256x256 px tile. If the projection is Spherical Mercator
+ * (the default) then `maxResolution` defaults to `40075016.68557849 / 256 =
+ * 156543.03392804097`.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution used to determine the resolution constraint.  It is
+ * used together with `maxResolution` (or `minZoom`) and `zoomFactor`.  If
+ * unspecified it is calculated assuming 29 zoom levels (with a factor of 2).
+ * If the projection is Spherical Mercator (the default) then `minResolution`
+ * defaults to `40075016.68557849 / 256 / Math.pow(2, 28) =
+ * 0.0005831682455839253`.
+ *
+ * @param {number|undefined} options.maxZoom The maximum zoom level used to determine the resolution constraint. It is
+ * used together with `minZoom` (or `maxResolution`) and `zoomFactor`. Default
+ * is `28`.  Note that if `minResolution` is also provided, it is given
+ * precedence over `maxZoom`.
+ *
+ * @param {number|undefined} options.minZoom The minimum zoom level used to determine the resolution constraint. It is
+ * used together with `maxZoom` (or `minResolution`) and `zoomFactor`. Default
+ * is `0`. Note that if `maxResolution` is also provided, it is given
+ * precedence over `minZoom`.
+ *
+ * @param {ol.ProjectionLike} options.projection The projection. Default is `EPSG:3857` (Spherical Mercator).
+ *
+ * @param {number|undefined} options.resolution The initial resolution for the view. The units are `projection` units per
+ * pixel (e.g. meters per pixel). An alternative to setting this is to set
+ * `zoom`. Default is `undefined`, and layer sources will not be fetched if
+ * neither this nor `zoom` are defined.
+ *
+ * @param {Array.<number>|undefined} options.resolutions Resolutions to determine the resolution constraint. If set the
+ * `maxResolution`, `minResolution`, `minZoom`, `maxZoom`, and `zoomFactor`
+ * options are ignored.
+ *
+ * @param {number|undefined} options.rotation The initial rotation for the view in radians (positive rotation clockwise).
+ * Default is `0`.
+ *
+ * @param {number|undefined} options.zoom Only used if `resolution` is not defined. Zoom level used to calculate the
+ * initial resolution for the view. The initial resolution is determined using
+ * the `ol.View#constrainResolution` method.
+ *
+ * @param {number|undefined} options.zoomFactor The zoom factor used to determine the resolution constraint.  Default is `2`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *   center: (ol.Coordinate|undefined),
+ *   zoom: (number|undefined),
+ *   resolution: (number|undefined),
+ *   rotation: (number|undefined),
+ *   anchor: (ol.Coordinate|undefined),
+ *   duration: (number|undefined),
+ *   easing: (undefined|function(number):number)
+ * }}
+ */
+export var AnimationOptions;
+
+/**
+ * @param {AnimationOptions} options TODO: repace this
+ *
+ * @param {ol.Coordinate|undefined} options.center The center of the view at the end of the animation.
+ *
+ * @param {number|undefined} options.zoom The zoom level of the view at the end of the animation.  This takes
+ * precedence over `resolution`.
+ *
+ * @param {number|undefined} options.resolution The resolution of the view at the end of the animation.  If `zoom` is also
+ * provided, this option will be ignored.
+ *
+ * @param {number|undefined} options.rotation The rotation of the view at the end of the animation.
+ *
+ * @param {ol.Coordinate|undefined} options.anchor Optional anchor to remained fixed during a rotation or resolution animation.
+ *
+ * @param {number|undefined} options.duration The duration of the animation in milliseconds (defaults to `1000`).
+ *
+ * @param {undefined|function(number):number} options.easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
+ * The function will be called for each frame with a number representing a
+ * fraction of the animation's duration.  The function should return a number
+ * between 0 and 1 representing the progress toward the destination state.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     collapsible: (boolean|undefined),
+ *     collapsed: (boolean|undefined),
+ *     tipLabel: (string|undefined),
+ *     label: (string|Node|undefined),
+ *     collapseLabel: (string|Node|undefined),
+ *     render: (function(ol.MapEvent)|undefined),
+ *     target: (Element|string|undefined)}}
+ */
+export var control_AttributionOptions;
+
+/**
+ * @param {control_AttributionOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name. Default is `ol-attribution`.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ * @param {boolean|undefined} options.collapsible Specify if attributions can be collapsed. If you use an OSM source,
+ * should be set to `false` — see
+ * {@link https://www.openstreetmap.org/copyright OSM Copyright} —
+ * Default is `true`.
+ *
+ * @param {boolean|undefined} options.collapsed Specify if attributions should be collapsed at startup. Default is `true`.
+ *
+ * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Attributions`
+ *
+ * @param {string|Node|undefined} options.label Text label to use for the collapsed attributions button. Default is `i`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|Node|undefined} options.collapseLabel Text label to use for the expanded attributions button. Default is `»`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ */
+
+
+/**
+ * @typedef {{element: (Element|undefined),
+ *     render: (function(ol.MapEvent)|undefined),
+ *     target: (Element|string|undefined)}}
+ */
+export var control_ControlOptions;
+
+/**
+ * @param {control_ControlOptions} options TODO: repace this
+ *
+ * @param {Element|undefined} options.element The element is the control's container element. This only needs to be
+ * specified if you're developing a custom control.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ */
+
+
+/**
+ * @typedef {{attribution: (boolean|undefined),
+ *     attributionOptions: (olx.control.AttributionOptions|undefined),
+ *     rotate: (boolean|undefined),
+ *     rotateOptions: (olx.control.RotateOptions|undefined),
+ *     zoom: (boolean|undefined),
+ *     zoomOptions: (olx.control.ZoomOptions|undefined)}}
+ */
+export var control_DefaultsOptions;
+
+/**
+ * @param {control_DefaultsOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.attribution Attribution. Default is `true`.
+ *
+ * @param {olx.control.AttributionOptions|undefined} options.attributionOptions Attribution options.
+ *
+ * @param {boolean|undefined} options.rotate Rotate. Default is `true`.
+ *
+ * @param {olx.control.RotateOptions|undefined} options.rotateOptions Rotate options.
+ *
+ * @param {boolean|undefined} options.zoom Zoom. Default is `true`.
+ *
+ * @param {olx.control.ZoomOptions|undefined} options.zoomOptions Zoom options.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     label: (string|Node|undefined),
+ *     labelActive: (string|Node|undefined),
+ *     tipLabel: (string|undefined),
+ *     keys: (boolean|undefined),
+ *     target: (Element|string|undefined),
+ *     source: (Element|string|undefined)}}
+ */
+export var control_FullScreenOptions;
+
+/**
+ * @param {control_FullScreenOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name. Default is `ol-full-screen`.
+ *
+ * @param {string|Node|undefined} options.label Text label to use for the button. Default is `\u2922` (NORTH EAST AND SOUTH WEST ARROW).
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|Node|undefined} options.labelActive Text label to use for the button when full-screen is active.
+ * Default is `\u00d7` (a cross).
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Toggle full-screen`
+ *
+ * @param {boolean|undefined} options.keys Full keyboard access.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ * @param {Element|string|undefined} options.source The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     coordinateFormat: (ol.CoordinateFormatType|undefined),
+ *     projection: ol.ProjectionLike,
+ *     render: (function(ol.MapEvent)|undefined),
+ *     target: (Element|string|undefined),
+ *     undefinedHTML: (string|undefined)}}
+ */
+export var control_MousePositionOptions;
+
+/**
+ * @param {control_MousePositionOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name. Default is `ol-mouse-position`.
+ *
+ * @param {ol.CoordinateFormatType|undefined} options.coordinateFormat Coordinate format.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ * @param {string|undefined} options.undefinedHTML Markup for undefined coordinates. Default is `` (empty string).
+ *
+ */
+
+
+/**
+ * @typedef {{collapsed: (boolean|undefined),
+ *     collapseLabel: (string|Node|undefined),
+ *     collapsible: (boolean|undefined),
+ *     label: (string|Node|undefined),
+ *     layers: (Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined),
+ *     render: (function(ol.MapEvent)|undefined),
+ *     target: (Element|string|undefined),
+ *     tipLabel: (string|undefined),
+ *     view: (ol.View|undefined)}}
+ */
+export var control_OverviewMapOptions;
+
+/**
+ * @param {control_OverviewMapOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.collapsed Whether the control should start collapsed or not (expanded).
+ * Default to `true`.
+ *
+ * @param {string|Node|undefined} options.collapseLabel Text label to use for the expanded overviewmap button. Default is `«`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {boolean|undefined} options.collapsible Whether the control can be collapsed or not. Default to `true`.
+ *
+ * @param {string|Node|undefined} options.label Text label to use for the collapsed overviewmap button. Default is `»`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined} options.layers Layers for the overview map. If not set, then all main map layers are used
+ * instead.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Overview map`
+ *
+ * @param {ol.View|undefined} options.view Custom view for the overview map. If not provided, a default view with
+ * an EPSG:3857 projection will be used.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     minWidth: (number|undefined),
+ *     render: (function(ol.MapEvent)|undefined),
+ *     target: (Element|string|undefined),
+ *     units: (ol.control.ScaleLineUnits|string|undefined)}}
+ */
+export var control_ScaleLineOptions;
+
+/**
+ * @param {control_ScaleLineOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS Class name. Default is `ol-scale-line`.
+ *
+ * @param {number|undefined} options.minWidth Minimum width in pixels. Default is `64`.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ * @param {ol.control.ScaleLineUnits|string|undefined} options.units Units. Default is `metric`.
+ *
+ */
+
+
+/**
+ * @typedef {{duration: (number|undefined),
+ *     className: (string|undefined),
+ *     label: (string|Element|undefined),
+ *     tipLabel: (string|undefined),
+ *     target: (Element|string|undefined),
+ *     render: (function(ol.MapEvent)|undefined),
+ *     resetNorth: (function()|undefined),
+ *     autoHide: (boolean|undefined)}}
+ */
+export var control_RotateOptions;
+
+/**
+ * @param {control_RotateOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name. Default is `ol-rotate`.
+ *
+ * @param {string|Element|undefined} options.label Text label to use for the rotate button. Default is `⇧`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|undefined} options.tipLabel Text label to use for the rotate tip. Default is `Reset rotation`
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
+ *
+ * @param {boolean|undefined} options.autoHide Hide the control when rotation is 0. Default is `true`.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ * @param {function()|undefined} options.resetNorth Function called when the control is clicked. This will override the
+ * default resetNorth.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ */
+
+
+/**
+ * @typedef {{duration: (number|undefined),
+ *     className: (string|undefined),
+ *     zoomInLabel: (string|Node|undefined),
+ *     zoomOutLabel: (string|Node|undefined),
+ *     zoomInTipLabel: (string|undefined),
+ *     zoomOutTipLabel: (string|undefined),
+ *     delta: (number|undefined),
+ *     target: (Element|string|undefined)}}
+ */
+export var control_ZoomOptions;
+
+/**
+ * @param {control_ZoomOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
+ *
+ * @param {string|undefined} options.className CSS class name. Default is `ol-zoom`.
+ *
+ * @param {string|Node|undefined} options.zoomInLabel Text label to use for the zoom-in button. Default is `+`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|Node|undefined} options.zoomOutLabel Text label to use for the zoom-out button. Default is `-`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|undefined} options.zoomInTipLabel Text label to use for the button tip. Default is `Zoom in`
+ *
+ * @param {string|undefined} options.zoomOutTipLabel Text label to use for the button tip. Default is `Zoom out`
+ *
+ * @param {number|undefined} options.delta The zoom delta applied on each click.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     duration: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     minResolution: (number|undefined),
+ *     render: (function(ol.MapEvent)|undefined)}}
+ */
+export var control_ZoomSliderOptions;
+
+/**
+ * @param {control_ZoomSliderOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name.
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `200`.
+ *
+ * @param {number|undefined} options.maxResolution Maximum resolution.
+ *
+ * @param {number|undefined} options.minResolution Minimum resolution.
+ *
+ * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * in a requestAnimationFrame callback.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     target: (Element|string|undefined),
+ *     label: (string|Node|undefined),
+ *     tipLabel: (string|undefined),
+ *     extent: (ol.Extent|undefined)}}
+ */
+export var control_ZoomToExtentOptions;
+
+/**
+ * @param {control_ZoomToExtentOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className Class name. Default is `ol-zoom-extent`.
+ *
+ * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * viewport.
+ *
+ * @param {string|Node|undefined} options.label Text label to use for the button. Default is `E`.
+ * Instead of text, also a Node (e.g. a `span` element) can be used.
+ *
+ * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Zoom to extent`
+ *
+ * @param {ol.Extent|undefined} options.extent The extent to zoom to. If undefined the validity extent of the view
+ * projection is used.
+ *
+ */
+
+
+/**
+ * @typedef {{dataProjection: ol.ProjectionLike,
+ *     extent: (ol.Extent|undefined),
+ *     featureProjection: ol.ProjectionLike,
+ *     rightHanded: (boolean|undefined)}}
+ */
+export var format_ReadOptions;
+
+/**
+ * @param {format_ReadOptions} options TODO: repace this
+ *
+ * @param {ol.ProjectionLike} options.dataProjection Projection of the data we are reading. If not provided, the projection will
+ * be derived from the data (where possible) or the `defaultDataProjection` of
+ * the format is assigned (where set). If the projection can not be derived from
+ * the data and if no `defaultDataProjection` is set for a format, the features
+ * will not be reprojected.
+ *
+ * @param {ol.Extent} options.extent Tile extent of the tile being read. This is only used and required for
+ * {@link ol.format.MVT}.
+ *
+ * @param {ol.ProjectionLike} options.featureProjection Projection of the feature geometries created by the format reader. If not
+ * provided, features will be returned in the `dataProjection`.
+ *
+ */
+
+
+/**
+ * @typedef {{dataProjection: ol.ProjectionLike,
+ *     featureProjection: ol.ProjectionLike,
+ *     rightHanded: (boolean|undefined),
+ *     decimals: (number|undefined)}}
+ */
+export var format_WriteOptions;
+
+/**
+ * @param {format_WriteOptions} options TODO: repace this
+ *
+ * @param {ol.ProjectionLike} options.dataProjection Projection of the data we are writing. If not provided, the
+ * `defaultDataProjection` of the format is assigned (where set). If no
+ * `defaultDataProjection` is set for a format, the features will be returned
+ * in the `featureProjection`.
+ *
+ * @param {ol.ProjectionLike} options.featureProjection Projection of the feature geometries that will be serialized by the format
+ * writer. If not provided, geometries are assumed to be in the
+ * `dataProjection` if that is set; in other words, they are not transformed.
+ *
+ * @param {boolean|undefined} options.rightHanded When writing geometries, follow the right-hand rule for linear ring
+ * orientation.  This means that polygons will have counter-clockwise exterior
+ * rings and clockwise interior rings.  By default, coordinates are serialized
+ * as they are provided at construction.  If `true`, the right-hand rule will
+ * be applied.  If `false`, the left-hand rule will be applied (clockwise for
+ * exterior and counter-clockwise for interior rings).  Note that not all
+ * formats support this.  The GeoJSON format does use this property when writing
+ * geometries.
+ *
+ *
+ * @param {number|undefined} options.decimals Maximum number of decimal places for coordinates. Coordinates are stored
+ * internally as floats, but floating-point arithmetic can create coordinates
+ * with a large number of decimal places, not generally wanted on output.
+ * Set a number here to round coordinates. Can also be used to ensure that
+ * coordinates read in can be written back out with the same number of decimals.
+ * Default is no rounding.
+ *
+ *
+ */
+
+
+/**
+ * @typedef {{defaultDataProjection: ol.ProjectionLike,
+ *     geometryName: (string|undefined),
+ *     extractGeometryName: (boolean|undefined),
+ *     featureProjection: ol.ProjectionLike}}
+ */
+export var format_GeoJSONOptions;
+
+/**
+ * @param {format_GeoJSONOptions} options TODO: repace this
+ *
+ * @param {ol.ProjectionLike} options.defaultDataProjection Default data projection. Default is `EPSG:4326`.
+ *
+ * @param {ol.ProjectionLike} options.featureProjection Projection for features read or written by the format.  Options passed to
+ * read or write methods will take precedence.
+ *
+ * @param {string|undefined} options.geometryName Geometry name to use when creating features.
+ *
+ * @param {boolean|undefined} options.extractGeometryName Certain GeoJSON providers include the geometry_name field in the feature
+ * geoJSON. If set to `true` the geoJSON reader will look for that field to
+ * set the geometry name. If both this field is set to `true` and a
+ * `geometryName` is provided, the `geometryName` will take precedence.
+ * Default is `false`.
+ *
+ */
+
+
+/**
+ * @typedef {{geometryName: (string|undefined)}}
+ */
+export var format_EsriJSONOptions;
+
+/**
+ * @param {format_EsriJSONOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.geometryName Geometry name to use when creating features.
+ *
+ */
+
+
+/**
+ * @typedef {{featureClass: (function((ol.geom.Geometry|Object.<string, *>)=)|
+ *         function(ol.geom.GeometryType,Array.<number>,
+ *             (Array.<number>|Array.<Array.<number>>),Object.<string, *>)|
+ *         undefined),
+ *     geometryName: (string|undefined),
+ *     layers: (Array.<string>|undefined),
+ *     layerName: (string|undefined)}}
+ */
+export var format_MVTOptions;
+
+/**
+ * @param {format_MVTOptions} options TODO: repace this
+ *
+ * @param {undefined|function((ol.geom.Geometry|Object.<string,*>)=)|    function(ol.geom.GeometryType,Array.<number>,
+        (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
+ options.featureClass Class for features returned by {@link ol.format.MVT#readFeatures}. Set to
+ * {@link ol.Feature} to get full editing and geometry support at the cost of
+ * decreased rendering performance. The default is {@link ol.render.Feature},
+ * which is optimized for rendering and hit detection.
+ *
+ * @param {string|undefined} options.geometryName Geometry name to use when creating features. Default is 'geometry'.
+ *
+ * @param {string|undefined} options.layerName Name of the feature attribute that holds the layer name. Default is 'layer'.
+ *
+ * @param {Array.<string>|undefined} options.layers Layers to read features from. If not provided, features will be read from all
+ * layers.
+ *
+ */
+
+
+/**
+ * @typedef {{factor: (number|undefined),
+ *     geometryLayout: (ol.geom.GeometryLayout|undefined)}}
+ */
+export var format_PolylineOptions;
+
+/**
+ * @param {format_PolylineOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.factor The factor by which the coordinates values will be scaled.
+ * Default is `1e5`.
+ *
+ * @param {ol.geom.GeometryLayout|undefined} options.geometryLayout Layout of the feature geometries created by the format reader.
+ * Default is `ol.geom.GeometryLayout.XY`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     defaultDataProjection: ol.ProjectionLike,
+ *     layerName: (string|undefined),
+ *     layers: (Array.<string>|undefined)
+ * }}
+ */
+export var format_TopoJSONOptions;
+
+/**
+ * @param {format_TopoJSONOptions} options TODO: repace this
+ *
+ * @param {ol.ProjectionLike} options.defaultDataProjection Default data projection. Default is `EPSG:4326`.
+ *
+ * @param {string|undefined} options.layerName Set the name of the TopoJSON topology `objects`'s children as feature
+ * property with the specified name. This means that when set to `'layer'`, a
+ * topology like
+ * ```
+ * {
+ *   "type": "Topology",
+ *   "objects": {
+ *     "example": {
+ *       "type": "GeometryCollection",
+ *       "geometries": []
+ *     }
+ *   }
+ * }
+ * ```
+ * will result in features that have a property `'layer'` set to `'example'`.
+ * When not set, no property will be added to features.
+ *
+ * @param {Array.<string>|undefined} options.layers Names of the TopoJSON topology's `objects`'s children to read features from.
+ * If not provided, features will be read from all children.
+ *
+ */
+
+
+/**
+ * @typedef {{altitudeMode: (ol.format.IGCZ|undefined)}}
+ */
+export var format_IGCOptions;
+
+/**
+ * @param {format_IGCOptions} options TODO: repace this
+ *
+ * @param {ol.format.IGCZ|undefined} options.altitudeMode Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
+ * is `none`.
+ *
+ */
+
+
+/**
+ * @typedef {{extractStyles: (boolean|undefined),
+ *     defaultStyle: (Array.<ol.style.Style>|undefined),
+ *     showPointNames: (boolean|undefined),
+ *     writeStyles: (boolean|undefined)}}
+ */
+export var format_KMLOptions;
+
+/**
+ * @param {format_KMLOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.extractStyles Extract styles from the KML. Default is `true`.
+ *
+ * @param {boolean|undefined} options.showPointNames Show names as labels for placemarks which contain points. Default is `true`.
+ *
+ * @param {Array.<ol.style.Style>|undefined} options.defaultStyle Default style. The default default style is the same as Google Earth.
+ *
+ * @param {boolean|undefined} options.writeStyles Write styles into KML. Default is `true`.
+ *
+ */
+
+
+/**
+ * @typedef {{featureNS: (Object.<string, string>|string|undefined),
+ *     featureType: (Array.<string>|string|undefined),
+ *     srsName: string,
+ *     surface: (boolean|undefined),
+ *     curve: (boolean|undefined),
+ *     multiCurve: (boolean|undefined),
+ *     multiSurface: (boolean|undefined),
+ *     schemaLocation: (string|undefined)}}
+ */
+export var format_GMLOptions;
+
+/**
+ * @param {format_GMLOptions} options TODO: repace this
+ *
+ * @param {Object.<string, string>|string|undefined} options.featureNS Feature namespace. If not defined will be derived from GML. If multiple
+ * feature types have been configured which come from different feature
+ * namespaces, this will be an object with the keys being the prefixes used
+ * in the entries of featureType array. The values of the object will be the
+ * feature namespaces themselves. So for instance there might be a featureType
+ * item `topp:states` in the `featureType` array and then there will be a key
+ * `topp` in the featureNS object with value `http://www.openplans.org/topp`.
+ *
+ * @param {Array.<string>|string|undefined} options.featureType Feature type(s) to parse. If multiple feature types need to be configured
+ * which come from different feature namespaces, `featureNS` will be an object
+ * with the keys being the prefixes used in the entries of featureType array.
+ * The values of the object will be the feature namespaces themselves.
+ * So for instance there might be a featureType item `topp:states` and then
+ * there will be a key named `topp` in the featureNS object with value
+ * `http://www.openplans.org/topp`.
+ *
+ * @param {string} options.srsName srsName to use when writing geometries.
+ *
+ * @param {boolean|undefined} options.surface Write gml:Surface instead of gml:Polygon elements. This also affects the
+ * elements in multi-part geometries. Default is `false`.
+ *
+ * @param {boolean|undefined} options.curve Write gml:Curve instead of gml:LineString elements. This also affects the
+ * elements in multi-part geometries. Default is `false`.
+ *
+ * @param {boolean|undefined} options.multiCurve Write gml:MultiCurve instead of gml:MultiLineString. Since the latter is
+ * deprecated in GML 3, the default is `true`.
+ *
+ * @param {boolean|undefined} options.multiSurface Write gml:multiSurface instead of gml:MultiPolygon. Since the latter is
+ * deprecated in GML 3, the default is `true`.
+ *
+ * @param {string|undefined} options.schemaLocation Optional schemaLocation to use when writing out the GML, this will override
+ * the default provided.
+ *
+ */
+
+
+/**
+ * @typedef {{readExtensions: (function(ol.Feature, Node)|undefined)}}
+ */
+export var format_GPXOptions;
+
+/**
+ * @param {format_GPXOptions} options TODO: repace this
+ *
+ * @param {function(ol.Feature, Node)|undefined} options.readExtensions Callback function to process `extensions` nodes.
+ * To prevent memory leaks, this callback function must
+ * not store any references to the node. Note that the `extensions`
+ * node is not allowed in GPX 1.0. Moreover, only `extensions`
+ * nodes from `wpt`, `rte` and `trk` can be processed, as those are
+ * directly mapped to a feature.
+ *
+ */
+
+
+/**
+ * @typedef {{featureNS: (Object.<string, string>|string|undefined),
+ *     featureType: (Array.<string>|string|undefined),
+ *     gmlFormat: (ol.format.GMLBase|undefined),
+ *     schemaLocation: (string|undefined)}}
+ */
+export var format_WFSOptions;
+
+/**
+ * @param {format_WFSOptions} options TODO: repace this
+ *
+ * @param {Object.<string, string>|string|undefined} options.featureNS The namespace URI used for features.
+ *
+ * @param {Array.<string>|string|undefined} options.featureType The feature type to parse. Only used for read operations.
+ *
+ * @param {ol.format.GMLBase|undefined} options.gmlFormat The GML format to use to parse the response. Default is `ol.format.GML3`.
+ *
+ * @param {string|undefined} options.schemaLocation Optional schemaLocation to use for serialization, this will override the
+ * default.
+ *
+ */
+
+
+/**
+ * @typedef {{featureNS: string,
+ *     featurePrefix: string,
+ *     featureTypes: Array.<string>,
+ *     srsName: (string|undefined),
+ *     handle: (string|undefined),
+ *     outputFormat: (string|undefined),
+ *     maxFeatures: (number|undefined),
+ *     geometryName: (string|undefined),
+ *     propertyNames: (Array.<string>|undefined),
+ *     startIndex: (number|undefined),
+ *     count: (number|undefined),
+ *     bbox: (ol.Extent|undefined),
+ *     filter: (ol.format.filter.Filter|undefined),
+ *     resultType: (string|undefined)}}
+ */
+export var format_WFSWriteGetFeatureOptions;
+
+/**
+ * @param {format_WFSWriteGetFeatureOptions} options TODO: repace this
+ *
+ * @param {string} options.featureNS The namespace URI used for features.
+ *
+ * @param {string} options.featurePrefix The prefix for the feature namespace.
+ *
+ * @param {Array.<string>} options.featureTypes The feature type names.
+ *
+ * @param {string|undefined} options.srsName SRS name. No srsName attribute will be set on geometries when this is not
+ * provided.
+ *
+ * @param {string|undefined} options.handle Handle.
+ *
+ * @param {string|undefined} options.outputFormat Output format.
+ *
+ * @param {number|undefined} options.maxFeatures Maximum number of features to fetch.
+ *
+ * @param {string|undefined} options.geometryName Geometry name to use in a BBOX filter.
+ *
+ * @param {Array.<string>|undefined} options.propertyNames Optional list of property names to serialize.
+ *
+ * @param {number|undefined} options.startIndex Start index to use for WFS paging. This is a WFS 2.0 feature backported to
+ * WFS 1.1.0 by some Web Feature Services.
+ *
+ * @param {number|undefined} options.count Number of features to retrieve when paging. This is a WFS 2.0 feature
+ * backported to WFS 1.1.0 by some Web Feature Services. Please note that some
+ * Web Feature Services have repurposed `maxfeatures` instead.
+ *
+ * @param {ol.Extent|undefined} options.bbox Extent to use for the BBOX filter.
+ *
+ * @param {ol.format.filter.Filter|undefined} options.filter Filter condition. See {@link ol.format.filter} for more information.
+ *
+ * @param {string|undefined} options.resultType Indicates what response should be returned, E.g. `hits` only includes the
+ * `numberOfFeatures` attribute in the response and no features.
+ *
+ */
+
+
+/**
+ * @typedef {{featureNS: string,
+ *     featurePrefix: string,
+ *     featureType: string,
+ *     srsName: (string|undefined),
+ *     handle: (string|undefined),
+ *     hasZ: (boolean|undefined),
+ *     nativeElements: Array.<Object>,
+ *     gmlOptions: (olx.format.GMLOptions|undefined),
+ *     version: (string|undefined)}}
+ */
+export var format_WFSWriteTransactionOptions;
+
+/**
+ * @param {format_WFSWriteTransactionOptions} options TODO: repace this
+ *
+ * @param {string} options.featureNS The namespace URI used for features.
+ *
+ * @param {string} options.featurePrefix The prefix for the feature namespace.
+ *
+ * @param {string} options.featureType The feature type name.
+ *
+ * @param {string|undefined} options.srsName SRS name. No srsName attribute will be set on geometries when this is not
+ * provided.
+ *
+ * @param {string|undefined} options.handle Handle.
+ *
+ * @param {boolean|undefined} options.hasZ Must be set to true if the transaction is for a 3D layer. This will allow
+ * the Z coordinate to be included in the transaction.
+ *
+ * @param {Array.<Object>} options.nativeElements Native elements. Currently not supported.
+ *
+ * @param {olx.format.GMLOptions|undefined} options.gmlOptions GML options for the WFS transaction writer.
+ *
+ * @param {string|undefined} options.version WFS version to use for the transaction. Can be either `1.0.0` or `1.1.0`.
+ * Default is `1.1.0`.
+ *
+ */
+
+
+/**
+ * @typedef {{splitCollection: (boolean|undefined)}}
+ */
+export var format_WKTOptions;
+
+/**
+ * @param {format_WKTOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.splitCollection Whether to split GeometryCollections into
+ * multiple features on reading. Default is `false`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     layers: (Array.<string>|undefined)
+ * }}
+ */
+export var format_WMSGetFeatureInfoOptions;
+
+/**
+ * @param {format_WMSGetFeatureInfoOptions} options TODO: repace this
+ *
+ * @param {Array.<string>|undefined} options.layers If set, only features of the given layers will be returned by the format
+ * when read.
+ *
+ */
+
+
+/**
+ * Interactions for the map. Default is `true` for all options.
+ * @typedef {{
+ *     altShiftDragRotate: (boolean|undefined),
+ *     constrainResolution: (boolean|undefined),
+ *     doubleClickZoom: (boolean|undefined),
+ *     keyboard: (boolean|undefined),
+ *     mouseWheelZoom: (boolean|undefined),
+ *     shiftDragZoom: (boolean|undefined),
+ *     dragPan: (boolean|undefined),
+ *     pinchRotate: (boolean|undefined),
+ *     pinchZoom: (boolean|undefined),
+ *     zoomDelta: (number|undefined),
+ *     zoomDuration: (number|undefined)
+ * }}
+ */
+export var interaction_DefaultsOptions;
+
+/**
+ * @param {interaction_DefaultsOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.altShiftDragRotate Whether Alt-Shift-drag rotate is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.constrainResolution Zoom to the closest integer zoom level after the wheel/trackpad or
+ * pinch gesture ends. Default is `false`.
+ *
+ * @param {boolean|undefined} options.doubleClickZoom Whether double click zoom is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.keyboard Whether keyboard interaction is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.mouseWheelZoom Whether mousewheel zoom is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.shiftDragZoom Whether Shift-drag zoom is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.dragPan Whether drag pan is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.pinchRotate Whether pinch rotate is desired. Default is `true`.
+ *
+ * @param {boolean|undefined} options.pinchZoom Whether pinch zoom is desired. Default is `true`.
+ *
+ * @param {number|undefined} options.zoomDelta Zoom delta.
+ *
+ * @param {number|undefined} options.zoomDuration Zoom duration.
+ *
+ */
+
+
+/**
+ * @typedef {{duration: (number|undefined),
+ *     delta: (number|undefined)}}
+ */
+export var interaction_DoubleClickZoomOptions;
+
+/**
+ * @param {interaction_DoubleClickZoomOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
+ *
+ * @param {number|undefined} options.delta The zoom delta applied on each double click, default is `1`.
+ *
+ */
+
+
+/**
+ * @typedef {{formatConstructors: (Array.<function(new: ol.format.Feature)>|undefined),
+ *     source: (ol.source.Vector|undefined),
+ *     projection: ol.ProjectionLike,
+ *     target: (Element|undefined)}}
+ */
+export var interaction_DragAndDropOptions;
+
+/**
+ * @param {interaction_DragAndDropOptions} options TODO: repace this
+ *
+ * @param {Array.<function(new: ol.format.Feature)>|undefined} options.formatConstructors Format constructors.
+ *
+ * @param {ol.source.Vector|undefined} options.source Optional vector source where features will be added.  If a source is provided
+ * all existing features will be removed and new features will be added when
+ * they are dropped on the target.  If you want to add features to a vector
+ * source without removing the existing features (append only), instead of
+ * providing the source option listen for the "addfeatures" event.
+ *
+ * @param {ol.ProjectionLike} options.projection Target projection. By default, the map's view's projection is used.
+ *
+ * @param {Element|undefined} options.target The element that is used as the drop target, default is the viewport element.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
+ *     minArea: (number|undefined),
+ *     boxEndCondition: (ol.DragBoxEndConditionType|undefined)}}
+ */
+export var interaction_DragBoxOptions;
+
+/**
+ * @param {interaction_DragBoxOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name for styling the box. The default is `ol-dragbox`.
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.always}.
+ *
+ * @param {number|undefined} options.minArea The minimum area of the box in pixel, this value is used by the default
+ * `boxEndCondition` function. Default is `64`.
+ *
+ * @param {ol.DragBoxEndConditionType|undefined} options.boxEndCondition A function that takes a {@link ol.MapBrowserEvent} and two
+ * {@link ol.Pixel}s to indicate whether a `boxend` event should be fired.
+ * Default is `true` if the area of the box is bigger than the `minArea` option.
+ *
+ */
+
+
+/**
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
+ *     kinetic: (ol.Kinetic|undefined)}}
+ */
+export var interaction_DragPanOptions;
+
+/**
+ * @param {interaction_DragPanOptions} options TODO: repace this
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.noModifierKeys}.
+ *
+ * @param {ol.Kinetic|undefined} options.kinetic Kinetic inertia to apply to the pan.
+ *
+ */
+
+
+/**
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
+ *     duration: (number|undefined)}}
+ */
+export var interaction_DragRotateAndZoomOptions;
+
+/**
+ * @param {interaction_DragRotateAndZoomOptions} options TODO: repace this
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.shiftKeyOnly}.
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `400`.
+ *
+ */
+
+
+/**
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
+ *     duration: (number|undefined)}}
+ */
+export var interaction_DragRotateOptions;
+
+/**
+ * @param {interaction_DragRotateOptions} options TODO: repace this
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.altShiftKeysOnly}.
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
+ *
+ */
+
+
+/**
+ * @typedef {{className: (string|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
+ *     duration: (number|undefined),
+ *     out: (boolean|undefined)}}
+ */
+export var interaction_DragZoomOptions;
+
+/**
+ * @param {interaction_DragZoomOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.className CSS class name for styling the box. The default is `ol-dragzoom`.
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.shiftKeyOnly}.
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `200`.
+ *
+ * @param {boolean|undefined} options.out Use interaction for zooming out. Default is `false`.
+ *
+ */
+
+
+/**
+ * @typedef {{clickTolerance: (number|undefined),
+ *     features: (ol.Collection.<ol.Feature>|undefined),
+ *     source: (ol.source.Vector|undefined),
+ *     snapTolerance: (number|undefined),
+ *     type: (ol.geom.GeometryType|string),
+ *     stopClick: (boolean|undefined),
+ *     maxPoints: (number|undefined),
+ *     minPoints: (number|undefined),
+ *     finishCondition: (ol.EventsConditionType|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     geometryFunction: (ol.DrawGeometryFunctionType|undefined),
+ *     geometryName: (string|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
+ *     freehand: (boolean|undefined),
+ *     freehandCondition: (ol.EventsConditionType|undefined),
+ *     wrapX: (boolean|undefined)}}
+ */
+export var interaction_DrawOptions;
+
+/**
+ * @param {interaction_DrawOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.clickTolerance The maximum distance in pixels between "down" and "up" for a "up" event
+ * to be considered a "click" event and actually add a point/vertex to the
+ * geometry being drawn.  Default is 6 pixels.  That value was chosen for
+ * the draw interaction to behave correctly on mouse as well as on touch
+ * devices.
+ *
+ * @param {ol.Collection.<ol.Feature>|undefined} options.features Destination collection for the drawn features.
+ *
+ * @param {ol.source.Vector|undefined} options.source Destination source for the drawn features.
+ *
+ * @param {number|undefined} options.snapTolerance Pixel distance for snapping to the drawing finish. Default is `12`.
+ *
+ * @param {ol.geom.GeometryType|string} options.type Drawing type ('Point', 'LineString', 'Polygon', 'MultiPoint',
+ * 'MultiLineString', 'MultiPolygon' or 'Circle').
+ *
+ * @param {boolean|undefined} options.stopClick Stop click, singleclick, and doubleclick events from firing during drawing.
+ * Default is `false`.
+ *
+ * @param {number|undefined} options.maxPoints The number of points that can be drawn before a polygon ring or line string
+ * is finished. The default is no restriction.
+ *
+ * @param {number|undefined} options.minPoints The number of points that must be drawn before a polygon ring or line string
+ * can be finished. Default is `3` for polygon rings and `2` for line strings.
+ *
+ * @param {ol.EventsConditionType|undefined} options.finishCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether the drawing can be finished.
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style for sketch features.
+ *
+ * @param {ol.DrawGeometryFunctionType|undefined} options.geometryFunction Function that is called when a geometry's coordinates are updated.
+ *
+ * @param {string|undefined} options.geometryName Geometry name to use for features created by the draw interaction.
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * By default {@link ol.events.condition.noModifierKeys}, i.e. a click, adds a
+ * vertex or deactivates freehand drawing.
+ *
+ * @param {boolean|undefined} options.freehand Operate in freehand mode for lines, polygons, and circles.  This makes the
+ * interaction always operate in freehand mode and takes precedence over any
+ * `freehandCondition` option.
+ *
+ * @param {ol.EventsConditionType|undefined} options.freehandCondition Condition that activates freehand drawing for lines and polygons. This
+ * function takes an {@link ol.MapBrowserEvent} and returns a boolean to
+ * indicate whether that event should be handled. The default is
+ * {@link ol.events.condition.shiftKeyOnly}, meaning that the Shift key
+ * activates freehand drawing.
+ *
+ * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
+ *
+ */
+
+
+/**
+ * @typedef {{extent: (ol.Extent|undefined),
+ *     boxStyle: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     pixelTolerance: (number|undefined),
+ *     pointerStyle: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     wrapX: (boolean|undefined)}}
+ * @api
+ */
+export var interaction_ExtentOptions;
+
+/**
+ * @param {interaction_ExtentOptions} options TODO: repace this
+ *
+ * @param {ol.Extent|undefined} options.extent Initial extent. Defaults to no initial extent
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.boxStyle Style for the drawn extent box.
+ * Defaults to ol.style.Style.createDefaultEditing()[ol.geom.GeometryType.POLYGON]
+ *
+ * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
+ * vertex for editing. Default is `10`.
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.pointerStyle Style for the cursor used to draw the extent.
+ * Defaults to ol.style.Style.createDefaultEditing()[ol.geom.GeometryType.POINT]
+ *
+ * @param {boolean|undefined} options.wrapX Wrap the drawn extent across multiple maps in the X direction?
+ * Only affects visuals, not functionality. Defaults to false.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     features: (ol.Collection.<ol.Feature>|undefined),
+ *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
+ *     hitTolerance: (number|undefined)
+ * }}
+ */
+export var interaction_TranslateOptions;
+
+/**
+ * @param {interaction_TranslateOptions} options TODO: repace this
+ *
+ * @param {ol.Collection.<ol.Feature>|undefined} options.features Only features contained in this collection will be able to be translated. If
+ * not specified, all features on the map will be able to be translated.
+ *
+ * @param {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} options.layers A list of layers from which features should be
+ * translated. Alternatively, a filter function can be provided. The
+ * function will be called for each layer in the map and should return
+ * `true` for layers that you want to be translatable. If the option is
+ * absent, all visible layers will be considered translatable.
+ *
+ * @param {number|undefined} options.hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL. Default is `0`.
+ *
+ */
+
+
+/**
+ * @typedef {{condition: (ol.EventsConditionType|undefined),
+ *     duration: (number|undefined),
+ *     pixelDelta: (number|undefined)}}
+ */
+export var interaction_KeyboardPanOptions;
+
+/**
+ * @param {interaction_KeyboardPanOptions} options TODO: repace this
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.noModifierKeys} and
+ * {@link ol.events.condition.targetNotEditable}.
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `100`.
+ *
+ * @param {number|undefined} options.pixelDelta Pixel The amount to pan on each key press. Default is `128` pixels.
+ *
+ */
+
+
+/**
+ * @typedef {{duration: (number|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
+ *     delta: (number|undefined)}}
+ */
+export var interaction_KeyboardZoomOptions;
+
+/**
+ * @param {interaction_KeyboardZoomOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `100`.
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * Default is {@link ol.events.condition.targetNotEditable}.
+ *
+ * @param {number|undefined} options.delta The amount to zoom on each key press. Default is `1`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     condition: (ol.EventsConditionType|undefined),
+ *     deleteCondition: (ol.EventsConditionType|undefined),
+ *     insertVertexCondition: (ol.EventsConditionType|undefined),
+ *     pixelTolerance: (number|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     source: (ol.source.Vector|undefined),
+ *     features: (ol.Collection.<ol.Feature>|undefined),
+ *     wrapX: (boolean|undefined)
+ * }}
+ */
+export var interaction_ModifyOptions;
+
+/**
+ * @param {interaction_ModifyOptions} options TODO: repace this
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event will be considered to add or move a vertex
+ * to the sketch.
+ * Default is {@link ol.events.condition.primaryAction}.
+ *
+ * @param {ol.EventsConditionType|undefined} options.deleteCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * By default, {@link ol.events.condition.singleClick} with
+ * {@link ol.events.condition.altKeyOnly} results in a vertex deletion.
+ *
+ * @param {ol.EventsConditionType|undefined} options.insertVertexCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether a new vertex can be added to the sketch features.
+ * Default is {@link ol.events.condition.always}
+ *
+ * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
+ * vertex for editing. Default is `10`.
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style used for the features being modified. By default the default edit
+ * style is used (see {@link ol.style}).
+ *
+ * @param {ol.source.Vector|undefined} options.source The vector source with features to modify.  If a vector source is not
+ * provided, a feature collection must be provided with the features option.
+ *
+ * @param {ol.Collection.<ol.Feature>|undefined} options.features The features the interaction works on.  If a feature collection is not
+ * provided, a vector source must be provided with the source option.
+ *
+ * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
+ *
+ */
+
+
+/**
+ * @typedef {{constrainResolution: (boolean|undefined),
+ *     duration: (number|undefined),
+ *     timeout: (number|undefined),
+ *     useAnchor: (boolean|undefined)}}
+ */
+export var interaction_MouseWheelZoomOptions;
+
+/**
+ * @param {interaction_MouseWheelZoomOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
+ *
+ * @param {number|undefined} options.timeout Mouse wheel timeout duration in milliseconds. Default is `80`.
+ *
+ * @param {boolean|undefined} options.constrainResolution When using a trackpad or magic mouse, zoom to the closest integer zoom level
+ * after the scroll gesture ends.
+ * Default is `false`.
+ *
+ * @param {boolean|undefined} options.useAnchor Enable zooming using the mouse's location as the anchor. Default is `true`.
+ * When set to false, zooming in and out will zoom to the center of the screen
+ * instead of zooming on the mouse's location.
+ *
+ */
+
+
+/**
+ * @typedef {{threshold: (number|undefined),
+ *     duration: (number|undefined)}}
+ */
+export var interaction_PinchRotateOptions;
+
+/**
+ * @param {interaction_PinchRotateOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration The duration of the animation in milliseconds. Default is `250`.
+ *
+ * @param {number|undefined} options.threshold Minimal angle in radians to start a rotation. Default is `0.3`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     duration: (number|undefined),
+ *     constrainResolution: (boolean|undefined)
+ * }}
+ */
+export var interaction_PinchZoomOptions;
+
+/**
+ * @param {interaction_PinchZoomOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `400`.
+ *
+ * @param {boolean|undefined} options.constrainResolution Zoom to the closest integer zoom level after the pinch gesture ends. Default is `false`.
+ *
+ */
+
+
+/**
+ * @typedef {{handleDownEvent: (function(ol.MapBrowserPointerEvent):boolean|undefined),
+ *     handleDragEvent: (function(ol.MapBrowserPointerEvent)|undefined),
+ *     handleEvent: (function(ol.MapBrowserEvent):boolean|undefined),
+ *     handleMoveEvent: (function(ol.MapBrowserPointerEvent)|undefined),
+ *     handleUpEvent: (function(ol.MapBrowserPointerEvent):boolean|undefined)}}
+ */
+export var interaction_PointerOptions;
+
+/**
+ * @param {interaction_PointerOptions} options TODO: repace this
+ *
+ * @param {(function(ol.MapBrowserPointerEvent):boolean|undefined)} options.handleDownEvent Function handling "down" events. If the function returns `true` then a drag
+ * sequence is started.
+ *
+ * @param {(function(ol.MapBrowserPointerEvent)|undefined)} options.handleDragEvent Function handling "drag" events. This function is called on "move" events
+ * during a drag sequence.
+ *
+ * @param {(function(ol.MapBrowserEvent):boolean|undefined)} options.handleEvent Method called by the map to notify the interaction that a browser event was
+ * dispatched to the map. The function may return `false` to prevent the
+ * propagation of the event to other interactions in the map's interactions
+ * chain.
+ *
+ * @param {(function(ol.MapBrowserPointerEvent)|undefined)} options.handleMoveEvent Function handling "move" events. This function is called on "move" events,
+ * also during a drag sequence (so during a drag sequence both the
+ * `handleDragEvent` function and this function are called).
+ *
+ * @param {(function(ol.MapBrowserPointerEvent):boolean|undefined)} options.handleUpEvent Function handling "up" events. If the function returns `false` then the
+ * current drag sequence is stopped.
+ *
+ */
+
+
+/**
+ * @typedef {{addCondition: (ol.EventsConditionType|undefined),
+ *     condition: (ol.EventsConditionType|undefined),
+ *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     removeCondition: (ol.EventsConditionType|undefined),
+ *     toggleCondition: (ol.EventsConditionType|undefined),
+ *     multi: (boolean|undefined),
+ *     features: (ol.Collection.<ol.Feature>|undefined),
+ *     filter: (ol.SelectFilterFunction|undefined),
+ *     wrapX: (boolean|undefined),
+ *     hitTolerance: (number|undefined)}}
+ */
+export var interaction_SelectOptions;
+
+/**
+ * @param {interaction_SelectOptions} options TODO: repace this
+ *
+ * @param {ol.EventsConditionType|undefined} options.addCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * By default, this is {@link ol.events.condition.never}. Use this if you want
+ * to use different events for add and remove instead of `toggle`.
+ *
+ * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * This is the event for the selected features as a whole. By default, this is
+ * {@link ol.events.condition.singleClick}. Clicking on a feature selects that
+ * feature and removes any that were in the selection. Clicking outside any
+ * feature removes all from the selection.
+ * See `toggle`, `add`, `remove` options for adding/removing extra features to/
+ * from the selection.
+ *
+ * @param {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} options.layers A list of layers from which features should be
+ * selected. Alternatively, a filter function can be provided. The
+ * function will be called for each layer in the map and should return
+ * `true` for layers that you want to be selectable. If the option is
+ * absent, all visible layers will be considered selectable.
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style for the selected features. By default the default edit style is used
+ * (see {@link ol.style}).
+ *
+ * @param {ol.EventsConditionType|undefined} options.removeCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * By default, this is {@link ol.events.condition.never}. Use this if you want
+ * to use different events for add and remove instead of `toggle`.
+ *
+ * @param {ol.EventsConditionType|undefined} options.toggleCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled.
+ * This is in addition to the `condition` event. By default,
+ * {@link ol.events.condition.shiftKeyOnly}, i.e. pressing `shift` as well as
+ * the `condition` event, adds that feature to the current selection if it is
+ * not currently selected, and removes it if it is.
+ * See `add` and `remove` if you want to use different events instead of a
+ * toggle.
+ *
+ * @param {boolean|undefined} options.multi A boolean that determines if the default behaviour should select only
+ * single features or all (overlapping) features at the clicked map
+ * position. Default is false i.e single select
+ *
+ * @param {ol.Collection.<ol.Feature>|undefined} options.features Collection where the interaction will place selected features. Optional. If
+ * not set the interaction will create a collection. In any case the collection
+ * used by the interaction is returned by
+ * {@link ol.interaction.Select#getFeatures}.
+ *
+ * @param {ol.SelectFilterFunction|undefined} options.filter A function that takes an {@link ol.Feature} and an {@link ol.layer.Layer} and
+ * returns `true` if the feature may be selected or `false` otherwise.
+ *
+ * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the selection overlay. Default is `true`.
+ *
+ * @param {number|undefined} options.hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
+ * will be checked for features. This only works for the canvas renderer and
+ * not for WebGL. Default is `0`.
+ *
+ */
+
+
+/**
+ * Options for snap
+ * @typedef {{
+ *     features: (ol.Collection.<ol.Feature>|undefined),
+ *     pixelTolerance: (number|undefined),
+ *     source: (ol.source.Vector|undefined),
+ *     edge: (boolean|undefined),
+ *     vertex: (boolean|undefined)
+ * }}
+ */
+export var interaction_SnapOptions;
+
+/**
+ * @param {interaction_SnapOptions} options TODO: repace this
+ *
+ * @param {ol.Collection.<ol.Feature>|undefined} options.features Snap to these features. Either this option or source should be provided.
+ *
+ * @param {boolean|undefined} options.edge Snap to edges. Default is `true`.
+ *
+ * @param {boolean|undefined} options.vertex Snap to vertices. Default is `true`.
+ *
+ * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
+ * vertex for snapping. Default is `10` pixels.
+ *
+ * @param {ol.source.Vector|undefined} options.source Snap to features from this source. Either this option or features should be provided
+ *
+ */
+
+
+/**
+ * @typedef {{opacity: (number|undefined),
+ *     visible: (boolean|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     zIndex: (number|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined)}}
+ */
+export var layer_BaseOptions;
+
+/**
+ * @param {layer_BaseOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true`.
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ */
+
+
+/**
+ * @typedef {{opacity: (number|undefined),
+ *     source: (ol.source.Source|undefined),
+ *     visible: (boolean|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     zIndex: (number|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined)}}
+ */
+export var layer_LayerOptions;
+
+/**
+ * @param {layer_LayerOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
+ *
+ * @param {ol.source.Source|undefined} options.source Source for this layer.  If not provided to the constructor, the source can
+ * be set by calling {@link ol.layer.Layer#setSource layer.setSource(source)}
+ * after construction.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ */
+
+
+/**
+ * @typedef {{opacity: (number|undefined),
+ *     visible: (boolean|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     zIndex: (number|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     layers: (Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined)}}
+ */
+export var layer_GroupOptions;
+
+/**
+ * @param {layer_GroupOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true`.
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ * @param {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} options.layers Child layers.
+ *
+ */
+
+
+/**
+ * @typedef {{gradient: (Array.<string>|undefined),
+ *     radius: (number|undefined),
+ *     blur: (number|undefined),
+ *     shadow: (number|undefined),
+ *     weight: (string|function(ol.Feature):number|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     opacity: (number|undefined),
+ *     source: (ol.source.Vector|undefined),
+ *     visible: (boolean|undefined),
+ *     zIndex: (number|undefined)}}
+ */
+export var layer_HeatmapOptions;
+
+/**
+ * @param {layer_HeatmapOptions} options TODO: repace this
+ *
+ * @param {Array.<string>|undefined} options.gradient The color gradient of the heatmap, specified as an array of CSS color
+ * strings. Default is `['#00f', '#0ff', '#0f0', '#ff0', '#f00']`.
+ *
+ * @param {number|undefined} options.radius Radius size in pixels. Default is `8`.
+ *
+ * @param {number|undefined} options.blur Blur size in pixels. Default is `15`.
+ *
+ * @param {number|undefined} options.shadow Shadow size in pixels. Default is `250`.
+ *
+ * @param {string|function(ol.Feature):number|undefined} options.weight The feature attribute to use for the weight or a function that returns a
+ * weight from a feature. Weight values should range from 0 to 1 (and values
+ * outside will be clamped to that range). Default is `weight`.
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
+ *
+ * @param {ol.source.Vector} options.source Source.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ */
+
+
+/**
+ * @typedef {{opacity: (number|undefined),
+ *     map: (ol.PluggableMap|undefined),
+ *     source: (ol.source.Image|undefined),
+ *     visible: (boolean|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     zIndex: (number|undefined)}}
+ */
+export var layer_ImageOptions;
+
+/**
+ * @param {layer_ImageOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
+ *
+ * @param {ol.source.Image} options.source Source for this layer.
+ *
+ * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * layers collection, and the layer will be rendered on top. This is useful for
+ * temporary layers. The standard way to add a layer to a map and have it
+ * managed by the map is to use {@link ol.Map#addLayer}.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ */
+
+
+/**
+ * @typedef {{opacity: (number|undefined),
+ *     preload: (number|undefined),
+ *     source: (ol.source.Tile|undefined),
+ *     map: (ol.PluggableMap|undefined),
+ *     visible: (boolean|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     useInterimTilesOnError: (boolean|undefined),
+ *     zIndex: (number|undefined)}}
+ */
+export var layer_TileOptions;
+
+/**
+ * @param {layer_TileOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
+ *
+ * @param {number|undefined} options.preload Preload. Load low-resolution tiles up to `preload` levels. By default
+ * `preload` is `0`, which means no preloading.
+ *
+ * @param {ol.source.Tile} options.source Source for this layer.
+ *
+ * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * layers collection, and the layer will be rendered on top. This is useful for
+ * temporary layers. The standard way to add a layer to a map and have it
+ * managed by the map is to use {@link ol.Map#addLayer}.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ * @param {boolean|undefined} options.useInterimTilesOnError Use interim tiles on error. Default is `true`.
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ */
+
+
+/**
+ * @typedef {{renderOrder: (ol.RenderOrderFunction|null|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     opacity: (number|undefined),
+ *     renderBuffer: (number|undefined),
+ *     renderMode: (ol.layer.VectorRenderType|string|undefined),
+ *     source: (ol.source.Vector|undefined),
+ *     map: (ol.PluggableMap|undefined),
+ *     declutter: (boolean|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     updateWhileAnimating: (boolean|undefined),
+ *     updateWhileInteracting: (boolean|undefined),
+ *     visible: (boolean|undefined),
+ *     zIndex: (number|undefined)}}
+ */
+export var layer_VectorOptions;
+
+/**
+ * @param {layer_VectorOptions} options TODO: repace this
+ *
+ * @param {ol.layer.VectorRenderType|string|undefined} options.renderMode Render mode for vector layers:
+ *  * `'image'`: Vector layers are rendered as images. Great performance, but
+ *    point symbols and texts are always rotated with the view and pixels are
+ *    scaled during zoom animations.
+ *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering
+ *    even during animations, but slower performance.
+ * Default is `vector`.
+ *
+ * @param {ol.RenderOrderFunction|null|undefined} options.renderOrder Render order. Function to be used when sorting features before rendering. By
+ * default features are drawn in the order that they are created. Use `null` to
+ * avoid the sort, but get an undefined draw order.
+ *
+ * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * layers collection, and the layer will be rendered on top. This is useful for
+ * temporary layers. The standard way to add a layer to a map and have it
+ * managed by the map is to use {@link ol.Map#addLayer}.
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
+ *
+ * @param {number|undefined} options.renderBuffer The buffer around the viewport extent used by the renderer when getting
+ * features from the vector source for the rendering or hit-detection.
+ * Recommended value: the size of the largest symbol, line width or label.
+ * Default is 100 pixels.
+ *
+ * @param {ol.source.Vector} options.source Source.
+ *
+ * @param {boolean|undefined} options.declutter Declutter images and text. Decluttering is applied to all image and text
+ * styles, and the priority is defined by the z-index of the style. Lower
+ * z-index means higher priority. Default is `false`.
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Layer style. See {@link ol.style} for default style which will be used if
+ * this is not defined.
+ *
+ * @param {boolean|undefined} options.updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
+ * This means that no vectors will be shown clipped, but the setting will have a
+ * performance impact for large amounts of vector data. When set to `false`,
+ * batches will be recreated when no animation is active.  Default is `false`.
+ *
+ * @param {boolean|undefined} options.updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
+ * See also `updateWhileAnimating`. Default is `false`.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ */
+
+
+/**
+ * @typedef {{extent: (ol.Extent|undefined),
+ *     map: (ol.PluggableMap|undefined),
+ *     minResolution: (number|undefined),
+ *     maxResolution: (number|undefined),
+ *     opacity: (number|undefined),
+ *     preload: (number|undefined),
+ *     renderBuffer: (number|undefined),
+ *     renderMode: (ol.layer.VectorTileRenderType|string|undefined),
+ *     renderOrder: (ol.RenderOrderFunction|undefined),
+ *     source: (ol.source.VectorTile|undefined),
+ *     declutter: (boolean|undefined),
+ *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     updateWhileAnimating: (boolean|undefined),
+ *     updateWhileInteracting: (boolean|undefined),
+ *     visible: (boolean|undefined),
+ *     zIndex: (number|undefined)}}
+ */
+export var layer_VectorTileOptions;
+
+/**
+ * @param {layer_VectorTileOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.renderBuffer The buffer around the tile extent used by the renderer when getting features
+ * from the vector tile for the rendering or hit-detection.
+ * Recommended value: Vector tiles are usually generated with a buffer, so this
+ * value should match the largest possible buffer of the used tiles. It should
+ * be at least the size of the largest point symbol or line width.
+ * Default is 100 pixels.
+ *
+ * @param {ol.layer.VectorTileRenderType|string|undefined} options.renderMode Render mode for vector tiles:
+ *  * `'image'`: Vector tiles are rendered as images. Great performance, but
+ *    point symbols and texts are always rotated with the view and pixels are
+ *    scaled during zoom animations.
+ *  * `'hybrid'`: Polygon and line elements are rendered as images, so pixels
+ *    are scaled during zoom animations. Point symbols and texts are accurately
+ *    rendered as vectors and can stay upright on rotated views.
+ *  * `'vector'`: Vector tiles are rendered as vectors. Most accurate rendering
+ *    even during animations, but slower performance than the other options.
+ *
+ * When `declutter` is set to `true`, `'hybrid'` will be used instead of
+ * `'image'`. The default is `'hybrid'`.
+ *
+ * @param {ol.RenderOrderFunction|undefined} options.renderOrder Render order. Function to be used when sorting features before rendering. By
+ * default features are drawn in the order that they are created.
+ *
+ * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * layers collection, and the layer will be rendered on top. This is useful for
+ * temporary layers. The standard way to add a layer to a map and have it
+ * managed by the map is to use {@link ol.Map#addLayer}.
+ *
+ * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * outside of this extent.
+ *
+ * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ *
+ * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ *
+ * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
+ *
+ * @param {number|undefined} options.preload Preload. Load low-resolution tiles up to `preload` levels. By default
+ * `preload` is `0`, which means no preloading.
+ *
+ * @param {ol.source.VectorTile|undefined} options.source Source.
+ *
+ * @param {boolean|undefined} options.declutter Declutter images and text. Decluttering is applied to all image and text
+ * styles, and the priority is defined by the z-index of the style. Lower
+ * z-index means higher priority. When set to `true`, a `renderMode` of
+ * `'image'` will be overridden with `'hybrid'`. Default is `false`.
+ *
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Layer style. See {@link ol.style} for default style which will be used if
+ * this is not defined.
+ *
+ * @param {boolean|undefined} options.updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
+ * This means that no vectors will be shown clipped, but the setting will have a
+ * performance impact for large amounts of vector data. When set to `false`,
+ * batches will be recreated when no animation is active.  Default is `false`.
+ *
+ * @param {boolean|undefined} options.updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
+ * See also `updateWhileAnimating`. Default is `false`.
+ *
+ * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
+ *
+ * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * ordered, first by Z-index and then by position. The default Z-index is 0.
+ *
+ */
+
+
+/**
+ * @typedef {{context: CanvasRenderingContext2D,
+ *     feature: (ol.Feature|ol.render.Feature),
+ *     geometry: ol.geom.SimpleGeometry,
+ *     pixelRatio: number,
+ *     resolution: number,
+ *     rotation: number}}
+ */
+export var render_State;
+
+/**
+ * @param {render_State} options TODO: repace this
+ *
+ * @param {CanvasRenderingContext2D} options.context Canvas context that the layer is being rendered to.
+ *
+ * @param {number} options.pixelRatio Pixel ratio used by the layer renderer.
+ *
+ * @param {number} options.resolution Resolution that the render batch was created and optimized for. This is
+ * not the view's resolution that is being rendered.
+ *
+ * @param {number} options.rotation Rotation of the rendered layer in radians.
+ *
+ */
+
+
+/**
+ * @typedef {{size: (ol.Size|undefined),
+ *     pixelRatio: (number|undefined)}}
+ */
+export var render_ToContextOptions;
+
+/**
+ * @param {render_ToContextOptions} options TODO: repace this
+ *
+ * @param {ol.Size|undefined} options.size Desired size of the canvas in css pixels. When provided, both canvas and css
+ * size will be set according to the `pixelRatio`. If not provided, the current
+ * canvas and css sizes will not be altered.
+ *
+ * @param {number|undefined} options.pixelRatio Pixel ratio (canvas pixel to css pixel ratio) for the canvas. Default
+ * is the detected device pixel ratio.
+ *
+ */
+
+
+/**
+ * @typedef {{cacheSize: (number|undefined),
+ *     culture: (string|undefined),
+ *     hidpi: (boolean|undefined),
+ *     key: string,
+ *     imagerySet: string,
+ *     maxZoom: (number|undefined),
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     wrapX: (boolean|undefined),
+ *     transition: (number|undefined)}}
+ */
+export var source_BingMapsOptions;
+
+/**
+ * @param {source_BingMapsOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {boolean|undefined} options.hidpi If `true` hidpi tiles will be requested. Default is `false`.
+ *
+ * @param {string|undefined} options.culture Culture code. Default is `en-us`.
+ *
+ * @param {string} options.key Bing Maps API key. Get yours at http://www.bingmapsportal.com/.
+ *
+ * @param {string} options.imagerySet Type of imagery.
+ *
+ * @param {number|undefined} options.maxZoom Max zoom. Default is what's advertized by the BingMaps service (`21`
+ * currently).
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     distance: (number|undefined),
+ *     extent: (ol.Extent|undefined),
+ *     format: (ol.format.Feature|undefined),
+ *     geometryFunction: (undefined|function(ol.Feature):ol.geom.Point),
+ *     logo: (string|undefined),
+ *     projection: ol.ProjectionLike,
+ *     source: ol.source.Vector,
+ *     wrapX: (boolean|undefined)}}
+ */
+export var source_ClusterOptions;
+
+/**
+ * @param {source_ClusterOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.distance Minimum distance in pixels between clusters. Default is `20`.
+ *
+ * @param {ol.Extent|undefined} options.extent Extent.
+ *
+ * @param {undefined|function(ol.Feature):ol.geom.Point} options.geometryFunction Function that takes an {@link ol.Feature} as argument and returns an
+ * {@link ol.geom.Point} as cluster calculation point for the feature. When a
+ * feature should not be considered for clustering, the function should return
+ * `null`. The default, which works when the underyling source contains point
+ * features only, is
+ * ```js
+ * function(feature) {
+ *   return feature.getGeometry();
+ * }
+ * ```
+ * See {@link ol.geom.Polygon#getInteriorPoint} for a way to get a cluster
+ * calculation point for polygons.
+ *
+ * @param {ol.format.Feature|undefined} options.format Format.
+ *
+ * @param {string|undefined} options.logo Logo.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {ol.source.Vector} options.source Source.
+ *
+ * @param {boolean|undefined} options.wrapX WrapX. Default is true
+ *
+ */
+
+
+/**
+ * @typedef {{preemptive: (boolean|undefined),
+ *     jsonp: (boolean|undefined),
+ *     tileJSON: (TileJSON|undefined),
+ *     url: (string|undefined)}}
+ */
+export var source_TileUTFGridOptions;
+
+/**
+ * @param {source_TileUTFGridOptions} options TODO: repace this
+ *
+ * @param {boolean|undefined} options.jsonp Use JSONP with callback to load the TileJSON. Useful when the server
+ * does not support CORS. Default is `false`.
+ *
+ * @param {boolean|undefined} options.preemptive If `true` the TileUTFGrid source loads the tiles based on their "visibility".
+ * This improves the speed of response, but increases traffic.
+ * Note that if set to `false`, you need to pass `true` as `opt_request`
+ * to the `forDataAtCoordinateAndResolution` method otherwise no data
+ * will ever be loaded.
+ * Default is `true`.
+ *
+ * @param {TileJSON|undefined} options.tileJSON TileJSON configuration for this source. If not provided, `url` must be
+ * configured.
+ *
+ * @param {string|undefined} options.url TileJSON endpoint that provides the configuration for this source. Request
+ * will be made through JSONP. If not provided, `tileJSON` must be configured.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *            cacheSize: (number|undefined),
+ *            crossOrigin: (null|string|undefined),
+ *            logo: (string|olx.LogoOptions|undefined),
+ *            opaque: (boolean|undefined),
+ *            projection: ol.ProjectionLike,
+ *            reprojectionErrorThreshold: (number|undefined),
+ *            state: (ol.source.State|undefined),
+ *            tileClass: (function(new: ol.ImageTile, ol.TileCoord,
+ *                                 ol.TileState, string, ?string,
+ *                                 ol.TileLoadFunctionType)|undefined),
+ *            tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *            tilePixelRatio: (number|undefined),
+ *            tileUrlFunction: (ol.TileUrlFunctionType|undefined),
+ *            url: (string|undefined),
+ *            urls: (Array.<string>|undefined),
+ *            wrapX: (boolean|undefined),
+ *            transition: (number|undefined)}}
+ */
+export var source_TileImageOptions;
+
+/**
+ * @param {source_TileImageOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {boolean|undefined} options.opaque Whether the layer is opaque.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.source.State|undefined} options.state Source state.
+ *
+ * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
+                ol.TileLoadFunctionType)|undefined}
+ options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
+ *
+ * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
+ * service advertizes 256px by 256px tiles but actually sends 512px
+ * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
+ * should be set to `2`. Default is `1`.
+ *
+ * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
+ *
+ * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
+ * used instead of defining each one separately in the `urls` option.
+ *
+ * @param {Array.<string>|undefined} options.urls An array of URL templates.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. The default, `undefined`, is to
+ * request out-of-bounds tiles from the server. When set to `false`, only one
+ * world will be rendered. When set to `true`, tiles will be requested for one
+ * world only, but they will be wrapped horizontally to render multiple worlds.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *            cacheSize: (number|undefined),
+ *            format: (ol.format.Feature|undefined),
+ *            logo: (string|olx.LogoOptions|undefined),
+ *            overlaps: (boolean|undefined),
+ *            projection: ol.ProjectionLike,
+ *            state: (ol.source.State|undefined),
+ *            tileClass: (function(new: ol.VectorTile, ol.TileCoord,
+ *                 ol.TileState, string, ol.format.Feature,
+ *                 ol.TileLoadFunctionType)|undefined),
+ *            tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *            tileUrlFunction: (ol.TileUrlFunctionType|undefined),
+ *            url: (string|undefined),
+ *            urls: (Array.<string>|undefined),
+ *            wrapX: (boolean|undefined),
+ *            transition: (number|undefined)}}
+ */
+export var source_VectorTileOptions;
+
+/**
+ * @param {source_VectorTileOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `128`.
+ *
+ * @param {ol.format.Feature|undefined} options.format Feature format for tiles. Used and required by the default
+ * `tileLoadFunction`.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {boolean|undefined} options.overlaps This source may have overlapping geometries. Default is `true`. Setting this
+ * to `false` (e.g. for sources with polygons that represent administrative
+ * boundaries or TopoJSON sources) allows the renderer to optimise fill and
+ * stroke operations.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {ol.source.State|undefined} options.state Source state.
+ *
+ * @param {function(new: ol.VectorTile, ol.TileCoord,                ol.TileState, string, ol.format.Feature,
+                ol.TileLoadFunctionType)|undefined}
+ options.tileClass Class used to instantiate vector tiles. Default is {@link ol.VectorTile}.
+ *
+ * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. Could look like this:
+ * ```js
+ * function(tile, url) {
+ *   tile.setLoader(function() {
+ *     var data = // ... fetch data
+ *     var format = tile.getFormat();
+ *     tile.setFeatures(format.readFeatures(data, {
+ *       // uncomment the line below for ol.format.MVT only
+ *       extent: tile.getExtent(),
+ *       featureProjection: map.getView().getProjection()
+ *     }));
+ *   };
+ * });
+ * ```
+ *
+ * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
+ *
+ * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
+ * used instead of defining each one separately in the `urls` option.
+ *
+ * @param {Array.<string>|undefined} options.urls An array of URL templates.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. When set to `false`, only one world
+ * will be rendered. When set to `true`, tiles will be wrapped horizontally to
+ * render multiple worlds. Default is `true`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{url: (string|undefined),
+ *     displayDpi: (number|undefined),
+ *     metersPerUnit: (number|undefined),
+ *     hidpi: (boolean|undefined),
+ *     useOverlay: (boolean|undefined),
+ *     projection: ol.ProjectionLike,
+ *     ratio: (number|undefined),
+ *     resolutions: (Array.<number>|undefined),
+ *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
+ *     params: (Object|undefined)}}
+ */
+export var source_ImageMapGuideOptions;
+
+/**
+ * @param {source_ImageMapGuideOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.url The mapagent url.
+ *
+ * @param {number|undefined} options.displayDpi The display resolution. Default is `96`.
+ *
+ * @param {number|undefined} options.metersPerUnit The meters-per-unit value. Default is `1`.
+ *
+ * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * server. Default is `true`.
+ *
+ * @param {boolean|undefined} options.useOverlay If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * twice the width and height of the map viewport, and so on. Must be `1` or
+ * higher. Default is `1`.
+ *
+ * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
+ *
+ * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
+ *
+ * @param {Object|undefined} options.params Additional parameters.
+ *
+ */
+
+
+/**
+ * @typedef {{cacheSize: (number|undefined),
+ *     layer: string,
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined)}}
+ */
+export var source_MapQuestOptions;
+
+/**
+ * @param {source_MapQuestOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {string} options.layer Layer. Possible values are `osm`, `sat`, and `hyb`.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ *
+ */
+
+
+/**
+ * @typedef {{projection: ol.ProjectionLike,
+ *     tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *     wrapX: (boolean|undefined)}}
+ */
+export var source_TileDebugOptions;
+
+/**
+ * @param {source_TileDebugOptions} options TODO: repace this
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     maxZoom: (number|undefined),
+ *     opaque: (boolean|undefined),
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined),
+ *     wrapX: (boolean|undefined)}}
+ */
+export var source_OSMOptions;
+
+/**
+ * @param {source_OSMOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * Default is `anonymous`.
+ *
+ * @param {number|undefined} options.maxZoom Max zoom. Default is `19`.
+ *
+ * @param {boolean|undefined} options.opaque Whether the layer is opaque. Default is `true`.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * Default is `https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png`.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     hidpi: (boolean|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
+ *     params: Object.<string,*>,
+ *     projection: ol.ProjectionLike,
+ *     ratio: (number|undefined),
+ *     resolutions: (Array.<number>|undefined),
+ *     url: (string|undefined)}}
+ */
+export var source_ImageArcGISRestOptions;
+
+/**
+ * @param {source_ImageArcGISRestOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * server. Default is `true`.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
+ *
+ * @param {Object.<string,*>|undefined} options.params ArcGIS Rest parameters. This field is optional. Service defaults will be
+ * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
+ * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
+ * and `IMAGESR` will be set dynamically. Set `LAYERS` to
+ * override the default service layer visibility. See
+ * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
+ * for further reference.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * twice the size of the map viewport, and so on. Default is `1.5`.
+ *
+ * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
+ *
+ * @param {string|undefined} options.url ArcGIS Rest service URL for a Map Service or Image Service. The
+ * url should include /MapServer or /ImageServer.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     canvasFunction: ol.CanvasFunctionType,
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     projection: ol.ProjectionLike,
+ *     ratio: (number|undefined),
+ *     resolutions: (Array.<number>|undefined),
+ *     state: (ol.source.State|undefined)}}
+ */
+export var source_ImageCanvasOptions;
+
+/**
+ * @param {source_ImageCanvasOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {ol.CanvasFunctionType} options.canvasFunction Canvas function. The function returning the canvas element used by the source
+ * as an image. The arguments passed to the function are: `{ol.Extent}` the
+ * image extent, `{number}` the image resolution, `{number}` the device pixel
+ * ratio, `{ol.Size}` the image size, and `{ol.proj.Projection}` the image
+ * projection. The canvas returned by this function is cached by the source. If
+ * the value returned by the function is later changed then
+ * `dispatchChangeEvent` should be called on the source for the source to
+ * invalidate the current cached image.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.ratio Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
+ * width and height of the map viewport, and so on. Must be `1` or higher.
+ * Default is `1.5`.
+ *
+ * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, new canvases will be created for these resolutions
+ * only.
+ *
+ * @param {ol.source.State|undefined} options.state Source state.
+ *
+ */
+
+
+/**
+ * @typedef {{sources: Array.<ol.source.Source>,
+ *     operation: (ol.RasterOperation|undefined),
+ *     lib: (Object|undefined),
+ *     threads: (number|undefined),
+ *     operationType: (ol.source.RasterOperationType|undefined)}}
+ * @api
+ */
+export var source_RasterOptions;
+
+/**
+ * @param {source_RasterOptions} options TODO: repace this
+ *
+ * @param {Array.<ol.source.Source>} options.sources Input sources.
+ *
+ * @param {ol.RasterOperation|undefined} options.operation Raster operation.  The operation will be called with data from input sources
+ * and the output will be assigned to the raster source.
+ *
+ * @param {Object|undefined} options.lib Functions that will be made available to operations run in a worker.
+ *
+ * @param {number|undefined} options.threads By default, operations will be run in a single worker thread.  To avoid using
+ * workers altogether, set `threads: 0`.  For pixel operations, operations can
+ * be run in multiple worker threads.  Note that there is additional overhead in
+ * transferring data to multiple workers, and that depending on the user's
+ * system, it may not be possible to parallelize the work.
+ *
+ * @param {ol.source.RasterOperationType|undefined} options.operationType Operation type.  Supported values are `'pixel'` and `'image'`.  By default,
+ * `'pixel'` operations are assumed, and operations will be called with an
+ * array of pixels from input sources.  If set to `'image'`, operations will
+ * be called with an array of ImageData objects from input sources.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     hidpi: (boolean|undefined),
+ *     serverType: (ol.source.WMSServerType|string|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
+ *     params: Object.<string,*>,
+ *     projection: ol.ProjectionLike,
+ *     ratio: (number|undefined),
+ *     resolutions: (Array.<number>|undefined),
+ *     url: (string|undefined)}}
+ */
+export var source_ImageWMSOptions;
+
+/**
+ * @param {source_ImageWMSOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * server. Default is `true`.
+ *
+ * @param {ol.source.WMSServerType|string|undefined} options.serverType The type of the remote WMS server: `mapserver`, `geoserver` or `qgis`. Only
+ * needed if `hidpi` is `true`. Default is `undefined`.
+ *
+ * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {Object.<string,*>} options.params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
+ * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
+ * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * twice the width and height of the map viewport, and so on. Must be `1` or
+ * higher. Default is `1.5`.
+ *
+ * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
+ *
+ * @param {string|undefined} options.url WMS service URL.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     cacheSize: (number|undefined),
+ *     layer: string,
+ *     minZoom: (number|undefined),
+ *     maxZoom: (number|undefined),
+ *     opaque: (boolean|undefined),
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined),
+ *     wrapX: (boolean|undefined)
+ * }}
+ */
+export var source_StamenOptions;
+
+/**
+ * @param {source_StamenOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {string} options.layer Layer.
+ *
+ * @param {number|undefined} options.minZoom Minimum zoom.
+ *
+ * @param {number|undefined} options.maxZoom Maximum zoom.
+ *
+ * @param {boolean|undefined} options.opaque Whether the layer is opaque.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     imageExtent: (ol.Extent),
+ *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
+ *     imageSize: (ol.Size|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     projection: ol.ProjectionLike,
+ *     url: string}}
+ */
+export var source_ImageStaticOptions;
+
+/**
+ * @param {source_ImageStaticOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {ol.Extent} options.imageExtent Extent of the image in map coordinates.  This is the [left, bottom, right,
+ * top] map coordinates of your image.
+ *
+ * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Optional logo.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {ol.Size|undefined} options.imageSize Size of the image in pixels. Usually the image size is auto-detected, so this
+ * only needs to be set if auto-detection fails for some reason.
+ *
+ * @param {string} options.url Image URL.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     params: (Object.<string, *>|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *     projection: ol.ProjectionLike,
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined),
+ *     urls: (Array.<string>|undefined),
+ *     wrapX: (boolean|undefined),
+ *     transition: (number|undefined)}}
+ */
+export var source_TileArcGISRestOptions;
+
+/**
+ * @param {source_TileArcGISRestOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {Object.<string,*>|undefined} options.params ArcGIS Rest parameters. This field is optional. Service defaults will be
+ * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
+ * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
+ * and `IMAGESR` will be set dynamically. Set `LAYERS` to
+ * override the default service layer visibility. See
+ * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
+ * for further reference.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
+ * server.
+ * If this is not defined, a default grid will be used: if there is a projection
+ * extent, the grid will be based on that; if not, a grid based on a global
+ * extent with origin at 0,0 will be used.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {string|undefined} options.url ArcGIS Rest service URL for a Map Service or Image Service. The
+ * url should include /MapServer or /ImageServer.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ * @param {Array.<string>|undefined} options.urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS Service supports multiple
+ * urls for export requests.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     jsonp: (boolean|undefined),
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     tileJSON: (TileJSON|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined),
+ *     wrapX: (boolean|undefined),
+ *     transition: (number|undefined)}}
+ */
+export var source_TileJSONOptions;
+
+/**
+ * @param {source_TileJSONOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Optional attributions for the source.  If provided, these will be used
+ * instead of any attribution data advertised by the server.  If not provided,
+ * any attributions advertised by the server will be used.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {boolean|undefined} options.jsonp Use JSONP with callback to load the TileJSON. Useful when the server
+ * does not support CORS. Default is `false`.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {TileJSON|undefined} options.tileJSON TileJSON configuration for this source. If not provided, `url` must be
+ * configured.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {string|undefined} options.url URL to the TileJSON file. If not provided, `tileJSON` must be configured.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     params: Object.<string,*>,
+ *     crossOrigin: (null|string|undefined),
+ *     gutter: (number|undefined),
+ *     hidpi: (boolean|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
+ *                          ol.TileState, string, ?string,
+ *                          ol.TileLoadFunctionType)|undefined),
+ *     tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *     projection: ol.ProjectionLike,
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     serverType: (ol.source.WMSServerType|string|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     url: (string|undefined),
+ *     urls: (Array.<string>|undefined),
+ *     wrapX: (boolean|undefined),
+ *     transition: (number|undefined)}}
+ */
+export var source_TileWMSOptions;
+
+/**
+ * @param {source_TileWMSOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {Object.<string,*>} options.params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
+ * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
+ * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {number|undefined} options.gutter The size in pixels of the gutter around image tiles to ignore. By setting
+ * this property to a non-zero value, images will be requested that are wider
+ * and taller than the tile size by a value of `2 x gutter`. Defaults to zero.
+ * Using a non-zero value allows artifacts of rendering at tile edges to be
+ * ignored. If you control the WMS service it is recommended to address
+ * "artifacts at tile edges" issues by properly configuring the WMS service. For
+ * example, MapServer has a `tile_map_edge_buffer` configuration parameter for
+ * this. See http://mapserver.org/output/tile_mode.html.
+ *
+ * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * server. Default is `true`.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
+                ol.TileLoadFunctionType)|undefined}
+ options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
+ *
+ * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
+ * server.
+ * If this is not defined, a default grid will be used: if there is a projection
+ * extent, the grid will be based on that; if not, a grid based on a global
+ * extent with origin at 0,0 will be used.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.source.WMSServerType|string|undefined} options.serverType The type of the remote WMS server. Currently only used when `hidpi` is
+ * `true`. Default is `undefined`.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {string|undefined} options.url WMS service URL.
+ *
+ * @param {Array.<string>|undefined} options.urls WMS service urls. Use this instead of `url` when the WMS supports multiple
+ * urls for GetMap requests.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. When set to `false`, only one world
+ * will be rendered. When `true`, tiles will be requested for one world only,
+ * but they will be wrapped horizontally to render multiple worlds. The default
+ * is `true`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     features: (Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined),
+ *     format: (ol.format.Feature|undefined),
+ *     loader: (ol.FeatureLoader|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     overlaps: (boolean|undefined),
+ *     strategy: (ol.LoadingStrategy|undefined),
+ *     url: (string|ol.FeatureUrlFunction|undefined),
+ *     useSpatialIndex: (boolean|undefined),
+ *     wrapX: (boolean|undefined)}}
+ */
+export var source_VectorOptions;
+
+/**
+ * @param {source_VectorOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined} options.features Features. If provided as {@link ol.Collection}, the features in the source
+ * and the collection will stay in sync.
+ *
+ * @param {ol.format.Feature|undefined} options.format The feature format used by the XHR feature loader when `url` is set.
+ * Required if `url` is set, otherwise ignored. Default is `undefined`.
+ *
+ * @param {ol.FeatureLoader|undefined} options.loader The loader function used to load features, from a remote source for example.
+ * If this is not set and `url` is set, the source will create and use an XHR
+ * feature loader.
+ *
+ * Example:
+ *
+ * ```js
+ * var vectorSource = new ol.source.Vector({
+ *   format: new ol.format.GeoJSON(),
+ *   loader: function(extent, resolution, projection) {
+ *      var proj = projection.getCode();
+ *      var url = 'https://ahocevar.com/geoserver/wfs?service=WFS&' +
+ *          'version=1.1.0&request=GetFeature&typename=osm:water_areas&' +
+ *          'outputFormat=application/json&srsname=' + proj + '&' +
+ *          'bbox=' + extent.join(',') + ',' + proj;
+ *      var xhr = new XMLHttpRequest();
+ *      xhr.open('GET', url);
+ *      var onError = function() {
+ *        vectorSource.removeLoadedExtent(extent);
+ *      }
+ *      xhr.onerror = onError;
+ *      xhr.onload = function() {
+ *        if (xhr.status == 200) {
+ *          vectorSource.addFeatures(
+ *              vectorSource.getFormat().readFeatures(xhr.responseText));
+ *        } else {
+ *          onError();
+ *        }
+ *      }
+ *      xhr.send();
+ *    },
+ *    strategy: ol.loadingstrategy.bbox
+ *  });
+ * ```
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {boolean|undefined} options.overlaps This source may have overlapping geometries. Default is `true`. Setting this
+ * to `false` (e.g. for sources with polygons that represent administrative
+ * boundaries or TopoJSON sources) allows the renderer to optimise fill and
+ * stroke operations.
+ *
+ * @param {ol.LoadingStrategy|undefined} options.strategy The loading strategy to use. By default an {@link ol.loadingstrategy.all}
+ * strategy is used, a one-off strategy which loads all features at once.
+ *
+ * @param {string|ol.FeatureUrlFunction|undefined} options.url Setting this option instructs the source to load features using an XHR loader
+ * (see {@link ol.featureloader.xhr}). Use a `string` and an
+ * {@link ol.loadingstrategy.all} for a one-off download of all features from
+ * the given URL. Use a {@link ol.FeatureUrlFunction} to generate the url with
+ * other loading strategies.
+ * Requires `format` to be set as well.
+ * When default XHR feature loader is provided, the features will
+ * be transformed from the data projection to the view projection
+ * during parsing. If your remote data source does not advertise its projection
+ * properly, this transformation will be incorrect. For some formats, the
+ * default projection (usually EPSG:4326) can be overridden by setting the
+ * defaultDataProjection constructor option on the format.
+ * Note that if a source contains non-feature data, such as a GeoJSON geometry
+ * or a KML NetworkLink, these will be ignored. Use a custom loader to load these.
+ *
+ * @param {boolean|undefined} options.useSpatialIndex By default, an RTree is used as spatial index. When features are removed and
+ * added frequently, and the total number of features is low, setting this to
+ * `false` may improve performance.
+ *
+ * Note that
+ * {@link ol.source.Vector#getFeaturesInExtent},
+ * {@link ol.source.Vector#getClosestFeatureToCoordinate} and
+ * {@link ol.source.Vector#getExtent} cannot be used when `useSpatialIndex` is
+ * set to `false`, and {@link ol.source.Vector#forEachFeatureInExtent} will loop
+ * through all features.
+ *
+ * When set to `false`, the features will be maintained in an
+ * {@link ol.Collection}, which can be retrieved through
+ * {@link ol.source.Vector#getFeaturesCollection}.
+ *
+ * The default is `true`.
+ *
+ * @param {boolean|undefined} options.wrapX Wrap the world horizontally. Default is `true`. For vector editing across the
+ * -180° and 180° meridians to work properly, this should be set to `false`. The
+ * resulting geometry coordinates will then exceed the world bounds.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (string|null|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     tileGrid: ol.tilegrid.WMTS,
+ *     projection: ol.ProjectionLike,
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     requestEncoding: (ol.source.WMTSRequestEncoding|string|undefined),
+ *     layer: string,
+ *     style: string,
+ *     tilePixelRatio: (number|undefined),
+ *     version: (string|undefined),
+ *     format: (string|undefined),
+ *     matrixSet: string,
+ *     dimensions: (!Object|undefined),
+ *     url: (string|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     urls: (Array.<string>|undefined),
+ *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
+ *                          ol.TileState, string, ?string,
+ *                          ol.TileLoadFunctionType)|undefined),
+ *     wrapX: (boolean|undefined),
+ *     transition: (number|undefined)}}
+ */
+export var source_WMTSOptions;
+
+/**
+ * @param {source_WMTSOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {string|null|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {ol.tilegrid.WMTS} options.tileGrid Tile grid.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {ol.source.WMTSRequestEncoding|string|undefined} options.requestEncoding Request encoding. Default is `KVP`.
+ *
+ * @param {string} options.layer Layer name as advertised in the WMTS capabilities.
+ *
+ * @param {string} options.style Style name as advertised in the WMTS capabilities.
+ *
+ * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
+                ol.TileLoadFunctionType)|undefined}
+ options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
+ *
+ * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
+ * service advertizes 256px by 256px tiles but actually sends 512px
+ * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
+ * should be set to `2`. Default is `1`.
+ *
+ * @param {string|undefined} options.version WMTS version. Default is `1.0.0`.
+ *
+ * @param {string|undefined} options.format Image format. Default is `image/jpeg`.
+ *
+ * @param {string} options.matrixSet Matrix set.
+ *
+ * @param {!Object|undefined} options.dimensions Additional "dimensions" for tile requests.  This is an object with properties
+ * named like the advertised WMTS dimensions.
+ *
+ * @param {string|undefined} options.url A URL for the service.  For the RESTful request encoding, this is a URL
+ * template.  For KVP encoding, it is normal URL. A `{?-?}` template pattern,
+ * for example `subdomain{a-f}.domain.com`, may be used instead of defining
+ * each one separately in the `urls` option.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {Array.<string>|undefined} options.urls An array of URLs.  Requests will be distributed among the URLs in this array.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `false`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     opaque: (boolean|undefined),
+ *     projection: ol.ProjectionLike,
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     maxZoom: (number|undefined),
+ *     minZoom: (number|undefined),
+ *     tileGrid: (ol.tilegrid.TileGrid|undefined),
+ *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
+ *     tilePixelRatio: (number|undefined),
+ *     tileSize: (number|ol.Size|undefined),
+ *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
+ *     url: (string|undefined),
+ *     urls: (Array.<string>|undefined),
+ *     wrapX: (boolean|undefined),
+ *     transition: (number|undefined)}}
+ */
+export var source_XYZOptions;
+
+/**
+ * @param {source_XYZOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {boolean|undefined} options.opaque Whether the layer is opaque.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection. Default is `EPSG:3857`.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {number|undefined} options.maxZoom Optional max zoom level. Default is `18`.
+ *
+ * @param {number|undefined} options.minZoom Optional min zoom level. Default is `0`.
+ *
+ * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
+ *
+ * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * ```js
+ * function(imageTile, src) {
+ *   imageTile.getImage().src = src;
+ * };
+ * ```
+ *
+ * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
+ * service advertizes 256px by 256px tiles but actually sends 512px
+ * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
+ * should be set to `2`. Default is `1`.
+ *
+ * @param {number|ol.Size|undefined} options.tileSize The tile size used by the tile service. Default is `[256, 256]` pixels.
+ *
+ * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
+ * Required if url or urls are not provided.
+ *
+ * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
+ * used instead of defining each one separately in the `urls` option.
+ *
+ * @param {Array.<string>|undefined} options.urls An array of URL templates.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     projection: ol.ProjectionLike,
+ *     maxZoom: (number|undefined),
+ *     minZoom: (number|undefined),
+ *     wrapX: (boolean|undefined),
+ *     config: (Object|undefined),
+ *     map: (string|undefined),
+ *     account: string}}
+ */
+export var source_CartoDBOptions;
+
+/**
+ * @param {source_CartoDBOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {ol.ProjectionLike} options.projection Projection. Default is `EPSG:3857`.
+ *
+ * @param {number|undefined} options.maxZoom Optional max zoom level. Default is `18`.
+ *
+ * @param {number|undefined} options.minZoom Minimum zoom.
+ *
+ * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
+ *
+ * @param {Object|undefined} options.config If using anonymous maps, the CartoDB config to use. See
+ * {@link http://docs.cartodb.com/cartodb-platform/maps-api/anonymous-maps/}
+ * for more detail.
+ * If using named maps, a key-value lookup with the template parameters.
+ * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
+ * for more detail.
+ *
+ * @param {string|undefined} options.map If using named maps, this will be the name of the template to load.
+ * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
+ * for more detail.
+ *
+ * @param {string} options.account CartoDB account name
+ *
+ */
+
+
+/**
+ * @typedef {{attributions: (ol.AttributionLike|undefined),
+ *     cacheSize: (number|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     logo: (string|olx.LogoOptions|undefined),
+ *     projection: (ol.ProjectionLike|undefined),
+ *     reprojectionErrorThreshold: (number|undefined),
+ *     url: !string,
+ *     tierSizeCalculation: (string|undefined),
+ *     size: ol.Size,
+ *     extent: (ol.Extent|undefined),
+ *     transition: (number|undefined),
+ *     tileSize: (number|undefined)}}
+ */
+export var source_ZoomifyOptions;
+
+/**
+ * @param {source_ZoomifyOptions} options TODO: repace this
+ *
+ * @param {ol.AttributionLike|undefined} options.attributions Attributions.
+ *
+ * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {string|olx.LogoOptions|undefined} options.logo Logo.
+ *
+ * @param {ol.ProjectionLike|undefined} options.projection Projection.
+ *
+ * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * Higher values can increase reprojection performance, but decrease precision.
+ *
+ * @param {!string} options.url URL template or base URL of the Zoomify service. A base URL is the fixed part
+ * of the URL, excluding the tile group, z, x, and y folder structure, e.g.
+ * `http://my.zoomify.info/IMAGE.TIF/`. A URL template must include
+ * `{TileGroup}`, `{x}`, `{y}`, and `{z}` placeholders, e.g.
+ * `http://my.zoomify.info/IMAGE.TIF/{TileGroup}/{z}-{x}-{y}.jpg`.
+ * Internet Imaging Protocol (IIP) with JTL extension can be also used with
+ * `{tileIndex}` and `{z}` placeholders, e.g.
+ * `http://my.zoomify.info?FIF=IMAGE.TIF&JTL={z},{tileIndex}`.
+ * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
+ * used instead of defining each one separately in the `urls` option.
+ *
+ * @param {string|undefined} options.tierSizeCalculation Tier size calculation method: `default` or `truncated`.
+ *
+ * @param {ol.Size} options.size Size of the image.
+ *
+ * @param {ol.Extent|undefined} options.extent Extent for the TileGrid that is created. Default sets the TileGrid in the
+ * fourth quadrant, meaning extent is `[0, -height, width, 0]`. To change the
+ * extent to the first quadrant (the default for OpenLayers 2) set the extent
+ * as `[0, 0, width, height]`.
+ *
+ * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * transition, pass `transition: 0`.
+ *
+ * @param {number|undefined} options.tileSize Tile size. Same tile size is used for all zoom levels. Default value is
+ * `256`.
+ *
+ */
+
+
+/**
+ * @typedef {{fill: (ol.style.Fill|undefined),
+ *     radius: number,
+ *     snapToPixel: (boolean|undefined),
+ *     stroke: (ol.style.Stroke|undefined),
+ *     atlasManager: (ol.style.AtlasManager|undefined)}}
+ */
+export var style_CircleOptions;
+
+/**
+ * @param {style_CircleOptions} options TODO: repace this
+ *
+ * @param {ol.style.Fill|undefined} options.fill Fill style.
+ *
+ * @param {number} options.radius Circle radius.
+ *
+ * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
+ * coordinate when drawing the circle in the output canvas. If `false`
+ * fractional numbers may be used. Using `true` allows for "sharp"
+ * rendering (no blur), while using `false` allows for "accurate"
+ * rendering. Note that accuracy is important if the circle's
+ * position is animated. Without it, the circle may jitter noticeably.
+ * Default value is `true`.
+ *
+ * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
+ *
+ * @param {ol.style.AtlasManager|undefined} options.atlasManager The atlas manager to use for this circle. When using WebGL it is
+ * recommended to use an atlas manager to avoid texture switching.
+ * If an atlas manager is given, the circle is added to an atlas.
+ * By default no atlas manager is used.
+ *
+ */
+
+
+/**
+ * @typedef {{color: (ol.Color|ol.ColorLike|undefined)}}
+ */
+export var style_FillOptions;
+
+/**
+ * @param {style_FillOptions} options TODO: repace this
+ *
+ * @param {ol.Color|ol.ColorLike|undefined} options.color A color, gradient or pattern. See {@link ol.color}
+ * and {@link ol.colorlike} for possible formats. Default null;
+ * if null, the Canvas/renderer default black will be used.
+ *
+ */
+
+
+/**
+ * @typedef {{anchor: (Array.<number>|undefined),
+ *     anchorOrigin: (ol.style.IconOrigin|undefined),
+ *     anchorXUnits: (ol.style.IconAnchorUnits|undefined),
+ *     anchorYUnits: (ol.style.IconAnchorUnits|undefined),
+ *     color: (ol.Color|string|undefined),
+ *     crossOrigin: (null|string|undefined),
+ *     img: (Image|HTMLCanvasElement|undefined),
+ *     offset: (Array.<number>|undefined),
+ *     offsetOrigin: (ol.style.IconOrigin|undefined),
+ *     opacity: (number|undefined),
+ *     scale: (number|undefined),
+ *     snapToPixel: (boolean|undefined),
+ *     rotateWithView: (boolean|undefined),
+ *     rotation: (number|undefined),
+ *     size: (ol.Size|undefined),
+ *     imgSize: (ol.Size|undefined),
+ *     src: (string|undefined)}}
+ */
+export var style_IconOptions;
+
+/**
+ * @param {style_IconOptions} options TODO: repace this
+ *
+ * @param {Array.<number>|undefined} options.anchor Anchor. Default value is `[0.5, 0.5]` (icon center).
+ *
+ * @param {ol.style.IconOrigin|undefined} options.anchorOrigin Origin of the anchor: `bottom-left`, `bottom-right`, `top-left` or
+ * `top-right`. Default is `top-left`.
+ *
+ * @param {ol.style.IconAnchorUnits|undefined} options.anchorXUnits Units in which the anchor x value is specified. A value of `'fraction'`
+ * indicates the x value is a fraction of the icon. A value of `'pixels'`
+ * indicates the x value in pixels. Default is `'fraction'`.
+ *
+ * @param {ol.style.IconAnchorUnits|undefined} options.anchorYUnits Units in which the anchor y value is specified. A value of `'fraction'`
+ * indicates the y value is a fraction of the icon. A value of `'pixels'`
+ * indicates the y value in pixels. Default is `'fraction'`.
+ *
+ * @param {ol.Color|string|undefined} options.color Color to tint the icon. If not specified, the icon will be left as is.
+ *
+ * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * `crossOrigin` value if you are using the WebGL renderer or if you want to
+ * access pixel data with the Canvas renderer.  See
+ * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * for more detail.
+ *
+ * @param {Image|HTMLCanvasElement|undefined} options.img Image object for the icon. If the `src` option is not provided then the
+ * provided image must already be loaded. And in that case, it is required
+ * to provide the size of the image, with the `imgSize` option.
+ *
+ * @param {Array.<number>|undefined} options.offset Offset, which, together with the size and the offset origin,
+ * define the sub-rectangle to use from the original icon image. Default value
+ * is `[0, 0]`.
+ *
+ * @param {ol.style.IconOrigin|undefined} options.offsetOrigin Origin of the offset: `bottom-left`, `bottom-right`, `top-left` or
+ * `top-right`. Default is `top-left`.
+ *
+ * @param {number|undefined} options.opacity Opacity of the icon. Default is `1`.
+ *
+ * @param {number|undefined} options.scale Scale. Default is `1`.
+ *
+ * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
+ * coordinate when drawing the icon in the output canvas. If `false`
+ * fractional numbers may be used. Using `true` allows for "sharp"
+ * rendering (no blur), while using `false` allows for "accurate"
+ * rendering. Note that accuracy is important if the icon's position
+ * is animated. Without it, the icon may jitter noticeably. Default
+ * value is `true`.
+ *
+ * @param {boolean|undefined} options.rotateWithView Whether to rotate the icon with the view. Default is `false`.
+ *
+ * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
+ *
+ * @param {ol.Size|undefined} options.size Icon size in pixel. Can be used together with `offset` to define the
+ * sub-rectangle to use from the origin (sprite) icon image.
+ *
+ * @param {ol.Size|undefined} options.imgSize Image size in pixels. Only required if `img` is set and `src` is not, and for
+ * SVG images in Internet Explorer 11. The provided `imgSize` needs to match
+ * the actual size of the image.
+ *
+ * @param {string|undefined} options.src Image source URI.
+ *
+ */
+
+
+/**
+ * Specify radius for regular polygons, or radius1 and radius2 for stars.
+ * @typedef {{fill: (ol.style.Fill|undefined),
+ *     points: number,
+ *     radius: (number|undefined),
+ *     radius1: (number|undefined),
+ *     radius2: (number|undefined),
+ *     angle: (number|undefined),
+ *     snapToPixel: (boolean|undefined),
+ *     stroke: (ol.style.Stroke|undefined),
+ *     rotation: (number|undefined),
+ *     rotateWithView: (boolean|undefined),
+ *     atlasManager: (ol.style.AtlasManager|undefined)}}
+ */
+export var style_RegularShapeOptions;
+
+/**
+ * @param {style_RegularShapeOptions} options TODO: repace this
+ *
+ * @param {ol.style.Fill|undefined} options.fill Fill style.
+ *
+ * @param {number} options.points Number of points for stars and regular polygons. In case of a polygon, the
+ * number of points is the number of sides.
+ *
+ * @param {number|undefined} options.radius Radius of a regular polygon.
+ *
+ * @param {number|undefined} options.radius1 Outer radius of a star.
+ *
+ * @param {number|undefined} options.radius2 Inner radius of a star.
+ *
+ * @param {number|undefined} options.angle Shape's angle in radians. A value of 0 will have one of the shape's point
+ * facing up.
+ * Default value is 0.
+ *
+ * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
+ * coordinate when drawing the shape in the output canvas. If `false`
+ * fractional numbers may be used. Using `true` allows for "sharp"
+ * rendering (no blur), while using `false` allows for "accurate"
+ * rendering. Note that accuracy is important if the shape's
+ * position is animated. Without it, the shape may jitter noticeably.
+ * Default value is `true`.
+ *
+ * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
+ *
+ * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
+ *
+ * @param {boolean|undefined} options.rotateWithView Whether to rotate the shape with the view. Default is `false`.
+ *
+ * @param {ol.style.AtlasManager|undefined} options.atlasManager The atlas manager to use for this symbol. When using WebGL it is
+ * recommended to use an atlas manager to avoid texture switching.
+ * If an atlas manager is given, the symbol is added to an atlas.
+ * By default no atlas manager is used.
+ *
+ */
+
+
+/**
+ * @typedef {{color: (ol.Color|ol.ColorLike|undefined),
+ *     lineCap: (string|undefined),
+ *     lineJoin: (string|undefined),
+ *     lineDash: (Array.<number>|undefined),
+ *     lineDashOffset: (number|undefined),
+ *     miterLimit: (number|undefined),
+ *     width: (number|undefined)}}
+ */
+export var style_StrokeOptions;
+
+/**
+ * @param {style_StrokeOptions} options TODO: repace this
+ *
+ * @param {ol.Color|ol.ColorLike|undefined} options.color A color, gradient or pattern. See {@link ol.color}
+ * and {@link ol.colorlike} for possible formats. Default null;
+ * if null, the Canvas/renderer default black will be used.
+ *
+ * @param {string|undefined} options.lineCap Line cap style: `butt`, `round`, or `square`. Default is `round`.
+ *
+ * @param {string|undefined} options.lineJoin Line join style: `bevel`, `round`, or `miter`. Default is `round`.
+ *
+ * @param {Array.<number>|undefined} options.lineDash Line dash pattern. Default is `undefined` (no dash). Please note that
+ * Internet Explorer 10 and lower [do not support][mdn] the `setLineDash`
+ * method on the `CanvasRenderingContext2D` and therefore this option will
+ * have no visual effect in these browsers.
+ *
+ * [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility
+ *
+ *
+ * @param {number|undefined} options.lineDashOffset Line dash offset. Default is '0'.
+ *
+ * @param {number|undefined} options.miterLimit Miter limit. Default is `10`.
+ *
+ * @param {number|undefined} options.width Width.
+ *
+ */
+
+
+/**
+ * @typedef {{font: (string|undefined),
+ *     maxAngle: (number|undefined),
+ *     offsetX: (number|undefined),
+ *     offsetY: (number|undefined),
+ *     overflow: (boolean|undefined),
+ *     placement: (ol.style.TextPlacement|string|undefined),
+ *     scale: (number|undefined),
+ *     rotateWithView: (boolean|undefined),
+ *     rotation: (number|undefined),
+ *     text: (string|undefined),
+ *     textAlign: (string|undefined),
+ *     textBaseline: (string|undefined),
+ *     fill: (ol.style.Fill|undefined),
+ *     stroke: (ol.style.Stroke|undefined),
+ *     backgroundFill: (ol.style.Fill|undefined),
+ *     backgroundStroke: (ol.style.Stroke|undefined),
+ *     padding: (Array.<number>|undefined)}}
+ */
+export var style_TextOptions;
+
+/**
+ * @param {style_TextOptions} options TODO: repace this
+ *
+ * @param {string|undefined} options.font Font style as CSS 'font' value, see:
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font}.
+ * Default is '10px sans-serif'
+ *
+ * @param {number|undefined} options.maxAngle When `placement` is set to `'line'`, allow a maximum angle between adjacent
+ * characters. The expected value is in radians, and the default is 45°
+ * (`Math.PI / 4`).
+ *
+ * @param {number|undefined} options.offsetX Horizontal text offset in pixels. A positive will shift the text right.
+ * Default is `0`.
+ *
+ * @param {number|undefined} options.offsetY Vertical text offset in pixels. A positive will shift the text down. Default
+ * is `0`.
+ *
+ * @param {boolean|undefined} options.overflow For polygon labels or when `placement` is set to `'line'`, allow text to
+ * exceed the width of the polygon at the label position or the length of
+ * the path that it follows. Default is `false`.
+ *
+ * @param {ol.style.TextPlacement|undefined} options.placement Text placement.
+ *
+ * @param {number|undefined} options.scale Scale.
+ *
+ * @param {boolean|undefined} options.rotateWithView Whether to rotate the text with the view. Default is `false`.
+ *
+ * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
+ *
+ * @param {string|undefined} options.text Text content.
+ *
+ * @param {string|undefined} options.textAlign Text alignment. Possible values: 'left', 'right', 'center', 'end' or 'start'.
+ * Default is 'center' for `placement: 'point'`. For `placement: 'line'`, the
+ * default is to let the renderer choose a placement where `maxAngle` is not
+ * exceeded.
+ *
+ * @param {string|undefined} options.textBaseline Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
+ * 'hanging', 'ideographic'. Default is 'middle'.
+ *
+ * @param {ol.style.Fill|undefined} options.fill Fill style. If none is provided, we'll use a dark fill-style (#333).
+ *
+ * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
+ *
+ * @param {ol.style.Fill|undefined} options.backgroundFill Fill style for the text background when `placement` is `'point'`. Default is
+ * no fill.
+ *
+ * @param {ol.style.Stroke|undefined} options.backgroundStroke Stroke style for the text background  when `placement` is `'point'`. Default
+ * is no stroke.
+ *
+ * @param {Array.<number>|undefined} options.padding Padding in pixels around the text for decluttering and background. The order
+ * of values in the array is `[top, right, bottom, left]`. Default is
+ * `[0, 0, 0, 0]`.
+ *
+ */
+
+
+/**
+ * @typedef {{geometry: (undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction),
+ *     fill: (ol.style.Fill|undefined),
+ *     image: (ol.style.Image|undefined),
+ *     renderer: (ol.StyleRenderFunction|undefined),
+ *     stroke: (ol.style.Stroke|undefined),
+ *     text: (ol.style.Text|undefined),
+ *     zIndex: (number|undefined)}}
+ */
+export var style_StyleOptions;
+
+/**
+ * @param {style_StyleOptions} options TODO: repace this
+ *
+ * @param {undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction} options.geometry Feature property or geometry or function returning a geometry to render for
+ * this style.
+ *
+ * @param {ol.style.Fill|undefined} options.fill Fill style.
+ *
+ * @param {ol.style.Image|undefined} options.image Image style.
+ *
+ * @param {ol.StyleRenderFunction|undefined} options.renderer Custom renderer. When configured, `fill`, `stroke` and `image` will be
+ * ignored, and the provided function will be called with each render frame for
+ * each geometry.
+ *
+ *
+ * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
+ *
+ * @param {ol.style.Text|undefined} options.text Text style.
+ *
+ * @param {number|undefined} options.zIndex Z index.
+ *
+ */
+
+
+/**
+ * @typedef {{extent: (ol.Extent|undefined),
+ *     minZoom: (number|undefined),
+ *     origin: (ol.Coordinate|undefined),
+ *     origins: (Array.<ol.Coordinate>|undefined),
+ *     resolutions: !Array.<number>,
+ *     sizes: (Array.<ol.Size>|undefined),
+ *     tileSize: (number|ol.Size|undefined),
+ *     tileSizes: (Array.<number|ol.Size>|undefined)}}
+ */
+export var tilegrid_TileGridOptions;
+
+/**
+ * @param {tilegrid_TileGridOptions} options TODO: repace this
+ *
+ * @param {ol.Extent|undefined} options.extent Extent for the tile grid. No tiles outside this extent will be requested by
+ * {@link ol.source.Tile} sources. When no `origin` or `origins` are
+ * configured, the `origin` will be set to the top-left corner of the extent.
+ *
+ * @param {number|undefined} options.minZoom Minimum zoom. Default is 0.
+ *
+ * @param {ol.Coordinate|undefined} options.origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
+ * Tile coordinates increase left to right and upwards. If not specified,
+ * `extent` or `origins` must be provided.
+ *
+ * @param {Array.<ol.Coordinate>|undefined} options.origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
+ * each zoom level. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution can have a different origin. Tile
+ * coordinates increase left to right and upwards. If not specified, `extent`
+ * or `origin` must be provided.
+ *
+ * @param {!Array.<number>} options.resolutions Resolutions. The array index of each resolution needs to match the zoom
+ * level. This means that even if a `minZoom` is configured, the resolutions
+ * array will have a length of `maxZoom + 1`.
+ *
+ * @param {number|ol.Size|undefined} options.tileSize Tile size. Default is `[256, 256]`.
+ *
+ * @param {Array.<number|ol.Size>|undefined} options.tileSizes Tile sizes. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution can have a different tile size.
+ *
+ */
+
+
+/**
+ * @typedef {{extent: (ol.Extent|undefined),
+ *     origin: (ol.Coordinate|undefined),
+ *     origins: (Array.<ol.Coordinate>|undefined),
+ *     resolutions: !Array.<number>,
+ *     matrixIds: !Array.<string>,
+ *     sizes: (Array.<ol.Size>|undefined),
+ *     tileSize: (number|ol.Size|undefined),
+ *     tileSizes: (Array.<number|ol.Size>|undefined)}}
+ */
+export var tilegrid_WMTSOptions;
+
+/**
+ * @param {tilegrid_WMTSOptions} options TODO: repace this
+ *
+ * @param {ol.Extent|undefined} options.extent Extent for the tile grid. No tiles outside this extent will be requested by
+ * {@link ol.source.Tile} sources. When no `origin` or `origins` are
+ * configured, the `origin` will be set to the top-left corner of the extent.
+ *
+ * @param {ol.Coordinate|undefined} options.origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
+ * Tile coordinates increase left to right and upwards. If not specified,
+ * `extent` or `origins` must be provided.
+ *
+ * @param {Array.<ol.Coordinate>|undefined} options.origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
+ * each zoom level. If given, the array length should match the length of the
+ * `resolutions` array, i.e. each resolution can have a different origin. Tile
+ * coordinates increase left to right and upwards. If not specified, `extent` or
+ * `origin` must be provided.
+ *
+ * @param {!Array.<number>} options.resolutions Resolutions. The array index of each resolution needs to match the zoom
+ * level. This means that even if a `minZoom` is configured, the resolutions
+ * array will have a length of `maxZoom + 1`
+ *
+ * @param {!Array.<string>} options.matrixIds matrix IDs. The length of this array needs to match the length of the
+ * `resolutions` array.
+ *
+ * @param {Array.<ol.Size>|undefined} options.sizes Number of tile rows and columns of the grid for each zoom level. The values
+ * here are the `TileMatrixWidth` and `TileMatrixHeight` advertised in the
+ * GetCapabilities response of the WMTS, and define the grid's extent together
+ * with the `origin`. An `extent` can be configured in addition, and will
+ * further limit the extent for which tile requests are made by sources. Note
+ * that when the top-left corner of the `extent` is used as `origin` or
+ * `origins`, then the `y` value must be negative because OpenLayers tile
+ * coordinates increase upwards.
+ *
+ * @param {number|ol.Size|undefined} options.tileSize Tile size.
+ *
+ * @param {Array.<number|ol.Size>|undefined} options.tileSizes Tile sizes. The length of this array needs to match the length of the
+ * `resolutions` array.
+ *
+ * @param {Array.<number>|undefined} options.widths Number of tile columns that cover the grid's extent for each zoom level. Only
+ * required when used with a source that has `wrapX` set to `true`, and only
+ * when the grid's origin differs from the one of the projection's extent. The
+ * array length has to match the length of the `resolutions` array, i.e. each
+ * resolution will have a matching entry here.
+ *
+ */
+
+
+/**
+ * @typedef {{extent: (ol.Extent|undefined),
+ *     maxZoom: (number|undefined),
+ *     minZoom: (number|undefined),
+ *     tileSize: (number|ol.Size|undefined)}}
+ */
+export var tilegrid_XYZOptions;
+
+/**
+ * @param {tilegrid_XYZOptions} options TODO: repace this
+ *
+ * @param {ol.Extent|undefined} options.extent Extent for the tile grid.  The origin for an XYZ tile grid is the top-left
+ * corner of the extent.  The zero level of the grid is defined by the
+ * resolution at which one tile fits in the provided extent.  If not provided,
+ * the extent of the EPSG:3857 projection is used.
+ *
+ * @param {number|undefined} options.maxZoom Maximum zoom.  The default is `ol.DEFAULT_MAX_ZOOM`.  This determines the
+ * number of levels in the grid set.  For example, a `maxZoom` of 21 means there
+ * are 22 levels in the grid set.
+ *
+ * @param {number|undefined} options.minZoom Minimum zoom. Default is 0.
+ *
+ * @param {number|ol.Size|undefined} options.tileSize Tile size in pixels. Default is `[256, 256]`.
+ *
+ */
+
+
+/**
+ * @typedef {{
+ *     size: (ol.Size|undefined),
+ *     padding: (!Array.<number>|undefined),
+ *     constrainResolution: (boolean|undefined),
+ *     nearest: (boolean|undefined),
+ *     maxZoom: (number|undefined),
+ *     minResolution: (number|undefined),
+ *     duration: (number|undefined),
+ *     easing: (undefined|function(number):number),
+ *     callback: (undefined|function(boolean))
+ * }}
+ */
+export var view_FitOptions;
+
+/**
+ * @param {view_FitOptions} options TODO: repace this
+ *
+ * @param {ol.Size|undefined} options.size The size in pixels of the box to fit the extent into. Default is
+ * the current size of the first map in the DOM that uses this view, or
+ * `[100, 100]` if no such map is found.
+ *
+ * @param {!Array.<number>|undefined} options.padding Padding (in pixels) to be cleared inside the view. Values in the array are
+ * top, right, bottom and left padding. Default is `[0, 0, 0, 0]`.
+ *
+ * @param {boolean|undefined} options.constrainResolution Constrain the resolution. Default is `true`.
+ *
+ * @param {boolean|undefined} options.nearest Get the nearest extent. Default is `false`.
+ *
+ * @param {number|undefined} options.minResolution Minimum resolution that we zoom to. Default is `0`.
+ *
+ * @param {number|undefined} options.maxZoom Maximum zoom level that we zoom to. If `minResolution` is given,
+ * this property is ignored.
+ *
+ * @param {number|undefined} options.duration The duration of the animation in milliseconds. By default, there is no
+ * animations.
+ *
+ * @param {undefined|function(number):number} options.easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
+ * The function will be called for each frame with a number representing a
+ * fraction of the animation's duration.  The function should return a number
+ * between 0 and 1 representing the progress toward the destination state.
+ *
+ * @param {undefined|function(boolean)} options.callback Optional function called when the view is in it's final position. The callback will be
+ * called with `true` if the animation series completed on its own or `false`
+ * if it was cancelled.
+ *
+ */
+
+
+/**
+ * @typedef {{animate: boolean,
+ *     coordinateToPixelTransform: ol.Transform,
+ *     extent: (null|ol.Extent),
+ *     focus: ol.Coordinate,
+ *     index: number,
+ *     layerStates: Object.<number, ol.LayerState>,
+ *     layerStatesArray: Array.<ol.LayerState>,
+ *     logos: Object.<string, (string|Element)>,
+ *     pixelRatio: number,
+ *     pixelToCoordinateTransform: ol.Transform,
+ *     postRenderFunctions: Array.<ol.PostRenderFunction>,
+ *     size: ol.Size,
+ *     skippedFeatureUids: !Object.<string, boolean>,
+ *     tileQueue: ol.TileQueue,
+ *     time: number,
+ *     usedTiles: Object.<string, Object.<string, ol.TileRange>>,
+ *     viewState: olx.ViewState,
+ *     viewHints: Array.<number>,
+ *     wantedTiles: !Object.<string, Object.<string, boolean>>}}
+ */
+export var FrameState;
+
+/**
+ * @param {FrameState} options TODO: repace this
+ *
+ * @param {number} options.pixelRatio
+ * @param {number} options.time
+ * @param {olx.ViewState} options.viewState
+ */
+
+
+/**
+ * @typedef {{center: ol.Coordinate,
+ *     projection: ol.proj.Projection,
+ *     resolution: number,
+ *     rotation: number,
+ *     zoom: number}}
+ */
+export var ViewState;
+
+/**
+ * @param {ViewState} options TODO: repace this
+ *
+ * @param {ol.Coordinate} options.center
+ * @param {ol.proj.Projection} options.projection
+ * @param {number} options.resolution
+ * @param {number} options.rotation
+ * @param {number} options.zoom The current zoom level.
+ *
+ */
+
+
+/**
+ * @typedef {{initialSize: (number|undefined),
+ *     maxSize: (number|undefined),
+ *     space: (number|undefined)}}
+ */
+export var style_AtlasManagerOptions;
+
+/**
+ * @param {style_AtlasManagerOptions} options TODO: repace this
+ *
+ * @param {number|undefined} options.initialSize The size in pixels of the first atlas image. Default is `256`.
+ *
+ * @param {number|undefined} options.maxSize The maximum size in pixels of atlas images. Default is
+ * `WEBGL_MAX_TEXTURE_SIZE` or 2048 if WebGL is not supported.
+ *
+ * @param {number|undefined} options.space The space in pixels between images (default: 1).
+ *
+ */
+
+
+/**
+ * @typedef {{handles: function(ol.renderer.Type):boolean,
+ *     create: function(Element, ol.PluggableMap):ol.renderer.Map}}
+ */
+export var MapRendererPlugin;
+
+/**
+ * @param {MapRendererPlugin} options TODO: repace this
+ *
+ * @param {function(ol.renderer.Type):boolean} options.handles Determine if this renderer handles the provided layer.
+ *
+ * @param {function(Element, ol.PluggableMap):ol.renderer.Map} options.create Create the map renderer.
+ *
+ */
+
+
+/**
+ * @typedef {{handles: function(ol.renderer.Type, ol.layer.Layer):boolean,
+ *     create: function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer}}
+ */
+export var LayerRendererPlugin;
+
+/**
+ * @param {LayerRendererPlugin} options TODO: repace this
+ *
+ * @param {function(ol.renderer.Type, ol.layer.Layer):boolean} options.handles Determine if this renderer handles the provided layer.
+ *
+ * @param {function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer} options.create Create a layer renderer.
+ *
+ */

--- a/externs/xol.js
+++ b/externs/xol.js
@@ -1,13 +1,5 @@
 
 /**
- * @typedef {Object} TileOptions
- * @property {number|undefined} transition A duration for tile opacity transitions.  By default, tiles will render with
- * an opacity transition that lasts 250 ms.  To change the duration, pass a
- * number in milliseconds.  A duration of 0 disables the opacity transition.
- */
-
-
-/**
  * @typedef {Object} AtPixelOptions
  * @property {((function(ol.layer.Layer): boolean)|undefined)} layerFilter Layer filter function. The filter function will receive one argument, the
  * {@link ol.layer.Layer layer-candidate} and it should return a boolean value.
@@ -16,48 +8,6 @@
  * @property {number|undefined} hitTolerance Hit-detection tolerance in pixels. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- */
-
-
-/**
- * @typedef {Object} OverlayOptions
- * @property {number|string|undefined} id Set the overlay id. The overlay id can be used with the
- * {@link ol.Map#getOverlayById} method.
- * @property {Element|undefined} element The overlay element.
- * @property {Array.<number>|undefined} offset Offsets in pixels used when positioning the overlay. The first element in the
- * array is the horizontal offset. A positive value shifts the overlay right.
- * The second element in the array is the vertical offset. A positive value
- * shifts the overlay down. Default is `[0, 0]`.
- * @property {ol.Coordinate|undefined} position The overlay position in map projection.
- * @property {ol.OverlayPositioning|string|undefined} positioning Defines how the overlay is actually positioned with respect to its `position`
- * property. Possible values are `'bottom-left'`, `'bottom-center'`,
- * `'bottom-right'`, `'center-left'`, `'center-center'`, `'center-right'`,
- * `'top-left'`, `'top-center'`, and `'top-right'`. Default is `'top-left'`.
- * @property {boolean|undefined} stopEvent Whether event propagation to the map viewport should be stopped. Default is
- * `true`. If `true` the overlay is placed in the same container as that of the
- * controls (CSS class name `ol-overlaycontainer-stopevent`); if `false` it is
- * placed in the container with CSS class name `ol-overlaycontainer`.
- * @property {boolean|undefined} insertFirst Whether the overlay is inserted first in the overlay container, or appended.
- * Default is `true`. If the overlay is placed in the same container as that of
- * the controls (see the `stopEvent` option) you will probably set `insertFirst`
- * to `true` so the overlay is displayed below the controls.
- * @property {boolean|undefined} autoPan If set to `true` the map is panned when calling `setPosition`, so that the
- * overlay is entirely visible in the current viewport.
- * The default is `false`.
- * @property {olx.OverlayPanOptions|undefined} autoPanAnimation The animation options used to pan the overlay into view. This animation
- * is only used when `autoPan` is enabled. A `duration` and `easing` may be
- * provided to customize the animation.
- * @property {number|undefined} autoPanMargin The margin (in pixels) between the overlay and the borders of the map when
- * autopanning. The default is `20`.
- * @property {string|undefined} className CSS class name. Default is `ol-overlay-container ol-selectable`.
- */
-
-
-/**
- * @typedef {Object} OverlayPanOptions
- * @property {number|undefined} duration The duration of the animation in milliseconds. Default is `1000`.
- * @property {undefined|function(number):number} easing The easing function to use. Can be an {@link ol.easing} or a custom function.
- * Default is {@link ol.easing.inAndOut}.
  */
 
 
@@ -75,57 +25,6 @@
  * `{number}` view resolution and an `{ol.Coordinate}` as arguments, and returns
  * the `{number}` resolution at the passed coordinate. If this is `undefined`,
  * the default {@link ol.proj#getPointResolution} function will be used.
- */
-
-
-/**
- * @typedef {Object} ViewOptions
- * @property {ol.Coordinate|undefined} center The initial center for the view. The coordinate system for the center is
- * specified with the `projection` option. Default is `undefined`, and layer
- * sources will not be fetched if this is not set.
- * @property {boolean|number|undefined} constrainRotation Rotation constraint. `false` means no constraint. `true` means no constraint,
- * but snap to zero near zero. A number constrains the rotation to that number
- * of values. For example, `4` will constrain the rotation to 0, 90, 180, and
- * 270 degrees. The default is `true`.
- * @property {boolean|undefined} enableRotation Enable rotation. Default is `true`. If `false` a rotation constraint that
- * always sets the rotation to zero is used. The `constrainRotation` option
- * has no effect if `enableRotation` is `false`.
- * @property {ol.Extent|undefined} extent The extent that constrains the center, in other words, center cannot be set
- * outside this extent. Default is `undefined`.
- * @property {number|undefined} maxResolution The maximum resolution used to determine the resolution constraint. It is
- * used together with `minResolution` (or `maxZoom`) and `zoomFactor`. If
- * unspecified it is calculated in such a way that the projection's validity
- * extent fits in a 256x256 px tile. If the projection is Spherical Mercator
- * (the default) then `maxResolution` defaults to `40075016.68557849 / 256 =
- * 156543.03392804097`.
- * @property {number|undefined} minResolution The minimum resolution used to determine the resolution constraint.  It is
- * used together with `maxResolution` (or `minZoom`) and `zoomFactor`.  If
- * unspecified it is calculated assuming 29 zoom levels (with a factor of 2).
- * If the projection is Spherical Mercator (the default) then `minResolution`
- * defaults to `40075016.68557849 / 256 / Math.pow(2, 28) =
- * 0.0005831682455839253`.
- * @property {number|undefined} maxZoom The maximum zoom level used to determine the resolution constraint. It is
- * used together with `minZoom` (or `maxResolution`) and `zoomFactor`. Default
- * is `28`.  Note that if `minResolution` is also provided, it is given
- * precedence over `maxZoom`.
- * @property {number|undefined} minZoom The minimum zoom level used to determine the resolution constraint. It is
- * used together with `maxZoom` (or `minResolution`) and `zoomFactor`. Default
- * is `0`. Note that if `maxResolution` is also provided, it is given
- * precedence over `minZoom`.
- * @property {ol.ProjectionLike} projection The projection. Default is `EPSG:3857` (Spherical Mercator).
- * @property {number|undefined} resolution The initial resolution for the view. The units are `projection` units per
- * pixel (e.g. meters per pixel). An alternative to setting this is to set
- * `zoom`. Default is `undefined`, and layer sources will not be fetched if
- * neither this nor `zoom` are defined.
- * @property {Array.<number>|undefined} resolutions Resolutions to determine the resolution constraint. If set the
- * `maxResolution`, `minResolution`, `minZoom`, `maxZoom`, and `zoomFactor`
- * options are ignored.
- * @property {number|undefined} rotation The initial rotation for the view in radians (positive rotation clockwise).
- * Default is `0`.
- * @property {number|undefined} zoom Only used if `resolution` is not defined. Zoom level used to calculate the
- * initial resolution for the view. The initial resolution is determined using
- * the `ol.View#constrainResolution` method.
- * @property {number|undefined} zoomFactor The zoom factor used to determine the resolution constraint.  Default is `2`.
  */
 
 
@@ -157,10 +56,10 @@
  * Default is `true`.
  * @property {boolean|undefined} collapsed Specify if attributions should be collapsed at startup. Default is `true`.
  * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Attributions`
- * @property {string|Node|undefined} label Text label to use for the collapsed attributions button. Default is `i`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
- * @property {string|Node|undefined} collapseLabel Text label to use for the expanded attributions button. Default is `»`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} label Text label to use for the collapsed attributions button. Default is `i`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} collapseLabel Text label to use for the expanded attributions button. Default is `»`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
  */
@@ -178,24 +77,13 @@
 
 
 /**
- * @typedef {Object} control_DefaultsOptions
- * @property {boolean|undefined} attribution Attribution. Default is `true`.
- * @property {olx.control.AttributionOptions|undefined} attributionOptions Attribution options.
- * @property {boolean|undefined} rotate Rotate. Default is `true`.
- * @property {olx.control.RotateOptions|undefined} rotateOptions Rotate options.
- * @property {boolean|undefined} zoom Zoom. Default is `true`.
- * @property {olx.control.ZoomOptions|undefined} zoomOptions Zoom options.
- */
-
-
-/**
  * @typedef {Object} control_FullScreenOptions
  * @property {string|undefined} className CSS class name. Default is `ol-full-screen`.
- * @property {string|Node|undefined} label Text label to use for the button. Default is `\u2922` (NORTH EAST AND SOUTH WEST ARROW).
- * Instead of text, also a Node (e.g. a `span` element) can be used.
- * @property {string|Node|undefined} labelActive Text label to use for the button when full-screen is active.
+ * @property {string|Element|undefined} label Text label to use for the button. Default is `\u2922` (NORTH EAST AND SOUTH WEST ARROW).
+ * Instead of text, also an element (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} labelActive Text label to use for the button when full-screen is active.
  * Default is `\u00d7` (a cross).
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Toggle full-screen`
  * @property {boolean|undefined} keys Full keyboard access.
  * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
@@ -207,7 +95,7 @@
 /**
  * @typedef {Object} control_MousePositionOptions
  * @property {string|undefined} className CSS class name. Default is `ol-mouse-position`.
- * @property {ol.CoordinateFormatType|undefined} coordinateFormat Coordinate format.
+ * @property {module:ol/coordinate~CoordinateFormat|undefined} coordinateFormat Coordinate format.
  * @property {ol.ProjectionLike} projection Projection.
  * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
@@ -221,11 +109,11 @@
  * @typedef {Object} control_OverviewMapOptions
  * @property {boolean|undefined} collapsed Whether the control should start collapsed or not (expanded).
  * Default to `true`.
- * @property {string|Node|undefined} collapseLabel Text label to use for the expanded overviewmap button. Default is `«`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} collapseLabel Text label to use for the expanded overviewmap button. Default is `«`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {boolean|undefined} collapsible Whether the control can be collapsed or not. Default to `true`.
- * @property {string|Node|undefined} label Text label to use for the collapsed overviewmap button. Default is `»`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} label Text label to use for the collapsed overviewmap button. Default is `»`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined} layers Layers for the overview map. If not set, then all main map layers are used
  * instead.
  * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
@@ -254,7 +142,7 @@
  * @typedef {Object} control_RotateOptions
  * @property {string|undefined} className CSS class name. Default is `ol-rotate`.
  * @property {string|Element|undefined} label Text label to use for the rotate button. Default is `⇧`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string|undefined} tipLabel Text label to use for the rotate tip. Default is `Reset rotation`
  * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
  * @property {boolean|undefined} autoHide Hide the control when rotation is 0. Default is `true`.
@@ -271,10 +159,10 @@
  * @typedef {Object} control_ZoomOptions
  * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
  * @property {string|undefined} className CSS class name. Default is `ol-zoom`.
- * @property {string|Node|undefined} zoomInLabel Text label to use for the zoom-in button. Default is `+`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
- * @property {string|Node|undefined} zoomOutLabel Text label to use for the zoom-out button. Default is `-`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} zoomInLabel Text label to use for the zoom-in button. Default is `+`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} zoomOutLabel Text label to use for the zoom-out button. Default is `-`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string|undefined} zoomInTipLabel Text label to use for the button tip. Default is `Zoom in`
  * @property {string|undefined} zoomOutTipLabel Text label to use for the button tip. Default is `Zoom out`
  * @property {number|undefined} delta The zoom delta applied on each click.
@@ -299,8 +187,8 @@
  * @property {string|undefined} className Class name. Default is `ol-zoom-extent`.
  * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * @property {string|Node|undefined} label Text label to use for the button. Default is `E`.
- * Instead of text, also a Node (e.g. a `span` element) can be used.
+ * @property {string|Element|undefined} label Text label to use for the button. Default is `E`.
+ * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Zoom to extent`
  * @property {ol.Extent|undefined} extent The extent to zoom to. If undefined the validity extent of the view
  * projection is used.
@@ -419,7 +307,7 @@
 
 /**
  * @typedef {Object} format_IGCOptions
- * @property {ol.format.IGCZ|undefined} altitudeMode Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
+ * @property {IGCZ|string|undefined} altitudeMode Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
  * is `none`.
  */
 
@@ -540,23 +428,6 @@
 
 
 /**
- * @typedef {Object} interaction_DefaultsOptions
- * @property {boolean|undefined} altShiftDragRotate Whether Alt-Shift-drag rotate is desired. Default is `true`.
- * @property {boolean|undefined} constrainResolution Zoom to the closest integer zoom level after the wheel/trackpad or
- * pinch gesture ends. Default is `false`.
- * @property {boolean|undefined} doubleClickZoom Whether double click zoom is desired. Default is `true`.
- * @property {boolean|undefined} keyboard Whether keyboard interaction is desired. Default is `true`.
- * @property {boolean|undefined} mouseWheelZoom Whether mousewheel zoom is desired. Default is `true`.
- * @property {boolean|undefined} shiftDragZoom Whether Shift-drag zoom is desired. Default is `true`.
- * @property {boolean|undefined} dragPan Whether drag pan is desired. Default is `true`.
- * @property {boolean|undefined} pinchRotate Whether pinch rotate is desired. Default is `true`.
- * @property {boolean|undefined} pinchZoom Whether pinch zoom is desired. Default is `true`.
- * @property {number|undefined} zoomDelta Zoom delta.
- * @property {number|undefined} zoomDuration Zoom duration.
- */
-
-
-/**
  * @typedef {Object} interaction_DoubleClickZoomOptions
  * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
  * @property {number|undefined} delta The zoom delta applied on each double click, default is `1`.
@@ -637,6 +508,8 @@
  * devices.
  * @property {ol.Collection.<ol.Feature>|undefined} features Destination collection for the drawn features.
  * @property {ol.source.Vector|undefined} source Destination source for the drawn features.
+ * @property {number|undefined} dragVertexDelay Delay in milliseconds after pointerdown before the current vertex can be
+ * dragged to its exact position. Default is 500 ms.
  * @property {number|undefined} snapTolerance Pixel distance for snapping to the drawing finish. Default is `12`.
  * @property {ol.geom.GeometryType|string} type Drawing type ('Point', 'LineString', 'Polygon', 'MultiPoint',
  * 'MultiLineString', 'MultiPolygon' or 'Circle').
@@ -744,6 +617,8 @@
 
 /**
  * @typedef {Object} interaction_MouseWheelZoomOptions
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * to indicate whether that event should be handled. Default is {@link ol.events.condition.always}.
  * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
  * @property {number|undefined} timeout Mouse wheel timeout duration in milliseconds. Default is `80`.
  * @property {boolean|undefined} constrainResolution When using a trackpad or magic mouse, zoom to the closest integer zoom level
@@ -982,6 +857,7 @@
  * z-index means higher priority. Default is `false`.
  * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} style Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
+ * @property {number|undefined} maxTilesLoading Maximum number tiles to load simultaneously.  Default is `16`.
  * @property {boolean|undefined} updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
  * This means that no vectors will be shown clipped, but the setting will have a
  * performance impact for large amounts of vector data. When set to `false`,
@@ -1053,16 +929,6 @@
  * @property {number} resolution Resolution that the render batch was created and optimized for. This is
  * not the view's resolution that is being rendered.
  * @property {number} rotation Rotation of the rendered layer in radians.
- */
-
-
-/**
- * @typedef {Object} render_ToContextOptions
- * @property {ol.Size|undefined} size Desired size of the canvas in css pixels. When provided, both canvas and css
- * size will be set according to the `pixelRatio`. If not provided, the current
- * canvas and css sizes will not be altered.
- * @property {number|undefined} pixelRatio Pixel ratio (canvas pixel to css pixel ratio) for the canvas. Default
- * is the detected device pixel ratio.
  */
 
 
@@ -2013,38 +1879,6 @@
 
 
 /**
- * @typedef {Object} view_FitOptions
- * @property {ol.Size|undefined} size The size in pixels of the box to fit the extent into. Default is
- * the current size of the first map in the DOM that uses this view, or
- * `[100, 100]` if no such map is found.
- * @property {!Array.<number>|undefined} padding Padding (in pixels) to be cleared inside the view. Values in the array are
- * top, right, bottom and left padding. Default is `[0, 0, 0, 0]`.
- * @property {boolean|undefined} constrainResolution Constrain the resolution. Default is `true`.
- * @property {boolean|undefined} nearest Get the nearest extent. Default is `false`.
- * @property {number|undefined} minResolution Minimum resolution that we zoom to. Default is `0`.
- * @property {number|undefined} maxZoom Maximum zoom level that we zoom to. If `minResolution` is given,
- * this property is ignored.
- * @property {number|undefined} duration The duration of the animation in milliseconds. By default, there is no
- * animations.
- * @property {undefined|function(number):number} easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
- * The function will be called for each frame with a number representing a
- * fraction of the animation's duration.  The function should return a number
- * between 0 and 1 representing the progress toward the destination state.
- * @property {undefined|function(boolean)} callback Optional function called when the view is in it's final position. The callback will be
- * called with `true` if the animation series completed on its own or `false`
- * if it was cancelled.
- */
-
-
-/**
- * @typedef {Object} FrameState
- * @property {number} pixelRatio 
- * @property {number} time 
- * @property {olx.ViewState} viewState 
- */
-
-
-/**
  * @typedef {Object} ViewState
  * @property {ol.Coordinate} center 
  * @property {ol.proj.Projection} projection 
@@ -2060,19 +1894,5 @@
  * @property {number|undefined} maxSize The maximum size in pixels of atlas images. Default is
  * `WEBGL_MAX_TEXTURE_SIZE` or 2048 if WebGL is not supported.
  * @property {number|undefined} space The space in pixels between images (default: 1).
- */
-
-
-/**
- * @typedef {Object} MapRendererPlugin
- * @property {function(ol.renderer.Type):boolean} handles Determine if this renderer handles the provided layer.
- * @property {function(Element, ol.PluggableMap):ol.renderer.Map} create Create the map renderer.
- */
-
-
-/**
- * @typedef {Object} LayerRendererPlugin
- * @property {function(ol.renderer.Type, ol.layer.Layer):boolean} handles Determine if this renderer handles the provided layer.
- * @property {function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer} create Create a layer renderer.
  */
 

--- a/externs/xol.js
+++ b/externs/xol.js
@@ -1,953 +1,336 @@
 
 /**
- * @typedef {{unique: (boolean|undefined)}}
- */
-export let CollectionOptions;
-
-/**
- * @param {CollectionOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.unique Disallow the same item from being added to the collection twice.  Default is
- * false.
- * 
- */
-
-
-/**
- * @typedef {{tracking: (boolean|undefined),
- *     trackingOptions: (GeolocationPositionOptions|undefined),
- *     projection: ol.ProjectionLike}}
- */
-export let GeolocationOptions;
-
-/**
- * @param {GeolocationOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.tracking Start Tracking. Default is `false`.
- * 
- * @param {GeolocationPositionOptions|undefined} options.trackingOptions Tracking options. See
- * {@link http://www.w3.org/TR/geolocation-API/#position_options_interface}.
- * 
- * @param {ol.ProjectionLike} options.projection The projection the position is reported in.
- * 
- */
-
-
-/**
- * Object literal with config options for the map logo.
- * @typedef {{href: (string), src: (string)}}
- */
-export let LogoOptions;
-
-/**
- * @param {LogoOptions} options TODO: repace this
- *
- * @param {string} options.href Link url for the logo. Will be followed when the logo is clicked.
- * 
- * @param {string} options.src Image src for the logo.
- * 
- */
-
-
-/**
- * @typedef {{map: (ol.PluggableMap|undefined),
- *     maxLines: (number|undefined),
- *     strokeStyle: (ol.style.Stroke|undefined),
- *     targetSize: (number|undefined),
- *     showLabels: (boolean|undefined),
- *     lonLabelFormatter: (undefined|function(number):string),
- *     latLabelFormatter: (undefined|function(number):string),
- *     lonLabelPosition: (number|undefined),
- *     latLabelPosition: (number|undefined),
- *     lonLabelStyle: (ol.style.Text|undefined),
- *     latLabelStyle: (ol.style.Text|undefined)}}
- */
-export let GraticuleOptions;
-
-/**
- * @param {GraticuleOptions} options TODO: repace this
- *
- * @param {ol.PluggableMap|undefined} options.map Reference to an `ol.Map` object.
- * 
- * @param {number|undefined} options.maxLines The maximum number of meridians and parallels from the center of the
- * map. The default value is 100, which means that at most 200 meridians
- * and 200 parallels will be displayed. The default value is appropriate
- * for conformal projections like Spherical Mercator. If you increase
- * the value more lines will be drawn and the drawing performance will
- * decrease.
- * 
- * @param {ol.style.Stroke|undefined} options.strokeStyle The stroke style to use for drawing the graticule. If not provided, the
- * lines will be drawn with `rgba(0,0,0,0.2)`, a not fully opaque black.
- * 
- * 
- * @param {number|undefined} options.targetSize The target size of the graticule cells, in pixels. Default
- * value is 100 pixels.
- * 
- * @param {boolean|undefined} options.showLabels Render a label with the respective latitude/longitude for each graticule
- * line. Default is false.
- * 
- * 
- * @param {undefined|function(number):string} options.lonLabelFormatter Label formatter for longitudes. This function is called with the longitude as
- * argument, and should return a formatted string representing the longitude.
- * By default, labels are formatted as degrees, minutes, seconds and hemisphere.
- * 
- * 
- * @param {undefined|function(number):string} options.latLabelFormatter Label formatter for latitudes. This function is called with the latitude as
- * argument, and should return a formatted string representing the latitude.
- * By default, labels are formatted as degrees, minutes, seconds and hemisphere.
- * 
- * 
- * @param {number|undefined} options.lonLabelPosition Longitude label position in fractions (0..1) of view extent. 0 means at the
- * bottom of the viewport, 1 means at the top. Default is 0.
- * 
- * @param {number|undefined} options.latLabelPosition Latitude label position in fractions (0..1) of view extent. 0 means at the
- * left of the viewport, 1 means at the right. Default is 1.
- * 
- * @param {ol.style.Text|undefined} options.lonLabelStyle Longitude label text style. The default is
- * ```js
- * new ol.style.Text({
- *   font: '12px Calibri,sans-serif',
- *   textBaseline: 'bottom',
- *   fill: new ol.style.Fill({
- *     color: 'rgba(0,0,0,1)'
- *   }),
- *   stroke: new ol.style.Stroke({
- *     color: 'rgba(255,255,255,1)',
- *     width: 3
- *   })
- * });
- * ```
- * Note that the default's `textBaseline` configuration will not work well for
- * `lonLabelPosition` configurations that position labels close to the top of
- * the viewport.
- * 
- * 
- * @param {ol.style.Text|undefined} options.latLabelStyle Latitude label text style. The default is
- * ```js
- * new ol.style.Text({
- *   font: '12px Calibri,sans-serif',
- *   textAlign: 'end',
- *   fill: new ol.style.Fill({
- *     color: 'rgba(0,0,0,1)'
- *   }),
- *   stroke: new ol.style.Stroke({
- *     color: 'rgba(255,255,255,1)',
- *     width: 3
- *   })
- * });
- * ```
- * Note that the default's `textAlign` configuration will not work well for
- * `latLabelPosition` configurations that position labels close to the left of
- * the viewport.
- * 
- * 
- */
-
-
-/**
- * Object literal with config options for interactions.
- * @typedef {{handleEvent: function(ol.MapBrowserEvent):boolean}}
- */
-export let interaction_InteractionOptions;
-
-/**
- * @param {interaction_InteractionOptions} options TODO: repace this
- *
- * @param {function(ol.MapBrowserEvent):boolean} options.handleEvent Method called by the map to notify the interaction that a browser event was
- * dispatched to the map. If the function returns a falsy value,
- * propagation of the event to other interactions in the map's interactions
- * chain will be prevented (this includes functions with no explicit return). See
- * {@link https://developer.mozilla.org/en-US/docs/Glossary/Falsy}
- * 
- */
-
-
-/**
- * Object literal with config options for the map.
- * @typedef {{controls: (ol.Collection.<ol.control.Control>|Array.<ol.control.Control>|undefined),
- *     pixelRatio: (number|undefined),
- *     interactions: (ol.Collection.<ol.interaction.Interaction>|Array.<ol.interaction.Interaction>|undefined),
- *     keyboardEventTarget: (Element|Document|string|undefined),
- *     layers: (Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined),
- *     loadTilesWhileAnimating: (boolean|undefined),
- *     loadTilesWhileInteracting: (boolean|undefined),
- *     logo: (boolean|string|olx.LogoOptions|Element|undefined),
- *     moveTolerance: (number|undefined),
- *     overlays: (ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined),
- *     renderer: (ol.renderer.Type|Array.<ol.renderer.Type>|undefined),
- *     target: (Element|string|undefined),
- *     view: (ol.View|undefined)}}
- */
-export let MapOptions;
-
-/**
- * @param {MapOptions} options TODO: repace this
- *
- * @param {ol.Collection.<ol.control.Control>|Array.<ol.control.Control>|undefined} options.controls Controls initially added to the map. If not specified,
- * {@link ol.control.defaults ol.control.defaults()} is used.
- * 
- * @param {number|undefined} options.pixelRatio The ratio between physical pixels and device-independent pixels (dips) on the
- * device. If `undefined` then it gets set by using `window.devicePixelRatio`.
- * 
- * @param {ol.Collection.<ol.interaction.Interaction>|Array.<ol.interaction.Interaction>|undefined} options.interactions Interactions that are initially added to the map. If not specified,
- * {@link ol.interaction.defaults ol.interaction.defaults()} is used.
- * 
- * @param {Element|Document|string|undefined} options.keyboardEventTarget The element to listen to keyboard events on. This determines when the
- * `KeyboardPan` and `KeyboardZoom` interactions trigger. For example, if this
- * option is set to `document` the keyboard interactions will always trigger. If
- * this option is not specified, the element the library listens to keyboard
- * events on is the map target (i.e. the user-provided div for the map). If this
- * is not `document` the target element needs to be focused for key events to be
- * emitted, requiring that the target element has a `tabindex` attribute.
- * 
- * @param {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} options.layers Layers. If this is not defined, a map with no layers will be rendered. Note
- * that layers are rendered in the order supplied, so if you want, for example,
- * a vector layer to appear on top of a tile layer, it must come after the tile
- * layer.
- * 
- * @param {boolean|undefined} options.loadTilesWhileAnimating When set to true, tiles will be loaded during animations. This may improve
- * the user experience, but can also make animations stutter on devices with
- * slow memory. Default is `false`.
- * 
- * @param {boolean|undefined} options.loadTilesWhileInteracting When set to true, tiles will be loaded while interacting with the map. This
- * may improve the user experience, but can also make map panning and zooming
- * choppy on devices with slow memory. Default is `false`.
- * 
- * @param {boolean|string|olx.LogoOptions|Element|undefined} options.logo The map logo. A logo to be displayed on the map at all times. If a string is
- * provided, it will be set as the image source of the logo. If an object is
- * provided, the `src` property should be the URL for an image and the `href`
- * property should be a URL for creating a link. If an element is provided,
- * the element will be used. To disable the map logo, set the option to
- * `false`. By default, the OpenLayers logo is shown.
- * 
- * @param {number|undefined} options.moveTolerance The minimum distance in pixels the cursor must move to be detected
- * as a map move event instead of a click. Increasing this value can make it
- * easier to click on the map.
- * Default is `1`.
- * 
- * @param {ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined} options.overlays Overlays initially added to the map. By default, no overlays are added.
- * 
- * @param {ol.renderer.Type|Array.<ol.renderer.Type>|undefined} options.renderer Renderer. By default, Canvas and WebGL renderers are tested for support
- * in that order, and the first supported used. Specify a
- * {@link ol.renderer.Type} here to use a specific renderer.
- * Note that the Canvas renderer fully supports vector data, but WebGL can only
- * render Point geometries.
- * 
- * @param {Element|string|undefined} options.target The container for the map, either the element itself or the `id` of the
- * element. If not specified at construction time, {@link ol.Map#setTarget}
- * must be called for the map to be rendered.
- * 
- * @param {ol.View|undefined} options.view The map's view.  No layer sources will be fetched unless this is specified at
- * construction time or through {@link ol.Map#setView}.
- * 
- */
-
-
-/**
- * Object literal with options for the {@link ol.Sphere.getLength} or
- * {@link ol.Sphere.getArea} functions.
- * @typedef {{projection: (ol.ProjectionLike|undefined),
- *    radius: (number|undefined)}}
- */
-export let SphereMetricOptions;
-
-/**
- * @param {SphereMetricOptions} options TODO: repace this
- *
- * @param {(ol.ProjectionLike|undefined)} options.projection Projection of the geometry.  By default, the geometry is assumed to be in
- * EPSG:3857 (Web Mercator).
- * 
- * @param {(number|undefined)} options.radius Sphere radius.  By default, the radius of the earth is used (Clarke 1866
- * Authalic Sphere).
- * 
- */
-
-
-/**
- * Options for tile constructors.
- * @typedef {{transition: (number|undefined)}}
- */
-export let TileOptions;
-
-/**
- * @param {TileOptions} options TODO: repace this
- *
- * @param {number|undefined} options.transition A duration for tile opacity transitions.  By default, tiles will render with
+ * @typedef {Object} TileOptions
+ * @property {number|undefined} transition A duration for tile opacity transitions.  By default, tiles will render with
  * an opacity transition that lasts 250 ms.  To change the duration, pass a
  * number in milliseconds.  A duration of 0 disables the opacity transition.
- * 
  */
 
 
 /**
- * Object literal with options for the {@link ol.Map#forEachFeatureAtPixel} and
- * {@link ol.Map#hasFeatureAtPixel} methods.
- * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
- *    hitTolerance: (number|undefined)}}
- */
-export let AtPixelOptions;
-
-/**
- * @param {AtPixelOptions} options TODO: repace this
- *
- * @param {((function(ol.layer.Layer): boolean)|undefined)} options.layerFilter Layer filter function. The filter function will receive one argument, the
+ * @typedef {Object} AtPixelOptions
+ * @property {((function(ol.layer.Layer): boolean)|undefined)} layerFilter Layer filter function. The filter function will receive one argument, the
  * {@link ol.layer.Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
  * will be tested for features. By default, all visible layers will be tested.
- * 
- * @param {number|undefined} options.hitTolerance Hit-detection tolerance in pixels. Pixels inside the radius around the given position
+ * @property {number|undefined} hitTolerance Hit-detection tolerance in pixels. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- * 
  */
 
 
 /**
- * Object literal with config options for the overlay.
- * @typedef {{id: (number|string|undefined),
- *     element: (Element|undefined),
- *     offset: (Array.<number>|undefined),
- *     position: (ol.Coordinate|undefined),
- *     positioning: (ol.OverlayPositioning|string|undefined),
- *     stopEvent: (boolean|undefined),
- *     insertFirst: (boolean|undefined),
- *     autoPan: (boolean|undefined),
- *     autoPanAnimation: (olx.OverlayPanOptions|undefined),
- *     autoPanMargin: (number|undefined),
- *     className: (string|undefined)}}
- */
-export let OverlayOptions;
-
-/**
- * @param {OverlayOptions} options TODO: repace this
- *
- * @param {number|string|undefined} options.id Set the overlay id. The overlay id can be used with the
+ * @typedef {Object} OverlayOptions
+ * @property {number|string|undefined} id Set the overlay id. The overlay id can be used with the
  * {@link ol.Map#getOverlayById} method.
- * 
- * @param {Element|undefined} options.element The overlay element.
- * 
- * @param {Array.<number>|undefined} options.offset Offsets in pixels used when positioning the overlay. The first element in the
+ * @property {Element|undefined} element The overlay element.
+ * @property {Array.<number>|undefined} offset Offsets in pixels used when positioning the overlay. The first element in the
  * array is the horizontal offset. A positive value shifts the overlay right.
  * The second element in the array is the vertical offset. A positive value
  * shifts the overlay down. Default is `[0, 0]`.
- * 
- * @param {ol.Coordinate|undefined} options.position The overlay position in map projection.
- * 
- * @param {ol.OverlayPositioning|string|undefined} options.positioning Defines how the overlay is actually positioned with respect to its `position`
+ * @property {ol.Coordinate|undefined} position The overlay position in map projection.
+ * @property {ol.OverlayPositioning|string|undefined} positioning Defines how the overlay is actually positioned with respect to its `position`
  * property. Possible values are `'bottom-left'`, `'bottom-center'`,
  * `'bottom-right'`, `'center-left'`, `'center-center'`, `'center-right'`,
  * `'top-left'`, `'top-center'`, and `'top-right'`. Default is `'top-left'`.
- * 
- * @param {boolean|undefined} options.stopEvent Whether event propagation to the map viewport should be stopped. Default is
+ * @property {boolean|undefined} stopEvent Whether event propagation to the map viewport should be stopped. Default is
  * `true`. If `true` the overlay is placed in the same container as that of the
  * controls (CSS class name `ol-overlaycontainer-stopevent`); if `false` it is
  * placed in the container with CSS class name `ol-overlaycontainer`.
- * 
- * @param {boolean|undefined} options.insertFirst Whether the overlay is inserted first in the overlay container, or appended.
+ * @property {boolean|undefined} insertFirst Whether the overlay is inserted first in the overlay container, or appended.
  * Default is `true`. If the overlay is placed in the same container as that of
  * the controls (see the `stopEvent` option) you will probably set `insertFirst`
  * to `true` so the overlay is displayed below the controls.
- * 
- * @param {boolean|undefined} options.autoPan If set to `true` the map is panned when calling `setPosition`, so that the
+ * @property {boolean|undefined} autoPan If set to `true` the map is panned when calling `setPosition`, so that the
  * overlay is entirely visible in the current viewport.
  * The default is `false`.
- * 
- * @param {olx.OverlayPanOptions|undefined} options.autoPanAnimation The animation options used to pan the overlay into view. This animation
+ * @property {olx.OverlayPanOptions|undefined} autoPanAnimation The animation options used to pan the overlay into view. This animation
  * is only used when `autoPan` is enabled. A `duration` and `easing` may be
  * provided to customize the animation.
- * 
- * @param {number|undefined} options.autoPanMargin The margin (in pixels) between the overlay and the borders of the map when
+ * @property {number|undefined} autoPanMargin The margin (in pixels) between the overlay and the borders of the map when
  * autopanning. The default is `20`.
- * 
- * @param {string|undefined} options.className CSS class name. Default is `ol-overlay-container ol-selectable`.
- * 
+ * @property {string|undefined} className CSS class name. Default is `ol-overlay-container ol-selectable`.
  */
 
 
 /**
- * @typedef {{
- *   duration: (number|undefined),
- *   easing: (undefined|function(number):number)
- * }}
- */
-export let OverlayPanOptions;
-
-/**
- * @param {OverlayPanOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration The duration of the animation in milliseconds. Default is `1000`.
- * 
- * @param {undefined|function(number):number} options.easing The easing function to use. Can be an {@link ol.easing} or a custom function.
+ * @typedef {Object} OverlayPanOptions
+ * @property {number|undefined} duration The duration of the animation in milliseconds. Default is `1000`.
+ * @property {undefined|function(number):number} easing The easing function to use. Can be an {@link ol.easing} or a custom function.
  * Default is {@link ol.easing.inAndOut}.
- * 
  */
 
 
 /**
- * Object literal with config options for the projection.
- * @typedef {{code: string,
- *     units: (ol.proj.Units|string|undefined),
- *     extent: (ol.Extent|undefined),
- *     axisOrientation: (string|undefined),
- *     global: (boolean|undefined),
- *     metersPerUnit: (number|undefined),
- *     worldExtent: (ol.Extent|undefined),
- *     getPointResolution: (function(number, ol.Coordinate):number|undefined) }}
- */
-export let ProjectionOptions;
-
-/**
- * @param {ProjectionOptions} options TODO: repace this
- *
- * @param {string} options.code The SRS identifier code, e.g. `EPSG:4326`.
- * 
- * @param {ol.proj.Units|string|undefined} options.units Units. Required unless a proj4 projection is defined for `code`.
- * 
- * @param {ol.Extent|undefined} options.extent The validity extent for the SRS.
- * 
- * @param {string|undefined} options.axisOrientation The axis orientation as specified in Proj4. The default is `enu`.
- * 
- * @param {boolean|undefined} options.global Whether the projection is valid for the whole globe. Default is `false`.
- * 
- * @param {number|undefined} options.metersPerUnit The meters per unit for the SRS. If not provided, the `units` are used to get
+ * @typedef {Object} ProjectionOptions
+ * @property {string} code The SRS identifier code, e.g. `EPSG:4326`.
+ * @property {ol.proj.Units|string|undefined} units Units. Required unless a proj4 projection is defined for `code`.
+ * @property {ol.Extent|undefined} extent The validity extent for the SRS.
+ * @property {string|undefined} axisOrientation The axis orientation as specified in Proj4. The default is `enu`.
+ * @property {boolean|undefined} global Whether the projection is valid for the whole globe. Default is `false`.
+ * @property {number|undefined} metersPerUnit The meters per unit for the SRS. If not provided, the `units` are used to get
  * the meters per unit from the {@link ol.proj.METERS_PER_UNIT} lookup table.
- * 
- * @param {ol.Extent|undefined} options.worldExtent The world extent for the SRS.
- * 
- * @param {(function(number, ol.Coordinate):number|undefined)} options.getPointResolution Function to determine resolution at a point. The function is called with a
+ * @property {ol.Extent|undefined} worldExtent The world extent for the SRS.
+ * @property {(function(number, ol.Coordinate):number|undefined)} getPointResolution Function to determine resolution at a point. The function is called with a
  * `{number}` view resolution and an `{ol.Coordinate}` as arguments, and returns
  * the `{number}` resolution at the passed coordinate. If this is `undefined`,
  * the default {@link ol.proj#getPointResolution} function will be used.
- * 
  */
 
 
 /**
- * Object literal with config options for the view.
- * @typedef {{center: (ol.Coordinate|undefined),
- *     constrainRotation: (boolean|number|undefined),
- *     enableRotation: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     minZoom: (number|undefined),
- *     maxZoom: (number|undefined),
- *     projection: ol.ProjectionLike,
- *     resolution: (number|undefined),
- *     resolutions: (Array.<number>|undefined),
- *     rotation: (number|undefined),
- *     zoom: (number|undefined),
- *     zoomFactor: (number|undefined)}}
- */
-export let ViewOptions;
-
-/**
- * @param {ViewOptions} options TODO: repace this
- *
- * @param {ol.Coordinate|undefined} options.center The initial center for the view. The coordinate system for the center is
+ * @typedef {Object} ViewOptions
+ * @property {ol.Coordinate|undefined} center The initial center for the view. The coordinate system for the center is
  * specified with the `projection` option. Default is `undefined`, and layer
  * sources will not be fetched if this is not set.
- * 
- * @param {boolean|number|undefined} options.constrainRotation Rotation constraint. `false` means no constraint. `true` means no constraint,
+ * @property {boolean|number|undefined} constrainRotation Rotation constraint. `false` means no constraint. `true` means no constraint,
  * but snap to zero near zero. A number constrains the rotation to that number
  * of values. For example, `4` will constrain the rotation to 0, 90, 180, and
  * 270 degrees. The default is `true`.
- * 
- * @param {boolean|undefined} options.enableRotation Enable rotation. Default is `true`. If `false` a rotation constraint that
+ * @property {boolean|undefined} enableRotation Enable rotation. Default is `true`. If `false` a rotation constraint that
  * always sets the rotation to zero is used. The `constrainRotation` option
  * has no effect if `enableRotation` is `false`.
- * 
- * @param {ol.Extent|undefined} options.extent The extent that constrains the center, in other words, center cannot be set
+ * @property {ol.Extent|undefined} extent The extent that constrains the center, in other words, center cannot be set
  * outside this extent. Default is `undefined`.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution used to determine the resolution constraint. It is
+ * @property {number|undefined} maxResolution The maximum resolution used to determine the resolution constraint. It is
  * used together with `minResolution` (or `maxZoom`) and `zoomFactor`. If
  * unspecified it is calculated in such a way that the projection's validity
  * extent fits in a 256x256 px tile. If the projection is Spherical Mercator
  * (the default) then `maxResolution` defaults to `40075016.68557849 / 256 =
  * 156543.03392804097`.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution used to determine the resolution constraint.  It is
+ * @property {number|undefined} minResolution The minimum resolution used to determine the resolution constraint.  It is
  * used together with `maxResolution` (or `minZoom`) and `zoomFactor`.  If
  * unspecified it is calculated assuming 29 zoom levels (with a factor of 2).
  * If the projection is Spherical Mercator (the default) then `minResolution`
  * defaults to `40075016.68557849 / 256 / Math.pow(2, 28) =
  * 0.0005831682455839253`.
- * 
- * @param {number|undefined} options.maxZoom The maximum zoom level used to determine the resolution constraint. It is
+ * @property {number|undefined} maxZoom The maximum zoom level used to determine the resolution constraint. It is
  * used together with `minZoom` (or `maxResolution`) and `zoomFactor`. Default
  * is `28`.  Note that if `minResolution` is also provided, it is given
  * precedence over `maxZoom`.
- * 
- * @param {number|undefined} options.minZoom The minimum zoom level used to determine the resolution constraint. It is
+ * @property {number|undefined} minZoom The minimum zoom level used to determine the resolution constraint. It is
  * used together with `maxZoom` (or `minResolution`) and `zoomFactor`. Default
  * is `0`. Note that if `maxResolution` is also provided, it is given
  * precedence over `minZoom`.
- * 
- * @param {ol.ProjectionLike} options.projection The projection. Default is `EPSG:3857` (Spherical Mercator).
- * 
- * @param {number|undefined} options.resolution The initial resolution for the view. The units are `projection` units per
+ * @property {ol.ProjectionLike} projection The projection. Default is `EPSG:3857` (Spherical Mercator).
+ * @property {number|undefined} resolution The initial resolution for the view. The units are `projection` units per
  * pixel (e.g. meters per pixel). An alternative to setting this is to set
  * `zoom`. Default is `undefined`, and layer sources will not be fetched if
  * neither this nor `zoom` are defined.
- * 
- * @param {Array.<number>|undefined} options.resolutions Resolutions to determine the resolution constraint. If set the
+ * @property {Array.<number>|undefined} resolutions Resolutions to determine the resolution constraint. If set the
  * `maxResolution`, `minResolution`, `minZoom`, `maxZoom`, and `zoomFactor`
  * options are ignored.
- * 
- * @param {number|undefined} options.rotation The initial rotation for the view in radians (positive rotation clockwise).
+ * @property {number|undefined} rotation The initial rotation for the view in radians (positive rotation clockwise).
  * Default is `0`.
- * 
- * @param {number|undefined} options.zoom Only used if `resolution` is not defined. Zoom level used to calculate the
+ * @property {number|undefined} zoom Only used if `resolution` is not defined. Zoom level used to calculate the
  * initial resolution for the view. The initial resolution is determined using
  * the `ol.View#constrainResolution` method.
- * 
- * @param {number|undefined} options.zoomFactor The zoom factor used to determine the resolution constraint.  Default is `2`.
- * 
+ * @property {number|undefined} zoomFactor The zoom factor used to determine the resolution constraint.  Default is `2`.
  */
 
 
 /**
- * @typedef {{
- *   center: (ol.Coordinate|undefined),
- *   zoom: (number|undefined),
- *   resolution: (number|undefined),
- *   rotation: (number|undefined),
- *   anchor: (ol.Coordinate|undefined),
- *   duration: (number|undefined),
- *   easing: (undefined|function(number):number)
- * }}
- */
-export let AnimationOptions;
-
-/**
- * @param {AnimationOptions} options TODO: repace this
- *
- * @param {ol.Coordinate|undefined} options.center The center of the view at the end of the animation.
- * 
- * @param {number|undefined} options.zoom The zoom level of the view at the end of the animation.  This takes
+ * @typedef {Object} AnimationOptions
+ * @property {ol.Coordinate|undefined} center The center of the view at the end of the animation.
+ * @property {number|undefined} zoom The zoom level of the view at the end of the animation.  This takes
  * precedence over `resolution`.
- * 
- * @param {number|undefined} options.resolution The resolution of the view at the end of the animation.  If `zoom` is also
+ * @property {number|undefined} resolution The resolution of the view at the end of the animation.  If `zoom` is also
  * provided, this option will be ignored.
- * 
- * @param {number|undefined} options.rotation The rotation of the view at the end of the animation.
- * 
- * @param {ol.Coordinate|undefined} options.anchor Optional anchor to remained fixed during a rotation or resolution animation.
- * 
- * @param {number|undefined} options.duration The duration of the animation in milliseconds (defaults to `1000`).
- * 
- * @param {undefined|function(number):number} options.easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
+ * @property {number|undefined} rotation The rotation of the view at the end of the animation.
+ * @property {ol.Coordinate|undefined} anchor Optional anchor to remained fixed during a rotation or resolution animation.
+ * @property {number|undefined} duration The duration of the animation in milliseconds (defaults to `1000`).
+ * @property {undefined|function(number):number} easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
  * The function will be called for each frame with a number representing a
  * fraction of the animation's duration.  The function should return a number
  * between 0 and 1 representing the progress toward the destination state.
- * 
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     collapsible: (boolean|undefined),
- *     collapsed: (boolean|undefined),
- *     tipLabel: (string|undefined),
- *     label: (string|Node|undefined),
- *     collapseLabel: (string|Node|undefined),
- *     render: (function(ol.MapEvent)|undefined),
- *     target: (Element|string|undefined)}}
- */
-export let control_AttributionOptions;
-
-/**
- * @param {control_AttributionOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name. Default is `ol-attribution`.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @typedef {Object} control_AttributionOptions
+ * @property {string|undefined} className CSS class name. Default is `ol-attribution`.
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
- * @param {boolean|undefined} options.collapsible Specify if attributions can be collapsed. If you use an OSM source,
+ * @property {boolean|undefined} collapsible Specify if attributions can be collapsed. If you use an OSM source,
  * should be set to `false` — see
  * {@link https://www.openstreetmap.org/copyright OSM Copyright} —
  * Default is `true`.
- * 
- * @param {boolean|undefined} options.collapsed Specify if attributions should be collapsed at startup. Default is `true`.
- * 
- * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Attributions`
- * 
- * @param {string|Node|undefined} options.label Text label to use for the collapsed attributions button. Default is `i`.
+ * @property {boolean|undefined} collapsed Specify if attributions should be collapsed at startup. Default is `true`.
+ * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Attributions`
+ * @property {string|Node|undefined} label Text label to use for the collapsed attributions button. Default is `i`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|Node|undefined} options.collapseLabel Text label to use for the expanded attributions button. Default is `»`.
+ * @property {string|Node|undefined} collapseLabel Text label to use for the expanded attributions button. Default is `»`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
  */
 
 
 /**
- * @typedef {{element: (Element|undefined),
- *     render: (function(ol.MapEvent)|undefined),
- *     target: (Element|string|undefined)}}
- */
-export let control_ControlOptions;
-
-/**
- * @param {control_ControlOptions} options TODO: repace this
- *
- * @param {Element|undefined} options.element The element is the control's container element. This only needs to be
+ * @typedef {Object} control_ControlOptions
+ * @property {Element|undefined} element The element is the control's container element. This only needs to be
  * specified if you're developing a custom control.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
  */
 
 
 /**
- * @typedef {{attribution: (boolean|undefined),
- *     attributionOptions: (olx.control.AttributionOptions|undefined),
- *     rotate: (boolean|undefined),
- *     rotateOptions: (olx.control.RotateOptions|undefined),
- *     zoom: (boolean|undefined),
- *     zoomOptions: (olx.control.ZoomOptions|undefined)}}
- */
-export let control_DefaultsOptions;
-
-/**
- * @param {control_DefaultsOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.attribution Attribution. Default is `true`.
- * 
- * @param {olx.control.AttributionOptions|undefined} options.attributionOptions Attribution options.
- * 
- * @param {boolean|undefined} options.rotate Rotate. Default is `true`.
- * 
- * @param {olx.control.RotateOptions|undefined} options.rotateOptions Rotate options.
- * 
- * @param {boolean|undefined} options.zoom Zoom. Default is `true`.
- * 
- * @param {olx.control.ZoomOptions|undefined} options.zoomOptions Zoom options.
- * 
+ * @typedef {Object} control_DefaultsOptions
+ * @property {boolean|undefined} attribution Attribution. Default is `true`.
+ * @property {olx.control.AttributionOptions|undefined} attributionOptions Attribution options.
+ * @property {boolean|undefined} rotate Rotate. Default is `true`.
+ * @property {olx.control.RotateOptions|undefined} rotateOptions Rotate options.
+ * @property {boolean|undefined} zoom Zoom. Default is `true`.
+ * @property {olx.control.ZoomOptions|undefined} zoomOptions Zoom options.
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     label: (string|Node|undefined),
- *     labelActive: (string|Node|undefined),
- *     tipLabel: (string|undefined),
- *     keys: (boolean|undefined),
- *     target: (Element|string|undefined),
- *     source: (Element|string|undefined)}}
- */
-export let control_FullScreenOptions;
-
-/**
- * @param {control_FullScreenOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name. Default is `ol-full-screen`.
- * 
- * @param {string|Node|undefined} options.label Text label to use for the button. Default is `\u2922` (NORTH EAST AND SOUTH WEST ARROW).
+ * @typedef {Object} control_FullScreenOptions
+ * @property {string|undefined} className CSS class name. Default is `ol-full-screen`.
+ * @property {string|Node|undefined} label Text label to use for the button. Default is `\u2922` (NORTH EAST AND SOUTH WEST ARROW).
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|Node|undefined} options.labelActive Text label to use for the button when full-screen is active.
+ * @property {string|Node|undefined} labelActive Text label to use for the button when full-screen is active.
  * Default is `\u00d7` (a cross).
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Toggle full-screen`
- * 
- * @param {boolean|undefined} options.keys Full keyboard access.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Toggle full-screen`
+ * @property {boolean|undefined} keys Full keyboard access.
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
- * @param {Element|string|undefined} options.source The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.
- * 
+ * @property {Element|string|undefined} source The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     coordinateFormat: (ol.CoordinateFormatType|undefined),
- *     projection: ol.ProjectionLike,
- *     render: (function(ol.MapEvent)|undefined),
- *     target: (Element|string|undefined),
- *     undefinedHTML: (string|undefined)}}
- */
-export let control_MousePositionOptions;
-
-/**
- * @param {control_MousePositionOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name. Default is `ol-mouse-position`.
- * 
- * @param {ol.CoordinateFormatType|undefined} options.coordinateFormat Coordinate format.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @typedef {Object} control_MousePositionOptions
+ * @property {string|undefined} className CSS class name. Default is `ol-mouse-position`.
+ * @property {ol.CoordinateFormatType|undefined} coordinateFormat Coordinate format.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
- * @param {string|undefined} options.undefinedHTML Markup for undefined coordinates. Default is `` (empty string).
- * 
+ * @property {string|undefined} undefinedHTML Markup for undefined coordinates. Default is `` (empty string).
  */
 
 
 /**
- * @typedef {{collapsed: (boolean|undefined),
- *     collapseLabel: (string|Node|undefined),
- *     collapsible: (boolean|undefined),
- *     label: (string|Node|undefined),
- *     layers: (Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined),
- *     render: (function(ol.MapEvent)|undefined),
- *     target: (Element|string|undefined),
- *     tipLabel: (string|undefined),
- *     view: (ol.View|undefined)}}
- */
-export let control_OverviewMapOptions;
-
-/**
- * @param {control_OverviewMapOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.collapsed Whether the control should start collapsed or not (expanded).
+ * @typedef {Object} control_OverviewMapOptions
+ * @property {boolean|undefined} collapsed Whether the control should start collapsed or not (expanded).
  * Default to `true`.
- * 
- * @param {string|Node|undefined} options.collapseLabel Text label to use for the expanded overviewmap button. Default is `«`.
+ * @property {string|Node|undefined} collapseLabel Text label to use for the expanded overviewmap button. Default is `«`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {boolean|undefined} options.collapsible Whether the control can be collapsed or not. Default to `true`.
- * 
- * @param {string|Node|undefined} options.label Text label to use for the collapsed overviewmap button. Default is `»`.
+ * @property {boolean|undefined} collapsible Whether the control can be collapsed or not. Default to `true`.
+ * @property {string|Node|undefined} label Text label to use for the collapsed overviewmap button. Default is `»`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined} options.layers Layers for the overview map. If not set, then all main map layers are used
+ * @property {Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined} layers Layers for the overview map. If not set, then all main map layers are used
  * instead.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
- * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Overview map`
- * 
- * @param {ol.View|undefined} options.view Custom view for the overview map. If not provided, a default view with
+ * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Overview map`
+ * @property {ol.View|undefined} view Custom view for the overview map. If not provided, a default view with
  * an EPSG:3857 projection will be used.
- * 
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     minWidth: (number|undefined),
- *     render: (function(ol.MapEvent)|undefined),
- *     target: (Element|string|undefined),
- *     units: (ol.control.ScaleLineUnits|string|undefined)}}
- */
-export let control_ScaleLineOptions;
-
-/**
- * @param {control_ScaleLineOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS Class name. Default is `ol-scale-line`.
- * 
- * @param {number|undefined} options.minWidth Minimum width in pixels. Default is `64`.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @typedef {Object} control_ScaleLineOptions
+ * @property {string|undefined} className CSS Class name. Default is `ol-scale-line`.
+ * @property {number|undefined} minWidth Minimum width in pixels. Default is `64`.
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
- * @param {ol.control.ScaleLineUnits|string|undefined} options.units Units. Default is `metric`.
- * 
+ * @property {ol.control.ScaleLineUnits|string|undefined} units Units. Default is `metric`.
  */
 
 
 /**
- * @typedef {{duration: (number|undefined),
- *     className: (string|undefined),
- *     label: (string|Element|undefined),
- *     tipLabel: (string|undefined),
- *     target: (Element|string|undefined),
- *     render: (function(ol.MapEvent)|undefined),
- *     resetNorth: (function()|undefined),
- *     autoHide: (boolean|undefined)}}
- */
-export let control_RotateOptions;
-
-/**
- * @param {control_RotateOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name. Default is `ol-rotate`.
- * 
- * @param {string|Element|undefined} options.label Text label to use for the rotate button. Default is `⇧`.
+ * @typedef {Object} control_RotateOptions
+ * @property {string|undefined} className CSS class name. Default is `ol-rotate`.
+ * @property {string|Element|undefined} label Text label to use for the rotate button. Default is `⇧`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|undefined} options.tipLabel Text label to use for the rotate tip. Default is `Reset rotation`
- * 
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- * 
- * @param {boolean|undefined} options.autoHide Hide the control when rotation is 0. Default is `true`.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @property {string|undefined} tipLabel Text label to use for the rotate tip. Default is `Reset rotation`
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
+ * @property {boolean|undefined} autoHide Hide the control when rotation is 0. Default is `true`.
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
- * @param {function()|undefined} options.resetNorth Function called when the control is clicked. This will override the
+ * @property {function()|undefined} resetNorth Function called when the control is clicked. This will override the
  * default resetNorth.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
  */
 
 
 /**
- * @typedef {{duration: (number|undefined),
- *     className: (string|undefined),
- *     zoomInLabel: (string|Node|undefined),
- *     zoomOutLabel: (string|Node|undefined),
- *     zoomInTipLabel: (string|undefined),
- *     zoomOutTipLabel: (string|undefined),
- *     delta: (number|undefined),
- *     target: (Element|string|undefined)}}
- */
-export let control_ZoomOptions;
-
-/**
- * @param {control_ZoomOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- * 
- * @param {string|undefined} options.className CSS class name. Default is `ol-zoom`.
- * 
- * @param {string|Node|undefined} options.zoomInLabel Text label to use for the zoom-in button. Default is `+`.
+ * @typedef {Object} control_ZoomOptions
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
+ * @property {string|undefined} className CSS class name. Default is `ol-zoom`.
+ * @property {string|Node|undefined} zoomInLabel Text label to use for the zoom-in button. Default is `+`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|Node|undefined} options.zoomOutLabel Text label to use for the zoom-out button. Default is `-`.
+ * @property {string|Node|undefined} zoomOutLabel Text label to use for the zoom-out button. Default is `-`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|undefined} options.zoomInTipLabel Text label to use for the button tip. Default is `Zoom in`
- * 
- * @param {string|undefined} options.zoomOutTipLabel Text label to use for the button tip. Default is `Zoom out`
- * 
- * @param {number|undefined} options.delta The zoom delta applied on each click.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @property {string|undefined} zoomInTipLabel Text label to use for the button tip. Default is `Zoom in`
+ * @property {string|undefined} zoomOutTipLabel Text label to use for the button tip. Default is `Zoom out`
+ * @property {number|undefined} delta The zoom delta applied on each click.
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     duration: (number|undefined),
- *     maxResolution: (number|undefined),
- *     minResolution: (number|undefined),
- *     render: (function(ol.MapEvent)|undefined)}}
- */
-export let control_ZoomSliderOptions;
-
-/**
- * @param {control_ZoomSliderOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name.
- * 
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `200`.
- * 
- * @param {number|undefined} options.maxResolution Maximum resolution.
- * 
- * @param {number|undefined} options.minResolution Minimum resolution.
- * 
- * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
+ * @typedef {Object} control_ZoomSliderOptions
+ * @property {string|undefined} className CSS class name.
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `200`.
+ * @property {number|undefined} maxResolution Maximum resolution.
+ * @property {number|undefined} minResolution Minimum resolution.
+ * @property {function(ol.MapEvent)|undefined} render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- * 
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     target: (Element|string|undefined),
- *     label: (string|Node|undefined),
- *     tipLabel: (string|undefined),
- *     extent: (ol.Extent|undefined)}}
- */
-export let control_ZoomToExtentOptions;
-
-/**
- * @param {control_ZoomToExtentOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className Class name. Default is `ol-zoom-extent`.
- * 
- * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
+ * @typedef {Object} control_ZoomToExtentOptions
+ * @property {string|undefined} className Class name. Default is `ol-zoom-extent`.
+ * @property {Element|string|undefined} target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- * 
- * @param {string|Node|undefined} options.label Text label to use for the button. Default is `E`.
+ * @property {string|Node|undefined} label Text label to use for the button. Default is `E`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- * 
- * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Zoom to extent`
- * 
- * @param {ol.Extent|undefined} options.extent The extent to zoom to. If undefined the validity extent of the view
+ * @property {string|undefined} tipLabel Text label to use for the button tip. Default is `Zoom to extent`
+ * @property {ol.Extent|undefined} extent The extent to zoom to. If undefined the validity extent of the view
  * projection is used.
- * 
  */
 
 
 /**
- * @typedef {{dataProjection: ol.ProjectionLike,
- *     extent: (ol.Extent|undefined),
- *     featureProjection: ol.ProjectionLike,
- *     rightHanded: (boolean|undefined)}}
- */
-export let format_ReadOptions;
-
-/**
- * @param {format_ReadOptions} options TODO: repace this
- *
- * @param {ol.ProjectionLike} options.dataProjection Projection of the data we are reading. If not provided, the projection will
+ * @typedef {Object} format_ReadOptions
+ * @property {ol.ProjectionLike} dataProjection Projection of the data we are reading. If not provided, the projection will
  * be derived from the data (where possible) or the `defaultDataProjection` of
  * the format is assigned (where set). If the projection can not be derived from
  * the data and if no `defaultDataProjection` is set for a format, the features
  * will not be reprojected.
- * 
- * @param {ol.Extent} options.extent Tile extent of the tile being read. This is only used and required for
+ * @property {ol.Extent} extent Tile extent of the tile being read. This is only used and required for
  * {@link ol.format.MVT}.
- * 
- * @param {ol.ProjectionLike} options.featureProjection Projection of the feature geometries created by the format reader. If not
+ * @property {ol.ProjectionLike} featureProjection Projection of the feature geometries created by the format reader. If not
  * provided, features will be returned in the `dataProjection`.
- * 
  */
 
 
 /**
- * @typedef {{dataProjection: ol.ProjectionLike,
- *     featureProjection: ol.ProjectionLike,
- *     rightHanded: (boolean|undefined),
- *     decimals: (number|undefined)}}
- */
-export let format_WriteOptions;
-
-/**
- * @param {format_WriteOptions} options TODO: repace this
- *
- * @param {ol.ProjectionLike} options.dataProjection Projection of the data we are writing. If not provided, the
+ * @typedef {Object} format_WriteOptions
+ * @property {ol.ProjectionLike} dataProjection Projection of the data we are writing. If not provided, the
  * `defaultDataProjection` of the format is assigned (where set). If no
  * `defaultDataProjection` is set for a format, the features will be returned
  * in the `featureProjection`.
- * 
- * @param {ol.ProjectionLike} options.featureProjection Projection of the feature geometries that will be serialized by the format
+ * @property {ol.ProjectionLike} featureProjection Projection of the feature geometries that will be serialized by the format
  * writer. If not provided, geometries are assumed to be in the
  * `dataProjection` if that is set; in other words, they are not transformed.
- * 
- * @param {boolean|undefined} options.rightHanded When writing geometries, follow the right-hand rule for linear ring
+ * @property {boolean|undefined} rightHanded When writing geometries, follow the right-hand rule for linear ring
  * orientation.  This means that polygons will have counter-clockwise exterior
  * rings and clockwise interior rings.  By default, coordinates are serialized
  * as they are provided at construction.  If `true`, the right-hand rule will
@@ -956,122 +339,64 @@ export let format_WriteOptions;
  * formats support this.  The GeoJSON format does use this property when writing
  * geometries.
  * 
- * 
- * @param {number|undefined} options.decimals Maximum number of decimal places for coordinates. Coordinates are stored
+ * @property {number|undefined} decimals Maximum number of decimal places for coordinates. Coordinates are stored
  * internally as floats, but floating-point arithmetic can create coordinates
  * with a large number of decimal places, not generally wanted on output.
  * Set a number here to round coordinates. Can also be used to ensure that
  * coordinates read in can be written back out with the same number of decimals.
  * Default is no rounding.
  * 
- * 
  */
 
 
 /**
- * @typedef {{defaultDataProjection: ol.ProjectionLike,
- *     geometryName: (string|undefined),
- *     extractGeometryName: (boolean|undefined),
- *     featureProjection: ol.ProjectionLike}}
- */
-export let format_GeoJSONOptions;
-
-/**
- * @param {format_GeoJSONOptions} options TODO: repace this
- *
- * @param {ol.ProjectionLike} options.defaultDataProjection Default data projection. Default is `EPSG:4326`.
- * 
- * @param {ol.ProjectionLike} options.featureProjection Projection for features read or written by the format.  Options passed to
+ * @typedef {Object} format_GeoJSONOptions
+ * @property {ol.ProjectionLike} defaultDataProjection Default data projection. Default is `EPSG:4326`.
+ * @property {ol.ProjectionLike} featureProjection Projection for features read or written by the format.  Options passed to
  * read or write methods will take precedence.
- * 
- * @param {string|undefined} options.geometryName Geometry name to use when creating features.
- * 
- * @param {boolean|undefined} options.extractGeometryName Certain GeoJSON providers include the geometry_name field in the feature
+ * @property {string|undefined} geometryName Geometry name to use when creating features.
+ * @property {boolean|undefined} extractGeometryName Certain GeoJSON providers include the geometry_name field in the feature
  * geoJSON. If set to `true` the geoJSON reader will look for that field to
  * set the geometry name. If both this field is set to `true` and a
  * `geometryName` is provided, the `geometryName` will take precedence.
  * Default is `false`.
- * 
  */
 
 
 /**
- * @typedef {{geometryName: (string|undefined)}}
- */
-export let format_EsriJSONOptions;
-
-/**
- * @param {format_EsriJSONOptions} options TODO: repace this
- *
- * @param {string|undefined} options.geometryName Geometry name to use when creating features.
- * 
+ * @typedef {Object} format_EsriJSONOptions
+ * @property {string|undefined} geometryName Geometry name to use when creating features.
  */
 
 
 /**
- * @typedef {{featureClass: (function((ol.geom.Geometry|Object.<string, *>)=)|
- *         function(ol.geom.GeometryType,Array.<number>,
- *             (Array.<number>|Array.<Array.<number>>),Object.<string, *>)|
- *         undefined),
- *     geometryName: (string|undefined),
- *     layers: (Array.<string>|undefined),
- *     layerName: (string|undefined)}}
- */
-export let format_MVTOptions;
-
-/**
- * @param {format_MVTOptions} options TODO: repace this
- *
- * @param {undefined|function((ol.geom.Geometry|Object.<string,*>)=)|    function(ol.geom.GeometryType,Array.<number>,
+ * @typedef {Object} format_MVTOptions
+ * @property {undefined|function((ol.geom.Geometry|Object.<string,*>)=)|    function(ol.geom.GeometryType,Array.<number>,
         (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
- options.featureClass Class for features returned by {@link ol.format.MVT#readFeatures}. Set to
+ featureClass Class for features returned by {@link ol.format.MVT#readFeatures}. Set to
  * {@link ol.Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link ol.render.Feature},
  * which is optimized for rendering and hit detection.
- * 
- * @param {string|undefined} options.geometryName Geometry name to use when creating features. Default is 'geometry'.
- * 
- * @param {string|undefined} options.layerName Name of the feature attribute that holds the layer name. Default is 'layer'.
- * 
- * @param {Array.<string>|undefined} options.layers Layers to read features from. If not provided, features will be read from all
+ * @property {string|undefined} geometryName Geometry name to use when creating features. Default is 'geometry'.
+ * @property {string|undefined} layerName Name of the feature attribute that holds the layer name. Default is 'layer'.
+ * @property {Array.<string>|undefined} layers Layers to read features from. If not provided, features will be read from all
  * layers.
- * 
  */
 
 
 /**
- * @typedef {{factor: (number|undefined),
- *     geometryLayout: (ol.geom.GeometryLayout|undefined)}}
- */
-export let format_PolylineOptions;
-
-/**
- * @param {format_PolylineOptions} options TODO: repace this
- *
- * @param {number|undefined} options.factor The factor by which the coordinates values will be scaled.
+ * @typedef {Object} format_PolylineOptions
+ * @property {number|undefined} factor The factor by which the coordinates values will be scaled.
  * Default is `1e5`.
- * 
- * @param {ol.geom.GeometryLayout|undefined} options.geometryLayout Layout of the feature geometries created by the format reader.
+ * @property {ol.geom.GeometryLayout|undefined} geometryLayout Layout of the feature geometries created by the format reader.
  * Default is `ol.geom.GeometryLayout.XY`.
- * 
  */
 
 
 /**
- * @typedef {{
- *     defaultDataProjection: ol.ProjectionLike,
- *     layerName: (string|undefined),
- *     layers: (Array.<string>|undefined)
- * }}
- */
-export let format_TopoJSONOptions;
-
-/**
- * @param {format_TopoJSONOptions} options TODO: repace this
- *
- * @param {ol.ProjectionLike} options.defaultDataProjection Default data projection. Default is `EPSG:4326`.
- * 
- * @param {string|undefined} options.layerName Set the name of the TopoJSON topology `objects`'s children as feature
+ * @typedef {Object} format_TopoJSONOptions
+ * @property {ol.ProjectionLike} defaultDataProjection Default data projection. Default is `EPSG:4326`.
+ * @property {string|undefined} layerName Set the name of the TopoJSON topology `objects`'s children as feature
  * property with the specified name. This means that when set to `'layer'`, a
  * topology like
  * ```
@@ -1087,804 +412,388 @@ export let format_TopoJSONOptions;
  * ```
  * will result in features that have a property `'layer'` set to `'example'`.
  * When not set, no property will be added to features.
- * 
- * @param {Array.<string>|undefined} options.layers Names of the TopoJSON topology's `objects`'s children to read features from.
+ * @property {Array.<string>|undefined} layers Names of the TopoJSON topology's `objects`'s children to read features from.
  * If not provided, features will be read from all children.
- * 
  */
 
 
 /**
- * @typedef {{altitudeMode: (ol.format.IGCZ|undefined)}}
- */
-export let format_IGCOptions;
-
-/**
- * @param {format_IGCOptions} options TODO: repace this
- *
- * @param {ol.format.IGCZ|undefined} options.altitudeMode Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
+ * @typedef {Object} format_IGCOptions
+ * @property {ol.format.IGCZ|undefined} altitudeMode Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
  * is `none`.
- * 
  */
 
 
 /**
- * @typedef {{extractStyles: (boolean|undefined),
- *     defaultStyle: (Array.<ol.style.Style>|undefined),
- *     showPointNames: (boolean|undefined),
- *     writeStyles: (boolean|undefined)}}
- */
-export let format_KMLOptions;
-
-/**
- * @param {format_KMLOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.extractStyles Extract styles from the KML. Default is `true`.
- * 
- * @param {boolean|undefined} options.showPointNames Show names as labels for placemarks which contain points. Default is `true`.
- * 
- * @param {Array.<ol.style.Style>|undefined} options.defaultStyle Default style. The default default style is the same as Google Earth.
- * 
- * @param {boolean|undefined} options.writeStyles Write styles into KML. Default is `true`.
- * 
+ * @typedef {Object} format_KMLOptions
+ * @property {boolean|undefined} extractStyles Extract styles from the KML. Default is `true`.
+ * @property {boolean|undefined} showPointNames Show names as labels for placemarks which contain points. Default is `true`.
+ * @property {Array.<ol.style.Style>|undefined} defaultStyle Default style. The default default style is the same as Google Earth.
+ * @property {boolean|undefined} writeStyles Write styles into KML. Default is `true`.
  */
 
 
 /**
- * @typedef {{featureNS: (Object.<string, string>|string|undefined),
- *     featureType: (Array.<string>|string|undefined),
- *     srsName: string,
- *     surface: (boolean|undefined),
- *     curve: (boolean|undefined),
- *     multiCurve: (boolean|undefined),
- *     multiSurface: (boolean|undefined),
- *     schemaLocation: (string|undefined)}}
- */
-export let format_GMLOptions;
-
-/**
- * @param {format_GMLOptions} options TODO: repace this
- *
- * @param {Object.<string, string>|string|undefined} options.featureNS Feature namespace. If not defined will be derived from GML. If multiple
+ * @typedef {Object} format_GMLOptions
+ * @property {Object.<string, string>|string|undefined} featureNS Feature namespace. If not defined will be derived from GML. If multiple
  * feature types have been configured which come from different feature
  * namespaces, this will be an object with the keys being the prefixes used
  * in the entries of featureType array. The values of the object will be the
  * feature namespaces themselves. So for instance there might be a featureType
  * item `topp:states` in the `featureType` array and then there will be a key
  * `topp` in the featureNS object with value `http://www.openplans.org/topp`.
- * 
- * @param {Array.<string>|string|undefined} options.featureType Feature type(s) to parse. If multiple feature types need to be configured
+ * @property {Array.<string>|string|undefined} featureType Feature type(s) to parse. If multiple feature types need to be configured
  * which come from different feature namespaces, `featureNS` will be an object
  * with the keys being the prefixes used in the entries of featureType array.
  * The values of the object will be the feature namespaces themselves.
  * So for instance there might be a featureType item `topp:states` and then
  * there will be a key named `topp` in the featureNS object with value
  * `http://www.openplans.org/topp`.
- * 
- * @param {string} options.srsName srsName to use when writing geometries.
- * 
- * @param {boolean|undefined} options.surface Write gml:Surface instead of gml:Polygon elements. This also affects the
+ * @property {string} srsName srsName to use when writing geometries.
+ * @property {boolean|undefined} surface Write gml:Surface instead of gml:Polygon elements. This also affects the
  * elements in multi-part geometries. Default is `false`.
- * 
- * @param {boolean|undefined} options.curve Write gml:Curve instead of gml:LineString elements. This also affects the
+ * @property {boolean|undefined} curve Write gml:Curve instead of gml:LineString elements. This also affects the
  * elements in multi-part geometries. Default is `false`.
- * 
- * @param {boolean|undefined} options.multiCurve Write gml:MultiCurve instead of gml:MultiLineString. Since the latter is
+ * @property {boolean|undefined} multiCurve Write gml:MultiCurve instead of gml:MultiLineString. Since the latter is
  * deprecated in GML 3, the default is `true`.
- * 
- * @param {boolean|undefined} options.multiSurface Write gml:multiSurface instead of gml:MultiPolygon. Since the latter is
+ * @property {boolean|undefined} multiSurface Write gml:multiSurface instead of gml:MultiPolygon. Since the latter is
  * deprecated in GML 3, the default is `true`.
- * 
- * @param {string|undefined} options.schemaLocation Optional schemaLocation to use when writing out the GML, this will override
+ * @property {string|undefined} schemaLocation Optional schemaLocation to use when writing out the GML, this will override
  * the default provided.
- * 
  */
 
 
 /**
- * @typedef {{readExtensions: (function(ol.Feature, Node)|undefined)}}
- */
-export let format_GPXOptions;
-
-/**
- * @param {format_GPXOptions} options TODO: repace this
- *
- * @param {function(ol.Feature, Node)|undefined} options.readExtensions Callback function to process `extensions` nodes.
+ * @typedef {Object} format_GPXOptions
+ * @property {function(ol.Feature, Node)|undefined} readExtensions Callback function to process `extensions` nodes.
  * To prevent memory leaks, this callback function must
  * not store any references to the node. Note that the `extensions`
  * node is not allowed in GPX 1.0. Moreover, only `extensions`
  * nodes from `wpt`, `rte` and `trk` can be processed, as those are
  * directly mapped to a feature.
- * 
  */
 
 
 /**
- * @typedef {{featureNS: (Object.<string, string>|string|undefined),
- *     featureType: (Array.<string>|string|undefined),
- *     gmlFormat: (ol.format.GMLBase|undefined),
- *     schemaLocation: (string|undefined)}}
- */
-export let format_WFSOptions;
-
-/**
- * @param {format_WFSOptions} options TODO: repace this
- *
- * @param {Object.<string, string>|string|undefined} options.featureNS The namespace URI used for features.
- * 
- * @param {Array.<string>|string|undefined} options.featureType The feature type to parse. Only used for read operations.
- * 
- * @param {ol.format.GMLBase|undefined} options.gmlFormat The GML format to use to parse the response. Default is `ol.format.GML3`.
- * 
- * @param {string|undefined} options.schemaLocation Optional schemaLocation to use for serialization, this will override the
+ * @typedef {Object} format_WFSOptions
+ * @property {Object.<string, string>|string|undefined} featureNS The namespace URI used for features.
+ * @property {Array.<string>|string|undefined} featureType The feature type to parse. Only used for read operations.
+ * @property {ol.format.GMLBase|undefined} gmlFormat The GML format to use to parse the response. Default is `ol.format.GML3`.
+ * @property {string|undefined} schemaLocation Optional schemaLocation to use for serialization, this will override the
  * default.
- * 
  */
 
 
 /**
- * @typedef {{featureNS: string,
- *     featurePrefix: string,
- *     featureTypes: Array.<string>,
- *     srsName: (string|undefined),
- *     handle: (string|undefined),
- *     outputFormat: (string|undefined),
- *     maxFeatures: (number|undefined),
- *     geometryName: (string|undefined),
- *     propertyNames: (Array.<string>|undefined),
- *     startIndex: (number|undefined),
- *     count: (number|undefined),
- *     bbox: (ol.Extent|undefined),
- *     filter: (ol.format.filter.Filter|undefined),
- *     resultType: (string|undefined)}}
- */
-export let format_WFSWriteGetFeatureOptions;
-
-/**
- * @param {format_WFSWriteGetFeatureOptions} options TODO: repace this
- *
- * @param {string} options.featureNS The namespace URI used for features.
- * 
- * @param {string} options.featurePrefix The prefix for the feature namespace.
- * 
- * @param {Array.<string>} options.featureTypes The feature type names.
- * 
- * @param {string|undefined} options.srsName SRS name. No srsName attribute will be set on geometries when this is not
+ * @typedef {Object} format_WFSWriteGetFeatureOptions
+ * @property {string} featureNS The namespace URI used for features.
+ * @property {string} featurePrefix The prefix for the feature namespace.
+ * @property {Array.<string>} featureTypes The feature type names.
+ * @property {string|undefined} srsName SRS name. No srsName attribute will be set on geometries when this is not
  * provided.
- * 
- * @param {string|undefined} options.handle Handle.
- * 
- * @param {string|undefined} options.outputFormat Output format.
- * 
- * @param {number|undefined} options.maxFeatures Maximum number of features to fetch.
- * 
- * @param {string|undefined} options.geometryName Geometry name to use in a BBOX filter.
- * 
- * @param {Array.<string>|undefined} options.propertyNames Optional list of property names to serialize.
- * 
- * @param {number|undefined} options.startIndex Start index to use for WFS paging. This is a WFS 2.0 feature backported to
+ * @property {string|undefined} handle Handle.
+ * @property {string|undefined} outputFormat Output format.
+ * @property {number|undefined} maxFeatures Maximum number of features to fetch.
+ * @property {string|undefined} geometryName Geometry name to use in a BBOX filter.
+ * @property {Array.<string>|undefined} propertyNames Optional list of property names to serialize.
+ * @property {number|undefined} startIndex Start index to use for WFS paging. This is a WFS 2.0 feature backported to
  * WFS 1.1.0 by some Web Feature Services.
- * 
- * @param {number|undefined} options.count Number of features to retrieve when paging. This is a WFS 2.0 feature
+ * @property {number|undefined} count Number of features to retrieve when paging. This is a WFS 2.0 feature
  * backported to WFS 1.1.0 by some Web Feature Services. Please note that some
  * Web Feature Services have repurposed `maxfeatures` instead.
- * 
- * @param {ol.Extent|undefined} options.bbox Extent to use for the BBOX filter.
- * 
- * @param {ol.format.filter.Filter|undefined} options.filter Filter condition. See {@link ol.format.filter} for more information.
- * 
- * @param {string|undefined} options.resultType Indicates what response should be returned, E.g. `hits` only includes the
+ * @property {ol.Extent|undefined} bbox Extent to use for the BBOX filter.
+ * @property {ol.format.filter.Filter|undefined} filter Filter condition. See {@link ol.format.filter} for more information.
+ * @property {string|undefined} resultType Indicates what response should be returned, E.g. `hits` only includes the
  * `numberOfFeatures` attribute in the response and no features.
- * 
  */
 
 
 /**
- * @typedef {{featureNS: string,
- *     featurePrefix: string,
- *     featureType: string,
- *     srsName: (string|undefined),
- *     handle: (string|undefined),
- *     hasZ: (boolean|undefined),
- *     nativeElements: Array.<Object>,
- *     gmlOptions: (olx.format.GMLOptions|undefined),
- *     version: (string|undefined)}}
- */
-export let format_WFSWriteTransactionOptions;
-
-/**
- * @param {format_WFSWriteTransactionOptions} options TODO: repace this
- *
- * @param {string} options.featureNS The namespace URI used for features.
- * 
- * @param {string} options.featurePrefix The prefix for the feature namespace.
- * 
- * @param {string} options.featureType The feature type name.
- * 
- * @param {string|undefined} options.srsName SRS name. No srsName attribute will be set on geometries when this is not
+ * @typedef {Object} format_WFSWriteTransactionOptions
+ * @property {string} featureNS The namespace URI used for features.
+ * @property {string} featurePrefix The prefix for the feature namespace.
+ * @property {string} featureType The feature type name.
+ * @property {string|undefined} srsName SRS name. No srsName attribute will be set on geometries when this is not
  * provided.
- * 
- * @param {string|undefined} options.handle Handle.
- * 
- * @param {boolean|undefined} options.hasZ Must be set to true if the transaction is for a 3D layer. This will allow
+ * @property {string|undefined} handle Handle.
+ * @property {boolean|undefined} hasZ Must be set to true if the transaction is for a 3D layer. This will allow
  * the Z coordinate to be included in the transaction.
- * 
- * @param {Array.<Object>} options.nativeElements Native elements. Currently not supported.
- * 
- * @param {olx.format.GMLOptions|undefined} options.gmlOptions GML options for the WFS transaction writer.
- * 
- * @param {string|undefined} options.version WFS version to use for the transaction. Can be either `1.0.0` or `1.1.0`.
+ * @property {Array.<Object>} nativeElements Native elements. Currently not supported.
+ * @property {olx.format.GMLOptions|undefined} gmlOptions GML options for the WFS transaction writer.
+ * @property {string|undefined} version WFS version to use for the transaction. Can be either `1.0.0` or `1.1.0`.
  * Default is `1.1.0`.
- * 
  */
 
 
 /**
- * @typedef {{splitCollection: (boolean|undefined)}}
- */
-export let format_WKTOptions;
-
-/**
- * @param {format_WKTOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.splitCollection Whether to split GeometryCollections into
+ * @typedef {Object} format_WKTOptions
+ * @property {boolean|undefined} splitCollection Whether to split GeometryCollections into
  * multiple features on reading. Default is `false`.
- * 
  */
 
 
 /**
- * @typedef {{
- *     layers: (Array.<string>|undefined)
- * }}
- */
-export let format_WMSGetFeatureInfoOptions;
-
-/**
- * @param {format_WMSGetFeatureInfoOptions} options TODO: repace this
- *
- * @param {Array.<string>|undefined} options.layers If set, only features of the given layers will be returned by the format
+ * @typedef {Object} format_WMSGetFeatureInfoOptions
+ * @property {Array.<string>|undefined} layers If set, only features of the given layers will be returned by the format
  * when read.
- * 
  */
 
 
 /**
- * Interactions for the map. Default is `true` for all options.
- * @typedef {{
- *     altShiftDragRotate: (boolean|undefined),
- *     constrainResolution: (boolean|undefined),
- *     doubleClickZoom: (boolean|undefined),
- *     keyboard: (boolean|undefined),
- *     mouseWheelZoom: (boolean|undefined),
- *     shiftDragZoom: (boolean|undefined),
- *     dragPan: (boolean|undefined),
- *     pinchRotate: (boolean|undefined),
- *     pinchZoom: (boolean|undefined),
- *     zoomDelta: (number|undefined),
- *     zoomDuration: (number|undefined)
- * }}
- */
-export let interaction_DefaultsOptions;
-
-/**
- * @param {interaction_DefaultsOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.altShiftDragRotate Whether Alt-Shift-drag rotate is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.constrainResolution Zoom to the closest integer zoom level after the wheel/trackpad or
+ * @typedef {Object} interaction_DefaultsOptions
+ * @property {boolean|undefined} altShiftDragRotate Whether Alt-Shift-drag rotate is desired. Default is `true`.
+ * @property {boolean|undefined} constrainResolution Zoom to the closest integer zoom level after the wheel/trackpad or
  * pinch gesture ends. Default is `false`.
- * 
- * @param {boolean|undefined} options.doubleClickZoom Whether double click zoom is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.keyboard Whether keyboard interaction is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.mouseWheelZoom Whether mousewheel zoom is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.shiftDragZoom Whether Shift-drag zoom is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.dragPan Whether drag pan is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.pinchRotate Whether pinch rotate is desired. Default is `true`.
- * 
- * @param {boolean|undefined} options.pinchZoom Whether pinch zoom is desired. Default is `true`.
- * 
- * @param {number|undefined} options.zoomDelta Zoom delta.
- * 
- * @param {number|undefined} options.zoomDuration Zoom duration.
- * 
+ * @property {boolean|undefined} doubleClickZoom Whether double click zoom is desired. Default is `true`.
+ * @property {boolean|undefined} keyboard Whether keyboard interaction is desired. Default is `true`.
+ * @property {boolean|undefined} mouseWheelZoom Whether mousewheel zoom is desired. Default is `true`.
+ * @property {boolean|undefined} shiftDragZoom Whether Shift-drag zoom is desired. Default is `true`.
+ * @property {boolean|undefined} dragPan Whether drag pan is desired. Default is `true`.
+ * @property {boolean|undefined} pinchRotate Whether pinch rotate is desired. Default is `true`.
+ * @property {boolean|undefined} pinchZoom Whether pinch zoom is desired. Default is `true`.
+ * @property {number|undefined} zoomDelta Zoom delta.
+ * @property {number|undefined} zoomDuration Zoom duration.
  */
 
 
 /**
- * @typedef {{duration: (number|undefined),
- *     delta: (number|undefined)}}
- */
-export let interaction_DoubleClickZoomOptions;
-
-/**
- * @param {interaction_DoubleClickZoomOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- * 
- * @param {number|undefined} options.delta The zoom delta applied on each double click, default is `1`.
- * 
+ * @typedef {Object} interaction_DoubleClickZoomOptions
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
+ * @property {number|undefined} delta The zoom delta applied on each double click, default is `1`.
  */
 
 
 /**
- * @typedef {{formatConstructors: (Array.<function(new: ol.format.Feature)>|undefined),
- *     source: (ol.source.Vector|undefined),
- *     projection: ol.ProjectionLike,
- *     target: (Element|undefined)}}
- */
-export let interaction_DragAndDropOptions;
-
-/**
- * @param {interaction_DragAndDropOptions} options TODO: repace this
- *
- * @param {Array.<function(new: ol.format.Feature)>|undefined} options.formatConstructors Format constructors.
- * 
- * @param {ol.source.Vector|undefined} options.source Optional vector source where features will be added.  If a source is provided
+ * @typedef {Object} interaction_DragAndDropOptions
+ * @property {Array.<function(new: ol.format.Feature)>|undefined} formatConstructors Format constructors.
+ * @property {ol.source.Vector|undefined} source Optional vector source where features will be added.  If a source is provided
  * all existing features will be removed and new features will be added when
  * they are dropped on the target.  If you want to add features to a vector
  * source without removing the existing features (append only), instead of
  * providing the source option listen for the "addfeatures" event.
- * 
- * @param {ol.ProjectionLike} options.projection Target projection. By default, the map's view's projection is used.
- * 
- * @param {Element|undefined} options.target The element that is used as the drop target, default is the viewport element.
- * 
+ * @property {ol.ProjectionLike} projection Target projection. By default, the map's view's projection is used.
+ * @property {Element|undefined} target The element that is used as the drop target, default is the viewport element.
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     condition: (ol.EventsConditionType|undefined),
- *     minArea: (number|undefined),
- *     boxEndCondition: (ol.DragBoxEndConditionType|undefined)}}
- */
-export let interaction_DragBoxOptions;
-
-/**
- * @param {interaction_DragBoxOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name for styling the box. The default is `ol-dragbox`.
- * 
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_DragBoxOptions
+ * @property {string|undefined} className CSS class name for styling the box. The default is `ol-dragbox`.
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.always}.
- * 
- * @param {number|undefined} options.minArea The minimum area of the box in pixel, this value is used by the default
+ * @property {number|undefined} minArea The minimum area of the box in pixel, this value is used by the default
  * `boxEndCondition` function. Default is `64`.
- * 
- * @param {ol.DragBoxEndConditionType|undefined} options.boxEndCondition A function that takes a {@link ol.MapBrowserEvent} and two
+ * @property {ol.DragBoxEndConditionType|undefined} boxEndCondition A function that takes a {@link ol.MapBrowserEvent} and two
  * {@link ol.Pixel}s to indicate whether a `boxend` event should be fired.
  * Default is `true` if the area of the box is bigger than the `minArea` option.
- * 
  */
 
 
 /**
- * @typedef {{condition: (ol.EventsConditionType|undefined),
- *     kinetic: (ol.Kinetic|undefined)}}
- */
-export let interaction_DragPanOptions;
-
-/**
- * @param {interaction_DragPanOptions} options TODO: repace this
- *
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_DragPanOptions
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.noModifierKeys}.
- * 
- * @param {ol.Kinetic|undefined} options.kinetic Kinetic inertia to apply to the pan.
- * 
+ * @property {ol.Kinetic|undefined} kinetic Kinetic inertia to apply to the pan.
  */
 
 
 /**
- * @typedef {{condition: (ol.EventsConditionType|undefined),
- *     duration: (number|undefined)}}
- */
-export let interaction_DragRotateAndZoomOptions;
-
-/**
- * @param {interaction_DragRotateAndZoomOptions} options TODO: repace this
- *
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_DragRotateAndZoomOptions
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.shiftKeyOnly}.
- * 
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `400`.
- * 
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `400`.
  */
 
 
 /**
- * @typedef {{condition: (ol.EventsConditionType|undefined),
- *     duration: (number|undefined)}}
- */
-export let interaction_DragRotateOptions;
-
-/**
- * @param {interaction_DragRotateOptions} options TODO: repace this
- *
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_DragRotateOptions
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.altShiftKeysOnly}.
- * 
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- * 
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
  */
 
 
 /**
- * @typedef {{className: (string|undefined),
- *     condition: (ol.EventsConditionType|undefined),
- *     duration: (number|undefined),
- *     out: (boolean|undefined)}}
- */
-export let interaction_DragZoomOptions;
-
-/**
- * @param {interaction_DragZoomOptions} options TODO: repace this
- *
- * @param {string|undefined} options.className CSS class name for styling the box. The default is `ol-dragzoom`.
- * 
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_DragZoomOptions
+ * @property {string|undefined} className CSS class name for styling the box. The default is `ol-dragzoom`.
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.shiftKeyOnly}.
- * 
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `200`.
- * 
- * @param {boolean|undefined} options.out Use interaction for zooming out. Default is `false`.
- * 
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `200`.
+ * @property {boolean|undefined} out Use interaction for zooming out. Default is `false`.
  */
 
 
 /**
- * @typedef {{clickTolerance: (number|undefined),
- *     features: (ol.Collection.<ol.Feature>|undefined),
- *     source: (ol.source.Vector|undefined),
- *     snapTolerance: (number|undefined),
- *     type: (ol.geom.GeometryType|string),
- *     stopClick: (boolean|undefined),
- *     maxPoints: (number|undefined),
- *     minPoints: (number|undefined),
- *     finishCondition: (ol.EventsConditionType|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     geometryFunction: (ol.DrawGeometryFunctionType|undefined),
- *     geometryName: (string|undefined),
- *     condition: (ol.EventsConditionType|undefined),
- *     freehand: (boolean|undefined),
- *     freehandCondition: (ol.EventsConditionType|undefined),
- *     wrapX: (boolean|undefined)}}
- */
-export let interaction_DrawOptions;
-
-/**
- * @param {interaction_DrawOptions} options TODO: repace this
- *
- * @param {number|undefined} options.clickTolerance The maximum distance in pixels between "down" and "up" for a "up" event
+ * @typedef {Object} interaction_DrawOptions
+ * @property {number|undefined} clickTolerance The maximum distance in pixels between "down" and "up" for a "up" event
  * to be considered a "click" event and actually add a point/vertex to the
  * geometry being drawn.  Default is 6 pixels.  That value was chosen for
  * the draw interaction to behave correctly on mouse as well as on touch
  * devices.
- * 
- * @param {ol.Collection.<ol.Feature>|undefined} options.features Destination collection for the drawn features.
- * 
- * @param {ol.source.Vector|undefined} options.source Destination source for the drawn features.
- * 
- * @param {number|undefined} options.snapTolerance Pixel distance for snapping to the drawing finish. Default is `12`.
- * 
- * @param {ol.geom.GeometryType|string} options.type Drawing type ('Point', 'LineString', 'Polygon', 'MultiPoint',
+ * @property {ol.Collection.<ol.Feature>|undefined} features Destination collection for the drawn features.
+ * @property {ol.source.Vector|undefined} source Destination source for the drawn features.
+ * @property {number|undefined} snapTolerance Pixel distance for snapping to the drawing finish. Default is `12`.
+ * @property {ol.geom.GeometryType|string} type Drawing type ('Point', 'LineString', 'Polygon', 'MultiPoint',
  * 'MultiLineString', 'MultiPolygon' or 'Circle').
- * 
- * @param {boolean|undefined} options.stopClick Stop click, singleclick, and doubleclick events from firing during drawing.
+ * @property {boolean|undefined} stopClick Stop click, singleclick, and doubleclick events from firing during drawing.
  * Default is `false`.
- * 
- * @param {number|undefined} options.maxPoints The number of points that can be drawn before a polygon ring or line string
+ * @property {number|undefined} maxPoints The number of points that can be drawn before a polygon ring or line string
  * is finished. The default is no restriction.
- * 
- * @param {number|undefined} options.minPoints The number of points that must be drawn before a polygon ring or line string
+ * @property {number|undefined} minPoints The number of points that must be drawn before a polygon ring or line string
  * can be finished. Default is `3` for polygon rings and `2` for line strings.
- * 
- * @param {ol.EventsConditionType|undefined} options.finishCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.EventsConditionType|undefined} finishCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether the drawing can be finished.
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style for sketch features.
- * 
- * @param {ol.DrawGeometryFunctionType|undefined} options.geometryFunction Function that is called when a geometry's coordinates are updated.
- * 
- * @param {string|undefined} options.geometryName Geometry name to use for features created by the draw interaction.
- * 
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} style Style for sketch features.
+ * @property {ol.DrawGeometryFunctionType|undefined} geometryFunction Function that is called when a geometry's coordinates are updated.
+ * @property {string|undefined} geometryName Geometry name to use for features created by the draw interaction.
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default {@link ol.events.condition.noModifierKeys}, i.e. a click, adds a
  * vertex or deactivates freehand drawing.
- * 
- * @param {boolean|undefined} options.freehand Operate in freehand mode for lines, polygons, and circles.  This makes the
+ * @property {boolean|undefined} freehand Operate in freehand mode for lines, polygons, and circles.  This makes the
  * interaction always operate in freehand mode and takes precedence over any
  * `freehandCondition` option.
- * 
- * @param {ol.EventsConditionType|undefined} options.freehandCondition Condition that activates freehand drawing for lines and polygons. This
+ * @property {ol.EventsConditionType|undefined} freehandCondition Condition that activates freehand drawing for lines and polygons. This
  * function takes an {@link ol.MapBrowserEvent} and returns a boolean to
  * indicate whether that event should be handled. The default is
  * {@link ol.events.condition.shiftKeyOnly}, meaning that the Shift key
  * activates freehand drawing.
- * 
- * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
- * 
+ * @property {boolean|undefined} wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
  */
 
 
 /**
- * @typedef {{extent: (ol.Extent|undefined),
- *     boxStyle: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     pixelTolerance: (number|undefined),
- *     pointerStyle: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     wrapX: (boolean|undefined)}}
- * @api
- */
-export let interaction_ExtentOptions;
-
-/**
- * @param {interaction_ExtentOptions} options TODO: repace this
- *
- * @param {ol.Extent|undefined} options.extent Initial extent. Defaults to no initial extent
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.boxStyle Style for the drawn extent box.
+ * @typedef {Object} interaction_ExtentOptions
+ * @property {ol.Extent|undefined} extent Initial extent. Defaults to no initial extent
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} boxStyle Style for the drawn extent box.
  * Defaults to ol.style.Style.createDefaultEditing()[ol.geom.GeometryType.POLYGON]
- * 
- * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
+ * @property {number|undefined} pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for editing. Default is `10`.
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.pointerStyle Style for the cursor used to draw the extent.
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} pointerStyle Style for the cursor used to draw the extent.
  * Defaults to ol.style.Style.createDefaultEditing()[ol.geom.GeometryType.POINT]
- * 
- * @param {boolean|undefined} options.wrapX Wrap the drawn extent across multiple maps in the X direction?
+ * @property {boolean|undefined} wrapX Wrap the drawn extent across multiple maps in the X direction?
  * Only affects visuals, not functionality. Defaults to false.
- * 
  */
 
 
 /**
- * @typedef {{
- *     features: (ol.Collection.<ol.Feature>|undefined),
- *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
- *     hitTolerance: (number|undefined)
- * }}
- */
-export let interaction_TranslateOptions;
-
-/**
- * @param {interaction_TranslateOptions} options TODO: repace this
- *
- * @param {ol.Collection.<ol.Feature>|undefined} options.features Only features contained in this collection will be able to be translated. If
+ * @typedef {Object} interaction_TranslateOptions
+ * @property {ol.Collection.<ol.Feature>|undefined} features Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
- * 
- * @param {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} options.layers A list of layers from which features should be
+ * @property {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} layers A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be translatable. If the option is
  * absent, all visible layers will be considered translatable.
- * 
- * @param {number|undefined} options.hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
+ * @property {number|undefined} hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- * 
  */
 
 
 /**
- * @typedef {{condition: (ol.EventsConditionType|undefined),
- *     duration: (number|undefined),
- *     pixelDelta: (number|undefined)}}
- */
-export let interaction_KeyboardPanOptions;
-
-/**
- * @param {interaction_KeyboardPanOptions} options TODO: repace this
- *
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_KeyboardPanOptions
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.noModifierKeys} and
  * {@link ol.events.condition.targetNotEditable}.
- * 
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `100`.
- * 
- * @param {number|undefined} options.pixelDelta Pixel The amount to pan on each key press. Default is `128` pixels.
- * 
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `100`.
+ * @property {number|undefined} pixelDelta Pixel The amount to pan on each key press. Default is `128` pixels.
  */
 
 
 /**
- * @typedef {{duration: (number|undefined),
- *     condition: (ol.EventsConditionType|undefined),
- *     delta: (number|undefined)}}
- */
-export let interaction_KeyboardZoomOptions;
-
-/**
- * @param {interaction_KeyboardZoomOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `100`.
- * 
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_KeyboardZoomOptions
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `100`.
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.targetNotEditable}.
- * 
- * @param {number|undefined} options.delta The amount to zoom on each key press. Default is `1`.
- * 
+ * @property {number|undefined} delta The amount to zoom on each key press. Default is `1`.
  */
 
 
 /**
- * @typedef {{
- *     condition: (ol.EventsConditionType|undefined),
- *     deleteCondition: (ol.EventsConditionType|undefined),
- *     insertVertexCondition: (ol.EventsConditionType|undefined),
- *     pixelTolerance: (number|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     source: (ol.source.Vector|undefined),
- *     features: (ol.Collection.<ol.Feature>|undefined),
- *     wrapX: (boolean|undefined)
- * }}
- */
-export let interaction_ModifyOptions;
-
-/**
- * @param {interaction_ModifyOptions} options TODO: repace this
- *
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_ModifyOptions
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event will be considered to add or move a vertex
  * to the sketch.
  * Default is {@link ol.events.condition.primaryAction}.
- * 
- * @param {ol.EventsConditionType|undefined} options.deleteCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.EventsConditionType|undefined} deleteCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default, {@link ol.events.condition.singleClick} with
  * {@link ol.events.condition.altKeyOnly} results in a vertex deletion.
- * 
- * @param {ol.EventsConditionType|undefined} options.insertVertexCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.EventsConditionType|undefined} insertVertexCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether a new vertex can be added to the sketch features.
  * Default is {@link ol.events.condition.always}
- * 
- * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
+ * @property {number|undefined} pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for editing. Default is `10`.
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style used for the features being modified. By default the default edit
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} style Style used for the features being modified. By default the default edit
  * style is used (see {@link ol.style}).
- * 
- * @param {ol.source.Vector|undefined} options.source The vector source with features to modify.  If a vector source is not
+ * @property {ol.source.Vector|undefined} source The vector source with features to modify.  If a vector source is not
  * provided, a feature collection must be provided with the features option.
- * 
- * @param {ol.Collection.<ol.Feature>|undefined} options.features The features the interaction works on.  If a feature collection is not
+ * @property {ol.Collection.<ol.Feature>|undefined} features The features the interaction works on.  If a feature collection is not
  * provided, a vector source must be provided with the source option.
- * 
- * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
- * 
+ * @property {boolean|undefined} wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
  */
 
 
 /**
- * @typedef {{constrainResolution: (boolean|undefined),
- *     duration: (number|undefined),
- *     timeout: (number|undefined),
- *     useAnchor: (boolean|undefined)}}
- */
-export let interaction_MouseWheelZoomOptions;
-
-/**
- * @param {interaction_MouseWheelZoomOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- * 
- * @param {number|undefined} options.timeout Mouse wheel timeout duration in milliseconds. Default is `80`.
- * 
- * @param {boolean|undefined} options.constrainResolution When using a trackpad or magic mouse, zoom to the closest integer zoom level
+ * @typedef {Object} interaction_MouseWheelZoomOptions
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `250`.
+ * @property {number|undefined} timeout Mouse wheel timeout duration in milliseconds. Default is `80`.
+ * @property {boolean|undefined} constrainResolution When using a trackpad or magic mouse, zoom to the closest integer zoom level
  * after the scroll gesture ends.
  * Default is `false`.
- * 
- * @param {boolean|undefined} options.useAnchor Enable zooming using the mouse's location as the anchor. Default is `true`.
+ * @property {boolean|undefined} useAnchor Enable zooming using the mouse's location as the anchor. Default is `true`.
  * When set to false, zooming in and out will zoom to the center of the screen
  * instead of zooming on the mouse's location.
- * 
  */
 
 
 /**
- * @typedef {{threshold: (number|undefined),
- *     duration: (number|undefined)}}
- */
-export let interaction_PinchRotateOptions;
-
-/**
- * @param {interaction_PinchRotateOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration The duration of the animation in milliseconds. Default is `250`.
- * 
- * @param {number|undefined} options.threshold Minimal angle in radians to start a rotation. Default is `0.3`.
- * 
+ * @typedef {Object} interaction_PinchRotateOptions
+ * @property {number|undefined} duration The duration of the animation in milliseconds. Default is `250`.
+ * @property {number|undefined} threshold Minimal angle in radians to start a rotation. Default is `0.3`.
  */
 
 
 /**
- * @typedef {{
- *     duration: (number|undefined),
- *     constrainResolution: (boolean|undefined)
- * }}
- */
-export let interaction_PinchZoomOptions;
-
-/**
- * @param {interaction_PinchZoomOptions} options TODO: repace this
- *
- * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `400`.
- * 
- * @param {boolean|undefined} options.constrainResolution Zoom to the closest integer zoom level after the pinch gesture ends. Default is `false`.
- * 
+ * @typedef {Object} interaction_PinchZoomOptions
+ * @property {number|undefined} duration Animation duration in milliseconds. Default is `400`.
+ * @property {boolean|undefined} constrainResolution Zoom to the closest integer zoom level after the pinch gesture ends. Default is `false`.
  */
 
 
 /**
- * @typedef {{handleDownEvent: (function(ol.MapBrowserPointerEvent):boolean|undefined),
- *     handleDragEvent: (function(ol.MapBrowserPointerEvent)|undefined),
- *     handleEvent: (function(ol.MapBrowserEvent):boolean|undefined),
- *     handleMoveEvent: (function(ol.MapBrowserPointerEvent)|undefined),
- *     handleUpEvent: (function(ol.MapBrowserPointerEvent):boolean|undefined)}}
- */
-export let interaction_PointerOptions;
-
-/**
- * @param {interaction_PointerOptions} options TODO: repace this
- *
- * @param {(function(ol.MapBrowserPointerEvent):boolean|undefined)} options.handleDownEvent Function handling "down" events. If the function returns `true` then a drag
+ * @typedef {Object} interaction_PointerOptions
+ * @property {(function(ol.MapBrowserPointerEvent):boolean|undefined)} handleDownEvent Function handling "down" events. If the function returns `true` then a drag
  * sequence is started.
- * 
- * @param {(function(ol.MapBrowserPointerEvent)|undefined)} options.handleDragEvent Function handling "drag" events. This function is called on "move" events
+ * @property {(function(ol.MapBrowserPointerEvent)|undefined)} handleDragEvent Function handling "drag" events. This function is called on "move" events
  * during a drag sequence.
- * 
- * @param {(function(ol.MapBrowserEvent):boolean|undefined)} options.handleEvent Method called by the map to notify the interaction that a browser event was
+ * @property {(function(ol.MapBrowserEvent):boolean|undefined)} handleEvent Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. The function may return `false` to prevent the
  * propagation of the event to other interactions in the map's interactions
  * chain.
- * 
- * @param {(function(ol.MapBrowserPointerEvent)|undefined)} options.handleMoveEvent Function handling "move" events. This function is called on "move" events,
+ * @property {(function(ol.MapBrowserPointerEvent)|undefined)} handleMoveEvent Function handling "move" events. This function is called on "move" events,
  * also during a drag sequence (so during a drag sequence both the
  * `handleDragEvent` function and this function are called).
- * 
- * @param {(function(ol.MapBrowserPointerEvent):boolean|undefined)} options.handleUpEvent Function handling "up" events. If the function returns `false` then the
+ * @property {(function(ol.MapBrowserPointerEvent):boolean|undefined)} handleUpEvent Function handling "up" events. If the function returns `false` then the
  * current drag sequence is stopped.
- * 
  */
 
 
 /**
- * @typedef {{addCondition: (ol.EventsConditionType|undefined),
- *     condition: (ol.EventsConditionType|undefined),
- *     layers: (undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     removeCondition: (ol.EventsConditionType|undefined),
- *     toggleCondition: (ol.EventsConditionType|undefined),
- *     multi: (boolean|undefined),
- *     features: (ol.Collection.<ol.Feature>|undefined),
- *     filter: (ol.SelectFilterFunction|undefined),
- *     wrapX: (boolean|undefined),
- *     hitTolerance: (number|undefined)}}
- */
-export let interaction_SelectOptions;
-
-/**
- * @param {interaction_SelectOptions} options TODO: repace this
- *
- * @param {ol.EventsConditionType|undefined} options.addCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @typedef {Object} interaction_SelectOptions
+ * @property {ol.EventsConditionType|undefined} addCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default, this is {@link ol.events.condition.never}. Use this if you want
  * to use different events for add and remove instead of `toggle`.
- * 
- * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.EventsConditionType|undefined} condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * This is the event for the selected features as a whole. By default, this is
  * {@link ol.events.condition.singleClick}. Clicking on a feature selects that
@@ -1892,22 +801,18 @@ export let interaction_SelectOptions;
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- * 
- * @param {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} options.layers A list of layers from which features should be
+ * @property {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} layers A list of layers from which features should be
  * selected. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be selectable. If the option is
  * absent, all visible layers will be considered selectable.
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style for the selected features. By default the default edit style is used
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} style Style for the selected features. By default the default edit style is used
  * (see {@link ol.style}).
- * 
- * @param {ol.EventsConditionType|undefined} options.removeCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.EventsConditionType|undefined} removeCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default, this is {@link ol.events.condition.never}. Use this if you want
  * to use different events for add and remove instead of `toggle`.
- * 
- * @param {ol.EventsConditionType|undefined} options.toggleCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
+ * @property {ol.EventsConditionType|undefined} toggleCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * This is in addition to the `condition` event. By default,
  * {@link ol.events.condition.shiftKeyOnly}, i.e. pressing `shift` as well as
@@ -1915,399 +820,189 @@ export let interaction_SelectOptions;
  * not currently selected, and removes it if it is.
  * See `add` and `remove` if you want to use different events instead of a
  * toggle.
- * 
- * @param {boolean|undefined} options.multi A boolean that determines if the default behaviour should select only
+ * @property {boolean|undefined} multi A boolean that determines if the default behaviour should select only
  * single features or all (overlapping) features at the clicked map
  * position. Default is false i.e single select
- * 
- * @param {ol.Collection.<ol.Feature>|undefined} options.features Collection where the interaction will place selected features. Optional. If
+ * @property {ol.Collection.<ol.Feature>|undefined} features Collection where the interaction will place selected features. Optional. If
  * not set the interaction will create a collection. In any case the collection
  * used by the interaction is returned by
  * {@link ol.interaction.Select#getFeatures}.
- * 
- * @param {ol.SelectFilterFunction|undefined} options.filter A function that takes an {@link ol.Feature} and an {@link ol.layer.Layer} and
+ * @property {ol.SelectFilterFunction|undefined} filter A function that takes an {@link ol.Feature} and an {@link ol.layer.Layer} and
  * returns `true` if the feature may be selected or `false` otherwise.
- * 
- * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the selection overlay. Default is `true`.
- * 
- * @param {number|undefined} options.hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
+ * @property {boolean|undefined} wrapX Wrap the world horizontally on the selection overlay. Default is `true`.
+ * @property {number|undefined} hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- * 
  */
 
 
 /**
- * Options for snap
- * @typedef {{
- *     features: (ol.Collection.<ol.Feature>|undefined),
- *     pixelTolerance: (number|undefined),
- *     source: (ol.source.Vector|undefined),
- *     edge: (boolean|undefined),
- *     vertex: (boolean|undefined)
- * }}
- */
-export let interaction_SnapOptions;
-
-/**
- * @param {interaction_SnapOptions} options TODO: repace this
- *
- * @param {ol.Collection.<ol.Feature>|undefined} options.features Snap to these features. Either this option or source should be provided.
- * 
- * @param {boolean|undefined} options.edge Snap to edges. Default is `true`.
- * 
- * @param {boolean|undefined} options.vertex Snap to vertices. Default is `true`.
- * 
- * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
+ * @typedef {Object} interaction_SnapOptions
+ * @property {ol.Collection.<ol.Feature>|undefined} features Snap to these features. Either this option or source should be provided.
+ * @property {boolean|undefined} edge Snap to edges. Default is `true`.
+ * @property {boolean|undefined} vertex Snap to vertices. Default is `true`.
+ * @property {number|undefined} pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for snapping. Default is `10` pixels.
- * 
- * @param {ol.source.Vector|undefined} options.source Snap to features from this source. Either this option or features should be provided
- * 
+ * @property {ol.source.Vector|undefined} source Snap to features from this source. Either this option or features should be provided
  */
 
 
 /**
- * @typedef {{opacity: (number|undefined),
- *     visible: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     zIndex: (number|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined)}}
- */
-export let layer_BaseOptions;
-
-/**
- * @param {layer_BaseOptions} options TODO: repace this
- *
- * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true`.
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @typedef {Object} layer_BaseOptions
+ * @property {number|undefined} opacity Opacity (0, 1). Default is `1`.
+ * @property {boolean|undefined} visible Visibility. Default is `true`.
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
  */
 
 
 /**
- * @typedef {{opacity: (number|undefined),
- *     source: (ol.source.Source|undefined),
- *     visible: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     zIndex: (number|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined)}}
- */
-export let layer_LayerOptions;
-
-/**
- * @param {layer_LayerOptions} options TODO: repace this
- *
- * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- * 
- * @param {ol.source.Source|undefined} options.source Source for this layer.  If not provided to the constructor, the source can
+ * @typedef {Object} layer_LayerOptions
+ * @property {number|undefined} opacity Opacity (0, 1). Default is `1`.
+ * @property {ol.source.Source|undefined} source Source for this layer.  If not provided to the constructor, the source can
  * be set by calling {@link ol.layer.Layer#setSource layer.setSource(source)}
  * after construction.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
  */
 
 
 /**
- * @typedef {{opacity: (number|undefined),
- *     visible: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     zIndex: (number|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     layers: (Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined)}}
- */
-export let layer_GroupOptions;
-
-/**
- * @param {layer_GroupOptions} options TODO: repace this
- *
- * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true`.
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @typedef {Object} layer_GroupOptions
+ * @property {number|undefined} opacity Opacity (0, 1). Default is `1`.
+ * @property {boolean|undefined} visible Visibility. Default is `true`.
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
- * @param {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} options.layers Child layers.
- * 
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ * @property {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} layers Child layers.
  */
 
 
 /**
- * @typedef {{gradient: (Array.<string>|undefined),
- *     radius: (number|undefined),
- *     blur: (number|undefined),
- *     shadow: (number|undefined),
- *     weight: (string|function(ol.Feature):number|undefined),
- *     extent: (ol.Extent|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     opacity: (number|undefined),
- *     source: (ol.source.Vector|undefined),
- *     visible: (boolean|undefined),
- *     zIndex: (number|undefined)}}
- */
-export let layer_HeatmapOptions;
-
-/**
- * @param {layer_HeatmapOptions} options TODO: repace this
- *
- * @param {Array.<string>|undefined} options.gradient The color gradient of the heatmap, specified as an array of CSS color
+ * @typedef {Object} layer_HeatmapOptions
+ * @property {Array.<string>|undefined} gradient The color gradient of the heatmap, specified as an array of CSS color
  * strings. Default is `['#00f', '#0ff', '#0f0', '#ff0', '#f00']`.
- * 
- * @param {number|undefined} options.radius Radius size in pixels. Default is `8`.
- * 
- * @param {number|undefined} options.blur Blur size in pixels. Default is `15`.
- * 
- * @param {number|undefined} options.shadow Shadow size in pixels. Default is `250`.
- * 
- * @param {string|function(ol.Feature):number|undefined} options.weight The feature attribute to use for the weight or a function that returns a
+ * @property {number|undefined} radius Radius size in pixels. Default is `8`.
+ * @property {number|undefined} blur Blur size in pixels. Default is `15`.
+ * @property {number|undefined} shadow Shadow size in pixels. Default is `250`.
+ * @property {string|function(ol.Feature):number|undefined} weight The feature attribute to use for the weight or a function that returns a
  * weight from a feature. Weight values should range from 0 to 1 (and values
  * outside will be clamped to that range). Default is `weight`.
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
- * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
- * 
- * @param {ol.source.Vector} options.source Source.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ * @property {number|undefined} opacity Opacity. 0-1. Default is `1`.
+ * @property {ol.source.Vector} source Source.
+ * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
  */
 
 
 /**
- * @typedef {{opacity: (number|undefined),
- *     map: (ol.PluggableMap|undefined),
- *     source: (ol.source.Image|undefined),
- *     visible: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     zIndex: (number|undefined)}}
- */
-export let layer_ImageOptions;
-
-/**
- * @param {layer_ImageOptions} options TODO: repace this
- *
- * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- * 
- * @param {ol.source.Image} options.source Source for this layer.
- * 
- * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * @typedef {Object} layer_ImageOptions
+ * @property {number|undefined} opacity Opacity (0, 1). Default is `1`.
+ * @property {ol.source.Image} source Source for this layer.
+ * @property {ol.PluggableMap|undefined} map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
  */
 
 
 /**
- * @typedef {{opacity: (number|undefined),
- *     preload: (number|undefined),
- *     source: (ol.source.Tile|undefined),
- *     map: (ol.PluggableMap|undefined),
- *     visible: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     useInterimTilesOnError: (boolean|undefined),
- *     zIndex: (number|undefined)}}
- */
-export let layer_TileOptions;
-
-/**
- * @param {layer_TileOptions} options TODO: repace this
- *
- * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- * 
- * @param {number|undefined} options.preload Preload. Load low-resolution tiles up to `preload` levels. By default
+ * @typedef {Object} layer_TileOptions
+ * @property {number|undefined} opacity Opacity (0, 1). Default is `1`.
+ * @property {number|undefined} preload Preload. Load low-resolution tiles up to `preload` levels. By default
  * `preload` is `0`, which means no preloading.
- * 
- * @param {ol.source.Tile} options.source Source for this layer.
- * 
- * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * @property {ol.source.Tile} source Source for this layer.
+ * @property {ol.PluggableMap|undefined} map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
- * @param {boolean|undefined} options.useInterimTilesOnError Use interim tiles on error. Default is `true`.
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ * @property {boolean|undefined} useInterimTilesOnError Use interim tiles on error. Default is `true`.
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
  */
 
 
 /**
- * @typedef {{renderOrder: (ol.RenderOrderFunction|null|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     opacity: (number|undefined),
- *     renderBuffer: (number|undefined),
- *     renderMode: (ol.layer.VectorRenderType|string|undefined),
- *     source: (ol.source.Vector|undefined),
- *     map: (ol.PluggableMap|undefined),
- *     declutter: (boolean|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     updateWhileAnimating: (boolean|undefined),
- *     updateWhileInteracting: (boolean|undefined),
- *     visible: (boolean|undefined),
- *     zIndex: (number|undefined)}}
- */
-export let layer_VectorOptions;
-
-/**
- * @param {layer_VectorOptions} options TODO: repace this
- *
- * @param {ol.layer.VectorRenderType|string|undefined} options.renderMode Render mode for vector layers:
+ * @typedef {Object} layer_VectorOptions
+ * @property {ol.layer.VectorRenderType|string|undefined} renderMode Render mode for vector layers:
  *  * `'image'`: Vector layers are rendered as images. Great performance, but
  *    point symbols and texts are always rotated with the view and pixels are
  *    scaled during zoom animations.
  *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering
  *    even during animations, but slower performance.
  * Default is `vector`.
- * 
- * @param {ol.RenderOrderFunction|null|undefined} options.renderOrder Render order. Function to be used when sorting features before rendering. By
+ * @property {ol.RenderOrderFunction|null|undefined} renderOrder Render order. Function to be used when sorting features before rendering. By
  * default features are drawn in the order that they are created. Use `null` to
  * avoid the sort, but get an undefined draw order.
- * 
- * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * @property {ol.PluggableMap|undefined} map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
- * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
- * 
- * @param {number|undefined} options.renderBuffer The buffer around the viewport extent used by the renderer when getting
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ * @property {number|undefined} opacity Opacity. 0-1. Default is `1`.
+ * @property {number|undefined} renderBuffer The buffer around the viewport extent used by the renderer when getting
  * features from the vector source for the rendering or hit-detection.
  * Recommended value: the size of the largest symbol, line width or label.
  * Default is 100 pixels.
- * 
- * @param {ol.source.Vector} options.source Source.
- * 
- * @param {boolean|undefined} options.declutter Declutter images and text. Decluttering is applied to all image and text
+ * @property {ol.source.Vector} source Source.
+ * @property {boolean|undefined} declutter Declutter images and text. Decluttering is applied to all image and text
  * styles, and the priority is defined by the z-index of the style. Lower
  * z-index means higher priority. Default is `false`.
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Layer style. See {@link ol.style} for default style which will be used if
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} style Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
- * 
- * @param {boolean|undefined} options.updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
+ * @property {boolean|undefined} updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
  * This means that no vectors will be shown clipped, but the setting will have a
  * performance impact for large amounts of vector data. When set to `false`,
  * batches will be recreated when no animation is active.  Default is `false`.
- * 
- * @param {boolean|undefined} options.updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
+ * @property {boolean|undefined} updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
  * See also `updateWhileAnimating`. Default is `false`.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
  */
 
 
 /**
- * @typedef {{extent: (ol.Extent|undefined),
- *     map: (ol.PluggableMap|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined),
- *     opacity: (number|undefined),
- *     preload: (number|undefined),
- *     renderBuffer: (number|undefined),
- *     renderMode: (ol.layer.VectorTileRenderType|string|undefined),
- *     renderOrder: (ol.RenderOrderFunction|undefined),
- *     source: (ol.source.VectorTile|undefined),
- *     declutter: (boolean|undefined),
- *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
- *     updateWhileAnimating: (boolean|undefined),
- *     updateWhileInteracting: (boolean|undefined),
- *     visible: (boolean|undefined),
- *     zIndex: (number|undefined)}}
- */
-export let layer_VectorTileOptions;
-
-/**
- * @param {layer_VectorTileOptions} options TODO: repace this
- *
- * @param {number|undefined} options.renderBuffer The buffer around the tile extent used by the renderer when getting features
+ * @typedef {Object} layer_VectorTileOptions
+ * @property {number|undefined} renderBuffer The buffer around the tile extent used by the renderer when getting features
  * from the vector tile for the rendering or hit-detection.
  * Recommended value: Vector tiles are usually generated with a buffer, so this
  * value should match the largest possible buffer of the used tiles. It should
  * be at least the size of the largest point symbol or line width.
  * Default is 100 pixels.
- * 
- * @param {ol.layer.VectorTileRenderType|string|undefined} options.renderMode Render mode for vector tiles:
+ * @property {ol.layer.VectorTileRenderType|string|undefined} renderMode Render mode for vector tiles:
  *  * `'image'`: Vector tiles are rendered as images. Great performance, but
  *    point symbols and texts are always rotated with the view and pixels are
  *    scaled during zoom animations.
@@ -2319,168 +1014,87 @@ export let layer_VectorTileOptions;
  * 
  * When `declutter` is set to `true`, `'hybrid'` will be used instead of
  * `'image'`. The default is `'hybrid'`.
- * 
- * @param {ol.RenderOrderFunction|undefined} options.renderOrder Render order. Function to be used when sorting features before rendering. By
+ * @property {ol.RenderOrderFunction|undefined} renderOrder Render order. Function to be used when sorting features before rendering. By
  * default features are drawn in the order that they are created.
- * 
- * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
+ * @property {ol.PluggableMap|undefined} map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- * 
- * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
+ * @property {ol.Extent|undefined} extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- * 
- * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- * 
- * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- * 
- * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
- * 
- * @param {number|undefined} options.preload Preload. Load low-resolution tiles up to `preload` levels. By default
+ * @property {number|undefined} minResolution The minimum resolution (inclusive) at which this layer will be visible.
+ * @property {number|undefined} maxResolution The maximum resolution (exclusive) below which this layer will be visible.
+ * @property {number|undefined} opacity Opacity. 0-1. Default is `1`.
+ * @property {number|undefined} preload Preload. Load low-resolution tiles up to `preload` levels. By default
  * `preload` is `0`, which means no preloading.
- * 
- * @param {ol.source.VectorTile|undefined} options.source Source.
- * 
- * @param {boolean|undefined} options.declutter Declutter images and text. Decluttering is applied to all image and text
+ * @property {ol.source.VectorTile|undefined} source Source.
+ * @property {boolean|undefined} declutter Declutter images and text. Decluttering is applied to all image and text
  * styles, and the priority is defined by the z-index of the style. Lower
  * z-index means higher priority. When set to `true`, a `renderMode` of
  * `'image'` will be overridden with `'hybrid'`. Default is `false`.
- * 
- * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Layer style. See {@link ol.style} for default style which will be used if
+ * @property {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} style Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
- * 
- * @param {boolean|undefined} options.updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
+ * @property {boolean|undefined} updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
  * This means that no vectors will be shown clipped, but the setting will have a
  * performance impact for large amounts of vector data. When set to `false`,
  * batches will be recreated when no animation is active.  Default is `false`.
- * 
- * @param {boolean|undefined} options.updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
+ * @property {boolean|undefined} updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
  * See also `updateWhileAnimating`. Default is `false`.
- * 
- * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- * 
- * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
+ * @property {boolean|undefined} visible Visibility. Default is `true` (visible).
+ * @property {number|undefined} zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- * 
  */
 
 
 /**
- * @typedef {{context: CanvasRenderingContext2D,
- *     feature: (ol.Feature|ol.render.Feature),
- *     geometry: ol.geom.SimpleGeometry,
- *     pixelRatio: number,
- *     resolution: number,
- *     rotation: number}}
- */
-export let render_State;
-
-/**
- * @param {render_State} options TODO: repace this
- *
- * @param {CanvasRenderingContext2D} options.context Canvas context that the layer is being rendered to.
- * 
- * @param {number} options.pixelRatio Pixel ratio used by the layer renderer.
- * 
- * @param {number} options.resolution Resolution that the render batch was created and optimized for. This is
+ * @typedef {Object} render_State
+ * @property {CanvasRenderingContext2D} context Canvas context that the layer is being rendered to.
+ * @property {number} pixelRatio Pixel ratio used by the layer renderer.
+ * @property {number} resolution Resolution that the render batch was created and optimized for. This is
  * not the view's resolution that is being rendered.
- * 
- * @param {number} options.rotation Rotation of the rendered layer in radians.
- * 
+ * @property {number} rotation Rotation of the rendered layer in radians.
  */
 
 
 /**
- * @typedef {{size: (ol.Size|undefined),
- *     pixelRatio: (number|undefined)}}
- */
-export let render_ToContextOptions;
-
-/**
- * @param {render_ToContextOptions} options TODO: repace this
- *
- * @param {ol.Size|undefined} options.size Desired size of the canvas in css pixels. When provided, both canvas and css
+ * @typedef {Object} render_ToContextOptions
+ * @property {ol.Size|undefined} size Desired size of the canvas in css pixels. When provided, both canvas and css
  * size will be set according to the `pixelRatio`. If not provided, the current
  * canvas and css sizes will not be altered.
- * 
- * @param {number|undefined} options.pixelRatio Pixel ratio (canvas pixel to css pixel ratio) for the canvas. Default
+ * @property {number|undefined} pixelRatio Pixel ratio (canvas pixel to css pixel ratio) for the canvas. Default
  * is the detected device pixel ratio.
- * 
  */
 
 
 /**
- * @typedef {{cacheSize: (number|undefined),
- *     culture: (string|undefined),
- *     hidpi: (boolean|undefined),
- *     key: string,
- *     imagerySet: string,
- *     maxZoom: (number|undefined),
- *     reprojectionErrorThreshold: (number|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     wrapX: (boolean|undefined),
- *     transition: (number|undefined)}}
- */
-export let source_BingMapsOptions;
-
-/**
- * @param {source_BingMapsOptions} options TODO: repace this
- *
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {boolean|undefined} options.hidpi If `true` hidpi tiles will be requested. Default is `false`.
- * 
- * @param {string|undefined} options.culture Culture code. Default is `en-us`.
- * 
- * @param {string} options.key Bing Maps API key. Get yours at http://www.bingmapsportal.com/.
- * 
- * @param {string} options.imagerySet Type of imagery.
- * 
- * @param {number|undefined} options.maxZoom Max zoom. Default is what's advertized by the BingMaps service (`21`
+ * @typedef {Object} source_BingMapsOptions
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {boolean|undefined} hidpi If `true` hidpi tiles will be requested. Default is `false`.
+ * @property {string|undefined} culture Culture code. Default is `en-us`.
+ * @property {string} key Bing Maps API key. Get yours at http://www.bingmapsportal.com/.
+ * @property {string} imagerySet Type of imagery.
+ * @property {number|undefined} maxZoom Max zoom. Default is what's advertized by the BingMaps service (`21`
  * currently).
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     distance: (number|undefined),
- *     extent: (ol.Extent|undefined),
- *     format: (ol.format.Feature|undefined),
- *     geometryFunction: (undefined|function(ol.Feature):ol.geom.Point),
- *     logo: (string|undefined),
- *     projection: ol.ProjectionLike,
- *     source: ol.source.Vector,
- *     wrapX: (boolean|undefined)}}
- */
-export let source_ClusterOptions;
-
-/**
- * @param {source_ClusterOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.distance Minimum distance in pixels between clusters. Default is `20`.
- * 
- * @param {ol.Extent|undefined} options.extent Extent.
- * 
- * @param {undefined|function(ol.Feature):ol.geom.Point} options.geometryFunction Function that takes an {@link ol.Feature} as argument and returns an
+ * @typedef {Object} source_ClusterOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} distance Minimum distance in pixels between clusters. Default is `20`.
+ * @property {ol.Extent|undefined} extent Extent.
+ * @property {undefined|function(ol.Feature):ol.geom.Point} geometryFunction Function that takes an {@link ol.Feature} as argument and returns an
  * {@link ol.geom.Point} as cluster calculation point for the feature. When a
  * feature should not be considered for clustering, the function should return
  * `null`. The default, which works when the underyling source contains point
@@ -2492,183 +1106,89 @@ export let source_ClusterOptions;
  * ```
  * See {@link ol.geom.Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
- * 
- * @param {ol.format.Feature|undefined} options.format Format.
- * 
- * @param {string|undefined} options.logo Logo.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {ol.source.Vector} options.source Source.
- * 
- * @param {boolean|undefined} options.wrapX WrapX. Default is true
- * 
+ * @property {ol.format.Feature|undefined} format Format.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {ol.source.Vector} source Source.
+ * @property {boolean|undefined} wrapX WrapX. Default is true
  */
 
 
 /**
- * @typedef {{preemptive: (boolean|undefined),
- *     jsonp: (boolean|undefined),
- *     tileJSON: (TileJSON|undefined),
- *     url: (string|undefined)}}
- */
-export let source_TileUTFGridOptions;
-
-/**
- * @param {source_TileUTFGridOptions} options TODO: repace this
- *
- * @param {boolean|undefined} options.jsonp Use JSONP with callback to load the TileJSON. Useful when the server
+ * @typedef {Object} source_TileUTFGridOptions
+ * @property {boolean|undefined} jsonp Use JSONP with callback to load the TileJSON. Useful when the server
  * does not support CORS. Default is `false`.
- * 
- * @param {boolean|undefined} options.preemptive If `true` the TileUTFGrid source loads the tiles based on their "visibility".
+ * @property {boolean|undefined} preemptive If `true` the TileUTFGrid source loads the tiles based on their "visibility".
  * This improves the speed of response, but increases traffic.
  * Note that if set to `false`, you need to pass `true` as `opt_request`
  * to the `forDataAtCoordinateAndResolution` method otherwise no data
  * will ever be loaded.
  * Default is `true`.
- * 
- * @param {TileJSON|undefined} options.tileJSON TileJSON configuration for this source. If not provided, `url` must be
+ * @property {TileJSON|undefined} tileJSON TileJSON configuration for this source. If not provided, `url` must be
  * configured.
- * 
- * @param {string|undefined} options.url TileJSON endpoint that provides the configuration for this source. Request
+ * @property {string|undefined} url TileJSON endpoint that provides the configuration for this source. Request
  * will be made through JSONP. If not provided, `tileJSON` must be configured.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *            cacheSize: (number|undefined),
- *            crossOrigin: (null|string|undefined),
- *            logo: (string|olx.LogoOptions|undefined),
- *            opaque: (boolean|undefined),
- *            projection: ol.ProjectionLike,
- *            reprojectionErrorThreshold: (number|undefined),
- *            state: (ol.source.State|undefined),
- *            tileClass: (function(new: ol.ImageTile, ol.TileCoord,
- *                                 ol.TileState, string, ?string,
- *                                 ol.TileLoadFunctionType)|undefined),
- *            tileGrid: (ol.tilegrid.TileGrid|undefined),
- *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *            tilePixelRatio: (number|undefined),
- *            tileUrlFunction: (ol.TileUrlFunctionType|undefined),
- *            url: (string|undefined),
- *            urls: (Array.<string>|undefined),
- *            wrapX: (boolean|undefined),
- *            transition: (number|undefined)}}
- */
-export let source_TileImageOptions;
-
-/**
- * @param {source_TileImageOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_TileImageOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {boolean|undefined} options.opaque Whether the layer is opaque.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {boolean|undefined} opaque Whether the layer is opaque.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.source.State|undefined} options.state Source state.
- * 
- * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
+ * @property {ol.source.State|undefined} state Source state.
+ * @property {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
                 ol.TileLoadFunctionType)|undefined}
- options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
- * 
- * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
+ * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid.
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
+ * @property {number|undefined} tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`. Default is `1`.
- * 
- * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
- * 
- * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @property {ol.TileUrlFunctionType|undefined} tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
+ * @property {string|undefined} url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- * 
- * @param {Array.<string>|undefined} options.urls An array of URL templates.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. The default, `undefined`, is to
+ * @property {Array.<string>|undefined} urls An array of URL templates.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. The default, `undefined`, is to
  * request out-of-bounds tiles from the server. When set to `false`, only one
  * world will be rendered. When set to `true`, tiles will be requested for one
  * world only, but they will be wrapped horizontally to render multiple worlds.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *            cacheSize: (number|undefined),
- *            format: (ol.format.Feature|undefined),
- *            logo: (string|olx.LogoOptions|undefined),
- *            overlaps: (boolean|undefined),
- *            projection: ol.ProjectionLike,
- *            state: (ol.source.State|undefined),
- *            tileClass: (function(new: ol.VectorTile, ol.TileCoord,
- *                 ol.TileState, string, ol.format.Feature,
- *                 ol.TileLoadFunctionType)|undefined),
- *            tileGrid: (ol.tilegrid.TileGrid|undefined),
- *            tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *            tileUrlFunction: (ol.TileUrlFunctionType|undefined),
- *            url: (string|undefined),
- *            urls: (Array.<string>|undefined),
- *            wrapX: (boolean|undefined),
- *            transition: (number|undefined)}}
- */
-export let source_VectorTileOptions;
-
-/**
- * @param {source_VectorTileOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `128`.
- * 
- * @param {ol.format.Feature|undefined} options.format Feature format for tiles. Used and required by the default
+ * @typedef {Object} source_VectorTileOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `128`.
+ * @property {ol.format.Feature|undefined} format Feature format for tiles. Used and required by the default
  * `tileLoadFunction`.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {boolean|undefined} options.overlaps This source may have overlapping geometries. Default is `true`. Setting this
+ * @property {boolean|undefined} overlaps This source may have overlapping geometries. Default is `true`. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {ol.source.State|undefined} options.state Source state.
- * 
- * @param {function(new: ol.VectorTile, ol.TileCoord,                ol.TileState, string, ol.format.Feature,
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {ol.source.State|undefined} state Source state.
+ * @property {function(new: ol.VectorTile, ol.TileCoord,                ol.TileState, string, ol.format.Feature,
                 ol.TileLoadFunctionType)|undefined}
- options.tileClass Class used to instantiate vector tiles. Default is {@link ol.VectorTile}.
- * 
- * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. Could look like this:
+ tileClass Class used to instantiate vector tiles. Default is {@link ol.VectorTile}.
+ * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid.
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. Could look like this:
  * ```js
  * function(tile, url) {
  *   tile.setLoader(function() {
@@ -2682,238 +1202,119 @@ export let source_VectorTileOptions;
  *   };
  * });
  * ```
- * 
- * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
- * 
- * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @property {ol.TileUrlFunctionType|undefined} tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
+ * @property {string|undefined} url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- * 
- * @param {Array.<string>|undefined} options.urls An array of URL templates.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. When set to `false`, only one world
+ * @property {Array.<string>|undefined} urls An array of URL templates.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. When set to `false`, only one world
  * will be rendered. When set to `true`, tiles will be wrapped horizontally to
  * render multiple worlds. Default is `true`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{url: (string|undefined),
- *     displayDpi: (number|undefined),
- *     metersPerUnit: (number|undefined),
- *     hidpi: (boolean|undefined),
- *     useOverlay: (boolean|undefined),
- *     projection: ol.ProjectionLike,
- *     ratio: (number|undefined),
- *     resolutions: (Array.<number>|undefined),
- *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
- *     params: (Object|undefined)}}
- */
-export let source_ImageMapGuideOptions;
-
-/**
- * @param {source_ImageMapGuideOptions} options TODO: repace this
- *
- * @param {string|undefined} options.url The mapagent url.
- * 
- * @param {number|undefined} options.displayDpi The display resolution. Default is `96`.
- * 
- * @param {number|undefined} options.metersPerUnit The meters-per-unit value. Default is `1`.
- * 
- * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * @typedef {Object} source_ImageMapGuideOptions
+ * @property {string|undefined} url The mapagent url.
+ * @property {number|undefined} displayDpi The display resolution. Default is `96`.
+ * @property {number|undefined} metersPerUnit The meters-per-unit value. Default is `1`.
+ * @property {boolean|undefined} hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- * 
- * @param {boolean|undefined} options.useOverlay If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * @property {boolean|undefined} useOverlay If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1`.
- * 
- * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
- * 
- * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- * 
- * @param {Object|undefined} options.params Additional parameters.
- * 
+ * @property {Array.<number>|undefined} resolutions Resolutions. If specified, requests will be made for these resolutions only.
+ * @property {ol.ImageLoadFunctionType|undefined} imageLoadFunction Optional function to load an image given a URL.
+ * @property {Object|undefined} params Additional parameters.
  */
 
 
 /**
- * @typedef {{cacheSize: (number|undefined),
- *     layer: string,
- *     reprojectionErrorThreshold: (number|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: (string|undefined)}}
- */
-export let source_MapQuestOptions;
-
-/**
- * @param {source_MapQuestOptions} options TODO: repace this
- *
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {string} options.layer Layer. Possible values are `osm`, `sat`, and `hyb`.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @typedef {Object} source_MapQuestOptions
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {string} layer Layer. Possible values are `osm`, `sat`, and `hyb`.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
- * 
+ * @property {string|undefined} url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  */
 
 
 /**
- * @typedef {{projection: ol.ProjectionLike,
- *     tileGrid: (ol.tilegrid.TileGrid|undefined),
- *     wrapX: (boolean|undefined)}}
- */
-export let source_TileDebugOptions;
-
-/**
- * @param {source_TileDebugOptions} options TODO: repace this
- *
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
+ * @typedef {Object} source_TileDebugOptions
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (null|string|undefined),
- *     maxZoom: (number|undefined),
- *     opaque: (boolean|undefined),
- *     reprojectionErrorThreshold: (number|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: (string|undefined),
- *     wrapX: (boolean|undefined)}}
- */
-export let source_OSMOptions;
-
-/**
- * @param {source_OSMOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_OSMOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
  * 
  * Default is `anonymous`.
- * 
- * @param {number|undefined} options.maxZoom Max zoom. Default is `19`.
- * 
- * @param {boolean|undefined} options.opaque Whether the layer is opaque. Default is `true`.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {number|undefined} maxZoom Max zoom. Default is `19`.
+ * @property {boolean|undefined} opaque Whether the layer is opaque. Default is `true`.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @property {string|undefined} url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * Default is `https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png`.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     crossOrigin: (null|string|undefined),
- *     hidpi: (boolean|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
- *     params: Object.<string,*>,
- *     projection: ol.ProjectionLike,
- *     ratio: (number|undefined),
- *     resolutions: (Array.<number>|undefined),
- *     url: (string|undefined)}}
- */
-export let source_ImageArcGISRestOptions;
-
-/**
- * @param {source_ImageArcGISRestOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_ImageArcGISRestOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * @property {boolean|undefined} hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- * 
- * @param {Object.<string,*>|undefined} options.params ArcGIS Rest parameters. This field is optional. Service defaults will be
+ * @property {ol.ImageLoadFunctionType|undefined} imageLoadFunction Optional function to load an image given a URL.
+ * @property {Object.<string,*>|undefined} params ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
  * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
  * and `IMAGESR` will be set dynamically. Set `LAYERS` to
  * override the default service layer visibility. See
  * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
  * for further reference.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the size of the map viewport, and so on. Default is `1.5`.
- * 
- * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
- * 
- * @param {string|undefined} options.url ArcGIS Rest service URL for a Map Service or Image Service. The
+ * @property {Array.<number>|undefined} resolutions Resolutions. If specified, requests will be made for these resolutions only.
+ * @property {string|undefined} url ArcGIS Rest service URL for a Map Service or Image Service. The
  * url should include /MapServer or /ImageServer.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     canvasFunction: ol.CanvasFunctionType,
- *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.ProjectionLike,
- *     ratio: (number|undefined),
- *     resolutions: (Array.<number>|undefined),
- *     state: (ol.source.State|undefined)}}
- */
-export let source_ImageCanvasOptions;
-
-/**
- * @param {source_ImageCanvasOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {ol.CanvasFunctionType} options.canvasFunction Canvas function. The function returning the canvas element used by the source
+ * @typedef {Object} source_ImageCanvasOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {ol.CanvasFunctionType} canvasFunction Canvas function. The function returning the canvas element used by the source
  * as an image. The arguments passed to the function are: `{ol.Extent}` the
  * image extent, `{number}` the image resolution, `{number}` the device pixel
  * ratio, `{ol.Size}` the image size, and `{ol.proj.Projection}` the image
@@ -2921,363 +1322,180 @@ export let source_ImageCanvasOptions;
  * the value returned by the function is later changed then
  * `dispatchChangeEvent` should be called on the source for the source to
  * invalidate the current cached image.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.ratio Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} ratio Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
  * width and height of the map viewport, and so on. Must be `1` or higher.
  * Default is `1.5`.
- * 
- * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, new canvases will be created for these resolutions
+ * @property {Array.<number>|undefined} resolutions Resolutions. If specified, new canvases will be created for these resolutions
  * only.
- * 
- * @param {ol.source.State|undefined} options.state Source state.
- * 
+ * @property {ol.source.State|undefined} state Source state.
  */
 
 
 /**
- * @typedef {{sources: Array.<ol.source.Source>,
- *     operation: (ol.RasterOperation|undefined),
- *     lib: (Object|undefined),
- *     threads: (number|undefined),
- *     operationType: (ol.source.RasterOperationType|undefined)}}
- * @api
- */
-export let source_RasterOptions;
-
-/**
- * @param {source_RasterOptions} options TODO: repace this
- *
- * @param {Array.<ol.source.Source>} options.sources Input sources.
- * 
- * @param {ol.RasterOperation|undefined} options.operation Raster operation.  The operation will be called with data from input sources
+ * @typedef {Object} source_RasterOptions
+ * @property {Array.<ol.source.Source>} sources Input sources.
+ * @property {ol.RasterOperation|undefined} operation Raster operation.  The operation will be called with data from input sources
  * and the output will be assigned to the raster source.
- * 
- * @param {Object|undefined} options.lib Functions that will be made available to operations run in a worker.
- * 
- * @param {number|undefined} options.threads By default, operations will be run in a single worker thread.  To avoid using
+ * @property {Object|undefined} lib Functions that will be made available to operations run in a worker.
+ * @property {number|undefined} threads By default, operations will be run in a single worker thread.  To avoid using
  * workers altogether, set `threads: 0`.  For pixel operations, operations can
  * be run in multiple worker threads.  Note that there is additional overhead in
  * transferring data to multiple workers, and that depending on the user's
  * system, it may not be possible to parallelize the work.
- * 
- * @param {ol.source.RasterOperationType|undefined} options.operationType Operation type.  Supported values are `'pixel'` and `'image'`.  By default,
+ * @property {ol.source.RasterOperationType|undefined} operationType Operation type.  Supported values are `'pixel'` and `'image'`.  By default,
  * `'pixel'` operations are assumed, and operations will be called with an
  * array of pixels from input sources.  If set to `'image'`, operations will
  * be called with an array of ImageData objects from input sources.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     crossOrigin: (null|string|undefined),
- *     hidpi: (boolean|undefined),
- *     serverType: (ol.source.WMSServerType|string|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
- *     params: Object.<string,*>,
- *     projection: ol.ProjectionLike,
- *     ratio: (number|undefined),
- *     resolutions: (Array.<number>|undefined),
- *     url: (string|undefined)}}
- */
-export let source_ImageWMSOptions;
-
-/**
- * @param {source_ImageWMSOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_ImageWMSOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * @property {boolean|undefined} hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- * 
- * @param {ol.source.WMSServerType|string|undefined} options.serverType The type of the remote WMS server: `mapserver`, `geoserver` or `qgis`. Only
+ * @property {ol.source.WMSServerType|string|undefined} serverType The type of the remote WMS server: `mapserver`, `geoserver` or `qgis`. Only
  * needed if `hidpi` is `true`. Default is `undefined`.
- * 
- * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {Object.<string,*>} options.params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
+ * @property {ol.ImageLoadFunctionType|undefined} imageLoadFunction Optional function to load an image given a URL.
+ * @property {Object.<string,*>} params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1.5`.
- * 
- * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
- * 
- * @param {string|undefined} options.url WMS service URL.
- * 
+ * @property {Array.<number>|undefined} resolutions Resolutions. If specified, requests will be made for these resolutions only.
+ * @property {string|undefined} url WMS service URL.
  */
 
 
 /**
- * @typedef {{
- *     cacheSize: (number|undefined),
- *     layer: string,
- *     minZoom: (number|undefined),
- *     maxZoom: (number|undefined),
- *     opaque: (boolean|undefined),
- *     reprojectionErrorThreshold: (number|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: (string|undefined),
- *     wrapX: (boolean|undefined)
- * }}
- */
-export let source_StamenOptions;
-
-/**
- * @param {source_StamenOptions} options TODO: repace this
- *
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {string} options.layer Layer.
- * 
- * @param {number|undefined} options.minZoom Minimum zoom.
- * 
- * @param {number|undefined} options.maxZoom Maximum zoom.
- * 
- * @param {boolean|undefined} options.opaque Whether the layer is opaque.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @typedef {Object} source_StamenOptions
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {string} layer Layer.
+ * @property {number|undefined} minZoom Minimum zoom.
+ * @property {number|undefined} maxZoom Maximum zoom.
+ * @property {boolean|undefined} opaque Whether the layer is opaque.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
+ * @property {string|undefined} url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     crossOrigin: (null|string|undefined),
- *     imageExtent: (ol.Extent),
- *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
- *     imageSize: (ol.Size|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.ProjectionLike,
- *     url: string}}
- */
-export let source_ImageStaticOptions;
-
-/**
- * @param {source_ImageStaticOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_ImageStaticOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {ol.Extent} options.imageExtent Extent of the image in map coordinates.  This is the [left, bottom, right,
+ * @property {ol.Extent} imageExtent Extent of the image in map coordinates.  This is the [left, bottom, right,
  * top] map coordinates of your image.
- * 
- * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Optional logo.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {ol.Size|undefined} options.imageSize Size of the image in pixels. Usually the image size is auto-detected, so this
+ * @property {ol.ImageLoadFunctionType|undefined} imageLoadFunction Optional function to load an image given a URL.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {ol.Size|undefined} imageSize Size of the image in pixels. Usually the image size is auto-detected, so this
  * only needs to be set if auto-detection fails for some reason.
- * 
- * @param {string} options.url Image URL.
- * 
+ * @property {string} url Image URL.
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (null|string|undefined),
- *     params: (Object.<string, *>|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     tileGrid: (ol.tilegrid.TileGrid|undefined),
- *     projection: ol.ProjectionLike,
- *     reprojectionErrorThreshold: (number|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: (string|undefined),
- *     urls: (Array.<string>|undefined),
- *     wrapX: (boolean|undefined),
- *     transition: (number|undefined)}}
- */
-export let source_TileArcGISRestOptions;
-
-/**
- * @param {source_TileArcGISRestOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_TileArcGISRestOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {Object.<string,*>|undefined} options.params ArcGIS Rest parameters. This field is optional. Service defaults will be
+ * @property {Object.<string,*>|undefined} params ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
  * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
  * and `IMAGESR` will be set dynamically. Set `LAYERS` to
  * override the default service layer visibility. See
  * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
  * for further reference.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
+ * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
  * server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {string|undefined} options.url ArcGIS Rest service URL for a Map Service or Image Service. The
+ * @property {string|undefined} url ArcGIS Rest service URL for a Map Service or Image Service. The
  * url should include /MapServer or /ImageServer.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
- * @param {Array.<string>|undefined} options.urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS Service supports multiple
+ * @property {Array.<string>|undefined} urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS Service supports multiple
  * urls for export requests.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (null|string|undefined),
- *     jsonp: (boolean|undefined),
- *     reprojectionErrorThreshold: (number|undefined),
- *     tileJSON: (TileJSON|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: (string|undefined),
- *     wrapX: (boolean|undefined),
- *     transition: (number|undefined)}}
- */
-export let source_TileJSONOptions;
-
-/**
- * @param {source_TileJSONOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Optional attributions for the source.  If provided, these will be used
+ * @typedef {Object} source_TileJSONOptions
+ * @property {ol.AttributionLike|undefined} attributions Optional attributions for the source.  If provided, these will be used
  * instead of any attribution data advertised by the server.  If not provided,
  * any attributions advertised by the server will be used.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {boolean|undefined} options.jsonp Use JSONP with callback to load the TileJSON. Useful when the server
+ * @property {boolean|undefined} jsonp Use JSONP with callback to load the TileJSON. Useful when the server
  * does not support CORS. Default is `false`.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {TileJSON|undefined} options.tileJSON TileJSON configuration for this source. If not provided, `url` must be
+ * @property {TileJSON|undefined} tileJSON TileJSON configuration for this source. If not provided, `url` must be
  * configured.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {string|undefined} options.url URL to the TileJSON file. If not provided, `tileJSON` must be configured.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {string|undefined} url URL to the TileJSON file. If not provided, `tileJSON` must be configured.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     params: Object.<string,*>,
- *     crossOrigin: (null|string|undefined),
- *     gutter: (number|undefined),
- *     hidpi: (boolean|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
- *                          ol.TileState, string, ?string,
- *                          ol.TileLoadFunctionType)|undefined),
- *     tileGrid: (ol.tilegrid.TileGrid|undefined),
- *     projection: ol.ProjectionLike,
- *     reprojectionErrorThreshold: (number|undefined),
- *     serverType: (ol.source.WMSServerType|string|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     url: (string|undefined),
- *     urls: (Array.<string>|undefined),
- *     wrapX: (boolean|undefined),
- *     transition: (number|undefined)}}
- */
-export let source_TileWMSOptions;
-
-/**
- * @param {source_TileWMSOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {Object.<string,*>} options.params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
+ * @typedef {Object} source_TileWMSOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {Object.<string,*>} params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {number|undefined} options.gutter The size in pixels of the gutter around image tiles to ignore. By setting
+ * @property {number|undefined} gutter The size in pixels of the gutter around image tiles to ignore. By setting
  * this property to a non-zero value, images will be requested that are wider
  * and taller than the tile size by a value of `2 x gutter`. Defaults to zero.
  * Using a non-zero value allows artifacts of rendering at tile edges to be
@@ -3285,79 +1503,47 @@ export let source_TileWMSOptions;
  * "artifacts at tile edges" issues by properly configuring the WMS service. For
  * example, MapServer has a `tile_map_edge_buffer` configuration parameter for
  * this. See http://mapserver.org/output/tile_mode.html.
- * 
- * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
+ * @property {boolean|undefined} hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
+ * @property {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
                 ol.TileLoadFunctionType)|undefined}
- options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
- * 
- * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
+ tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
+ * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
  * server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.source.WMSServerType|string|undefined} options.serverType The type of the remote WMS server. Currently only used when `hidpi` is
+ * @property {ol.source.WMSServerType|string|undefined} serverType The type of the remote WMS server. Currently only used when `hidpi` is
  * `true`. Default is `undefined`.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {string|undefined} options.url WMS service URL.
- * 
- * @param {Array.<string>|undefined} options.urls WMS service urls. Use this instead of `url` when the WMS supports multiple
+ * @property {string|undefined} url WMS service URL.
+ * @property {Array.<string>|undefined} urls WMS service urls. Use this instead of `url` when the WMS supports multiple
  * urls for GetMap requests.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. When set to `false`, only one world
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. When set to `false`, only one world
  * will be rendered. When `true`, tiles will be requested for one world only,
  * but they will be wrapped horizontally to render multiple worlds. The default
  * is `true`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     features: (Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined),
- *     format: (ol.format.Feature|undefined),
- *     loader: (ol.FeatureLoader|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     overlaps: (boolean|undefined),
- *     strategy: (ol.LoadingStrategy|undefined),
- *     url: (string|ol.FeatureUrlFunction|undefined),
- *     useSpatialIndex: (boolean|undefined),
- *     wrapX: (boolean|undefined)}}
- */
-export let source_VectorOptions;
-
-/**
- * @param {source_VectorOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined} options.features Features. If provided as {@link ol.Collection}, the features in the source
+ * @typedef {Object} source_VectorOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined} features Features. If provided as {@link ol.Collection}, the features in the source
  * and the collection will stay in sync.
- * 
- * @param {ol.format.Feature|undefined} options.format The feature format used by the XHR feature loader when `url` is set.
+ * @property {ol.format.Feature|undefined} format The feature format used by the XHR feature loader when `url` is set.
  * Required if `url` is set, otherwise ignored. Default is `undefined`.
- * 
- * @param {ol.FeatureLoader|undefined} options.loader The loader function used to load features, from a remote source for example.
+ * @property {ol.FeatureLoader|undefined} loader The loader function used to load features, from a remote source for example.
  * If this is not set and `url` is set, the source will create and use an XHR
  * feature loader.
  * 
@@ -3391,18 +1577,13 @@ export let source_VectorOptions;
  *    strategy: ol.loadingstrategy.bbox
  *  });
  * ```
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {boolean|undefined} options.overlaps This source may have overlapping geometries. Default is `true`. Setting this
+ * @property {boolean|undefined} overlaps This source may have overlapping geometries. Default is `true`. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
- * 
- * @param {ol.LoadingStrategy|undefined} options.strategy The loading strategy to use. By default an {@link ol.loadingstrategy.all}
+ * @property {ol.LoadingStrategy|undefined} strategy The loading strategy to use. By default an {@link ol.loadingstrategy.all}
  * strategy is used, a one-off strategy which loads all features at once.
- * 
- * @param {string|ol.FeatureUrlFunction|undefined} options.url Setting this option instructs the source to load features using an XHR loader
+ * @property {string|ol.FeatureUrlFunction|undefined} url Setting this option instructs the source to load features using an XHR loader
  * (see {@link ol.featureloader.xhr}). Use a `string` and an
  * {@link ol.loadingstrategy.all} for a one-off download of all features from
  * the given URL. Use a {@link ol.FeatureUrlFunction} to generate the url with
@@ -3416,8 +1597,7 @@ export let source_VectorOptions;
  * defaultDataProjection constructor option on the format.
  * Note that if a source contains non-feature data, such as a GeoJSON geometry
  * or a KML NetworkLink, these will be ignored. Use a custom loader to load these.
- * 
- * @param {boolean|undefined} options.useSpatialIndex By default, an RTree is used as spatial index. When features are removed and
+ * @property {boolean|undefined} useSpatialIndex By default, an RTree is used as spatial index. When features are removed and
  * added frequently, and the total number of features is low, setting this to
  * `false` may improve performance.
  * 
@@ -3433,281 +1613,135 @@ export let source_VectorOptions;
  * {@link ol.source.Vector#getFeaturesCollection}.
  * 
  * The default is `true`.
- * 
- * @param {boolean|undefined} options.wrapX Wrap the world horizontally. Default is `true`. For vector editing across the
+ * @property {boolean|undefined} wrapX Wrap the world horizontally. Default is `true`. For vector editing across the
  * -180° and 180° meridians to work properly, this should be set to `false`. The
  * resulting geometry coordinates will then exceed the world bounds.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (string|null|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     tileGrid: ol.tilegrid.WMTS,
- *     projection: ol.ProjectionLike,
- *     reprojectionErrorThreshold: (number|undefined),
- *     requestEncoding: (ol.source.WMTSRequestEncoding|string|undefined),
- *     layer: string,
- *     style: string,
- *     tilePixelRatio: (number|undefined),
- *     version: (string|undefined),
- *     format: (string|undefined),
- *     matrixSet: string,
- *     dimensions: (!Object|undefined),
- *     url: (string|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     urls: (Array.<string>|undefined),
- *     tileClass: (function(new: ol.ImageTile, ol.TileCoord,
- *                          ol.TileState, string, ?string,
- *                          ol.TileLoadFunctionType)|undefined),
- *     wrapX: (boolean|undefined),
- *     transition: (number|undefined)}}
- */
-export let source_WMTSOptions;
-
-/**
- * @param {source_WMTSOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {string|null|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_WMTSOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {string|null|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {ol.tilegrid.WMTS} options.tileGrid Tile grid.
- * 
- * @param {ol.ProjectionLike} options.projection Projection.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {ol.tilegrid.WMTS} tileGrid Tile grid.
+ * @property {ol.ProjectionLike} projection Projection.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {ol.source.WMTSRequestEncoding|string|undefined} options.requestEncoding Request encoding. Default is `KVP`.
- * 
- * @param {string} options.layer Layer name as advertised in the WMTS capabilities.
- * 
- * @param {string} options.style Style name as advertised in the WMTS capabilities.
- * 
- * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
+ * @property {ol.source.WMTSRequestEncoding|string|undefined} requestEncoding Request encoding. Default is `KVP`.
+ * @property {string} layer Layer name as advertised in the WMTS capabilities.
+ * @property {string} style Style name as advertised in the WMTS capabilities.
+ * @property {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
                 ol.TileLoadFunctionType)|undefined}
- options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
- * 
- * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
+ tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
+ * @property {number|undefined} tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`. Default is `1`.
- * 
- * @param {string|undefined} options.version WMTS version. Default is `1.0.0`.
- * 
- * @param {string|undefined} options.format Image format. Default is `image/jpeg`.
- * 
- * @param {string} options.matrixSet Matrix set.
- * 
- * @param {!Object|undefined} options.dimensions Additional "dimensions" for tile requests.  This is an object with properties
+ * @property {string|undefined} version WMTS version. Default is `1.0.0`.
+ * @property {string|undefined} format Image format. Default is `image/jpeg`.
+ * @property {string} matrixSet Matrix set.
+ * @property {!Object|undefined} dimensions Additional "dimensions" for tile requests.  This is an object with properties
  * named like the advertised WMTS dimensions.
- * 
- * @param {string|undefined} options.url A URL for the service.  For the RESTful request encoding, this is a URL
+ * @property {string|undefined} url A URL for the service.  For the RESTful request encoding, this is a URL
  * template.  For KVP encoding, it is normal URL. A `{?-?}` template pattern,
  * for example `subdomain{a-f}.domain.com`, may be used instead of defining
  * each one separately in the `urls` option.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {Array.<string>|undefined} options.urls An array of URLs.  Requests will be distributed among the URLs in this array.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `false`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {Array.<string>|undefined} urls An array of URLs.  Requests will be distributed among the URLs in this array.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `false`.
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (null|string|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     opaque: (boolean|undefined),
- *     projection: ol.ProjectionLike,
- *     reprojectionErrorThreshold: (number|undefined),
- *     maxZoom: (number|undefined),
- *     minZoom: (number|undefined),
- *     tileGrid: (ol.tilegrid.TileGrid|undefined),
- *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
- *     tilePixelRatio: (number|undefined),
- *     tileSize: (number|ol.Size|undefined),
- *     tileUrlFunction: (ol.TileUrlFunctionType|undefined),
- *     url: (string|undefined),
- *     urls: (Array.<string>|undefined),
- *     wrapX: (boolean|undefined),
- *     transition: (number|undefined)}}
- */
-export let source_XYZOptions;
-
-/**
- * @param {source_XYZOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_XYZOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {boolean|undefined} options.opaque Whether the layer is opaque.
- * 
- * @param {ol.ProjectionLike} options.projection Projection. Default is `EPSG:3857`.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {boolean|undefined} opaque Whether the layer is opaque.
+ * @property {ol.ProjectionLike} projection Projection. Default is `EPSG:3857`.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {number|undefined} options.maxZoom Optional max zoom level. Default is `18`.
- * 
- * @param {number|undefined} options.minZoom Optional min zoom level. Default is `0`.
- * 
- * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- * 
- * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
+ * @property {number|undefined} maxZoom Optional max zoom level. Default is `18`.
+ * @property {number|undefined} minZoom Optional min zoom level. Default is `0`.
+ * @property {ol.tilegrid.TileGrid|undefined} tileGrid Tile grid.
+ * @property {ol.TileLoadFunctionType|undefined} tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- * 
- * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
+ * @property {number|undefined} tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`. Default is `1`.
- * 
- * @param {number|ol.Size|undefined} options.tileSize The tile size used by the tile service. Default is `[256, 256]` pixels.
- * 
- * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
+ * @property {number|ol.Size|undefined} tileSize The tile size used by the tile service. Default is `[256, 256]` pixels.
+ * @property {ol.TileUrlFunctionType|undefined} tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
  * Required if url or urls are not provided.
- * 
- * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @property {string|undefined} url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- * 
- * @param {Array.<string>|undefined} options.urls An array of URL templates.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {Array.<string>|undefined} urls An array of URL templates.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (null|string|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     projection: ol.ProjectionLike,
- *     maxZoom: (number|undefined),
- *     minZoom: (number|undefined),
- *     wrapX: (boolean|undefined),
- *     config: (Object|undefined),
- *     map: (string|undefined),
- *     account: string}}
- */
-export let source_CartoDBOptions;
-
-/**
- * @param {source_CartoDBOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_CartoDBOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {ol.ProjectionLike} options.projection Projection. Default is `EPSG:3857`.
- * 
- * @param {number|undefined} options.maxZoom Optional max zoom level. Default is `18`.
- * 
- * @param {number|undefined} options.minZoom Minimum zoom.
- * 
- * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- * 
- * @param {Object|undefined} options.config If using anonymous maps, the CartoDB config to use. See
+ * @property {ol.ProjectionLike} projection Projection. Default is `EPSG:3857`.
+ * @property {number|undefined} maxZoom Optional max zoom level. Default is `18`.
+ * @property {number|undefined} minZoom Minimum zoom.
+ * @property {boolean|undefined} wrapX Whether to wrap the world horizontally. Default is `true`.
+ * @property {Object|undefined} config If using anonymous maps, the CartoDB config to use. See
  * {@link http://docs.cartodb.com/cartodb-platform/maps-api/anonymous-maps/}
  * for more detail.
  * If using named maps, a key-value lookup with the template parameters.
  * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
  * for more detail.
- * 
- * @param {string|undefined} options.map If using named maps, this will be the name of the template to load.
+ * @property {string|undefined} map If using named maps, this will be the name of the template to load.
  * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
  * for more detail.
- * 
- * @param {string} options.account CartoDB account name
- * 
+ * @property {string} account CartoDB account name
  */
 
 
 /**
- * @typedef {{attributions: (ol.AttributionLike|undefined),
- *     cacheSize: (number|undefined),
- *     crossOrigin: (null|string|undefined),
- *     logo: (string|olx.LogoOptions|undefined),
- *     projection: (ol.ProjectionLike|undefined),
- *     reprojectionErrorThreshold: (number|undefined),
- *     url: !string,
- *     tierSizeCalculation: (string|undefined),
- *     size: ol.Size,
- *     extent: (ol.Extent|undefined),
- *     transition: (number|undefined),
- *     tileSize: (number|undefined)}}
- */
-export let source_ZoomifyOptions;
-
-/**
- * @param {source_ZoomifyOptions} options TODO: repace this
- *
- * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- * 
- * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @typedef {Object} source_ZoomifyOptions
+ * @property {ol.AttributionLike|undefined} attributions Attributions.
+ * @property {number|undefined} cacheSize Cache size. Default is `2048`.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- * 
- * @param {ol.ProjectionLike|undefined} options.projection Projection.
- * 
- * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
+ * @property {ol.ProjectionLike|undefined} projection Projection.
+ * @property {number|undefined} reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- * 
- * @param {!string} options.url URL template or base URL of the Zoomify service. A base URL is the fixed part
+ * @property {!string} url URL template or base URL of the Zoomify service. A base URL is the fixed part
  * of the URL, excluding the tile group, z, x, and y folder structure, e.g.
  * `http://my.zoomify.info/IMAGE.TIF/`. A URL template must include
  * `{TileGroup}`, `{x}`, `{y}`, and `{z}` placeholders, e.g.
@@ -3717,445 +1751,235 @@ export let source_ZoomifyOptions;
  * `http://my.zoomify.info?FIF=IMAGE.TIF&JTL={z},{tileIndex}`.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- * 
- * @param {string|undefined} options.tierSizeCalculation Tier size calculation method: `default` or `truncated`.
- * 
- * @param {ol.Size} options.size Size of the image.
- * 
- * @param {ol.Extent|undefined} options.extent Extent for the TileGrid that is created. Default sets the TileGrid in the
+ * @property {string|undefined} tierSizeCalculation Tier size calculation method: `default` or `truncated`.
+ * @property {ol.Size} size Size of the image.
+ * @property {ol.Extent|undefined} extent Extent for the TileGrid that is created. Default sets the TileGrid in the
  * fourth quadrant, meaning extent is `[0, -height, width, 0]`. To change the
  * extent to the first quadrant (the default for OpenLayers 2) set the extent
  * as `[0, 0, width, height]`.
- * 
- * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
+ * @property {number|undefined} transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * 
- * @param {number|undefined} options.tileSize Tile size. Same tile size is used for all zoom levels. Default value is
+ * @property {number|undefined} tileSize Tile size. Same tile size is used for all zoom levels. Default value is
  * `256`.
- * 
  */
 
 
 /**
- * @typedef {{fill: (ol.style.Fill|undefined),
- *     radius: number,
- *     snapToPixel: (boolean|undefined),
- *     stroke: (ol.style.Stroke|undefined),
- *     atlasManager: (ol.style.AtlasManager|undefined)}}
- */
-export let style_CircleOptions;
-
-/**
- * @param {style_CircleOptions} options TODO: repace this
- *
- * @param {ol.style.Fill|undefined} options.fill Fill style.
- * 
- * @param {number} options.radius Circle radius.
- * 
- * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
+ * @typedef {Object} style_CircleOptions
+ * @property {ol.style.Fill|undefined} fill Fill style.
+ * @property {number} radius Circle radius.
+ * @property {boolean|undefined} snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
  * coordinate when drawing the circle in the output canvas. If `false`
  * fractional numbers may be used. Using `true` allows for "sharp"
  * rendering (no blur), while using `false` allows for "accurate"
  * rendering. Note that accuracy is important if the circle's
  * position is animated. Without it, the circle may jitter noticeably.
  * Default value is `true`.
- * 
- * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- * 
- * @param {ol.style.AtlasManager|undefined} options.atlasManager The atlas manager to use for this circle. When using WebGL it is
+ * @property {ol.style.Stroke|undefined} stroke Stroke style.
+ * @property {ol.style.AtlasManager|undefined} atlasManager The atlas manager to use for this circle. When using WebGL it is
  * recommended to use an atlas manager to avoid texture switching.
  * If an atlas manager is given, the circle is added to an atlas.
  * By default no atlas manager is used.
- * 
  */
 
 
 /**
- * @typedef {{color: (ol.Color|ol.ColorLike|undefined)}}
- */
-export let style_FillOptions;
-
-/**
- * @param {style_FillOptions} options TODO: repace this
- *
- * @param {ol.Color|ol.ColorLike|undefined} options.color A color, gradient or pattern. See {@link ol.color}
+ * @typedef {Object} style_FillOptions
+ * @property {ol.Color|ol.ColorLike|undefined} color A color, gradient or pattern. See {@link ol.color}
  * and {@link ol.colorlike} for possible formats. Default null;
  * if null, the Canvas/renderer default black will be used.
- * 
  */
 
 
 /**
- * @typedef {{anchor: (Array.<number>|undefined),
- *     anchorOrigin: (ol.style.IconOrigin|undefined),
- *     anchorXUnits: (ol.style.IconAnchorUnits|undefined),
- *     anchorYUnits: (ol.style.IconAnchorUnits|undefined),
- *     color: (ol.Color|string|undefined),
- *     crossOrigin: (null|string|undefined),
- *     img: (Image|HTMLCanvasElement|undefined),
- *     offset: (Array.<number>|undefined),
- *     offsetOrigin: (ol.style.IconOrigin|undefined),
- *     opacity: (number|undefined),
- *     scale: (number|undefined),
- *     snapToPixel: (boolean|undefined),
- *     rotateWithView: (boolean|undefined),
- *     rotation: (number|undefined),
- *     size: (ol.Size|undefined),
- *     imgSize: (ol.Size|undefined),
- *     src: (string|undefined)}}
- */
-export let style_IconOptions;
-
-/**
- * @param {style_IconOptions} options TODO: repace this
- *
- * @param {Array.<number>|undefined} options.anchor Anchor. Default value is `[0.5, 0.5]` (icon center).
- * 
- * @param {ol.style.IconOrigin|undefined} options.anchorOrigin Origin of the anchor: `bottom-left`, `bottom-right`, `top-left` or
+ * @typedef {Object} style_IconOptions
+ * @property {Array.<number>|undefined} anchor Anchor. Default value is `[0.5, 0.5]` (icon center).
+ * @property {ol.style.IconOrigin|undefined} anchorOrigin Origin of the anchor: `bottom-left`, `bottom-right`, `top-left` or
  * `top-right`. Default is `top-left`.
- * 
- * @param {ol.style.IconAnchorUnits|undefined} options.anchorXUnits Units in which the anchor x value is specified. A value of `'fraction'`
+ * @property {ol.style.IconAnchorUnits|undefined} anchorXUnits Units in which the anchor x value is specified. A value of `'fraction'`
  * indicates the x value is a fraction of the icon. A value of `'pixels'`
  * indicates the x value in pixels. Default is `'fraction'`.
- * 
- * @param {ol.style.IconAnchorUnits|undefined} options.anchorYUnits Units in which the anchor y value is specified. A value of `'fraction'`
+ * @property {ol.style.IconAnchorUnits|undefined} anchorYUnits Units in which the anchor y value is specified. A value of `'fraction'`
  * indicates the y value is a fraction of the icon. A value of `'pixels'`
  * indicates the y value in pixels. Default is `'fraction'`.
- * 
- * @param {ol.Color|string|undefined} options.color Color to tint the icon. If not specified, the icon will be left as is.
- * 
- * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
+ * @property {ol.Color|string|undefined} color Color to tint the icon. If not specified, the icon will be left as is.
+ * @property {null|string|undefined} crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- * 
- * @param {Image|HTMLCanvasElement|undefined} options.img Image object for the icon. If the `src` option is not provided then the
+ * @property {Image|HTMLCanvasElement|undefined} img Image object for the icon. If the `src` option is not provided then the
  * provided image must already be loaded. And in that case, it is required
  * to provide the size of the image, with the `imgSize` option.
- * 
- * @param {Array.<number>|undefined} options.offset Offset, which, together with the size and the offset origin,
+ * @property {Array.<number>|undefined} offset Offset, which, together with the size and the offset origin,
  * define the sub-rectangle to use from the original icon image. Default value
  * is `[0, 0]`.
- * 
- * @param {ol.style.IconOrigin|undefined} options.offsetOrigin Origin of the offset: `bottom-left`, `bottom-right`, `top-left` or
+ * @property {ol.style.IconOrigin|undefined} offsetOrigin Origin of the offset: `bottom-left`, `bottom-right`, `top-left` or
  * `top-right`. Default is `top-left`.
- * 
- * @param {number|undefined} options.opacity Opacity of the icon. Default is `1`.
- * 
- * @param {number|undefined} options.scale Scale. Default is `1`.
- * 
- * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
+ * @property {number|undefined} opacity Opacity of the icon. Default is `1`.
+ * @property {number|undefined} scale Scale. Default is `1`.
+ * @property {boolean|undefined} snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
  * coordinate when drawing the icon in the output canvas. If `false`
  * fractional numbers may be used. Using `true` allows for "sharp"
  * rendering (no blur), while using `false` allows for "accurate"
  * rendering. Note that accuracy is important if the icon's position
  * is animated. Without it, the icon may jitter noticeably. Default
  * value is `true`.
- * 
- * @param {boolean|undefined} options.rotateWithView Whether to rotate the icon with the view. Default is `false`.
- * 
- * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
- * 
- * @param {ol.Size|undefined} options.size Icon size in pixel. Can be used together with `offset` to define the
+ * @property {boolean|undefined} rotateWithView Whether to rotate the icon with the view. Default is `false`.
+ * @property {number|undefined} rotation Rotation in radians (positive rotation clockwise). Default is `0`.
+ * @property {ol.Size|undefined} size Icon size in pixel. Can be used together with `offset` to define the
  * sub-rectangle to use from the origin (sprite) icon image.
- * 
- * @param {ol.Size|undefined} options.imgSize Image size in pixels. Only required if `img` is set and `src` is not, and for
+ * @property {ol.Size|undefined} imgSize Image size in pixels. Only required if `img` is set and `src` is not, and for
  * SVG images in Internet Explorer 11. The provided `imgSize` needs to match
  * the actual size of the image.
- * 
- * @param {string|undefined} options.src Image source URI.
- * 
+ * @property {string|undefined} src Image source URI.
  */
 
 
 /**
- * Specify radius for regular polygons, or radius1 and radius2 for stars.
- * @typedef {{fill: (ol.style.Fill|undefined),
- *     points: number,
- *     radius: (number|undefined),
- *     radius1: (number|undefined),
- *     radius2: (number|undefined),
- *     angle: (number|undefined),
- *     snapToPixel: (boolean|undefined),
- *     stroke: (ol.style.Stroke|undefined),
- *     rotation: (number|undefined),
- *     rotateWithView: (boolean|undefined),
- *     atlasManager: (ol.style.AtlasManager|undefined)}}
- */
-export let style_RegularShapeOptions;
-
-/**
- * @param {style_RegularShapeOptions} options TODO: repace this
- *
- * @param {ol.style.Fill|undefined} options.fill Fill style.
- * 
- * @param {number} options.points Number of points for stars and regular polygons. In case of a polygon, the
+ * @typedef {Object} style_RegularShapeOptions
+ * @property {ol.style.Fill|undefined} fill Fill style.
+ * @property {number} points Number of points for stars and regular polygons. In case of a polygon, the
  * number of points is the number of sides.
- * 
- * @param {number|undefined} options.radius Radius of a regular polygon.
- * 
- * @param {number|undefined} options.radius1 Outer radius of a star.
- * 
- * @param {number|undefined} options.radius2 Inner radius of a star.
- * 
- * @param {number|undefined} options.angle Shape's angle in radians. A value of 0 will have one of the shape's point
+ * @property {number|undefined} radius Radius of a regular polygon.
+ * @property {number|undefined} radius1 Outer radius of a star.
+ * @property {number|undefined} radius2 Inner radius of a star.
+ * @property {number|undefined} angle Shape's angle in radians. A value of 0 will have one of the shape's point
  * facing up.
  * Default value is 0.
- * 
- * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
+ * @property {boolean|undefined} snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
  * coordinate when drawing the shape in the output canvas. If `false`
  * fractional numbers may be used. Using `true` allows for "sharp"
  * rendering (no blur), while using `false` allows for "accurate"
  * rendering. Note that accuracy is important if the shape's
  * position is animated. Without it, the shape may jitter noticeably.
  * Default value is `true`.
- * 
- * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- * 
- * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
- * 
- * @param {boolean|undefined} options.rotateWithView Whether to rotate the shape with the view. Default is `false`.
- * 
- * @param {ol.style.AtlasManager|undefined} options.atlasManager The atlas manager to use for this symbol. When using WebGL it is
+ * @property {ol.style.Stroke|undefined} stroke Stroke style.
+ * @property {number|undefined} rotation Rotation in radians (positive rotation clockwise). Default is `0`.
+ * @property {boolean|undefined} rotateWithView Whether to rotate the shape with the view. Default is `false`.
+ * @property {ol.style.AtlasManager|undefined} atlasManager The atlas manager to use for this symbol. When using WebGL it is
  * recommended to use an atlas manager to avoid texture switching.
  * If an atlas manager is given, the symbol is added to an atlas.
  * By default no atlas manager is used.
- * 
  */
 
 
 /**
- * @typedef {{color: (ol.Color|ol.ColorLike|undefined),
- *     lineCap: (string|undefined),
- *     lineJoin: (string|undefined),
- *     lineDash: (Array.<number>|undefined),
- *     lineDashOffset: (number|undefined),
- *     miterLimit: (number|undefined),
- *     width: (number|undefined)}}
- */
-export let style_StrokeOptions;
-
-/**
- * @param {style_StrokeOptions} options TODO: repace this
- *
- * @param {ol.Color|ol.ColorLike|undefined} options.color A color, gradient or pattern. See {@link ol.color}
+ * @typedef {Object} style_StrokeOptions
+ * @property {ol.Color|ol.ColorLike|undefined} color A color, gradient or pattern. See {@link ol.color}
  * and {@link ol.colorlike} for possible formats. Default null;
  * if null, the Canvas/renderer default black will be used.
- * 
- * @param {string|undefined} options.lineCap Line cap style: `butt`, `round`, or `square`. Default is `round`.
- * 
- * @param {string|undefined} options.lineJoin Line join style: `bevel`, `round`, or `miter`. Default is `round`.
- * 
- * @param {Array.<number>|undefined} options.lineDash Line dash pattern. Default is `undefined` (no dash). Please note that
+ * @property {string|undefined} lineCap Line cap style: `butt`, `round`, or `square`. Default is `round`.
+ * @property {string|undefined} lineJoin Line join style: `bevel`, `round`, or `miter`. Default is `round`.
+ * @property {Array.<number>|undefined} lineDash Line dash pattern. Default is `undefined` (no dash). Please note that
  * Internet Explorer 10 and lower [do not support][mdn] the `setLineDash`
  * method on the `CanvasRenderingContext2D` and therefore this option will
  * have no visual effect in these browsers.
  * 
  * [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility
  * 
- * 
- * @param {number|undefined} options.lineDashOffset Line dash offset. Default is '0'.
- * 
- * @param {number|undefined} options.miterLimit Miter limit. Default is `10`.
- * 
- * @param {number|undefined} options.width Width.
- * 
+ * @property {number|undefined} lineDashOffset Line dash offset. Default is '0'.
+ * @property {number|undefined} miterLimit Miter limit. Default is `10`.
+ * @property {number|undefined} width Width.
  */
 
 
 /**
- * @typedef {{font: (string|undefined),
- *     maxAngle: (number|undefined),
- *     offsetX: (number|undefined),
- *     offsetY: (number|undefined),
- *     overflow: (boolean|undefined),
- *     placement: (ol.style.TextPlacement|string|undefined),
- *     scale: (number|undefined),
- *     rotateWithView: (boolean|undefined),
- *     rotation: (number|undefined),
- *     text: (string|undefined),
- *     textAlign: (string|undefined),
- *     textBaseline: (string|undefined),
- *     fill: (ol.style.Fill|undefined),
- *     stroke: (ol.style.Stroke|undefined),
- *     backgroundFill: (ol.style.Fill|undefined),
- *     backgroundStroke: (ol.style.Stroke|undefined),
- *     padding: (Array.<number>|undefined)}}
- */
-export let style_TextOptions;
-
-/**
- * @param {style_TextOptions} options TODO: repace this
- *
- * @param {string|undefined} options.font Font style as CSS 'font' value, see:
+ * @typedef {Object} style_TextOptions
+ * @property {string|undefined} font Font style as CSS 'font' value, see:
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font}.
  * Default is '10px sans-serif'
- * 
- * @param {number|undefined} options.maxAngle When `placement` is set to `'line'`, allow a maximum angle between adjacent
+ * @property {number|undefined} maxAngle When `placement` is set to `'line'`, allow a maximum angle between adjacent
  * characters. The expected value is in radians, and the default is 45°
  * (`Math.PI / 4`).
- * 
- * @param {number|undefined} options.offsetX Horizontal text offset in pixels. A positive will shift the text right.
+ * @property {number|undefined} offsetX Horizontal text offset in pixels. A positive will shift the text right.
  * Default is `0`.
- * 
- * @param {number|undefined} options.offsetY Vertical text offset in pixels. A positive will shift the text down. Default
+ * @property {number|undefined} offsetY Vertical text offset in pixels. A positive will shift the text down. Default
  * is `0`.
- * 
- * @param {boolean|undefined} options.overflow For polygon labels or when `placement` is set to `'line'`, allow text to
+ * @property {boolean|undefined} overflow For polygon labels or when `placement` is set to `'line'`, allow text to
  * exceed the width of the polygon at the label position or the length of
  * the path that it follows. Default is `false`.
- * 
- * @param {ol.style.TextPlacement|undefined} options.placement Text placement.
- * 
- * @param {number|undefined} options.scale Scale.
- * 
- * @param {boolean|undefined} options.rotateWithView Whether to rotate the text with the view. Default is `false`.
- * 
- * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
- * 
- * @param {string|undefined} options.text Text content.
- * 
- * @param {string|undefined} options.textAlign Text alignment. Possible values: 'left', 'right', 'center', 'end' or 'start'.
+ * @property {ol.style.TextPlacement|undefined} placement Text placement.
+ * @property {number|undefined} scale Scale.
+ * @property {boolean|undefined} rotateWithView Whether to rotate the text with the view. Default is `false`.
+ * @property {number|undefined} rotation Rotation in radians (positive rotation clockwise). Default is `0`.
+ * @property {string|undefined} text Text content.
+ * @property {string|undefined} textAlign Text alignment. Possible values: 'left', 'right', 'center', 'end' or 'start'.
  * Default is 'center' for `placement: 'point'`. For `placement: 'line'`, the
  * default is to let the renderer choose a placement where `maxAngle` is not
  * exceeded.
- * 
- * @param {string|undefined} options.textBaseline Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
+ * @property {string|undefined} textBaseline Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
  * 'hanging', 'ideographic'. Default is 'middle'.
- * 
- * @param {ol.style.Fill|undefined} options.fill Fill style. If none is provided, we'll use a dark fill-style (#333).
- * 
- * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- * 
- * @param {ol.style.Fill|undefined} options.backgroundFill Fill style for the text background when `placement` is `'point'`. Default is
+ * @property {ol.style.Fill|undefined} fill Fill style. If none is provided, we'll use a dark fill-style (#333).
+ * @property {ol.style.Stroke|undefined} stroke Stroke style.
+ * @property {ol.style.Fill|undefined} backgroundFill Fill style for the text background when `placement` is `'point'`. Default is
  * no fill.
- * 
- * @param {ol.style.Stroke|undefined} options.backgroundStroke Stroke style for the text background  when `placement` is `'point'`. Default
+ * @property {ol.style.Stroke|undefined} backgroundStroke Stroke style for the text background  when `placement` is `'point'`. Default
  * is no stroke.
- * 
- * @param {Array.<number>|undefined} options.padding Padding in pixels around the text for decluttering and background. The order
+ * @property {Array.<number>|undefined} padding Padding in pixels around the text for decluttering and background. The order
  * of values in the array is `[top, right, bottom, left]`. Default is
  * `[0, 0, 0, 0]`.
- * 
  */
 
 
 /**
- * @typedef {{geometry: (undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction),
- *     fill: (ol.style.Fill|undefined),
- *     image: (ol.style.Image|undefined),
- *     renderer: (ol.StyleRenderFunction|undefined),
- *     stroke: (ol.style.Stroke|undefined),
- *     text: (ol.style.Text|undefined),
- *     zIndex: (number|undefined)}}
- */
-export let style_StyleOptions;
-
-/**
- * @param {style_StyleOptions} options TODO: repace this
- *
- * @param {undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction} options.geometry Feature property or geometry or function returning a geometry to render for
+ * @typedef {Object} style_StyleOptions
+ * @property {undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction} geometry Feature property or geometry or function returning a geometry to render for
  * this style.
- * 
- * @param {ol.style.Fill|undefined} options.fill Fill style.
- * 
- * @param {ol.style.Image|undefined} options.image Image style.
- * 
- * @param {ol.StyleRenderFunction|undefined} options.renderer Custom renderer. When configured, `fill`, `stroke` and `image` will be
+ * @property {ol.style.Fill|undefined} fill Fill style.
+ * @property {ol.style.Image|undefined} image Image style.
+ * @property {ol.StyleRenderFunction|undefined} renderer Custom renderer. When configured, `fill`, `stroke` and `image` will be
  * ignored, and the provided function will be called with each render frame for
  * each geometry.
  * 
- * 
- * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- * 
- * @param {ol.style.Text|undefined} options.text Text style.
- * 
- * @param {number|undefined} options.zIndex Z index.
- * 
+ * @property {ol.style.Stroke|undefined} stroke Stroke style.
+ * @property {ol.style.Text|undefined} text Text style.
+ * @property {number|undefined} zIndex Z index.
  */
 
 
 /**
- * @typedef {{extent: (ol.Extent|undefined),
- *     minZoom: (number|undefined),
- *     origin: (ol.Coordinate|undefined),
- *     origins: (Array.<ol.Coordinate>|undefined),
- *     resolutions: !Array.<number>,
- *     sizes: (Array.<ol.Size>|undefined),
- *     tileSize: (number|ol.Size|undefined),
- *     tileSizes: (Array.<number|ol.Size>|undefined)}}
- */
-export let tilegrid_TileGridOptions;
-
-/**
- * @param {tilegrid_TileGridOptions} options TODO: repace this
- *
- * @param {ol.Extent|undefined} options.extent Extent for the tile grid. No tiles outside this extent will be requested by
+ * @typedef {Object} tilegrid_TileGridOptions
+ * @property {ol.Extent|undefined} extent Extent for the tile grid. No tiles outside this extent will be requested by
  * {@link ol.source.Tile} sources. When no `origin` or `origins` are
  * configured, the `origin` will be set to the top-left corner of the extent.
- * 
- * @param {number|undefined} options.minZoom Minimum zoom. Default is 0.
- * 
- * @param {ol.Coordinate|undefined} options.origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
+ * @property {number|undefined} minZoom Minimum zoom. Default is 0.
+ * @property {ol.Coordinate|undefined} origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
  * Tile coordinates increase left to right and upwards. If not specified,
  * `extent` or `origins` must be provided.
- * 
- * @param {Array.<ol.Coordinate>|undefined} options.origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
+ * @property {Array.<ol.Coordinate>|undefined} origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
  * each zoom level. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different origin. Tile
  * coordinates increase left to right and upwards. If not specified, `extent`
  * or `origin` must be provided.
- * 
- * @param {!Array.<number>} options.resolutions Resolutions. The array index of each resolution needs to match the zoom
+ * @property {!Array.<number>} resolutions Resolutions. The array index of each resolution needs to match the zoom
  * level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`.
- * 
- * @param {number|ol.Size|undefined} options.tileSize Tile size. Default is `[256, 256]`.
- * 
- * @param {Array.<number|ol.Size>|undefined} options.tileSizes Tile sizes. If given, the array length should match the length of the
+ * @property {number|ol.Size|undefined} tileSize Tile size. Default is `[256, 256]`.
+ * @property {Array.<number|ol.Size>|undefined} tileSizes Tile sizes. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different tile size.
- * 
  */
 
 
 /**
- * @typedef {{extent: (ol.Extent|undefined),
- *     origin: (ol.Coordinate|undefined),
- *     origins: (Array.<ol.Coordinate>|undefined),
- *     resolutions: !Array.<number>,
- *     matrixIds: !Array.<string>,
- *     sizes: (Array.<ol.Size>|undefined),
- *     tileSize: (number|ol.Size|undefined),
- *     tileSizes: (Array.<number|ol.Size>|undefined)}}
- */
-export let tilegrid_WMTSOptions;
-
-/**
- * @param {tilegrid_WMTSOptions} options TODO: repace this
- *
- * @param {ol.Extent|undefined} options.extent Extent for the tile grid. No tiles outside this extent will be requested by
+ * @typedef {Object} tilegrid_WMTSOptions
+ * @property {ol.Extent|undefined} extent Extent for the tile grid. No tiles outside this extent will be requested by
  * {@link ol.source.Tile} sources. When no `origin` or `origins` are
  * configured, the `origin` will be set to the top-left corner of the extent.
- * 
- * @param {ol.Coordinate|undefined} options.origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
+ * @property {ol.Coordinate|undefined} origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
  * Tile coordinates increase left to right and upwards. If not specified,
  * `extent` or `origins` must be provided.
- * 
- * @param {Array.<ol.Coordinate>|undefined} options.origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
+ * @property {Array.<ol.Coordinate>|undefined} origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
  * each zoom level. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different origin. Tile
  * coordinates increase left to right and upwards. If not specified, `extent` or
  * `origin` must be provided.
- * 
- * @param {!Array.<number>} options.resolutions Resolutions. The array index of each resolution needs to match the zoom
+ * @property {!Array.<number>} resolutions Resolutions. The array index of each resolution needs to match the zoom
  * level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`
- * 
- * @param {!Array.<string>} options.matrixIds matrix IDs. The length of this array needs to match the length of the
+ * @property {!Array.<string>} matrixIds matrix IDs. The length of this array needs to match the length of the
  * `resolutions` array.
- * 
- * @param {Array.<ol.Size>|undefined} options.sizes Number of tile rows and columns of the grid for each zoom level. The values
+ * @property {Array.<ol.Size>|undefined} sizes Number of tile rows and columns of the grid for each zoom level. The values
  * here are the `TileMatrixWidth` and `TileMatrixHeight` advertised in the
  * GetCapabilities response of the WMTS, and define the grid's extent together
  * with the `origin`. An `extent` can be configured in addition, and will
@@ -4163,198 +1987,92 @@ export let tilegrid_WMTSOptions;
  * that when the top-left corner of the `extent` is used as `origin` or
  * `origins`, then the `y` value must be negative because OpenLayers tile
  * coordinates increase upwards.
- * 
- * @param {number|ol.Size|undefined} options.tileSize Tile size.
- * 
- * @param {Array.<number|ol.Size>|undefined} options.tileSizes Tile sizes. The length of this array needs to match the length of the
+ * @property {number|ol.Size|undefined} tileSize Tile size.
+ * @property {Array.<number|ol.Size>|undefined} tileSizes Tile sizes. The length of this array needs to match the length of the
  * `resolutions` array.
- * 
- * @param {Array.<number>|undefined} options.widths Number of tile columns that cover the grid's extent for each zoom level. Only
+ * @property {Array.<number>|undefined} widths Number of tile columns that cover the grid's extent for each zoom level. Only
  * required when used with a source that has `wrapX` set to `true`, and only
  * when the grid's origin differs from the one of the projection's extent. The
  * array length has to match the length of the `resolutions` array, i.e. each
  * resolution will have a matching entry here.
- * 
  */
 
 
 /**
- * @typedef {{extent: (ol.Extent|undefined),
- *     maxZoom: (number|undefined),
- *     minZoom: (number|undefined),
- *     tileSize: (number|ol.Size|undefined)}}
- */
-export let tilegrid_XYZOptions;
-
-/**
- * @param {tilegrid_XYZOptions} options TODO: repace this
- *
- * @param {ol.Extent|undefined} options.extent Extent for the tile grid.  The origin for an XYZ tile grid is the top-left
+ * @typedef {Object} tilegrid_XYZOptions
+ * @property {ol.Extent|undefined} extent Extent for the tile grid.  The origin for an XYZ tile grid is the top-left
  * corner of the extent.  The zero level of the grid is defined by the
  * resolution at which one tile fits in the provided extent.  If not provided,
  * the extent of the EPSG:3857 projection is used.
- * 
- * @param {number|undefined} options.maxZoom Maximum zoom.  The default is `ol.DEFAULT_MAX_ZOOM`.  This determines the
+ * @property {number|undefined} maxZoom Maximum zoom.  The default is `ol.DEFAULT_MAX_ZOOM`.  This determines the
  * number of levels in the grid set.  For example, a `maxZoom` of 21 means there
  * are 22 levels in the grid set.
- * 
- * @param {number|undefined} options.minZoom Minimum zoom. Default is 0.
- * 
- * @param {number|ol.Size|undefined} options.tileSize Tile size in pixels. Default is `[256, 256]`.
- * 
+ * @property {number|undefined} minZoom Minimum zoom. Default is 0.
+ * @property {number|ol.Size|undefined} tileSize Tile size in pixels. Default is `[256, 256]`.
  */
 
 
 /**
- * @typedef {{
- *     size: (ol.Size|undefined),
- *     padding: (!Array.<number>|undefined),
- *     constrainResolution: (boolean|undefined),
- *     nearest: (boolean|undefined),
- *     maxZoom: (number|undefined),
- *     minResolution: (number|undefined),
- *     duration: (number|undefined),
- *     easing: (undefined|function(number):number),
- *     callback: (undefined|function(boolean))
- * }}
- */
-export let view_FitOptions;
-
-/**
- * @param {view_FitOptions} options TODO: repace this
- *
- * @param {ol.Size|undefined} options.size The size in pixels of the box to fit the extent into. Default is
+ * @typedef {Object} view_FitOptions
+ * @property {ol.Size|undefined} size The size in pixels of the box to fit the extent into. Default is
  * the current size of the first map in the DOM that uses this view, or
  * `[100, 100]` if no such map is found.
- * 
- * @param {!Array.<number>|undefined} options.padding Padding (in pixels) to be cleared inside the view. Values in the array are
+ * @property {!Array.<number>|undefined} padding Padding (in pixels) to be cleared inside the view. Values in the array are
  * top, right, bottom and left padding. Default is `[0, 0, 0, 0]`.
- * 
- * @param {boolean|undefined} options.constrainResolution Constrain the resolution. Default is `true`.
- * 
- * @param {boolean|undefined} options.nearest Get the nearest extent. Default is `false`.
- * 
- * @param {number|undefined} options.minResolution Minimum resolution that we zoom to. Default is `0`.
- * 
- * @param {number|undefined} options.maxZoom Maximum zoom level that we zoom to. If `minResolution` is given,
+ * @property {boolean|undefined} constrainResolution Constrain the resolution. Default is `true`.
+ * @property {boolean|undefined} nearest Get the nearest extent. Default is `false`.
+ * @property {number|undefined} minResolution Minimum resolution that we zoom to. Default is `0`.
+ * @property {number|undefined} maxZoom Maximum zoom level that we zoom to. If `minResolution` is given,
  * this property is ignored.
- * 
- * @param {number|undefined} options.duration The duration of the animation in milliseconds. By default, there is no
+ * @property {number|undefined} duration The duration of the animation in milliseconds. By default, there is no
  * animations.
- * 
- * @param {undefined|function(number):number} options.easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
+ * @property {undefined|function(number):number} easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
  * The function will be called for each frame with a number representing a
  * fraction of the animation's duration.  The function should return a number
  * between 0 and 1 representing the progress toward the destination state.
- * 
- * @param {undefined|function(boolean)} options.callback Optional function called when the view is in it's final position. The callback will be
+ * @property {undefined|function(boolean)} callback Optional function called when the view is in it's final position. The callback will be
  * called with `true` if the animation series completed on its own or `false`
  * if it was cancelled.
- * 
  */
 
 
 /**
- * @typedef {{animate: boolean,
- *     coordinateToPixelTransform: ol.Transform,
- *     extent: (null|ol.Extent),
- *     focus: ol.Coordinate,
- *     index: number,
- *     layerStates: Object.<number, ol.LayerState>,
- *     layerStatesArray: Array.<ol.LayerState>,
- *     logos: Object.<string, (string|Element)>,
- *     pixelRatio: number,
- *     pixelToCoordinateTransform: ol.Transform,
- *     postRenderFunctions: Array.<ol.PostRenderFunction>,
- *     size: ol.Size,
- *     skippedFeatureUids: !Object.<string, boolean>,
- *     tileQueue: ol.TileQueue,
- *     time: number,
- *     usedTiles: Object.<string, Object.<string, ol.TileRange>>,
- *     viewState: olx.ViewState,
- *     viewHints: Array.<number>,
- *     wantedTiles: !Object.<string, Object.<string, boolean>>}}
- */
-export let FrameState;
-
-/**
- * @param {FrameState} options TODO: repace this
- *
- * @param {number} options.pixelRatio 
- * @param {number} options.time 
- * @param {olx.ViewState} options.viewState 
+ * @typedef {Object} FrameState
+ * @property {number} pixelRatio 
+ * @property {number} time 
+ * @property {olx.ViewState} viewState 
  */
 
 
 /**
- * @typedef {{center: ol.Coordinate,
- *     projection: ol.proj.Projection,
- *     resolution: number,
- *     rotation: number,
- *     zoom: number}}
- */
-export let ViewState;
-
-/**
- * @param {ViewState} options TODO: repace this
- *
- * @param {ol.Coordinate} options.center 
- * @param {ol.proj.Projection} options.projection 
- * @param {number} options.resolution 
- * @param {number} options.rotation 
- * @param {number} options.zoom The current zoom level.
- * 
+ * @typedef {Object} ViewState
+ * @property {ol.Coordinate} center 
+ * @property {ol.proj.Projection} projection 
+ * @property {number} resolution 
+ * @property {number} rotation 
+ * @property {number} zoom The current zoom level.
  */
 
 
 /**
- * @typedef {{initialSize: (number|undefined),
- *     maxSize: (number|undefined),
- *     space: (number|undefined)}}
- */
-export let style_AtlasManagerOptions;
-
-/**
- * @param {style_AtlasManagerOptions} options TODO: repace this
- *
- * @param {number|undefined} options.initialSize The size in pixels of the first atlas image. Default is `256`.
- * 
- * @param {number|undefined} options.maxSize The maximum size in pixels of atlas images. Default is
+ * @typedef {Object} style_AtlasManagerOptions
+ * @property {number|undefined} initialSize The size in pixels of the first atlas image. Default is `256`.
+ * @property {number|undefined} maxSize The maximum size in pixels of atlas images. Default is
  * `WEBGL_MAX_TEXTURE_SIZE` or 2048 if WebGL is not supported.
- * 
- * @param {number|undefined} options.space The space in pixels between images (default: 1).
- * 
+ * @property {number|undefined} space The space in pixels between images (default: 1).
  */
 
 
 /**
- * @typedef {{handles: function(ol.renderer.Type):boolean,
- *     create: function(Element, ol.PluggableMap):ol.renderer.Map}}
- */
-export let MapRendererPlugin;
-
-/**
- * @param {MapRendererPlugin} options TODO: repace this
- *
- * @param {function(ol.renderer.Type):boolean} options.handles Determine if this renderer handles the provided layer.
- * 
- * @param {function(Element, ol.PluggableMap):ol.renderer.Map} options.create Create the map renderer.
- * 
+ * @typedef {Object} MapRendererPlugin
+ * @property {function(ol.renderer.Type):boolean} handles Determine if this renderer handles the provided layer.
+ * @property {function(Element, ol.PluggableMap):ol.renderer.Map} create Create the map renderer.
  */
 
 
 /**
- * @typedef {{handles: function(ol.renderer.Type, ol.layer.Layer):boolean,
- *     create: function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer}}
- */
-export let LayerRendererPlugin;
-
-/**
- * @param {LayerRendererPlugin} options TODO: repace this
- *
- * @param {function(ol.renderer.Type, ol.layer.Layer):boolean} options.handles Determine if this renderer handles the provided layer.
- * 
- * @param {function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer} options.create Create a layer renderer.
- * 
+ * @typedef {Object} LayerRendererPlugin
+ * @property {function(ol.renderer.Type, ol.layer.Layer):boolean} handles Determine if this renderer handles the provided layer.
+ * @property {function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer} create Create a layer renderer.
  */
 

--- a/externs/xol.js
+++ b/externs/xol.js
@@ -2,14 +2,14 @@
 /**
  * @typedef {{unique: (boolean|undefined)}}
  */
-export var CollectionOptions;
+export let CollectionOptions;
 
 /**
  * @param {CollectionOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.unique Disallow the same item from being added to the collection twice.  Default is
  * false.
- *
+ * 
  */
 
 
@@ -18,18 +18,18 @@ export var CollectionOptions;
  *     trackingOptions: (GeolocationPositionOptions|undefined),
  *     projection: ol.ProjectionLike}}
  */
-export var GeolocationOptions;
+export let GeolocationOptions;
 
 /**
  * @param {GeolocationOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.tracking Start Tracking. Default is `false`.
- *
+ * 
  * @param {GeolocationPositionOptions|undefined} options.trackingOptions Tracking options. See
  * {@link http://www.w3.org/TR/geolocation-API/#position_options_interface}.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection The projection the position is reported in.
- *
+ * 
  */
 
 
@@ -37,15 +37,15 @@ export var GeolocationOptions;
  * Object literal with config options for the map logo.
  * @typedef {{href: (string), src: (string)}}
  */
-export var LogoOptions;
+export let LogoOptions;
 
 /**
  * @param {LogoOptions} options TODO: repace this
  *
  * @param {string} options.href Link url for the logo. Will be followed when the logo is clicked.
- *
+ * 
  * @param {string} options.src Image src for the logo.
- *
+ * 
  */
 
 
@@ -62,47 +62,47 @@ export var LogoOptions;
  *     lonLabelStyle: (ol.style.Text|undefined),
  *     latLabelStyle: (ol.style.Text|undefined)}}
  */
-export var GraticuleOptions;
+export let GraticuleOptions;
 
 /**
  * @param {GraticuleOptions} options TODO: repace this
  *
  * @param {ol.PluggableMap|undefined} options.map Reference to an `ol.Map` object.
- *
+ * 
  * @param {number|undefined} options.maxLines The maximum number of meridians and parallels from the center of the
  * map. The default value is 100, which means that at most 200 meridians
  * and 200 parallels will be displayed. The default value is appropriate
  * for conformal projections like Spherical Mercator. If you increase
  * the value more lines will be drawn and the drawing performance will
  * decrease.
- *
+ * 
  * @param {ol.style.Stroke|undefined} options.strokeStyle The stroke style to use for drawing the graticule. If not provided, the
  * lines will be drawn with `rgba(0,0,0,0.2)`, a not fully opaque black.
- *
- *
+ * 
+ * 
  * @param {number|undefined} options.targetSize The target size of the graticule cells, in pixels. Default
  * value is 100 pixels.
- *
+ * 
  * @param {boolean|undefined} options.showLabels Render a label with the respective latitude/longitude for each graticule
  * line. Default is false.
- *
- *
+ * 
+ * 
  * @param {undefined|function(number):string} options.lonLabelFormatter Label formatter for longitudes. This function is called with the longitude as
  * argument, and should return a formatted string representing the longitude.
  * By default, labels are formatted as degrees, minutes, seconds and hemisphere.
- *
- *
+ * 
+ * 
  * @param {undefined|function(number):string} options.latLabelFormatter Label formatter for latitudes. This function is called with the latitude as
  * argument, and should return a formatted string representing the latitude.
  * By default, labels are formatted as degrees, minutes, seconds and hemisphere.
- *
- *
+ * 
+ * 
  * @param {number|undefined} options.lonLabelPosition Longitude label position in fractions (0..1) of view extent. 0 means at the
  * bottom of the viewport, 1 means at the top. Default is 0.
- *
+ * 
  * @param {number|undefined} options.latLabelPosition Latitude label position in fractions (0..1) of view extent. 0 means at the
  * left of the viewport, 1 means at the right. Default is 1.
- *
+ * 
  * @param {ol.style.Text|undefined} options.lonLabelStyle Longitude label text style. The default is
  * ```js
  * new ol.style.Text({
@@ -120,8 +120,8 @@ export var GraticuleOptions;
  * Note that the default's `textBaseline` configuration will not work well for
  * `lonLabelPosition` configurations that position labels close to the top of
  * the viewport.
- *
- *
+ * 
+ * 
  * @param {ol.style.Text|undefined} options.latLabelStyle Latitude label text style. The default is
  * ```js
  * new ol.style.Text({
@@ -139,8 +139,8 @@ export var GraticuleOptions;
  * Note that the default's `textAlign` configuration will not work well for
  * `latLabelPosition` configurations that position labels close to the left of
  * the viewport.
- *
- *
+ * 
+ * 
  */
 
 
@@ -148,7 +148,7 @@ export var GraticuleOptions;
  * Object literal with config options for interactions.
  * @typedef {{handleEvent: function(ol.MapBrowserEvent):boolean}}
  */
-export var interaction_InteractionOptions;
+export let interaction_InteractionOptions;
 
 /**
  * @param {interaction_InteractionOptions} options TODO: repace this
@@ -158,7 +158,7 @@ export var interaction_InteractionOptions;
  * propagation of the event to other interactions in the map's interactions
  * chain will be prevented (this includes functions with no explicit return). See
  * {@link https://developer.mozilla.org/en-US/docs/Glossary/Falsy}
- *
+ * 
  */
 
 
@@ -178,20 +178,20 @@ export var interaction_InteractionOptions;
  *     target: (Element|string|undefined),
  *     view: (ol.View|undefined)}}
  */
-export var MapOptions;
+export let MapOptions;
 
 /**
  * @param {MapOptions} options TODO: repace this
  *
  * @param {ol.Collection.<ol.control.Control>|Array.<ol.control.Control>|undefined} options.controls Controls initially added to the map. If not specified,
  * {@link ol.control.defaults ol.control.defaults()} is used.
- *
+ * 
  * @param {number|undefined} options.pixelRatio The ratio between physical pixels and device-independent pixels (dips) on the
  * device. If `undefined` then it gets set by using `window.devicePixelRatio`.
- *
+ * 
  * @param {ol.Collection.<ol.interaction.Interaction>|Array.<ol.interaction.Interaction>|undefined} options.interactions Interactions that are initially added to the map. If not specified,
  * {@link ol.interaction.defaults ol.interaction.defaults()} is used.
- *
+ * 
  * @param {Element|Document|string|undefined} options.keyboardEventTarget The element to listen to keyboard events on. This determines when the
  * `KeyboardPan` and `KeyboardZoom` interactions trigger. For example, if this
  * option is set to `document` the keyboard interactions will always trigger. If
@@ -199,47 +199,47 @@ export var MapOptions;
  * events on is the map target (i.e. the user-provided div for the map). If this
  * is not `document` the target element needs to be focused for key events to be
  * emitted, requiring that the target element has a `tabindex` attribute.
- *
+ * 
  * @param {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} options.layers Layers. If this is not defined, a map with no layers will be rendered. Note
  * that layers are rendered in the order supplied, so if you want, for example,
  * a vector layer to appear on top of a tile layer, it must come after the tile
  * layer.
- *
+ * 
  * @param {boolean|undefined} options.loadTilesWhileAnimating When set to true, tiles will be loaded during animations. This may improve
  * the user experience, but can also make animations stutter on devices with
  * slow memory. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.loadTilesWhileInteracting When set to true, tiles will be loaded while interacting with the map. This
  * may improve the user experience, but can also make map panning and zooming
  * choppy on devices with slow memory. Default is `false`.
- *
+ * 
  * @param {boolean|string|olx.LogoOptions|Element|undefined} options.logo The map logo. A logo to be displayed on the map at all times. If a string is
  * provided, it will be set as the image source of the logo. If an object is
  * provided, the `src` property should be the URL for an image and the `href`
  * property should be a URL for creating a link. If an element is provided,
  * the element will be used. To disable the map logo, set the option to
  * `false`. By default, the OpenLayers logo is shown.
- *
+ * 
  * @param {number|undefined} options.moveTolerance The minimum distance in pixels the cursor must move to be detected
  * as a map move event instead of a click. Increasing this value can make it
  * easier to click on the map.
  * Default is `1`.
- *
+ * 
  * @param {ol.Collection.<ol.Overlay>|Array.<ol.Overlay>|undefined} options.overlays Overlays initially added to the map. By default, no overlays are added.
- *
+ * 
  * @param {ol.renderer.Type|Array.<ol.renderer.Type>|undefined} options.renderer Renderer. By default, Canvas and WebGL renderers are tested for support
  * in that order, and the first supported used. Specify a
  * {@link ol.renderer.Type} here to use a specific renderer.
  * Note that the Canvas renderer fully supports vector data, but WebGL can only
  * render Point geometries.
- *
+ * 
  * @param {Element|string|undefined} options.target The container for the map, either the element itself or the `id` of the
  * element. If not specified at construction time, {@link ol.Map#setTarget}
  * must be called for the map to be rendered.
- *
+ * 
  * @param {ol.View|undefined} options.view The map's view.  No layer sources will be fetched unless this is specified at
  * construction time or through {@link ol.Map#setView}.
- *
+ * 
  */
 
 
@@ -249,17 +249,17 @@ export var MapOptions;
  * @typedef {{projection: (ol.ProjectionLike|undefined),
  *    radius: (number|undefined)}}
  */
-export var SphereMetricOptions;
+export let SphereMetricOptions;
 
 /**
  * @param {SphereMetricOptions} options TODO: repace this
  *
  * @param {(ol.ProjectionLike|undefined)} options.projection Projection of the geometry.  By default, the geometry is assumed to be in
  * EPSG:3857 (Web Mercator).
- *
+ * 
  * @param {(number|undefined)} options.radius Sphere radius.  By default, the radius of the earth is used (Clarke 1866
  * Authalic Sphere).
- *
+ * 
  */
 
 
@@ -267,7 +267,7 @@ export var SphereMetricOptions;
  * Options for tile constructors.
  * @typedef {{transition: (number|undefined)}}
  */
-export var TileOptions;
+export let TileOptions;
 
 /**
  * @param {TileOptions} options TODO: repace this
@@ -275,7 +275,7 @@ export var TileOptions;
  * @param {number|undefined} options.transition A duration for tile opacity transitions.  By default, tiles will render with
  * an opacity transition that lasts 250 ms.  To change the duration, pass a
  * number in milliseconds.  A duration of 0 disables the opacity transition.
- *
+ * 
  */
 
 
@@ -285,7 +285,7 @@ export var TileOptions;
  * @typedef {{layerFilter: ((function(ol.layer.Layer): boolean)|undefined),
  *    hitTolerance: (number|undefined)}}
  */
-export var AtPixelOptions;
+export let AtPixelOptions;
 
 /**
  * @param {AtPixelOptions} options TODO: repace this
@@ -294,11 +294,11 @@ export var AtPixelOptions;
  * {@link ol.layer.Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
  * will be tested for features. By default, all visible layers will be tested.
- *
+ * 
  * @param {number|undefined} options.hitTolerance Hit-detection tolerance in pixels. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- *
+ * 
  */
 
 
@@ -316,51 +316,51 @@ export var AtPixelOptions;
  *     autoPanMargin: (number|undefined),
  *     className: (string|undefined)}}
  */
-export var OverlayOptions;
+export let OverlayOptions;
 
 /**
  * @param {OverlayOptions} options TODO: repace this
  *
  * @param {number|string|undefined} options.id Set the overlay id. The overlay id can be used with the
  * {@link ol.Map#getOverlayById} method.
- *
+ * 
  * @param {Element|undefined} options.element The overlay element.
- *
+ * 
  * @param {Array.<number>|undefined} options.offset Offsets in pixels used when positioning the overlay. The first element in the
  * array is the horizontal offset. A positive value shifts the overlay right.
  * The second element in the array is the vertical offset. A positive value
  * shifts the overlay down. Default is `[0, 0]`.
- *
+ * 
  * @param {ol.Coordinate|undefined} options.position The overlay position in map projection.
- *
+ * 
  * @param {ol.OverlayPositioning|string|undefined} options.positioning Defines how the overlay is actually positioned with respect to its `position`
  * property. Possible values are `'bottom-left'`, `'bottom-center'`,
  * `'bottom-right'`, `'center-left'`, `'center-center'`, `'center-right'`,
  * `'top-left'`, `'top-center'`, and `'top-right'`. Default is `'top-left'`.
- *
+ * 
  * @param {boolean|undefined} options.stopEvent Whether event propagation to the map viewport should be stopped. Default is
  * `true`. If `true` the overlay is placed in the same container as that of the
  * controls (CSS class name `ol-overlaycontainer-stopevent`); if `false` it is
  * placed in the container with CSS class name `ol-overlaycontainer`.
- *
+ * 
  * @param {boolean|undefined} options.insertFirst Whether the overlay is inserted first in the overlay container, or appended.
  * Default is `true`. If the overlay is placed in the same container as that of
  * the controls (see the `stopEvent` option) you will probably set `insertFirst`
  * to `true` so the overlay is displayed below the controls.
- *
+ * 
  * @param {boolean|undefined} options.autoPan If set to `true` the map is panned when calling `setPosition`, so that the
  * overlay is entirely visible in the current viewport.
  * The default is `false`.
- *
+ * 
  * @param {olx.OverlayPanOptions|undefined} options.autoPanAnimation The animation options used to pan the overlay into view. This animation
  * is only used when `autoPan` is enabled. A `duration` and `easing` may be
  * provided to customize the animation.
- *
+ * 
  * @param {number|undefined} options.autoPanMargin The margin (in pixels) between the overlay and the borders of the map when
  * autopanning. The default is `20`.
- *
+ * 
  * @param {string|undefined} options.className CSS class name. Default is `ol-overlay-container ol-selectable`.
- *
+ * 
  */
 
 
@@ -370,16 +370,16 @@ export var OverlayOptions;
  *   easing: (undefined|function(number):number)
  * }}
  */
-export var OverlayPanOptions;
+export let OverlayPanOptions;
 
 /**
  * @param {OverlayPanOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration The duration of the animation in milliseconds. Default is `1000`.
- *
+ * 
  * @param {undefined|function(number):number} options.easing The easing function to use. Can be an {@link ol.easing} or a custom function.
  * Default is {@link ol.easing.inAndOut}.
- *
+ * 
  */
 
 
@@ -394,31 +394,31 @@ export var OverlayPanOptions;
  *     worldExtent: (ol.Extent|undefined),
  *     getPointResolution: (function(number, ol.Coordinate):number|undefined) }}
  */
-export var ProjectionOptions;
+export let ProjectionOptions;
 
 /**
  * @param {ProjectionOptions} options TODO: repace this
  *
  * @param {string} options.code The SRS identifier code, e.g. `EPSG:4326`.
- *
+ * 
  * @param {ol.proj.Units|string|undefined} options.units Units. Required unless a proj4 projection is defined for `code`.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The validity extent for the SRS.
- *
+ * 
  * @param {string|undefined} options.axisOrientation The axis orientation as specified in Proj4. The default is `enu`.
- *
+ * 
  * @param {boolean|undefined} options.global Whether the projection is valid for the whole globe. Default is `false`.
- *
+ * 
  * @param {number|undefined} options.metersPerUnit The meters per unit for the SRS. If not provided, the `units` are used to get
  * the meters per unit from the {@link ol.proj.METERS_PER_UNIT} lookup table.
- *
+ * 
  * @param {ol.Extent|undefined} options.worldExtent The world extent for the SRS.
- *
+ * 
  * @param {(function(number, ol.Coordinate):number|undefined)} options.getPointResolution Function to determine resolution at a point. The function is called with a
  * `{number}` view resolution and an `{ol.Coordinate}` as arguments, and returns
  * the `{number}` resolution at the passed coordinate. If this is `undefined`,
  * the default {@link ol.proj#getPointResolution} function will be used.
- *
+ * 
  */
 
 
@@ -439,7 +439,7 @@ export var ProjectionOptions;
  *     zoom: (number|undefined),
  *     zoomFactor: (number|undefined)}}
  */
-export var ViewOptions;
+export let ViewOptions;
 
 /**
  * @param {ViewOptions} options TODO: repace this
@@ -447,63 +447,63 @@ export var ViewOptions;
  * @param {ol.Coordinate|undefined} options.center The initial center for the view. The coordinate system for the center is
  * specified with the `projection` option. Default is `undefined`, and layer
  * sources will not be fetched if this is not set.
- *
+ * 
  * @param {boolean|number|undefined} options.constrainRotation Rotation constraint. `false` means no constraint. `true` means no constraint,
  * but snap to zero near zero. A number constrains the rotation to that number
  * of values. For example, `4` will constrain the rotation to 0, 90, 180, and
  * 270 degrees. The default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.enableRotation Enable rotation. Default is `true`. If `false` a rotation constraint that
  * always sets the rotation to zero is used. The `constrainRotation` option
  * has no effect if `enableRotation` is `false`.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The extent that constrains the center, in other words, center cannot be set
  * outside this extent. Default is `undefined`.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution used to determine the resolution constraint. It is
  * used together with `minResolution` (or `maxZoom`) and `zoomFactor`. If
  * unspecified it is calculated in such a way that the projection's validity
  * extent fits in a 256x256 px tile. If the projection is Spherical Mercator
  * (the default) then `maxResolution` defaults to `40075016.68557849 / 256 =
  * 156543.03392804097`.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution used to determine the resolution constraint.  It is
  * used together with `maxResolution` (or `minZoom`) and `zoomFactor`.  If
  * unspecified it is calculated assuming 29 zoom levels (with a factor of 2).
  * If the projection is Spherical Mercator (the default) then `minResolution`
  * defaults to `40075016.68557849 / 256 / Math.pow(2, 28) =
  * 0.0005831682455839253`.
- *
+ * 
  * @param {number|undefined} options.maxZoom The maximum zoom level used to determine the resolution constraint. It is
  * used together with `minZoom` (or `maxResolution`) and `zoomFactor`. Default
  * is `28`.  Note that if `minResolution` is also provided, it is given
  * precedence over `maxZoom`.
- *
+ * 
  * @param {number|undefined} options.minZoom The minimum zoom level used to determine the resolution constraint. It is
  * used together with `maxZoom` (or `minResolution`) and `zoomFactor`. Default
  * is `0`. Note that if `maxResolution` is also provided, it is given
  * precedence over `minZoom`.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection The projection. Default is `EPSG:3857` (Spherical Mercator).
- *
+ * 
  * @param {number|undefined} options.resolution The initial resolution for the view. The units are `projection` units per
  * pixel (e.g. meters per pixel). An alternative to setting this is to set
  * `zoom`. Default is `undefined`, and layer sources will not be fetched if
  * neither this nor `zoom` are defined.
- *
+ * 
  * @param {Array.<number>|undefined} options.resolutions Resolutions to determine the resolution constraint. If set the
  * `maxResolution`, `minResolution`, `minZoom`, `maxZoom`, and `zoomFactor`
  * options are ignored.
- *
+ * 
  * @param {number|undefined} options.rotation The initial rotation for the view in radians (positive rotation clockwise).
  * Default is `0`.
- *
+ * 
  * @param {number|undefined} options.zoom Only used if `resolution` is not defined. Zoom level used to calculate the
  * initial resolution for the view. The initial resolution is determined using
  * the `ol.View#constrainResolution` method.
- *
+ * 
  * @param {number|undefined} options.zoomFactor The zoom factor used to determine the resolution constraint.  Default is `2`.
- *
+ * 
  */
 
 
@@ -518,30 +518,30 @@ export var ViewOptions;
  *   easing: (undefined|function(number):number)
  * }}
  */
-export var AnimationOptions;
+export let AnimationOptions;
 
 /**
  * @param {AnimationOptions} options TODO: repace this
  *
  * @param {ol.Coordinate|undefined} options.center The center of the view at the end of the animation.
- *
+ * 
  * @param {number|undefined} options.zoom The zoom level of the view at the end of the animation.  This takes
  * precedence over `resolution`.
- *
+ * 
  * @param {number|undefined} options.resolution The resolution of the view at the end of the animation.  If `zoom` is also
  * provided, this option will be ignored.
- *
+ * 
  * @param {number|undefined} options.rotation The rotation of the view at the end of the animation.
- *
+ * 
  * @param {ol.Coordinate|undefined} options.anchor Optional anchor to remained fixed during a rotation or resolution animation.
- *
+ * 
  * @param {number|undefined} options.duration The duration of the animation in milliseconds (defaults to `1000`).
- *
+ * 
  * @param {undefined|function(number):number} options.easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
  * The function will be called for each frame with a number representing a
  * fraction of the animation's duration.  The function should return a number
  * between 0 and 1 representing the progress toward the destination state.
- *
+ * 
  */
 
 
@@ -555,34 +555,34 @@ export var AnimationOptions;
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|string|undefined)}}
  */
-export var control_AttributionOptions;
+export let control_AttributionOptions;
 
 /**
  * @param {control_AttributionOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name. Default is `ol-attribution`.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  * @param {boolean|undefined} options.collapsible Specify if attributions can be collapsed. If you use an OSM source,
  * should be set to `false` — see
  * {@link https://www.openstreetmap.org/copyright OSM Copyright} —
  * Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.collapsed Specify if attributions should be collapsed at startup. Default is `true`.
- *
+ * 
  * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Attributions`
- *
+ * 
  * @param {string|Node|undefined} options.label Text label to use for the collapsed attributions button. Default is `i`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|Node|undefined} options.collapseLabel Text label to use for the expanded attributions button. Default is `»`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  */
 
 
@@ -591,20 +591,20 @@ export var control_AttributionOptions;
  *     render: (function(ol.MapEvent)|undefined),
  *     target: (Element|string|undefined)}}
  */
-export var control_ControlOptions;
+export let control_ControlOptions;
 
 /**
  * @param {control_ControlOptions} options TODO: repace this
  *
  * @param {Element|undefined} options.element The element is the control's container element. This only needs to be
  * specified if you're developing a custom control.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  */
 
 
@@ -616,23 +616,23 @@ export var control_ControlOptions;
  *     zoom: (boolean|undefined),
  *     zoomOptions: (olx.control.ZoomOptions|undefined)}}
  */
-export var control_DefaultsOptions;
+export let control_DefaultsOptions;
 
 /**
  * @param {control_DefaultsOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.attribution Attribution. Default is `true`.
- *
+ * 
  * @param {olx.control.AttributionOptions|undefined} options.attributionOptions Attribution options.
- *
+ * 
  * @param {boolean|undefined} options.rotate Rotate. Default is `true`.
- *
+ * 
  * @param {olx.control.RotateOptions|undefined} options.rotateOptions Rotate options.
- *
+ * 
  * @param {boolean|undefined} options.zoom Zoom. Default is `true`.
- *
+ * 
  * @param {olx.control.ZoomOptions|undefined} options.zoomOptions Zoom options.
- *
+ * 
  */
 
 
@@ -645,29 +645,29 @@ export var control_DefaultsOptions;
  *     target: (Element|string|undefined),
  *     source: (Element|string|undefined)}}
  */
-export var control_FullScreenOptions;
+export let control_FullScreenOptions;
 
 /**
  * @param {control_FullScreenOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name. Default is `ol-full-screen`.
- *
+ * 
  * @param {string|Node|undefined} options.label Text label to use for the button. Default is `\u2922` (NORTH EAST AND SOUTH WEST ARROW).
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|Node|undefined} options.labelActive Text label to use for the button when full-screen is active.
  * Default is `\u00d7` (a cross).
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Toggle full-screen`
- *
+ * 
  * @param {boolean|undefined} options.keys Full keyboard access.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  * @param {Element|string|undefined} options.source The element to be displayed fullscreen. When not provided, the element containing the map viewport will be displayed fullscreen.
- *
+ * 
  */
 
 
@@ -679,25 +679,25 @@ export var control_FullScreenOptions;
  *     target: (Element|string|undefined),
  *     undefinedHTML: (string|undefined)}}
  */
-export var control_MousePositionOptions;
+export let control_MousePositionOptions;
 
 /**
  * @param {control_MousePositionOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name. Default is `ol-mouse-position`.
- *
+ * 
  * @param {ol.CoordinateFormatType|undefined} options.coordinateFormat Coordinate format.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  * @param {string|undefined} options.undefinedHTML Markup for undefined coordinates. Default is `` (empty string).
- *
+ * 
  */
 
 
@@ -712,36 +712,36 @@ export var control_MousePositionOptions;
  *     tipLabel: (string|undefined),
  *     view: (ol.View|undefined)}}
  */
-export var control_OverviewMapOptions;
+export let control_OverviewMapOptions;
 
 /**
  * @param {control_OverviewMapOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.collapsed Whether the control should start collapsed or not (expanded).
  * Default to `true`.
- *
+ * 
  * @param {string|Node|undefined} options.collapseLabel Text label to use for the expanded overviewmap button. Default is `«`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {boolean|undefined} options.collapsible Whether the control can be collapsed or not. Default to `true`.
- *
+ * 
  * @param {string|Node|undefined} options.label Text label to use for the collapsed overviewmap button. Default is `»`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {Array.<ol.layer.Layer>|ol.Collection.<ol.layer.Layer>|undefined} options.layers Layers for the overview map. If not set, then all main map layers are used
  * instead.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Overview map`
- *
+ * 
  * @param {ol.View|undefined} options.view Custom view for the overview map. If not provided, a default view with
  * an EPSG:3857 projection will be used.
- *
+ * 
  */
 
 
@@ -752,23 +752,23 @@ export var control_OverviewMapOptions;
  *     target: (Element|string|undefined),
  *     units: (ol.control.ScaleLineUnits|string|undefined)}}
  */
-export var control_ScaleLineOptions;
+export let control_ScaleLineOptions;
 
 /**
  * @param {control_ScaleLineOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS Class name. Default is `ol-scale-line`.
- *
+ * 
  * @param {number|undefined} options.minWidth Minimum width in pixels. Default is `64`.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  * @param {ol.control.ScaleLineUnits|string|undefined} options.units Units. Default is `metric`.
- *
+ * 
  */
 
 
@@ -782,31 +782,31 @@ export var control_ScaleLineOptions;
  *     resetNorth: (function()|undefined),
  *     autoHide: (boolean|undefined)}}
  */
-export var control_RotateOptions;
+export let control_RotateOptions;
 
 /**
  * @param {control_RotateOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name. Default is `ol-rotate`.
- *
+ * 
  * @param {string|Element|undefined} options.label Text label to use for the rotate button. Default is `⇧`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|undefined} options.tipLabel Text label to use for the rotate tip. Default is `Reset rotation`
- *
+ * 
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- *
+ * 
  * @param {boolean|undefined} options.autoHide Hide the control when rotation is 0. Default is `true`.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  * @param {function()|undefined} options.resetNorth Function called when the control is clicked. This will override the
  * default resetNorth.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  */
 
 
@@ -820,30 +820,30 @@ export var control_RotateOptions;
  *     delta: (number|undefined),
  *     target: (Element|string|undefined)}}
  */
-export var control_ZoomOptions;
+export let control_ZoomOptions;
 
 /**
  * @param {control_ZoomOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- *
+ * 
  * @param {string|undefined} options.className CSS class name. Default is `ol-zoom`.
- *
+ * 
  * @param {string|Node|undefined} options.zoomInLabel Text label to use for the zoom-in button. Default is `+`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|Node|undefined} options.zoomOutLabel Text label to use for the zoom-out button. Default is `-`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|undefined} options.zoomInTipLabel Text label to use for the button tip. Default is `Zoom in`
- *
+ * 
  * @param {string|undefined} options.zoomOutTipLabel Text label to use for the button tip. Default is `Zoom out`
- *
+ * 
  * @param {number|undefined} options.delta The zoom delta applied on each click.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  */
 
 
@@ -854,22 +854,22 @@ export var control_ZoomOptions;
  *     minResolution: (number|undefined),
  *     render: (function(ol.MapEvent)|undefined)}}
  */
-export var control_ZoomSliderOptions;
+export let control_ZoomSliderOptions;
 
 /**
  * @param {control_ZoomSliderOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name.
- *
+ * 
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `200`.
- *
+ * 
  * @param {number|undefined} options.maxResolution Maximum resolution.
- *
+ * 
  * @param {number|undefined} options.minResolution Minimum resolution.
- *
+ * 
  * @param {function(ol.MapEvent)|undefined} options.render Function called when the control should be re-rendered. This is called
  * in a requestAnimationFrame callback.
- *
+ * 
  */
 
 
@@ -880,24 +880,24 @@ export var control_ZoomSliderOptions;
  *     tipLabel: (string|undefined),
  *     extent: (ol.Extent|undefined)}}
  */
-export var control_ZoomToExtentOptions;
+export let control_ZoomToExtentOptions;
 
 /**
  * @param {control_ZoomToExtentOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className Class name. Default is `ol-zoom-extent`.
- *
+ * 
  * @param {Element|string|undefined} options.target Specify a target if you want the control to be rendered outside of the map's
  * viewport.
- *
+ * 
  * @param {string|Node|undefined} options.label Text label to use for the button. Default is `E`.
  * Instead of text, also a Node (e.g. a `span` element) can be used.
- *
+ * 
  * @param {string|undefined} options.tipLabel Text label to use for the button tip. Default is `Zoom to extent`
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The extent to zoom to. If undefined the validity extent of the view
  * projection is used.
- *
+ * 
  */
 
 
@@ -907,7 +907,7 @@ export var control_ZoomToExtentOptions;
  *     featureProjection: ol.ProjectionLike,
  *     rightHanded: (boolean|undefined)}}
  */
-export var format_ReadOptions;
+export let format_ReadOptions;
 
 /**
  * @param {format_ReadOptions} options TODO: repace this
@@ -917,13 +917,13 @@ export var format_ReadOptions;
  * the format is assigned (where set). If the projection can not be derived from
  * the data and if no `defaultDataProjection` is set for a format, the features
  * will not be reprojected.
- *
+ * 
  * @param {ol.Extent} options.extent Tile extent of the tile being read. This is only used and required for
  * {@link ol.format.MVT}.
- *
+ * 
  * @param {ol.ProjectionLike} options.featureProjection Projection of the feature geometries created by the format reader. If not
  * provided, features will be returned in the `dataProjection`.
- *
+ * 
  */
 
 
@@ -933,7 +933,7 @@ export var format_ReadOptions;
  *     rightHanded: (boolean|undefined),
  *     decimals: (number|undefined)}}
  */
-export var format_WriteOptions;
+export let format_WriteOptions;
 
 /**
  * @param {format_WriteOptions} options TODO: repace this
@@ -942,11 +942,11 @@ export var format_WriteOptions;
  * `defaultDataProjection` of the format is assigned (where set). If no
  * `defaultDataProjection` is set for a format, the features will be returned
  * in the `featureProjection`.
- *
+ * 
  * @param {ol.ProjectionLike} options.featureProjection Projection of the feature geometries that will be serialized by the format
  * writer. If not provided, geometries are assumed to be in the
  * `dataProjection` if that is set; in other words, they are not transformed.
- *
+ * 
  * @param {boolean|undefined} options.rightHanded When writing geometries, follow the right-hand rule for linear ring
  * orientation.  This means that polygons will have counter-clockwise exterior
  * rings and clockwise interior rings.  By default, coordinates are serialized
@@ -955,16 +955,16 @@ export var format_WriteOptions;
  * exterior and counter-clockwise for interior rings).  Note that not all
  * formats support this.  The GeoJSON format does use this property when writing
  * geometries.
- *
- *
+ * 
+ * 
  * @param {number|undefined} options.decimals Maximum number of decimal places for coordinates. Coordinates are stored
  * internally as floats, but floating-point arithmetic can create coordinates
  * with a large number of decimal places, not generally wanted on output.
  * Set a number here to round coordinates. Can also be used to ensure that
  * coordinates read in can be written back out with the same number of decimals.
  * Default is no rounding.
- *
- *
+ * 
+ * 
  */
 
 
@@ -974,37 +974,37 @@ export var format_WriteOptions;
  *     extractGeometryName: (boolean|undefined),
  *     featureProjection: ol.ProjectionLike}}
  */
-export var format_GeoJSONOptions;
+export let format_GeoJSONOptions;
 
 /**
  * @param {format_GeoJSONOptions} options TODO: repace this
  *
  * @param {ol.ProjectionLike} options.defaultDataProjection Default data projection. Default is `EPSG:4326`.
- *
+ * 
  * @param {ol.ProjectionLike} options.featureProjection Projection for features read or written by the format.  Options passed to
  * read or write methods will take precedence.
- *
+ * 
  * @param {string|undefined} options.geometryName Geometry name to use when creating features.
- *
+ * 
  * @param {boolean|undefined} options.extractGeometryName Certain GeoJSON providers include the geometry_name field in the feature
  * geoJSON. If set to `true` the geoJSON reader will look for that field to
  * set the geometry name. If both this field is set to `true` and a
  * `geometryName` is provided, the `geometryName` will take precedence.
  * Default is `false`.
- *
+ * 
  */
 
 
 /**
  * @typedef {{geometryName: (string|undefined)}}
  */
-export var format_EsriJSONOptions;
+export let format_EsriJSONOptions;
 
 /**
  * @param {format_EsriJSONOptions} options TODO: repace this
  *
  * @param {string|undefined} options.geometryName Geometry name to use when creating features.
- *
+ * 
  */
 
 
@@ -1017,7 +1017,7 @@ export var format_EsriJSONOptions;
  *     layers: (Array.<string>|undefined),
  *     layerName: (string|undefined)}}
  */
-export var format_MVTOptions;
+export let format_MVTOptions;
 
 /**
  * @param {format_MVTOptions} options TODO: repace this
@@ -1028,14 +1028,14 @@ export var format_MVTOptions;
  * {@link ol.Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link ol.render.Feature},
  * which is optimized for rendering and hit detection.
- *
+ * 
  * @param {string|undefined} options.geometryName Geometry name to use when creating features. Default is 'geometry'.
- *
+ * 
  * @param {string|undefined} options.layerName Name of the feature attribute that holds the layer name. Default is 'layer'.
- *
+ * 
  * @param {Array.<string>|undefined} options.layers Layers to read features from. If not provided, features will be read from all
  * layers.
- *
+ * 
  */
 
 
@@ -1043,17 +1043,17 @@ export var format_MVTOptions;
  * @typedef {{factor: (number|undefined),
  *     geometryLayout: (ol.geom.GeometryLayout|undefined)}}
  */
-export var format_PolylineOptions;
+export let format_PolylineOptions;
 
 /**
  * @param {format_PolylineOptions} options TODO: repace this
  *
  * @param {number|undefined} options.factor The factor by which the coordinates values will be scaled.
  * Default is `1e5`.
- *
+ * 
  * @param {ol.geom.GeometryLayout|undefined} options.geometryLayout Layout of the feature geometries created by the format reader.
  * Default is `ol.geom.GeometryLayout.XY`.
- *
+ * 
  */
 
 
@@ -1064,13 +1064,13 @@ export var format_PolylineOptions;
  *     layers: (Array.<string>|undefined)
  * }}
  */
-export var format_TopoJSONOptions;
+export let format_TopoJSONOptions;
 
 /**
  * @param {format_TopoJSONOptions} options TODO: repace this
  *
  * @param {ol.ProjectionLike} options.defaultDataProjection Default data projection. Default is `EPSG:4326`.
- *
+ * 
  * @param {string|undefined} options.layerName Set the name of the TopoJSON topology `objects`'s children as feature
  * property with the specified name. This means that when set to `'layer'`, a
  * topology like
@@ -1087,24 +1087,24 @@ export var format_TopoJSONOptions;
  * ```
  * will result in features that have a property `'layer'` set to `'example'`.
  * When not set, no property will be added to features.
- *
+ * 
  * @param {Array.<string>|undefined} options.layers Names of the TopoJSON topology's `objects`'s children to read features from.
  * If not provided, features will be read from all children.
- *
+ * 
  */
 
 
 /**
  * @typedef {{altitudeMode: (ol.format.IGCZ|undefined)}}
  */
-export var format_IGCOptions;
+export let format_IGCOptions;
 
 /**
  * @param {format_IGCOptions} options TODO: repace this
  *
  * @param {ol.format.IGCZ|undefined} options.altitudeMode Altitude mode. Possible values are `barometric`, `gps`, and `none`. Default
  * is `none`.
- *
+ * 
  */
 
 
@@ -1114,19 +1114,19 @@ export var format_IGCOptions;
  *     showPointNames: (boolean|undefined),
  *     writeStyles: (boolean|undefined)}}
  */
-export var format_KMLOptions;
+export let format_KMLOptions;
 
 /**
  * @param {format_KMLOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.extractStyles Extract styles from the KML. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.showPointNames Show names as labels for placemarks which contain points. Default is `true`.
- *
+ * 
  * @param {Array.<ol.style.Style>|undefined} options.defaultStyle Default style. The default default style is the same as Google Earth.
- *
+ * 
  * @param {boolean|undefined} options.writeStyles Write styles into KML. Default is `true`.
- *
+ * 
  */
 
 
@@ -1140,7 +1140,7 @@ export var format_KMLOptions;
  *     multiSurface: (boolean|undefined),
  *     schemaLocation: (string|undefined)}}
  */
-export var format_GMLOptions;
+export let format_GMLOptions;
 
 /**
  * @param {format_GMLOptions} options TODO: repace this
@@ -1152,7 +1152,7 @@ export var format_GMLOptions;
  * feature namespaces themselves. So for instance there might be a featureType
  * item `topp:states` in the `featureType` array and then there will be a key
  * `topp` in the featureNS object with value `http://www.openplans.org/topp`.
- *
+ * 
  * @param {Array.<string>|string|undefined} options.featureType Feature type(s) to parse. If multiple feature types need to be configured
  * which come from different feature namespaces, `featureNS` will be an object
  * with the keys being the prefixes used in the entries of featureType array.
@@ -1160,31 +1160,31 @@ export var format_GMLOptions;
  * So for instance there might be a featureType item `topp:states` and then
  * there will be a key named `topp` in the featureNS object with value
  * `http://www.openplans.org/topp`.
- *
+ * 
  * @param {string} options.srsName srsName to use when writing geometries.
- *
+ * 
  * @param {boolean|undefined} options.surface Write gml:Surface instead of gml:Polygon elements. This also affects the
  * elements in multi-part geometries. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.curve Write gml:Curve instead of gml:LineString elements. This also affects the
  * elements in multi-part geometries. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.multiCurve Write gml:MultiCurve instead of gml:MultiLineString. Since the latter is
  * deprecated in GML 3, the default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.multiSurface Write gml:multiSurface instead of gml:MultiPolygon. Since the latter is
  * deprecated in GML 3, the default is `true`.
- *
+ * 
  * @param {string|undefined} options.schemaLocation Optional schemaLocation to use when writing out the GML, this will override
  * the default provided.
- *
+ * 
  */
 
 
 /**
  * @typedef {{readExtensions: (function(ol.Feature, Node)|undefined)}}
  */
-export var format_GPXOptions;
+export let format_GPXOptions;
 
 /**
  * @param {format_GPXOptions} options TODO: repace this
@@ -1195,7 +1195,7 @@ export var format_GPXOptions;
  * node is not allowed in GPX 1.0. Moreover, only `extensions`
  * nodes from `wpt`, `rte` and `trk` can be processed, as those are
  * directly mapped to a feature.
- *
+ * 
  */
 
 
@@ -1205,20 +1205,20 @@ export var format_GPXOptions;
  *     gmlFormat: (ol.format.GMLBase|undefined),
  *     schemaLocation: (string|undefined)}}
  */
-export var format_WFSOptions;
+export let format_WFSOptions;
 
 /**
  * @param {format_WFSOptions} options TODO: repace this
  *
  * @param {Object.<string, string>|string|undefined} options.featureNS The namespace URI used for features.
- *
+ * 
  * @param {Array.<string>|string|undefined} options.featureType The feature type to parse. Only used for read operations.
- *
+ * 
  * @param {ol.format.GMLBase|undefined} options.gmlFormat The GML format to use to parse the response. Default is `ol.format.GML3`.
- *
+ * 
  * @param {string|undefined} options.schemaLocation Optional schemaLocation to use for serialization, this will override the
  * default.
- *
+ * 
  */
 
 
@@ -1238,44 +1238,44 @@ export var format_WFSOptions;
  *     filter: (ol.format.filter.Filter|undefined),
  *     resultType: (string|undefined)}}
  */
-export var format_WFSWriteGetFeatureOptions;
+export let format_WFSWriteGetFeatureOptions;
 
 /**
  * @param {format_WFSWriteGetFeatureOptions} options TODO: repace this
  *
  * @param {string} options.featureNS The namespace URI used for features.
- *
+ * 
  * @param {string} options.featurePrefix The prefix for the feature namespace.
- *
+ * 
  * @param {Array.<string>} options.featureTypes The feature type names.
- *
+ * 
  * @param {string|undefined} options.srsName SRS name. No srsName attribute will be set on geometries when this is not
  * provided.
- *
+ * 
  * @param {string|undefined} options.handle Handle.
- *
+ * 
  * @param {string|undefined} options.outputFormat Output format.
- *
+ * 
  * @param {number|undefined} options.maxFeatures Maximum number of features to fetch.
- *
+ * 
  * @param {string|undefined} options.geometryName Geometry name to use in a BBOX filter.
- *
+ * 
  * @param {Array.<string>|undefined} options.propertyNames Optional list of property names to serialize.
- *
+ * 
  * @param {number|undefined} options.startIndex Start index to use for WFS paging. This is a WFS 2.0 feature backported to
  * WFS 1.1.0 by some Web Feature Services.
- *
+ * 
  * @param {number|undefined} options.count Number of features to retrieve when paging. This is a WFS 2.0 feature
  * backported to WFS 1.1.0 by some Web Feature Services. Please note that some
  * Web Feature Services have repurposed `maxfeatures` instead.
- *
+ * 
  * @param {ol.Extent|undefined} options.bbox Extent to use for the BBOX filter.
- *
+ * 
  * @param {ol.format.filter.Filter|undefined} options.filter Filter condition. See {@link ol.format.filter} for more information.
- *
+ * 
  * @param {string|undefined} options.resultType Indicates what response should be returned, E.g. `hits` only includes the
  * `numberOfFeatures` attribute in the response and no features.
- *
+ * 
  */
 
 
@@ -1290,46 +1290,46 @@ export var format_WFSWriteGetFeatureOptions;
  *     gmlOptions: (olx.format.GMLOptions|undefined),
  *     version: (string|undefined)}}
  */
-export var format_WFSWriteTransactionOptions;
+export let format_WFSWriteTransactionOptions;
 
 /**
  * @param {format_WFSWriteTransactionOptions} options TODO: repace this
  *
  * @param {string} options.featureNS The namespace URI used for features.
- *
+ * 
  * @param {string} options.featurePrefix The prefix for the feature namespace.
- *
+ * 
  * @param {string} options.featureType The feature type name.
- *
+ * 
  * @param {string|undefined} options.srsName SRS name. No srsName attribute will be set on geometries when this is not
  * provided.
- *
+ * 
  * @param {string|undefined} options.handle Handle.
- *
+ * 
  * @param {boolean|undefined} options.hasZ Must be set to true if the transaction is for a 3D layer. This will allow
  * the Z coordinate to be included in the transaction.
- *
+ * 
  * @param {Array.<Object>} options.nativeElements Native elements. Currently not supported.
- *
+ * 
  * @param {olx.format.GMLOptions|undefined} options.gmlOptions GML options for the WFS transaction writer.
- *
+ * 
  * @param {string|undefined} options.version WFS version to use for the transaction. Can be either `1.0.0` or `1.1.0`.
  * Default is `1.1.0`.
- *
+ * 
  */
 
 
 /**
  * @typedef {{splitCollection: (boolean|undefined)}}
  */
-export var format_WKTOptions;
+export let format_WKTOptions;
 
 /**
  * @param {format_WKTOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.splitCollection Whether to split GeometryCollections into
  * multiple features on reading. Default is `false`.
- *
+ * 
  */
 
 
@@ -1338,14 +1338,14 @@ export var format_WKTOptions;
  *     layers: (Array.<string>|undefined)
  * }}
  */
-export var format_WMSGetFeatureInfoOptions;
+export let format_WMSGetFeatureInfoOptions;
 
 /**
  * @param {format_WMSGetFeatureInfoOptions} options TODO: repace this
  *
  * @param {Array.<string>|undefined} options.layers If set, only features of the given layers will be returned by the format
  * when read.
- *
+ * 
  */
 
 
@@ -1365,34 +1365,34 @@ export var format_WMSGetFeatureInfoOptions;
  *     zoomDuration: (number|undefined)
  * }}
  */
-export var interaction_DefaultsOptions;
+export let interaction_DefaultsOptions;
 
 /**
  * @param {interaction_DefaultsOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.altShiftDragRotate Whether Alt-Shift-drag rotate is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.constrainResolution Zoom to the closest integer zoom level after the wheel/trackpad or
  * pinch gesture ends. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.doubleClickZoom Whether double click zoom is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.keyboard Whether keyboard interaction is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.mouseWheelZoom Whether mousewheel zoom is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.shiftDragZoom Whether Shift-drag zoom is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.dragPan Whether drag pan is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.pinchRotate Whether pinch rotate is desired. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.pinchZoom Whether pinch zoom is desired. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.zoomDelta Zoom delta.
- *
+ * 
  * @param {number|undefined} options.zoomDuration Zoom duration.
- *
+ * 
  */
 
 
@@ -1400,15 +1400,15 @@ export var interaction_DefaultsOptions;
  * @typedef {{duration: (number|undefined),
  *     delta: (number|undefined)}}
  */
-export var interaction_DoubleClickZoomOptions;
+export let interaction_DoubleClickZoomOptions;
 
 /**
  * @param {interaction_DoubleClickZoomOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- *
+ * 
  * @param {number|undefined} options.delta The zoom delta applied on each double click, default is `1`.
- *
+ * 
  */
 
 
@@ -1418,23 +1418,23 @@ export var interaction_DoubleClickZoomOptions;
  *     projection: ol.ProjectionLike,
  *     target: (Element|undefined)}}
  */
-export var interaction_DragAndDropOptions;
+export let interaction_DragAndDropOptions;
 
 /**
  * @param {interaction_DragAndDropOptions} options TODO: repace this
  *
  * @param {Array.<function(new: ol.format.Feature)>|undefined} options.formatConstructors Format constructors.
- *
+ * 
  * @param {ol.source.Vector|undefined} options.source Optional vector source where features will be added.  If a source is provided
  * all existing features will be removed and new features will be added when
  * they are dropped on the target.  If you want to add features to a vector
  * source without removing the existing features (append only), instead of
  * providing the source option listen for the "addfeatures" event.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Target projection. By default, the map's view's projection is used.
- *
+ * 
  * @param {Element|undefined} options.target The element that is used as the drop target, default is the viewport element.
- *
+ * 
  */
 
 
@@ -1444,24 +1444,24 @@ export var interaction_DragAndDropOptions;
  *     minArea: (number|undefined),
  *     boxEndCondition: (ol.DragBoxEndConditionType|undefined)}}
  */
-export var interaction_DragBoxOptions;
+export let interaction_DragBoxOptions;
 
 /**
  * @param {interaction_DragBoxOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name for styling the box. The default is `ol-dragbox`.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.always}.
- *
+ * 
  * @param {number|undefined} options.minArea The minimum area of the box in pixel, this value is used by the default
  * `boxEndCondition` function. Default is `64`.
- *
+ * 
  * @param {ol.DragBoxEndConditionType|undefined} options.boxEndCondition A function that takes a {@link ol.MapBrowserEvent} and two
  * {@link ol.Pixel}s to indicate whether a `boxend` event should be fired.
  * Default is `true` if the area of the box is bigger than the `minArea` option.
- *
+ * 
  */
 
 
@@ -1469,7 +1469,7 @@ export var interaction_DragBoxOptions;
  * @typedef {{condition: (ol.EventsConditionType|undefined),
  *     kinetic: (ol.Kinetic|undefined)}}
  */
-export var interaction_DragPanOptions;
+export let interaction_DragPanOptions;
 
 /**
  * @param {interaction_DragPanOptions} options TODO: repace this
@@ -1477,9 +1477,9 @@ export var interaction_DragPanOptions;
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.noModifierKeys}.
- *
+ * 
  * @param {ol.Kinetic|undefined} options.kinetic Kinetic inertia to apply to the pan.
- *
+ * 
  */
 
 
@@ -1487,7 +1487,7 @@ export var interaction_DragPanOptions;
  * @typedef {{condition: (ol.EventsConditionType|undefined),
  *     duration: (number|undefined)}}
  */
-export var interaction_DragRotateAndZoomOptions;
+export let interaction_DragRotateAndZoomOptions;
 
 /**
  * @param {interaction_DragRotateAndZoomOptions} options TODO: repace this
@@ -1495,9 +1495,9 @@ export var interaction_DragRotateAndZoomOptions;
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.shiftKeyOnly}.
- *
+ * 
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `400`.
- *
+ * 
  */
 
 
@@ -1505,7 +1505,7 @@ export var interaction_DragRotateAndZoomOptions;
  * @typedef {{condition: (ol.EventsConditionType|undefined),
  *     duration: (number|undefined)}}
  */
-export var interaction_DragRotateOptions;
+export let interaction_DragRotateOptions;
 
 /**
  * @param {interaction_DragRotateOptions} options TODO: repace this
@@ -1513,9 +1513,9 @@ export var interaction_DragRotateOptions;
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.altShiftKeysOnly}.
- *
+ * 
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- *
+ * 
  */
 
 
@@ -1525,21 +1525,21 @@ export var interaction_DragRotateOptions;
  *     duration: (number|undefined),
  *     out: (boolean|undefined)}}
  */
-export var interaction_DragZoomOptions;
+export let interaction_DragZoomOptions;
 
 /**
  * @param {interaction_DragZoomOptions} options TODO: repace this
  *
  * @param {string|undefined} options.className CSS class name for styling the box. The default is `ol-dragzoom`.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.shiftKeyOnly}.
- *
+ * 
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `200`.
- *
+ * 
  * @param {boolean|undefined} options.out Use interaction for zooming out. Default is `false`.
- *
+ * 
  */
 
 
@@ -1561,7 +1561,7 @@ export var interaction_DragZoomOptions;
  *     freehandCondition: (ol.EventsConditionType|undefined),
  *     wrapX: (boolean|undefined)}}
  */
-export var interaction_DrawOptions;
+export let interaction_DrawOptions;
 
 /**
  * @param {interaction_DrawOptions} options TODO: repace this
@@ -1571,51 +1571,51 @@ export var interaction_DrawOptions;
  * geometry being drawn.  Default is 6 pixels.  That value was chosen for
  * the draw interaction to behave correctly on mouse as well as on touch
  * devices.
- *
+ * 
  * @param {ol.Collection.<ol.Feature>|undefined} options.features Destination collection for the drawn features.
- *
+ * 
  * @param {ol.source.Vector|undefined} options.source Destination source for the drawn features.
- *
+ * 
  * @param {number|undefined} options.snapTolerance Pixel distance for snapping to the drawing finish. Default is `12`.
- *
+ * 
  * @param {ol.geom.GeometryType|string} options.type Drawing type ('Point', 'LineString', 'Polygon', 'MultiPoint',
  * 'MultiLineString', 'MultiPolygon' or 'Circle').
- *
+ * 
  * @param {boolean|undefined} options.stopClick Stop click, singleclick, and doubleclick events from firing during drawing.
  * Default is `false`.
- *
+ * 
  * @param {number|undefined} options.maxPoints The number of points that can be drawn before a polygon ring or line string
  * is finished. The default is no restriction.
- *
+ * 
  * @param {number|undefined} options.minPoints The number of points that must be drawn before a polygon ring or line string
  * can be finished. Default is `3` for polygon rings and `2` for line strings.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.finishCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether the drawing can be finished.
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style for sketch features.
- *
+ * 
  * @param {ol.DrawGeometryFunctionType|undefined} options.geometryFunction Function that is called when a geometry's coordinates are updated.
- *
+ * 
  * @param {string|undefined} options.geometryName Geometry name to use for features created by the draw interaction.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default {@link ol.events.condition.noModifierKeys}, i.e. a click, adds a
  * vertex or deactivates freehand drawing.
- *
+ * 
  * @param {boolean|undefined} options.freehand Operate in freehand mode for lines, polygons, and circles.  This makes the
  * interaction always operate in freehand mode and takes precedence over any
  * `freehandCondition` option.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.freehandCondition Condition that activates freehand drawing for lines and polygons. This
  * function takes an {@link ol.MapBrowserEvent} and returns a boolean to
  * indicate whether that event should be handled. The default is
  * {@link ol.events.condition.shiftKeyOnly}, meaning that the Shift key
  * activates freehand drawing.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
- *
+ * 
  */
 
 
@@ -1627,25 +1627,25 @@ export var interaction_DrawOptions;
  *     wrapX: (boolean|undefined)}}
  * @api
  */
-export var interaction_ExtentOptions;
+export let interaction_ExtentOptions;
 
 /**
  * @param {interaction_ExtentOptions} options TODO: repace this
  *
  * @param {ol.Extent|undefined} options.extent Initial extent. Defaults to no initial extent
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.boxStyle Style for the drawn extent box.
  * Defaults to ol.style.Style.createDefaultEditing()[ol.geom.GeometryType.POLYGON]
- *
+ * 
  * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for editing. Default is `10`.
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.pointerStyle Style for the cursor used to draw the extent.
  * Defaults to ol.style.Style.createDefaultEditing()[ol.geom.GeometryType.POINT]
- *
+ * 
  * @param {boolean|undefined} options.wrapX Wrap the drawn extent across multiple maps in the X direction?
  * Only affects visuals, not functionality. Defaults to false.
- *
+ * 
  */
 
 
@@ -1656,24 +1656,24 @@ export var interaction_ExtentOptions;
  *     hitTolerance: (number|undefined)
  * }}
  */
-export var interaction_TranslateOptions;
+export let interaction_TranslateOptions;
 
 /**
  * @param {interaction_TranslateOptions} options TODO: repace this
  *
  * @param {ol.Collection.<ol.Feature>|undefined} options.features Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
- *
+ * 
  * @param {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} options.layers A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be translatable. If the option is
  * absent, all visible layers will be considered translatable.
- *
+ * 
  * @param {number|undefined} options.hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- *
+ * 
  */
 
 
@@ -1682,7 +1682,7 @@ export var interaction_TranslateOptions;
  *     duration: (number|undefined),
  *     pixelDelta: (number|undefined)}}
  */
-export var interaction_KeyboardPanOptions;
+export let interaction_KeyboardPanOptions;
 
 /**
  * @param {interaction_KeyboardPanOptions} options TODO: repace this
@@ -1691,11 +1691,11 @@ export var interaction_KeyboardPanOptions;
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.noModifierKeys} and
  * {@link ol.events.condition.targetNotEditable}.
- *
+ * 
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `100`.
- *
+ * 
  * @param {number|undefined} options.pixelDelta Pixel The amount to pan on each key press. Default is `128` pixels.
- *
+ * 
  */
 
 
@@ -1704,19 +1704,19 @@ export var interaction_KeyboardPanOptions;
  *     condition: (ol.EventsConditionType|undefined),
  *     delta: (number|undefined)}}
  */
-export var interaction_KeyboardZoomOptions;
+export let interaction_KeyboardZoomOptions;
 
 /**
  * @param {interaction_KeyboardZoomOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `100`.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol.events.condition.targetNotEditable}.
- *
+ * 
  * @param {number|undefined} options.delta The amount to zoom on each key press. Default is `1`.
- *
+ * 
  */
 
 
@@ -1732,7 +1732,7 @@ export var interaction_KeyboardZoomOptions;
  *     wrapX: (boolean|undefined)
  * }}
  */
-export var interaction_ModifyOptions;
+export let interaction_ModifyOptions;
 
 /**
  * @param {interaction_ModifyOptions} options TODO: repace this
@@ -1741,30 +1741,30 @@ export var interaction_ModifyOptions;
  * to indicate whether that event will be considered to add or move a vertex
  * to the sketch.
  * Default is {@link ol.events.condition.primaryAction}.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.deleteCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default, {@link ol.events.condition.singleClick} with
  * {@link ol.events.condition.altKeyOnly} results in a vertex deletion.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.insertVertexCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether a new vertex can be added to the sketch features.
  * Default is {@link ol.events.condition.always}
- *
+ * 
  * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for editing. Default is `10`.
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style used for the features being modified. By default the default edit
  * style is used (see {@link ol.style}).
- *
+ * 
  * @param {ol.source.Vector|undefined} options.source The vector source with features to modify.  If a vector source is not
  * provided, a feature collection must be provided with the features option.
- *
+ * 
  * @param {ol.Collection.<ol.Feature>|undefined} options.features The features the interaction works on.  If a feature collection is not
  * provided, a vector source must be provided with the source option.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the sketch overlay. Default is `false`.
- *
+ * 
  */
 
 
@@ -1774,23 +1774,23 @@ export var interaction_ModifyOptions;
  *     timeout: (number|undefined),
  *     useAnchor: (boolean|undefined)}}
  */
-export var interaction_MouseWheelZoomOptions;
+export let interaction_MouseWheelZoomOptions;
 
 /**
  * @param {interaction_MouseWheelZoomOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `250`.
- *
+ * 
  * @param {number|undefined} options.timeout Mouse wheel timeout duration in milliseconds. Default is `80`.
- *
+ * 
  * @param {boolean|undefined} options.constrainResolution When using a trackpad or magic mouse, zoom to the closest integer zoom level
  * after the scroll gesture ends.
  * Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.useAnchor Enable zooming using the mouse's location as the anchor. Default is `true`.
  * When set to false, zooming in and out will zoom to the center of the screen
  * instead of zooming on the mouse's location.
- *
+ * 
  */
 
 
@@ -1798,15 +1798,15 @@ export var interaction_MouseWheelZoomOptions;
  * @typedef {{threshold: (number|undefined),
  *     duration: (number|undefined)}}
  */
-export var interaction_PinchRotateOptions;
+export let interaction_PinchRotateOptions;
 
 /**
  * @param {interaction_PinchRotateOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration The duration of the animation in milliseconds. Default is `250`.
- *
+ * 
  * @param {number|undefined} options.threshold Minimal angle in radians to start a rotation. Default is `0.3`.
- *
+ * 
  */
 
 
@@ -1816,15 +1816,15 @@ export var interaction_PinchRotateOptions;
  *     constrainResolution: (boolean|undefined)
  * }}
  */
-export var interaction_PinchZoomOptions;
+export let interaction_PinchZoomOptions;
 
 /**
  * @param {interaction_PinchZoomOptions} options TODO: repace this
  *
  * @param {number|undefined} options.duration Animation duration in milliseconds. Default is `400`.
- *
+ * 
  * @param {boolean|undefined} options.constrainResolution Zoom to the closest integer zoom level after the pinch gesture ends. Default is `false`.
- *
+ * 
  */
 
 
@@ -1835,29 +1835,29 @@ export var interaction_PinchZoomOptions;
  *     handleMoveEvent: (function(ol.MapBrowserPointerEvent)|undefined),
  *     handleUpEvent: (function(ol.MapBrowserPointerEvent):boolean|undefined)}}
  */
-export var interaction_PointerOptions;
+export let interaction_PointerOptions;
 
 /**
  * @param {interaction_PointerOptions} options TODO: repace this
  *
  * @param {(function(ol.MapBrowserPointerEvent):boolean|undefined)} options.handleDownEvent Function handling "down" events. If the function returns `true` then a drag
  * sequence is started.
- *
+ * 
  * @param {(function(ol.MapBrowserPointerEvent)|undefined)} options.handleDragEvent Function handling "drag" events. This function is called on "move" events
  * during a drag sequence.
- *
+ * 
  * @param {(function(ol.MapBrowserEvent):boolean|undefined)} options.handleEvent Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. The function may return `false` to prevent the
  * propagation of the event to other interactions in the map's interactions
  * chain.
- *
+ * 
  * @param {(function(ol.MapBrowserPointerEvent)|undefined)} options.handleMoveEvent Function handling "move" events. This function is called on "move" events,
  * also during a drag sequence (so during a drag sequence both the
  * `handleDragEvent` function and this function are called).
- *
+ * 
  * @param {(function(ol.MapBrowserPointerEvent):boolean|undefined)} options.handleUpEvent Function handling "up" events. If the function returns `false` then the
  * current drag sequence is stopped.
- *
+ * 
  */
 
 
@@ -1874,7 +1874,7 @@ export var interaction_PointerOptions;
  *     wrapX: (boolean|undefined),
  *     hitTolerance: (number|undefined)}}
  */
-export var interaction_SelectOptions;
+export let interaction_SelectOptions;
 
 /**
  * @param {interaction_SelectOptions} options TODO: repace this
@@ -1883,7 +1883,7 @@ export var interaction_SelectOptions;
  * to indicate whether that event should be handled.
  * By default, this is {@link ol.events.condition.never}. Use this if you want
  * to use different events for add and remove instead of `toggle`.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.condition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * This is the event for the selected features as a whole. By default, this is
@@ -1892,21 +1892,21 @@ export var interaction_SelectOptions;
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- *
+ * 
  * @param {undefined|Array.<ol.layer.Layer>|function(ol.layer.Layer): boolean} options.layers A list of layers from which features should be
  * selected. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be selectable. If the option is
  * absent, all visible layers will be considered selectable.
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Style for the selected features. By default the default edit style is used
  * (see {@link ol.style}).
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.removeCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * By default, this is {@link ol.events.condition.never}. Use this if you want
  * to use different events for add and remove instead of `toggle`.
- *
+ * 
  * @param {ol.EventsConditionType|undefined} options.toggleCondition A function that takes an {@link ol.MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * This is in addition to the `condition` event. By default,
@@ -1915,25 +1915,25 @@ export var interaction_SelectOptions;
  * not currently selected, and removes it if it is.
  * See `add` and `remove` if you want to use different events instead of a
  * toggle.
- *
+ * 
  * @param {boolean|undefined} options.multi A boolean that determines if the default behaviour should select only
  * single features or all (overlapping) features at the clicked map
  * position. Default is false i.e single select
- *
+ * 
  * @param {ol.Collection.<ol.Feature>|undefined} options.features Collection where the interaction will place selected features. Optional. If
  * not set the interaction will create a collection. In any case the collection
  * used by the interaction is returned by
  * {@link ol.interaction.Select#getFeatures}.
- *
+ * 
  * @param {ol.SelectFilterFunction|undefined} options.filter A function that takes an {@link ol.Feature} and an {@link ol.layer.Layer} and
  * returns `true` if the feature may be selected or `false` otherwise.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Wrap the world horizontally on the selection overlay. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.hitTolerance Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features. This only works for the canvas renderer and
  * not for WebGL. Default is `0`.
- *
+ * 
  */
 
 
@@ -1947,22 +1947,22 @@ export var interaction_SelectOptions;
  *     vertex: (boolean|undefined)
  * }}
  */
-export var interaction_SnapOptions;
+export let interaction_SnapOptions;
 
 /**
  * @param {interaction_SnapOptions} options TODO: repace this
  *
  * @param {ol.Collection.<ol.Feature>|undefined} options.features Snap to these features. Either this option or source should be provided.
- *
+ * 
  * @param {boolean|undefined} options.edge Snap to edges. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.vertex Snap to vertices. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.pixelTolerance Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for snapping. Default is `10` pixels.
- *
+ * 
  * @param {ol.source.Vector|undefined} options.source Snap to features from this source. Either this option or features should be provided
- *
+ * 
  */
 
 
@@ -1974,25 +1974,25 @@ export var interaction_SnapOptions;
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined)}}
  */
-export var layer_BaseOptions;
+export let layer_BaseOptions;
 
 /**
  * @param {layer_BaseOptions} options TODO: repace this
  *
  * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true`.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  */
 
 
@@ -2005,29 +2005,29 @@ export var layer_BaseOptions;
  *     minResolution: (number|undefined),
  *     maxResolution: (number|undefined)}}
  */
-export var layer_LayerOptions;
+export let layer_LayerOptions;
 
 /**
  * @param {layer_LayerOptions} options TODO: repace this
  *
  * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- *
+ * 
  * @param {ol.source.Source|undefined} options.source Source for this layer.  If not provided to the constructor, the source can
  * be set by calling {@link ol.layer.Layer#setSource layer.setSource(source)}
  * after construction.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  */
 
 
@@ -2040,27 +2040,27 @@ export var layer_LayerOptions;
  *     maxResolution: (number|undefined),
  *     layers: (Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined)}}
  */
-export var layer_GroupOptions;
+export let layer_GroupOptions;
 
 /**
  * @param {layer_GroupOptions} options TODO: repace this
  *
  * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true`.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  * @param {Array.<ol.layer.Base>|ol.Collection.<ol.layer.Base>|undefined} options.layers Child layers.
- *
+ * 
  */
 
 
@@ -2078,40 +2078,40 @@ export var layer_GroupOptions;
  *     visible: (boolean|undefined),
  *     zIndex: (number|undefined)}}
  */
-export var layer_HeatmapOptions;
+export let layer_HeatmapOptions;
 
 /**
  * @param {layer_HeatmapOptions} options TODO: repace this
  *
  * @param {Array.<string>|undefined} options.gradient The color gradient of the heatmap, specified as an array of CSS color
  * strings. Default is `['#00f', '#0ff', '#0f0', '#ff0', '#f00']`.
- *
+ * 
  * @param {number|undefined} options.radius Radius size in pixels. Default is `8`.
- *
+ * 
  * @param {number|undefined} options.blur Blur size in pixels. Default is `15`.
- *
+ * 
  * @param {number|undefined} options.shadow Shadow size in pixels. Default is `250`.
- *
+ * 
  * @param {string|function(ol.Feature):number|undefined} options.weight The feature attribute to use for the weight or a function that returns a
  * weight from a feature. Weight values should range from 0 to 1 (and values
  * outside will be clamped to that range). Default is `weight`.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
- *
+ * 
  * @param {ol.source.Vector} options.source Source.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  */
 
 
@@ -2125,32 +2125,32 @@ export var layer_HeatmapOptions;
  *     maxResolution: (number|undefined),
  *     zIndex: (number|undefined)}}
  */
-export var layer_ImageOptions;
+export let layer_ImageOptions;
 
 /**
  * @param {layer_ImageOptions} options TODO: repace this
  *
  * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- *
+ * 
  * @param {ol.source.Image} options.source Source for this layer.
- *
+ * 
  * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  */
 
 
@@ -2166,37 +2166,37 @@ export var layer_ImageOptions;
  *     useInterimTilesOnError: (boolean|undefined),
  *     zIndex: (number|undefined)}}
  */
-export var layer_TileOptions;
+export let layer_TileOptions;
 
 /**
  * @param {layer_TileOptions} options TODO: repace this
  *
  * @param {number|undefined} options.opacity Opacity (0, 1). Default is `1`.
- *
+ * 
  * @param {number|undefined} options.preload Preload. Load low-resolution tiles up to `preload` levels. By default
  * `preload` is `0`, which means no preloading.
- *
+ * 
  * @param {ol.source.Tile} options.source Source for this layer.
- *
+ * 
  * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  * @param {boolean|undefined} options.useInterimTilesOnError Use interim tiles on error. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  */
 
 
@@ -2216,7 +2216,7 @@ export var layer_TileOptions;
  *     visible: (boolean|undefined),
  *     zIndex: (number|undefined)}}
  */
-export var layer_VectorOptions;
+export let layer_VectorOptions;
 
 /**
  * @param {layer_VectorOptions} options TODO: repace this
@@ -2228,52 +2228,52 @@ export var layer_VectorOptions;
  *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering
  *    even during animations, but slower performance.
  * Default is `vector`.
- *
+ * 
  * @param {ol.RenderOrderFunction|null|undefined} options.renderOrder Render order. Function to be used when sorting features before rendering. By
  * default features are drawn in the order that they are created. Use `null` to
  * avoid the sort, but get an undefined draw order.
- *
+ * 
  * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
- *
+ * 
  * @param {number|undefined} options.renderBuffer The buffer around the viewport extent used by the renderer when getting
  * features from the vector source for the rendering or hit-detection.
  * Recommended value: the size of the largest symbol, line width or label.
  * Default is 100 pixels.
- *
+ * 
  * @param {ol.source.Vector} options.source Source.
- *
+ * 
  * @param {boolean|undefined} options.declutter Declutter images and text. Decluttering is applied to all image and text
  * styles, and the priority is defined by the z-index of the style. Lower
  * z-index means higher priority. Default is `false`.
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
- *
+ * 
  * @param {boolean|undefined} options.updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
  * This means that no vectors will be shown clipped, but the setting will have a
  * performance impact for large amounts of vector data. When set to `false`,
  * batches will be recreated when no animation is active.  Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
  * See also `updateWhileAnimating`. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  */
 
 
@@ -2295,7 +2295,7 @@ export var layer_VectorOptions;
  *     visible: (boolean|undefined),
  *     zIndex: (number|undefined)}}
  */
-export var layer_VectorTileOptions;
+export let layer_VectorTileOptions;
 
 /**
  * @param {layer_VectorTileOptions} options TODO: repace this
@@ -2306,7 +2306,7 @@ export var layer_VectorTileOptions;
  * value should match the largest possible buffer of the used tiles. It should
  * be at least the size of the largest point symbol or line width.
  * Default is 100 pixels.
- *
+ * 
  * @param {ol.layer.VectorTileRenderType|string|undefined} options.renderMode Render mode for vector tiles:
  *  * `'image'`: Vector tiles are rendered as images. Great performance, but
  *    point symbols and texts are always rotated with the view and pixels are
@@ -2316,53 +2316,53 @@ export var layer_VectorTileOptions;
  *    rendered as vectors and can stay upright on rotated views.
  *  * `'vector'`: Vector tiles are rendered as vectors. Most accurate rendering
  *    even during animations, but slower performance than the other options.
- *
+ * 
  * When `declutter` is set to `true`, `'hybrid'` will be used instead of
  * `'image'`. The default is `'hybrid'`.
- *
+ * 
  * @param {ol.RenderOrderFunction|undefined} options.renderOrder Render order. Function to be used when sorting features before rendering. By
  * default features are drawn in the order that they are created.
- *
+ * 
  * @param {ol.PluggableMap|undefined} options.map Sets the layer as overlay on a map. The map will not manage this layer in its
  * layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it
  * managed by the map is to use {@link ol.Map#addLayer}.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent The bounding extent for layer rendering.  The layer will not be rendered
  * outside of this extent.
- *
+ * 
  * @param {number|undefined} options.minResolution The minimum resolution (inclusive) at which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.maxResolution The maximum resolution (exclusive) below which this layer will be visible.
- *
+ * 
  * @param {number|undefined} options.opacity Opacity. 0-1. Default is `1`.
- *
+ * 
  * @param {number|undefined} options.preload Preload. Load low-resolution tiles up to `preload` levels. By default
  * `preload` is `0`, which means no preloading.
- *
+ * 
  * @param {ol.source.VectorTile|undefined} options.source Source.
- *
+ * 
  * @param {boolean|undefined} options.declutter Declutter images and text. Decluttering is applied to all image and text
  * styles, and the priority is defined by the z-index of the style. Lower
  * z-index means higher priority. When set to `true`, a `renderMode` of
  * `'image'` will be overridden with `'hybrid'`. Default is `false`.
- *
+ * 
  * @param {ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined} options.style Layer style. See {@link ol.style} for default style which will be used if
  * this is not defined.
- *
+ * 
  * @param {boolean|undefined} options.updateWhileAnimating When set to `true`, feature batches will be recreated during animations.
  * This means that no vectors will be shown clipped, but the setting will have a
  * performance impact for large amounts of vector data. When set to `false`,
  * batches will be recreated when no animation is active.  Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.updateWhileInteracting When set to `true`, feature batches will be recreated during interactions.
  * See also `updateWhileAnimating`. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.visible Visibility. Default is `true` (visible).
- *
+ * 
  * @param {number|undefined} options.zIndex The z-index for layer rendering.  At rendering time, the layers will be
  * ordered, first by Z-index and then by position. The default Z-index is 0.
- *
+ * 
  */
 
 
@@ -2374,20 +2374,20 @@ export var layer_VectorTileOptions;
  *     resolution: number,
  *     rotation: number}}
  */
-export var render_State;
+export let render_State;
 
 /**
  * @param {render_State} options TODO: repace this
  *
  * @param {CanvasRenderingContext2D} options.context Canvas context that the layer is being rendered to.
- *
+ * 
  * @param {number} options.pixelRatio Pixel ratio used by the layer renderer.
- *
+ * 
  * @param {number} options.resolution Resolution that the render batch was created and optimized for. This is
  * not the view's resolution that is being rendered.
- *
+ * 
  * @param {number} options.rotation Rotation of the rendered layer in radians.
- *
+ * 
  */
 
 
@@ -2395,7 +2395,7 @@ export var render_State;
  * @typedef {{size: (ol.Size|undefined),
  *     pixelRatio: (number|undefined)}}
  */
-export var render_ToContextOptions;
+export let render_ToContextOptions;
 
 /**
  * @param {render_ToContextOptions} options TODO: repace this
@@ -2403,10 +2403,10 @@ export var render_ToContextOptions;
  * @param {ol.Size|undefined} options.size Desired size of the canvas in css pixels. When provided, both canvas and css
  * size will be set according to the `pixelRatio`. If not provided, the current
  * canvas and css sizes will not be altered.
- *
+ * 
  * @param {number|undefined} options.pixelRatio Pixel ratio (canvas pixel to css pixel ratio) for the canvas. Default
  * is the detected device pixel ratio.
- *
+ * 
  */
 
 
@@ -2422,39 +2422,39 @@ export var render_ToContextOptions;
  *     wrapX: (boolean|undefined),
  *     transition: (number|undefined)}}
  */
-export var source_BingMapsOptions;
+export let source_BingMapsOptions;
 
 /**
  * @param {source_BingMapsOptions} options TODO: repace this
  *
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {boolean|undefined} options.hidpi If `true` hidpi tiles will be requested. Default is `false`.
- *
+ * 
  * @param {string|undefined} options.culture Culture code. Default is `en-us`.
- *
+ * 
  * @param {string} options.key Bing Maps API key. Get yours at http://www.bingmapsportal.com/.
- *
+ * 
  * @param {string} options.imagerySet Type of imagery.
- *
+ * 
  * @param {number|undefined} options.maxZoom Max zoom. Default is what's advertized by the BingMaps service (`21`
  * currently).
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -2469,17 +2469,17 @@ export var source_BingMapsOptions;
  *     source: ol.source.Vector,
  *     wrapX: (boolean|undefined)}}
  */
-export var source_ClusterOptions;
+export let source_ClusterOptions;
 
 /**
  * @param {source_ClusterOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.distance Minimum distance in pixels between clusters. Default is `20`.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent Extent.
- *
+ * 
  * @param {undefined|function(ol.Feature):ol.geom.Point} options.geometryFunction Function that takes an {@link ol.Feature} as argument and returns an
  * {@link ol.geom.Point} as cluster calculation point for the feature. When a
  * feature should not be considered for clustering, the function should return
@@ -2492,17 +2492,17 @@ export var source_ClusterOptions;
  * ```
  * See {@link ol.geom.Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
- *
+ * 
  * @param {ol.format.Feature|undefined} options.format Format.
- *
+ * 
  * @param {string|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {ol.source.Vector} options.source Source.
- *
+ * 
  * @param {boolean|undefined} options.wrapX WrapX. Default is true
- *
+ * 
  */
 
 
@@ -2512,27 +2512,27 @@ export var source_ClusterOptions;
  *     tileJSON: (TileJSON|undefined),
  *     url: (string|undefined)}}
  */
-export var source_TileUTFGridOptions;
+export let source_TileUTFGridOptions;
 
 /**
  * @param {source_TileUTFGridOptions} options TODO: repace this
  *
  * @param {boolean|undefined} options.jsonp Use JSONP with callback to load the TileJSON. Useful when the server
  * does not support CORS. Default is `false`.
- *
+ * 
  * @param {boolean|undefined} options.preemptive If `true` the TileUTFGrid source loads the tiles based on their "visibility".
  * This improves the speed of response, but increases traffic.
  * Note that if set to `false`, you need to pass `true` as `opt_request`
  * to the `forDataAtCoordinateAndResolution` method otherwise no data
  * will ever be loaded.
  * Default is `true`.
- *
+ * 
  * @param {TileJSON|undefined} options.tileJSON TileJSON configuration for this source. If not provided, `url` must be
  * configured.
- *
+ * 
  * @param {string|undefined} options.url TileJSON endpoint that provides the configuration for this source. Request
  * will be made through JSONP. If not provided, `tileJSON` must be configured.
- *
+ * 
  */
 
 
@@ -2557,66 +2557,66 @@ export var source_TileUTFGridOptions;
  *            wrapX: (boolean|undefined),
  *            transition: (number|undefined)}}
  */
-export var source_TileImageOptions;
+export let source_TileImageOptions;
 
 /**
  * @param {source_TileImageOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {boolean|undefined} options.opaque Whether the layer is opaque.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.source.State|undefined} options.state Source state.
- *
+ * 
  * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
                 ol.TileLoadFunctionType)|undefined}
  options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
- *
+ * 
  * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`. Default is `1`.
- *
+ * 
  * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
- *
+ * 
  * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- *
+ * 
  * @param {Array.<string>|undefined} options.urls An array of URL templates.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. The default, `undefined`, is to
  * request out-of-bounds tiles from the server. When set to `false`, only one
  * world will be rendered. When set to `true`, tiles will be requested for one
  * world only, but they will be wrapped horizontally to render multiple worlds.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -2639,35 +2639,35 @@ export var source_TileImageOptions;
  *            wrapX: (boolean|undefined),
  *            transition: (number|undefined)}}
  */
-export var source_VectorTileOptions;
+export let source_VectorTileOptions;
 
 /**
  * @param {source_VectorTileOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `128`.
- *
+ * 
  * @param {ol.format.Feature|undefined} options.format Feature format for tiles. Used and required by the default
  * `tileLoadFunction`.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {boolean|undefined} options.overlaps This source may have overlapping geometries. Default is `true`. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {ol.source.State|undefined} options.state Source state.
- *
+ * 
  * @param {function(new: ol.VectorTile, ol.TileCoord,                ol.TileState, string, ol.format.Feature,
                 ol.TileLoadFunctionType)|undefined}
  options.tileClass Class used to instantiate vector tiles. Default is {@link ol.VectorTile}.
- *
+ * 
  * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. Could look like this:
  * ```js
  * function(tile, url) {
@@ -2682,22 +2682,22 @@ export var source_VectorTileOptions;
  *   };
  * });
  * ```
- *
+ * 
  * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
- *
+ * 
  * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- *
+ * 
  * @param {Array.<string>|undefined} options.urls An array of URL templates.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. When set to `false`, only one world
  * will be rendered. When set to `true`, tiles will be wrapped horizontally to
  * render multiple worlds. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -2713,34 +2713,34 @@ export var source_VectorTileOptions;
  *     imageLoadFunction: (ol.ImageLoadFunctionType|undefined),
  *     params: (Object|undefined)}}
  */
-export var source_ImageMapGuideOptions;
+export let source_ImageMapGuideOptions;
 
 /**
  * @param {source_ImageMapGuideOptions} options TODO: repace this
  *
  * @param {string|undefined} options.url The mapagent url.
- *
+ * 
  * @param {number|undefined} options.displayDpi The display resolution. Default is `96`.
- *
+ * 
  * @param {number|undefined} options.metersPerUnit The meters-per-unit value. Default is `1`.
- *
+ * 
  * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.useOverlay If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1`.
- *
+ * 
  * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
- *
+ * 
  * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- *
+ * 
  * @param {Object|undefined} options.params Additional parameters.
- *
+ * 
  */
 
 
@@ -2751,27 +2751,27 @@ export var source_ImageMapGuideOptions;
  *     tileLoadFunction: (ol.TileLoadFunctionType|undefined),
  *     url: (string|undefined)}}
  */
-export var source_MapQuestOptions;
+export let source_MapQuestOptions;
 
 /**
  * @param {source_MapQuestOptions} options TODO: repace this
  *
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {string} options.layer Layer. Possible values are `osm`, `sat`, and `hyb`.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
- *
+ * 
  */
 
 
@@ -2780,17 +2780,17 @@ export var source_MapQuestOptions;
  *     tileGrid: (ol.tilegrid.TileGrid|undefined),
  *     wrapX: (boolean|undefined)}}
  */
-export var source_TileDebugOptions;
+export let source_TileDebugOptions;
 
 /**
  * @param {source_TileDebugOptions} options TODO: repace this
  *
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  */
 
 
@@ -2805,42 +2805,42 @@ export var source_TileDebugOptions;
  *     url: (string|undefined),
  *     wrapX: (boolean|undefined)}}
  */
-export var source_OSMOptions;
+export let source_OSMOptions;
 
 /**
  * @param {source_OSMOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * Default is `anonymous`.
- *
+ * 
  * @param {number|undefined} options.maxZoom Max zoom. Default is `19`.
- *
+ * 
  * @param {boolean|undefined} options.opaque Whether the layer is opaque. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * Default is `https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png`.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  */
 
 
@@ -2856,26 +2856,26 @@ export var source_OSMOptions;
  *     resolutions: (Array.<number>|undefined),
  *     url: (string|undefined)}}
  */
-export var source_ImageArcGISRestOptions;
+export let source_ImageArcGISRestOptions;
 
 /**
  * @param {source_ImageArcGISRestOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- *
+ * 
  * @param {Object.<string,*>|undefined} options.params ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
  * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
@@ -2883,17 +2883,17 @@ export var source_ImageArcGISRestOptions;
  * override the default service layer visibility. See
  * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
  * for further reference.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the size of the map viewport, and so on. Default is `1.5`.
- *
+ * 
  * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
- *
+ * 
  * @param {string|undefined} options.url ArcGIS Rest service URL for a Map Service or Image Service. The
  * url should include /MapServer or /ImageServer.
- *
+ * 
  */
 
 
@@ -2906,13 +2906,13 @@ export var source_ImageArcGISRestOptions;
  *     resolutions: (Array.<number>|undefined),
  *     state: (ol.source.State|undefined)}}
  */
-export var source_ImageCanvasOptions;
+export let source_ImageCanvasOptions;
 
 /**
  * @param {source_ImageCanvasOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {ol.CanvasFunctionType} options.canvasFunction Canvas function. The function returning the canvas element used by the source
  * as an image. The arguments passed to the function are: `{ol.Extent}` the
  * image extent, `{number}` the image resolution, `{number}` the device pixel
@@ -2921,20 +2921,20 @@ export var source_ImageCanvasOptions;
  * the value returned by the function is later changed then
  * `dispatchChangeEvent` should be called on the source for the source to
  * invalidate the current cached image.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.ratio Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
  * width and height of the map viewport, and so on. Must be `1` or higher.
  * Default is `1.5`.
- *
+ * 
  * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, new canvases will be created for these resolutions
  * only.
- *
+ * 
  * @param {ol.source.State|undefined} options.state Source state.
- *
+ * 
  */
 
 
@@ -2946,29 +2946,29 @@ export var source_ImageCanvasOptions;
  *     operationType: (ol.source.RasterOperationType|undefined)}}
  * @api
  */
-export var source_RasterOptions;
+export let source_RasterOptions;
 
 /**
  * @param {source_RasterOptions} options TODO: repace this
  *
  * @param {Array.<ol.source.Source>} options.sources Input sources.
- *
+ * 
  * @param {ol.RasterOperation|undefined} options.operation Raster operation.  The operation will be called with data from input sources
  * and the output will be assigned to the raster source.
- *
+ * 
  * @param {Object|undefined} options.lib Functions that will be made available to operations run in a worker.
- *
+ * 
  * @param {number|undefined} options.threads By default, operations will be run in a single worker thread.  To avoid using
  * workers altogether, set `threads: 0`.  For pixel operations, operations can
  * be run in multiple worker threads.  Note that there is additional overhead in
  * transferring data to multiple workers, and that depending on the user's
  * system, it may not be possible to parallelize the work.
- *
+ * 
  * @param {ol.source.RasterOperationType|undefined} options.operationType Operation type.  Supported values are `'pixel'` and `'image'`.  By default,
  * `'pixel'` operations are assumed, and operations will be called with an
  * array of pixels from input sources.  If set to `'image'`, operations will
  * be called with an array of ImageData objects from input sources.
- *
+ * 
  */
 
 
@@ -2985,43 +2985,43 @@ export var source_RasterOptions;
  *     resolutions: (Array.<number>|undefined),
  *     url: (string|undefined)}}
  */
-export var source_ImageWMSOptions;
+export let source_ImageWMSOptions;
 
 /**
  * @param {source_ImageWMSOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- *
+ * 
  * @param {ol.source.WMSServerType|string|undefined} options.serverType The type of the remote WMS server: `mapserver`, `geoserver` or `qgis`. Only
  * needed if `hidpi` is `true`. Default is `undefined`.
- *
+ * 
  * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {Object.<string,*>} options.params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.ratio Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher. Default is `1.5`.
- *
+ * 
  * @param {Array.<number>|undefined} options.resolutions Resolutions. If specified, requests will be made for these resolutions only.
- *
+ * 
  * @param {string|undefined} options.url WMS service URL.
- *
+ * 
  */
 
 
@@ -3038,35 +3038,35 @@ export var source_ImageWMSOptions;
  *     wrapX: (boolean|undefined)
  * }}
  */
-export var source_StamenOptions;
+export let source_StamenOptions;
 
 /**
  * @param {source_StamenOptions} options TODO: repace this
  *
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {string} options.layer Layer.
- *
+ * 
  * @param {number|undefined} options.minZoom Minimum zoom.
- *
+ * 
  * @param {number|undefined} options.maxZoom Maximum zoom.
- *
+ * 
  * @param {boolean|undefined} options.opaque Whether the layer is opaque.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  */
 
 
@@ -3080,33 +3080,33 @@ export var source_StamenOptions;
  *     projection: ol.ProjectionLike,
  *     url: string}}
  */
-export var source_ImageStaticOptions;
+export let source_ImageStaticOptions;
 
 /**
  * @param {source_ImageStaticOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {ol.Extent} options.imageExtent Extent of the image in map coordinates.  This is the [left, bottom, right,
  * top] map coordinates of your image.
- *
+ * 
  * @param {ol.ImageLoadFunctionType|undefined} options.imageLoadFunction Optional function to load an image given a URL.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Optional logo.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {ol.Size|undefined} options.imageSize Size of the image in pixels. Usually the image size is auto-detected, so this
  * only needs to be set if auto-detection fails for some reason.
- *
+ * 
  * @param {string} options.url Image URL.
- *
+ * 
  */
 
 
@@ -3125,21 +3125,21 @@ export var source_ImageStaticOptions;
  *     wrapX: (boolean|undefined),
  *     transition: (number|undefined)}}
  */
-export var source_TileArcGISRestOptions;
+export let source_TileArcGISRestOptions;
 
 /**
  * @param {source_TileArcGISRestOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {Object.<string,*>|undefined} options.params ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
  * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
@@ -3147,38 +3147,38 @@ export var source_TileArcGISRestOptions;
  * override the default service layer visibility. See
  * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
  * for further reference.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
  * server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {string|undefined} options.url ArcGIS Rest service URL for a Map Service or Image Service. The
  * url should include /MapServer or /ImageServer.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  * @param {Array.<string>|undefined} options.urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS Service supports multiple
  * urls for export requests.
- *
+ * 
  */
 
 
@@ -3194,7 +3194,7 @@ export var source_TileArcGISRestOptions;
  *     wrapX: (boolean|undefined),
  *     transition: (number|undefined)}}
  */
-export var source_TileJSONOptions;
+export let source_TileJSONOptions;
 
 /**
  * @param {source_TileJSONOptions} options TODO: repace this
@@ -3202,38 +3202,38 @@ export var source_TileJSONOptions;
  * @param {ol.AttributionLike|undefined} options.attributions Optional attributions for the source.  If provided, these will be used
  * instead of any attribution data advertised by the server.  If not provided,
  * any attributions advertised by the server will be used.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {boolean|undefined} options.jsonp Use JSONP with callback to load the TileJSON. Useful when the server
  * does not support CORS. Default is `false`.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {TileJSON|undefined} options.tileJSON TileJSON configuration for this source. If not provided, `url` must be
  * configured.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {string|undefined} options.url URL to the TileJSON file. If not provided, `tileJSON` must be configured.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -3258,25 +3258,25 @@ export var source_TileJSONOptions;
  *     wrapX: (boolean|undefined),
  *     transition: (number|undefined)}}
  */
-export var source_TileWMSOptions;
+export let source_TileWMSOptions;
 
 /**
  * @param {source_TileWMSOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {Object.<string,*>} options.params WMS request parameters. At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {number|undefined} options.gutter The size in pixels of the gutter around image tiles to ignore. By setting
  * this property to a non-zero value, images will be requested that are wider
  * and taller than the tile size by a value of `2 x gutter`. Defaults to zero.
@@ -3285,50 +3285,50 @@ export var source_TileWMSOptions;
  * "artifacts at tile edges" issues by properly configuring the WMS service. For
  * example, MapServer has a `tile_map_edge_buffer` configuration parameter for
  * this. See http://mapserver.org/output/tile_mode.html.
- *
+ * 
  * @param {boolean|undefined} options.hidpi Use the `ol.Map#pixelRatio` value when requesting the image from the remote
  * server. Default is `true`.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
                 ol.TileLoadFunctionType)|undefined}
  options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
- *
+ * 
  * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid. Base this on the resolutions, tilesize and extent supported by the
  * server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.source.WMSServerType|string|undefined} options.serverType The type of the remote WMS server. Currently only used when `hidpi` is
  * `true`. Default is `undefined`.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {string|undefined} options.url WMS service URL.
- *
+ * 
  * @param {Array.<string>|undefined} options.urls WMS service urls. Use this instead of `url` when the WMS supports multiple
  * urls for GetMap requests.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. When set to `false`, only one world
  * will be rendered. When `true`, tiles will be requested for one world only,
  * but they will be wrapped horizontally to render multiple worlds. The default
  * is `true`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -3344,25 +3344,25 @@ export var source_TileWMSOptions;
  *     useSpatialIndex: (boolean|undefined),
  *     wrapX: (boolean|undefined)}}
  */
-export var source_VectorOptions;
+export let source_VectorOptions;
 
 /**
  * @param {source_VectorOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {Array.<ol.Feature>|ol.Collection.<ol.Feature>|undefined} options.features Features. If provided as {@link ol.Collection}, the features in the source
  * and the collection will stay in sync.
- *
+ * 
  * @param {ol.format.Feature|undefined} options.format The feature format used by the XHR feature loader when `url` is set.
  * Required if `url` is set, otherwise ignored. Default is `undefined`.
- *
+ * 
  * @param {ol.FeatureLoader|undefined} options.loader The loader function used to load features, from a remote source for example.
  * If this is not set and `url` is set, the source will create and use an XHR
  * feature loader.
- *
+ * 
  * Example:
- *
+ * 
  * ```js
  * var vectorSource = new ol.source.Vector({
  *   format: new ol.format.GeoJSON(),
@@ -3391,17 +3391,17 @@ export var source_VectorOptions;
  *    strategy: ol.loadingstrategy.bbox
  *  });
  * ```
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {boolean|undefined} options.overlaps This source may have overlapping geometries. Default is `true`. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
- *
+ * 
  * @param {ol.LoadingStrategy|undefined} options.strategy The loading strategy to use. By default an {@link ol.loadingstrategy.all}
  * strategy is used, a one-off strategy which loads all features at once.
- *
+ * 
  * @param {string|ol.FeatureUrlFunction|undefined} options.url Setting this option instructs the source to load features using an XHR loader
  * (see {@link ol.featureloader.xhr}). Use a `string` and an
  * {@link ol.loadingstrategy.all} for a one-off download of all features from
@@ -3416,28 +3416,28 @@ export var source_VectorOptions;
  * defaultDataProjection constructor option on the format.
  * Note that if a source contains non-feature data, such as a GeoJSON geometry
  * or a KML NetworkLink, these will be ignored. Use a custom loader to load these.
- *
+ * 
  * @param {boolean|undefined} options.useSpatialIndex By default, an RTree is used as spatial index. When features are removed and
  * added frequently, and the total number of features is low, setting this to
  * `false` may improve performance.
- *
+ * 
  * Note that
  * {@link ol.source.Vector#getFeaturesInExtent},
  * {@link ol.source.Vector#getClosestFeatureToCoordinate} and
  * {@link ol.source.Vector#getExtent} cannot be used when `useSpatialIndex` is
  * set to `false`, and {@link ol.source.Vector#forEachFeatureInExtent} will loop
  * through all features.
- *
+ * 
  * When set to `false`, the features will be maintained in an
  * {@link ol.Collection}, which can be retrieved through
  * {@link ol.source.Vector#getFeaturesCollection}.
- *
+ * 
  * The default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Wrap the world horizontally. Default is `true`. For vector editing across the
  * -180° and 180° meridians to work properly, this should be set to `false`. The
  * resulting geometry coordinates will then exceed the world bounds.
- *
+ * 
  */
 
 
@@ -3466,73 +3466,73 @@ export var source_VectorOptions;
  *     wrapX: (boolean|undefined),
  *     transition: (number|undefined)}}
  */
-export var source_WMTSOptions;
+export let source_WMTSOptions;
 
 /**
  * @param {source_WMTSOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {string|null|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.tilegrid.WMTS} options.tileGrid Tile grid.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {ol.source.WMTSRequestEncoding|string|undefined} options.requestEncoding Request encoding. Default is `KVP`.
- *
+ * 
  * @param {string} options.layer Layer name as advertised in the WMTS capabilities.
- *
+ * 
  * @param {string} options.style Style name as advertised in the WMTS capabilities.
- *
+ * 
  * @param {function(new: ol.ImageTile, ol.TileCoord,                ol.TileState, string, ?string,
                 ol.TileLoadFunctionType)|undefined}
  options.tileClass Class used to instantiate image tiles. Default is {@link ol.ImageTile}.
- *
+ * 
  * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`. Default is `1`.
- *
+ * 
  * @param {string|undefined} options.version WMTS version. Default is `1.0.0`.
- *
+ * 
  * @param {string|undefined} options.format Image format. Default is `image/jpeg`.
- *
+ * 
  * @param {string} options.matrixSet Matrix set.
- *
+ * 
  * @param {!Object|undefined} options.dimensions Additional "dimensions" for tile requests.  This is an object with properties
  * named like the advertised WMTS dimensions.
- *
+ * 
  * @param {string|undefined} options.url A URL for the service.  For the RESTful request encoding, this is a URL
  * template.  For KVP encoding, it is normal URL. A `{?-?}` template pattern,
  * for example `subdomain{a-f}.domain.com`, may be used instead of defining
  * each one separately in the `urls` option.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {Array.<string>|undefined} options.urls An array of URLs.  Requests will be distributed among the URLs in this array.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `false`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -3556,64 +3556,64 @@ export var source_WMTSOptions;
  *     wrapX: (boolean|undefined),
  *     transition: (number|undefined)}}
  */
-export var source_XYZOptions;
+export let source_XYZOptions;
 
 /**
  * @param {source_XYZOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {boolean|undefined} options.opaque Whether the layer is opaque.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection. Default is `EPSG:3857`.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {number|undefined} options.maxZoom Optional max zoom level. Default is `18`.
- *
+ * 
  * @param {number|undefined} options.minZoom Optional min zoom level. Default is `0`.
- *
+ * 
  * @param {ol.tilegrid.TileGrid|undefined} options.tileGrid Tile grid.
- *
+ * 
  * @param {ol.TileLoadFunctionType|undefined} options.tileLoadFunction Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
  * };
  * ```
- *
+ * 
  * @param {number|undefined} options.tilePixelRatio The pixel ratio used by the tile service. For example, if the tile
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`. Default is `1`.
- *
+ * 
  * @param {number|ol.Size|undefined} options.tileSize The tile size used by the tile service. Default is `[256, 256]` pixels.
- *
+ * 
  * @param {ol.TileUrlFunctionType|undefined} options.tileUrlFunction Optional function to get tile URL given a tile coordinate and the projection.
  * Required if url or urls are not provided.
- *
+ * 
  * @param {string|undefined} options.url URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- *
+ * 
  * @param {Array.<string>|undefined} options.urls An array of URL templates.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  */
 
 
@@ -3630,44 +3630,44 @@ export var source_XYZOptions;
  *     map: (string|undefined),
  *     account: string}}
  */
-export var source_CartoDBOptions;
+export let source_CartoDBOptions;
 
 /**
  * @param {source_CartoDBOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.ProjectionLike} options.projection Projection. Default is `EPSG:3857`.
- *
+ * 
  * @param {number|undefined} options.maxZoom Optional max zoom level. Default is `18`.
- *
+ * 
  * @param {number|undefined} options.minZoom Minimum zoom.
- *
+ * 
  * @param {boolean|undefined} options.wrapX Whether to wrap the world horizontally. Default is `true`.
- *
+ * 
  * @param {Object|undefined} options.config If using anonymous maps, the CartoDB config to use. See
  * {@link http://docs.cartodb.com/cartodb-platform/maps-api/anonymous-maps/}
  * for more detail.
  * If using named maps, a key-value lookup with the template parameters.
  * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
  * for more detail.
- *
+ * 
  * @param {string|undefined} options.map If using named maps, this will be the name of the template to load.
  * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
  * for more detail.
- *
+ * 
  * @param {string} options.account CartoDB account name
- *
+ * 
  */
 
 
@@ -3685,28 +3685,28 @@ export var source_CartoDBOptions;
  *     transition: (number|undefined),
  *     tileSize: (number|undefined)}}
  */
-export var source_ZoomifyOptions;
+export let source_ZoomifyOptions;
 
 /**
  * @param {source_ZoomifyOptions} options TODO: repace this
  *
  * @param {ol.AttributionLike|undefined} options.attributions Attributions.
- *
+ * 
  * @param {number|undefined} options.cacheSize Cache size. Default is `2048`.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {string|olx.LogoOptions|undefined} options.logo Logo.
- *
+ * 
  * @param {ol.ProjectionLike|undefined} options.projection Projection.
- *
+ * 
  * @param {number|undefined} options.reprojectionErrorThreshold Maximum allowed reprojection error (in pixels). Default is `0.5`.
  * Higher values can increase reprojection performance, but decrease precision.
- *
+ * 
  * @param {!string} options.url URL template or base URL of the Zoomify service. A base URL is the fixed part
  * of the URL, excluding the tile group, z, x, and y folder structure, e.g.
  * `http://my.zoomify.info/IMAGE.TIF/`. A URL template must include
@@ -3717,22 +3717,22 @@ export var source_ZoomifyOptions;
  * `http://my.zoomify.info?FIF=IMAGE.TIF&JTL={z},{tileIndex}`.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- *
+ * 
  * @param {string|undefined} options.tierSizeCalculation Tier size calculation method: `default` or `truncated`.
- *
+ * 
  * @param {ol.Size} options.size Size of the image.
- *
+ * 
  * @param {ol.Extent|undefined} options.extent Extent for the TileGrid that is created. Default sets the TileGrid in the
  * fourth quadrant, meaning extent is `[0, -height, width, 0]`. To change the
  * extent to the first quadrant (the default for OpenLayers 2) set the extent
  * as `[0, 0, width, height]`.
- *
+ * 
  * @param {number|undefined} options.transition Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- *
+ * 
  * @param {number|undefined} options.tileSize Tile size. Same tile size is used for all zoom levels. Default value is
  * `256`.
- *
+ * 
  */
 
 
@@ -3743,15 +3743,15 @@ export var source_ZoomifyOptions;
  *     stroke: (ol.style.Stroke|undefined),
  *     atlasManager: (ol.style.AtlasManager|undefined)}}
  */
-export var style_CircleOptions;
+export let style_CircleOptions;
 
 /**
  * @param {style_CircleOptions} options TODO: repace this
  *
  * @param {ol.style.Fill|undefined} options.fill Fill style.
- *
+ * 
  * @param {number} options.radius Circle radius.
- *
+ * 
  * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
  * coordinate when drawing the circle in the output canvas. If `false`
  * fractional numbers may be used. Using `true` allows for "sharp"
@@ -3759,21 +3759,21 @@ export var style_CircleOptions;
  * rendering. Note that accuracy is important if the circle's
  * position is animated. Without it, the circle may jitter noticeably.
  * Default value is `true`.
- *
+ * 
  * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- *
+ * 
  * @param {ol.style.AtlasManager|undefined} options.atlasManager The atlas manager to use for this circle. When using WebGL it is
  * recommended to use an atlas manager to avoid texture switching.
  * If an atlas manager is given, the circle is added to an atlas.
  * By default no atlas manager is used.
- *
+ * 
  */
 
 
 /**
  * @typedef {{color: (ol.Color|ol.ColorLike|undefined)}}
  */
-export var style_FillOptions;
+export let style_FillOptions;
 
 /**
  * @param {style_FillOptions} options TODO: repace this
@@ -3781,7 +3781,7 @@ export var style_FillOptions;
  * @param {ol.Color|ol.ColorLike|undefined} options.color A color, gradient or pattern. See {@link ol.color}
  * and {@link ol.colorlike} for possible formats. Default null;
  * if null, the Canvas/renderer default black will be used.
- *
+ * 
  */
 
 
@@ -3804,47 +3804,47 @@ export var style_FillOptions;
  *     imgSize: (ol.Size|undefined),
  *     src: (string|undefined)}}
  */
-export var style_IconOptions;
+export let style_IconOptions;
 
 /**
  * @param {style_IconOptions} options TODO: repace this
  *
  * @param {Array.<number>|undefined} options.anchor Anchor. Default value is `[0.5, 0.5]` (icon center).
- *
+ * 
  * @param {ol.style.IconOrigin|undefined} options.anchorOrigin Origin of the anchor: `bottom-left`, `bottom-right`, `top-left` or
  * `top-right`. Default is `top-left`.
- *
+ * 
  * @param {ol.style.IconAnchorUnits|undefined} options.anchorXUnits Units in which the anchor x value is specified. A value of `'fraction'`
  * indicates the x value is a fraction of the icon. A value of `'pixels'`
  * indicates the x value in pixels. Default is `'fraction'`.
- *
+ * 
  * @param {ol.style.IconAnchorUnits|undefined} options.anchorYUnits Units in which the anchor y value is specified. A value of `'fraction'`
  * indicates the y value is a fraction of the icon. A value of `'pixels'`
  * indicates the y value in pixels. Default is `'fraction'`.
- *
+ * 
  * @param {ol.Color|string|undefined} options.color Color to tint the icon. If not specified, the icon will be left as is.
- *
+ * 
  * @param {null|string|undefined} options.crossOrigin The `crossOrigin` attribute for loaded images.  Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
  * for more detail.
- *
+ * 
  * @param {Image|HTMLCanvasElement|undefined} options.img Image object for the icon. If the `src` option is not provided then the
  * provided image must already be loaded. And in that case, it is required
  * to provide the size of the image, with the `imgSize` option.
- *
+ * 
  * @param {Array.<number>|undefined} options.offset Offset, which, together with the size and the offset origin,
  * define the sub-rectangle to use from the original icon image. Default value
  * is `[0, 0]`.
- *
+ * 
  * @param {ol.style.IconOrigin|undefined} options.offsetOrigin Origin of the offset: `bottom-left`, `bottom-right`, `top-left` or
  * `top-right`. Default is `top-left`.
- *
+ * 
  * @param {number|undefined} options.opacity Opacity of the icon. Default is `1`.
- *
+ * 
  * @param {number|undefined} options.scale Scale. Default is `1`.
- *
+ * 
  * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
  * coordinate when drawing the icon in the output canvas. If `false`
  * fractional numbers may be used. Using `true` allows for "sharp"
@@ -3852,20 +3852,20 @@ export var style_IconOptions;
  * rendering. Note that accuracy is important if the icon's position
  * is animated. Without it, the icon may jitter noticeably. Default
  * value is `true`.
- *
+ * 
  * @param {boolean|undefined} options.rotateWithView Whether to rotate the icon with the view. Default is `false`.
- *
+ * 
  * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
- *
+ * 
  * @param {ol.Size|undefined} options.size Icon size in pixel. Can be used together with `offset` to define the
  * sub-rectangle to use from the origin (sprite) icon image.
- *
+ * 
  * @param {ol.Size|undefined} options.imgSize Image size in pixels. Only required if `img` is set and `src` is not, and for
  * SVG images in Internet Explorer 11. The provided `imgSize` needs to match
  * the actual size of the image.
- *
+ * 
  * @param {string|undefined} options.src Image source URI.
- *
+ * 
  */
 
 
@@ -3883,26 +3883,26 @@ export var style_IconOptions;
  *     rotateWithView: (boolean|undefined),
  *     atlasManager: (ol.style.AtlasManager|undefined)}}
  */
-export var style_RegularShapeOptions;
+export let style_RegularShapeOptions;
 
 /**
  * @param {style_RegularShapeOptions} options TODO: repace this
  *
  * @param {ol.style.Fill|undefined} options.fill Fill style.
- *
+ * 
  * @param {number} options.points Number of points for stars and regular polygons. In case of a polygon, the
  * number of points is the number of sides.
- *
+ * 
  * @param {number|undefined} options.radius Radius of a regular polygon.
- *
+ * 
  * @param {number|undefined} options.radius1 Outer radius of a star.
- *
+ * 
  * @param {number|undefined} options.radius2 Inner radius of a star.
- *
+ * 
  * @param {number|undefined} options.angle Shape's angle in radians. A value of 0 will have one of the shape's point
  * facing up.
  * Default value is 0.
- *
+ * 
  * @param {boolean|undefined} options.snapToPixel If `true` integral numbers of pixels are used as the X and Y pixel
  * coordinate when drawing the shape in the output canvas. If `false`
  * fractional numbers may be used. Using `true` allows for "sharp"
@@ -3910,18 +3910,18 @@ export var style_RegularShapeOptions;
  * rendering. Note that accuracy is important if the shape's
  * position is animated. Without it, the shape may jitter noticeably.
  * Default value is `true`.
- *
+ * 
  * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- *
+ * 
  * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
- *
+ * 
  * @param {boolean|undefined} options.rotateWithView Whether to rotate the shape with the view. Default is `false`.
- *
+ * 
  * @param {ol.style.AtlasManager|undefined} options.atlasManager The atlas manager to use for this symbol. When using WebGL it is
  * recommended to use an atlas manager to avoid texture switching.
  * If an atlas manager is given, the symbol is added to an atlas.
  * By default no atlas manager is used.
- *
+ * 
  */
 
 
@@ -3934,7 +3934,7 @@ export var style_RegularShapeOptions;
  *     miterLimit: (number|undefined),
  *     width: (number|undefined)}}
  */
-export var style_StrokeOptions;
+export let style_StrokeOptions;
 
 /**
  * @param {style_StrokeOptions} options TODO: repace this
@@ -3942,25 +3942,25 @@ export var style_StrokeOptions;
  * @param {ol.Color|ol.ColorLike|undefined} options.color A color, gradient or pattern. See {@link ol.color}
  * and {@link ol.colorlike} for possible formats. Default null;
  * if null, the Canvas/renderer default black will be used.
- *
+ * 
  * @param {string|undefined} options.lineCap Line cap style: `butt`, `round`, or `square`. Default is `round`.
- *
+ * 
  * @param {string|undefined} options.lineJoin Line join style: `bevel`, `round`, or `miter`. Default is `round`.
- *
+ * 
  * @param {Array.<number>|undefined} options.lineDash Line dash pattern. Default is `undefined` (no dash). Please note that
  * Internet Explorer 10 and lower [do not support][mdn] the `setLineDash`
  * method on the `CanvasRenderingContext2D` and therefore this option will
  * have no visual effect in these browsers.
- *
+ * 
  * [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility
- *
- *
+ * 
+ * 
  * @param {number|undefined} options.lineDashOffset Line dash offset. Default is '0'.
- *
+ * 
  * @param {number|undefined} options.miterLimit Miter limit. Default is `10`.
- *
+ * 
  * @param {number|undefined} options.width Width.
- *
+ * 
  */
 
 
@@ -3983,7 +3983,7 @@ export var style_StrokeOptions;
  *     backgroundStroke: (ol.style.Stroke|undefined),
  *     padding: (Array.<number>|undefined)}}
  */
-export var style_TextOptions;
+export let style_TextOptions;
 
 /**
  * @param {style_TextOptions} options TODO: repace this
@@ -3991,53 +3991,53 @@ export var style_TextOptions;
  * @param {string|undefined} options.font Font style as CSS 'font' value, see:
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font}.
  * Default is '10px sans-serif'
- *
+ * 
  * @param {number|undefined} options.maxAngle When `placement` is set to `'line'`, allow a maximum angle between adjacent
  * characters. The expected value is in radians, and the default is 45°
  * (`Math.PI / 4`).
- *
+ * 
  * @param {number|undefined} options.offsetX Horizontal text offset in pixels. A positive will shift the text right.
  * Default is `0`.
- *
+ * 
  * @param {number|undefined} options.offsetY Vertical text offset in pixels. A positive will shift the text down. Default
  * is `0`.
- *
+ * 
  * @param {boolean|undefined} options.overflow For polygon labels or when `placement` is set to `'line'`, allow text to
  * exceed the width of the polygon at the label position or the length of
  * the path that it follows. Default is `false`.
- *
+ * 
  * @param {ol.style.TextPlacement|undefined} options.placement Text placement.
- *
+ * 
  * @param {number|undefined} options.scale Scale.
- *
+ * 
  * @param {boolean|undefined} options.rotateWithView Whether to rotate the text with the view. Default is `false`.
- *
+ * 
  * @param {number|undefined} options.rotation Rotation in radians (positive rotation clockwise). Default is `0`.
- *
+ * 
  * @param {string|undefined} options.text Text content.
- *
+ * 
  * @param {string|undefined} options.textAlign Text alignment. Possible values: 'left', 'right', 'center', 'end' or 'start'.
  * Default is 'center' for `placement: 'point'`. For `placement: 'line'`, the
  * default is to let the renderer choose a placement where `maxAngle` is not
  * exceeded.
- *
+ * 
  * @param {string|undefined} options.textBaseline Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
  * 'hanging', 'ideographic'. Default is 'middle'.
- *
+ * 
  * @param {ol.style.Fill|undefined} options.fill Fill style. If none is provided, we'll use a dark fill-style (#333).
- *
+ * 
  * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- *
+ * 
  * @param {ol.style.Fill|undefined} options.backgroundFill Fill style for the text background when `placement` is `'point'`. Default is
  * no fill.
- *
+ * 
  * @param {ol.style.Stroke|undefined} options.backgroundStroke Stroke style for the text background  when `placement` is `'point'`. Default
  * is no stroke.
- *
+ * 
  * @param {Array.<number>|undefined} options.padding Padding in pixels around the text for decluttering and background. The order
  * of values in the array is `[top, right, bottom, left]`. Default is
  * `[0, 0, 0, 0]`.
- *
+ * 
  */
 
 
@@ -4050,29 +4050,29 @@ export var style_TextOptions;
  *     text: (ol.style.Text|undefined),
  *     zIndex: (number|undefined)}}
  */
-export var style_StyleOptions;
+export let style_StyleOptions;
 
 /**
  * @param {style_StyleOptions} options TODO: repace this
  *
  * @param {undefined|string|ol.geom.Geometry|ol.StyleGeometryFunction} options.geometry Feature property or geometry or function returning a geometry to render for
  * this style.
- *
+ * 
  * @param {ol.style.Fill|undefined} options.fill Fill style.
- *
+ * 
  * @param {ol.style.Image|undefined} options.image Image style.
- *
+ * 
  * @param {ol.StyleRenderFunction|undefined} options.renderer Custom renderer. When configured, `fill`, `stroke` and `image` will be
  * ignored, and the provided function will be called with each render frame for
  * each geometry.
- *
- *
+ * 
+ * 
  * @param {ol.style.Stroke|undefined} options.stroke Stroke style.
- *
+ * 
  * @param {ol.style.Text|undefined} options.text Text style.
- *
+ * 
  * @param {number|undefined} options.zIndex Z index.
- *
+ * 
  */
 
 
@@ -4086,7 +4086,7 @@ export var style_StyleOptions;
  *     tileSize: (number|ol.Size|undefined),
  *     tileSizes: (Array.<number|ol.Size>|undefined)}}
  */
-export var tilegrid_TileGridOptions;
+export let tilegrid_TileGridOptions;
 
 /**
  * @param {tilegrid_TileGridOptions} options TODO: repace this
@@ -4094,28 +4094,28 @@ export var tilegrid_TileGridOptions;
  * @param {ol.Extent|undefined} options.extent Extent for the tile grid. No tiles outside this extent will be requested by
  * {@link ol.source.Tile} sources. When no `origin` or `origins` are
  * configured, the `origin` will be set to the top-left corner of the extent.
- *
+ * 
  * @param {number|undefined} options.minZoom Minimum zoom. Default is 0.
- *
+ * 
  * @param {ol.Coordinate|undefined} options.origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
  * Tile coordinates increase left to right and upwards. If not specified,
  * `extent` or `origins` must be provided.
- *
+ * 
  * @param {Array.<ol.Coordinate>|undefined} options.origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
  * each zoom level. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different origin. Tile
  * coordinates increase left to right and upwards. If not specified, `extent`
  * or `origin` must be provided.
- *
+ * 
  * @param {!Array.<number>} options.resolutions Resolutions. The array index of each resolution needs to match the zoom
  * level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`.
- *
+ * 
  * @param {number|ol.Size|undefined} options.tileSize Tile size. Default is `[256, 256]`.
- *
+ * 
  * @param {Array.<number|ol.Size>|undefined} options.tileSizes Tile sizes. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different tile size.
- *
+ * 
  */
 
 
@@ -4129,7 +4129,7 @@ export var tilegrid_TileGridOptions;
  *     tileSize: (number|ol.Size|undefined),
  *     tileSizes: (Array.<number|ol.Size>|undefined)}}
  */
-export var tilegrid_WMTSOptions;
+export let tilegrid_WMTSOptions;
 
 /**
  * @param {tilegrid_WMTSOptions} options TODO: repace this
@@ -4137,24 +4137,24 @@ export var tilegrid_WMTSOptions;
  * @param {ol.Extent|undefined} options.extent Extent for the tile grid. No tiles outside this extent will be requested by
  * {@link ol.source.Tile} sources. When no `origin` or `origins` are
  * configured, the `origin` will be set to the top-left corner of the extent.
- *
+ * 
  * @param {ol.Coordinate|undefined} options.origin The tile grid origin, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`).
  * Tile coordinates increase left to right and upwards. If not specified,
  * `extent` or `origins` must be provided.
- *
+ * 
  * @param {Array.<ol.Coordinate>|undefined} options.origins Tile grid origins, i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for
  * each zoom level. If given, the array length should match the length of the
  * `resolutions` array, i.e. each resolution can have a different origin. Tile
  * coordinates increase left to right and upwards. If not specified, `extent` or
  * `origin` must be provided.
- *
+ * 
  * @param {!Array.<number>} options.resolutions Resolutions. The array index of each resolution needs to match the zoom
  * level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`
- *
+ * 
  * @param {!Array.<string>} options.matrixIds matrix IDs. The length of this array needs to match the length of the
  * `resolutions` array.
- *
+ * 
  * @param {Array.<ol.Size>|undefined} options.sizes Number of tile rows and columns of the grid for each zoom level. The values
  * here are the `TileMatrixWidth` and `TileMatrixHeight` advertised in the
  * GetCapabilities response of the WMTS, and define the grid's extent together
@@ -4163,18 +4163,18 @@ export var tilegrid_WMTSOptions;
  * that when the top-left corner of the `extent` is used as `origin` or
  * `origins`, then the `y` value must be negative because OpenLayers tile
  * coordinates increase upwards.
- *
+ * 
  * @param {number|ol.Size|undefined} options.tileSize Tile size.
- *
+ * 
  * @param {Array.<number|ol.Size>|undefined} options.tileSizes Tile sizes. The length of this array needs to match the length of the
  * `resolutions` array.
- *
+ * 
  * @param {Array.<number>|undefined} options.widths Number of tile columns that cover the grid's extent for each zoom level. Only
  * required when used with a source that has `wrapX` set to `true`, and only
  * when the grid's origin differs from the one of the projection's extent. The
  * array length has to match the length of the `resolutions` array, i.e. each
  * resolution will have a matching entry here.
- *
+ * 
  */
 
 
@@ -4184,7 +4184,7 @@ export var tilegrid_WMTSOptions;
  *     minZoom: (number|undefined),
  *     tileSize: (number|ol.Size|undefined)}}
  */
-export var tilegrid_XYZOptions;
+export let tilegrid_XYZOptions;
 
 /**
  * @param {tilegrid_XYZOptions} options TODO: repace this
@@ -4193,15 +4193,15 @@ export var tilegrid_XYZOptions;
  * corner of the extent.  The zero level of the grid is defined by the
  * resolution at which one tile fits in the provided extent.  If not provided,
  * the extent of the EPSG:3857 projection is used.
- *
+ * 
  * @param {number|undefined} options.maxZoom Maximum zoom.  The default is `ol.DEFAULT_MAX_ZOOM`.  This determines the
  * number of levels in the grid set.  For example, a `maxZoom` of 21 means there
  * are 22 levels in the grid set.
- *
+ * 
  * @param {number|undefined} options.minZoom Minimum zoom. Default is 0.
- *
+ * 
  * @param {number|ol.Size|undefined} options.tileSize Tile size in pixels. Default is `[256, 256]`.
- *
+ * 
  */
 
 
@@ -4218,7 +4218,7 @@ export var tilegrid_XYZOptions;
  *     callback: (undefined|function(boolean))
  * }}
  */
-export var view_FitOptions;
+export let view_FitOptions;
 
 /**
  * @param {view_FitOptions} options TODO: repace this
@@ -4226,31 +4226,31 @@ export var view_FitOptions;
  * @param {ol.Size|undefined} options.size The size in pixels of the box to fit the extent into. Default is
  * the current size of the first map in the DOM that uses this view, or
  * `[100, 100]` if no such map is found.
- *
+ * 
  * @param {!Array.<number>|undefined} options.padding Padding (in pixels) to be cleared inside the view. Values in the array are
  * top, right, bottom and left padding. Default is `[0, 0, 0, 0]`.
- *
+ * 
  * @param {boolean|undefined} options.constrainResolution Constrain the resolution. Default is `true`.
- *
+ * 
  * @param {boolean|undefined} options.nearest Get the nearest extent. Default is `false`.
- *
+ * 
  * @param {number|undefined} options.minResolution Minimum resolution that we zoom to. Default is `0`.
- *
+ * 
  * @param {number|undefined} options.maxZoom Maximum zoom level that we zoom to. If `minResolution` is given,
  * this property is ignored.
- *
+ * 
  * @param {number|undefined} options.duration The duration of the animation in milliseconds. By default, there is no
  * animations.
- *
+ * 
  * @param {undefined|function(number):number} options.easing The easing function used during the animation (defaults to {@link ol.easing.inAndOut}).
  * The function will be called for each frame with a number representing a
  * fraction of the animation's duration.  The function should return a number
  * between 0 and 1 representing the progress toward the destination state.
- *
+ * 
  * @param {undefined|function(boolean)} options.callback Optional function called when the view is in it's final position. The callback will be
  * called with `true` if the animation series completed on its own or `false`
  * if it was cancelled.
- *
+ * 
  */
 
 
@@ -4275,14 +4275,14 @@ export var view_FitOptions;
  *     viewHints: Array.<number>,
  *     wantedTiles: !Object.<string, Object.<string, boolean>>}}
  */
-export var FrameState;
+export let FrameState;
 
 /**
  * @param {FrameState} options TODO: repace this
  *
- * @param {number} options.pixelRatio
- * @param {number} options.time
- * @param {olx.ViewState} options.viewState
+ * @param {number} options.pixelRatio 
+ * @param {number} options.time 
+ * @param {olx.ViewState} options.viewState 
  */
 
 
@@ -4293,17 +4293,17 @@ export var FrameState;
  *     rotation: number,
  *     zoom: number}}
  */
-export var ViewState;
+export let ViewState;
 
 /**
  * @param {ViewState} options TODO: repace this
  *
- * @param {ol.Coordinate} options.center
- * @param {ol.proj.Projection} options.projection
- * @param {number} options.resolution
- * @param {number} options.rotation
+ * @param {ol.Coordinate} options.center 
+ * @param {ol.proj.Projection} options.projection 
+ * @param {number} options.resolution 
+ * @param {number} options.rotation 
  * @param {number} options.zoom The current zoom level.
- *
+ * 
  */
 
 
@@ -4312,18 +4312,18 @@ export var ViewState;
  *     maxSize: (number|undefined),
  *     space: (number|undefined)}}
  */
-export var style_AtlasManagerOptions;
+export let style_AtlasManagerOptions;
 
 /**
  * @param {style_AtlasManagerOptions} options TODO: repace this
  *
  * @param {number|undefined} options.initialSize The size in pixels of the first atlas image. Default is `256`.
- *
+ * 
  * @param {number|undefined} options.maxSize The maximum size in pixels of atlas images. Default is
  * `WEBGL_MAX_TEXTURE_SIZE` or 2048 if WebGL is not supported.
- *
+ * 
  * @param {number|undefined} options.space The space in pixels between images (default: 1).
- *
+ * 
  */
 
 
@@ -4331,15 +4331,15 @@ export var style_AtlasManagerOptions;
  * @typedef {{handles: function(ol.renderer.Type):boolean,
  *     create: function(Element, ol.PluggableMap):ol.renderer.Map}}
  */
-export var MapRendererPlugin;
+export let MapRendererPlugin;
 
 /**
  * @param {MapRendererPlugin} options TODO: repace this
  *
  * @param {function(ol.renderer.Type):boolean} options.handles Determine if this renderer handles the provided layer.
- *
+ * 
  * @param {function(Element, ol.PluggableMap):ol.renderer.Map} options.create Create the map renderer.
- *
+ * 
  */
 
 
@@ -4347,13 +4347,14 @@ export var MapRendererPlugin;
  * @typedef {{handles: function(ol.renderer.Type, ol.layer.Layer):boolean,
  *     create: function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer}}
  */
-export var LayerRendererPlugin;
+export let LayerRendererPlugin;
 
 /**
  * @param {LayerRendererPlugin} options TODO: repace this
  *
  * @param {function(ol.renderer.Type, ol.layer.Layer):boolean} options.handles Determine if this renderer handles the provided layer.
- *
+ * 
  * @param {function(ol.renderer.Map, ol.layer.Layer):ol.renderer.Layer} options.create Create a layer renderer.
- *
+ * 
  */
+

--- a/tasks/.eslintrc
+++ b/tasks/.eslintrc
@@ -1,6 +1,8 @@
 {
   "env": {
-    "node": true,
-    "es6": true
+    "node": true
+  },
+  parserOptions: {
+    ecmaVersion: '2017'
   }
 }

--- a/tasks/t.js
+++ b/tasks/t.js
@@ -1,0 +1,191 @@
+const fs = require('fs');
+const util = require('util');
+const path = require('path');
+
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+const externs = path.resolve(__dirname, '../externs');
+
+function parse(source) {
+  const length = source.length;
+
+  let index = 0;
+  const IN_CODE = 'in code';
+  const IN_COMMENT = 'in comment';
+
+  function next() {
+    const char = source.charAt(index);
+    ++index;
+    return char;
+  }
+
+  function scanLine() {
+    let char = next();
+    let line = '';
+    while (index < length && char !== '\n') {
+      line += char;
+      char = next();
+    }
+    return line;
+  }
+
+  let state = IN_CODE;
+  const blocks = [];
+  let comment;
+  while (index < length) {
+    const line = scanLine();
+    if (state === IN_CODE) {
+      if (line === '/**') {
+        state = IN_COMMENT;
+        comment = '';
+      }
+      continue;
+    }
+
+    // in a comment
+    if (!line) {
+      continue;
+    }
+
+    if (line !== ' */') {
+      comment += line + '\n';
+      continue;
+    }
+
+    // comment is done
+    const code = scanLine();
+    if (code.startsWith('olx')) {
+      blocks.push({code, comment});
+    }
+    state = IN_CODE;
+  }
+  return blocks;
+}
+
+function processParam(name, comment) {
+  const IN_DESCRIPTION = 'in description';
+  const IN_TYPE = 'in type';
+  const DONE = 'done';
+
+  const lines = comment.split('\n');
+  lines.pop(); // ends with newline
+  let description = '';
+  let type;
+  let state = IN_DESCRIPTION;
+  lines.forEach(line => {
+    if (state === DONE) {
+      throw new Error(`Extra comment after @api for param ${name}:\n${comment}`);
+    }
+
+    if (!(line.startsWith(' * ') || line === ' *')) {
+      throw new Error(`Unexpected comment start for param ${name}:\n${comment}`);
+    }
+
+    if (line.indexOf('@type ') === 3) {
+      state = IN_TYPE;
+      if (type) {
+        throw new Error(`Duplicate type for param ${name}:\n${comment}`);
+      }
+      type = line.slice(9);
+      return;
+    }
+
+    if (line.indexOf('@api') === 3) {
+      state = DONE;
+      return;
+    }
+
+    if (state === IN_DESCRIPTION) {
+      if (type) {
+        throw new Error(`Description after type for param ${name}:\n${comment}`);
+      }
+      description += line.slice(3) + '\n';
+      return;
+    }
+
+    type += line.slice(3) + '\n';
+  });
+
+  return {name, type, description};
+}
+
+function getName(name) {
+  if (!name.startsWith('olx.')) {
+    throw new Error(`Unexpected name: ${name}`);
+  }
+  return name.slice(4).replace(/\./g, '_');
+}
+
+function processBlock(block, data) {
+  const name = getName(block.code.slice(0, -1));
+
+  const protoStart = name.indexOf('_prototype_');
+  if (protoStart > 0) {
+    const parentName = name.slice(0, protoStart);
+    const childName = name.slice(protoStart + 11);
+    if (!(parentName in data)) {
+      throw new Error(`No parent for ${block.code}`);
+    }
+    const param = processParam(childName, block.comment);
+    data[parentName].params.push(param);
+    return;
+  }
+
+  if (block.comment.indexOf('@typedef') === -1) {
+    if (block.comment.indexOf('Namespace.') === -1) {
+      throw new Error(`Unexpected comment for ${block.code}`);
+    }
+    return;
+  }
+
+  data[name] = {
+    name,
+    comment: block.comment,
+    params: []
+  };
+}
+
+function processBlocks(blocks) {
+  const data = {};
+  blocks.forEach(block => processBlock(block, data));
+  return data;
+}
+
+function format(data) {
+  let source = '';
+  for (const name in data) {
+    const comment = data[name].comment;
+
+    // add the @typedef
+    source += `\n/**\n${comment} */\n`;
+    source += `export var ${name};\n\n`;
+
+    const params = data[name].params;
+    if (!params.length) {
+      throw new Error(`No params for ${name}`);
+    }
+
+    source += '/**\n';
+    source += ` * @param {${name}} options TODO: repace this\n *\n`;
+    params.forEach(param => {
+      const description = param.description.split('\n').join('\n * ');
+      source += ` * @param ${param.type} options.${param.name} ${description}\n`;
+    });
+    source += ' */\n\n';
+  }
+  return source;
+}
+
+async function main() {
+  const source = String(await readFile(path.join(externs, 'olx.js')));
+  const blocks = parse(source);
+  const data = processBlocks(blocks);
+  const output = format(data);
+  await writeFile(path.join(externs, 'xol.js'), output);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    process.stdout.write(`${err.stack}\n`, () => process.exit(1));
+  });
+}

--- a/tasks/t.js
+++ b/tasks/t.js
@@ -158,7 +158,7 @@ function format(data) {
 
     // add the @typedef
     source += `\n/**\n${comment} */\n`;
-    source += `export var ${name};\n\n`;
+    source += `export let ${name};\n\n`;
 
     const params = data[name].params;
     if (!params.length) {

--- a/tasks/t.js
+++ b/tasks/t.js
@@ -154,22 +154,18 @@ function processBlocks(blocks) {
 function format(data) {
   let source = '';
   for (const name in data) {
-    const comment = data[name].comment;
 
     // add the @typedef
-    source += `\n/**\n${comment} */\n`;
-    source += `export let ${name};\n\n`;
+    source += `\n/**\n * @typedef {Object} ${name}\n`;
 
     const params = data[name].params;
     if (!params.length) {
       throw new Error(`No params for ${name}`);
     }
 
-    source += '/**\n';
-    source += ` * @param {${name}} options TODO: repace this\n *\n`;
     params.forEach(param => {
-      const description = param.description.split('\n').join('\n * ');
-      source += ` * @param ${param.type} options.${param.name} ${description}\n`;
+      const description = param.description.replace(/\n$/, '').split('\n').join('\n * ');
+      source += ` * @property ${param.type} ${param.name} ${description}\n`;
     });
     source += ' */\n\n';
   }


### PR DESCRIPTION
This distributes things in the `externs/olx.js` file to places where they belong.

The `@typedef` annotations for the compiler will get added to the relevant module.  For example, a `FooOptions` type will go in the `ol/Foo` module.  The other `@type` annotations will get distributed as `@param` annotations in the modules where they belong.  For example, `FooOptions.prototype.bar` will become `options.bar` in for the constructor in `ol/Foo`.

Note that for 5.x, we assume applications being built together with the library, so no externs like the ones in `externs/olx.js` are needed any more. Since the full build will not be built with Closure Compiler any more, we do not need the externs there either (previously they helped us avoid renaming of properties in object literals passed from the application to the library).
