### PR TITLE
forEachLayerAtPixel signature, hitTolerance

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -45,6 +45,28 @@ The following methods did get the optional this (i.e. opt_this) arguments remove
 * source/TileUTFGrid#forDataAtCoordinateAndResolution
 * source/Vector#forEachFeature, #forEachFeatureInExtent, #forEachFeatureIntersectingExtent
 
+
+#### `Map#forEachLayerAtPixel` parameters have changed
+ 
+If you are using the layer filter, please note that you now have to pass in the layer filter via an `AtPixelOptions` object. If you are not using the layer filter the usage has not changed.
+
+Old syntax:
+```
+    map.forEachLayerAtPixel(pixel, callback, callbackThis, layerFilterFn, layerFilterThis);
+```
+
+New syntax:
+
+```
+    map.forEachLayerAtPixel(pixel, callback, {
+        layerFilter: layerFilterFn
+    });
+```
+
+To bind a function to a this, please use the bind method of the function (See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).
+
+This change is due to the introduction of the `hitTolerance` parameter which can be passed in via this `AtPixelOptions` object, too.
+
 ### v4.6.0
 
 #### Renamed `exceedLength` option of `ol.style.Text` to `overflow`

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -574,20 +574,13 @@ _ol_PluggableMap_.prototype.getFeaturesAtPixel = function(pixel, opt_options) {
  *     [R, G, B, A] pixel values (0 - 255) and will be `null` for layer types
  *     that do not currently support this argument. To stop detection, callback
  *     functions can return a truthy value.
- * @param {S=} opt_this Value to use as `this` when executing `callback`.
- * @param {(function(this: U, ol.layer.Layer): boolean)=} opt_layerFilter Layer
- *     filter function. The filter function will receive one argument, the
- *     {@link ol.layer.Layer layer-candidate} and it should return a boolean
- *     value. Only layers which are visible and for which this function returns
- *     `true` will be tested for features. By default, all visible layers will
- *     be tested.
- * @param {U=} opt_this2 Value to use as `this` when executing `layerFilter`.
+ * @param {olx.AtPixelOptions=} opt_options Optional options.
  * @return {T|undefined} Callback result, i.e. the return value of last
  * callback execution, or the first truthy callback return value.
- * @template S,T,U
+ * @template S,T
  * @api
  */
-_ol_PluggableMap_.prototype.forEachLayerAtPixel = function(pixel, callback, opt_this, opt_layerFilter, opt_this2) {
+_ol_PluggableMap_.prototype.forEachLayerAtPixel = function(pixel, callback, opt_options) {
   if (!this.frameState_) {
     return;
   }

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -584,12 +584,14 @@ _ol_PluggableMap_.prototype.forEachLayerAtPixel = function(pixel, callback, opt_
   if (!this.frameState_) {
     return;
   }
-  var thisArg = opt_this !== undefined ? opt_this : null;
-  var layerFilter = opt_layerFilter !== undefined ? opt_layerFilter : TRUE;
-  var thisArg2 = opt_this2 !== undefined ? opt_this2 : null;
+  opt_options = opt_options !== undefined ? opt_options : {};
+  var hitTolerance = opt_options.hitTolerance !== undefined ?
+    opt_options.hitTolerance * this.frameState_.pixelRatio : 0;
+  var layerFilter = opt_options.layerFilter !== undefined ?
+    opt_options.layerFilter : TRUE;
   return this.renderer_.forEachLayerAtPixel(
-      pixel, this.frameState_, callback, thisArg,
-      layerFilter, thisArg2);
+      pixel, this.frameState_, hitTolerance, callback, null,
+      layerFilter, null);
 };
 
 

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -162,6 +162,7 @@ _ol_renderer_Map_.prototype.forEachFeatureAtCoordinate = function(coordinate, fr
  * @abstract
  * @param {ol.Pixel} pixel Pixel.
  * @param {olx.FrameState} frameState FrameState.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {function(this: S, ol.layer.Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
  *     callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
@@ -173,7 +174,7 @@ _ol_renderer_Map_.prototype.forEachFeatureAtCoordinate = function(coordinate, fr
  * @return {T|undefined} Callback result.
  * @template S,T,U
  */
-_ol_renderer_Map_.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg,
+_ol_renderer_Map_.prototype.forEachLayerAtPixel = function(pixel, frameState, hitTolerance, callback, thisArg,
     layerFilter, thisArg2) {};
 
 

--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -118,7 +118,7 @@ _ol_renderer_canvas_IntermediateCanvas_.prototype.forEachFeatureAtCoordinate = f
 /**
  * @inheritDoc
  */
-_ol_renderer_canvas_IntermediateCanvas_.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, callback, thisArg) {
+_ol_renderer_canvas_IntermediateCanvas_.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
   if (!this.getImage()) {
     return undefined;
   }

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -101,14 +101,15 @@ _ol_renderer_canvas_Layer_.prototype.dispatchComposeEvent_ = function(type, cont
 /**
  * @param {ol.Coordinate} coordinate Coordinate.
  * @param {olx.FrameState} frameState FrameState.
+ * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {function(this: S, ol.layer.Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
  *     callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|undefined} Callback result.
  * @template S,T,U
  */
-_ol_renderer_canvas_Layer_.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, callback, thisArg) {
-  var hasFeature = this.forEachFeatureAtCoordinate(coordinate, frameState, 0, TRUE, this);
+_ol_renderer_canvas_Layer_.prototype.forEachLayerAtCoordinate = function(coordinate, frameState, hitTolerance, callback, thisArg) {
+  var hasFeature = this.forEachFeatureAtCoordinate(coordinate, frameState, hitTolerance, TRUE, this);
 
   if (hasFeature) {
     return callback.call(thisArg, this.getLayer(), null);

--- a/src/ol/renderer/canvas/Map.js
+++ b/src/ol/renderer/canvas/Map.js
@@ -207,7 +207,7 @@ _ol_renderer_canvas_Map_.prototype.renderFrame = function(frameState) {
 /**
  * @inheritDoc
  */
-_ol_renderer_canvas_Map_.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg,
+_ol_renderer_canvas_Map_.prototype.forEachLayerAtPixel = function(pixel, frameState, hitTolerance, callback, thisArg,
     layerFilter, thisArg2) {
   var result;
   var viewState = frameState.viewState;
@@ -227,7 +227,7 @@ _ol_renderer_canvas_Map_.prototype.forEachLayerAtPixel = function(pixel, frameSt
         layerFilter.call(thisArg2, layer)) {
       var layerRenderer = /** @type {ol.renderer.canvas.Layer} */ (this.getLayerRenderer(layer));
       result = layerRenderer.forEachLayerAtCoordinate(
-          coordinate, frameState, callback, thisArg);
+          coordinate, frameState, hitTolerance, callback, thisArg);
       if (result) {
         return result;
       }

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -573,7 +573,7 @@ _ol_renderer_webgl_Map_.prototype.hasFeatureAtCoordinate = function(coordinate, 
 /**
  * @inheritDoc
  */
-_ol_renderer_webgl_Map_.prototype.forEachLayerAtPixel = function(pixel, frameState, callback, thisArg,
+_ol_renderer_webgl_Map_.prototype.forEachLayerAtPixel = function(pixel, frameState, hitTolerance, callback, thisArg,
     layerFilter, thisArg2) {
   if (this.getGL().isContextLost()) {
     return false;


### PR DESCRIPTION
This pull request is a follow up to #5995, fixes #7283 and also adresses #7284.

What it contains:
* unified signature for forEachLayerAtPixel and forEachFeatureAtPixel. This is an api change.
* hitTolerance parameter for forEachLayerAtPixel.
* removes some uneccessary thisArgs

There is one thing missing, and I don't really know how to handle this at the moment. it is about renderer/canvas/IntermediateCanvas#forEachLayerAtPixel. There the same mechanism regarding the hitTolerance is needed that is normally used in the render/canvas/ReplayGroup.
I see 2 solutions for this right now: 1. move the hitTolerance mechanism to another class that is accessible for both classes or 2. defer the hitDetection functionality in IntermediateCanvas to some render class that has access.