### PR TITLE
Import assert function directly

### DIFF
--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/extent
  */
-import asserts from './asserts.js';
+import {assert} from './asserts.js';
 import Corner from './extent/Corner.js';
 import Relationship from './extent/Relationship.js';
 
@@ -488,7 +488,7 @@ export function getCorner(extent, corner) {
   } else if (corner === Corner.TOP_RIGHT) {
     coordinate = getTopRight(extent);
   } else {
-    asserts.assert(false, 13); // Invalid corner
+    assert(false, 13); // Invalid corner
   }
   return /** @type {!ol.Coordinate} */ (coordinate);
 }


### PR DESCRIPTION
This changes one remaining occurence from

```js
import asserts from './asserts.js';
```

to

```js
import {assert} from './asserts.js';
```

and gets rid of the following warning:

```
WARNING in ./src/ol/extent.js
491:4-11 "export 'default' (imported as 'asserts') was not found in './asserts.js'
 @ ./src/ol/extent.js
 @ ./test/spec/ol/extent.test.js
```

Please review.