### PR TITLE
Revert "Set Chrome version to 62.0 in SauceLab config"

### DIFF
--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -69,8 +69,7 @@ module.exports = function(karma) {
     const customLaunchers = {
       SL_Chrome: {
         base: 'SauceLabs',
-        browserName: 'chrome',
-        version: '62.0'
+        browserName: 'chrome'
       },
       SL_Firefox: {
         base: 'SauceLabs',


### PR DESCRIPTION
Checking if the Chrome > 62.0 issues are fixed at Sauce Labs