### PR TITLE
Overriding ol.source.Vector#refresh() to trigger an actual refresh, fix #7044

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -885,6 +885,14 @@ VectorSource.prototype.loadFeatures = function(extent, resolution, projection) {
   }
 };
 
+/**
+ * Refreshes the source by clearing all features. clear() dispatches a
+ * 'change' event that triggers a reload of all features.
+ * @api
+ */
+VectorSource.prototype.refresh = function() {
+  this.clear();
+};
 
 /**
  * Remove an extent from the list of loaded extents.


### PR DESCRIPTION
This pull request is supposed to fix #7044

ol.source.refresh() only dispatches a 'change' event. While this
triggers a reload, the #loadFeatures() method checks if the extents of
already loaded features match the extents of features to be loaded.
Features where only the content changed (eg metadata) won't be refreshed
using this approach.
Hence this commits overrides ol.source.Vector#refresh() to clear all
features. The triggered reload will properly refresh all features.

Thank you for your interest in making OpenLayers better!

In order to get your proposed changes merged into the master branch, we ask you to please make sure the following boxes are checked *before* submitting your pull request.

- [x] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
- [x] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).
