### PR TITLE
Background fill stroke

### DIFF
--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -993,7 +993,9 @@ _ol_render_canvas_Replay_.prototype.applyStroke = function(state) {
 _ol_render_canvas_Replay_.prototype.updateFillStyle = function(state, applyFill, geometry) {
   var fillStyle = state.fillStyle;
   if (typeof fillStyle !== 'string' || state.currentFillStyle != fillStyle) {
-    applyFill.call(this, state, geometry);
+    if (fillStyle !== undefined) {
+      applyFill.call(this, state, geometry);
+    }
     state.currentFillStyle = fillStyle;
   }
 };
@@ -1018,7 +1020,9 @@ _ol_render_canvas_Replay_.prototype.updateStrokeStyle = function(state, applyStr
       state.currentLineJoin != lineJoin ||
       state.currentLineWidth != lineWidth ||
       state.currentMiterLimit != miterLimit) {
-    applyStroke.call(this, state);
+    if (strokeStyle !== undefined) {
+      applyStroke.call(this, state);
+    }
     state.currentStrokeStyle = strokeStyle;
     state.currentLineCap = lineCap;
     state.currentLineDash = lineDash;

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -151,7 +151,9 @@ _ol_style_Text_.prototype.clone = function() {
     fill: this.getFill() ? this.getFill().clone() : undefined,
     stroke: this.getStroke() ? this.getStroke().clone() : undefined,
     offsetX: this.getOffsetX(),
-    offsetY: this.getOffsetY()
+    offsetY: this.getOffsetY(),
+    backgroundFill: this.getBackgroundFill() ? this.getBackgroundFill().clone() : undefined,
+    backgroundStroke: this.getBackgroundStroke() ? this.getBackgroundStroke().clone() : undefined
   });
 };
 

--- a/test/spec/ol/style/text.test.js
+++ b/test/spec/ol/style/text.test.js
@@ -52,6 +52,12 @@ describe('ol.style.Text', function() {
         }),
         stroke: new _ol_style_Stroke_({
           color: '#319FD3'
+        }),
+        backgroundFill: new _ol_style_Fill_({
+          color: 'white'
+        }),
+        backgroundStroke: new _ol_style_Stroke_({
+          color: 'black'
         })
       });
       var clone = original.clone();
@@ -66,6 +72,8 @@ describe('ol.style.Text', function() {
       expect(original.getTextBaseline()).to.eql(clone.getTextBaseline());
       expect(original.getStroke().getColor()).to.eql(clone.getStroke().getColor());
       expect(original.getFill().getColor()).to.eql(clone.getFill().getColor());
+      expect(original.getBackgroundStroke().getColor()).to.eql(clone.getBackgroundStroke().getColor());
+      expect(original.getBackgroundFill().getColor()).to.eql(clone.getBackgroundFill().getColor());
     });
 
     it('the clone does not reference the same objects as the original', function() {


### PR DESCRIPTION
Fixes #7659

Working on this revealed another issue when using `backgroundFill` without `backgroundStroke`, because the dash array can be null in such cases. That issue is also fixed.