### PR TITLE
Hit detect text background

### DIFF
--- a/src/ol/render/canvas/PolygonReplay.js
+++ b/src/ol/render/canvas/PolygonReplay.js
@@ -216,7 +216,7 @@ _ol_render_canvas_PolygonReplay_.prototype.setFillStrokeStyles_ = function(geome
   var state = this.state;
   var fillStyle = state.fillStyle;
   if (fillStyle !== undefined) {
-    this.updateFillStyle(state, this.applyFill, geometry);
+    this.updateFillStyle(state, this.createFill, geometry);
   }
   if (state.strokeStyle !== undefined) {
     this.updateStrokeStyle(state, this.applyStroke);

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -268,7 +268,10 @@ _ol_render_canvas_Replay_.prototype.replayImage_ = function(context, x, y, image
     createOrUpdate(boxX, boxY, boxX + boxW, boxY + boxH, box);
   }
   var canvas = context.canvas;
-  var intersects = box[0] <= canvas.width && box[2] >= 0 && box[1] <= canvas.height && box[3] >= 0;
+  var strokePadding = strokeInstruction ? (strokeInstruction[2] * scale / 2) : 0;
+  var intersects =
+      box[0] - strokePadding <= canvas.width && box[2] + strokePadding >= 0 &&
+      box[1] - strokePadding <= canvas.height && box[3] + strokePadding >= 0;
 
   if (snapToPixel) {
     x = Math.round(x);

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -264,8 +264,10 @@ _ol_render_canvas_TextReplay_.prototype.drawText = function(geometry, feature) {
     this.beginGeometry(geometry, feature);
     if (textState.backgroundFill || textState.backgroundStroke) {
       this.setFillStrokeStyle(textState.backgroundFill, textState.backgroundStroke);
-      this.updateFillStyle(this.state, this.applyFill, geometry);
+      this.updateFillStyle(this.state, this.createFill, geometry);
+      this.hitDetectionInstructions.push(this.createFill(this.state, geometry));
       this.updateStrokeStyle(this.state, this.applyStroke);
+      this.hitDetectionInstructions.push(this.createStroke(this.state));
     }
     this.drawTextImage_(label, begin, end);
     this.endGeometry(geometry, feature);

--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -352,6 +352,9 @@ describe('ol.rendering.style.Text', function() {
       }));
       features[2].getStyle().getText().setPadding([5, 10, 15, 0]);
       map.getView().fit(vectorSource.getExtent());
+      map.once('postrender', function() {
+        expect(map.getFeaturesAtPixel([178, 120])).to.have.length(1);
+      });
       expectResemble(map, 'rendering/ol/style/expected/text-background.png', IMAGE_TOLERANCE, done);
     });
 


### PR DESCRIPTION
Currently, text backgrounds are not hit detected. With this change, text background fill and stroke are applied properly to hit detection replays, and the text box stroke is considered too.