### PR TITLE
Improved drawing experience on touch devices

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,13 @@
 
 ### Next release
 
+#### Changed behavior of the `Draw` interaction
+
+For better drawing experience, especially on mobile devices, two changes were made to the behavior of the Draw interaction:
+
+ 1. On long press, the current vertex can be moved to its desired position.
+ 2. When moving the mouse or panning the map, no draw cursor is shown, and the geometry being drawn is not updated. But because of 1., the draw cursor will appear on long press.
+
 #### Changes in proj4 integration
 
 Because relying on a globally available proj4 is not practical with ES modules, we have made a change to the way we integrate proj4:

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -9,6 +9,8 @@ For better drawing experience, especially on mobile devices, two changes were ma
  1. On long press, the current vertex can be moved to its desired position.
  2. When moving the mouse or panning the map, no draw cursor is shown, and the geometry being drawn is not updated. But because of 1., the draw cursor will appear on long press.
 
+To get the old behavior, configure the `Drag` interaction with `dragVertexDelay: 0`.
+
 #### Changes in proj4 integration
 
 Because relying on a globally available proj4 is not practical with ES modules, we have made a change to the way we integrate proj4:

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,12 +4,10 @@
 
 #### Changed behavior of the `Draw` interaction
 
-For better drawing experience, especially on mobile devices, two changes were made to the behavior of the Draw interaction:
+For better drawing experience, two changes were made to the behavior of the Draw interaction:
 
- 1. On long press, the current vertex can be moved to its desired position.
- 2. When moving the mouse or panning the map, no draw cursor is shown, and the geometry being drawn is not updated. But because of 1., the draw cursor will appear on long press.
-
-To get the old behavior, configure the `Drag` interaction with `dragVertexDelay: 0`.
+ 1. On long press, the current vertex can be dragged to its desired position.
+ 2. On touch move (e.g. when panning the map on a mobile device), no draw cursor is shown, and the geometry being drawn is not updated. But because of 1., the draw cursor will appear on long press. Mouse moves are not affected by this change.
 
 #### Changes in proj4 integration
 

--- a/examples/draw-and-modify-features.js
+++ b/examples/draw-and-modify-features.js
@@ -71,4 +71,9 @@ typeSelect.onchange = function() {
   addInteractions();
 };
 
+// Avoid context menu for long taps when editing on mobile
+map.getTargetElement().oncontextmenu = function(e) {
+  e.preventDefault();
+};
+
 addInteractions();

--- a/examples/draw-and-modify-features.js
+++ b/examples/draw-and-modify-features.js
@@ -71,9 +71,4 @@ typeSelect.onchange = function() {
   addInteractions();
 };
 
-// Avoid context menu for long taps when editing on mobile
-map.getTargetElement().oncontextmenu = function(e) {
-  e.preventDefault();
-};
-
 addInteractions();

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -2356,6 +2356,7 @@ olx.interaction.DragZoomOptions.prototype.out;
  * @typedef {{clickTolerance: (number|undefined),
  *     features: (ol.Collection.<ol.Feature>|undefined),
  *     source: (ol.source.Vector|undefined),
+ *     dragVertexDelay: (number|undefined),
  *     snapTolerance: (number|undefined),
  *     type: (ol.geom.GeometryType|string),
  *     stopClick: (boolean|undefined),
@@ -2399,6 +2400,14 @@ olx.interaction.DrawOptions.prototype.features;
  * @api
  */
 olx.interaction.DrawOptions.prototype.source;
+
+
+/**
+ * Delay in milliseconds after pointerdown before the current vertex can be
+ * dragged to its exact position. Default is 500 ms.
+ * @type {number|undefined}
+ */
+olx.interaction.DrawOptions.prototype.dragVertexDelay;
 
 
 /**

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -267,6 +267,8 @@ const PluggableMap = function(options) {
    */
   this.keyHandlerKeys_ = null;
 
+  _ol_events_.listen(this.viewport_, EventType.CONTEXTMENU,
+    this.handleBrowserEvent, this);
   _ol_events_.listen(this.viewport_, EventType.WHEEL,
     this.handleBrowserEvent, this);
   _ol_events_.listen(this.viewport_, EventType.MOUSEWHEEL,
@@ -491,6 +493,8 @@ PluggableMap.prototype.addOverlayInternal_ = function(overlay) {
  */
 PluggableMap.prototype.disposeInternal = function() {
   this.mapBrowserEventHandler_.dispose();
+  _ol_events_.unlisten(this.viewport_, EventType.CONTEXTMENU,
+    this.handleBrowserEvent, this);
   _ol_events_.unlisten(this.viewport_, EventType.WHEEL,
     this.handleBrowserEvent, this);
   _ol_events_.unlisten(this.viewport_, EventType.MOUSEWHEEL,

--- a/src/ol/events/EventType.js
+++ b/src/ol/events/EventType.js
@@ -15,6 +15,7 @@ export default {
   CHANGE: 'change',
 
   CLEAR: 'clear',
+  CONTEXTMENU: 'contextmenu',
   CLICK: 'click',
   DBLCLICK: 'dblclick',
   DRAGENTER: 'dragenter',

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -61,6 +61,12 @@ const Draw = function(options) {
    * @type {number}
    * @private
    */
+  this.downTimeout_;
+
+  /**
+   * @type {number}
+   * @private
+   */
   this.lastDragTime_;
 
   /**
@@ -333,7 +339,7 @@ Draw.handleEvent = function(event) {
   this.freehand_ = this.mode_ !== Draw.Mode_.POINT && this.freehandCondition_(event);
   let move = event.type === MapBrowserEventType.POINTERMOVE;
   let pass = true;
-  if (!this.freehand_ && this.lastDragTime_ && event.type === MapBrowserEventType.POINTERDRAG) {
+  if (this.lastDragTime_ && event.type === MapBrowserEventType.POINTERDRAG) {
     const now = Date.now();
     if (now - this.lastDragTime_ >= 500) {
       this.downPx_ = event.pixel;
@@ -547,9 +553,6 @@ Draw.prototype.startDrawing_ = function(event) {
     this.sketchLineCoords_ = this.sketchCoords_[0];
   } else {
     this.sketchCoords_ = [start.slice(), start.slice()];
-    if (this.mode_ === Draw.Mode_.CIRCLE) {
-      this.sketchLineCoords_ = this.sketchCoords_;
-    }
   }
   if (this.sketchLineCoords_) {
     this.sketchLine_ = new Feature(

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -19,6 +19,7 @@ import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
 import MultiPolygon from '../geom/MultiPolygon.js';
+import MouseSource from '../pointer/MouseSource.js';
 import Point from '../geom/Point.js';
 import Polygon, {fromCircle, makeRegular} from '../geom/Polygon.js';
 import DrawEventType from '../interaction/DrawEventType.js';
@@ -374,9 +375,10 @@ Draw.handleEvent = function(event) {
     pass = false;
   } else if (move) {
     pass = event.type === MapBrowserEventType.POINTERMOVE;
-    if (pass && this.freehand_ || this.dragVertexDelay_ === 0) {
+    if (pass && this.freehand_) {
       pass = this.handlePointerMove_(event);
-    } else if (event.type === MapBrowserEventType.POINTERDRAG && !this.downTimeout_) {
+    } else if (event.pointerEvent.pointerType == MouseSource.POINTER_TYPE ||
+        (event.type === MapBrowserEventType.POINTERDRAG && !this.downTimeout_)) {
       this.handlePointerMove_(event);
     }
   } else if (event.type === MapBrowserEventType.DBLCLICK) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -2,6 +2,7 @@
  * @module ol/interaction/Draw
  */
 import {inherits} from '../index.js';
+import EventType from '../events/EventType.js';
 import Feature from '../Feature.js';
 import MapBrowserEventType from '../MapBrowserEventType.js';
 import MapBrowserPointerEvent from '../MapBrowserPointerEvent.js';
@@ -336,6 +337,10 @@ Draw.prototype.setMap = function(map) {
  * @api
  */
 Draw.handleEvent = function(event) {
+  if (event.originalEvent.type === EventType.CONTEXTMENU) {
+    // Avoid context menu for long taps when drawing on mobile
+    event.preventDefault();
+  }
   this.freehand_ = this.mode_ !== Draw.Mode_.POINT && this.freehandCondition_(event);
   let move = event.type === MapBrowserEventType.POINTERMOVE;
   let pass = true;

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -423,6 +423,9 @@ Draw.prototype.handlePointerMove_ = function(event) {
     this.shouldHandle_ = this.freehand_ ?
       squaredDistance > this.squaredClickTolerance_ :
       squaredDistance <= this.squaredClickTolerance_;
+    if (!this.shouldHandle_) {
+      return true;
+    }
   }
 
   if (this.finishCoordinate_) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -206,6 +206,12 @@ const Draw = function(options) {
   this.geometryFunction_ = geometryFunction;
 
   /**
+   * @type {number}
+   * @private
+   */
+  this.dragVertexDelay_ = options.dragVertexDelay !== undefined ? options.dragVertexDelay : 500;
+
+  /**
    * Finish coordinate for the feature (first point for polygons, last point for
    * linestrings).
    * @type {ol.Coordinate}
@@ -346,7 +352,7 @@ Draw.handleEvent = function(event) {
   let pass = true;
   if (this.lastDragTime_ && event.type === MapBrowserEventType.POINTERDRAG) {
     const now = Date.now();
-    if (now - this.lastDragTime_ >= 500) {
+    if (now - this.lastDragTime_ >= this.dragVertexDelay_) {
       this.downPx_ = event.pixel;
       this.shouldHandle_ = !this.freehand_;
       move = true;
@@ -368,7 +374,7 @@ Draw.handleEvent = function(event) {
     pass = false;
   } else if (move) {
     pass = event.type === MapBrowserEventType.POINTERMOVE;
-    if (pass && this.freehand_) {
+    if (pass && this.freehand_ || this.dragVertexDelay_ === 0) {
       pass = this.handlePointerMove_(event);
     } else if (event.type === MapBrowserEventType.POINTERDRAG && !this.downTimeout_) {
       this.handlePointerMove_(event);
@@ -401,7 +407,7 @@ Draw.handleDownEvent_ = function(event) {
     this.downTimeout_ = setTimeout(function() {
       this.handlePointerMove_(new MapBrowserPointerEvent(
         MapBrowserEventType.POINTERMOVE, event.map, event.pointerEvent, event.frameState));
-    }.bind(this), 500);
+    }.bind(this), this.dragVertexDelay_);
     this.downPx_ = event.pixel;
     return true;
   } else {

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -339,7 +339,6 @@ describe('ol.interaction.Draw', function() {
       simulateEvent('pointermove', 20, 30);
 
       // freehand
-      simulateEvent('pointerdown', 20, 30, true);
       simulateEvent('pointermove', 20, 30, true);
       simulateEvent('pointerdrag', 20, 30, true);
       simulateEvent('pointermove', 30, 40, true);

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -103,6 +103,15 @@ describe('ol.interaction.Draw', function() {
       expect(draw.freehandCondition_(event)).to.be(true);
     });
 
+    it('accepts a dragVertexDelay option', function() {
+      const draw = new Draw({
+        source: source,
+        type: 'LineString',
+        dragVertexDelay: 42
+      });
+      expect(draw.dragVertexDelay_).to.be(42);
+    });
+
   });
 
   describe('specifying a geometryName', function() {
@@ -393,6 +402,38 @@ describe('ol.interaction.Draw', function() {
       const geometry = features[0].getGeometry();
       expect(geometry).to.be.a(LineString);
       expect(geometry.getCoordinates()).to.eql([[10, -20], [30, -20]]);
+    });
+
+    it('allows dragging of the vertex after dragVertexDelay', function(done) {
+      // first point
+      simulateEvent('pointermove', 10, 20);
+      simulateEvent('pointerdown', 10, 20);
+      simulateEvent('pointerup', 10, 20);
+
+      // second point, drag vertex
+      simulateEvent('pointermove', 15, 20);
+      simulateEvent('pointerdown', 15, 20);
+      setTimeout(function() {
+        simulateEvent('pointermove', 20, 10);
+        simulateEvent('pointerdrag', 20, 10);
+        simulateEvent('pointerup', 20, 10);
+        // third point
+        simulateEvent('pointermove', 30, 20);
+        simulateEvent('pointerdown', 30, 20);
+        simulateEvent('pointerup', 30, 20);
+
+        // finish on third point
+        simulateEvent('pointerdown', 30, 20);
+        simulateEvent('pointerup', 30, 20);
+
+        const features = source.getFeatures();
+        expect(features).to.have.length(1);
+        const geometry = features[0].getGeometry();
+        expect(geometry).to.be.a(LineString);
+        expect(geometry.getCoordinates()).to.eql([[10, -20], [20, -10], [30, -20]]);
+
+        done();
+      }, 600);
     });
 
     it('triggers draw events', function() {


### PR DESCRIPTION
With this change, the Draw interaction allows accurate drawing when using finger/stylus. Geometries are not being updated while panning the map, and the vertex being drawn can be moved before lifting the finger/stylus when in a long press gesture.

On mouse devices, long press works now too, but nothing else changes.
