### PR TITLE
Do not use (I)CLA anymore

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,3 @@ In order to get your proposed changes merged into the master branch, we ask you 
 - [ ] It contains one or more small, incremental, logically separate commits, with no merge commits.
 - [ ] I have used clear commit messages.
 - [ ] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
-- [ ] The work herein is covered by a valid [Contributor License Agreement (CLA)](https://github.com/openlayers/cla).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,7 @@ This page describes what you need to know to contribute code to OpenLayers as a 
 
 ## Contributor License Agreement
 
-Before accepting a contribution, we ask that you provide us a Contributor
-License Agreement.  If you are making your contribution as part of work for
-your employer, please follow the guidelines on submitting a [Corporate
-Contributor License Agreement](https://raw.github.com/openlayers/cla/master/ccla.txt). If you are
-making your contribution as an individual, you can submit a digital [Individual
-Contributor License Agreement](https://docs.google.com/spreadsheet/viewform?formkey=dGNNVUJEMXF2dERTU0FXM3JjNVBQblE6MQ).
+Your contribution will be under our [license](https://raw.githubusercontent.com/openlayers/openlayers/master/LICENSE.md) as per [GitHub's terms of service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license).
 
 
 ## Pull request guidelines


### PR DESCRIPTION
As per https://ben.balter.com/2018/01/02/why-you-probably-shouldnt-add-a-cla-to-your-open-source-project/ we can get rid of our (I)CLA process, and point to GitHub's terms of service and our license instead.