### PR TITLE
Named exports from ol/events

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -2,7 +2,7 @@
  * @module ol/Feature
  */
 import {assert} from './asserts.js';
-import _ol_events_ from './events.js';
+import {listen, unlisten, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 import {inherits} from './index.js';
 import BaseObject from './Object.js';
@@ -90,7 +90,7 @@ const Feature = function(opt_geometryOrProperties) {
    */
   this.geometryChangeKey_ = null;
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(this.geometryName_),
     this.handleGeometryChanged_, this);
 
@@ -205,12 +205,12 @@ Feature.prototype.handleGeometryChange_ = function() {
  */
 Feature.prototype.handleGeometryChanged_ = function() {
   if (this.geometryChangeKey_) {
-    _ol_events_.unlistenByKey(this.geometryChangeKey_);
+    unlistenByKey(this.geometryChangeKey_);
     this.geometryChangeKey_ = null;
   }
   const geometry = this.getGeometry();
   if (geometry) {
-    this.geometryChangeKey_ = _ol_events_.listen(geometry,
+    this.geometryChangeKey_ = listen(geometry,
       EventType.CHANGE, this.handleGeometryChange_, this);
   }
   this.changed();
@@ -269,11 +269,11 @@ Feature.prototype.setId = function(id) {
  * @api
  */
 Feature.prototype.setGeometryName = function(name) {
-  _ol_events_.unlisten(
+  unlisten(
     this, BaseObject.getChangeEventType(this.geometryName_),
     this.handleGeometryChanged_, this);
   this.geometryName_ = name;
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(this.geometryName_),
     this.handleGeometryChanged_, this);
   this.handleGeometryChanged_();

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -4,7 +4,7 @@
 import {inherits} from './index.js';
 import GeolocationProperty from './GeolocationProperty.js';
 import BaseObject from './Object.js';
-import _ol_events_ from './events.js';
+import {listen} from './events.js';
 import EventType from './events/EventType.js';
 import {circular as circularPolygon} from './geom/Polygon.js';
 import _ol_has_ from './has.js';
@@ -78,10 +78,10 @@ const Geolocation = function(opt_options) {
    */
   this.watchId_ = undefined;
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(GeolocationProperty.PROJECTION),
     this.handleProjectionChanged_, this);
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(GeolocationProperty.TRACKING),
     this.handleTrackingChanged_, this);
 

--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -4,7 +4,7 @@
 import {inherits} from './index.js';
 import _ol_ImageBase_ from './ImageBase.js';
 import ImageState from './ImageState.js';
-import _ol_events_ from './events.js';
+import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 import {getHeight} from './extent.js';
 
@@ -108,9 +108,9 @@ _ol_Image_.prototype.load = function() {
     this.state = ImageState.LOADING;
     this.changed();
     this.imageListenerKeys_ = [
-      _ol_events_.listenOnce(this.image_, EventType.ERROR,
+      listenOnce(this.image_, EventType.ERROR,
         this.handleImageError_, this),
-      _ol_events_.listenOnce(this.image_, EventType.LOAD,
+      listenOnce(this.image_, EventType.LOAD,
         this.handleImageLoad_, this)
     ];
     this.imageLoadFunction_(this, this.src_);
@@ -132,7 +132,7 @@ _ol_Image_.prototype.setImage = function(image) {
  * @private
  */
 _ol_Image_.prototype.unlistenImage_ = function() {
-  this.imageListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.imageListenerKeys_.forEach(unlistenByKey);
   this.imageListenerKeys_ = null;
 };
 export default _ol_Image_;

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -5,7 +5,7 @@ import {inherits} from './index.js';
 import Tile from './Tile.js';
 import TileState from './TileState.js';
 import {createCanvasContext2D} from './dom.js';
-import _ol_events_ from './events.js';
+import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 
 /**
@@ -142,9 +142,9 @@ ImageTile.prototype.load = function() {
     this.state = TileState.LOADING;
     this.changed();
     this.imageListenerKeys_ = [
-      _ol_events_.listenOnce(this.image_, EventType.ERROR,
+      listenOnce(this.image_, EventType.ERROR,
         this.handleImageError_, this),
-      _ol_events_.listenOnce(this.image_, EventType.LOAD,
+      listenOnce(this.image_, EventType.LOAD,
         this.handleImageLoad_, this)
     ];
     this.tileLoadFunction_(this, this.src_);
@@ -158,7 +158,7 @@ ImageTile.prototype.load = function() {
  * @private
  */
 ImageTile.prototype.unlistenImage_ = function() {
-  this.imageListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.imageListenerKeys_.forEach(unlistenByKey);
   this.imageListenerKeys_ = null;
 };
 

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -5,7 +5,7 @@ import {inherits} from './index.js';
 import _ol_has_ from './has.js';
 import MapBrowserEventType from './MapBrowserEventType.js';
 import MapBrowserPointerEvent from './MapBrowserPointerEvent.js';
-import _ol_events_ from './events.js';
+import {listen, unlistenByKey} from './events.js';
 import EventTarget from './events/EventTarget.js';
 import PointerEventType from './pointer/EventType.js';
 import PointerEventHandler from './pointer/PointerEventHandler.js';
@@ -96,7 +96,7 @@ const MapBrowserEventHandler = function(map, moveTolerance) {
    * @type {?ol.EventsKey}
    * @private
    */
-  this.pointerdownListenerKey_ = _ol_events_.listen(this.pointerEventHandler_,
+  this.pointerdownListenerKey_ = listen(this.pointerEventHandler_,
     PointerEventType.POINTERDOWN,
     this.handlePointerDown_, this);
 
@@ -104,7 +104,7 @@ const MapBrowserEventHandler = function(map, moveTolerance) {
    * @type {?ol.EventsKey}
    * @private
    */
-  this.relayedListenerKey_ = _ol_events_.listen(this.pointerEventHandler_,
+  this.relayedListenerKey_ = listen(this.pointerEventHandler_,
     PointerEventType.POINTERMOVE,
     this.relayEvent_, this);
 
@@ -180,7 +180,7 @@ MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
   }
 
   if (this.activePointers_ === 0) {
-    this.dragListenerKeys_.forEach(_ol_events_.unlistenByKey);
+    this.dragListenerKeys_.forEach(unlistenByKey);
     this.dragListenerKeys_.length = 0;
     this.dragging_ = false;
     this.down_ = null;
@@ -221,10 +221,10 @@ MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
         new PointerEventHandler(document);
 
     this.dragListenerKeys_.push(
-      _ol_events_.listen(this.documentPointerEventHandler_,
+      listen(this.documentPointerEventHandler_,
         MapBrowserEventType.POINTERMOVE,
         this.handlePointerMove_, this),
-      _ol_events_.listen(this.documentPointerEventHandler_,
+      listen(this.documentPointerEventHandler_,
         MapBrowserEventType.POINTERUP,
         this.handlePointerUp_, this),
       /* Note that the listener for `pointercancel is set up on
@@ -240,7 +240,7 @@ MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
        * only receive a `touchcancel` from `pointerEventHandler_`, because it is
        * only registered there.
        */
-      _ol_events_.listen(this.pointerEventHandler_,
+      listen(this.pointerEventHandler_,
         MapBrowserEventType.POINTERCANCEL,
         this.handlePointerUp_, this)
     );
@@ -301,15 +301,15 @@ MapBrowserEventHandler.prototype.isMoving_ = function(pointerEvent) {
  */
 MapBrowserEventHandler.prototype.disposeInternal = function() {
   if (this.relayedListenerKey_) {
-    _ol_events_.unlistenByKey(this.relayedListenerKey_);
+    unlistenByKey(this.relayedListenerKey_);
     this.relayedListenerKey_ = null;
   }
   if (this.pointerdownListenerKey_) {
-    _ol_events_.unlistenByKey(this.pointerdownListenerKey_);
+    unlistenByKey(this.pointerdownListenerKey_);
     this.pointerdownListenerKey_ = null;
   }
 
-  this.dragListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.dragListenerKeys_.forEach(unlistenByKey);
   this.dragListenerKeys_.length = 0;
 
   if (this.documentPointerEventHandler_) {

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -2,7 +2,7 @@
  * @module ol/Observable
  */
 import {inherits} from './index.js';
-import _ol_events_ from './events.js';
+import {listen, unlistenByKey, unlisten, listenOnce} from './events.js';
 import EventTarget from './events/EventTarget.js';
 import EventType from './events/EventType.js';
 
@@ -44,10 +44,10 @@ inherits(Observable, EventTarget);
 Observable.unByKey = function(key) {
   if (Array.isArray(key)) {
     for (let i = 0, ii = key.length; i < ii; ++i) {
-      _ol_events_.unlistenByKey(key[i]);
+      unlistenByKey(key[i]);
     }
   } else {
-    _ol_events_.unlistenByKey(/** @type {ol.EventsKey} */ (key));
+    unlistenByKey(/** @type {ol.EventsKey} */ (key));
   }
 };
 
@@ -101,11 +101,11 @@ Observable.prototype.on = function(type, listener) {
     const len = type.length;
     const keys = new Array(len);
     for (let i = 0; i < len; ++i) {
-      keys[i] = _ol_events_.listen(this, type[i], listener);
+      keys[i] = listen(this, type[i], listener);
     }
     return keys;
   } else {
-    return _ol_events_.listen(
+    return listen(
       this, /** @type {string} */ (type), listener);
   }
 };
@@ -125,11 +125,11 @@ Observable.prototype.once = function(type, listener) {
     const len = type.length;
     const keys = new Array(len);
     for (let i = 0; i < len; ++i) {
-      keys[i] = _ol_events_.listenOnce(this, type[i], listener);
+      keys[i] = listenOnce(this, type[i], listener);
     }
     return keys;
   } else {
-    return _ol_events_.listenOnce(
+    return listenOnce(
       this, /** @type {string} */ (type), listener);
   }
 };
@@ -144,11 +144,11 @@ Observable.prototype.once = function(type, listener) {
 Observable.prototype.un = function(type, listener) {
   if (Array.isArray(type)) {
     for (let i = 0, ii = type.length; i < ii; ++i) {
-      _ol_events_.unlisten(this, type[i], listener);
+      unlisten(this, type[i], listener);
     }
     return;
   } else {
-    _ol_events_.unlisten(this, /** @type {string} */ (type), listener);
+    unlisten(this, /** @type {string} */ (type), listener);
   }
 };
 export default Observable;

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -7,7 +7,7 @@ import BaseObject from './Object.js';
 import OverlayPositioning from './OverlayPositioning.js';
 import {CLASS_SELECTABLE} from './css.js';
 import {removeNode, removeChildren, outerWidth, outerHeight} from './dom.js';
-import _ol_events_ from './events.js';
+import {listen, unlistenByKey} from './events.js';
 import {containsExtent} from './extent.js';
 
 
@@ -125,23 +125,23 @@ const Overlay = function(options) {
    */
   this.mapPostrenderListenerKey = null;
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(Property.ELEMENT),
     this.handleElementChanged, this);
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(Property.MAP),
     this.handleMapChanged, this);
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(Property.OFFSET),
     this.handleOffsetChanged, this);
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(Property.POSITION),
     this.handlePositionChanged, this);
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(Property.POSITIONING),
     this.handlePositioningChanged, this);
 
@@ -249,12 +249,12 @@ Overlay.prototype.handleElementChanged = function() {
 Overlay.prototype.handleMapChanged = function() {
   if (this.mapPostrenderListenerKey) {
     removeNode(this.element);
-    _ol_events_.unlistenByKey(this.mapPostrenderListenerKey);
+    unlistenByKey(this.mapPostrenderListenerKey);
     this.mapPostrenderListenerKey = null;
   }
   const map = this.getMap();
   if (map) {
-    this.mapPostrenderListenerKey = _ol_events_.listen(map,
+    this.mapPostrenderListenerKey = listen(map,
       MapEventType.POSTRENDER, this.render, this);
     this.updatePixelPosition();
     const container = this.stopEvent ?

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -17,7 +17,7 @@ import View from './View.js';
 import ViewHint from './ViewHint.js';
 import {assert} from './asserts.js';
 import {removeNode} from './dom.js';
-import _ol_events_ from './events.js';
+import {listen, unlistenByKey, unlisten} from './events.js';
 import Event from './events/Event.js';
 import EventType from './events/EventType.js';
 import {createEmpty, clone, createOrUpdateEmpty, equals, getForViewAndSize, isEmpty} from './extent.js';
@@ -240,7 +240,7 @@ const PluggableMap = function(options) {
     EventType.WHEEL
   ];
   for (let i = 0, ii = overlayEvents.length; i < ii; ++i) {
-    _ol_events_.listen(this.overlayContainerStopEvent_, overlayEvents[i],
+    listen(this.overlayContainerStopEvent_, overlayEvents[i],
       Event.stopPropagation);
   }
   this.viewport_.appendChild(this.overlayContainerStopEvent_);
@@ -251,7 +251,7 @@ const PluggableMap = function(options) {
    */
   this.mapBrowserEventHandler_ = new MapBrowserEventHandler(this, options.moveTolerance);
   for (const key in MapBrowserEventType) {
-    _ol_events_.listen(this.mapBrowserEventHandler_, MapBrowserEventType[key],
+    listen(this.mapBrowserEventHandler_, MapBrowserEventType[key],
       this.handleMapBrowserEvent, this);
   }
 
@@ -267,11 +267,11 @@ const PluggableMap = function(options) {
    */
   this.keyHandlerKeys_ = null;
 
-  _ol_events_.listen(this.viewport_, EventType.CONTEXTMENU,
+  listen(this.viewport_, EventType.CONTEXTMENU,
     this.handleBrowserEvent, this);
-  _ol_events_.listen(this.viewport_, EventType.WHEEL,
+  listen(this.viewport_, EventType.WHEEL,
     this.handleBrowserEvent, this);
-  _ol_events_.listen(this.viewport_, EventType.MOUSEWHEEL,
+  listen(this.viewport_, EventType.MOUSEWHEEL,
     this.handleBrowserEvent, this);
 
   /**
@@ -338,14 +338,14 @@ const PluggableMap = function(options) {
    */
   this.skippedFeatureUids_ = {};
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(MapProperty.LAYERGROUP),
     this.handleLayerGroupChanged_, this);
-  _ol_events_.listen(this, BaseObject.getChangeEventType(MapProperty.VIEW),
+  listen(this, BaseObject.getChangeEventType(MapProperty.VIEW),
     this.handleViewChanged_, this);
-  _ol_events_.listen(this, BaseObject.getChangeEventType(MapProperty.SIZE),
+  listen(this, BaseObject.getChangeEventType(MapProperty.SIZE),
     this.handleSizeChanged_, this);
-  _ol_events_.listen(this, BaseObject.getChangeEventType(MapProperty.TARGET),
+  listen(this, BaseObject.getChangeEventType(MapProperty.TARGET),
     this.handleTargetChanged_, this);
 
   // setProperties will trigger the rendering of the map if the map
@@ -361,7 +361,7 @@ const PluggableMap = function(options) {
       control.setMap(this);
     }.bind(this));
 
-  _ol_events_.listen(this.controls, CollectionEventType.ADD,
+  listen(this.controls, CollectionEventType.ADD,
     /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -369,7 +369,7 @@ const PluggableMap = function(options) {
       event.element.setMap(this);
     }, this);
 
-  _ol_events_.listen(this.controls, CollectionEventType.REMOVE,
+  listen(this.controls, CollectionEventType.REMOVE,
     /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -386,7 +386,7 @@ const PluggableMap = function(options) {
       interaction.setMap(this);
     }.bind(this));
 
-  _ol_events_.listen(this.interactions, CollectionEventType.ADD,
+  listen(this.interactions, CollectionEventType.ADD,
     /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -394,7 +394,7 @@ const PluggableMap = function(options) {
       event.element.setMap(this);
     }, this);
 
-  _ol_events_.listen(this.interactions, CollectionEventType.REMOVE,
+  listen(this.interactions, CollectionEventType.REMOVE,
     /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -404,7 +404,7 @@ const PluggableMap = function(options) {
 
   this.overlays_.forEach(this.addOverlayInternal_.bind(this));
 
-  _ol_events_.listen(this.overlays_, CollectionEventType.ADD,
+  listen(this.overlays_, CollectionEventType.ADD,
     /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -412,7 +412,7 @@ const PluggableMap = function(options) {
       this.addOverlayInternal_(/** @type {ol.Overlay} */ (event.element));
     }, this);
 
-  _ol_events_.listen(this.overlays_, CollectionEventType.REMOVE,
+  listen(this.overlays_, CollectionEventType.REMOVE,
     /**
        * @param {ol.Collection.Event} event Collection event.
        */
@@ -493,11 +493,11 @@ PluggableMap.prototype.addOverlayInternal_ = function(overlay) {
  */
 PluggableMap.prototype.disposeInternal = function() {
   this.mapBrowserEventHandler_.dispose();
-  _ol_events_.unlisten(this.viewport_, EventType.CONTEXTMENU,
+  unlisten(this.viewport_, EventType.CONTEXTMENU,
     this.handleBrowserEvent, this);
-  _ol_events_.unlisten(this.viewport_, EventType.WHEEL,
+  unlisten(this.viewport_, EventType.WHEEL,
     this.handleBrowserEvent, this);
-  _ol_events_.unlisten(this.viewport_, EventType.MOUSEWHEEL,
+  unlisten(this.viewport_, EventType.MOUSEWHEEL,
     this.handleBrowserEvent, this);
   if (this.handleResize_ !== undefined) {
     window.removeEventListener(EventType.RESIZE,
@@ -1004,7 +1004,7 @@ PluggableMap.prototype.handleTargetChanged_ = function() {
 
   if (this.keyHandlerKeys_) {
     for (let i = 0, ii = this.keyHandlerKeys_.length; i < ii; ++i) {
-      _ol_events_.unlistenByKey(this.keyHandlerKeys_[i]);
+      unlistenByKey(this.keyHandlerKeys_[i]);
     }
     this.keyHandlerKeys_ = null;
   }
@@ -1023,9 +1023,9 @@ PluggableMap.prototype.handleTargetChanged_ = function() {
     const keyboardEventTarget = !this.keyboardEventTarget_ ?
       targetElement : this.keyboardEventTarget_;
     this.keyHandlerKeys_ = [
-      _ol_events_.listen(keyboardEventTarget, EventType.KEYDOWN,
+      listen(keyboardEventTarget, EventType.KEYDOWN,
         this.handleBrowserEvent, this),
-      _ol_events_.listen(keyboardEventTarget, EventType.KEYPRESS,
+      listen(keyboardEventTarget, EventType.KEYPRESS,
         this.handleBrowserEvent, this)
     ];
 
@@ -1063,20 +1063,20 @@ PluggableMap.prototype.handleViewPropertyChanged_ = function() {
  */
 PluggableMap.prototype.handleViewChanged_ = function() {
   if (this.viewPropertyListenerKey_) {
-    _ol_events_.unlistenByKey(this.viewPropertyListenerKey_);
+    unlistenByKey(this.viewPropertyListenerKey_);
     this.viewPropertyListenerKey_ = null;
   }
   if (this.viewChangeListenerKey_) {
-    _ol_events_.unlistenByKey(this.viewChangeListenerKey_);
+    unlistenByKey(this.viewChangeListenerKey_);
     this.viewChangeListenerKey_ = null;
   }
   const view = this.getView();
   if (view) {
     this.viewport_.setAttribute('data-view', getUid(view));
-    this.viewPropertyListenerKey_ = _ol_events_.listen(
+    this.viewPropertyListenerKey_ = listen(
       view, ObjectEventType.PROPERTYCHANGE,
       this.handleViewPropertyChanged_, this);
-    this.viewChangeListenerKey_ = _ol_events_.listen(
+    this.viewChangeListenerKey_ = listen(
       view, EventType.CHANGE,
       this.handleViewPropertyChanged_, this);
   }
@@ -1089,16 +1089,16 @@ PluggableMap.prototype.handleViewChanged_ = function() {
  */
 PluggableMap.prototype.handleLayerGroupChanged_ = function() {
   if (this.layerGroupPropertyListenerKeys_) {
-    this.layerGroupPropertyListenerKeys_.forEach(_ol_events_.unlistenByKey);
+    this.layerGroupPropertyListenerKeys_.forEach(unlistenByKey);
     this.layerGroupPropertyListenerKeys_ = null;
   }
   const layerGroup = this.getLayerGroup();
   if (layerGroup) {
     this.layerGroupPropertyListenerKeys_ = [
-      _ol_events_.listen(
+      listen(
         layerGroup, ObjectEventType.PROPERTYCHANGE,
         this.render, this),
-      _ol_events_.listen(
+      listen(
         layerGroup, EventType.CHANGE,
         this.render, this)
     ];

--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from './index.js';
 import TileState from './TileState.js';
-import _ol_events_ from './events.js';
+import {listen, unlisten} from './events.js';
 import EventType from './events/EventType.js';
 import PriorityQueue from './structs/PriorityQueue.js';
 
@@ -65,7 +65,7 @@ TileQueue.prototype.enqueue = function(element) {
   const added = PriorityQueue.prototype.enqueue.call(this, element);
   if (added) {
     const tile = element[0];
-    _ol_events_.listen(tile, EventType.CHANGE,
+    listen(tile, EventType.CHANGE,
       this.handleTileChange, this);
   }
   return added;
@@ -89,7 +89,7 @@ TileQueue.prototype.handleTileChange = function(event) {
   const state = tile.getState();
   if (state === TileState.LOADED || state === TileState.ERROR ||
       state === TileState.EMPTY || state === TileState.ABORT) {
-    _ol_events_.unlisten(tile, EventType.CHANGE,
+    unlisten(tile, EventType.CHANGE,
       this.handleTileChange, this);
     const tileKey = tile.getKey();
     if (tileKey in this.tilesLoadingKeys_) {

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -5,7 +5,7 @@ import {getUid, inherits} from './index.js';
 import Tile from './Tile.js';
 import TileState from './TileState.js';
 import {createCanvasContext2D} from './dom.js';
-import _ol_events_ from './events.js';
+import {listen, unlistenByKey} from './events.js';
 import {getHeight, getIntersection, getWidth} from './extent.js';
 import EventType from './events/EventType.js';
 import {loadFeaturesXhr} from './featureloader.js';
@@ -111,7 +111,7 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
             tileUrl == undefined ? '' : tileUrl,
             format, tileLoadFunction);
           this.sourceTileListenerKeys_.push(
-            _ol_events_.listen(sourceTile, EventType.CHANGE, handleTileChange));
+            listen(sourceTile, EventType.CHANGE, handleTileChange));
         }
         sourceTile.consumers++;
         this.tileKeys.push(sourceTileKey);
@@ -145,9 +145,9 @@ VectorImageTile.prototype.disposeInternal = function() {
   }
   this.tileKeys.length = 0;
   this.sourceTiles_ = null;
-  this.loadListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.loadListenerKeys_.forEach(unlistenByKey);
   this.loadListenerKeys_.length = 0;
-  this.sourceTileListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.sourceTileListenerKeys_.forEach(unlistenByKey);
   this.sourceTileListenerKeys_.length = 0;
   Tile.prototype.disposeInternal.call(this);
 };
@@ -234,7 +234,7 @@ VectorImageTile.prototype.load = function() {
         sourceTile.load();
       }
       if (sourceTile.state == TileState.LOADING) {
-        const key = _ol_events_.listen(sourceTile, EventType.CHANGE, function(e) {
+        const key = listen(sourceTile, EventType.CHANGE, function(e) {
           const state = sourceTile.getState();
           if (state == TileState.LOADED ||
               state == TileState.ERROR) {
@@ -277,7 +277,7 @@ VectorImageTile.prototype.finishLoading_ = function() {
     }
   }
   if (loaded == this.tileKeys.length) {
-    this.loadListenerKeys_.forEach(_ol_events_.unlistenByKey);
+    this.loadListenerKeys_.forEach(unlistenByKey);
     this.loadListenerKeys_.length = 0;
     this.setState(TileState.LOADED);
   } else {

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -6,7 +6,7 @@ import {equals} from '../array.js';
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 import {removeChildren, replaceNode} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import Layer from '../layer/Layer.js';
 
@@ -87,7 +87,7 @@ const Attribution = function(opt_options) {
   button.title = tipLabel;
   button.appendChild(activeLabel);
 
-  _ol_events_.listen(button, EventType.CLICK, this.handleClick_, this);
+  listen(button, EventType.CLICK, this.handleClick_, this);
 
   const cssClasses = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL +
       (this.collapsed_ && this.collapsible_ ? ' ol-collapsed' : '') +

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -5,7 +5,7 @@ import {inherits, nullFunction} from '../index.js';
 import MapEventType from '../MapEventType.js';
 import BaseObject from '../Object.js';
 import {removeNode} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 
 /**
  * @classdesc
@@ -110,7 +110,7 @@ Control.prototype.setMap = function(map) {
     removeNode(this.element);
   }
   for (let i = 0, ii = this.listenerKeys.length; i < ii; ++i) {
-    _ol_events_.unlistenByKey(this.listenerKeys[i]);
+    unlistenByKey(this.listenerKeys[i]);
   }
   this.listenerKeys.length = 0;
   this.map_ = map;
@@ -119,7 +119,7 @@ Control.prototype.setMap = function(map) {
       this.target_ : map.getOverlayContainerStopEvent();
     target.appendChild(this.element);
     if (this.render !== nullFunction) {
-      this.listenerKeys.push(_ol_events_.listen(map,
+      this.listenerKeys.push(listen(map,
         MapEventType.POSTRENDER, this.render, this));
     }
     map.render();

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE, CLASS_UNSUPPORTED} from '../css.js';
 import {replaceNode} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 
 /**
@@ -61,7 +61,7 @@ const FullScreen = function(opt_options) {
   button.title = tipLabel;
   button.appendChild(this.labelNode_);
 
-  _ol_events_.listen(button, EventType.CLICK,
+  listen(button, EventType.CLICK,
     this.handleClick_, this);
 
   const cssClasses = this.cssClassName_ + ' ' + CLASS_UNSELECTABLE +
@@ -161,7 +161,7 @@ FullScreen.prototype.handleFullScreenChange_ = function() {
 FullScreen.prototype.setMap = function(map) {
   Control.prototype.setMap.call(this, map);
   if (map) {
-    this.listenerKeys.push(_ol_events_.listen(document,
+    this.listenerKeys.push(listen(document,
       FullScreen.getChangeType_(),
       this.handleFullScreenChange_, this)
     );

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -3,7 +3,7 @@
  */
 
 import {inherits} from '../index.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import BaseObject from '../Object.js';
 import Control from '../control/Control.js';
@@ -38,7 +38,7 @@ const MousePosition = function(opt_options) {
     target: options.target
   });
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(MousePosition.Property_.PROJECTION),
     this.handleProjectionChanged_, this);
 
@@ -171,9 +171,9 @@ MousePosition.prototype.setMap = function(map) {
   if (map) {
     const viewport = map.getViewport();
     this.listenerKeys.push(
-      _ol_events_.listen(viewport, EventType.MOUSEMOVE,
+      listen(viewport, EventType.MOUSEMOVE,
         this.handleMouseMove, this),
-      _ol_events_.listen(viewport, EventType.MOUSEOUT,
+      listen(viewport, EventType.MOUSEOUT,
         this.handleMouseOut, this)
     );
   }

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -15,7 +15,7 @@ import Control from '../control/Control.js';
 import _ol_coordinate_ from '../coordinate.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 import {replaceNode} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listen, listenOnce, unlisten} from '../events.js';
 import EventType from '../events/EventType.js';
 import {containsExtent, getBottomLeft, getBottomRight, getTopLeft, getTopRight, scaleFromCenter} from '../extent.js';
 
@@ -101,7 +101,7 @@ const OverviewMap = function(opt_options) {
   button.title = tipLabel;
   button.appendChild(activeLabel);
 
-  _ol_events_.listen(button, EventType.CLICK,
+  listen(button, EventType.CLICK,
     this.handleClick_, this);
 
   /**
@@ -225,7 +225,7 @@ OverviewMap.prototype.setMap = function(map) {
 
   if (map) {
     this.ovmap_.setTarget(this.ovmapDiv_);
-    this.listenerKeys.push(_ol_events_.listen(
+    this.listenerKeys.push(listen(
       map, ObjectEventType.PROPERTYCHANGE,
       this.handleMapPropertyChange_, this));
 
@@ -269,7 +269,7 @@ OverviewMap.prototype.handleMapPropertyChange_ = function(event) {
  * @private
  */
 OverviewMap.prototype.bindView_ = function(view) {
-  _ol_events_.listen(view,
+  listen(view,
     BaseObject.getChangeEventType(ViewProperty.ROTATION),
     this.handleRotationChanged_, this);
 };
@@ -281,7 +281,7 @@ OverviewMap.prototype.bindView_ = function(view) {
  * @private
  */
 OverviewMap.prototype.unbindView_ = function(view) {
-  _ol_events_.unlisten(view,
+  unlisten(view,
     BaseObject.getChangeEventType(ViewProperty.ROTATION),
     this.handleRotationChanged_, this);
 };
@@ -503,7 +503,7 @@ OverviewMap.prototype.handleToggle_ = function() {
   if (!this.collapsed_ && !ovmap.isRendered()) {
     ovmap.updateSize();
     this.resetExtent_();
-    _ol_events_.listenOnce(ovmap, MapEventType.POSTRENDER,
+    listenOnce(ovmap, MapEventType.POSTRENDER,
       function(event) {
         this.updateBox_();
       },

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -5,7 +5,7 @@
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_HIDDEN, CLASS_UNSELECTABLE} from '../css.js';
 import {easeOut} from '../easing.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {inherits} from '../index.js';
 
@@ -51,7 +51,7 @@ const Rotate = function(opt_options) {
   button.title = tipLabel;
   button.appendChild(this.label_);
 
-  _ol_events_.listen(button, EventType.CLICK,
+  listen(button, EventType.CLICK,
     Rotate.prototype.handleClick_, this);
 
   const cssClasses = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL;

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -7,7 +7,7 @@ import {assert} from '../asserts.js';
 import Control from '../control/Control.js';
 import ScaleLineUnits from '../control/ScaleLineUnits.js';
 import {CLASS_UNSELECTABLE} from '../css.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import {getPointResolution, METERS_PER_UNIT} from '../proj.js';
 import Units from '../proj/Units.js';
 
@@ -85,7 +85,7 @@ const ScaleLine = function(opt_options) {
     target: options.target
   });
 
-  _ol_events_.listen(
+  listen(
     this, BaseObject.getChangeEventType(ScaleLine.Property_.UNITS),
     this.handleUnitsChanged_, this);
 

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -2,7 +2,7 @@
  * @module ol/control/Zoom
  */
 import {inherits} from '../index.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
@@ -43,7 +43,7 @@ const Zoom = function(opt_options) {
     typeof zoomInLabel === 'string' ? document.createTextNode(zoomInLabel) : zoomInLabel
   );
 
-  _ol_events_.listen(inElement, EventType.CLICK,
+  listen(inElement, EventType.CLICK,
     Zoom.prototype.handleClick_.bind(this, delta));
 
   const outElement = document.createElement('button');
@@ -54,7 +54,7 @@ const Zoom = function(opt_options) {
     typeof zoomOutLabel === 'string' ? document.createTextNode(zoomOutLabel) : zoomOutLabel
   );
 
-  _ol_events_.listen(outElement, EventType.CLICK,
+  listen(outElement, EventType.CLICK,
     Zoom.prototype.handleClick_.bind(this, -delta));
 
   const cssClasses = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL;

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -8,7 +8,7 @@ import ViewHint from '../ViewHint.js';
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 import {easeOut} from '../easing.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import {clamp} from '../math.js';
@@ -113,16 +113,16 @@ const ZoomSlider = function(opt_options) {
    */
   this.dragger_ = new PointerEventHandler(containerElement);
 
-  _ol_events_.listen(this.dragger_, PointerEventType.POINTERDOWN,
+  listen(this.dragger_, PointerEventType.POINTERDOWN,
     this.handleDraggerStart_, this);
-  _ol_events_.listen(this.dragger_, PointerEventType.POINTERMOVE,
+  listen(this.dragger_, PointerEventType.POINTERMOVE,
     this.handleDraggerDrag_, this);
-  _ol_events_.listen(this.dragger_, PointerEventType.POINTERUP,
+  listen(this.dragger_, PointerEventType.POINTERUP,
     this.handleDraggerEnd_, this);
 
-  _ol_events_.listen(containerElement, EventType.CLICK,
+  listen(containerElement, EventType.CLICK,
     this.handleContainerClick_, this);
-  _ol_events_.listen(thumbElement, EventType.CLICK,
+  listen(thumbElement, EventType.CLICK,
     Event.stopPropagation);
 
   const render = options.render ? options.render : ZoomSlider.render;

--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -2,7 +2,7 @@
  * @module ol/control/ZoomToExtent
  */
 import {inherits} from '../index.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
@@ -39,7 +39,7 @@ const ZoomToExtent = function(opt_options) {
     typeof label === 'string' ? document.createTextNode(label) : label
   );
 
-  _ol_events_.listen(button, EventType.CLICK,
+  listen(button, EventType.CLICK,
     this.handleClick_, this);
 
   const cssClasses = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL;

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -2,25 +2,24 @@
  * @module ol/events
  */
 import {clear} from './obj.js';
-const _ol_events_ = {};
 
 
 /**
  * @param {ol.EventsKey} listenerObj Listener object.
  * @return {ol.EventsListenerFunctionType} Bound listener.
  */
-_ol_events_.bindListener_ = function(listenerObj) {
+export function bindListener(listenerObj) {
   const boundListener = function(evt) {
     const listener = listenerObj.listener;
     const bindTo = listenerObj.bindTo || listenerObj.target;
     if (listenerObj.callOnce) {
-      _ol_events_.unlistenByKey(listenerObj);
+      unlistenByKey(listenerObj);
     }
     return listener.call(bindTo, evt);
   };
   listenerObj.boundListener = boundListener;
   return boundListener;
-};
+}
 
 
 /**
@@ -33,9 +32,8 @@ _ol_events_.bindListener_ = function(listenerObj) {
  * @param {boolean=} opt_setDeleteIndex Set the deleteIndex on the matching
  *     listener, for {@link ol.events.unlistenByKey}.
  * @return {ol.EventsKey|undefined} The matching listener object.
- * @private
  */
-_ol_events_.findListener_ = function(listeners, listener, opt_this,
+export function findListener(listeners, listener, opt_this,
   opt_setDeleteIndex) {
   let listenerObj;
   for (let i = 0, ii = listeners.length; i < ii; ++i) {
@@ -49,7 +47,7 @@ _ol_events_.findListener_ = function(listeners, listener, opt_this,
     }
   }
   return undefined;
-};
+}
 
 
 /**
@@ -57,10 +55,10 @@ _ol_events_.findListener_ = function(listeners, listener, opt_this,
  * @param {string} type Type.
  * @return {Array.<ol.EventsKey>|undefined} Listeners.
  */
-_ol_events_.getListeners = function(target, type) {
+export function getListeners(target, type) {
   const listenerMap = target.ol_lm;
   return listenerMap ? listenerMap[type] : undefined;
-};
+}
 
 
 /**
@@ -69,15 +67,14 @@ _ol_events_.getListeners = function(target, type) {
  * @param {ol.EventTargetLike} target Target.
  * @return {!Object.<string, Array.<ol.EventsKey>>} Map of
  *     listeners by event type.
- * @private
  */
-_ol_events_.getListenerMap_ = function(target) {
+function getListenerMap(target) {
   let listenerMap = target.ol_lm;
   if (!listenerMap) {
     listenerMap = target.ol_lm = {};
   }
   return listenerMap;
-};
+}
 
 
 /**
@@ -86,10 +83,9 @@ _ol_events_.getListenerMap_ = function(target) {
  * map, it will be removed from the target.
  * @param {ol.EventTargetLike} target Target.
  * @param {string} type Type.
- * @private
  */
-_ol_events_.removeListeners_ = function(target, type) {
-  const listeners = _ol_events_.getListeners(target, type);
+function removeListeners(target, type) {
+  const listeners = getListeners(target, type);
   if (listeners) {
     for (let i = 0, ii = listeners.length; i < ii; ++i) {
       target.removeEventListener(type, listeners[i].boundListener);
@@ -104,7 +100,7 @@ _ol_events_.removeListeners_ = function(target, type) {
       }
     }
   }
-};
+}
 
 
 /**
@@ -122,13 +118,13 @@ _ol_events_.removeListeners_ = function(target, type) {
  * @param {boolean=} opt_once If true, add the listener as one-off listener.
  * @return {ol.EventsKey} Unique key for the listener.
  */
-_ol_events_.listen = function(target, type, listener, opt_this, opt_once) {
-  const listenerMap = _ol_events_.getListenerMap_(target);
+export function listen(target, type, listener, opt_this, opt_once) {
+  const listenerMap = getListenerMap(target);
   let listeners = listenerMap[type];
   if (!listeners) {
     listeners = listenerMap[type] = [];
   }
-  let listenerObj = _ol_events_.findListener_(listeners, listener, opt_this,
+  let listenerObj = findListener(listeners, listener, opt_this,
     false);
   if (listenerObj) {
     if (!opt_once) {
@@ -143,12 +139,12 @@ _ol_events_.listen = function(target, type, listener, opt_this, opt_once) {
       target: target,
       type: type
     });
-    target.addEventListener(type, _ol_events_.bindListener_(listenerObj));
+    target.addEventListener(type, bindListener(listenerObj));
     listeners.push(listenerObj);
   }
 
   return listenerObj;
-};
+}
 
 
 /**
@@ -171,9 +167,9 @@ _ol_events_.listen = function(target, type, listener, opt_this, opt_once) {
  *     listener. Default is the `target`.
  * @return {ol.EventsKey} Key for unlistenByKey.
  */
-_ol_events_.listenOnce = function(target, type, listener, opt_this) {
-  return _ol_events_.listen(target, type, listener, opt_this, true);
-};
+export function listenOnce(target, type, listener, opt_this) {
+  return listen(target, type, listener, opt_this, true);
+}
 
 
 /**
@@ -189,16 +185,16 @@ _ol_events_.listenOnce = function(target, type, listener, opt_this) {
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
  */
-_ol_events_.unlisten = function(target, type, listener, opt_this) {
-  const listeners = _ol_events_.getListeners(target, type);
+export function unlisten(target, type, listener, opt_this) {
+  const listeners = getListeners(target, type);
   if (listeners) {
-    const listenerObj = _ol_events_.findListener_(listeners, listener, opt_this,
+    const listenerObj = findListener(listeners, listener, opt_this,
       true);
     if (listenerObj) {
-      _ol_events_.unlistenByKey(listenerObj);
+      unlistenByKey(listenerObj);
     }
   }
-};
+}
 
 
 /**
@@ -210,22 +206,22 @@ _ol_events_.unlisten = function(target, type, listener, opt_this) {
  *
  * @param {ol.EventsKey} key The key.
  */
-_ol_events_.unlistenByKey = function(key) {
+export function unlistenByKey(key) {
   if (key && key.target) {
     key.target.removeEventListener(key.type, key.boundListener);
-    const listeners = _ol_events_.getListeners(key.target, key.type);
+    const listeners = getListeners(key.target, key.type);
     if (listeners) {
       const i = 'deleteIndex' in key ? key.deleteIndex : listeners.indexOf(key);
       if (i !== -1) {
         listeners.splice(i, 1);
       }
       if (listeners.length === 0) {
-        _ol_events_.removeListeners_(key.target, key.type);
+        removeListeners(key.target, key.type);
       }
     }
     clear(key);
   }
-};
+}
 
 
 /**
@@ -234,10 +230,9 @@ _ol_events_.unlistenByKey = function(key) {
  *
  * @param {ol.EventTargetLike} target Target.
  */
-_ol_events_.unlistenAll = function(target) {
-  const listenerMap = _ol_events_.getListenerMap_(target);
+export function unlistenAll(target) {
+  const listenerMap = getListenerMap(target);
   for (const type in listenerMap) {
-    _ol_events_.removeListeners_(target, type);
+    removeListeners(target, type);
   }
-};
-export default _ol_events_;
+}

--- a/src/ol/events/EventTarget.js
+++ b/src/ol/events/EventTarget.js
@@ -3,7 +3,7 @@
  */
 import {inherits, nullFunction} from '../index.js';
 import Disposable from '../Disposable.js';
-import _ol_events_ from '../events.js';
+import {unlistenAll} from '../events.js';
 import Event from '../events/Event.js';
 
 /**
@@ -109,7 +109,7 @@ EventTarget.prototype.dispatchEvent = function(event) {
  * @inheritDoc
  */
 EventTarget.prototype.disposeInternal = function() {
-  _ol_events_.unlistenAll(this);
+  unlistenAll(this);
 };
 
 

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -2,7 +2,7 @@
  * @module ol/geom/GeometryCollection
  */
 import {inherits} from '../index.js';
-import _ol_events_ from '../events.js';
+import {listen, unlisten} from '../events.js';
 import EventType from '../events/EventType.js';
 import {createOrUpdateEmpty, closestSquaredDistanceXY, extend, getCenter} from '../extent.js';
 import Geometry from '../geom/Geometry.js';
@@ -56,7 +56,7 @@ GeometryCollection.prototype.unlistenGeometriesChange_ = function() {
     return;
   }
   for (let i = 0, ii = this.geometries_.length; i < ii; ++i) {
-    _ol_events_.unlisten(
+    unlisten(
       this.geometries_[i], EventType.CHANGE,
       this.changed, this);
   }
@@ -71,7 +71,7 @@ GeometryCollection.prototype.listenGeometriesChange_ = function() {
     return;
   }
   for (let i = 0, ii = this.geometries_.length; i < ii; ++i) {
-    _ol_events_.listen(
+    listen(
       this.geometries_[i], EventType.CHANGE,
       this.changed, this);
   }

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -5,7 +5,7 @@
 
 import {inherits} from '../index.js';
 import {TRUE} from '../functions.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import Interaction from '../interaction/Interaction.js';
@@ -159,13 +159,13 @@ DragAndDrop.prototype.registerListeners_ = function() {
   if (map) {
     const dropArea = this.target ? this.target : map.getViewport();
     this.dropListenKeys_ = [
-      _ol_events_.listen(dropArea, EventType.DROP,
+      listen(dropArea, EventType.DROP,
         DragAndDrop.handleDrop_, this),
-      _ol_events_.listen(dropArea, EventType.DRAGENTER,
+      listen(dropArea, EventType.DRAGENTER,
         DragAndDrop.handleStop_, this),
-      _ol_events_.listen(dropArea, EventType.DRAGOVER,
+      listen(dropArea, EventType.DRAGOVER,
         DragAndDrop.handleStop_, this),
-      _ol_events_.listen(dropArea, EventType.DROP,
+      listen(dropArea, EventType.DROP,
         DragAndDrop.handleStop_, this)
     ];
   }
@@ -218,7 +218,7 @@ DragAndDrop.prototype.tryReadFeatures_ = function(format, text, options) {
  */
 DragAndDrop.prototype.unregisterListeners_ = function() {
   if (this.dropListenKeys_) {
-    this.dropListenKeys_.forEach(_ol_events_.unlistenByKey);
+    this.dropListenKeys_.forEach(unlistenByKey);
     this.dropListenKeys_ = null;
   }
 };

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -8,7 +8,7 @@ import MapBrowserEventType from '../MapBrowserEventType.js';
 import MapBrowserPointerEvent from '../MapBrowserPointerEvent.js';
 import BaseObject from '../Object.js';
 import _ol_coordinate_ from '../coordinate.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import Event from '../events/Event.js';
 import _ol_events_condition_ from '../events/condition.js';
 import {boundingExtent, getBottomLeft, getBottomRight, getTopLeft, getTopRight} from '../extent.js';
@@ -306,7 +306,7 @@ const Draw = function(options) {
       options.freehandCondition : _ol_events_condition_.shiftKeyOnly;
   }
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(InteractionProperty.ACTIVE),
     this.updateState_, this);
 

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -9,7 +9,7 @@ import MapBrowserEventType from '../MapBrowserEventType.js';
 import MapBrowserPointerEvent from '../MapBrowserPointerEvent.js';
 import {equals} from '../array.js';
 import _ol_coordinate_ from '../coordinate.js';
-import _ol_events_ from '../events.js';
+import {listen, unlisten} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import _ol_events_condition_ from '../events/condition.js';
@@ -196,9 +196,9 @@ const Modify = function(options) {
   if (options.source) {
     this.source_ = options.source;
     features = new Collection(this.source_.getFeatures());
-    _ol_events_.listen(this.source_, VectorEventType.ADDFEATURE,
+    listen(this.source_, VectorEventType.ADDFEATURE,
       this.handleSourceAdd_, this);
-    _ol_events_.listen(this.source_, VectorEventType.REMOVEFEATURE,
+    listen(this.source_, VectorEventType.REMOVEFEATURE,
       this.handleSourceRemove_, this);
   } else {
     features = options.features;
@@ -214,9 +214,9 @@ const Modify = function(options) {
   this.features_ = features;
 
   this.features_.forEach(this.addFeature_.bind(this));
-  _ol_events_.listen(this.features_, CollectionEventType.ADD,
+  listen(this.features_, CollectionEventType.ADD,
     this.handleFeatureAdd_, this);
-  _ol_events_.listen(this.features_, CollectionEventType.REMOVE,
+  listen(this.features_, CollectionEventType.REMOVE,
     this.handleFeatureRemove_, this);
 
   /**
@@ -256,7 +256,7 @@ Modify.prototype.addFeature_ = function(feature) {
   if (map && map.isRendered() && this.getActive()) {
     this.handlePointerAtPixel_(this.lastPixel_, map);
   }
-  _ol_events_.listen(feature, EventType.CHANGE,
+  listen(feature, EventType.CHANGE,
     this.handleFeatureChange_, this);
 };
 
@@ -286,7 +286,7 @@ Modify.prototype.removeFeature_ = function(feature) {
     this.overlay_.getSource().removeFeature(this.vertexFeature_);
     this.vertexFeature_ = null;
   }
-  _ol_events_.unlisten(feature, EventType.CHANGE,
+  unlisten(feature, EventType.CHANGE,
     this.handleFeatureChange_, this);
 };
 

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -4,7 +4,7 @@
 import {getUid, inherits} from '../index.js';
 import CollectionEventType from '../CollectionEventType.js';
 import {extend, includes} from '../array.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import Event from '../events/Event.js';
 import _ol_events_condition_ from '../events/condition.js';
 import {TRUE} from '../functions.js';
@@ -135,9 +135,9 @@ const Select = function(opt_options) {
   this.featureLayerAssociation_ = {};
 
   const features = this.featureOverlay_.getSource().getFeaturesCollection();
-  _ol_events_.listen(features, CollectionEventType.ADD,
+  listen(features, CollectionEventType.ADD,
     this.addFeature_, this);
-  _ol_events_.listen(features, CollectionEventType.REMOVE,
+  listen(features, CollectionEventType.REMOVE,
     this.removeFeature_, this);
 
 };

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -5,7 +5,7 @@ import {getUid, inherits} from '../index.js';
 import Collection from '../Collection.js';
 import CollectionEventType from '../CollectionEventType.js';
 import _ol_coordinate_ from '../coordinate.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {boundingExtent, createEmpty} from '../extent.js';
 import {TRUE, FALSE} from '../functions.js';
@@ -160,7 +160,7 @@ inherits(Snap, PointerInteraction);
  * @api
  */
 Snap.prototype.addFeature = function(feature, opt_listen) {
-  const listen = opt_listen !== undefined ? opt_listen : true;
+  const register = opt_listen !== undefined ? opt_listen : true;
   const feature_uid = getUid(feature);
   const geometry = feature.getGeometry();
   if (geometry) {
@@ -171,8 +171,8 @@ Snap.prototype.addFeature = function(feature, opt_listen) {
     }
   }
 
-  if (listen) {
-    this.featureChangeListenerKeys_[feature_uid] = _ol_events_.listen(
+  if (register) {
+    this.featureChangeListenerKeys_[feature_uid] = listen(
       feature,
       EventType.CHANGE,
       this.handleFeatureChange_, this);
@@ -268,7 +268,7 @@ Snap.prototype.handleFeatureChange_ = function(evt) {
  * @api
  */
 Snap.prototype.removeFeature = function(feature, opt_unlisten) {
-  const unlisten = opt_unlisten !== undefined ? opt_unlisten : true;
+  const unregister = opt_unlisten !== undefined ? opt_unlisten : true;
   const feature_uid = getUid(feature);
   const extent = this.indexedFeaturesExtents_[feature_uid];
   if (extent) {
@@ -284,8 +284,8 @@ Snap.prototype.removeFeature = function(feature, opt_unlisten) {
     }
   }
 
-  if (unlisten) {
-    _ol_events_.unlistenByKey(this.featureChangeListenerKeys_[feature_uid]);
+  if (unregister) {
+    unlistenByKey(this.featureChangeListenerKeys_[feature_uid]);
     delete this.featureChangeListenerKeys_[feature_uid];
   }
 };
@@ -300,7 +300,7 @@ Snap.prototype.setMap = function(map) {
   const features = this.getFeatures_();
 
   if (currentMap) {
-    keys.forEach(_ol_events_.unlistenByKey);
+    keys.forEach(unlistenByKey);
     keys.length = 0;
     features.forEach(this.forEachFeatureRemove_.bind(this));
   }
@@ -309,16 +309,16 @@ Snap.prototype.setMap = function(map) {
   if (map) {
     if (this.features_) {
       keys.push(
-        _ol_events_.listen(this.features_, CollectionEventType.ADD,
+        listen(this.features_, CollectionEventType.ADD,
           this.handleFeatureAdd_, this),
-        _ol_events_.listen(this.features_, CollectionEventType.REMOVE,
+        listen(this.features_, CollectionEventType.REMOVE,
           this.handleFeatureRemove_, this)
       );
     } else if (this.source_) {
       keys.push(
-        _ol_events_.listen(this.source_, VectorEventType.ADDFEATURE,
+        listen(this.source_, VectorEventType.ADDFEATURE,
           this.handleFeatureAdd_, this),
-        _ol_events_.listen(this.source_, VectorEventType.REMOVEFEATURE,
+        listen(this.source_, VectorEventType.REMOVEFEATURE,
           this.handleFeatureRemove_, this)
       );
     }

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import Collection from '../Collection.js';
 import BaseObject from '../Object.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import Event from '../events/Event.js';
 import {TRUE} from '../functions.js';
 import {includes} from '../array.js';
@@ -79,7 +79,7 @@ const Translate = function(opt_options) {
    */
   this.lastFeature_ = null;
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(InteractionProperty.ACTIVE),
     this.handleActiveChanged_, this);
 

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -7,7 +7,7 @@ import CollectionEventType from '../CollectionEventType.js';
 import BaseObject from '../Object.js';
 import ObjectEventType from '../ObjectEventType.js';
 import {assert} from '../asserts.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {getIntersection} from '../extent.js';
 import BaseLayer from '../layer/Base.js';
@@ -57,7 +57,7 @@ const LayerGroup = function(opt_options) {
    */
   this.listenerKeys_ = {};
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(Property.LAYERS),
     this.handleLayersChanged_, this);
 
@@ -93,18 +93,18 @@ LayerGroup.prototype.handleLayerChange_ = function() {
  * @private
  */
 LayerGroup.prototype.handleLayersChanged_ = function(event) {
-  this.layersListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.layersListenerKeys_.forEach(unlistenByKey);
   this.layersListenerKeys_.length = 0;
 
   const layers = this.getLayers();
   this.layersListenerKeys_.push(
-    _ol_events_.listen(layers, CollectionEventType.ADD,
+    listen(layers, CollectionEventType.ADD,
       this.handleLayersAdd_, this),
-    _ol_events_.listen(layers, CollectionEventType.REMOVE,
+    listen(layers, CollectionEventType.REMOVE,
       this.handleLayersRemove_, this));
 
   for (const id in this.listenerKeys_) {
-    this.listenerKeys_[id].forEach(_ol_events_.unlistenByKey);
+    this.listenerKeys_[id].forEach(unlistenByKey);
   }
   clear(this.listenerKeys_);
 
@@ -112,9 +112,9 @@ LayerGroup.prototype.handleLayersChanged_ = function(event) {
   for (let i = 0, ii = layersArray.length; i < ii; i++) {
     const layer = layersArray[i];
     this.listenerKeys_[getUid(layer).toString()] = [
-      _ol_events_.listen(layer, ObjectEventType.PROPERTYCHANGE,
+      listen(layer, ObjectEventType.PROPERTYCHANGE,
         this.handleLayerChange_, this),
-      _ol_events_.listen(layer, EventType.CHANGE,
+      listen(layer, EventType.CHANGE,
         this.handleLayerChange_, this)
     ];
   }
@@ -131,9 +131,9 @@ LayerGroup.prototype.handleLayersAdd_ = function(collectionEvent) {
   const layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
   const key = getUid(layer).toString();
   this.listenerKeys_[key] = [
-    _ol_events_.listen(layer, ObjectEventType.PROPERTYCHANGE,
+    listen(layer, ObjectEventType.PROPERTYCHANGE,
       this.handleLayerChange_, this),
-    _ol_events_.listen(layer, EventType.CHANGE,
+    listen(layer, EventType.CHANGE,
       this.handleLayerChange_, this)
   ];
   this.changed();
@@ -147,7 +147,7 @@ LayerGroup.prototype.handleLayersAdd_ = function(collectionEvent) {
 LayerGroup.prototype.handleLayersRemove_ = function(collectionEvent) {
   const layer = /** @type {ol.layer.Base} */ (collectionEvent.element);
   const key = getUid(layer).toString();
-  this.listenerKeys_[key].forEach(_ol_events_.unlistenByKey);
+  this.listenerKeys_[key].forEach(unlistenByKey);
   delete this.listenerKeys_[key];
   this.changed();
 };

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/layer/Heatmap
  */
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import {inherits} from '../index.js';
 import BaseObject from '../Object.js';
 import {createCanvasContext2D} from '../dom.js';
@@ -80,7 +80,7 @@ const Heatmap = function(opt_options) {
    */
   this.styleCache_ = null;
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(Property.GRADIENT),
     this.handleGradientChanged_, this);
 
@@ -90,10 +90,10 @@ const Heatmap = function(opt_options) {
 
   this.setRadius(options.radius !== undefined ? options.radius : 8);
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(Property.BLUR),
     this.handleStyleChanged_, this);
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(Property.RADIUS),
     this.handleStyleChanged_, this);
 
@@ -133,7 +133,7 @@ const Heatmap = function(opt_options) {
   // The render order is not relevant for a heatmap representation.
   this.setRenderOrder(null);
 
-  _ol_events_.listen(this, RenderEventType.RENDER, this.handleRender_, this);
+  listen(this, RenderEventType.RENDER, this.handleRender_, this);
 };
 
 inherits(Heatmap, VectorLayer);

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/layer/Layer
  */
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {getUid, inherits} from '../index.js';
 import BaseObject from '../Object.js';
@@ -62,7 +62,7 @@ const Layer = function(options) {
     this.setMap(options.map);
   }
 
-  _ol_events_.listen(this,
+  listen(this,
     BaseObject.getChangeEventType(LayerProperty.SOURCE),
     this.handleSourcePropertyChange_, this);
 
@@ -141,12 +141,12 @@ Layer.prototype.handleSourceChange_ = function() {
  */
 Layer.prototype.handleSourcePropertyChange_ = function() {
   if (this.sourceChangeKey_) {
-    _ol_events_.unlistenByKey(this.sourceChangeKey_);
+    unlistenByKey(this.sourceChangeKey_);
     this.sourceChangeKey_ = null;
   }
   const source = this.getSource();
   if (source) {
-    this.sourceChangeKey_ = _ol_events_.listen(source,
+    this.sourceChangeKey_ = listen(source,
       EventType.CHANGE, this.handleSourceChange_, this);
   }
   this.changed();
@@ -167,18 +167,18 @@ Layer.prototype.handleSourcePropertyChange_ = function() {
  */
 Layer.prototype.setMap = function(map) {
   if (this.mapPrecomposeKey_) {
-    _ol_events_.unlistenByKey(this.mapPrecomposeKey_);
+    unlistenByKey(this.mapPrecomposeKey_);
     this.mapPrecomposeKey_ = null;
   }
   if (!map) {
     this.changed();
   }
   if (this.mapRenderKey_) {
-    _ol_events_.unlistenByKey(this.mapRenderKey_);
+    unlistenByKey(this.mapRenderKey_);
     this.mapRenderKey_ = null;
   }
   if (map) {
-    this.mapPrecomposeKey_ = _ol_events_.listen(
+    this.mapPrecomposeKey_ = listen(
       map, RenderEventType.PRECOMPOSE, function(evt) {
         const layerState = this.getLayerState();
         layerState.managed = false;
@@ -186,7 +186,7 @@ Layer.prototype.setMap = function(map) {
         evt.frameState.layerStatesArray.push(layerState);
         evt.frameState.layerStates[getUid(this)] = layerState;
       }, this);
-    this.mapRenderKey_ = _ol_events_.listen(
+    this.mapRenderKey_ = listen(
       this, EventType.CHANGE, map.render, map);
     this.changed();
   }

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -32,7 +32,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import {inherits} from '../index.js';
-import _ol_events_ from '../events.js';
+import {listen, unlisten} from '../events.js';
 import EventTarget from '../events/EventTarget.js';
 import _ol_has_ from '../has.js';
 import PointerEventType from '../pointer/EventType.js';
@@ -176,7 +176,7 @@ PointerEventHandler.prototype.eventHandler_ = function(inEvent) {
  */
 PointerEventHandler.prototype.addEvents_ = function(events) {
   events.forEach(function(eventName) {
-    _ol_events_.listen(this.element_, eventName, this.eventHandler_, this);
+    listen(this.element_, eventName, this.eventHandler_, this);
   }.bind(this));
 };
 
@@ -188,7 +188,7 @@ PointerEventHandler.prototype.addEvents_ = function(events) {
  */
 PointerEventHandler.prototype.removeEvents_ = function(events) {
   events.forEach(function(e) {
-    _ol_events_.unlisten(this.element_, e, this.eventHandler_, this);
+    unlisten(this.element_, e, this.eventHandler_, this);
   }.bind(this));
 };
 

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -5,7 +5,7 @@ import {getUid, inherits, nullFunction} from '../index.js';
 import ImageState from '../ImageState.js';
 import Observable from '../Observable.js';
 import TileState from '../TileState.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {FALSE} from '../functions.js';
 import SourceState from '../source/State.js';
@@ -115,7 +115,7 @@ LayerRenderer.prototype.handleImageChange_ = function(event) {
 LayerRenderer.prototype.loadImage = function(image) {
   let imageState = image.getState();
   if (imageState != ImageState.LOADED && imageState != ImageState.ERROR) {
-    _ol_events_.listen(image, EventType.CHANGE, this.handleImageChange_, this);
+    listen(image, EventType.CHANGE, this.handleImageChange_, this);
   }
   if (imageState == ImageState.IDLE) {
     image.load();

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -3,7 +3,7 @@
  */
 import {getUid, inherits, nullFunction} from '../index.js';
 import Disposable from '../Disposable.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {getWidth} from '../extent.js';
 import {TRUE} from '../functions.js';
@@ -219,7 +219,7 @@ MapRenderer.prototype.getLayerRenderer = function(layer) {
     }
     if (renderer) {
       this.layerRenderers_[layerKey] = renderer;
-      this.layerRendererListeners_[layerKey] = _ol_events_.listen(renderer,
+      this.layerRendererListeners_[layerKey] = listen(renderer,
         EventType.CHANGE, this.handleLayerRendererChange_, this);
     } else {
       throw new Error('Unable to create renderer for layer: ' + layer.getType());
@@ -281,7 +281,7 @@ MapRenderer.prototype.removeLayerRendererByKey_ = function(layerKey) {
   const layerRenderer = this.layerRenderers_[layerKey];
   delete this.layerRenderers_[layerKey];
 
-  _ol_events_.unlistenByKey(this.layerRendererListeners_[layerKey]);
+  unlistenByKey(this.layerRendererListeners_[layerKey]);
   delete this.layerRendererListeners_[layerKey];
 
   return layerRenderer;

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -5,7 +5,7 @@ import {getUid, inherits} from '../../index.js';
 import LayerType from '../../LayerType.js';
 import ViewHint from '../../ViewHint.js';
 import {createCanvasContext2D} from '../../dom.js';
-import _ol_events_ from '../../events.js';
+import {listen, unlisten} from '../../events.js';
 import EventType from '../../events/EventType.js';
 import rbush from 'rbush';
 import {buffer, createEmpty, containsExtent, getWidth} from '../../extent.js';
@@ -79,7 +79,7 @@ const CanvasVectorLayerRenderer = function(vectorLayer) {
    */
   this.context = createCanvasContext2D();
 
-  _ol_events_.listen(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
+  listen(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
 
 };
 
@@ -112,7 +112,7 @@ CanvasVectorLayerRenderer['create'] = function(mapRenderer, layer) {
  * @inheritDoc
  */
 CanvasVectorLayerRenderer.prototype.disposeInternal = function() {
-  _ol_events_.unlisten(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
+  unlisten(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
   CanvasLayerRenderer.prototype.disposeInternal.call(this);
 };
 

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -5,7 +5,7 @@ import {getUid, inherits} from '../../index.js';
 import LayerType from '../../LayerType.js';
 import TileState from '../../TileState.js';
 import {createCanvasContext2D} from '../../dom.js';
-import _ol_events_ from '../../events.js';
+import {listen, unlisten} from '../../events.js';
 import EventType from '../../events/EventType.js';
 import rbush from 'rbush';
 import {buffer, containsCoordinate, equals, getIntersection, getTopLeft, intersects} from '../../extent.js';
@@ -64,7 +64,7 @@ const CanvasVectorTileLayerRenderer = function(layer) {
   this.zDirection =
       layer.getRenderMode() == _ol_layer_VectorTileRenderType_.VECTOR ? 1 : 0;
 
-  _ol_events_.listen(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
+  listen(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
 
 };
 
@@ -119,7 +119,7 @@ CanvasVectorTileLayerRenderer.VECTOR_REPLAYS = {
  * @inheritDoc
  */
 CanvasVectorTileLayerRenderer.prototype.disposeInternal = function() {
-  _ol_events_.unlisten(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
+  unlisten(_ol_render_canvas_.labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
   CanvasTileLayerRenderer.prototype.disposeInternal.call(this);
 };
 

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -6,7 +6,7 @@ import {inherits} from '../../index.js';
 import {stableSort} from '../../array.js';
 import {CLASS_UNSELECTABLE} from '../../css.js';
 import {createCanvasContext2D} from '../../dom.js';
-import _ol_events_ from '../../events.js';
+import {listen} from '../../events.js';
 import _ol_has_ from '../../has.js';
 import Layer from '../../layer/Layer.js';
 import RenderEvent from '../../render/Event.js';
@@ -92,9 +92,9 @@ const WebGLMapRenderer = function(container, map) {
    */
   this.context_ = new _ol_webgl_Context_(this.canvas_, this.gl_);
 
-  _ol_events_.listen(this.canvas_, ContextEventType.LOST,
+  listen(this.canvas_, ContextEventType.LOST,
     this.handleWebGLContextLost, this);
-  _ol_events_.listen(this.canvas_, ContextEventType.RESTORED,
+  listen(this.canvas_, ContextEventType.RESTORED,
     this.handleWebGLContextRestored, this);
 
   /**

--- a/src/ol/reproj/Image.js
+++ b/src/ol/reproj/Image.js
@@ -5,7 +5,7 @@ import {ERROR_THRESHOLD} from './common.js';
 import {inherits} from '../index.js';
 import _ol_ImageBase_ from '../ImageBase.js';
 import ImageState from '../ImageState.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {getCenter, getIntersection, getHeight, getWidth} from '../extent.js';
 import _ol_reproj_ from '../reproj.js';
@@ -172,7 +172,7 @@ ReprojImage.prototype.load = function() {
     if (sourceState == ImageState.LOADED || sourceState == ImageState.ERROR) {
       this.reproject_();
     } else {
-      this.sourceListenerKey_ = _ol_events_.listen(this.sourceImage_,
+      this.sourceListenerKey_ = listen(this.sourceImage_,
         EventType.CHANGE, function(e) {
           const sourceState = this.sourceImage_.getState();
           if (sourceState == ImageState.LOADED || sourceState == ImageState.ERROR) {
@@ -190,7 +190,7 @@ ReprojImage.prototype.load = function() {
  * @private
  */
 ReprojImage.prototype.unlistenSource_ = function() {
-  _ol_events_.unlistenByKey(/** @type {!ol.EventsKey} */ (this.sourceListenerKey_));
+  unlistenByKey(/** @type {!ol.EventsKey} */ (this.sourceListenerKey_));
   this.sourceListenerKey_ = null;
 };
 export default ReprojImage;

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -5,7 +5,7 @@ import {ERROR_THRESHOLD} from './common.js';
 import {inherits} from '../index.js';
 import Tile from '../Tile.js';
 import TileState from '../TileState.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {getArea, getCenter, getIntersection} from '../extent.js';
 import {clamp} from '../math.js';
@@ -264,13 +264,13 @@ ReprojTile.prototype.load = function() {
       if (state == TileState.IDLE || state == TileState.LOADING) {
         leftToLoad++;
 
-        const sourceListenKey = _ol_events_.listen(tile, EventType.CHANGE,
+        const sourceListenKey = listen(tile, EventType.CHANGE,
           function(e) {
             const state = tile.getState();
             if (state == TileState.LOADED ||
                   state == TileState.ERROR ||
                   state == TileState.EMPTY) {
-              _ol_events_.unlistenByKey(sourceListenKey);
+              unlistenByKey(sourceListenKey);
               leftToLoad--;
               if (leftToLoad === 0) {
                 this.unlistenSources_();
@@ -300,7 +300,7 @@ ReprojTile.prototype.load = function() {
  * @private
  */
 ReprojTile.prototype.unlistenSources_ = function() {
-  this.sourcesListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.sourcesListenerKeys_.forEach(unlistenByKey);
   this.sourcesListenerKeys_ = null;
 };
 export default ReprojTile;

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import _ol_Image_ from '../Image.js';
 import {assert} from '../asserts.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {containsExtent, getHeight, getWidth} from '../extent.js';
 import {assign} from '../obj.js';
@@ -173,7 +173,7 @@ ImageArcGISRest.prototype.getImageInternal = function(extent, resolution, pixelR
 
   this.renderedRevision_ = this.getRevision();
 
-  _ol_events_.listen(this.image_, EventType.CHANGE,
+  listen(this.image_, EventType.CHANGE,
     this.handleImageChange, this);
 
   return this.image_;

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../index.js';
 import _ol_Image_ from '../Image.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {containsExtent, getCenter, getHeight, getWidth, scaleFromCenter} from '../extent.js';
 import {assign} from '../obj.js';
@@ -144,7 +144,7 @@ ImageMapGuide.prototype.getImageInternal = function(extent, resolution, pixelRat
     image = new _ol_Image_(extent, resolution, pixelRatio,
       imageUrl, this.crossOrigin_,
       this.imageLoadFunction_);
-    _ol_events_.listen(image, EventType.CHANGE,
+    listen(image, EventType.CHANGE,
       this.handleImageChange, this);
   } else {
     image = null;

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -5,7 +5,7 @@ import {inherits} from '../index.js';
 import _ol_Image_ from '../Image.js';
 import ImageState from '../ImageState.js';
 import {createCanvasContext2D} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {intersects, getHeight, getWidth} from '../extent.js';
 import {get as getProjection} from '../proj.js';
@@ -47,7 +47,7 @@ const Static = function(options) {
    */
   this.imageSize_ = options.imageSize ? options.imageSize : null;
 
-  _ol_events_.listen(this.image_, EventType.CHANGE,
+  listen(this.image_, EventType.CHANGE,
     this.handleImageChange, this);
 
 };

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -6,7 +6,7 @@ import {DEFAULT_WMS_VERSION} from './common.js';
 import {inherits} from '../index.js';
 import _ol_Image_ from '../Image.js';
 import {assert} from '../asserts.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {containsExtent, getCenter, getForViewAndSize, getHeight, getWidth} from '../extent.js';
 import {assign} from '../obj.js';
@@ -236,7 +236,7 @@ ImageWMS.prototype.getImageInternal = function(extent, resolution, pixelRatio, p
 
   this.renderedRevision_ = this.getRevision();
 
-  _ol_events_.listen(this.image_, EventType.CHANGE,
+  listen(this.image_, EventType.CHANGE,
     this.handleImageChange, this);
 
   return this.image_;

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -5,7 +5,7 @@ import {getUid, inherits} from '../index.js';
 import ImageCanvas from '../ImageCanvas.js';
 import TileQueue from '../TileQueue.js';
 import {createCanvasContext2D} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import {Processor} from 'pixelworks';
@@ -82,7 +82,7 @@ const RasterSource = function(options) {
   this.renderers_ = createRenderers(options.sources);
 
   for (let r = 0, rr = this.renderers_.length; r < rr; ++r) {
-    _ol_events_.listen(this.renderers_[r], EventType.CHANGE,
+    listen(this.renderers_[r], EventType.CHANGE,
       this.changed, this);
   }
 

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -6,7 +6,7 @@ import {getUid, inherits} from '../index.js';
 import ImageTile from '../ImageTile.js';
 import TileCache from '../TileCache.js';
 import TileState from '../TileState.js';
-import _ol_events_ from '../events.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {equivalent, get as getProjection} from '../proj.js';
 import ReprojTile from '../reproj/Tile.js';
@@ -224,7 +224,7 @@ TileImage.prototype.createTile_ = function(z, x, y, pixelRatio, projection, key)
     this.tileLoadFunction,
     this.tileOptions);
   tile.key = key;
-  _ol_events_.listen(tile, EventType.CHANGE,
+  listen(tile, EventType.CHANGE,
     this.handleTileChange, this);
   return tile;
 };

--- a/src/ol/source/TileUTFGrid.js
+++ b/src/ol/source/TileUTFGrid.js
@@ -6,7 +6,7 @@ import Tile from '../Tile.js';
 import TileState from '../TileState.js';
 import {createFromTemplates, nullTileUrlFunction} from '../tileurlfunction.js';
 import {assert} from '../asserts.js';
-import _ol_events_ from '../events.js';
+import {listenOnce} from '../events.js';
 import EventType from '../events/EventType.js';
 import {applyTransform, intersects} from '../extent.js';
 import _ol_net_ from '../net.js';
@@ -371,7 +371,7 @@ UTFGrid.Tile_.prototype.getData = function(coordinate) {
  */
 UTFGrid.Tile_.prototype.forDataAtCoordinate = function(coordinate, callback, opt_this, opt_request) {
   if (this.state == TileState.IDLE && opt_request === true) {
-    _ol_events_.listenOnce(this, EventType.CHANGE, function(e) {
+    listenOnce(this, EventType.CHANGE, function(e) {
       callback.call(opt_this, this.getData(coordinate));
     }, this);
     this.loadInternal_();

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -8,7 +8,7 @@ import CollectionEventType from '../CollectionEventType.js';
 import ObjectEventType from '../ObjectEventType.js';
 import {extend} from '../array.js';
 import {assert} from '../asserts.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import {containsExtent, equals} from '../extent.js';
@@ -203,9 +203,9 @@ VectorSource.prototype.addFeatureInternal = function(feature) {
  */
 VectorSource.prototype.setupChangeEvents_ = function(featureKey, feature) {
   this.featureChangeKeys_[featureKey] = [
-    _ol_events_.listen(feature, EventType.CHANGE,
+    listen(feature, EventType.CHANGE,
       this.handleFeatureChange_, this),
-    _ol_events_.listen(feature, ObjectEventType.PROPERTYCHANGE,
+    listen(feature, ObjectEventType.PROPERTYCHANGE,
       this.handleFeatureChange_, this)
   ];
 };
@@ -295,7 +295,7 @@ VectorSource.prototype.addFeaturesInternal = function(features) {
  */
 VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
   let modifyingCollection = false;
-  _ol_events_.listen(this, VectorEventType.ADDFEATURE,
+  listen(this, VectorEventType.ADDFEATURE,
     function(evt) {
       if (!modifyingCollection) {
         modifyingCollection = true;
@@ -303,7 +303,7 @@ VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
         modifyingCollection = false;
       }
     });
-  _ol_events_.listen(this, VectorEventType.REMOVEFEATURE,
+  listen(this, VectorEventType.REMOVEFEATURE,
     function(evt) {
       if (!modifyingCollection) {
         modifyingCollection = true;
@@ -311,7 +311,7 @@ VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
         modifyingCollection = false;
       }
     });
-  _ol_events_.listen(collection, CollectionEventType.ADD,
+  listen(collection, CollectionEventType.ADD,
     function(evt) {
       if (!modifyingCollection) {
         modifyingCollection = true;
@@ -319,7 +319,7 @@ VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
         modifyingCollection = false;
       }
     }, this);
-  _ol_events_.listen(collection, CollectionEventType.REMOVE,
+  listen(collection, CollectionEventType.REMOVE,
     function(evt) {
       if (!modifyingCollection) {
         modifyingCollection = true;
@@ -340,7 +340,7 @@ VectorSource.prototype.clear = function(opt_fast) {
   if (opt_fast) {
     for (const featureId in this.featureChangeKeys_) {
       const keys = this.featureChangeKeys_[featureId];
-      keys.forEach(_ol_events_.unlistenByKey);
+      keys.forEach(unlistenByKey);
     }
     if (!this.featuresCollection_) {
       this.featureChangeKeys_ = {};
@@ -798,7 +798,7 @@ VectorSource.prototype.removeFeature = function(feature) {
  */
 VectorSource.prototype.removeFeatureInternal = function(feature) {
   const featureKey = getUid(feature).toString();
-  this.featureChangeKeys_[featureKey].forEach(_ol_events_.unlistenByKey);
+  this.featureChangeKeys_[featureKey].forEach(unlistenByKey);
   delete this.featureChangeKeys_[featureKey];
   const id = feature.getId();
   if (id !== undefined) {

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -5,7 +5,7 @@ import {getUid, inherits} from '../index.js';
 import ImageState from '../ImageState.js';
 import {assert} from '../asserts.js';
 import {asArray} from '../color.js';
-import _ol_events_ from '../events.js';
+import {listen, unlisten} from '../events.js';
 import EventType from '../events/EventType.js';
 import IconAnchorUnits from '../style/IconAnchorUnits.js';
 import IconImage from '../style/IconImage.js';
@@ -354,7 +354,7 @@ Icon.prototype.getSize = function() {
  * @override
  */
 Icon.prototype.listenImageChange = function(listener, thisArg) {
-  return _ol_events_.listen(this.iconImage_, EventType.CHANGE,
+  return listen(this.iconImage_, EventType.CHANGE,
     listener, thisArg);
 };
 
@@ -376,7 +376,7 @@ Icon.prototype.load = function() {
  * @override
  */
 Icon.prototype.unlistenImageChange = function(listener, thisArg) {
-  _ol_events_.unlisten(this.iconImage_, EventType.CHANGE,
+  unlisten(this.iconImage_, EventType.CHANGE,
     listener, thisArg);
 };
 export default Icon;

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../index.js';
 import {createCanvasContext2D} from '../dom.js';
-import _ol_events_ from '../events.js';
+import {listenOnce, unlistenByKey} from '../events.js';
 import EventTarget from '../events/EventTarget.js';
 import EventType from '../events/EventType.js';
 import ImageState from '../ImageState.js';
@@ -222,9 +222,9 @@ IconImage.prototype.load = function() {
   if (this.imageState_ == ImageState.IDLE) {
     this.imageState_ = ImageState.LOADING;
     this.imageListenerKeys_ = [
-      _ol_events_.listenOnce(this.image_, EventType.ERROR,
+      listenOnce(this.image_, EventType.ERROR,
         this.handleImageError_, this),
-      _ol_events_.listenOnce(this.image_, EventType.LOAD,
+      listenOnce(this.image_, EventType.LOAD,
         this.handleImageLoad_, this)
     ];
     try {
@@ -271,7 +271,7 @@ IconImage.prototype.replaceColor_ = function() {
  * @private
  */
 IconImage.prototype.unlistenImage_ = function() {
-  this.imageListenerKeys_.forEach(_ol_events_.unlistenByKey);
+  this.imageListenerKeys_.forEach(unlistenByKey);
   this.imageListenerKeys_ = null;
 };
 export default IconImage;

--- a/src/ol/webgl/Context.js
+++ b/src/ol/webgl/Context.js
@@ -4,7 +4,7 @@
 import {WEBGL_EXTENSIONS, getUid, inherits} from '../index.js';
 import Disposable from '../Disposable.js';
 import {includes} from '../array.js';
-import _ol_events_ from '../events.js';
+import {listen, unlistenAll} from '../events.js';
 import {clear} from '../obj.js';
 import _ol_webgl_ from '../webgl.js';
 import ContextEventType from '../webgl/ContextEventType.js';
@@ -84,9 +84,9 @@ const _ol_webgl_Context_ = function(canvas, gl) {
     gl.getExtension('OES_element_index_uint');
   }
 
-  _ol_events_.listen(this.canvas_, ContextEventType.LOST,
+  listen(this.canvas_, ContextEventType.LOST,
     this.handleWebGLContextLost, this);
-  _ol_events_.listen(this.canvas_, ContextEventType.RESTORED,
+  listen(this.canvas_, ContextEventType.RESTORED,
     this.handleWebGLContextRestored, this);
 
 };
@@ -145,7 +145,7 @@ _ol_webgl_Context_.prototype.deleteBuffer = function(buf) {
  * @inheritDoc
  */
 _ol_webgl_Context_.prototype.disposeInternal = function() {
-  _ol_events_.unlistenAll(this.canvas_);
+  unlistenAll(this.canvas_);
   const gl = this.getGL();
   if (!gl.isContextLost()) {
     for (const key in this.bufferCache_) {

--- a/test/rendering/ol/reproj/image.test.js
+++ b/test/rendering/ol/reproj/image.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
 import ReprojImage from '../../../../src/ol/reproj/Image.js';
@@ -21,7 +21,7 @@ describe('ol.rendering.reproj.Image', function() {
         return source.getImage(extent, resolution, pixelRatio, sourceProj);
       });
     if (image.getState() == 0) { // IDLE
-      _ol_events_.listen(image, 'change', function(e) {
+      listen(image, 'change', function(e) {
         if (image.getState() == 2) { // LOADED
           expect(imagesRequested).to.be(1);
           resembleCanvas(image.getImage(), expectedUrl, IMAGE_TOLERANCE, done);

--- a/test/rendering/ol/reproj/tile.test.js
+++ b/test/rendering/ol/reproj/tile.test.js
@@ -1,5 +1,5 @@
 import TileState from '../../../../src/ol/TileState.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
 import ReprojTile from '../../../../src/ol/reproj/Tile.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
@@ -24,7 +24,7 @@ describe('ol.rendering.reproj.Tile', function() {
         return source.getTile(z, x, y, pixelRatio, sourceProjection);
       });
     if (tile.getState() == TileState.IDLE) {
-      _ol_events_.listen(tile, 'change', function(e) {
+      listen(tile, 'change', function(e) {
         if (tile.getState() == TileState.LOADED) {
           expect(tilesRequested).to.be(expectedRequests);
           resembleCanvas(tile.getImage(), expectedUrl, 7.5, done);

--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen} from '../../../src/ol/events.js';
 import Collection from '../../../src/ol/Collection.js';
 import CollectionEventType from '../../../src/ol/CollectionEventType.js';
 
@@ -37,7 +37,7 @@ describe('ol.collection', function() {
     });
     it('returns the correct new length of the collection', function() {
       let length;
-      _ol_events_.listen(collection, 'add', function(event) {
+      listen(collection, 'add', function(event) {
         if (event.element === 'remove_me') {
           collection.remove(event.element);
         }
@@ -118,7 +118,7 @@ describe('ol.collection', function() {
     it('fires a remove event', function() {
       const collection = new Collection([0, 1, 2]);
       const cb = sinon.spy();
-      _ol_events_.listen(collection, CollectionEventType.REMOVE, cb);
+      listen(collection, CollectionEventType.REMOVE, cb);
       expect(collection.remove(1)).to.eql(1);
       expect(cb).to.be.called();
       expect(cb.lastCall.args[0].element).to.eql(1);
@@ -141,10 +141,10 @@ describe('ol.collection', function() {
     it('does dispatch events', function() {
       const collection = new Collection(['a', 'b']);
       let added, removed;
-      _ol_events_.listen(collection, CollectionEventType.ADD, function(e) {
+      listen(collection, CollectionEventType.ADD, function(e) {
         added = e.element;
       });
-      _ol_events_.listen(
+      listen(
         collection, CollectionEventType.REMOVE, function(e) {
           removed = e.element;
         });
@@ -158,7 +158,7 @@ describe('ol.collection', function() {
     it('does dispatch events', function() {
       const collection = new Collection(['a']);
       let removed;
-      _ol_events_.listen(
+      listen(
         collection, CollectionEventType.REMOVE, function(e) {
           removed = e.element;
         });
@@ -171,7 +171,7 @@ describe('ol.collection', function() {
     it('does dispatch events', function() {
       const collection = new Collection([0, 2]);
       let added;
-      _ol_events_.listen(
+      listen(
         collection, CollectionEventType.ADD, function(e) {
           added = e.element;
         });
@@ -183,7 +183,7 @@ describe('ol.collection', function() {
   describe('setAt beyond end', function() {
     it('triggers events properly', function() {
       const added = [];
-      _ol_events_.listen(
+      listen(
         collection, CollectionEventType.ADD, function(e) {
           added.push(e.element);
         });
@@ -204,7 +204,7 @@ describe('ol.collection', function() {
     beforeEach(function() {
       collection = new Collection([0, 1, 2]);
       cb = sinon.spy();
-      _ol_events_.listen(collection, 'change:length', cb);
+      listen(collection, 'change:length', cb);
     });
 
     describe('insertAt', function() {
@@ -233,7 +233,7 @@ describe('ol.collection', function() {
     it('triggers add when pushing', function() {
       const collection = new Collection();
       let elem;
-      _ol_events_.listen(collection, CollectionEventType.ADD, function(e) {
+      listen(collection, CollectionEventType.ADD, function(e) {
         elem = e.element;
       });
       const length = collection.push(1);
@@ -250,8 +250,8 @@ describe('ol.collection', function() {
     });
     describe('setAt', function() {
       it('triggers remove', function() {
-        _ol_events_.listen(collection, CollectionEventType.ADD, cb1);
-        _ol_events_.listen(collection, CollectionEventType.REMOVE, cb2);
+        listen(collection, CollectionEventType.ADD, cb1);
+        listen(collection, CollectionEventType.REMOVE, cb2);
         collection.setAt(0, 2);
         expect(cb2.lastCall.args[0].element).to.eql(1);
         expect(cb1.lastCall.args[0].element).to.eql(2);
@@ -259,7 +259,7 @@ describe('ol.collection', function() {
     });
     describe('pop', function() {
       it('triggers remove', function() {
-        _ol_events_.listen(collection, CollectionEventType.REMOVE, cb1);
+        listen(collection, CollectionEventType.REMOVE, cb1);
         collection.pop();
         expect(cb1.lastCall.args[0].element).to.eql(1);
       });
@@ -277,7 +277,7 @@ describe('ol.collection', function() {
     it('fires events', function() {
       const collection = new Collection();
       const elems = [];
-      _ol_events_.listen(collection, CollectionEventType.ADD, function(e) {
+      listen(collection, CollectionEventType.ADD, function(e) {
         elems.push(e.element);
       });
       collection.extend([1, 2]);

--- a/test/spec/ol/events.test.js
+++ b/test/spec/ol/events.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen, listenOnce, bindListener, unlisten, unlistenAll, unlistenByKey, findListener, getListeners} from '../../../src/ol/events.js';
 import EventTarget from '../../../src/ol/events/EventTarget.js';
 
 describe('ol.events', function() {
@@ -13,13 +13,13 @@ describe('ol.events', function() {
     };
   });
 
-  describe('bindListener_()', function() {
+  describe('bindListener()', function() {
     it('binds a listener and returns a bound listener function', function() {
       const listenerObj = {
         listener: sinon.spy(),
         bindTo: {id: 1}
       };
-      const boundListener = _ol_events_.bindListener_(listenerObj);
+      const boundListener = bindListener(listenerObj);
       expect(listenerObj.boundListener).to.equal(boundListener);
       boundListener();
       expect(listenerObj.listener.thisValues[0]).to.equal(listenerObj.bindTo);
@@ -29,7 +29,7 @@ describe('ol.events', function() {
         listener: sinon.spy(),
         target: {id: 1}
       };
-      const boundListener = _ol_events_.bindListener_(listenerObj);
+      const boundListener = bindListener(listenerObj);
       expect(listenerObj.boundListener).to.equal(boundListener);
       boundListener();
       expect(listenerObj.listener.thisValues[0]).to.equal(listenerObj.target);
@@ -42,19 +42,16 @@ describe('ol.events', function() {
         bindTo: bindTo,
         callOnce: true
       };
-      const unlistenSpy = sinon.spy(_ol_events_, 'unlistenByKey'); // eslint-disable-line openlayers-internal/no-missing-requires
       listenerObj.listener = function() {
         expect(this).to.equal(bindTo);
-        expect(unlistenSpy.firstCall.args[0]).to.eql(listenerObj);
       };
-      const boundListener = _ol_events_.bindListener_(listenerObj);
+      const boundListener = bindListener(listenerObj);
       expect(listenerObj.boundListener).to.equal(boundListener);
       boundListener();
-      unlistenSpy.restore();
     });
   });
 
-  describe('findListener_()', function() {
+  describe('findListener()', function() {
     let listener, listenerObj, listeners;
 
     beforeEach(function() {
@@ -69,18 +66,18 @@ describe('ol.events', function() {
 
     it('searches a listener array for a specific listener', function() {
       const bindTo = {id: 1};
-      let result = _ol_events_.findListener_(listeners, listener);
+      let result = findListener(listeners, listener);
       expect(result).to.be(listenerObj);
-      result = _ol_events_.findListener_(listeners, listener, bindTo);
+      result = findListener(listeners, listener, bindTo);
       expect(result).to.be(undefined);
       listenerObj.bindTo = bindTo;
-      result = _ol_events_.findListener_(listeners, listener);
+      result = findListener(listeners, listener);
       expect(result).to.be(undefined);
-      result = _ol_events_.findListener_(listeners, listener, bindTo);
+      result = findListener(listeners, listener, bindTo);
       expect(result).to.be(listenerObj);
     });
     it('marks the delete index on a listener object', function() {
-      const result = _ol_events_.findListener_(listeners, listener, undefined, true);
+      const result = findListener(listeners, listener, undefined, true);
       expect(result).to.be(listenerObj);
       expect(listenerObj.deleteIndex).to.be(0);
     });
@@ -88,37 +85,37 @@ describe('ol.events', function() {
 
   describe('getListeners()', function() {
     it('returns listeners for a target and type', function() {
-      const foo = _ol_events_.listen(target, 'foo', function() {});
-      const bar = _ol_events_.listen(target, 'bar', function() {});
-      expect (_ol_events_.getListeners(target, 'foo')).to.eql([foo]);
-      expect (_ol_events_.getListeners(target, 'bar')).to.eql([bar]);
+      const foo = listen(target, 'foo', function() {});
+      const bar = listen(target, 'bar', function() {});
+      expect (getListeners(target, 'foo')).to.eql([foo]);
+      expect (getListeners(target, 'bar')).to.eql([bar]);
     });
     it('returns undefined when no listeners are registered', function() {
-      expect (_ol_events_.getListeners(target, 'foo')).to.be(undefined);
+      expect (getListeners(target, 'foo')).to.be(undefined);
     });
   });
 
   describe('listen()', function() {
     it('calls addEventListener on the target', function() {
-      _ol_events_.listen(target, 'foo', function() {});
+      listen(target, 'foo', function() {});
       expect(add.callCount).to.be(1);
     });
     it('returns a key', function() {
-      const key = _ol_events_.listen(target, 'foo', function() {});
+      const key = listen(target, 'foo', function() {});
       expect(key).to.be.a(Object);
     });
     it('does not add the same listener twice', function() {
       const listener = function() {};
-      const key1 = _ol_events_.listen(target, 'foo', listener);
-      const key2 = _ol_events_.listen(target, 'foo', listener);
+      const key1 = listen(target, 'foo', listener);
+      const key2 = listen(target, 'foo', listener);
       expect(key1).to.equal(key2);
       expect(add.callCount).to.be(1);
     });
     it('only treats listeners as same when all args are equal', function() {
       const listener = function() {};
-      _ol_events_.listen(target, 'foo', listener, {});
-      _ol_events_.listen(target, 'foo', listener, {});
-      _ol_events_.listen(target, 'foo', listener, undefined);
+      listen(target, 'foo', listener, {});
+      listen(target, 'foo', listener, {});
+      listen(target, 'foo', listener, undefined);
       expect(add.callCount).to.be(3);
     });
   });
@@ -126,7 +123,7 @@ describe('ol.events', function() {
   describe('listenOnce()', function() {
     it('creates a one-off listener', function() {
       const listener = sinon.spy();
-      const key = _ol_events_.listenOnce(target, 'foo', listener);
+      const key = listenOnce(target, 'foo', listener);
       expect(add.callCount).to.be(1);
       expect(key.callOnce).to.be(true);
       key.boundListener();
@@ -135,17 +132,17 @@ describe('ol.events', function() {
     });
     it('does not add the same listener twice', function() {
       const listener = function() {};
-      const key1 = _ol_events_.listenOnce(target, 'foo', listener);
-      const key2 = _ol_events_.listenOnce(target, 'foo', listener);
+      const key1 = listenOnce(target, 'foo', listener);
+      const key2 = listenOnce(target, 'foo', listener);
       expect(key1).to.equal(key2);
       expect(add.callCount).to.be(1);
       expect(key1.callOnce).to.be(true);
     });
     it('listen() can turn a one-off listener into a permanent one', function() {
       const listener = sinon.spy();
-      let key = _ol_events_.listenOnce(target, 'foo', listener);
+      let key = listenOnce(target, 'foo', listener);
       expect(key.callOnce).to.be(true);
-      key = _ol_events_.listen(target, 'foo', listener);
+      key = listen(target, 'foo', listener);
       expect(add.callCount).to.be(1);
       expect(key.callOnce).to.be(false);
       key.boundListener();
@@ -156,42 +153,42 @@ describe('ol.events', function() {
   describe('unlisten()', function() {
     it('unregisters previously registered listeners', function() {
       const listener = function() {};
-      _ol_events_.listen(target, 'foo', listener);
-      _ol_events_.unlisten(target, 'foo', listener);
-      expect(_ol_events_.getListeners(target, 'foo')).to.be(undefined);
+      listen(target, 'foo', listener);
+      unlisten(target, 'foo', listener);
+      expect(getListeners(target, 'foo')).to.be(undefined);
     });
     it('works with multiple types', function() {
       const listener = function() {};
-      _ol_events_.listen(target, ['foo', 'bar'], listener);
-      _ol_events_.unlisten(target, ['bar', 'foo'], listener);
-      expect(_ol_events_.getListeners(target, 'foo')).to.be(undefined);
-      expect(_ol_events_.getListeners(target, 'bar')).to.be(undefined);
+      listen(target, ['foo', 'bar'], listener);
+      unlisten(target, ['bar', 'foo'], listener);
+      expect(getListeners(target, 'foo')).to.be(undefined);
+      expect(getListeners(target, 'bar')).to.be(undefined);
     });
   });
 
   describe('unlistenByKey()', function() {
     it('unregisters previously registered listeners', function() {
-      const key = _ol_events_.listen(target, 'foo', function() {});
-      _ol_events_.unlistenByKey(key);
-      expect(_ol_events_.getListeners(target, 'foo')).to.be(undefined);
+      const key = listen(target, 'foo', function() {});
+      unlistenByKey(key);
+      expect(getListeners(target, 'foo')).to.be(undefined);
     });
     it('works with multiple types', function() {
-      const key = _ol_events_.listen(target, ['foo', 'bar'], function() {});
-      _ol_events_.unlistenByKey(key);
-      expect(_ol_events_.getListeners(target, 'foo')).to.be(undefined);
-      expect(_ol_events_.getListeners(target, 'bar')).to.be(undefined);
+      const key = listen(target, ['foo', 'bar'], function() {});
+      unlistenByKey(key);
+      expect(getListeners(target, 'foo')).to.be(undefined);
+      expect(getListeners(target, 'bar')).to.be(undefined);
     });
   });
 
   describe('unlistenAll()', function() {
     it('unregisters all listeners registered for a target', function() {
       const keys = [
-        _ol_events_.listen(target, 'foo', function() {}),
-        _ol_events_.listen(target, 'bar', function() {})
+        listen(target, 'foo', function() {}),
+        listen(target, 'bar', function() {})
       ];
-      _ol_events_.unlistenAll(target);
-      expect(_ol_events_.getListeners(target, 'foo')).to.be(undefined);
-      expect(_ol_events_.getListeners(target, 'bar')).to.be(undefined);
+      unlistenAll(target);
+      expect(getListeners(target, 'foo')).to.be(undefined);
+      expect(getListeners(target, 'bar')).to.be(undefined);
       expect('ol_lm' in target).to.be(false);
       expect(keys).to.eql([{}, {}]);
     });
@@ -201,17 +198,17 @@ describe('ol.events', function() {
     it('does not register duplicated listeners', function() {
       const target = new EventTarget();
       const listener = function() {};
-      const key1 = _ol_events_.listen(target, 'foo', listener);
+      const key1 = listen(target, 'foo', listener);
       expect(target.getListeners('foo')).to.eql([key1.boundListener]);
-      const key2 = _ol_events_.listen(target, 'foo', listener);
+      const key2 = listen(target, 'foo', listener);
       expect(key2.boundListener).to.equal(key1.boundListener);
       expect(target.getListeners('foo')).to.eql([key1.boundListener]);
     });
     it('registers multiple listeners if this object is different', function() {
       const target = new EventTarget();
       const listener = function() {};
-      const key1 = _ol_events_.listen(target, 'foo', listener, {});
-      const key2 = _ol_events_.listen(target, 'foo', listener, {});
+      const key1 = listen(target, 'foo', listener, {});
+      const key2 = listen(target, 'foo', listener, {});
       expect(key1.boundListener).to.not.equal(key2.boundListener);
       expect(target.getListeners('foo')).to.eql(
         [key1.boundListener, key2.boundListener]);

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -1,5 +1,5 @@
 import Disposable from '../../../../src/ol/Disposable.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import Event from '../../../../src/ol/events/Event.js';
 import EventTarget from '../../../../src/ol/events/EventTarget.js';
 
@@ -154,7 +154,7 @@ describe('ol.events.EventTarget', function() {
 
   describe('#dispose()', function() {
     it('cleans up foreign references', function() {
-      _ol_events_.listen(eventTarget, 'foo', spy1, document);
+      listen(eventTarget, 'foo', spy1, document);
       expect(eventTarget.hasListener('foo')).to.be(true);
       eventTarget.dispose();
       expect(eventTarget.hasListener('foo')).to.be(false);

--- a/test/spec/ol/imagetile.test.js
+++ b/test/spec/ol/imagetile.test.js
@@ -1,6 +1,6 @@
 import ImageTile from '../../../src/ol/ImageTile.js';
 import TileState from '../../../src/ol/TileState.js';
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen, unlistenByKey} from '../../../src/ol/events.js';
 import EventType from '../../../src/ol/events/EventType.js';
 import ImageSource from '../../../src/ol/source/Image.js';
 
@@ -18,7 +18,7 @@ describe('ol.ImageTile', function() {
 
       let previousState = tile.getState();
 
-      _ol_events_.listen(tile, EventType.CHANGE, function(event) {
+      listen(tile, EventType.CHANGE, function(event) {
         const state = tile.getState();
         if (previousState == TileState.IDLE) {
           expect(state).to.be(TileState.LOADING);
@@ -43,7 +43,7 @@ describe('ol.ImageTile', function() {
 
       let previousState = tile.getState();
 
-      _ol_events_.listen(tile, EventType.CHANGE, function(event) {
+      listen(tile, EventType.CHANGE, function(event) {
         const state = tile.getState();
         if (previousState == TileState.ERROR) {
           expect(state).to.be(TileState.LOADING);
@@ -66,12 +66,12 @@ describe('ol.ImageTile', function() {
       const tileLoadFunction = ImageSource.defaultImageLoadFunction;
       const tile = new ImageTile(tileCoord, state, src, null, tileLoadFunction);
 
-      const key = _ol_events_.listen(tile, EventType.CHANGE, function(event) {
+      const key = listen(tile, EventType.CHANGE, function(event) {
         const state = tile.getState();
         if (state == TileState.ERROR) {
           expect(state).to.be(TileState.ERROR);
           expect(tile.image_).to.be.a(HTMLCanvasElement);
-          _ol_events_.unlistenByKey(key);
+          unlistenByKey(key);
           tile.load();
           expect(tile.image_).to.be.a(HTMLImageElement);
           done();

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -3,7 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import MapBrowserPointerEvent from '../../../../src/ol/MapBrowserPointerEvent.js';
 import View from '../../../../src/ol/View.js';
 import {equals} from '../../../../src/ol/array.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
@@ -205,8 +205,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       const ds = sinon.spy();
       const de = sinon.spy();
-      _ol_events_.listen(draw, 'drawstart', ds);
-      _ol_events_.listen(draw, 'drawend', de);
+      listen(draw, 'drawstart', ds);
+      listen(draw, 'drawend', de);
       simulateEvent('pointermove', 10, 20);
       simulateEvent('pointerdown', 10, 20);
       simulateEvent('pointerup', 10, 20);
@@ -222,7 +222,7 @@ describe('ol.interaction.Draw', function() {
         end: 0,
         addfeature: 0
       };
-      _ol_events_.listen(draw, 'drawend',
+      listen(draw, 'drawend',
         function() {
           expect(receivedEvents.end).to.be(0);
           expect(receivedEvents.addfeature).to.be(0);
@@ -439,8 +439,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       const ds = sinon.spy();
       const de = sinon.spy();
-      _ol_events_.listen(draw, 'drawstart', ds);
-      _ol_events_.listen(draw, 'drawend', de);
+      listen(draw, 'drawstart', ds);
+      listen(draw, 'drawend', de);
 
       // first point
       simulateEvent('pointermove', 10, 20);
@@ -703,8 +703,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       const ds = sinon.spy();
       const de = sinon.spy();
-      _ol_events_.listen(draw, 'drawstart', ds);
-      _ol_events_.listen(draw, 'drawend', de);
+      listen(draw, 'drawstart', ds);
+      listen(draw, 'drawend', de);
 
       // first point
       simulateEvent('pointermove', 10, 20);
@@ -861,8 +861,8 @@ describe('ol.interaction.Draw', function() {
     it('triggers draw events', function() {
       const ds = sinon.spy();
       const de = sinon.spy();
-      _ol_events_.listen(draw, 'drawstart', ds);
-      _ol_events_.listen(draw, 'drawend', de);
+      listen(draw, 'drawstart', ds);
+      listen(draw, 'drawend', de);
 
       // first point
       simulateEvent('pointermove', 10, 20);
@@ -1088,7 +1088,7 @@ describe('ol.interaction.Draw', function() {
 
     it('dispatches a drawstart event', function() {
       const spy = sinon.spy();
-      _ol_events_.listen(draw, 'drawstart', spy);
+      listen(draw, 'drawstart', spy);
       draw.extend(feature);
       expect(spy.callCount).to.be(1);
     });

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -3,7 +3,7 @@ import Feature from '../../../../src/ol/Feature.js';
 import Map from '../../../../src/ol/Map.js';
 import MapBrowserPointerEvent from '../../../../src/ol/MapBrowserPointerEvent.js';
 import View from '../../../../src/ol/View.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {getListeners} from '../../../../src/ol/events.js';
 import _ol_events_condition_ from '../../../../src/ol/events/condition.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
@@ -604,11 +604,11 @@ describe('ol.interaction.Modify', function() {
   });
 
   describe('handle feature change', function() {
-    let getListeners;
+    let getModifyListeners;
 
     beforeEach(function() {
-      getListeners = function(feature, modify) {
-        const listeners = _ol_events_.getListeners(
+      getModifyListeners = function(feature, modify) {
+        const listeners = getListeners(
           feature, 'change');
         return listeners.filter(function(listener) {
           return listener.bindTo === modify;
@@ -628,7 +628,7 @@ describe('ol.interaction.Modify', function() {
 
       let listeners;
 
-      listeners = getListeners(feature, modify);
+      listeners = getModifyListeners(feature, modify);
       expect(listeners).to.have.length(1);
 
       let firstSegmentData;
@@ -652,7 +652,7 @@ describe('ol.interaction.Modify', function() {
       expect(firstSegmentData.segment[0]).to.eql([1, 1]);
       expect(firstSegmentData.segment[1]).to.eql([1, 1]);
 
-      listeners = getListeners(feature, modify);
+      listeners = getModifyListeners(feature, modify);
       expect(listeners).to.have.length(1);
     });
 
@@ -665,7 +665,7 @@ describe('ol.interaction.Modify', function() {
       const feature = features[0];
       let listeners;
 
-      listeners = getListeners(feature, modify);
+      listeners = getModifyListeners(feature, modify);
       expect(listeners).to.have.length(1);
 
       let firstSegmentData;
@@ -690,7 +690,7 @@ describe('ol.interaction.Modify', function() {
       expect(firstSegmentData.segment[0]).to.eql([1, 1]);
       expect(firstSegmentData.segment[1]).to.eql([10, 20]);
 
-      listeners = getListeners(feature, modify);
+      listeners = getModifyListeners(feature, modify);
       expect(listeners).to.have.length(1);
     });
   });

--- a/test/spec/ol/mapbrowserevent.test.js
+++ b/test/spec/ol/mapbrowserevent.test.js
@@ -1,6 +1,6 @@
 import Map from '../../../src/ol/Map.js';
 import MapBrowserEventHandler from '../../../src/ol/MapBrowserEventHandler.js';
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen} from '../../../src/ol/events.js';
 import _ol_has_ from '../../../src/ol/has.js';
 import PointerEvent from '../../../src/ol/pointer/PointerEvent.js';
 
@@ -21,13 +21,13 @@ describe('ol.MapBrowserEventHandler', function() {
       }));
 
       clickSpy = sinon.spy();
-      _ol_events_.listen(handler, 'click', clickSpy);
+      listen(handler, 'click', clickSpy);
 
       singleclickSpy = sinon.spy();
-      _ol_events_.listen(handler, 'singleclick', singleclickSpy);
+      listen(handler, 'singleclick', singleclickSpy);
 
       dblclickSpy = sinon.spy();
-      _ol_events_.listen(handler, 'dblclick', dblclickSpy);
+      listen(handler, 'dblclick', dblclickSpy);
 
     });
 

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -1,5 +1,5 @@
 import BaseObject from '../../../src/ol/Object.js';
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen} from '../../../src/ol/events.js';
 
 
 describe('ol.Object', function() {
@@ -115,10 +115,10 @@ describe('ol.Object', function() {
 
     beforeEach(function() {
       listener1 = sinon.spy();
-      _ol_events_.listen(o, 'change:k', listener1);
+      listen(o, 'change:k', listener1);
 
       listener2 = sinon.spy();
-      _ol_events_.listen(o, 'propertychange', listener2);
+      listen(o, 'propertychange', listener2);
     });
 
     it('dispatches events', function() {
@@ -148,10 +148,10 @@ describe('ol.Object', function() {
 
     beforeEach(function() {
       listener1 = sinon.spy();
-      _ol_events_.listen(o, 'change:k', listener1);
+      listen(o, 'change:k', listener1);
 
       listener2 = sinon.spy();
-      _ol_events_.listen(o, 'propertychange', listener2);
+      listen(o, 'propertychange', listener2);
     });
 
     it('dispatches events to object', function() {
@@ -224,9 +224,9 @@ describe('ol.Object', function() {
 
     beforeEach(function() {
       listener1 = sinon.spy();
-      _ol_events_.listen(o, 'change:k', listener1);
+      listen(o, 'change:k', listener1);
       listener2 = sinon.spy();
-      _ol_events_.listen(o, 'change:K', listener2);
+      listen(o, 'change:K', listener2);
     });
 
     it('dispatches the expected event', function() {

--- a/test/spec/ol/pointer/mousesource.test.js
+++ b/test/spec/ol/pointer/mousesource.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import EventTarget from '../../../../src/ol/events/EventTarget.js';
 import _ol_has_ from '../../../../src/ol/has.js';
 import PointerEventHandler from '../../../../src/ol/pointer/PointerEventHandler.js';
@@ -31,7 +31,7 @@ describe('ol.pointer.MouseSource', function() {
 
   describe('simulated mouse events', function() {
     it('prevents simulated mouse events', function() {
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
 
       // simulates that a mouse event is triggered from a touch
       simulateTouchEvent('touchstart', 10, 20);
@@ -42,7 +42,7 @@ describe('ol.pointer.MouseSource', function() {
     });
 
     it('dispatches real mouse events', function() {
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
 
       // the two events are at different positions
       simulateTouchEvent('touchstart', 10, 20);
@@ -55,7 +55,7 @@ describe('ol.pointer.MouseSource', function() {
       // set the timeout to a lower value, to speed up the tests
       TouchSource.DEDUP_TIMEOUT = 100;
 
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
 
       // first simulate a touch event, then a mouse event
       // at the same position after a timeout

--- a/test/spec/ol/pointer/pointereventhandler.test.js
+++ b/test/spec/ol/pointer/pointereventhandler.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import EventTarget from '../../../../src/ol/events/EventTarget.js';
 import _ol_has_ from '../../../../src/ol/has.js';
 import MouseSource from '../../../../src/ol/pointer/MouseSource.js';
@@ -46,7 +46,7 @@ describe('ol.pointer.PointerEventHandler', function() {
 
   describe('pointer down', function() {
     it('fires pointerdown events', function() {
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
       simulateEvent('mousedown', 0, 0);
       expect(eventSpy.calledOnce).to.be.ok();
 
@@ -60,7 +60,7 @@ describe('ol.pointer.PointerEventHandler', function() {
 
   describe('pointer up', function() {
     it('fires pointerup events', function() {
-      _ol_events_.listen(handler, 'pointerup', eventSpy);
+      listen(handler, 'pointerup', eventSpy);
       simulateEvent('mousedown', 0, 0);
       simulateEvent('mouseup', 0, 0);
       expect(eventSpy.calledOnce).to.be.ok();
@@ -69,7 +69,7 @@ describe('ol.pointer.PointerEventHandler', function() {
 
   describe('pointer move', function() {
     it('fires pointermove events', function() {
-      _ol_events_.listen(handler, 'pointermove', eventSpy);
+      listen(handler, 'pointermove', eventSpy);
       simulateEvent('mousemove', 0, 0);
       expect(eventSpy.calledOnce).to.be.ok();
     });
@@ -80,8 +80,8 @@ describe('ol.pointer.PointerEventHandler', function() {
       const enterEventSpy = sinon.spy();
       const overEventSpy = sinon.spy();
 
-      _ol_events_.listen(handler, 'pointerenter', enterEventSpy);
-      _ol_events_.listen(handler, 'pointerover', overEventSpy);
+      listen(handler, 'pointerenter', enterEventSpy);
+      listen(handler, 'pointerover', overEventSpy);
 
       simulateEvent('mouseover', 0, 0);
 
@@ -95,8 +95,8 @@ describe('ol.pointer.PointerEventHandler', function() {
       const leaveEventSpy = sinon.spy();
       const outEventSpy = sinon.spy();
 
-      _ol_events_.listen(handler, 'pointerleave', leaveEventSpy);
-      _ol_events_.listen(handler, 'pointerout', outEventSpy);
+      listen(handler, 'pointerleave', leaveEventSpy);
+      listen(handler, 'pointerout', outEventSpy);
 
       simulateEvent('mouseout', 0, 0);
 

--- a/test/spec/ol/pointer/touchsource.test.js
+++ b/test/spec/ol/pointer/touchsource.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import Event from '../../../../src/ol/events/Event.js';
 import EventTarget from '../../../../src/ol/events/EventTarget.js';
 import _ol_has_ from '../../../../src/ol/has.js';
@@ -28,7 +28,7 @@ describe('ol.pointer.TouchSource', function() {
 
   describe('pointer event creation', function() {
     it('generates pointer events for each touch contact', function() {
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
 
       simulateTouchEvent('touchstart', [
         {identifier: 3, clientX: 10, clientY: 11},
@@ -55,7 +55,7 @@ describe('ol.pointer.TouchSource', function() {
     });
 
     it('creates the right pointer events', function() {
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
 
       // first touch
       simulateTouchEvent('touchstart', [
@@ -74,7 +74,7 @@ describe('ol.pointer.TouchSource', function() {
 
       // first touch moves
       const moveEventSpy = sinon.spy();
-      _ol_events_.listen(handler, 'pointermove', moveEventSpy);
+      listen(handler, 'pointermove', moveEventSpy);
 
       simulateTouchEvent('touchmove', [
         {identifier: 3, clientX: 15, clientY: 16}
@@ -84,7 +84,7 @@ describe('ol.pointer.TouchSource', function() {
 
       // and then both touches go up
       const upEventSpy = sinon.spy();
-      _ol_events_.listen(handler, 'pointerup', upEventSpy);
+      listen(handler, 'pointerup', upEventSpy);
 
       simulateTouchEvent('touchend', [
         {identifier: 3, clientX: 15, clientY: 16},
@@ -96,7 +96,7 @@ describe('ol.pointer.TouchSource', function() {
     });
 
     it('handles flawed touches', function() {
-      _ol_events_.listen(handler, 'pointerdown', eventSpy);
+      listen(handler, 'pointerdown', eventSpy);
 
       // first touch
       simulateTouchEvent('touchstart', [
@@ -107,7 +107,7 @@ describe('ol.pointer.TouchSource', function() {
 
       // second touch, but the first touch has disappeared
       const cancelEventSpy = sinon.spy();
-      _ol_events_.listen(handler, 'pointercancel', cancelEventSpy);
+      listen(handler, 'pointercancel', cancelEventSpy);
       simulateTouchEvent('touchstart', [
         {identifier: 4, clientX: 30, clientY: 45}
       ], [{identifier: 4}]

--- a/test/spec/ol/render/canvas/index.test.js
+++ b/test/spec/ol/render/canvas/index.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../../../src/ol/events.js';
+import {listen, unlisten} from '../../../../../src/ol/events.js';
 import {clear} from '../../../../../src/ol/obj.js';
 import _ol_render_canvas_ from '../../../../../src/ol/render/canvas.js';
 
@@ -24,11 +24,11 @@ describe('ol.render.canvas', function() {
     it('does not clear label cache and measurements for unavailable fonts', function(done) {
       this.timeout(3000);
       const spy = sinon.spy();
-      _ol_events_.listen(_ol_render_canvas_.labelCache, 'clear', spy);
+      listen(_ol_render_canvas_.labelCache, 'clear', spy);
       const interval = setInterval(function() {
         if (_ol_render_canvas_.checkedFonts_['foo'] == retries && _ol_render_canvas_.checkedFonts_['sans-serif'] == retries) {
           clearInterval(interval);
-          _ol_events_.unlisten(_ol_render_canvas_.labelCache, 'clear', spy);
+          unlisten(_ol_render_canvas_.labelCache, 'clear', spy);
           expect(spy.callCount).to.be(0);
           expect(_ol_render_canvas_.measureContext_).to.not.be(null);
           expect(_ol_render_canvas_.textHeights_).to.not.eql({});
@@ -40,11 +40,11 @@ describe('ol.render.canvas', function() {
 
     it('does not clear label cache and measurements for available fonts', function(done) {
       const spy = sinon.spy();
-      _ol_events_.listen(_ol_render_canvas_.labelCache, 'clear', spy);
+      listen(_ol_render_canvas_.labelCache, 'clear', spy);
       const interval = setInterval(function() {
         if (_ol_render_canvas_.checkedFonts_['sans-serif'] == retries) {
           clearInterval(interval);
-          _ol_events_.unlisten(_ol_render_canvas_.labelCache, 'clear', spy);
+          unlisten(_ol_render_canvas_.labelCache, 'clear', spy);
           expect(spy.callCount).to.be(0);
           expect(_ol_render_canvas_.measureContext_).to.not.be(null);
           expect(_ol_render_canvas_.textHeights_).to.not.eql({});
@@ -56,11 +56,11 @@ describe('ol.render.canvas', function() {
 
     it('does not clear label cache and measurements for the \'monospace\' font', function(done) {
       const spy = sinon.spy();
-      _ol_events_.listen(_ol_render_canvas_.labelCache, 'clear', spy);
+      listen(_ol_render_canvas_.labelCache, 'clear', spy);
       const interval = setInterval(function() {
         if (_ol_render_canvas_.checkedFonts_['monospace'] == retries) {
           clearInterval(interval);
-          _ol_events_.unlisten(_ol_render_canvas_.labelCache, 'clear', spy);
+          unlisten(_ol_render_canvas_.labelCache, 'clear', spy);
           expect(spy.callCount).to.be(0);
           expect(_ol_render_canvas_.measureContext_).to.not.be(null);
           expect(_ol_render_canvas_.textHeights_).to.not.eql({});
@@ -72,7 +72,7 @@ describe('ol.render.canvas', function() {
 
     it('clears label cache and measurements for fonts that become available', function(done) {
       head.appendChild(font);
-      _ol_events_.listen(_ol_render_canvas_.labelCache, 'clear', function() {
+      listen(_ol_render_canvas_.labelCache, 'clear', function() {
         expect(_ol_render_canvas_.measureContext_).to.be(null);
         expect(_ol_render_canvas_.textHeights_).to.eql({});
         done();

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -1,5 +1,5 @@
 import {nullFunction} from '../../../../src/ol/index.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {getListeners} from '../../../../src/ol/events.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
@@ -54,7 +54,7 @@ describe('ol.renderer.vector', function() {
           style, squaredTolerance, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
-        listeners = _ol_events_.getListeners(
+        listeners = getListeners(
           iconStyle.iconImage_, 'change');
         expect(listeners.length).to.eql(1);
 
@@ -63,7 +63,7 @@ describe('ol.renderer.vector', function() {
           style, squaredTolerance, listener, listenerThis);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
-        listeners = _ol_events_.getListeners(
+        listeners = getListeners(
           iconStyle.iconImage_, 'change');
         expect(listeners.length).to.eql(1);
       });

--- a/test/spec/ol/reproj/image.test.js
+++ b/test/spec/ol/reproj/image.test.js
@@ -1,5 +1,5 @@
 import _ol_Image_ from '../../../../src/ol/Image.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
 import ReprojImage from '../../../../src/ol/reproj/Image.js';
 
@@ -22,7 +22,7 @@ describe('ol.reproj.Image', function() {
   it('changes state as expected', function(done) {
     const image = createImage(1);
     expect(image.getState()).to.be(0); // IDLE
-    _ol_events_.listen(image, 'change', function() {
+    listen(image, 'change', function() {
       if (image.getState() == 2) { // LOADED
         done();
       }
@@ -32,7 +32,7 @@ describe('ol.reproj.Image', function() {
 
   it('returns correct canvas size', function(done) {
     const image = createImage(1);
-    _ol_events_.listen(image, 'change', function() {
+    listen(image, 'change', function() {
       if (image.getState() == 2) { // LOADED
         const canvas = image.getImage();
         expect(canvas.width).to.be(36);
@@ -45,7 +45,7 @@ describe('ol.reproj.Image', function() {
 
   it('respects pixelRatio', function(done) {
     const image = createImage(2);
-    _ol_events_.listen(image, 'change', function() {
+    listen(image, 'change', function() {
       if (image.getState() == 2) { // LOADED
         const canvas = image.getImage();
         expect(canvas.width).to.be(72);

--- a/test/spec/ol/reproj/tile.test.js
+++ b/test/spec/ol/reproj/tile.test.js
@@ -1,5 +1,5 @@
 import ImageTile from '../../../../src/ol/ImageTile.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import {addCommon, clearAllProjections, get as getProjection} from '../../../../src/ol/proj.js';
 import {register} from '../../../../src/ol/proj/proj4.js';
 import ReprojTile from '../../../../src/ol/reproj/Tile.js';
@@ -43,7 +43,7 @@ describe('ol.reproj.Tile', function() {
   it('changes state as expected', function(done) {
     const tile = createTile(1);
     expect(tile.getState()).to.be(0); // IDLE
-    _ol_events_.listen(tile, 'change', function() {
+    listen(tile, 'change', function() {
       if (tile.getState() == 2) { // LOADED
         done();
       }
@@ -77,7 +77,7 @@ describe('ol.reproj.Tile', function() {
 
   it('respects tile size of target tile grid', function(done) {
     const tile = createTile(1, [100, 40]);
-    _ol_events_.listen(tile, 'change', function() {
+    listen(tile, 'change', function() {
       if (tile.getState() == 2) { // LOADED
         const canvas = tile.getImage();
         expect(canvas.width).to.be(100);
@@ -90,7 +90,7 @@ describe('ol.reproj.Tile', function() {
 
   it('respects pixelRatio', function(done) {
     const tile = createTile(3, [60, 20]);
-    _ol_events_.listen(tile, 'change', function() {
+    listen(tile, 'change', function() {
       if (tile.getState() == 2) { // LOADED
         const canvas = tile.getImage();
         expect(canvas.width).to.be(180);

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -1,7 +1,7 @@
 import ImageTile from '../../../../src/ol/ImageTile.js';
 import TileState from '../../../../src/ol/TileState.js';
 import {createFromTemplate} from '../../../../src/ol/tileurlfunction.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import {addCommon, clearAllProjections, get as getProjection} from '../../../../src/ol/proj.js';
 import {register} from '../../../../src/ol/proj/proj4.js';
 import _ol_proj_EPSG3857_ from '../../../../src/ol/proj/EPSG3857.js';
@@ -148,7 +148,7 @@ describe('ol.source.TileImage', function() {
       const tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.a(ReprojTile);
 
-      _ol_events_.listen(tile, 'change', function() {
+      listen(tile, 'change', function() {
         if (tile.getState() == 2) { // LOADED
           done();
         }
@@ -167,7 +167,7 @@ describe('ol.source.TileImage', function() {
       const tile = source.getTile(0, 0, -1, 1, proj);
       expect(tile).to.be.a(ReprojTile);
 
-      _ol_events_.listen(tile, 'change', function() {
+      listen(tile, 'change', function() {
         if (tile.getState() == 2) { // LOADED
           done();
         }

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -1,4 +1,4 @@
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import Collection from '../../../../src/ol/Collection.js';
 import Feature from '../../../../src/ol/Feature.js';
 import Map from '../../../../src/ol/Map.js';
@@ -67,7 +67,7 @@ describe('ol.source.Vector', function() {
 
       it('fires a change event', function() {
         const listener = sinon.spy();
-        _ol_events_.listen(vectorSource, 'change', listener);
+        listen(vectorSource, 'change', listener);
         vectorSource.addFeature(pointFeature);
         expect(listener).to.be.called();
       });
@@ -139,11 +139,11 @@ describe('ol.source.Vector', function() {
 
       it('removes all features using fast path', function() {
         const changeSpy = sinon.spy();
-        _ol_events_.listen(vectorSource, 'change', changeSpy);
+        listen(vectorSource, 'change', changeSpy);
         const removeFeatureSpy = sinon.spy();
-        _ol_events_.listen(vectorSource, 'removefeature', removeFeatureSpy);
+        listen(vectorSource, 'removefeature', removeFeatureSpy);
         const clearSourceSpy = sinon.spy();
-        _ol_events_.listen(vectorSource, 'clear', clearSourceSpy);
+        listen(vectorSource, 'clear', clearSourceSpy);
         vectorSource.clear(true);
         expect(vectorSource.getFeatures()).to.eql([]);
         expect(vectorSource.isEmpty()).to.be(true);
@@ -157,11 +157,11 @@ describe('ol.source.Vector', function() {
 
       it('removes all features using slow path', function() {
         const changeSpy = sinon.spy();
-        _ol_events_.listen(vectorSource, 'change', changeSpy);
+        listen(vectorSource, 'change', changeSpy);
         const removeFeatureSpy = sinon.spy();
-        _ol_events_.listen(vectorSource, 'removefeature', removeFeatureSpy);
+        listen(vectorSource, 'removefeature', removeFeatureSpy);
         const clearSourceSpy = sinon.spy();
-        _ol_events_.listen(vectorSource, 'clear', clearSourceSpy);
+        listen(vectorSource, 'clear', clearSourceSpy);
         vectorSource.clear();
         expect(vectorSource.getFeatures()).to.eql([]);
         expect(vectorSource.isEmpty()).to.be(true);
@@ -225,7 +225,7 @@ describe('ol.source.Vector', function() {
 
       it('fires a change event', function() {
         const listener = sinon.spy();
-        _ol_events_.listen(vectorSource, 'change', listener);
+        listen(vectorSource, 'change', listener);
         vectorSource.removeFeature(features[0]);
         expect(listener).to.be.called();
       });
@@ -311,7 +311,7 @@ describe('ol.source.Vector', function() {
       const feature = new Feature(new Point([1, 1]));
       vectorSource.addFeature(feature);
       const listener = sinon.spy();
-      _ol_events_.listen(vectorSource, 'change', listener);
+      listen(vectorSource, 'change', listener);
       feature.set('foo', 'bar');
       expect(listener).to.be.called();
     });

--- a/test/spec/ol/source/zoomify.test.js
+++ b/test/spec/ol/source/zoomify.test.js
@@ -1,5 +1,5 @@
 import {DEFAULT_TILE_SIZE} from '../../../../src/ol/tilegrid/common.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import Projection from '../../../../src/ol/proj/Projection.js';
 import Zoomify from '../../../../src/ol/source/Zoomify.js';
 import TileGrid from '../../../../src/ol/tilegrid/TileGrid.js';
@@ -301,7 +301,7 @@ describe('ol.source.Zoomify', function() {
 
       const tile = source.getTile(0, 0, -1, 1, proj);
 
-      _ol_events_.listen(tile, 'change', function() {
+      listen(tile, 'change', function() {
         if (tile.getState() == 2) { // LOADED
           const img = tile.getImage();
           expect(img).to.be.a(HTMLCanvasElement);

--- a/test/spec/ol/style/iconimagecache.test.js
+++ b/test/spec/ol/style/iconimagecache.test.js
@@ -1,5 +1,5 @@
 import {nullFunction} from '../../../../src/ol/index.js';
-import _ol_events_ from '../../../../src/ol/events.js';
+import {listen} from '../../../../src/ol/events.js';
 import {iconImageCache} from '../../../../src/ol/style.js';
 import IconImage from '../../../../src/ol/style/IconImage.js';
 
@@ -42,13 +42,13 @@ describe('ol.style.IconImageCache', function() {
 
       src = '0';
       iconImage = new IconImage(null, src);
-      _ol_events_.listen(iconImage, 'change', nullFunction, false);
+      listen(iconImage, 'change', nullFunction, false);
       iconImageCache.set(src, null, null, iconImage);
       expect(iconImageCache.cacheSize_).to.eql(4);
 
       src = '4';
       iconImage = new IconImage(null, src);
-      _ol_events_.listen(iconImage, 'change', nullFunction, false);
+      listen(iconImage, 'change', nullFunction, false);
       iconImageCache.set(src, null, null, iconImage);
       expect(iconImageCache.cacheSize_).to.eql(5);
 

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -1,7 +1,7 @@
 import TileState from '../../../src/ol/TileState.js';
 import VectorImageTile, {defaultLoadFunction} from '../../../src/ol/VectorImageTile.js';
 import VectorTile from '../../../src/ol/VectorTile.js';
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen, listenOnce} from '../../../src/ol/events.js';
 import GeoJSON from '../../../src/ol/format/GeoJSON.js';
 import {get as getProjection} from '../../../src/ol/proj.js';
 import _ol_tilegrid_ from '../../../src/ol/tilegrid.js';
@@ -24,7 +24,7 @@ describe('ol.VectorImageTile', function() {
     const loader = sourceTile.loader_;
     expect(typeof loader).to.be('function');
 
-    _ol_events_.listen(sourceTile, 'change', function(e) {
+    listen(sourceTile, 'change', function(e) {
       expect(sourceTile.getFeatures().length).to.be.greaterThan(0);
       done();
     });
@@ -45,7 +45,7 @@ describe('ol.VectorImageTile', function() {
 
     tile.load();
     let calls = 0;
-    _ol_events_.listen(tile, 'change', function(e) {
+    listen(tile, 'change', function(e) {
       ++calls;
       expect(tile.getState()).to.be(calls == 2 ? TileState.LOADED : TileState.ERROR);
       if (calls == 2) {
@@ -69,7 +69,7 @@ describe('ol.VectorImageTile', function() {
 
     tile.load();
 
-    _ol_events_.listen(tile, 'change', function(e) {
+    listen(tile, 'change', function(e) {
       expect(tile.getState()).to.be(TileState.ERROR);
       done();
     });
@@ -85,7 +85,7 @@ describe('ol.VectorImageTile', function() {
 
     tile.load();
 
-    _ol_events_.listen(tile, 'change', function() {
+    listen(tile, 'change', function() {
       expect(tile.getState()).to.be(TileState.EMPTY);
       done();
     });
@@ -141,7 +141,7 @@ describe('ol.VectorImageTile', function() {
       1, getProjection('EPSG:3857'), VectorTile, function() {});
 
     tile.load();
-    _ol_events_.listenOnce(tile, 'change', function() {
+    listenOnce(tile, 'change', function() {
       expect(tile.getState()).to.be(TileState.LOADED);
       expect(tile.loadListenerKeys_.length).to.be(0);
       expect(tile.tileKeys.length).to.be(4);

--- a/test/spec/ol/vectortile.test.js
+++ b/test/spec/ol/vectortile.test.js
@@ -1,7 +1,7 @@
 import Feature from '../../../src/ol/Feature.js';
 import {defaultLoadFunction} from '../../../src/ol/VectorImageTile.js';
 import VectorTile from '../../../src/ol/VectorTile.js';
-import _ol_events_ from '../../../src/ol/events.js';
+import {listen} from '../../../src/ol/events.js';
 import TextFeature from '../../../src/ol/format/TextFeature.js';
 import {get as getProjection} from '../../../src/ol/proj.js';
 import Projection from '../../../src/ol/proj/Projection.js';
@@ -27,7 +27,7 @@ describe('ol.VectorTile', function() {
 
     defaultLoadFunction(tile, url);
     const loader = tile.loader_;
-    _ol_events_.listen(tile, 'change', function(e) {
+    listen(tile, 'change', function(e) {
       expect(tile.getFeatures().length).to.be.greaterThan(0);
       expect(tile.getProjection().getUnits()).to.be('tile-pixels');
       done();


### PR DESCRIPTION
This reworks `ol/events` to use named exports.