### PR TITLE
Adds option to retain MousePosition when pointer leaves viewport

### DIFF
--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -31,7 +31,9 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * callback.
  * @property {Element|string} [target] Specify a target if you want the
  * control to be rendered outside of the map's viewport.
- * @property {string} [undefinedHTML=''] Markup for undefined coordinates.
+ * @property {string} [undefinedHTML=''] Markup for undefined coordinates.  If
+ * `undefined`, then the last pointer position is retained when the pointer
+ * moves outside the viewport.
  */
 
 

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -72,6 +72,8 @@ const MousePosition = function(opt_options) {
     this.setProjection(options.projection);
   }
 
+  this.clearOnMouseOut_ = options.clearOnMouseOut !== undefined ? options.clearOnMouseOut : true;
+
   /**
    * @private
    * @type {string}
@@ -190,11 +192,13 @@ MousePosition.prototype.setMap = function(map) {
   if (map) {
     const viewport = map.getViewport();
     this.listenerKeys.push(
-      listen(viewport, EventType.MOUSEMOVE,
-        this.handleMouseMove, this),
-      listen(viewport, EventType.MOUSEOUT,
-        this.handleMouseOut, this)
+      listen(viewport, EventType.MOUSEMOVE, this.handleMouseMove, this)
     );
+    if (this.clearOnMouseOut_) {
+      this.listenerKeys.push(
+        listen(viewport, EventType.MOUSEOUT, this.handleMouseOut, this)
+      );
+    }
   }
 };
 

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -72,13 +72,17 @@ const MousePosition = function(opt_options) {
     this.setProjection(options.projection);
   }
 
-  this.clearOnMouseOut_ = options.clearOnMouseOut !== undefined ? options.clearOnMouseOut : true;
-
   /**
    * @private
    * @type {string}
    */
-  this.undefinedHTML_ = options.undefinedHTML !== undefined ? options.undefinedHTML : '';
+  this.undefinedHTML_ = 'undefinedHTML' in options ? options.undefinedHTML : '';
+
+  /**
+   * @private
+   * @type {boolean}
+   */
+  this.renderOnMouseOut_ = this.undefinedHTML_ !== undefined;
 
   /**
    * @private
@@ -194,7 +198,7 @@ MousePosition.prototype.setMap = function(map) {
     this.listenerKeys.push(
       listen(viewport, EventType.MOUSEMOVE, this.handleMouseMove, this)
     );
-    if (this.clearOnMouseOut_) {
+    if (this.renderOnMouseOut_) {
       this.listenerKeys.push(
         listen(viewport, EventType.MOUSEOUT, this.handleMouseOut, this)
       );
@@ -232,7 +236,7 @@ MousePosition.prototype.setProjection = function(projection) {
  * @private
  */
 MousePosition.prototype.updateHTML_ = function(pixel) {
-  let html = this.undefinedHTML_;
+  let html = this.undefinedHTML_ === undefined ? ' ' : this.undefinedHTML_;
   if (pixel && this.mapProjection_) {
     if (!this.transform_) {
       const projection = this.getProjection();

--- a/test/spec/ol/control/mouseposition.test.js
+++ b/test/spec/ol/control/mouseposition.test.js
@@ -65,40 +65,38 @@ describe('ol.control.MousePosition', function() {
       document.querySelector('div.ol-viewport').dispatchEvent(evt);
     }
 
-    describe('clearOnMouseOut', function() {
-      it('sets div.ol-mouse-position undefinedHTML when clearOnMouseOut=true', function(done) {
+    describe('undefinedHTML', function() {
+      it('sets div.ol-mouse-position to options.undefinedHTML when mouse moves out', function(done) {
         const ctrl = new MousePosition({
-          undefinedHTML: 'undefined',
-          clearOnMouseOut: true
+          undefinedHTML: 'some text'
         });
         ctrl.setMap(map);
         map.renderSync();
 
         const element = document.querySelector('.ol-mouse-position', map.getTarget());
-        expect(element.innerText).to.be('undefined');
+        expect(element.innerText).to.be('some text');
 
         simulateEvent(EventType.MOUSEMOVE, 20, 30);
         map.renderSync();
         expect(element.innerText).to.be('20,-30');
 
         map.once('postrender', function() {
-          expect(element.innerText).to.be('undefined');
+          expect(element.innerText).to.be('some text');
           done();
         });
         simulateEvent(EventType.MOUSEOUT, width + 1, height + 1);
         map.renderSync();
       });
 
-      it('keeps div.ol-mouse-position set when clearOnMouseOut=false', function(done) {
+      it('Retain mouse position in div.ol-mouse-position when options.undefinedHTML=undefined and mouse moves outside the viewport', function(done) {
         const ctrl = new MousePosition({
-          undefinedHTML: 'undefined',
-          clearOnMouseOut: false
+          undefinedHTML: undefined
         });
         ctrl.setMap(map);
         map.renderSync();
 
         const element = document.querySelector('.ol-mouse-position', map.getTarget());
-        expect(element.innerText).to.be('undefined');
+        expect(element.innerHTML).to.be(' ');
 
         target.dispatchEvent(new MouseEvent('mousemove'));
         simulateEvent(EventType.MOUSEMOVE, 20, 30);

--- a/test/spec/ol/control/mouseposition.test.js
+++ b/test/spec/ol/control/mouseposition.test.js
@@ -1,4 +1,8 @@
+import Map from '../../../../src/ol/Map.js';
 import MousePosition from '../../../../src/ol/control/MousePosition.js';
+import View from '../../../../src/ol/View.js';
+
+import EventType from '../../../../src/ol/events/EventType.js';
 
 describe('ol.control.MousePosition', function() {
 
@@ -20,4 +24,92 @@ describe('ol.control.MousePosition', function() {
 
   });
 
+  describe('configuration options', function() {
+    let target, map;
+    const width = 360;
+    const height = 180;
+
+    beforeEach(function() {
+      target = document.createElement('div');
+      const style = target.style;
+      style.position = 'absolute';
+      style.left = '-1000px';
+      style.top = '-1000px';
+      style.width = width + 'px';
+      style.height = height + 'px';
+
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        controls: [],
+        view: new View({
+          projection: 'EPSG:4326',
+          center: [0, 0],
+          resolution: 1
+        })
+      });
+    });
+    afterEach(function() {
+      map.dispose();
+      document.body.removeChild(target);
+    });
+
+    function simulateEvent(type, x, y) {
+      const viewport = map.getViewport();
+      // calculated in case body has top < 0 (test runner with small window)
+      const position = viewport.getBoundingClientRect();
+      const evt = new MouseEvent(type, {
+        clientX: position.left + x + width / 2,
+        clientY: position.top + y + height / 2
+      });
+      document.querySelector('div.ol-viewport').dispatchEvent(evt);
+    }
+
+    describe('clearOnMouseOut', function() {
+      it('sets div.ol-mouse-position undefinedHTML when clearOnMouseOut=true', function(done) {
+        const ctrl = new MousePosition({
+          undefinedHTML: 'undefined',
+          clearOnMouseOut: true
+        });
+        ctrl.setMap(map);
+        map.renderSync();
+
+        const element = document.querySelector('.ol-mouse-position', map.getTarget());
+        expect(element.innerText).to.be('undefined');
+
+        simulateEvent(EventType.MOUSEMOVE, 20, 30);
+        map.renderSync();
+        expect(element.innerText).to.be('20,-30');
+
+        map.once('postrender', function() {
+          expect(element.innerText).to.be('undefined');
+          done();
+        });
+        simulateEvent(EventType.MOUSEOUT, width + 1, height + 1);
+        map.renderSync();
+      });
+
+      it('keeps div.ol-mouse-position set when clearOnMouseOut=false', function(done) {
+        const ctrl = new MousePosition({
+          undefinedHTML: 'undefined',
+          clearOnMouseOut: false
+        });
+        ctrl.setMap(map);
+        map.renderSync();
+
+        const element = document.querySelector('.ol-mouse-position', map.getTarget());
+        expect(element.innerText).to.be('undefined');
+
+        target.dispatchEvent(new MouseEvent('mousemove'));
+        simulateEvent(EventType.MOUSEMOVE, 20, 30);
+        map.renderSync();
+        map.once('postrender', function() {
+          expect(element.innerText).to.be('20,-30');
+          done();
+        });
+        simulateEvent(EventType.MOUSEOUT, width + 1, height + 1);
+        map.renderSync();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Implements #2914. 

Note I added a new option `clearOnMouseOut` rather than override [the default value](https://github.com/openlayers/openlayers/blob/master/src/ol/control/MousePosition.js#L56) for `undefinedHTML` as suggested here:  https://github.com/openlayers/openlayers/issues/2914#issuecomment-363461367

Let me know if you'd rather I change the default `undefinedHTML` behavior, which would break the API as fredj noted.