### PR TITLE
Use STATIC_DRAW as default WebGL buffer usage

### DIFF
--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -30,7 +30,7 @@ const WebGLBuffer = function(opt_arr, opt_usage) {
    * @private
    * @type {number}
    */
-  this.usage_ = opt_usage !== undefined ? opt_usage : BufferUsage;
+  this.usage_ = opt_usage !== undefined ? opt_usage : BufferUsage.STATIC_DRAW;
 
 };
 


### PR DESCRIPTION
Fixup for  #7787 

See: https://github.com/openlayers/openlayers/pull/7787/commits/62b29003483e969183eeb0249b77b645c5ff5456#r166941451