### PR TITLE
Named exports from ol/tilecoord

### DIFF
--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from './index.js';
 import LRUCache from './structs/LRUCache.js';
-import _ol_tilecoord_ from './tilecoord.js';
+import {fromKey, getKey} from './tilecoord.js';
 
 /**
  * @constructor
@@ -45,11 +45,11 @@ TileCache.prototype.pruneExceptNewestZ = function() {
     return;
   }
   const key = this.peekFirstKey();
-  const tileCoord = _ol_tilecoord_.fromKey(key);
+  const tileCoord = fromKey(key);
   const z = tileCoord[0];
   this.forEach(function(tile) {
     if (tile.tileCoord[0] !== z) {
-      this.remove(_ol_tilecoord_.getKey(tile.tileCoord));
+      this.remove(getKey(tile.tileCoord));
       tile.dispose();
     }
   }, this);

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -8,7 +8,7 @@ import {jsonp as requestJSONP} from '../net.js';
 import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import SourceState from '../source/State.js';
 import TileImage from '../source/TileImage.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {createOrUpdate, quadKey} from '../tilecoord.js';
 import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 /**
@@ -159,14 +159,12 @@ BingMaps.prototype.handleImageryMetadataResponse = function(response) {
           if (!tileCoord) {
             return undefined;
           } else {
-            _ol_tilecoord_.createOrUpdate(tileCoord[0], tileCoord[1],
-              -tileCoord[2] - 1, quadKeyTileCoord);
+            createOrUpdate(tileCoord[0], tileCoord[1], -tileCoord[2] - 1, quadKeyTileCoord);
             let url = imageUrl;
             if (hidpi) {
               url += '&dpi=d1&device=mobile';
             }
-            return url.replace('{quadkey}', _ol_tilecoord_.quadKey(
-              quadKeyTileCoord));
+            return url.replace('{quadkey}', quadKey(quadKeyTileCoord));
           }
         }
       );

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -8,7 +8,7 @@ import Event from '../events/Event.js';
 import {equivalent} from '../proj.js';
 import {toSize, scale as scaleSize} from '../size.js';
 import Source from '../source/Source.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {getKeyZXY, withinExtentAndZ} from '../tilecoord.js';
 import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.js';
 
 /**
@@ -120,7 +120,7 @@ TileSource.prototype.forEachLoadedTile = function(projection, z, tileRange, call
   let tile, tileCoordKey, loaded;
   for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (let y = tileRange.minY; y <= tileRange.maxY; ++y) {
-      tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+      tileCoordKey = getKeyZXY(z, x, y);
       loaded = false;
       if (tileCache.containsKey(tileCoordKey)) {
         tile = /** @type {!ol.Tile} */ (tileCache.get(tileCoordKey));
@@ -283,7 +283,7 @@ TileSource.prototype.getTileCoordForTileUrlFunction = function(tileCoord, opt_pr
   if (this.getWrapX() && projection.isGlobal()) {
     tileCoord = wrapX(tileGrid, tileCoord, projection);
   }
-  return _ol_tilecoord_.withinExtentAndZ(tileCoord, tileGrid) ? tileCoord : null;
+  return withinExtentAndZ(tileCoord, tileGrid) ? tileCoord : null;
 };
 
 

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -7,7 +7,7 @@ import {modulo} from '../math.js';
 import {assign} from '../obj.js';
 import {toSize, scale as scaleSize} from '../size.js';
 import TileImage from '../source/TileImage.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {hash as tileCoordHash} from '../tilecoord.js';
 import {appendParams} from '../uri.js';
 
 /**
@@ -118,7 +118,7 @@ TileArcGISRest.prototype.getRequestUrl_ = function(tileCoord, tileSize, tileExte
   if (urls.length == 1) {
     url = urls[0];
   } else {
-    const index = modulo(_ol_tilecoord_.hash(tileCoord), urls.length);
+    const index = modulo(tileCoordHash(tileCoord), urls.length);
     url = urls[index];
   }
 

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -7,7 +7,7 @@ import TileState from '../TileState.js';
 import {createCanvasContext2D} from '../dom.js';
 import {toSize} from '../size.js';
 import TileSource from '../source/Tile.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {getKeyZXY} from '../tilecoord.js';
 
 
 /**
@@ -106,7 +106,7 @@ inherits(TileDebug, TileSource);
  * @inheritDoc
  */
 TileDebug.prototype.getTile = function(z, x, y) {
-  const tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
     return /** @type {!ol.source.LabeledTile} */ (this.tileCache.get(tileCoordKey));
   } else {

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -11,7 +11,7 @@ import EventType from '../events/EventType.js';
 import {equivalent, get as getProjection} from '../proj.js';
 import ReprojTile from '../reproj/Tile.js';
 import UrlTile from '../source/UrlTile.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {getKey, getKeyZXY} from '../tilecoord.js';
 import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
 
 /**
@@ -242,7 +242,7 @@ TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection) {
     const cache = this.getTileCacheForProjection(projection);
     const tileCoord = [z, x, y];
     let tile;
-    const tileCoordKey = _ol_tilecoord_.getKey(tileCoord);
+    const tileCoordKey = getKey(tileCoord);
     if (cache.containsKey(tileCoordKey)) {
       tile = /** @type {!ol.Tile} */ (cache.get(tileCoordKey));
     }
@@ -289,7 +289,7 @@ TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection) {
  */
 TileImage.prototype.getTileInternal = function(z, x, y, pixelRatio, projection) {
   let tile = null;
-  const tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const tileCoordKey = getKeyZXY(z, x, y);
   const key = this.getKey();
   if (!this.tileCache.containsKey(tileCoordKey)) {
     tile = this.createTile_(z, x, y, pixelRatio, projection, key);

--- a/src/ol/source/TileUTFGrid.js
+++ b/src/ol/source/TileUTFGrid.js
@@ -13,7 +13,7 @@ import {jsonp as requestJSONP} from '../net.js';
 import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import SourceState from '../source/State.js';
 import TileSource from '../source/Tile.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {getKeyZXY} from '../tilecoord.js';
 import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 
@@ -447,7 +447,7 @@ UTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
  * @inheritDoc
  */
 UTFGrid.prototype.getTile = function(z, x, y, pixelRatio, projection) {
-  const tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {
@@ -472,7 +472,7 @@ UTFGrid.prototype.getTile = function(z, x, y, pixelRatio, projection) {
  * @inheritDoc
  */
 UTFGrid.prototype.useTile = function(z, x, y) {
-  const tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
     this.tileCache.get(tileCoordKey);
   }

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -13,7 +13,7 @@ import {calculateSourceResolution} from '../reproj.js';
 import {toSize, buffer as bufferSize, scale as scaleSize} from '../size.js';
 import TileImage from '../source/TileImage.js';
 import WMSServerType from '../source/WMSServerType.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {hash as tileCoordHash} from '../tilecoord.js';
 import {compareVersions} from '../string.js';
 import {appendParams} from '../uri.js';
 
@@ -247,7 +247,7 @@ TileWMS.prototype.getRequestUrl_ = function(tileCoord, tileSize, tileExtent,
   if (urls.length == 1) {
     url = urls[0];
   } else {
-    const index = modulo(_ol_tilecoord_.hash(tileCoord), urls.length);
+    const index = modulo(tileCoordHash(tileCoord), urls.length);
     url = urls[index];
   }
   return appendParams(url, params);

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -6,7 +6,7 @@ import TileState from '../TileState.js';
 import {expandUrl, createFromTemplates, nullTileUrlFunction} from '../tileurlfunction.js';
 import TileSource from '../source/Tile.js';
 import TileEventType from '../source/TileEventType.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {getKeyZXY} from '../tilecoord.js';
 
 /**
  * @classdesc
@@ -195,7 +195,7 @@ UrlTile.prototype.setUrls = function(urls) {
  * @inheritDoc
  */
 UrlTile.prototype.useTile = function(z, x, y) {
-  const tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
     this.tileCache.get(tileCoordKey);
   }

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -7,7 +7,7 @@ import VectorImageTile, {defaultLoadFunction} from '../VectorImageTile.js';
 import VectorTile from '../VectorTile.js';
 import {toSize} from '../size.js';
 import UrlTile from '../source/UrlTile.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {getKeyZXY} from '../tilecoord.js';
 import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.js';
 
 /**
@@ -110,7 +110,7 @@ VectorTileSource.prototype.clear = function() {
  * @inheritDoc
  */
 VectorTileSource.prototype.getTile = function(z, x, y, pixelRatio, projection) {
-  const tileCoordKey = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(tileCoordKey));
   } else {

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/tilecoord
  */
-const _ol_tilecoord_ = {};
 
 
 /**
@@ -11,7 +10,7 @@ const _ol_tilecoord_ = {};
  * @param {ol.TileCoord=} opt_tileCoord Tile coordinate.
  * @return {ol.TileCoord} Tile coordinate.
  */
-_ol_tilecoord_.createOrUpdate = function(z, x, y, opt_tileCoord) {
+export function createOrUpdate(z, x, y, opt_tileCoord) {
   if (opt_tileCoord !== undefined) {
     opt_tileCoord[0] = z;
     opt_tileCoord[1] = x;
@@ -20,7 +19,7 @@ _ol_tilecoord_.createOrUpdate = function(z, x, y, opt_tileCoord) {
   } else {
     return [z, x, y];
   }
-};
+}
 
 
 /**
@@ -29,9 +28,9 @@ _ol_tilecoord_.createOrUpdate = function(z, x, y, opt_tileCoord) {
  * @param {number} y Y.
  * @return {string} Key.
  */
-_ol_tilecoord_.getKeyZXY = function(z, x, y) {
+export function getKeyZXY(z, x, y) {
   return z + '/' + x + '/' + y;
-};
+}
 
 
 /**
@@ -39,9 +38,9 @@ _ol_tilecoord_.getKeyZXY = function(z, x, y) {
  * @param {ol.TileCoord} tileCoord The tile coord.
  * @return {string} Key.
  */
-_ol_tilecoord_.getKey = function(tileCoord) {
-  return _ol_tilecoord_.getKeyZXY(tileCoord[0], tileCoord[1], tileCoord[2]);
-};
+export function getKey(tileCoord) {
+  return getKeyZXY(tileCoord[0], tileCoord[1], tileCoord[2]);
+}
 
 
 /**
@@ -49,25 +48,25 @@ _ol_tilecoord_.getKey = function(tileCoord) {
  * @param {string} key The tile coord key.
  * @return {ol.TileCoord} The tile coord.
  */
-_ol_tilecoord_.fromKey = function(key) {
+export function fromKey(key) {
   return key.split('/').map(Number);
-};
+}
 
 
 /**
  * @param {ol.TileCoord} tileCoord Tile coord.
  * @return {number} Hash.
  */
-_ol_tilecoord_.hash = function(tileCoord) {
+export function hash(tileCoord) {
   return (tileCoord[1] << tileCoord[0]) + tileCoord[2];
-};
+}
 
 
 /**
  * @param {ol.TileCoord} tileCoord Tile coord.
  * @return {string} Quad key.
  */
-_ol_tilecoord_.quadKey = function(tileCoord) {
+export function quadKey(tileCoord) {
   const z = tileCoord[0];
   const digits = new Array(z);
   let mask = 1 << (z - 1);
@@ -85,7 +84,7 @@ _ol_tilecoord_.quadKey = function(tileCoord) {
     mask >>= 1;
   }
   return digits.join('');
-};
+}
 
 
 /**
@@ -93,7 +92,7 @@ _ol_tilecoord_.quadKey = function(tileCoord) {
  * @param {!ol.tilegrid.TileGrid} tileGrid Tile grid.
  * @return {boolean} Tile coordinate is within extent and zoom level range.
  */
-_ol_tilecoord_.withinExtentAndZ = function(tileCoord, tileGrid) {
+export function withinExtentAndZ(tileCoord, tileGrid) {
   const z = tileCoord[0];
   const x = tileCoord[1];
   const y = tileCoord[2];
@@ -113,5 +112,4 @@ _ol_tilecoord_.withinExtentAndZ = function(tileCoord, tileGrid) {
   } else {
     return tileRange.containsXY(x, y);
   }
-};
-export default _ol_tilecoord_;
+}

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -8,7 +8,7 @@ import {isSorted, linearFindNearest} from '../array.js';
 import {createOrUpdate, getTopLeft} from '../extent.js';
 import {clamp} from '../math.js';
 import {toSize} from '../size.js';
-import _ol_tilecoord_ from '../tilecoord.js';
+import {createOrUpdate as tileCoordCreateOrUpdate} from '../tilecoord.js';
 
 /**
  * @classdesc
@@ -422,7 +422,7 @@ TileGrid.prototype.getTileCoordForXYAndResolution_ = function(
     tileCoordY = Math.floor(tileCoordY);
   }
 
-  return _ol_tilecoord_.createOrUpdate(z, tileCoordX, tileCoordY, opt_tileCoord);
+  return tileCoordCreateOrUpdate(z, tileCoordX, tileCoordY, opt_tileCoord);
 };
 
 
@@ -461,7 +461,7 @@ TileGrid.prototype.getTileCoordForXYAndZ_ = function(x, y, z, reverseIntersectio
     tileCoordY = Math.floor(tileCoordY);
   }
 
-  return _ol_tilecoord_.createOrUpdate(z, tileCoordX, tileCoordY, opt_tileCoord);
+  return tileCoordCreateOrUpdate(z, tileCoordX, tileCoordY, opt_tileCoord);
 };
 
 

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -3,7 +3,7 @@
  */
 import {assert} from './asserts.js';
 import {modulo} from './math.js';
-import _ol_tilecoord_ from './tilecoord.js';
+import {hash as tileCoordHash} from './tilecoord.js';
 
 
 /**
@@ -80,7 +80,7 @@ export function createFromTileUrlFunctions(tileUrlFunctions) {
       if (!tileCoord) {
         return undefined;
       } else {
-        const h = _ol_tilecoord_.hash(tileCoord);
+        const h = tileCoordHash(tileCoord);
         const index = modulo(h, tileUrlFunctions.length);
         return tileUrlFunctions[index](tileCoord, pixelRatio, projection);
       }

--- a/test/spec/ol/renderer/layer.test.js
+++ b/test/spec/ol/renderer/layer.test.js
@@ -5,7 +5,7 @@ import Layer from '../../../../src/ol/layer/Layer.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
 import LayerRenderer from '../../../../src/ol/renderer/Layer.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
-import _ol_tilecoord_ from '../../../../src/ol/tilecoord.js';
+import {fromKey} from '../../../../src/ol/tilecoord.js';
 
 
 describe('ol.renderer.Layer', function() {
@@ -129,13 +129,13 @@ describe('ol.renderer.Layer', function() {
     it('accesses tiles from current zoom level last', function(done) {
       // expect most recent tile in the cache to be from zoom level 0
       const key = source.tileCache.peekFirstKey();
-      const tileCoord = _ol_tilecoord_.fromKey(key);
+      const tileCoord = fromKey(key);
       expect(tileCoord[0]).to.be(0);
 
       map.once('moveend', function() {
         // expect most recent tile in the cache to be from zoom level 4
         const key = source.tileCache.peekFirstKey();
-        const tileCoord = _ol_tilecoord_.fromKey(key);
+        const tileCoord = fromKey(key);
         expect(tileCoord[0]).to.be(4);
         done();
       });

--- a/test/spec/ol/source/bingmaps.test.js
+++ b/test/spec/ol/source/bingmaps.test.js
@@ -1,5 +1,5 @@
 import BingMaps from '../../../../src/ol/source/BingMaps.js';
-import _ol_tilecoord_ from '../../../../src/ol/tilecoord.js';
+import {quadKey} from '../../../../src/ol/tilecoord.js';
 import Observable from '../../../../src/ol/Observable.js';
 
 
@@ -48,28 +48,28 @@ describe('ol.source.BingMaps', function() {
 
       tileUrl = source.tileUrlFunction(
         tileGrid.getTileCoordForCoordAndZ(coordinate, 1), 1, projection);
-      expect(tileUrl.match(regex)[1]).to.equal(_ol_tilecoord_.quadKey([1, 1, 0]));
+      expect(tileUrl.match(regex)[1]).to.equal(quadKey([1, 1, 0]));
 
       tileUrl = source.tileUrlFunction(
         tileGrid.getTileCoordForCoordAndZ(coordinate, 2), 1, projection);
-      expect(tileUrl.match(regex)[1]).to.equal(_ol_tilecoord_.quadKey([2, 2, 1]));
+      expect(tileUrl.match(regex)[1]).to.equal(quadKey([2, 2, 1]));
 
       tileUrl = source.tileUrlFunction(
         tileGrid.getTileCoordForCoordAndZ(coordinate, 3), 1, projection);
-      expect(tileUrl.match(regex)[1]).to.equal(_ol_tilecoord_.quadKey([3, 4, 2]));
+      expect(tileUrl.match(regex)[1]).to.equal(quadKey([3, 4, 2]));
 
       tileUrl = source.tileUrlFunction(
         tileGrid.getTileCoordForCoordAndZ(coordinate, 4), 1, projection);
-      expect(tileUrl.match(regex)[1]).to.equal(_ol_tilecoord_.quadKey([4, 8, 5]));
+      expect(tileUrl.match(regex)[1]).to.equal(quadKey([4, 8, 5]));
 
       tileUrl = source.tileUrlFunction(
         tileGrid.getTileCoordForCoordAndZ(coordinate, 5), 1, projection);
-      expect(tileUrl.match(regex)[1]).to.equal(_ol_tilecoord_.quadKey(
+      expect(tileUrl.match(regex)[1]).to.equal(quadKey(
         [5, 16, 11]));
 
       tileUrl = source.tileUrlFunction(
         tileGrid.getTileCoordForCoordAndZ(coordinate, 6), 1, projection);
-      expect(tileUrl.match(regex)[1]).to.equal(_ol_tilecoord_.quadKey(
+      expect(tileUrl.match(regex)[1]).to.equal(quadKey(
         [6, 33, 22]));
 
     });

--- a/test/spec/ol/source/tile.test.js
+++ b/test/spec/ol/source/tile.test.js
@@ -5,7 +5,7 @@ import {get as getProjection} from '../../../../src/ol/proj.js';
 import Projection from '../../../../src/ol/proj/Projection.js';
 import Source from '../../../../src/ol/source/Source.js';
 import TileSource from '../../../../src/ol/source/Tile.js';
-import _ol_tilecoord_ from '../../../../src/ol/tilecoord.js';
+import {getKeyZXY} from '../../../../src/ol/tilecoord.js';
 import TileGrid from '../../../../src/ol/tilegrid/TileGrid.js';
 
 
@@ -42,7 +42,7 @@ inherits(MockTile, TileSource);
  * @inheritDoc
  */
 MockTile.prototype.getTile = function(z, x, y) {
-  const key = _ol_tilecoord_.getKeyZXY(z, x, y);
+  const key = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(key)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(key));
   } else {

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -8,7 +8,7 @@ import {WORLD_EXTENT} from '../../../../src/ol/proj/epsg3857.js';
 import Projection from '../../../../src/ol/proj/Projection.js';
 import ReprojTile from '../../../../src/ol/reproj/Tile.js';
 import TileImage from '../../../../src/ol/source/TileImage.js';
-import _ol_tilecoord_ from '../../../../src/ol/tilecoord.js';
+import {getKeyZXY} from '../../../../src/ol/tilecoord.js';
 import {createXYZ, createForProjection} from '../../../../src/ol/tilegrid.js';
 
 
@@ -51,7 +51,7 @@ describe('ol.source.TileImage', function() {
       expect(source.getKey()).to.be('');
       source.getTileInternal(0, 0, -1, 1, getProjection('EPSG:3857'));
       expect(source.tileCache.getCount()).to.be(1);
-      tile = source.tileCache.get(_ol_tilecoord_.getKeyZXY(0, 0, -1));
+      tile = source.tileCache.get(getKeyZXY(0, 0, -1));
     });
 
     it('gets the tile from the cache', function() {

--- a/test/spec/ol/tilecache.test.js
+++ b/test/spec/ol/tilecache.test.js
@@ -1,6 +1,6 @@
 import Tile from '../../../src/ol/Tile.js';
 import TileCache from '../../../src/ol/TileCache.js';
-import _ol_tilecoord_ from '../../../src/ol/tilecoord.js';
+import {getKey} from '../../../src/ol/tilecoord.js';
 
 
 describe('ol.TileCache', function() {
@@ -21,7 +21,7 @@ describe('ol.TileCache', function() {
       sinon.spy(tiles[0], 'dispose');
 
       tiles.forEach(function(tile) {
-        cache.set(_ol_tilecoord_.getKey(tile.tileCoord), tile);
+        cache.set(getKey(tile.tileCoord), tile);
       });
 
       cache.pruneExceptNewestZ();

--- a/test/spec/ol/tilecoord.test.js
+++ b/test/spec/ol/tilecoord.test.js
@@ -1,4 +1,10 @@
-import _ol_tilecoord_ from '../../../src/ol/tilecoord.js';
+import {
+  quadKey,
+  getKey,
+  fromKey,
+  hash,
+  withinExtentAndZ
+} from '../../../src/ol/tilecoord.js';
 import TileGrid from '../../../src/ol/tilegrid/TileGrid.js';
 
 
@@ -16,14 +22,14 @@ describe('ol.TileCoord', function() {
   describe('call quadKey', function() {
     it('returns expected string', function() {
       const tileCoord = [3, 3, 5];
-      const s = _ol_tilecoord_.quadKey(tileCoord);
+      const s = quadKey(tileCoord);
       expect(s).to.eql('213');
     });
   });
 
   describe('getKey()', function() {
     it('returns a key for a tile coord', function() {
-      const key = _ol_tilecoord_.getKey([1, 2, 3]);
+      const key = getKey([1, 2, 3]);
       expect(key).to.eql('1/2/3');
     });
   });
@@ -31,9 +37,9 @@ describe('ol.TileCoord', function() {
   describe('fromKey()', function() {
     it('returns a tile coord given a key', function() {
       const tileCoord = [1, 2, 3];
-      const key = _ol_tilecoord_.getKey(tileCoord);
+      const key = getKey(tileCoord);
 
-      const returned = _ol_tilecoord_.fromKey(key);
+      const returned = fromKey(key);
       expect(returned).to.eql(tileCoord);
     });
   });
@@ -42,8 +48,8 @@ describe('ol.TileCoord', function() {
     it('produces different hashes for different tile coords', function() {
       const tileCoord1 = [3, 2, 1];
       const tileCoord2 = [3, 1, 1];
-      expect(_ol_tilecoord_.hash(tileCoord1)).not.to.eql(
-        _ol_tilecoord_.hash(tileCoord2));
+      expect(hash(tileCoord1)).not.to.eql(
+        hash(tileCoord2));
     });
   });
 
@@ -56,9 +62,9 @@ describe('ol.TileCoord', function() {
         resolutions: [2, 1],
         minZoom: 1
       });
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([1, 0, -1], tileGrid)).to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([2, 0, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([1, 0, -1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([2, 0, -1], tileGrid)).to.be(false);
     });
 
     it('restricts by extent when extent defines tile ranges', function() {
@@ -68,9 +74,9 @@ describe('ol.TileCoord', function() {
         tileSize: 10,
         resolutions: [1]
       });
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 1, -2], tileGrid)).to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 2, -1], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, -3], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, -2], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 2, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, -3], tileGrid)).to.be(false);
     });
 
     it('restricts by extent when sizes define tile ranges', function() {
@@ -80,12 +86,12 @@ describe('ol.TileCoord', function() {
         tileSize: 10,
         resolutions: [1]
       });
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, 0], tileGrid)).to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, -1, 0], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 2, 2], tileGrid)).to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 3, 0], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, 3], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, 0], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, -1, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 2, 2], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 3, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, 3], tileGrid)).to.be(false);
     });
 
     it('restricts by extent when sizes (neg y) define tile ranges', function() {
@@ -95,12 +101,12 @@ describe('ol.TileCoord', function() {
         tileSize: 10,
         resolutions: [1]
       });
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, -1], tileGrid)).to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, -1, -1], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, 0], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 2, -3], tileGrid)).to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 3, -1], tileGrid)).to.be(false);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, -4], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, -1, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 2, -3], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 3, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, -4], tileGrid)).to.be(false);
     });
 
     it('does not restrict by extent with no extent or sizes', function() {
@@ -109,13 +115,13 @@ describe('ol.TileCoord', function() {
         tileSize: 10,
         resolutions: [1]
       });
-      expect(_ol_tilecoord_.withinExtentAndZ([0, Infinity, 0], tileGrid))
+      expect(withinExtentAndZ([0, Infinity, 0], tileGrid))
         .to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, Infinity], tileGrid))
+      expect(withinExtentAndZ([0, 0, Infinity], tileGrid))
         .to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, -Infinity, 0], tileGrid))
+      expect(withinExtentAndZ([0, -Infinity, 0], tileGrid))
         .to.be(true);
-      expect(_ol_tilecoord_.withinExtentAndZ([0, 0, Infinity], tileGrid))
+      expect(withinExtentAndZ([0, 0, Infinity], tileGrid))
         .to.be(true);
     });
   });

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -1,5 +1,4 @@
 import {expandUrl, createFromTemplate, createFromTemplates, createFromTileUrlFunctions} from '../../../src/ol/tileurlfunction.js';
-import _ol_tilecoord_ from '../../../src/ol/tilecoord.js';
 import {createXYZ} from '../../../src/ol/tilegrid.js';
 import TileGrid from '../../../src/ol/tilegrid/TileGrid.js';
 
@@ -78,32 +77,12 @@ describe('ol.TileUrlFunction', function() {
     const tileGrid = createXYZ();
     it('creates expected URL', function() {
       const templates = [
-        'http://tile-1/{z}/{x}/{y}',
-        'http://tile-2/{z}/{x}/{y}',
-        'http://tile-3/{z}/{x}/{y}'
+        'http://tile-1/{z}/{x}/{y}'
       ];
       const tileUrlFunction = createFromTemplates(templates, tileGrid);
       const tileCoord = [3, 2, -2];
 
-      /* eslint-disable openlayers-internal/no-missing-requires */
-      sinon.stub(_ol_tilecoord_, 'hash').callsFake(function() {
-        return 3;
-      });
       expect(tileUrlFunction(tileCoord)).to.eql('http://tile-1/3/2/1');
-      _ol_tilecoord_.hash.restore();
-
-      sinon.stub(_ol_tilecoord_, 'hash').callsFake(function() {
-        return 2;
-      });
-      expect(tileUrlFunction(tileCoord)).to.eql('http://tile-3/3/2/1');
-      _ol_tilecoord_.hash.restore();
-
-      sinon.stub(_ol_tilecoord_, 'hash').callsFake(function() {
-        return 1;
-      });
-      expect(tileUrlFunction(tileCoord)).to.eql('http://tile-2/3/2/1');
-      _ol_tilecoord_.hash.restore();
-      /* eslint-enable */
     });
   });
 


### PR DESCRIPTION
See #7779.

Please note that I changed the test `createFromTemplates` in `tileurlfunction.test.js` which used to override the `hash` method with sinon. I have removed most of the test and cannot say whether this is still testing anything useful.

Please review.