### PR TITLE
Remove private static members from constructors

### DIFF
--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -36,16 +36,15 @@ inherits(GeometryCollection, Geometry);
 
 /**
  * @param {Array.<ol.geom.Geometry>} geometries Geometries.
- * @private
  * @return {Array.<ol.geom.Geometry>} Cloned geometries.
  */
-GeometryCollection.cloneGeometries_ = function(geometries) {
+function cloneGeometries(geometries) {
   const clonedGeometries = [];
   for (let i = 0, ii = geometries.length; i < ii; ++i) {
     clonedGeometries.push(geometries[i].clone());
   }
   return clonedGeometries;
-};
+}
 
 
 /**
@@ -140,7 +139,7 @@ GeometryCollection.prototype.computeExtent = function(extent) {
  * @api
  */
 GeometryCollection.prototype.getGeometries = function() {
-  return GeometryCollection.cloneGeometries_(this.geometries_);
+  return cloneGeometries(this.geometries_);
 };
 
 
@@ -262,8 +261,7 @@ GeometryCollection.prototype.scale = function(sx, opt_sy, opt_anchor) {
  * @api
  */
 GeometryCollection.prototype.setGeometries = function(geometries) {
-  this.setGeometriesArray(
-    GeometryCollection.cloneGeometries_(geometries));
+  this.setGeometriesArray(cloneGeometries(geometries));
 };
 
 

--- a/src/ol/render/webgl/LineStringReplay.js
+++ b/src/ol/render/webgl/LineStringReplay.js
@@ -16,6 +16,23 @@ import Locations from '../webgl/linestringreplay/defaultshader/Locations.js';
 import _ol_webgl_ from '../../webgl.js';
 import WebGLBuffer from '../../webgl/Buffer.js';
 
+
+/**
+ * @enum {number}
+ */
+const Instruction = {
+  ROUND: 2,
+  BEGIN_LINE: 3,
+  END_LINE: 5,
+  BEGIN_LINE_CAP: 7,
+  END_LINE_CAP: 11,
+  BEVEL_FIRST: 13,
+  BEVEL_SECOND: 17,
+  MITER_BOTTOM: 19,
+  MITER_TOP: 23
+};
+
+
 /**
  * @constructor
  * @extends {ol.render.webgl.Replay}
@@ -85,7 +102,7 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
   let numVertices = this.vertices.length;
   let numIndices = this.indices.length;
   //To save a vertex, the direction of a point is a product of the sign (1 or -1), a prime from
-  //ol.render.webgl.LineStringReplay.Instruction_, and a rounding factor (1 or 2). If the product is even,
+  //Instruction, and a rounding factor (1 or 2). If the product is even,
   //we round it. If it is odd, we don't.
   const lineJoin = this.state_.lineJoin === 'bevel' ? 0 :
     this.state_.lineJoin === 'miter' ? 1 : 2;
@@ -121,10 +138,10 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
 
         if (lineCap) {
           numVertices = this.addVertices_([0, 0], p1, p2,
-            lastSign * WebGLLineStringReplay.Instruction_.BEGIN_LINE_CAP * lineCap, numVertices);
+            lastSign * Instruction.BEGIN_LINE_CAP * lineCap, numVertices);
 
           numVertices = this.addVertices_([0, 0], p1, p2,
-            -lastSign * WebGLLineStringReplay.Instruction_.BEGIN_LINE_CAP * lineCap, numVertices);
+            -lastSign * Instruction.BEGIN_LINE_CAP * lineCap, numVertices);
 
           this.indices[numIndices++] = n + 2;
           this.indices[numIndices++] = n;
@@ -137,10 +154,10 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
         }
 
         numVertices = this.addVertices_([0, 0], p1, p2,
-          lastSign * WebGLLineStringReplay.Instruction_.BEGIN_LINE * (lineCap || 1), numVertices);
+          lastSign * Instruction.BEGIN_LINE * (lineCap || 1), numVertices);
 
         numVertices = this.addVertices_([0, 0], p1, p2,
-          -lastSign * WebGLLineStringReplay.Instruction_.BEGIN_LINE * (lineCap || 1), numVertices);
+          -lastSign * Instruction.BEGIN_LINE * (lineCap || 1), numVertices);
 
         lastIndex = numVertices / 7 - 1;
 
@@ -156,10 +173,10 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
         p0 = p0 || [0, 0];
 
         numVertices = this.addVertices_(p0, p1, [0, 0],
-          lastSign * WebGLLineStringReplay.Instruction_.END_LINE * (lineCap || 1), numVertices);
+          lastSign * Instruction.END_LINE * (lineCap || 1), numVertices);
 
         numVertices = this.addVertices_(p0, p1, [0, 0],
-          -lastSign * WebGLLineStringReplay.Instruction_.END_LINE * (lineCap || 1), numVertices);
+          -lastSign * Instruction.END_LINE * (lineCap || 1), numVertices);
 
         this.indices[numIndices++] = n;
         this.indices[numIndices++] = lastIndex - 1;
@@ -171,10 +188,10 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
 
         if (lineCap) {
           numVertices = this.addVertices_(p0, p1, [0, 0],
-            lastSign * WebGLLineStringReplay.Instruction_.END_LINE_CAP * lineCap, numVertices);
+            lastSign * Instruction.END_LINE_CAP * lineCap, numVertices);
 
           numVertices = this.addVertices_(p0, p1, [0, 0],
-            -lastSign * WebGLLineStringReplay.Instruction_.END_LINE_CAP * lineCap, numVertices);
+            -lastSign * Instruction.END_LINE_CAP * lineCap, numVertices);
 
           this.indices[numIndices++] = n + 2;
           this.indices[numIndices++] = n;
@@ -197,13 +214,13 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
       ? -1 : 1;
 
     numVertices = this.addVertices_(p0, p1, p2,
-      sign * WebGLLineStringReplay.Instruction_.BEVEL_FIRST * (lineJoin || 1), numVertices);
+      sign * Instruction.BEVEL_FIRST * (lineJoin || 1), numVertices);
 
     numVertices = this.addVertices_(p0, p1, p2,
-      sign * WebGLLineStringReplay.Instruction_.BEVEL_SECOND * (lineJoin || 1), numVertices);
+      sign * Instruction.BEVEL_SECOND * (lineJoin || 1), numVertices);
 
     numVertices = this.addVertices_(p0, p1, p2,
-      -sign * WebGLLineStringReplay.Instruction_.MITER_BOTTOM * (lineJoin || 1), numVertices);
+      -sign * Instruction.MITER_BOTTOM * (lineJoin || 1), numVertices);
 
     if (i > offset) {
       this.indices[numIndices++] = n;
@@ -225,7 +242,7 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
     //Add miter
     if (lineJoin) {
       numVertices = this.addVertices_(p0, p1, p2,
-        sign * WebGLLineStringReplay.Instruction_.MITER_TOP * lineJoin, numVertices);
+        sign * Instruction.MITER_TOP * lineJoin, numVertices);
 
       this.indices[numIndices++] = n + 1;
       this.indices[numIndices++] = n + 3;
@@ -239,10 +256,10 @@ WebGLLineStringReplay.prototype.drawCoordinates_ = function(flatCoordinates, off
       ? 1 : -1;
 
     numVertices = this.addVertices_(p0, p1, p2,
-      sign * WebGLLineStringReplay.Instruction_.BEVEL_FIRST * (lineJoin || 1), numVertices);
+      sign * Instruction.BEVEL_FIRST * (lineJoin || 1), numVertices);
 
     numVertices = this.addVertices_(p0, p1, p2,
-      -sign * WebGLLineStringReplay.Instruction_.MITER_BOTTOM * (lineJoin || 1), numVertices);
+      -sign * Instruction.MITER_BOTTOM * (lineJoin || 1), numVertices);
 
     this.indices[numIndices++] = n;
     this.indices[numIndices++] = lastIndex - 1;
@@ -664,19 +681,4 @@ WebGLLineStringReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeS
   }
 };
 
-/**
- * @enum {number}
- * @private
- */
-WebGLLineStringReplay.Instruction_ = {
-  ROUND: 2,
-  BEGIN_LINE: 3,
-  END_LINE: 5,
-  BEGIN_LINE_CAP: 7,
-  END_LINE_CAP: 11,
-  BEVEL_FIRST: 13,
-  BEVEL_SECOND: 17,
-  MITER_BOTTOM: 19,
-  MITER_TOP: 23
-};
 export default WebGLLineStringReplay;

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -14,6 +14,25 @@ import WebGLPolygonReplay from '../webgl/PolygonReplay.js';
 import WebGLTextReplay from '../webgl/TextReplay.js';
 
 /**
+ * @type {Array.<number>}
+ */
+const HIT_DETECTION_SIZE = [1, 1];
+
+/**
+ * @type {Object.<ol.render.ReplayType,
+ *                function(new: ol.render.webgl.Replay, number,
+ *                ol.Extent)>}
+ */
+const BATCH_CONSTRUCTORS = {
+  'Circle': WebGLCircleReplay,
+  'Image': WebGLImageReplay,
+  'LineString': WebGLLineStringReplay,
+  'Polygon': WebGLPolygonReplay,
+  'Text': WebGLTextReplay
+};
+
+
+/**
  * @constructor
  * @extends {ol.render.ReplayGroup}
  * @param {number} tolerance Tolerance.
@@ -115,7 +134,7 @@ WebGLReplayGroup.prototype.getReplay = function(zIndex, replayType) {
     /**
      * @type {Function}
      */
-    const Constructor = WebGLReplayGroup.BATCH_CONSTRUCTORS_[replayType];
+    const Constructor = BATCH_CONSTRUCTORS[replayType];
     replay = new Constructor(this.tolerance_, this.maxExtent_);
     replays[replayType] = replay;
   }
@@ -246,12 +265,12 @@ WebGLReplayGroup.prototype.forEachFeatureAtCoordinate = function(
   }
 
   return this.replayHitDetection_(context,
-    coordinate, resolution, rotation, WebGLReplayGroup.HIT_DETECTION_SIZE_,
+    coordinate, resolution, rotation, HIT_DETECTION_SIZE,
     pixelRatio, opacity, skippedFeaturesHash,
     /**
-       * @param {ol.Feature|ol.render.Feature} feature Feature.
-       * @return {?} Callback result.
-       */
+     * @param {ol.Feature|ol.render.Feature} feature Feature.
+     * @return {?} Callback result.
+     */
     function(feature) {
       const imageData = new Uint8Array(4);
       gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, imageData);
@@ -287,12 +306,12 @@ WebGLReplayGroup.prototype.hasFeatureAtCoordinate = function(
     gl.FRAMEBUFFER, context.getHitDetectionFramebuffer());
 
   const hasFeature = this.replayHitDetection_(context,
-    coordinate, resolution, rotation, WebGLReplayGroup.HIT_DETECTION_SIZE_,
+    coordinate, resolution, rotation, HIT_DETECTION_SIZE,
     pixelRatio, opacity, skippedFeaturesHash,
     /**
-       * @param {ol.Feature|ol.render.Feature} feature Feature.
-       * @return {boolean} Is there a feature?
-       */
+     * @param {ol.Feature|ol.render.Feature} feature Feature.
+     * @return {boolean} Is there a feature?
+     */
     function(feature) {
       const imageData = new Uint8Array(4);
       gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, imageData);
@@ -302,25 +321,4 @@ WebGLReplayGroup.prototype.hasFeatureAtCoordinate = function(
   return hasFeature !== undefined;
 };
 
-/**
- * @const
- * @private
- * @type {Array.<number>}
- */
-WebGLReplayGroup.HIT_DETECTION_SIZE_ = [1, 1];
-
-/**
- * @const
- * @private
- * @type {Object.<ol.render.ReplayType,
- *                function(new: ol.render.webgl.Replay, number,
- *                ol.Extent)>}
- */
-WebGLReplayGroup.BATCH_CONSTRUCTORS_ = {
-  'Circle': WebGLCircleReplay,
-  'Image': WebGLImageReplay,
-  'LineString': WebGLLineStringReplay,
-  'Polygon': WebGLPolygonReplay,
-  'Text': WebGLTextReplay
-};
 export default WebGLReplayGroup;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -24,7 +24,6 @@ const MapRenderer = function(container, map) {
 
   Disposable.call(this);
 
-
   /**
    * @private
    * @type {ol.PluggableMap}
@@ -81,11 +80,10 @@ MapRenderer.prototype.removeLayerRenderers = function() {
 /**
  * @param {ol.PluggableMap} map Map.
  * @param {olx.FrameState} frameState Frame state.
- * @private
  */
-MapRenderer.expireIconCache_ = function(map, frameState) {
+function expireIconCache(map, frameState) {
   iconImageCache.expire();
-};
+}
 
 
 /**
@@ -314,9 +312,7 @@ MapRenderer.prototype.removeUnusedLayerRenderers_ = function(map, frameState) {
  * @protected
  */
 MapRenderer.prototype.scheduleExpireIconCache = function(frameState) {
-  frameState.postRenderFunctions.push(
-    /** @type {ol.PostRenderFunction} */ (MapRenderer.expireIconCache_)
-  );
+  frameState.postRenderFunctions.push(/** @type {ol.PostRenderFunction} */ (expireIconCache));
 };
 
 

--- a/test/spec/ol/render/canvas/replaygroup.test.js
+++ b/test/spec/ol/render/canvas/replaygroup.test.js
@@ -1,4 +1,4 @@
-import CanvasReplayGroup from '../../../../../src/ol/render/canvas/ReplayGroup.js';
+import {getCircleArray} from '../../../../../src/ol/render/canvas/ReplayGroup.js';
 
 
 describe('ol.render.canvas.ReplayGroup', function() {
@@ -8,7 +8,7 @@ describe('ol.render.canvas.ReplayGroup', function() {
       const radius = 10;
       const minRadiusSq = Math.pow(radius - Math.SQRT2, 2);
       const maxRadiusSq = Math.pow(radius + Math.SQRT2, 2);
-      const circleArray = CanvasReplayGroup.getCircleArray_(radius);
+      const circleArray = getCircleArray(radius);
       const size = radius * 2 + 1;
       expect(circleArray.length).to.be(size);
 


### PR DESCRIPTION
See #7802.

`getCircleArray` in `CanvasReplayGroup` is exported only because the function is used in the tests