### PR TITLE
Run typecheck after tests, because of its current verbosity

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "homepage": "https://openlayers.org/",
   "scripts": {
     "lint": "eslint tasks test src/ol examples transforms",
-    "pretest": "npm run lint && npm run typecheck",
+    "pretest": "npm run lint",
+    "posttest": "npm run typecheck",
     "test": "npm run karma -- --single-run",
     "karma": "karma start test/karma.config.js",
     "serve-examples": "mkdir -p build/examples && webpack --config examples/webpack/config.js --watch & serve build/examples",


### PR DESCRIPTION
Until we have transitioned the type to module path types, we'll get 1000s of warnings from the typecheck task. So I decided to run karma before the typechecks, to make it easier to analyze failing tests.