### PR TITLE
Use toString instead of asString in asColorLike

### DIFF
--- a/src/ol/colorlike.js
+++ b/src/ol/colorlike.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/colorlike
  */
-import {asString} from './color.js';
+import {toString} from './color.js';
 
 
 /**
@@ -13,7 +13,7 @@ export function asColorLike(color) {
   if (isColorLike(color)) {
     return /** @type {string|CanvasPattern|CanvasGradient} */ (color);
   } else {
-    return asString(/** @type {ol.Color} */ (color));
+    return toString(/** @type {ol.Color} */ (color));
   }
 }
 


### PR DESCRIPTION
To avoid the double `typeof color === 'string'` check: first in `isColorLike` function and the in `toString` function.

See https://jsperf.com/ol-ascolorlike
