### PR TITLE
Refactor constraints static methods to module functions

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -3,10 +3,10 @@
  */
 import {DEFAULT_TILE_SIZE} from './tilegrid/common.js';
 import {inherits, getUid, nullFunction} from './index.js';
-import CenterConstraint from './CenterConstraint.js';
+import {createExtent, none as centerNone} from './centerconstraint.js';
 import BaseObject from './Object.js';
-import ResolutionConstraint from './ResolutionConstraint.js';
-import RotationConstraint from './RotationConstraint.js';
+import {createSnapToResolutions, createSnapToPower} from './resolutionconstraint.js';
+import {createSnapToZero, createSnapToN, none as rotationNone, disable} from './rotationconstraint.js';
 import ViewHint from './ViewHint.js';
 import ViewProperty from './ViewProperty.js';
 import {linearFindNearest} from './array.js';
@@ -1092,9 +1092,9 @@ View.prototype.setZoom = function(zoom) {
  */
 export function createCenterConstraint(options) {
   if (options.extent !== undefined) {
-    return CenterConstraint.createExtent(options.extent);
+    return createExtent(options.extent);
   } else {
-    return CenterConstraint.none;
+    return centerNone;
   }
 }
 
@@ -1128,7 +1128,7 @@ export function createResolutionConstraint(options) {
     maxResolution = resolutions[minZoom];
     minResolution = resolutions[maxZoom] !== undefined ?
       resolutions[maxZoom] : resolutions[resolutions.length - 1];
-    resolutionConstraint = ResolutionConstraint.createSnapToResolutions(
+    resolutionConstraint = createSnapToResolutions(
       resolutions);
   } else {
     // calculate the default min and max resolution
@@ -1173,7 +1173,7 @@ export function createResolutionConstraint(options) {
       Math.log(maxResolution / minResolution) / Math.log(zoomFactor));
     minResolution = maxResolution / Math.pow(zoomFactor, maxZoom - minZoom);
 
-    resolutionConstraint = ResolutionConstraint.createSnapToPower(
+    resolutionConstraint = createSnapToPower(
       zoomFactor, maxResolution, maxZoom - minZoom);
   }
   return {constraint: resolutionConstraint, maxResolution: maxResolution,
@@ -1191,16 +1191,16 @@ export function createRotationConstraint(options) {
   if (enableRotation) {
     const constrainRotation = options.constrainRotation;
     if (constrainRotation === undefined || constrainRotation === true) {
-      return RotationConstraint.createSnapToZero();
+      return createSnapToZero();
     } else if (constrainRotation === false) {
-      return RotationConstraint.none;
+      return rotationNone;
     } else if (typeof constrainRotation === 'number') {
-      return RotationConstraint.createSnapToN(constrainRotation);
+      return createSnapToN(constrainRotation);
     } else {
-      return RotationConstraint.none;
+      return rotationNone;
     }
   } else {
-    return RotationConstraint.disable;
+    return disable;
   }
 }
 

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -1,15 +1,14 @@
 /**
- * @module ol/CenterConstraint
+ * @module ol/centerconstraint
  */
 import {clamp} from './math.js';
-const CenterConstraint = {};
 
 
 /**
  * @param {ol.Extent} extent Extent.
  * @return {ol.CenterConstraintType} The constraint.
  */
-CenterConstraint.createExtent = function(extent) {
+export function createExtent(extent) {
   return (
     /**
      * @param {ol.Coordinate|undefined} center Center.
@@ -26,14 +25,13 @@ CenterConstraint.createExtent = function(extent) {
       }
     }
   );
-};
+}
 
 
 /**
  * @param {ol.Coordinate|undefined} center Center.
  * @return {ol.Coordinate|undefined} Center.
  */
-CenterConstraint.none = function(center) {
+export function none(center) {
   return center;
-};
-export default CenterConstraint;
+}

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -2,7 +2,7 @@
  * @module ol/interaction/DragRotate
  */
 import {inherits} from '../index.js';
-import RotationConstraint from '../RotationConstraint.js';
+import {disable} from '../rotationconstraint.js';
 import ViewHint from '../ViewHint.js';
 import {altShiftKeysOnly, mouseOnly, mouseActionButton} from '../events/condition.js';
 import {FALSE} from '../functions.js';
@@ -65,7 +65,7 @@ function handleDragEvent(mapBrowserEvent) {
 
   const map = mapBrowserEvent.map;
   const view = map.getView();
-  if (view.getConstraints().rotation === RotationConstraint.disable) {
+  if (view.getConstraints().rotation === disable) {
     return;
   }
   const size = map.getSize();

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -2,7 +2,7 @@
  * @module ol/interaction/DragRotateAndZoom
  */
 import {inherits} from '../index.js';
-import RotationConstraint from '../RotationConstraint.js';
+import {disable} from '../rotationconstraint.js';
 import ViewHint from '../ViewHint.js';
 import {shiftKeyOnly, mouseOnly} from '../events/condition.js';
 import Interaction from '../interaction/Interaction.js';
@@ -85,7 +85,7 @@ function handleDragEvent(mapBrowserEvent) {
   const theta = Math.atan2(deltaY, deltaX);
   const magnitude = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
   const view = map.getView();
-  if (view.getConstraints().rotation !== RotationConstraint.disable && this.lastAngle_ !== undefined) {
+  if (view.getConstraints().rotation !== disable && this.lastAngle_ !== undefined) {
     const angleDelta = theta - this.lastAngle_;
     Interaction.rotateWithoutConstraints(
       view, view.getRotation() - angleDelta);

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -6,7 +6,7 @@ import ViewHint from '../ViewHint.js';
 import {FALSE} from '../functions.js';
 import Interaction from '../interaction/Interaction.js';
 import PointerInteraction from '../interaction/Pointer.js';
-import RotationConstraint from '../RotationConstraint.js';
+import {disable} from '../rotationconstraint.js';
 
 /**
  * @classdesc
@@ -97,7 +97,7 @@ function handleDragEvent(mapBrowserEvent) {
 
   const map = mapBrowserEvent.map;
   const view = map.getView();
-  if (view.getConstraints().rotation === RotationConstraint.disable) {
+  if (view.getConstraints().rotation === disable) {
     return;
   }
 

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -1,16 +1,14 @@
 /**
- * @module ol/ResolutionConstraint
+ * @module ol/resolutionconstraint
  */
 import {linearFindNearest} from './array.js';
 import {clamp} from './math.js';
-const ResolutionConstraint = {};
-
 
 /**
  * @param {Array.<number>} resolutions Resolutions.
  * @return {ol.ResolutionConstraintType} Zoom function.
  */
-ResolutionConstraint.createSnapToResolutions = function(resolutions) {
+export function createSnapToResolutions(resolutions) {
   return (
     /**
      * @param {number|undefined} resolution Resolution.
@@ -34,7 +32,7 @@ ResolutionConstraint.createSnapToResolutions = function(resolutions) {
       }
     }
   );
-};
+}
 
 
 /**
@@ -43,7 +41,7 @@ ResolutionConstraint.createSnapToResolutions = function(resolutions) {
  * @param {number=} opt_maxLevel Maximum level.
  * @return {ol.ResolutionConstraintType} Zoom function.
  */
-ResolutionConstraint.createSnapToPower = function(power, maxResolution, opt_maxLevel) {
+export function createSnapToPower(power, maxResolution, opt_maxLevel) {
   return (
     /**
      * @param {number|undefined} resolution Resolution.
@@ -65,5 +63,4 @@ ResolutionConstraint.createSnapToPower = function(power, maxResolution, opt_maxL
         return undefined;
       }
     });
-};
-export default ResolutionConstraint;
+}

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -1,22 +1,20 @@
 /**
- * @module ol/RotationConstraint
+ * @module ol/rotationconstraint
  */
 import {toRadians} from './math.js';
-const RotationConstraint = {};
-
 
 /**
  * @param {number|undefined} rotation Rotation.
  * @param {number} delta Delta.
  * @return {number|undefined} Rotation.
  */
-RotationConstraint.disable = function(rotation, delta) {
+export function disable(rotation, delta) {
   if (rotation !== undefined) {
     return 0;
   } else {
     return undefined;
   }
-};
+}
 
 
 /**
@@ -24,20 +22,20 @@ RotationConstraint.disable = function(rotation, delta) {
  * @param {number} delta Delta.
  * @return {number|undefined} Rotation.
  */
-RotationConstraint.none = function(rotation, delta) {
+export function none(rotation, delta) {
   if (rotation !== undefined) {
     return rotation + delta;
   } else {
     return undefined;
   }
-};
+}
 
 
 /**
  * @param {number} n N.
  * @return {ol.RotationConstraintType} Rotation constraint.
  */
-RotationConstraint.createSnapToN = function(n) {
+export function createSnapToN(n) {
   const theta = 2 * Math.PI / n;
   return (
     /**
@@ -53,14 +51,14 @@ RotationConstraint.createSnapToN = function(n) {
         return undefined;
       }
     });
-};
+}
 
 
 /**
  * @param {number=} opt_tolerance Tolerance.
  * @return {ol.RotationConstraintType} Rotation constraint.
  */
-RotationConstraint.createSnapToZero = function(opt_tolerance) {
+export function createSnapToZero(opt_tolerance) {
   const tolerance = opt_tolerance || toRadians(5);
   return (
     /**
@@ -79,5 +77,4 @@ RotationConstraint.createSnapToZero = function(opt_tolerance) {
         return undefined;
       }
     });
-};
-export default RotationConstraint;
+}

--- a/test/spec/ol/resolutionconstraint.test.js
+++ b/test/spec/ol/resolutionconstraint.test.js
@@ -1,14 +1,14 @@
-import ResolutionConstraint from '../../../src/ol/ResolutionConstraint.js';
+import {createSnapToResolutions, createSnapToPower} from '../../../src/ol/resolutionconstraint.js';
 
 
-describe('ol.ResolutionConstraint', function() {
+describe('ol.resolutionconstraint', function() {
 
   describe('SnapToResolution', function() {
 
     let resolutionConstraint;
 
     beforeEach(function() {
-      resolutionConstraint = ResolutionConstraint.createSnapToResolutions(
+      resolutionConstraint = createSnapToResolutions(
         [1000, 500, 250, 100]);
     });
 
@@ -46,7 +46,7 @@ describe('ol.ResolutionConstraint', function() {
 
     beforeEach(function() {
       resolutionConstraint =
-          ResolutionConstraint.createSnapToResolutions(
+          createSnapToResolutions(
             [1000, 500, 250, 100]);
     });
 
@@ -96,7 +96,7 @@ describe('ol.ResolutionConstraint', function() {
 
     beforeEach(function() {
       resolutionConstraint =
-          ResolutionConstraint.createSnapToPower(2, 1024, 10);
+          createSnapToPower(2, 1024, 10);
     });
 
     describe('delta 0', function() {
@@ -154,7 +154,7 @@ describe('ol.ResolutionConstraint', function() {
 
     beforeEach(function() {
       resolutionConstraint =
-          ResolutionConstraint.createSnapToPower(2, 1024, 10);
+          createSnapToPower(2, 1024, 10);
     });
 
     describe('delta 0, direction 0', function() {

--- a/test/spec/ol/rotationconstraint.test.js
+++ b/test/spec/ol/rotationconstraint.test.js
@@ -1,12 +1,12 @@
-import RotationConstraint from '../../../src/ol/RotationConstraint.js';
+import {createSnapToZero} from '../../../src/ol/rotationconstraint.js';
 
 
-describe('ol.RotationConstraint', function() {
+describe('ol.rotationconstraint', function() {
 
   describe('SnapToZero', function() {
 
     it('returns expected rotation value', function() {
-      const rotationConstraint = RotationConstraint.createSnapToZero(0.3);
+      const rotationConstraint = createSnapToZero(0.3);
 
       expect(rotationConstraint(0.1, 0)).to.eql(0);
       expect(rotationConstraint(0.2, 0)).to.eql(0);


### PR DESCRIPTION
This refactors static methods to statuc module functions for CenterConstraint, ResolutionConstraint and RotationConstraint and renames them to lowercase modules because they are no longer default exporting a pseudo static class. https://github.com/openlayers/openlayers/issues/7801.

- [x] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [x] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
