### PR TITLE
Add new maxTilesLoading option to ol/PluggableMap

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -3649,6 +3649,7 @@ olx.layer.TileOptions.prototype.zIndex;
  *     map: (ol.PluggableMap|undefined),
  *     declutter: (boolean|undefined),
  *     style: (ol.style.Style|Array.<ol.style.Style>|ol.StyleFunction|undefined),
+ *     maxTilesLoading: (number|undefined),
  *     updateWhileAnimating: (boolean|undefined),
  *     updateWhileInteracting: (boolean|undefined),
  *     visible: (boolean|undefined),
@@ -3762,6 +3763,12 @@ olx.layer.VectorOptions.prototype.declutter;
  */
 olx.layer.VectorOptions.prototype.style;
 
+
+/**
+ * Maximum number tiles to load simultaneously.  Default is `16`.
+ * @type {number|undefined}
+ */
+olx.layer.VectorOptions.prototype.maxTilesLoading;
 
 /**
  * When set to `true`, feature batches will be recreated during animations.

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -76,6 +76,8 @@ export let MapOptions;
  *     Note that layers are rendered in the order supplied, so if you want, for
  *     example, a vector layer to appear on top of a tile layer, it must come
  *     after the tile layer.
+ * @param {number|undefined} options.maxTilesLoading Maximum number tiles to load
+ *     simultaneously.  Default is `16`.
  * @param {boolean|undefined} options.loadTilesWhileAnimating When set to true,
  *     tiles will be loaded during animations. This may improve the user
  *     experience, but can also make animations stutter on devices with slow
@@ -114,6 +116,12 @@ const PluggableMap = function(options) {
   BaseObject.call(this);
 
   const optionsInternal = createOptionsInternal(options);
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.maxTilesLoading_ = options.maxTilesLoading !== undefined ? options.maxTilesLoading : 16;
 
   /**
    * @type {boolean}
@@ -945,7 +953,7 @@ PluggableMap.prototype.handlePostRender = function() {
   //   loading tiles that will quickly disappear from view.
   const tileQueue = this.tileQueue_;
   if (!tileQueue.isEmpty()) {
-    let maxTotalLoading = 16;
+    let maxTotalLoading = this.maxTilesLoading_;
     let maxNewLoads = maxTotalLoading;
     if (frameState) {
       const hints = frameState.viewHints;


### PR DESCRIPTION
To be able to set the maximum number of currently loading tiles.

related to #7101 

The number of tiles to load when animating or interacting could also be made configurable (currently 8).