### PR TITLE
Add and use a constant for the collapsed CSS class

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -4,7 +4,7 @@
 import {inherits} from '../index.js';
 import {equals} from '../array.js';
 import Control from '../control/Control.js';
-import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
+import {CLASS_CONTROL, CLASS_UNSELECTABLE, CLASS_COLLAPSED} from '../css.js';
 import {removeChildren, replaceNode} from '../dom.js';
 import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
@@ -90,7 +90,7 @@ const Attribution = function(opt_options) {
   listen(button, EventType.CLICK, this.handleClick_, this);
 
   const cssClasses = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL +
-      (this.collapsed_ && this.collapsible_ ? ' ol-collapsed' : '') +
+      (this.collapsed_ && this.collapsible_ ? ' ' + CLASS_COLLAPSED : '') +
       (this.collapsible_ ? '' : ' ol-uncollapsible');
   const element = document.createElement('div');
   element.className = cssClasses;
@@ -246,7 +246,7 @@ Attribution.prototype.handleClick_ = function(event) {
  * @private
  */
 Attribution.prototype.handleToggle_ = function() {
-  this.element.classList.toggle('ol-collapsed');
+  this.element.classList.toggle(CLASS_COLLAPSED);
   if (this.collapsed_) {
     replaceNode(this.collapseLabel_, this.label_);
   } else {

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -13,7 +13,7 @@ import OverlayPositioning from '../OverlayPositioning.js';
 import ViewProperty from '../ViewProperty.js';
 import Control from '../control/Control.js';
 import {rotate as rotateCoordinate, add as addCoordinate} from '../coordinate.js';
-import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
+import {CLASS_CONTROL, CLASS_UNSELECTABLE, CLASS_COLLAPSED} from '../css.js';
 import {replaceNode} from '../dom.js';
 import {listen, listenOnce, unlisten} from '../events.js';
 import EventType from '../events/EventType.js';
@@ -150,7 +150,7 @@ const OverviewMap = function(opt_options) {
   this.ovmap_.addOverlay(this.boxOverlay_);
 
   const cssClasses = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL +
-      (this.collapsed_ && this.collapsible_ ? ' ol-collapsed' : '') +
+      (this.collapsed_ && this.collapsible_ ? ' ' + CLASS_COLLAPSED : '') +
       (this.collapsible_ ? '' : ' ol-uncollapsible');
   const element = document.createElement('div');
   element.className = cssClasses;
@@ -491,7 +491,7 @@ OverviewMap.prototype.handleClick_ = function(event) {
  * @private
  */
 OverviewMap.prototype.handleToggle_ = function() {
-  this.element.classList.toggle('ol-collapsed');
+  this.element.classList.toggle(CLASS_COLLAPSED);
   if (this.collapsed_) {
     replaceNode(this.collapseLabel_, this.label_);
   } else {

--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -49,6 +49,16 @@ export const CLASS_CONTROL = 'ol-control';
 
 
 /**
+ * The CSS class that we'll give the DOM elements that are collapsed, i.e.
+ * to those elements which usually can be expanded.
+ *
+ * @const
+ * @type {string}
+ */
+export const CLASS_COLLAPSED = 'ol-collapsed';
+
+
+/**
  * Get the list of font families from a font spec.  Note that this doesn't work
  * for font families that have commas in them.
  * @param {string} The CSS font property.


### PR DESCRIPTION
This is a small refactoring which introduces `CLASS_COLLAPSED` which is used by two controls.

Please review. 