### PR TITLE
Allow setting the label cache size

### DIFF
--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -93,7 +93,10 @@ export const defaultLineWidth = 1;
 
 
 /**
+ * The label cache for text rendering. To change the default cache size of 2048
+ * entries, use {@link ol.structs.LRUCache#setSize}.
  * @type {ol.structs.LRUCache.<HTMLCanvasElement>}
+ * @api
  */
 export const labelCache = new LRUCache();
 

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -268,6 +268,16 @@ LRUCache.prototype.set = function(key, value) {
 
 
 /**
+ * Set a maximum number of entries for the cache.
+ * @param {number} size Cache size.
+ * @api
+ */
+LRUCache.prototype.setSize = function(size) {
+  this.highWaterMark = size;
+};
+
+
+/**
  * Prune the cache.
  */
 LRUCache.prototype.prune = function() {

--- a/test/spec/ol/structs/lrucache.test.js
+++ b/test/spec/ol/structs/lrucache.test.js
@@ -280,4 +280,14 @@ describe('ol.structs.LRUCache', function() {
     });
   });
 
+  describe('setting the cache size', function() {
+    it('sets the cache size', function() {
+      lruCache.setSize(2);
+      expect(lruCache.highWaterMark).to.be(2);
+      fillLRUCache(lruCache);
+      lruCache.prune();
+      expect(lruCache.getKeys().length).to.be(2);
+    });
+  });
+
 });


### PR DESCRIPTION
After this change, the label cache size (default: 2048 entries) can be adjusted for cases where more different labels than that are used:
```js
import {labelCache} from 'ol/render/canvas';
labelCache.setSize(4096);
```

Fixes #7778.