### PR TITLE
Use nomnom@1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "marked": "0.3.16",
     "mocha": "5.0.1",
     "mustache": "^2.3.0",
-    "nomnom": "2.0.0",
+    "nomnom": "1.8.1",
     "pixelmatch": "^4.0.2",
     "proj4": "2.4.4",
     "recast": "0.14.4",


### PR DESCRIPTION
See https://github.com/zaach/jsonlint/issues/103#issuecomment-367416531.  The 2.0.0 version brought in by #7848 was a mistake.