### PR TITLE
Add a unicode symbol for symbol font detection

### DIFF
--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -129,7 +129,7 @@ export const checkFont = (function() {
   const size = '32px ';
   const referenceFonts = ['monospace', 'serif'];
   const len = referenceFonts.length;
-  const text = 'wmytzilWMYTZIL@#/&?$%10';
+  const text = 'wmytzilWMYTZIL@#/&?$%10\uF013';
   let interval, referenceWidth;
 
   function isAvailable(font) {


### PR DESCRIPTION
Symbol fonts do not always provide the full range of ASCII characters, so we also need to include a unicode symbol to the width comparison string to properly detect them.

Fix #7885.