### PR TITLE
ScaleLine fix for non-degree based units

### DIFF
--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -191,7 +191,8 @@ ScaleLine.prototype.updateElement_ = function() {
     Units.METERS;
   let pointResolution =
       getPointResolution(projection, viewState.resolution, center, pointResolutionUnits);
-  if (projection.getUnits() != Units.DEGREES && units == ScaleLineUnits.METRIC) {
+  if (projection.getUnits() != Units.DEGREES && projection.getMetersPerUnit()
+    && pointResolutionUnits == Units.METERS) {
     pointResolution *= projection.getMetersPerUnit();
   }
 

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -289,7 +289,7 @@ describe('ol.control.ScaleLine', function() {
       ctrl.setUnits('nautical');
       expect(ctrl.element_.innerText).to.be('0.05 nm');
 
-      ctrl.setUnits('imperial');
+      ctrl.setUnits('us');
       expect(ctrl.element_.innerText).to.be('500 ft');
 
 
@@ -317,7 +317,7 @@ describe('ol.control.ScaleLine', function() {
       ctrl.setUnits('nautical');
       expect(ctrl.element_.innerText).to.be('0.00005 nm');
 
-      ctrl.setUnits('imperial');
+      ctrl.setUnits('us');
       expect(ctrl.element_.innerText).to.be('5 in');
     });
 

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -369,6 +369,16 @@ describe('ol.control.ScaleLine', function() {
       }
     };
 
+    const getImperialUnit = function(zoom) {
+      if (zoom >= 21) {
+        return 'in';
+      } else if (zoom >= 10) {
+        return 'ft';
+      } else {
+        return 'mi';
+      }
+    };
+
     beforeEach(function() {
       currentZoom = 33;
       renderedHtmls = {};
@@ -427,6 +437,9 @@ describe('ol.control.ScaleLine', function() {
         const currentHtml = ctrl.element_.innerHTML;
         expect(currentHtml in renderedHtmls).to.be(false);
         renderedHtmls[currentHtml] = true;
+
+        const unit = ctrl.innerElement_.textContent.match(/\d+ (.+)/)[1];
+        expect(unit).to.eql(getImperialUnit(currentZoom));
       }
     });
     it('nautical: is rendered differently for different zoomlevels', function() {

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -279,7 +279,13 @@ describe('ol.control.ScaleLine', function() {
         })
       }));
       map.renderSync();
+
+      ctrl.setUnits('metric');
       expect(ctrl.element_.innerText).to.be('100 m');
+
+      ctrl.setUnits('imperial');
+      expect(ctrl.element_.innerText).to.be('500 ft');
+
       map.setView(new View({
         center: [0, 0],
         zoom: 0,
@@ -294,7 +300,12 @@ describe('ol.control.ScaleLine', function() {
         })
       }));
       map.renderSync();
+
+      ctrl.setUnits('metric');
       expect(ctrl.element_.innerText).to.be('100 mm');
+
+      ctrl.setUnits('imperial');
+      expect(ctrl.element_.innerText).to.be('5 in');
     });
 
     it('Metric display works with Geographic (EPSG:4326) projection', function() {

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -286,6 +286,13 @@ describe('ol.control.ScaleLine', function() {
       ctrl.setUnits('imperial');
       expect(ctrl.element_.innerText).to.be('500 ft');
 
+      ctrl.setUnits('nautical');
+      expect(ctrl.element_.innerText).to.be('0.05 nm');
+
+      ctrl.setUnits('imperial');
+      expect(ctrl.element_.innerText).to.be('500 ft');
+
+
       map.setView(new View({
         center: [0, 0],
         zoom: 0,
@@ -303,6 +310,12 @@ describe('ol.control.ScaleLine', function() {
 
       ctrl.setUnits('metric');
       expect(ctrl.element_.innerText).to.be('100 mm');
+
+      ctrl.setUnits('imperial');
+      expect(ctrl.element_.innerText).to.be('5 in');
+
+      ctrl.setUnits('nautical');
+      expect(ctrl.element_.innerText).to.be('0.00005 nm');
 
       ctrl.setUnits('imperial');
       expect(ctrl.element_.innerText).to.be('5 in');


### PR DESCRIPTION
I'm thinking of possibly using `[FEET, METERS, USFEET]` instead for `projection.getUnits()` test, it's not yet clear which is the right solution. 

Fixes #7907.