### PR TITLE
Some easy window cleanups

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -507,7 +507,7 @@ PluggableMap.prototype.disposeInternal = function() {
   unlisten(this.viewport_, EventType.MOUSEWHEEL,
     this.handleBrowserEvent, this);
   if (this.handleResize_ !== undefined) {
-    window.removeEventListener(EventType.RESIZE,
+    removeEventListener(EventType.RESIZE,
       this.handleResize_, false);
     this.handleResize_ = undefined;
   }
@@ -1012,7 +1012,7 @@ PluggableMap.prototype.handleTargetChanged_ = function() {
     this.renderer_.removeLayerRenderers();
     removeNode(this.viewport_);
     if (this.handleResize_ !== undefined) {
-      window.removeEventListener(EventType.RESIZE,
+      removeEventListener(EventType.RESIZE,
         this.handleResize_, false);
       this.handleResize_ = undefined;
     }
@@ -1030,7 +1030,7 @@ PluggableMap.prototype.handleTargetChanged_ = function() {
 
     if (!this.handleResize_) {
       this.handleResize_ = this.updateSize.bind(this);
-      window.addEventListener(EventType.RESIZE,
+      addEventListener(EventType.RESIZE,
         this.handleResize_, false);
     }
   }

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -41,7 +41,7 @@ let WEBGL_EXTENSIONS; // value is set below
 let HAS_WEBGL = false;
 
 
-if ('WebGLRenderingContext' in window) {
+if (typeof window !== 'undefined' && 'WebGLRenderingContext' in window) {
   try {
     const canvas = /** @type {HTMLCanvasElement} */
         (document.createElement('CANVAS'));

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -167,7 +167,7 @@ export const checkFont = (function() {
       }
     }
     if (done) {
-      window.clearInterval(interval);
+      clearInterval(interval);
       interval = undefined;
     }
   }
@@ -184,7 +184,7 @@ export const checkFont = (function() {
         if (!isAvailable(fontFamily)) {
           checked[fontFamily] = 0;
           if (interval === undefined) {
-            interval = window.setInterval(check, 32);
+            interval = setInterval(check, 32);
           }
         }
       }


### PR DESCRIPTION
The library or part of it could be useful in the context of web workers or inside node.
However, in these cases, there is no `window` variable.

This PR removes some unnecessary usages of the `window` prefix.
More cleanup might come in a future PR; notably to address usages in `has.js`.