### PR TITLE
Use listen function instead of on

### DIFF
--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -2,6 +2,7 @@
  * @module ol/Graticule
  */
 import {degreesToStringHDMS} from './coordinate.js';
+import {listen, unlistenByKey} from './events.js';
 import {intersects, getCenter} from './extent.js';
 import GeometryLayout from './geom/GeometryLayout.js';
 import LineString from './geom/LineString.js';
@@ -129,8 +130,13 @@ const Graticule = function(opt_options) {
   this.map_ = null;
 
   /**
-   * @type {ol.proj.Projection}
+   * @type {?ol.EventsKey}
    * @private
+   */
+  this.postcomposeListenerKey_ = null;
+
+  /**
+   * @type {ol.proj.Projection}
    */
   this.projection_ = null;
 
@@ -721,11 +727,12 @@ Graticule.prototype.updateProjectionInfo_ = function(projection) {
  */
 Graticule.prototype.setMap = function(map) {
   if (this.map_) {
-    this.map_.un(RenderEventType.POSTCOMPOSE, this.handlePostCompose_, this);
+    unlistenByKey(this.postcomposeListenerKey_);
+    this.postcomposeListenerKey_ = null;
     this.map_.render();
   }
   if (map) {
-    map.on(RenderEventType.POSTCOMPOSE, this.handlePostCompose_, this);
+    this.postcomposeListenerKey_ = listen(map, RenderEventType.POSTCOMPOSE, this.handlePostCompose_, this);
     map.render();
   }
   this.map_ = map;

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -6,6 +6,7 @@ import {getUid, inherits} from '../index.js';
 import {assert} from '../asserts.js';
 import Feature from '../Feature.js';
 import {scale as scaleCoordinate, add as addCoordinate} from '../coordinate.js';
+import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 import {buffer, createEmpty, createOrUpdateFromCoordinate} from '../extent.js';
 import Point from '../geom/Point.js';
@@ -66,8 +67,7 @@ const Cluster = function(options) {
    */
   this.source = options.source;
 
-  this.source.on(EventType.CHANGE,
-    Cluster.prototype.refresh, this);
+  listen(this.source, EventType.CHANGE, this.refresh, this);
 };
 
 inherits(Cluster, VectorSource);


### PR DESCRIPTION
In #7614, the `opt_this` argument was removed from `Observable#on`, `#once` and `#un` but internal code was not adapted.
