### PR TITLE
Make sure namespaces are populated after they were created

### DIFF
--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -103,7 +103,7 @@ function generateExports(symbols, namespaces, imports) {
       nsdefs.push(`${ns[i]} = {};`);
     }
   }
-  blocks = imports.concat(nsdefs).concat(blocks);
+  blocks = imports.concat(nsdefs.sort()).concat(blocks.sort());
   blocks.push('');
   return blocks.join('\n');
 }


### PR DESCRIPTION
The `build` target currently fails because `ol.source.OSM.ATTRIBUTION` is added to `ol.source.OSM` before it is created. By sorting the lines that generate and populate namespaces properly, this can be easily fixed.