### PR TITLE
Remove setAttributeNS function from ol/xml

### DIFF
--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -17,7 +17,7 @@ import {assign} from '../obj.js';
 import {get as getProjection, transformExtent} from '../proj.js';
 import {createElementNS, getAllTextContent, makeArrayPusher, makeChildAppender,
   makeReplacer, makeSimpleNodeFactory, OBJECT_PROPERTY_NODE_FACTORY, parseNode,
-  pushParseAndPop, pushSerializeAndPop, setAttributeNS} from '../xml.js';
+  pushParseAndPop, pushSerializeAndPop, XML_SCHEMA_INSTANCE_URI} from '../xml.js';
 
 
 /**
@@ -1139,10 +1139,8 @@ GML3.prototype.writeFeatures;
  */
 GML3.prototype.writeFeaturesNode = function(features, opt_options) {
   opt_options = this.adaptOptions(opt_options);
-  const node = createElementNS('http://www.opengis.net/gml',
-    'featureMembers');
-  setAttributeNS(node, 'http://www.w3.org/2001/XMLSchema-instance',
-    'xsi:schemaLocation', this.schemaLocation);
+  const node = createElementNS('http://www.opengis.net/gml', 'featureMembers');
+  node.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', this.schemaLocation);
   const context = {
     srsName: this.srsName,
     hasZ: this.hasZ,

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -15,7 +15,7 @@ import {get as getProjection} from '../proj.js';
 import {createElementNS, makeArrayPusher, makeArraySerializer, makeChildAppender,
   makeObjectPropertySetter, makeSequence, makeSimpleNodeFactory, makeStructureNS,
   OBJECT_PROPERTY_NODE_FACTORY, parseNode, pushParseAndPop, pushSerializeAndPop,
-  setAttributeNS} from '../xml.js';
+  XML_SCHEMA_INSTANCE_URI} from '../xml.js';
 
 /**
  * @classdesc
@@ -729,8 +729,8 @@ function writeWptType(node, coordinate, objectStack) {
   const namespaceURI = parentNode.namespaceURI;
   const properties = context['properties'];
   //FIXME Projection handling
-  setAttributeNS(node, null, 'lat', coordinate[1]);
-  setAttributeNS(node, null, 'lon', coordinate[0]);
+  node.setAttributeNS(null, 'lat', coordinate[1]);
+  node.setAttributeNS(null, 'lon', coordinate[0]);
   const geometryLayout = context['geometryLayout'];
   switch (geometryLayout) {
     case GeometryLayout.XYZM:
@@ -875,9 +875,8 @@ GPX.prototype.writeFeaturesNode = function(features, opt_options) {
   //FIXME Serialize metadata
   const gpx = createElementNS('http://www.topografix.com/GPX/1/1', 'gpx');
   const xmlnsUri = 'http://www.w3.org/2000/xmlns/';
-  const xmlSchemaInstanceUri = 'http://www.w3.org/2001/XMLSchema-instance';
-  setAttributeNS(gpx, xmlnsUri, 'xmlns:xsi', xmlSchemaInstanceUri);
-  setAttributeNS(gpx, xmlSchemaInstanceUri, 'xsi:schemaLocation', SCHEMA_LOCATION);
+  gpx.setAttributeNS(xmlnsUri, 'xmlns:xsi', XML_SCHEMA_INSTANCE_URI);
+  gpx.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', SCHEMA_LOCATION);
   gpx.setAttribute('version', '1.1');
   gpx.setAttribute('creator', 'OpenLayers');
 

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -31,7 +31,7 @@ import {createElementNS, getAllTextContent, isDocument, isNode, makeArrayExtende
   makeArrayPusher, makeChildAppender, makeObjectPropertySetter,
   makeReplacer, makeSequence, makeSimpleNodeFactory, makeStructureNS,
   OBJECT_PROPERTY_NODE_FACTORY, parse, parseNode, pushParseAndPop,
-  pushSerializeAndPop, setAttributeNS} from '../xml.js';
+  pushSerializeAndPop, XML_SCHEMA_INSTANCE_URI} from '../xml.js';
 
 
 /**
@@ -2961,12 +2961,9 @@ KML.prototype.writeFeaturesNode = function(features, opt_options) {
   opt_options = this.adaptOptions(opt_options);
   const kml = createElementNS(NAMESPACE_URIS[4], 'kml');
   const xmlnsUri = 'http://www.w3.org/2000/xmlns/';
-  const xmlSchemaInstanceUri = 'http://www.w3.org/2001/XMLSchema-instance';
-  setAttributeNS(kml, xmlnsUri, 'xmlns:gx',
-    GX_NAMESPACE_URIS[0]);
-  setAttributeNS(kml, xmlnsUri, 'xmlns:xsi', xmlSchemaInstanceUri);
-  setAttributeNS(kml, xmlSchemaInstanceUri, 'xsi:schemaLocation',
-    SCHEMA_LOCATION);
+  kml.setAttributeNS(xmlnsUri, 'xmlns:gx', GX_NAMESPACE_URIS[0]);
+  kml.setAttributeNS(xmlnsUri, 'xmlns:xsi', XML_SCHEMA_INSTANCE_URI);
+  kml.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', SCHEMA_LOCATION);
 
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: kml};
   const properties = {};

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -14,7 +14,7 @@ import {assign} from '../obj.js';
 import {get as getProjection} from '../proj.js';
 import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
   makeObjectPropertySetter, makeSimpleNodeFactory, parse, parseNode,
-  pushParseAndPop, pushSerializeAndPop, setAttributeNS} from '../xml.js';
+  pushParseAndPop, pushSerializeAndPop, XML_SCHEMA_INSTANCE_URI} from '../xml.js';
 
 
 /**
@@ -432,7 +432,7 @@ function writeDelete(node, feature, objectStack) {
   const featureNS = context['featureNS'];
   const typeName = getTypeName(featurePrefix, featureType);
   node.setAttribute('typeName', typeName);
-  setAttributeNS(node, XMLNS, 'xmlns:' + featurePrefix, featureNS);
+  node.setAttributeNS(XMLNS, 'xmlns:' + featurePrefix, featureNS);
   const fid = feature.getId();
   if (fid !== undefined) {
     writeOgcFidFilter(node, fid, objectStack);
@@ -468,7 +468,7 @@ function writeUpdate(node, feature, objectStack) {
   const typeName = getTypeName(featurePrefix, featureType);
   const geometryName = feature.getGeometryName();
   node.setAttribute('typeName', typeName);
-  setAttributeNS(node, XMLNS, 'xmlns:' + featurePrefix, featureNS);
+  node.setAttributeNS(XMLNS, 'xmlns:' + featurePrefix, featureNS);
   const fid = feature.getId();
   if (fid !== undefined) {
     const keys = feature.getKeys();
@@ -594,7 +594,7 @@ function writeQuery(node, featureType, objectStack) {
     node.setAttribute('srsName', srsName);
   }
   if (featureNS) {
-    setAttributeNS(node, XMLNS, 'xmlns:' + featurePrefix, featureNS);
+    node.setAttributeNS(XMLNS, 'xmlns:' + featurePrefix, featureNS);
   }
   const item = /** @type {module:ol/xml~NodeStackItem} */ (assign({}, context));
   item.node = node;
@@ -920,8 +920,7 @@ WFS.prototype.writeGetFeature = function(options) {
       }
     }
   }
-  setAttributeNS(node, 'http://www.w3.org/2001/XMLSchema-instance',
-    'xsi:schemaLocation', this.schemaLocation_);
+  node.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', this.schemaLocation_);
   /** @type {module:ol/xml~NodeStackItem} */
   const context = {
     node: node,
@@ -966,8 +965,7 @@ WFS.prototype.writeTransaction = function(inserts, updates, deletes, options) {
     }
   }
   const schemaLocation = SCHEMA_LOCATIONS[version];
-  setAttributeNS(node, 'http://www.w3.org/2001/XMLSchema-instance',
-    'xsi:schemaLocation', schemaLocation);
+  node.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', schemaLocation);
   const featurePrefix = options.featurePrefix ? options.featurePrefix : FEATURE_PREFIX;
   if (inserts) {
     obj = {node: node, 'featureNS': options.featureNS,

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -25,12 +25,17 @@ import {extend} from './array.js';
 
 /**
  * This document should be used when creating nodes for XML serializations. This
- * document is also used by {@link module:ol/xml~createElementNS} and
- * {@link module:ol/xml~setAttributeNS}
+ * document is also used by {@link module:ol/xml~createElementNS}
  * @const
  * @type {Document}
  */
 export const DOCUMENT = document.implementation.createDocument('', '', null);
+
+
+/**
+ * @type {string}
+ */
+export const XML_SCHEMA_INSTANCE_URI = 'http://www.w3.org/2001/XMLSchema-instance';
 
 
 /**
@@ -109,17 +114,6 @@ export function isNode(value) {
  */
 export function getAttributeNS(node, namespaceURI, name) {
   return node.getAttributeNS(namespaceURI, name) || '';
-}
-
-
-/**
- * @param {Node} node Node.
- * @param {?string} namespaceURI Namespace URI.
- * @param {string} name Attribute name.
- * @param {string|number} value Value.
- */
-export function setAttributeNS(node, namespaceURI, name, value) {
-  node.setAttributeNS(namespaceURI, name, value);
 }
 
 


### PR DESCRIPTION
The function is only an _alias_ to the native function:
```js
export function setAttributeNS(node, namespaceURI, name, value) {
  node.setAttributeNS(namespaceURI, name, value);
}
```

And create a const for the `XMLSchema-instance` URI

