### PR TITLE
Use path type instead of ol.Extent

### DIFF
--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -16,7 +16,7 @@ import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
  * @property {string|Element} [label='E'] Text label to use for the button.
  * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string} [tipLabel='Zoom to extent'] Text label to use for the button tip.
- * @property {ol.Extent} [extent] The extent to zoom to. If undefined the validity
+ * @property {module:ol/extent~Extent} [extent] The extent to zoom to. If undefined the validity
  * extent of the view projection is used.
  */
 

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -13,7 +13,7 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
  * the `defaultDataProjection` of the format is assigned (where set). If the projection
  * can not be derived from the data and if no `defaultDataProjection` is set for a format,
  * the features will not be reprojected.
- * @property {ol.Extent} extent Tile extent of the tile being read. This is only used and
+ * @property {module:ol/extent~Extent} extent Tile extent of the tile being read. This is only used and
  * required for {@link ol.format.MVT}.
  * @property {ol.ProjectionLike} featureProjection Projection of the feature geometries
  * created by the format reader. If not provided, features will be returned in the

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -47,7 +47,7 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
  * @property {number|undefined} count Number of features to retrieve when paging. This is a
  * WFS 2.0 feature backported to WFS 1.1.0 by some Web Feature Services. Please note that some
  * Web Feature Services have repurposed `maxfeatures` instead.
- * @property {ol.Extent|undefined} bbox Extent to use for the BBOX filter.
+ * @property {module:ol/extent~Extent} [bbox] Extent to use for the BBOX filter.
  * @property {ol.format.filter.Filter|undefined} filter Filter condition. See
  * {@link ol.format.filter} for more information.
  * @property {string|undefined} resultType Indicates what response should be returned,

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -9,7 +9,7 @@ import {METERS_PER_UNIT} from '../proj/Units.js';
  * @property {string} code The SRS identifier code, e.g. `EPSG:4326`.
  * @property {module:ol/proj/Units~Units|string|undefined} units Units. Required unless a
  * proj4 projection is defined for `code`.
- * @property {ol.Extent|undefined} extent The validity extent for the SRS.
+ * @property {module:ol/extent~Extent} [extent] The validity extent for the SRS.
  * @property {string|undefined} axisOrientation The axis orientation as specified
  * in Proj4. The default is `enu`.
  * @property {boolean|undefined} global Whether the projection is valid for the
@@ -17,7 +17,7 @@ import {METERS_PER_UNIT} from '../proj/Units.js';
  * @property {number|undefined} metersPerUnit The meters per unit for the SRS.
  * If not provided, the `units` are used to get the meters per unit from the {@link module:ol/proj/Units~METERS_PER_UNIT}
  * lookup table.
- * @property {ol.Extent|undefined} worldExtent The world extent for the SRS.
+ * @property {module:ol/extent~Extent} [worldExtent] The world extent for the SRS.
  * @property {(function(number, ol.Coordinate):number|undefined)} getPointResolution
  * Function to determine resolution at a point. The function is called with a
  * `{number}` view resolution and an `{ol.Coordinate}` as arguments, and returns

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -74,7 +74,8 @@ module.exports = function(karma) {
       },
       SL_Firefox: {
         base: 'SauceLabs',
-        browserName: 'firefox'
+        browserName: 'firefox',
+        version: '58'
       },
       SL_Edge: {
         base: 'SauceLabs',


### PR DESCRIPTION
With this pull request, `ol.Extent` is replaced with its path type counterpart throughout the library. See #7947.