### PR TITLE
Move olx.layer.BaseOptions to ol/layer/Base

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -7,67 +7,6 @@ let olx;
 
 /**
  * @typedef {{opacity: (number|undefined),
- *     visible: (boolean|undefined),
- *     extent: (ol.Extent|undefined),
- *     zIndex: (number|undefined),
- *     minResolution: (number|undefined),
- *     maxResolution: (number|undefined)}}
- */
-olx.layer.BaseOptions;
-
-
-/**
- * Opacity (0, 1). Default is `1`.
- * @type {number|undefined}
- * @api
- */
-olx.layer.BaseOptions.prototype.opacity;
-
-
-/**
- * Visibility. Default is `true`.
- * @type {boolean|undefined}
- * @api
- */
-olx.layer.BaseOptions.prototype.visible;
-
-
-/**
- * The bounding extent for layer rendering.  The layer will not be rendered
- * outside of this extent.
- * @type {ol.Extent|undefined}
- * @api
- */
-olx.layer.BaseOptions.prototype.extent;
-
-
-/**
- * The z-index for layer rendering.  At rendering time, the layers will be
- * ordered, first by Z-index and then by position. The default Z-index is 0.
- * @type {number|undefined}
- * @api
- */
-olx.layer.BaseOptions.prototype.zIndex;
-
-
-/**
- * The minimum resolution (inclusive) at which this layer will be visible.
- * @type {number|undefined}
- * @api
- */
-olx.layer.BaseOptions.prototype.minResolution;
-
-
-/**
- * The maximum resolution (exclusive) below which this layer will be visible.
- * @type {number|undefined}
- * @api
- */
-olx.layer.BaseOptions.prototype.maxResolution;
-
-
-/**
- * @typedef {{opacity: (number|undefined),
  *     source: (ol.source.Source|undefined),
  *     visible: (boolean|undefined),
  *     extent: (ol.Extent|undefined),

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -7,6 +7,22 @@ import LayerProperty from '../layer/Property.js';
 import {clamp} from '../math.js';
 import {assign} from '../obj.js';
 
+
+/**
+ * @typedef {Object} Options
+ * @property {number} [opacity=1] Opacity (0, 1).
+ * @property {boolean} [visible=true] Visibility.
+ * @property {ol.Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * rendered outside of this extent.
+ * @property {number} [zIndex=0] The z-index for layer rendering.  At rendering time, the layers
+ * will be ordered, first by Z-index and then by position.
+ * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
+ * visible.
+ * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
+ * be visible.
+ */
+
+
 /**
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
@@ -18,7 +34,7 @@ import {assign} from '../obj.js';
  * @constructor
  * @abstract
  * @extends {module:ol/Object~BaseObject}
- * @param {olx.layer.BaseOptions} options Layer options.
+ * @param {module:ol/layer/Base~Options} options Layer options.
  * @api
  */
 const BaseLayer = function(options) {

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -53,7 +53,7 @@ const Layer = function(options) {
   const baseOptions = assign({}, options);
   delete baseOptions.source;
 
-  BaseLayer.call(this, /** @type {olx.layer.BaseOptions} */ (baseOptions));
+  BaseLayer.call(this, /** @type {module:ol/layer/Base~Options} */ (baseOptions));
 
   /**
    * @private


### PR DESCRIPTION
See #7947. First PR to check if I'm doing things properly and get early feedback, I'm planning to do the rest of the externs migration for `ol.layer` in one go in a second PR if everything is good so far.