### PR TITLE
[doc] dispatchChangeEvent -> changed

### DIFF
--- a/externs/olx.js
+++ b/externs/olx.js
@@ -929,7 +929,7 @@ olx.source.ImageCanvasOptions.prototype.attributions;
  * ratio, `{ol.Size}` the image size, and `{module:ol/proj/Projection~Projection}` the image
  * projection. The canvas returned by this function is cached by the source. If
  * the value returned by the function is later changed then
- * `dispatchChangeEvent` should be called on the source for the source to
+ * `changed` should be called on the source for the source to
  * invalidate the current cached image.
  * @type {ol.CanvasFunctionType}
  * @api

--- a/externs/olx.js
+++ b/externs/olx.js
@@ -930,7 +930,7 @@ olx.source.ImageCanvasOptions.prototype.attributions;
  * projection. The canvas returned by this function is cached by the source. If
  * the value returned by the function is later changed then
  * `changed` should be called on the source for the source to
- * invalidate the current cached image.
+ * invalidate the current cached image. See @link: {@link module:ol/Observable~Observable#changed}
  * @type {ol.CanvasFunctionType}
  * @api
  */


### PR DESCRIPTION
I think this is the only place in code that documents dispatchChangeEvent, but I think it means "changed" instead.  I also created  https://github.com/openlayers/openlayers/compare/master...nyurik:patch-1#diff-946befd18169a7196da938115c099af4  but I'm not sure if that's an autogenerated file or not.

P.S. It would be great to make it into a doc link instead of simply text.  Not sure what the doc semantics would be.