### PR TITLE
Set `user-select: text` for .ol-selectable

### DIFF
--- a/css/ol.css
+++ b/css/ol.css
@@ -44,10 +44,10 @@
 }
 .ol-selectable {
   -webkit-touch-callout: default;
-  -webkit-user-select: auto;
-  -moz-user-select: auto;
-  -ms-user-select: auto;
-  user-select: auto;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
 }
 .ol-grabbing {
   cursor: -webkit-grabbing;


### PR DESCRIPTION
In order to allow a user to select content within an element with the `.ol-selectable` class the `user-select` CSS property should be `text`. 

The current value of `auto` results in a computed value of `none` due to the rule `.ol-viewport, .ol-unselectable` specifying `user-select: none`. According to the [the specification](https://www.w3.org/TR/css-ui-4/#valdef-user-select-auto):

> if the computed value of `user-select` on the parent of this element is `none`, the computed value is `none`

Tested manually on Chromium, Firefox and IE11.