### PR TITLE
Only process loaded tiles

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -176,7 +176,7 @@ CanvasVectorTileLayerRenderer.prototype.createReplayGroup_ = function(tile, fram
   const zIndexKeys = {};
   for (let t = 0, tt = tile.tileKeys.length; t < tt; ++t) {
     const sourceTile = tile.getTile(tile.tileKeys[t]);
-    if (sourceTile.getState() == TileState.ERROR) {
+    if (sourceTile.getState() != TileState.LOADED) {
       continue;
     }
 
@@ -286,7 +286,7 @@ CanvasVectorTileLayerRenderer.prototype.forEachFeatureAtCoordinate = function(co
     }
     for (let t = 0, tt = tile.tileKeys.length; t < tt; ++t) {
       const sourceTile = tile.getTile(tile.tileKeys[t]);
-      if (sourceTile.getState() == TileState.ERROR) {
+      if (sourceTile.getState() != TileState.LOADED) {
         continue;
       }
       replayGroup = sourceTile.getReplayGroup(layer, tile.tileCoord.toString());
@@ -395,7 +395,7 @@ CanvasVectorTileLayerRenderer.prototype.postCompose = function(context, frameSta
     let transform = undefined;
     for (let t = 0, tt = tile.tileKeys.length; t < tt; ++t) {
       const sourceTile = tile.getTile(tile.tileKeys[t]);
-      if (sourceTile.getState() == TileState.ERROR) {
+      if (sourceTile.getState() != TileState.LOADED) {
         continue;
       }
       const replayGroup = sourceTile.getReplayGroup(layer, tileCoord.toString());
@@ -500,7 +500,7 @@ CanvasVectorTileLayerRenderer.prototype.renderTileImage_ = function(
     const tileExtent = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent);
     for (let i = 0, ii = tile.tileKeys.length; i < ii; ++i) {
       const sourceTile = tile.getTile(tile.tileKeys[i]);
-      if (sourceTile.getState() == TileState.ERROR) {
+      if (sourceTile.getState() != TileState.LOADED) {
         continue;
       }
       const pixelScale = pixelRatio / resolution;

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -61,7 +61,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       feature2.setStyle(featureStyle);
       const TileClass = function() {
         VectorTile.apply(this, arguments);
-        this.setState('loaded');
+        this.setState(TileState.LOADED);
         this.setFeatures([feature1, feature2, feature3]);
         this.setProjection(getProjection('EPSG:4326'));
         tileCallback(this);
@@ -292,8 +292,9 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     let layer, renderer, replayGroup;
     const TileClass = function() {
       VectorImageTile.apply(this, arguments);
-      this.setState('loaded');
+      this.setState(TileState.LOADED);
       const sourceTile = new VectorTile([0, 0, 0]);
+      sourceTile.setState(TileState.LOADED);
       sourceTile.setProjection(getProjection('EPSG:3857'));
       sourceTile.getReplayGroup = function() {
         return replayGroup;


### PR DESCRIPTION
In situations where a subset of a `VectorImageTile`'s source tiles are not available (i.e. when source tile grid and image tile grid differ, or when a custom tile url function returns undefined because it decides that a tile is not available), we currently fill the tile queue with tiles that never become available.

This can be fixed by only processing tiles with state `LOADED`.