### PR TITLE
Rename constructor options typedef to 'Options'

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -45,7 +45,7 @@ inherits(CollectionEvent, Event);
 
 
 /**
- * @typedef {Object} CollectionOptions
+ * @typedef {Object} Options
  * @property {boolean} [unique=false] Disallow the same item from being added to
  * the collection twice.
  */
@@ -62,7 +62,7 @@ inherits(CollectionEvent, Event);
  * @extends {module:ol/Object~Object}
  * @fires module:ol/Collection~CollectionEvent
  * @param {Array.<T>=} opt_array Array.
- * @param {module:ol/Collection~CollectionOptions=} opt_options Collection options.
+ * @param {module:ol/Collection~Options=} opt_options Collection options.
  * @template T
  * @api
  */

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -13,7 +13,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
 
 
 /**
- * @typedef {Object} GeolocationOptions
+ * @typedef {Object} Options
  * @property {boolean} [tracking=false] Start Tracking right after
  * instantiation.
  * @property {GeolocationPositionOptions} [trackingOptions] Tracking options.
@@ -46,7 +46,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
  * @fires error
  * @constructor
  * @extends {module:ol/Object~Object}
- * @param {module:ol/Geolocation~GeolocationOptions=} opt_options Options.
+ * @param {module:ol/Geolocation~Options=} opt_options Options.
  * @api
  */
 const Geolocation = function(opt_options) {

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -41,7 +41,7 @@ const INTERVALS = [
  */
 
 /**
- * @typedef {Object} GraticuleOptions
+ * @typedef {Object} Options
  * @property {module:ol/PluggableMap~PluggableMap} [map] Reference to an
  * {@link module:ol/Map~Map} object.
  * @property {number} [maxLines=100] The maximum number of meridians and
@@ -109,7 +109,7 @@ const INTERVALS = [
 /**
  * Render a grid for a coordinate system on a map.
  * @constructor
- * @param {module:ol/Graticule~GraticuleOptions=} opt_options Options.
+ * @param {module:ol/Graticule~Options=} opt_options Options.
  * @api
  */
 const Graticule = function(opt_options) {

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -12,7 +12,7 @@ import {containsExtent} from './extent.js';
 
 
 /**
- * @typedef {Object} OverlayOptions
+ * @typedef {Object} Options
  * @property {number|string} [id] Set the overlay id. The overlay id can be used
  * with the {@link module:ol/Map~Map#getOverlayById} method.
  * @property {Element} [element] The overlay element.
@@ -41,7 +41,7 @@ import {containsExtent} from './extent.js';
  * @property {boolean} [autoPan=false] If set to `true` the map is panned when
  * calling `setPosition`, so that the overlay is entirely visible in the current
  * viewport.
- * @property {module:ol/Overlay~OverlayPanOptions} [autoPanAnimation] The
+ * @property {module:ol/Overlay~PanOptions} [autoPanAnimation] The
  * animation options used to pan the overlay into view. This animation is only
  * used when `autoPan` is enabled. A `duration` and `easing` may be provided to
  * customize the animation.
@@ -53,7 +53,7 @@ import {containsExtent} from './extent.js';
 
 
 /**
- * @typedef {Object} OverlayPanOptions
+ * @typedef {Object} PanOptions
  * @property {number} [duration=1000] The duration of the animation in
  * milliseconds.
  * @property {function(number):number} [easing] The easing function to use. Can
@@ -95,7 +95,7 @@ const Property = {
  *
  * @constructor
  * @extends {module:ol/Object~Object}
- * @param {module:ol/Overlay~OverlayOptions} options Overlay options.
+ * @param {module:ol/Overlay~Options} options Overlay options.
  * @api
  */
 const Overlay = function(options) {
@@ -104,7 +104,7 @@ const Overlay = function(options) {
 
   /**
    * @protected
-   * @type {module:ol/Overlay~OverlayOptions}
+   * @type {module:ol/Overlay~Options}
    */
   this.options = options;
 
@@ -144,9 +144,9 @@ const Overlay = function(options) {
 
   /**
    * @protected
-   * @type {module:ol/Overlay~OverlayPanOptions}
+   * @type {module:ol/Overlay~PanOptions}
    */
-  this.autoPanAnimation = options.autoPanAnimation || /** @type {module:ol/Overlay~OverlayPanOptions} */ ({});
+  this.autoPanAnimation = options.autoPanAnimation || /** @type {module:ol/Overlay~PanOptions} */ ({});
 
   /**
    * @protected
@@ -592,7 +592,7 @@ Overlay.prototype.updateRenderedPosition = function(pixel, mapSize) {
 
 /**
  * returns the options this Overlay has been created with
- * @return {module:ol/Overlay~OverlayOptions} overlay options
+ * @return {module:ol/Overlay~Options} overlay options
  */
 Overlay.prototype.getOptions = function() {
   return this.options;

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -29,8 +29,6 @@ const Direction = {
  * @typedef {Object} Options
  * @property {string} [className='ol-zoomslider'] CSS class name.
  * @property {number} [duration=200] Animation duration in milliseconds.
- * @property {number|undefined} maxResolution Maximum resolution.
- * @property {number|undefined} minResolution Minimum resolution.
  * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  */


### PR DESCRIPTION
And remove two unused properties in ZoomSlider options