### PR TITLE
Generate correct includes list for `build-index` script on windows hosts.

### DIFF
--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -20,9 +20,10 @@ function getSymbols(callback) {
   });
 }
 
+const srcPath = path.posix.resolve(__dirname, '../src').replace(/\\/g,'/');
 function getPath(name) {
-  const fullPath = require.resolve(path.resolve('src', name));
-  return './' + path.posix.relative('src/', fullPath);
+  const fullPath = require.resolve(path.resolve('src', name)).replace(/\\/g,'/');
+  return './' + path.posix.relative(srcPath, fullPath);
 }
 
 /**

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -22,8 +22,8 @@ function getSymbols(callback) {
 
 const srcPath = path.posix.resolve(__dirname, '../src').replace(/\\/g,'/');
 function getPath(name) {
-  const fullPath = require.resolve(path.resolve('src', name)).replace(/\\/g,'/');
-  return './' + path.posix.relative(srcPath, fullPath);
+  const fullPath = require.resolve(path.resolve('src', name));
+  return './' + path.posix.relative(srcPath, fullPath.replace(/\\/g,'/'));
 }
 
 /**


### PR DESCRIPTION
npm command `build-index` created invalid paths on windows machines.

- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [x] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [x] I have used clear commit messages.
- [ ] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
