### PR TITLE
Move various typedefs out of typdefs.js

### DIFF
--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -76,6 +76,16 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
 
 
 /**
+ * Total deleted; total inserted; total updated; array of insert ids.
+ * @typedef {Object} TransactionResponse
+ * @property {number} totalDeleted
+ * @property {number} totalInserted
+ * @property {number} totalUpdated
+ * @property {Array.<string>} insertIds
+ */
+
+
+/**
  * @type {string}
  */
 const FEATURE_PREFIX = 'feature';
@@ -223,7 +233,7 @@ WFS.prototype.readFeaturesFromNode = function(node, opt_options) {
  * Read transaction response of the source.
  *
  * @param {Document|Node|Object|string} source Source.
- * @return {ol.WFSTransactionResponse|undefined} Transaction response.
+ * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
  * @api
  */
 WFS.prototype.readTransactionResponse = function(source) {
@@ -392,7 +402,7 @@ const TRANSACTION_RESPONSE_PARSERS = {
 
 /**
  * @param {Document} doc Document.
- * @return {ol.WFSTransactionResponse|undefined} Transaction response.
+ * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
  */
 WFS.prototype.readTransactionResponseFromDocument = function(doc) {
   for (let n = doc.firstChild; n; n = n.nextSibling) {
@@ -406,11 +416,11 @@ WFS.prototype.readTransactionResponseFromDocument = function(doc) {
 
 /**
  * @param {Node} node Node.
- * @return {ol.WFSTransactionResponse|undefined} Transaction response.
+ * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
  */
 WFS.prototype.readTransactionResponseFromNode = function(node) {
   return pushParseAndPop(
-    /** @type {ol.WFSTransactionResponse} */({}),
+    /** @type {module:ol/format/WFS~TransactionResponse} */({}),
     TRANSACTION_RESPONSE_PARSERS, node, []);
 };
 

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -68,6 +68,14 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
 
 
 /**
+ * Number of features; bounds/extent.
+ * @typedef {Object} FeatureCollectionMetadata
+ * @property {number} numberOfFeatures
+ * @property {module:ol/extent~Extent} bounds
+ */
+
+
+/**
  * @type {string}
  */
 const FEATURE_PREFIX = 'feature';
@@ -237,7 +245,7 @@ WFS.prototype.readTransactionResponse = function(source) {
  * Read feature collection metadata of the source.
  *
  * @param {Document|Node|Object|string} source Source.
- * @return {ol.WFSFeatureCollectionMetadata|undefined}
+ * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
  *     FeatureCollection metadata.
  * @api
  */
@@ -259,7 +267,7 @@ WFS.prototype.readFeatureCollectionMetadata = function(source) {
 
 /**
  * @param {Document} doc Document.
- * @return {ol.WFSFeatureCollectionMetadata|undefined}
+ * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
  *     FeatureCollection metadata.
  */
 WFS.prototype.readFeatureCollectionMetadataFromDocument = function(doc) {
@@ -286,7 +294,7 @@ const FEATURE_COLLECTION_PARSERS = {
 
 /**
  * @param {Node} node Node.
- * @return {ol.WFSFeatureCollectionMetadata|undefined}
+ * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
  *     FeatureCollection metadata.
  */
 WFS.prototype.readFeatureCollectionMetadataFromNode = function(node) {
@@ -295,7 +303,7 @@ WFS.prototype.readFeatureCollectionMetadataFromNode = function(node) {
     node.getAttribute('numberOfFeatures'));
   result['numberOfFeatures'] = value;
   return pushParseAndPop(
-    /** @type {ol.WFSFeatureCollectionMetadata} */ (result),
+    /** @type {module:ol/format/WFS~FeatureCollectionMetadata} */ (result),
     FEATURE_COLLECTION_PARSERS, node, [], this.gmlFormat_);
 };
 

--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -8,7 +8,7 @@ import XYZ from '../source/XYZ.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -14,7 +14,7 @@ import VectorSource from '../source/Vector.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [distance=20] Minimum distance in pixels between clusters.
  * @property {module:ol/extent~Extent} [extent] Extent.
  * @property {ol.format.Feature} [format] Format.

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -69,7 +69,7 @@ inherits(ImageSourceEvent, Event);
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions]
+ * @property {module:ol/source/Source~AttributionLike} [attributions]
  * @property {module:ol/extent~Extent} [extent]
  * @property {module:ol/proj~ProjectionLike} projection
  * @property {Array.<number>} [resolutions]

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -14,7 +14,7 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -8,7 +8,7 @@ import ImageSource from '../source/Image.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {ol.CanvasFunctionType} [canvasFunction] Canvas function.
  * The function returning the canvas element used by the source
  * as an image. The arguments passed to the function are: `{module:ol/extent~Extent}` the

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -13,7 +13,7 @@ import ImageSource, {defaultImageLoadFunction} from '../source/Image.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -19,7 +19,7 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -19,7 +19,7 @@ export const ATTRIBUTION = '&copy; ' +
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -23,6 +23,25 @@ import {create as createTransform} from '../transform.js';
 
 
 /**
+ * A function that takes an array of input data, performs some operation, and
+ * returns an array of output data.
+ * For `pixel` type operations, the function will be called with an array of
+ * pixels, where each pixel is an array of four numbers (`[r, g, b, a]`) in the
+ * range of 0 - 255. It should return a single pixel array.
+ * For `'image'` type operations, functions will be called with an array of
+ * {@link ImageData https://developer.mozilla.org/en-US/docs/Web/API/ImageData}
+ * and should return a single {@link ImageData
+ * https://developer.mozilla.org/en-US/docs/Web/API/ImageData}.  The operations
+ * are called with a second "data" argument, which can be used for storage.  The
+ * data object is accessible from raster events, where it can be initialized in
+ * "beforeoperations" and accessed again in "afteroperations".
+ *
+ * @typedef {function((Array.<Array.<number>>|Array.<ImageData>), Object):
+ *     (Array.<number>|ImageData)} Operation
+ */
+
+
+/**
  * @enum {string}
  */
 const RasterEventType = {
@@ -85,7 +104,7 @@ inherits(RasterSourceEvent, Event);
 /**
  * @typedef {Object} Options
  * @property {Array.<module:ol/source/Source~Source>} sources Input sources.
- * @property {ol.RasterOperation} [operation] Raster operation.
+ * @property {module:ol/source/Raster~Operation} [operation] Raster operation.
  * The operation will be called with data from input sources
  * and the output will be assigned to the raster source.
  * @property {Object} [lib] Functions that will be made available to operations run in a worker.
@@ -105,7 +124,7 @@ inherits(RasterSourceEvent, Event);
 /**
  * @classdesc
  * A source that transforms data from any number of input sources using an
- * {@link ol.RasterOperation} function to transform input pixel values into
+ * {@link module:ol/source/Raster~Operation} function to transform input pixel values into
  * output pixel values.
  *
  * @constructor
@@ -222,7 +241,7 @@ inherits(RasterSource, ImageSource);
 
 /**
  * Set the operation.
- * @param {ol.RasterOperation} operation New operation.
+ * @param {module:ol/source/Raster~Operation} operation New operation.
  * @param {Object=} opt_lib Functions that will be available to operations run
  *     in a worker.
  * @api

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -9,14 +9,22 @@ import SourceState from '../source/State.js';
 
 
 /**
+ * A function that returns a string or an array of strings representing source
+ * attributions.
+ *
+ * @typedef {function(module:ol/PluggableMap~FrameState): (string|Array.<string>)} Attribution
+ */
+
+
+/**
  * A type that can be used to provide attribution information for data sources.
  *
  * It represents either
  * * a simple string (e.g. `'© Acme Inc.'`)
  * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
- * * a function that returns a string or array of strings (`{@link ol.Attribution}`)
+ * * a function that returns a string or array of strings (`{@link module:ol/source/Source~Attribution}`)
  *
- * @typedef {string|Array.<string>|ol.Attribution} AttributionLike
+ * @typedef {string|Array.<string>|module:ol/source/Source~Attribution} AttributionLike
  */
 
 
@@ -55,7 +63,7 @@ const Source = function(options) {
 
   /**
    * @private
-   * @type {?ol.Attribution}
+   * @type {?module:ol/source/Source~Attribution}
    */
   this.attributions_ = this.adaptAttributions_(options.attributions);
 
@@ -79,7 +87,7 @@ inherits(Source, BaseObject);
 /**
  * Turns the attributions option into an attributions function.
  * @param {module:ol/source/Source~AttributionLike|undefined} attributionLike The attribution option.
- * @return {?ol.Attribution} An attribution function (or null).
+ * @return {?module:ol/source/Source~Attribution} An attribution function (or null).
  */
 Source.prototype.adaptAttributions_ = function(attributionLike) {
   if (!attributionLike) {
@@ -116,7 +124,7 @@ Source.prototype.forEachFeatureAtCoordinate = UNDEFINED;
 
 /**
  * Get the attribution function for the source.
- * @return {?ol.Attribution} Attribution function.
+ * @return {?module:ol/source/Source~Attribution} Attribution function.
  */
 Source.prototype.getAttributions = function() {
   return this.attributions_;
@@ -170,7 +178,7 @@ Source.prototype.refresh = function() {
 /**
  * Set the attributions of the source.
  * @param {module:ol/source/Source~AttributionLike|undefined} attributions Attributions.
- *     Can be passed as `string`, `Array<string>`, `{@link ol.Attribution}`,
+ *     Can be passed as `string`, `Array<string>`, `{@link module:ol/source/Source~Attribution}`,
  *     or `undefined`.
  * @api
  */

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -9,8 +9,20 @@ import SourceState from '../source/State.js';
 
 
 /**
+ * A type that can be used to provide attribution information for data sources.
+ *
+ * It represents either
+ * * a simple string (e.g. `'© Acme Inc.'`)
+ * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
+ * * a function that returns a string or array of strings (`{@link ol.Attribution}`)
+ *
+ * @typedef {string|Array.<string>|ol.Attribution} AttributionLike
+ */
+
+
+/**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions]
+ * @property {module:ol/source/Source~AttributionLike} [attributions]
  * @property {module:ol/proj~ProjectionLike} projection
  * @property {module:ol/source/State~State} [state]
  * @property {boolean} [wrapX]
@@ -66,7 +78,7 @@ inherits(Source, BaseObject);
 
 /**
  * Turns the attributions option into an attributions function.
- * @param {ol.AttributionLike|undefined} attributionLike The attribution option.
+ * @param {module:ol/source/Source~AttributionLike|undefined} attributionLike The attribution option.
  * @return {?ol.Attribution} An attribution function (or null).
  */
 Source.prototype.adaptAttributions_ = function(attributionLike) {
@@ -157,7 +169,7 @@ Source.prototype.refresh = function() {
 
 /**
  * Set the attributions of the source.
- * @param {ol.AttributionLike|undefined} attributions Attributions.
+ * @param {module:ol/source/Source~AttributionLike|undefined} attributions Attributions.
  *     Can be passed as `string`, `Array<string>`, `{@link ol.Attribution}`,
  *     or `undefined`.
  * @api

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -14,7 +14,7 @@ import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.j
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions]
+ * @property {module:ol/source/Source~AttributionLike} [attributions]
  * @property {number} [cacheSize]
  * @property {module:ol/extent~Extent} [extent]
  * @property {boolean} [opaque]

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -16,7 +16,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -19,7 +19,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -19,7 +19,7 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -10,7 +10,7 @@ import {getKeyZXY} from '../tilecoord.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions]
+ * @property {module:ol/source/Source~AttributionLike} [attributions]
  * @property {number} [cacheSize]
  * @property {module:ol/extent~Extent} [extent]
  * @property {boolean} [opaque]

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -50,7 +50,7 @@ inherits(VectorSourceEvent, Event);
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {Array.<module:ol/Feature~Feature>|ol.Collection.<module:ol/Feature~Feature>} [features]
  * Features. If provided as {@link ol.Collection}, the features in the source
  * and the collection will stay in sync.

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -12,7 +12,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=128] Cache size.
  * @property {module:ol/format/Feature~FeatureFormat} [format] Feature format for tiles. Used and required by the default.
  * @property {boolean} [overlaps=true] This source may have overlapping geometries. Setting this

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -14,7 +14,7 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -7,7 +7,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -81,7 +81,7 @@ CustomTile.prototype.getImage = function() {
 
 /**
  * @typedef {Object} Options
- * @property {ol.AttributionLike} [attributions] Attributions.
+ * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -34,6 +34,18 @@ import ImageStyle from '../style/Image.js';
 
 
 /**
+ * @typedef {Object} RenderOptions
+ * @property {module:ol/colorlike~ColorLike} [strokeStyle]
+ * @property {number} strokeWidth
+ * @property {number} size
+ * @property {string} lineCap
+ * @property {Array.<number>} lineDash
+ * @property {string} lineJoin
+ * @property {number} miterLimit
+ */
+
+
+/**
  * @classdesc
  * Set regular shape style for vector features. The resulting shape will be
  * a regular polygon when `radius` is provided, or a star when `radius1` and
@@ -378,7 +390,7 @@ RegularShape.prototype.render_ = function(atlasManager) {
 
   let size = 2 * (this.radius_ + strokeWidth) + 1;
 
-  /** @type {ol.RegularShapeRenderOptions} */
+  /** @type {module:ol/style/RegularShape~RenderOptions} */
   const renderOptions = {
     strokeStyle: strokeStyle,
     strokeWidth: strokeWidth,
@@ -441,7 +453,7 @@ RegularShape.prototype.render_ = function(atlasManager) {
 
 /**
  * @private
- * @param {ol.RegularShapeRenderOptions} renderOptions Render options.
+ * @param {module:ol/style/RegularShape~RenderOptions} renderOptions Render options.
  * @param {CanvasRenderingContext2D} context The rendering context.
  * @param {number} x The origin for the symbol (x).
  * @param {number} y The origin for the symbol (y).
@@ -502,7 +514,7 @@ RegularShape.prototype.draw_ = function(renderOptions, context, x, y) {
 
 /**
  * @private
- * @param {ol.RegularShapeRenderOptions} renderOptions Render options.
+ * @param {module:ol/style/RegularShape~RenderOptions} renderOptions Render options.
  */
 RegularShape.prototype.createHitDetectionCanvas_ = function(renderOptions) {
   this.hitDetectionImageSize_ = [renderOptions.size, renderOptions.size];
@@ -522,7 +534,7 @@ RegularShape.prototype.createHitDetectionCanvas_ = function(renderOptions) {
 
 /**
  * @private
- * @param {ol.RegularShapeRenderOptions} renderOptions Render options.
+ * @param {module:ol/style/RegularShape~RenderOptions} renderOptions Render options.
  * @param {CanvasRenderingContext2D} context The context.
  * @param {number} x The origin for the symbol (x).
  * @param {number} y The origin for the symbol (y).

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -151,14 +151,6 @@ ol.RasterOperation;
 
 
 /**
- * Number of features; bounds/extent.
- * @typedef {{numberOfFeatures: number,
- *            bounds: module:ol/extent~Extent}}
- */
-ol.WFSFeatureCollectionMetadata;
-
-
-/**
  * Total deleted; total inserted; total updated; array of insert ids.
  * @typedef {{totalDeleted: number,
  *            totalInserted: number,

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -22,19 +22,6 @@ const ol = {};
 
 
 /**
- * A type that can be used to provide attribution information for data sources.
- *
- * It represents either
- * * a simple string (e.g. `'© Acme Inc.'`)
- * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
- * * a function that returns a string or array of strings (`{@link ol.Attribution}`)
- *
- * @typedef {string|Array.<string>|ol.Attribution}
- */
-ol.AttributionLike;
-
-
-/**
  * A function that returns a string or an array of strings representing source
  * attributions.
  *

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -151,20 +151,6 @@ ol.RasterOperation;
 
 
 /**
- * @typedef {{
- *   strokeStyle: (module:ol/colorlike~ColorLike|undefined),
- *   strokeWidth: number,
- *   size: number,
- *   lineCap: string,
- *   lineDash: Array.<number>,
- *   lineJoin: string,
- *   miterLimit: number
- * }}
- */
-ol.RegularShapeRenderOptions;
-
-
-/**
  * Number of features; bounds/extent.
  * @typedef {{numberOfFeatures: number,
  *            bounds: module:ol/extent~Extent}}

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -128,23 +128,3 @@ ol.DeclutterGroup;
  * @typedef {function(module:ol/extent~Extent, number): Array.<module:ol/extent~Extent>}
  */
 ol.LoadingStrategy;
-
-
-/**
- * A function that takes an array of input data, performs some operation, and
- * returns an array of output data.
- * For `pixel` type operations, the function will be called with an array of
- * pixels, where each pixel is an array of four numbers (`[r, g, b, a]`) in the
- * range of 0 - 255. It should return a single pixel array.
- * For `'image'` type operations, functions will be called with an array of
- * {@link ImageData https://developer.mozilla.org/en-US/docs/Web/API/ImageData}
- * and should return a single {@link ImageData
- * https://developer.mozilla.org/en-US/docs/Web/API/ImageData}.  The operations
- * are called with a second "data" argument, which can be used for storage.  The
- * data object is accessible from raster events, where it can be initialized in
- * "beforeoperations" and accessed again in "afteroperations".
- *
- * @typedef {function((Array.<Array.<number>>|Array.<ImageData>), Object):
- *     (Array.<number>|ImageData)}
- */
-ol.RasterOperation;

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -148,13 +148,3 @@ ol.LoadingStrategy;
  *     (Array.<number>|ImageData)}
  */
 ol.RasterOperation;
-
-
-/**
- * Total deleted; total inserted; total updated; array of insert ids.
- * @typedef {{totalDeleted: number,
- *            totalInserted: number,
- *            totalUpdated: number,
- *            insertIds: Array.<string>}}
- */
-ol.WFSTransactionResponse;

--- a/src/ol/typedefs.js
+++ b/src/ol/typedefs.js
@@ -22,15 +22,6 @@ const ol = {};
 
 
 /**
- * A function that returns a string or an array of strings representing source
- * attributions.
- *
- * @typedef {function(olx.FrameState): (string|Array.<string>)}
- */
-ol.Attribution;
-
-
-/**
  * @typedef {{fillStyle: module:ol/colorlike~ColorLike}}
  */
 ol.CanvasFillState;


### PR DESCRIPTION
Subtask of #7947

ol.Attribution and ol.AttributionLike are used all over ol/source. Although not really related to the base class ol/source/Source, it did seem as the best place to put the typedefs there.

Together with my other pull requests, this moves all typdefs out of typdefs.js but `ol.LoadingStrategy`. I don't know where to put that.