### PR TITLE
Allow unprefixed WMTS tileMatrix identifiers

### DIFF
--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -150,7 +150,15 @@ export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matri
     // TileMatrixSet from unavailable matrix levels.
     if (matrixLimits.length > 0) {
       matrixAvailable = find(matrixLimits, function(elt_ml) {
-        return elt[identifierPropName] == elt_ml[matrixIdsPropName];
+        if (elt[identifierPropName] == elt_ml[matrixIdsPropName]) {
+          return true;
+        }
+        // Fallback for tileMatrix identifiers that don't get prefixed
+        // by their tileMatrixSet identifiers.
+        if (elt[identifierPropName].indexOf(':') === -1) {
+          return matrixSet[identifierPropName] + ':' + elt[identifierPropName] === elt_ml[matrixIdsPropName];
+        }
+        return false;
       });
     } else {
       matrixAvailable = true;

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -143,16 +143,15 @@ export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matri
     return b[scaleDenominatorPropName] - a[scaleDenominatorPropName];
   });
 
-  matrixSet[matrixIdsPropName].forEach(function(elt, index, array) {
+  matrixSet[matrixIdsPropName].forEach(function(elt) {
 
     let matrixAvailable;
     // use of matrixLimits to filter TileMatrices from GetCapabilities
     // TileMatrixSet from unavailable matrix levels.
     if (matrixLimits.length > 0) {
-      matrixAvailable = find(matrixLimits,
-        function(elt_ml, index_ml, array_ml) {
-          return elt[identifierPropName] == elt_ml[matrixIdsPropName];
-        });
+      matrixAvailable = find(matrixLimits, function(elt_ml) {
+        return elt[identifierPropName] == elt_ml[matrixIdsPropName];
+      });
     } else {
       matrixAvailable = true;
     }

--- a/test/spec/ol/format/wmts/ign.xml
+++ b/test/spec/ol/format/wmts/ign.xml
@@ -248,6 +248,25 @@ Conditions Générales d'Utilisation disponibles ici : http://professionnels.ign
           </TileMatrixLimits>
         </TileMatrixSetLimits>
       </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>Prefixed</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>Prefixed:0</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>1</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>1</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>Prefixed:1</TileMatrix>
+            <MinTileRow>0</MinTileRow>
+            <MaxTileRow>2</MaxTileRow>
+            <MinTileCol>0</MinTileCol>
+            <MaxTileCol>2</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
+      </TileMatrixSetLink>
     </Layer>
     <TileMatrixSet>
       <ows:Identifier>PM</ows:Identifier>
@@ -449,6 +468,28 @@ Conditions Générales d'Utilisation disponibles ici : http://professionnels.ign
         <TileHeight>256</TileHeight>
         <MatrixWidth>512</MatrixWidth>
         <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+    <TileMatrixSet>
+      <ows:Identifier>Prefixed</ows:Identifier>
+      <ows:SupportedCRS>EPSG:3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178958533332</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.0143588959472254</ScaleDenominator>
+        <TopLeftCorner>-20037508 20037508</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
       </TileMatrix>
     </TileMatrixSet>
   </Contents>

--- a/test/spec/ol/format/wmtscapabilities.test.js
+++ b/test/spec/ol/format/wmtscapabilities.test.js
@@ -136,21 +136,24 @@ describe('ol.format.WMTSCapabilities', function() {
 
       const layer = capabilities.Contents.Layer[0];
       expect(layer.TileMatrixSetLink).to.be.an('array');
-      expect(layer.TileMatrixSetLink).to.have.length(1);
-      expect(layer.TileMatrixSetLink[0].TileMatrixSet).to.be
-        .eql('PM');
+      expect(layer.TileMatrixSetLink).to.have.length(2);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSet).to.be.eql('PM');
       expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits).to.be.an('array');
       expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits).to.have.length(20);
-      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].TileMatrix)
-        .to.be.eql('0');
-      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MinTileRow)
-        .to.be.eql(0);
-      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MaxTileRow)
-        .to.be.eql(1);
-      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MinTileCol)
-        .to.be.eql(0);
-      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MaxTileCol)
-        .to.be.eql(1);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].TileMatrix).to.be.eql('0');
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MinTileRow).to.be.eql(0);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MaxTileRow).to.be.eql(1);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MinTileCol).to.be.eql(0);
+      expect(layer.TileMatrixSetLink[0].TileMatrixSetLimits[0].MaxTileCol).to.be.eql(1);
+
+      expect(layer.TileMatrixSetLink[1].TileMatrixSet).to.be.eql('Prefixed');
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits).to.be.an('array');
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits).to.have.length(2);
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits[0].TileMatrix).to.be.eql('Prefixed:0');
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits[0].MinTileRow).to.be.eql(0);
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits[0].MaxTileRow).to.be.eql(1);
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits[0].MinTileCol).to.be.eql(0);
+      expect(layer.TileMatrixSetLink[1].TileMatrixSetLimits[0].MaxTileCol).to.be.eql(1);
 
     });
 

--- a/test/spec/ol/tilegrid/wmts.test.js
+++ b/test/spec/ol/tilegrid/wmts.test.js
@@ -145,5 +145,30 @@ describe('ol.tilegrid.WMTS', function() {
             Array.apply(null, Array(20)).map(Number.prototype.valueOf, 256));
 
         });
+
+      it('can use prefixed matrixLimits', function() {
+        const matrixSetObj = capabilities.Contents.TileMatrixSet[1];
+        const matrixLimitArray = capabilities.Contents.Layer[0].TileMatrixSetLink[1].TileMatrixSetLimits;
+        const tileGrid = createFromCapabilitiesMatrixSet(matrixSetObj, undefined, matrixLimitArray);
+        expect(tileGrid.matrixIds_).to.be.an('array');
+        expect(tileGrid.matrixIds_).to.have.length(2);
+        expect(tileGrid.matrixIds_).to.eql(['0', '1']);
+
+        expect(tileGrid.resolutions_).to.be.an('array');
+        expect(tileGrid.resolutions_).to.have.length(2);
+        expect(tileGrid.resolutions_).to.eql([156543.033928041, 78271.51696402048]);
+
+        expect(tileGrid.origins_).to.be.an('array');
+        expect(tileGrid.origins_).to.have.length(2);
+        expect(tileGrid.origins_).to.eql(
+          Array.apply(null, Array(2)).map(Array.prototype.valueOf, [-20037508, 20037508])
+        );
+
+        expect(tileGrid.tileSizes_).to.be.an('array');
+        expect(tileGrid.tileSizes_).to.have.length(2);
+        expect(tileGrid.tileSizes_).to.eql(
+          Array.apply(null, Array(2)).map(Number.prototype.valueOf, 256)
+        );
+      });
     });
 });


### PR DESCRIPTION
replace #7167
fixes #6699

Original code by @filipheymans