### PR TITLE
Fix some jsdoc path types

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -25,7 +25,7 @@ const Property = {
  * @constructor
  * @extends {module:ol/events/Event~Event}
  * @implements {oli.CollectionEvent}
- * @param {module:ol/CollectionEventType~CollectionEventType} type Type.
+ * @param {module:ol/CollectionEventType} type Type.
  * @param {*=} opt_element Element.
  */
 export const CollectionEvent = function(type, opt_element) {

--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -59,7 +59,7 @@ inherits(CollectionEvent, Event);
  * Collection as a whole.
  *
  * @constructor
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @fires module:ol/Collection~CollectionEvent
  * @param {Array.<T>=} opt_array Array.
  * @param {module:ol/Collection~Options=} opt_options Collection options.

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -18,7 +18,7 @@ import Style from './style/Style.js';
  * Features can be styled individually with `setStyle`; otherwise they use the
  * style of their vector layer.
  *
- * Note that attribute properties are set as {@link module:ol/Object~Object} properties on
+ * Note that attribute properties are set as {@link module:ol/Object~BaseObject} properties on
  * the feature object, so they are observable, and have get/set accessors.
  *
  * Typically, a feature has a single geometry property. You can set the
@@ -52,7 +52,7 @@ import Style from './style/Style.js';
  * ```
  *
  * @constructor
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @param {module:ol/geom/Geometry~Geometry|Object.<string, *>=} opt_geometryOrProperties
  * You may pass a Geometry object directly, or an object literal containing
  * properties. If you pass an object literal, you may include a Geometry

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -45,7 +45,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
  *
  * @fires error
  * @constructor
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @param {module:ol/Geolocation~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -605,7 +605,7 @@ Graticule.prototype.getParallels = function() {
 
 
 /**
- * @param {module:ol/render/Event~Event} e Event.
+ * @param {module:ol/render/Event~RenderEvent} e Event.
  * @private
  */
 Graticule.prototype.handlePostCompose_ = function(e) {

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -9,10 +9,16 @@ import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 
 /**
+ * @typedef {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord,
+ * module:ol/TileState, string, ?string, ol.TileLoadFunctionType)} TileClass
+ * @api
+ */
+
+/**
  * @constructor
  * @extends {module:ol/Tile~Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  * @param {string} src Image source URI.
  * @param {?string} crossOrigin Cross origin.
  * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -62,8 +62,8 @@ import CanvasVectorTileLayerRenderer from './renderer/canvas/VectorTileLayer.js'
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent
- * @fires module:ol/render/Event~Event#postcompose
- * @fires module:ol/render/Event~Event#precompose
+ * @fires module:ol/render/Event~RenderEvent#postcompose
+ * @fires module:ol/render/Event~RenderEvent#precompose
  * @api
  */
 const Map = function(options) {

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -10,7 +10,7 @@ import {assign} from './obj.js';
 
 /**
  * @classdesc
- * Events emitted by {@link module:ol/Object~Object} instances are instances of
+ * Events emitted by {@link module:ol/Object~BaseObject} instances are instances of
  * this type.
  *
  * @param {string} type The event type.
@@ -71,7 +71,7 @@ inherits(ObjectEvent, Event);
  * `object.set('prop', 'value')`, and retrieve that with `object.get('prop')`.
  * You can listen for changes on that property value with
  * `object.on('change:prop', listener)`. You can get a list of all
- * properties with {@link module:ol/Object~Object#getProperties}.
+ * properties with {@link module:ol/Object~BaseObject#getProperties}.
  *
  * Note that the observable properties are separate from standard JS properties.
  * You can, for example, give your map object a title with

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -94,7 +94,7 @@ const Property = {
  *     map.addOverlay(popup);
  *
  * @constructor
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @param {module:ol/Overlay~Options} options Overlay options.
  * @api
  */

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -136,8 +136,8 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent
- * @fires module:ol/render/Event~Event#postcompose
- * @fires module:ol/render/Event~Event#precompose
+ * @fires module:ol/render/Event~RenderEvent#postcompose
+ * @fires module:ol/render/Event~RenderEvent#precompose
  * @api
  */
 const PluggableMap = function(options) {

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -132,7 +132,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @constructor
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -16,7 +16,6 @@ import EventType from './events/EventType.js';
  * @api
  */
 
-
 /**
  * {@link module:ol/source/Tile~Tile} sources use a function of this type to get
  * the url that provides a tile for a given tile coordinate.
@@ -49,7 +48,7 @@ import EventType from './events/EventType.js';
  * @abstract
  * @extends {module:ol/events/EventTarget~EventTarget}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  * @param {module:ol/Tile~Options=} opt_options Tile options.
  */
 const Tile = function(tileCoord, state, opt_options) {
@@ -64,7 +63,7 @@ const Tile = function(tileCoord, state, opt_options) {
 
   /**
    * @protected
-   * @type {module:ol/TileState~TileState}
+   * @type {module:ol/TileState}
    */
   this.state = state;
 
@@ -190,14 +189,14 @@ Tile.prototype.getTileCoord = function() {
 
 
 /**
- * @return {module:ol/TileState~TileState} State.
+ * @return {module:ol/TileState} State.
  */
 Tile.prototype.getState = function() {
   return this.state;
 };
 
 /**
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  */
 Tile.prototype.setState = function(state) {
   this.state = state;

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -24,7 +24,7 @@ import {loadFeaturesXhr} from './featureloader.js';
  * @constructor
  * @extends {module:ol/Tile~Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  * @param {number} sourceRevision Source revision.
  * @param {module:ol/format/Feature~FeatureFormat} format Feature format.
  * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
@@ -35,7 +35,7 @@ import {loadFeaturesXhr} from './featureloader.js';
  * @param {Object.<string, module:ol/VectorTile~VectorTile>} sourceTiles Source tiles.
  * @param {number} pixelRatio Pixel ratio.
  * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @param {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState~TileState, string,
+ * @param {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
  *     module:ol/format/Feature~FeatureFormat, module:ol/Tile~LoadFunction)} tileClass Class to
  *     instantiate for source tiles.
  * @param {function(this: module:ol/source/VectorTile~VectorTile, module:ol/events/Event~Event)} handleTileChange

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -6,10 +6,16 @@ import Tile from './Tile.js';
 import TileState from './TileState.js';
 
 /**
+ * @typedef {function(new: ol.VectorTile, module:ol/tilecoord~TileCoord,
+ * module:ol/TileState, string, ?string, ol.TileLoadFunctionType)} TileClass
+ * @api
+ */
+
+/**
  * @constructor
  * @extends {module:ol/Tile~Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  * @param {string} src Data source url.
  * @param {module:ol/format/Feature~FeatureFormat} format Feature format.
  * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -225,7 +225,7 @@ const DEFAULT_MIN_ZOOM = 0;
  * default the center is not constrained at all.
  *
  * @constructor
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @param {module:ol/View~ViewOptions=} opt_options View options.
  * @api
  */

--- a/src/ol/WebGLMap.js
+++ b/src/ol/WebGLMap.js
@@ -62,8 +62,8 @@ import WebGLVectorLayerRenderer from './renderer/webgl/VectorLayer.js';
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent
- * @fires module:ol/render/Event~Event#postcompose
- * @fires module:ol/render/Event~Event#precompose
+ * @fires module:ol/render/Event~RenderEvent#postcompose
+ * @fires module:ol/render/Event~RenderEvent#precompose
  * @api
  */
 const WebGLMap = function(options) {

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -24,7 +24,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @const
- * @type {Object.<module:ol/geom/GeometryType~GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry~Geometry>}
+ * @type {Object.<module:ol/geom/GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry~Geometry>}
  */
 const GEOMETRY_READERS = {};
 GEOMETRY_READERS[GeometryType.POINT] = readPointGeometry;
@@ -90,7 +90,7 @@ function readGeometry(object, opt_options) {
   if (!object) {
     return null;
   }
-  /** @type {module:ol/geom/GeometryType~GeometryType} */
+  /** @type {module:ol/geom/GeometryType} */
   let type;
   if (typeof object.x === 'number' && typeof object.y === 'number') {
     type = GeometryType.POINT;

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -125,7 +125,7 @@ FeatureFormat.prototype.getLastExtent = function() {
 
 /**
  * @abstract
- * @return {module:ol/format/FormatType~FormatType} Format.
+ * @return {module:ol/format/FormatType} Format.
  */
 FeatureFormat.prototype.getType = function() {};
 

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -24,7 +24,7 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {function((module:ol/geom/Geometry~Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType~GeometryType,Array.<number>,(Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)} [featureClass]
+ * @property {function((module:ol/geom/Geometry~Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType,Array.<number>,(Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)} [featureClass]
  * Class for features returned by {@link ol.format.MVT#readFeatures}. Set to
  * {@link module:ol/Feature~Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link module:ol/render/Feature~RenderFeature},
@@ -64,7 +64,7 @@ const MVT = function(opt_options) {
   /**
    * @private
    * @type {function((module:ol/geom/Geometry~Geometry|Object.<string,*>)=)|
-   *     function(module:ol/geom/GeometryType~GeometryType,Array.<number>,
+   *     function(module:ol/geom/GeometryType,Array.<number>,
    *         (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
    */
   this.featureClass_ = options.featureClass ?
@@ -272,10 +272,10 @@ MVT.prototype.readRawGeometry_ = function(pbf, feature, flatCoordinates, ends) {
  * @param {number} type The raw feature's geometry type
  * @param {number} numEnds Number of ends of the flat coordinates of the
  * geometry.
- * @return {module:ol/geom/GeometryType~GeometryType} The geometry type.
+ * @return {module:ol/geom/GeometryType} The geometry type.
  */
 function getGeometryType(type, numEnds) {
-  /** @type {module:ol/geom/GeometryType~GeometryType} */
+  /** @type {module:ol/geom/GeometryType} */
   let geometryType;
   if (type === 1) {
     geometryType = numEnds === 1 ?

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -10,6 +10,7 @@ import {get as getProjection, getTransform} from '../proj.js';
 import Units from '../proj/Units.js';
 import {create as createTransform, compose as composeTransform} from '../transform.js';
 
+
 /**
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
@@ -203,7 +204,7 @@ Geometry.prototype.getSimplifiedGeometry = function(squaredTolerance) {};
 /**
  * Get the type of this geometry.
  * @abstract
- * @return {module:ol/geom/GeometryType~GeometryType} Geometry type.
+ * @return {module:ol/geom/GeometryType} Geometry type.
  */
 Geometry.prototype.getType = function() {};
 

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -106,7 +106,7 @@ inherits(DragBoxEvent, Event);
  * This interaction is only supported for mouse devices.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @fires module:ol/interaction/DragBox~DragBoxEvent
  * @param {module:ol/interaction/DragBox~Options=} opt_options Options.
  * @api

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -24,7 +24,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  * Allows the user to pan the map by dragging the map.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/DragPan~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -29,7 +29,7 @@ import PointerInteraction from '../interaction/Pointer.js';
  * This interaction is only supported for mouse devices.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/DragRotate~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -30,7 +30,7 @@ import PointerInteraction from '../interaction/Pointer.js';
  * And this interaction is not included in the default interactions.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/DragRotateAndZoom~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -31,7 +31,7 @@ import {createEditingStyle} from '../style/Style.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/geom/GeometryType~GeometryType} type Geometry type of
+ * @property {module:ol/geom/GeometryType} type Geometry type of
  * the geometries being drawn with this instance.
  * @property {number} [clickTolerance=6] The maximum distance in pixels between
  * "down" and "up" for a "up" event to be considered a "click" event and
@@ -222,10 +222,10 @@ const Draw = function(options) {
 
   /**
    * Geometry type.
-   * @type {module:ol/geom/GeometryType~GeometryType}
+   * @type {module:ol/geom/GeometryType}
    * @private
    */
-  this.type_ = /** @type {module:ol/geom/GeometryType~GeometryType} */ (options.type);
+  this.type_ = /** @type {module:ol/geom/GeometryType} */ (options.type);
 
   /**
    * Drawing mode (derived from geometry type.
@@ -1008,7 +1008,7 @@ export function createBox() {
 /**
  * Get the drawing mode.  The mode for mult-part geometries is the same as for
  * their single-part cousins.
- * @param {module:ol/geom/GeometryType~GeometryType} type Geometry type.
+ * @param {module:ol/geom/GeometryType} type Geometry type.
  * @return {module:ol/interaction/Draw~Mode} Drawing mode.
  */
 function getMode(type) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -156,7 +156,7 @@ inherits(DrawEvent, Event);
  * Interaction for drawing feature geometries.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @fires module:ol/interaction/Draw~DrawEvent
  * @param {module:ol/interaction/Draw~Options} options Options.
  * @api

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -23,12 +23,12 @@ import {createEditingStyle} from '../style/Style.js';
  * initial extent.
  * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [boxStyle]
  * Style for the drawn extent box. Defaults to
- * {@link module:ol/style/Style~createEditing()[module:ol/geom/GeometryType~GeometryType.POLYGON]}
+ * {@link module:ol/style/Style~createEditing()[module:ol/geom/GeometryType.POLYGON]}
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
  * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [pointerStyle]
  * Style for the cursor used to draw the extent. Defaults to
- * {@link module:ol/style/Style~createEditing()[module:ol/geom/GeometryType~GeometryType.POINT]}
+ * {@link module:ol/style/Style~createEditing()[module:ol/geom/GeometryType.POINT]}
  * @property {boolean} [wrapX=false] Wrap the drawn extent across multiple maps
  * in the X direction? Only affects visuals, not functionality.
  */

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -78,7 +78,7 @@ inherits(ExtentInteractionEvent, Event);
  * This interaction is only supported for mouse devices.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @fires module:ol/interaction/Extent~Event
  * @param {module:ol/interaction/Extent~Options=} opt_options Options.
  * @api

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -23,12 +23,12 @@ import {createEditingStyle} from '../style/Style.js';
  * initial extent.
  * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [boxStyle]
  * Style for the drawn extent box. Defaults to
- * {@link module:ol/style/Style~createEditing()[module:ol/geom/GeometryType.POLYGON]}
+ * {@link module:ol/style/Style~createEditing()['Polygon']}
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
  * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [pointerStyle]
  * Style for the cursor used to draw the extent. Defaults to
- * {@link module:ol/style/Style~createEditing()[module:ol/geom/GeometryType.POINT]}
+ * {@link module:ol/style/Style~createEditing()['Point']}
  * @property {boolean} [wrapX=false] Wrap the drawn extent across multiple maps
  * in the X direction? Only affects visuals, not functionality.
  */

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -33,7 +33,7 @@ import {clamp} from '../math.js';
  *
  * @constructor
  * @param {module:ol/interaction/Interaction~InteractionOptions} options Options.
- * @extends {module:ol/Object~Object}
+ * @extends {module:ol/Object~BaseObject}
  * @api
  */
 const Interaction = function(options) {

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -136,7 +136,7 @@ inherits(ModifyEvent, Event);
  * for deletion, use the `deleteCondition` option.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/Modify~Options} options Options.
  * @fires module:ol/interaction/Modify~ModifyEvent
  * @api

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -23,7 +23,7 @@ import {disable} from '../rotationconstraint.js';
  * on a touch screen.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/PinchRotate~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -22,7 +22,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  * on a touch screen.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/PinchZoom~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -64,7 +64,7 @@ import RBush from '../structs/RBush.js';
  *     });
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @param {module:ol/interaction/Snap~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -92,7 +92,7 @@ inherits(TranslateEvent, Event);
  * Interaction for translating (moving) features.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~Pointer}
+ * @extends {module:ol/interaction/Pointer~PointerInteraction}
  * @fires module:ol/interaction/Translate~TranslateEvent
  * @param {module:ol/interaction/Translate~Options=} opt_options Options.
  * @api

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -28,7 +28,7 @@ import {assign} from '../obj.js';
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
  * Note that with `module:ol/layer/Base~BaseLayer` and all its subclasses, any property set in
- * the options is set as a {@link module:ol/Object~BaseObject} property on the layer object, so
+ * the options is set as a {@link module:ol/Object~BaseObject property on the layer object, so
  * is observable, and has get/set accessors.
  *
  * @constructor

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -69,7 +69,7 @@ const BaseLayer = function(options) {
 
   /**
    * The layer type.
-   * @type {module:ol/LayerType~LayerType}
+   * @type {module:ol/LayerType}
    * @protected;
    */
   this.type;
@@ -81,7 +81,7 @@ inherits(BaseLayer, BaseObject);
 
 /**
  * Get the layer type (used when creating a layer renderer).
- * @return {module:ol/LayerType~LayerType} The layer type.
+ * @return {module:ol/LayerType} The layer type.
  */
 BaseLayer.prototype.getType = function() {
   return this.type;

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -58,7 +58,7 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
 /**
  * @classdesc
  * Layer for rendering vector data as a heatmap.
- * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -47,7 +47,7 @@ const ImageLayer = function(opt_options) {
   /**
    * The layer type.
    * @protected
-   * @type {module:ol/LayerType~LayerType}
+   * @type {module:ol/LayerType}
    */
   this.type = LayerType.IMAGE;
 

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -30,7 +30,7 @@ import Layer from '../layer/Layer.js';
  * @classdesc
  * Server-rendered images that are available for arbitrary extents and
  * resolutions.
- * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -61,7 +61,7 @@ const TileLayer = function(opt_options) {
   /**
    * The layer type.
    * @protected
-   * @type {module:ol/LayerType~LayerType}
+   * @type {module:ol/LayerType}
    */
   this.type = LayerType.TILE;
 

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -35,7 +35,7 @@ import {assign} from '../obj.js';
  * @classdesc
  * For layer sources that provide pre-rendered, tiled images in grids that are
  * organized by zoom levels for specific resolutions.
- * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -64,7 +64,7 @@ const Property = {
 /**
  * @classdesc
  * Vector data that is rendered client-side.
- * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * Note that any property set in the options is set as a {@link }
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -27,7 +27,7 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  * @property {number} [renderBuffer=100] The buffer in pixels around the viewport extent used by the
  * renderer when getting features from the vector source for the rendering or hit-detection.
  * Recommended value: the size of the largest symbol, line width or label.
- * @property {module:ol/layer/VectorRenderType~VectorRenderType|string} [renderMode='vector'] Render mode for vector layers:
+ * @property {module:ol/layer/VectorRenderType|string} [renderMode='vector'] Render mode for vector layers:
  *  * `'image'`: Vector layers are rendered as images. Great performance, but point symbols and
  *    texts are always rotated with the view and pixels are scaled during zoom animations.
  *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering even during
@@ -50,6 +50,22 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  * @property {boolean} [updateWhileInteracting=false] When set to `true`, feature batches will be
  * recreated during interactions. See also `updateWhileAnimating`.
  */
+
+
+/**
+ * @enum {string}
+ * Render mode for vector layers:
+ *  * `'image'`: Vector layers are rendered as images. Great performance, but
+ *    point symbols and texts are always rotated with the view and pixels are
+ *    scaled during zoom animations.
+ *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering
+ *    even during animations, but slower performance.
+ * @api
+ */
+export const RenderType = {
+  IMAGE: 'image',
+  VECTOR: 'vector'
+};
 
 
 /**
@@ -138,7 +154,7 @@ const VectorLayer = function(opt_options) {
   /**
    * The layer type.
    * @protected
-   * @type {module:ol/LayerType~LayerType}
+   * @type {module:ol/LayerType}
    */
   this.type = LayerType.VECTOR;
 
@@ -258,7 +274,7 @@ VectorLayer.prototype.setStyle = function(style) {
 
 
 /**
- * @return {module:ol/layer/VectorRenderType~VectorRenderType|string} The render mode.
+ * @return {module:ol/layer/VectorRenderType|string} The render mode.
  */
 VectorLayer.prototype.getRenderMode = function() {
   return this.renderMode_;

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -71,7 +71,7 @@ import {assign} from '../obj.js';
 /**
  * @classdesc
  * Layer for vector tile data that is rendered client-side.
- * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * Note that any property set in the options is set as a {@link }
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -11,6 +11,26 @@ import {assign} from '../obj.js';
 
 
 /**
+ * @enum {string}
+ * Render mode for vector tiles:
+ *  * `'image'`: Vector tiles are rendered as images. Great performance, but
+ *    point symbols and texts are always rotated with the view and pixels are
+ *    scaled during zoom animations.
+ *  * `'hybrid'`: Polygon and line elements are rendered as images, so pixels
+ *    are scaled during zoom animations. Point symbols and texts are accurately
+ *    rendered as vectors and can stay upright on rotated views.
+ *  * `'vector'`: Vector tiles are rendered as vectors. Most accurate rendering
+ *    even during animations, but slower performance than the other options.
+ * @api
+ */
+export const RenderType = {
+  IMAGE: 'image',
+  HYBRID: 'hybrid',
+  VECTOR: 'vector'
+};
+
+
+/**
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
@@ -30,7 +50,7 @@ import {assign} from '../obj.js';
  * Recommended value: Vector tiles are usually generated with a buffer, so this value should match
  * the largest possible buffer of the used tiles. It should be at least the size of the largest
  * point symbol or line width.
- * @property {module:ol/layer/VectorRenderType~VectorRenderType|string} [renderMode='hybrid'] Render mode for vector tiles:
+ * @property {module:ol/layer/VectorTileRenderType|string} [renderMode='hybrid'] Render mode for vector tiles:
  *  * `'image'`: Vector tiles are rendered as images. Great performance, but point symbols and texts
  *    are always rotated with the view and pixels are scaled during zoom animations.
  *  * `'hybrid'`: Polygon and line elements are rendered as images, so pixels are scaled during zoom
@@ -71,7 +91,7 @@ import {assign} from '../obj.js';
 /**
  * @classdesc
  * Layer for vector tile data that is rendered client-side.
- * Note that any property set in the options is set as a {@link }
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
@@ -107,7 +127,7 @@ const VectorTileLayer = function(opt_options) {
   /**
    * The layer type.
    * @protected
-   * @type {module:ol/LayerType~LayerType}
+   * @type {module:ol/LayerType}
    */
   this.type = LayerType.VECTOR_TILE;
 

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -17,7 +17,7 @@ import {create as createTransform, compose as composeTransform} from '../transfo
  * through the API is limited to getting the type and extent of the geometry.
  *
  * @constructor
- * @param {module:ol/geom/GeometryType~GeometryType} type Geometry type.
+ * @param {module:ol/geom/GeometryType} type Geometry type.
  * @param {Array.<number>} flatCoordinates Flat coordinates. These always need
  *     to be right-handed for polygons.
  * @param {Array.<number>|Array.<Array.<number>>} ends Ends or Endss.
@@ -39,7 +39,7 @@ const RenderFeature = function(type, flatCoordinates, ends, properties, id) {
 
   /**
    * @private
-   * @type {module:ol/geom/GeometryType~GeometryType}
+   * @type {module:ol/geom/GeometryType}
    */
   this.type_ = type;
 
@@ -249,7 +249,7 @@ RenderFeature.prototype.getStyleFunction = UNDEFINED;
 
 /**
  * Get the type of this feature's geometry.
- * @return {module:ol/geom/GeometryType~GeometryType} Geometry type.
+ * @return {module:ol/geom/GeometryType} Geometry type.
  * @api
  */
 RenderFeature.prototype.getType = function() {

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -41,7 +41,7 @@ const MapRenderer = function(map) {
 
   /**
    * @private
-   * @type {Array.<module:ol/renderer/Layer~LayerRenderer}
+   * @type {Array.<module:ol/renderer/Layer~LayerRenderer>}
    */
   this.layerRendererConstructors_ = [];
 

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -16,7 +16,7 @@ const SIMPLIFY_TOLERANCE = 0.5;
 
 /**
  * @const
- * @type {Object.<module:ol/geom/GeometryType~GeometryType,
+ * @type {Object.<module:ol/geom/GeometryType,
  *                function(module:ol/render/ReplayGroup~ReplayGroup, module:ol/geom/Geometry~Geometry,
  *                         module:ol/style/Style~Style, Object)>}
  */

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -27,9 +27,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * @property {boolean} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {module:ol/source/State~State} [state] Source state.
- * @property {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord,
- *                 module:ol/TileState~TileState, string, ?string,
- *                 ol.TileLoadFunctionType)} [tileClass] Class used to instantiate image tiles.
+ * @property {module:ol/ImageTile~TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/ImageTile~ImageTile}.
  * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid.
  * @property {ol.TileLoadFunctionType} [tileLoadFunction] Optional function to load a tile given a URL. The default is
@@ -95,7 +93,7 @@ const TileImage = function(options) {
 
   /**
    * @protected
-   * @type {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord, module:ol/TileState~TileState, string,
+   * @type {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
    *        ?string, module:ol/Tile~LoadFunction, module:ol/Tile~Options=)}
    */
   this.tileClass = options.tileClass !== undefined ?

--- a/src/ol/source/TileUTFGrid.js
+++ b/src/ol/source/TileUTFGrid.js
@@ -21,7 +21,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * @constructor
  * @extends {module:ol/Tile~Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  * @param {string} src Image source URI.
  * @param {module:ol/extent~Extent} extent Extent of the tile.
  * @param {boolean} preemptive Load the tile when visible (before it's needed).

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -43,10 +43,8 @@ import {appendParams} from '../uri.js';
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {boolean} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord,
- *                 module:ol/TileState~TileState, string, ?string,
- *                 ol.TileLoadFunctionType)} [tileClass] Class used to instantiate image tiles.
- * Default is {@link module:ol/ImageTile~ImageTile}.
+ * @property {module:ol/ImageTile~TileClass} [tileClass] Class used to instantiate image tiles.
+ * Default is {@link module:ol/ImageTile~TileClass}.
  * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid. Base this on the resolutions,
  * tilesize and extent supported by the server.
  * If this is not defined, a default grid will be used: if there is a projection

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -21,9 +21,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * stroke operations.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {module:ol/source/State~State} [state] Source state.
- * @property {function(new: ol.VectorTile, module:ol/tilecoord~TileCoord,
- *                 module:ol/TileState~TileState, string, ?string,
- *                 ol.TileLoadFunctionType)} [tileClass] Class used to instantiate image tiles.
+ * @property {module:ol/VectorTile~TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link ol.VectorTile}.
  * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid.
  * @property {ol.TileLoadFunctionType} [tileLoadFunction]
@@ -118,7 +116,7 @@ const VectorTile = function(options) {
 
   /**
    * @protected
-   * @type {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState~TileState, string,
+   * @type {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
    *        module:ol/format/Feature~FeatureFormat, module:ol/Tile~LoadFunction)}
    */
   this.tileClass = options.tileClass ? options.tileClass : Tile;

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -27,9 +27,7 @@ import {appendParams} from '../uri.js';
  * @property {ol.source.WMTSRequestEncoding|string} [requestEncoding='KVP'] Request encoding.
  * @property {string} layer Layer name as advertised in the WMTS capabilities.
  * @property {string} style Style name as advertised in the WMTS capabilities.
- * @property {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord,
- *                 module:ol/TileState~TileState, string, ?string,
- *                 ol.TileLoadFunctionType)} [tileClass]  Class used to instantiate image tiles. Default is {@link module:ol/ImageTile~ImageTile}.
+ * @property {module:ol/ImageTile~TileClass} [tileClass]  Class used to instantiate image tiles. Default is {@link module:ol/ImageTile~ImageTile}.
  * @property {number} [tilePixelRatio=1] The pixel ratio used by the tile service.
  * For example, if the tile service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -28,7 +28,7 @@ const TierSizeCalculation = {
  * @extends {module:ol/ImageTile~ImageTile}
  * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid TileGrid that the tile belongs to.
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileState~TileState} state State.
+ * @param {module:ol/TileState} state State.
  * @param {string} src Image source URI.
  * @param {?string} crossOrigin Cross origin.
  * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -380,10 +380,10 @@ export function createDefaultStyle(feature, resolution) {
 
 /**
  * Default styles for editing features.
- * @return {Object.<module:ol/geom/GeometryType~GeometryType, Array.<module:ol/style/Style~Style>>} Styles
+ * @return {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style~Style>>} Styles
  */
 export function createEditingStyle() {
-  /** @type {Object.<module:ol/geom/GeometryType~GeometryType, Array.<module:ol/style/Style~Style>>} */
+  /** @type {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style~Style>>} */
   const styles = {};
   const white = [255, 255, 255, 1];
   const blue = [0, 153, 255, 1];

--- a/src/ol/style/index.jsdoc
+++ b/src/ol/style/index.jsdoc
@@ -25,19 +25,20 @@
  *
  * A separate editing style has the following defaults:
  * ```js
+ * import GeometryType from ol/geom/GeometryType
  *  var white = [255, 255, 255, 1];
  *  var blue = [0, 153, 255, 1];
  *  var width = 3;
- *  styles[module:ol/geom/GeometryType.POLYGON] = [
+ *  styles[GeometryType.POLYGON] = [
  *    new ol.style.Style({
  *      fill: new ol.style.Fill({
  *        color: [255, 255, 255, 0.5]
  *      })
  *    })
  *  ];
- *  styles[module:ol/geom/GeometryType.MULTI_POLYGON] =
- *      styles[module:ol/geom/GeometryType.POLYGON];
- *  styles[module:ol/geom/GeometryType.LINE_STRING] = [
+ *  styles[GeometryType.MULTI_POLYGON] =
+ *      styles[GeometryType.POLYGON];
+ *  styles[GeometryType.LINE_STRING] = [
  *    new ol.style.Style({
  *      stroke: new ol.style.Stroke({
  *        color: white,
@@ -51,9 +52,9 @@
  *      })
  *    })
  *  ];
- *  styles[module:ol/geom/GeometryType.MULTI_LINE_STRING] =
- *      styles[module:ol/geom/GeometryType.LINE_STRING];
- *  styles[module:ol/geom/GeometryType.POINT] = [
+ *  styles[GeometryType.MULTI_LINE_STRING] =
+ *      styles[GeometryType.LINE_STRING];
+ *  styles[GeometryType.POINT] = [
  *    new ol.style.Style({
  *      image: new ol.style.Circle({
  *        radius: width * 2,
@@ -68,11 +69,11 @@
  *      zIndex: Infinity
  *    })
  *  ];
- *  styles[module:ol/geom/GeometryType.MULTI_POINT] =
- *      styles[module:ol/geom/GeometryType.POINT];
- *  styles[module:ol/geom/GeometryType.GEOMETRY_COLLECTION] =
- *      styles[module:ol/geom/GeometryType.POLYGON].concat(
- *          styles[module:ol/geom/GeometryType.POINT]
+ *  styles[GeometryType.MULTI_POINT] =
+ *      styles[GeometryType.POINT];
+ *  styles[GEOMETRY_COLLECTION] =
+ *      styles[GeometryType.POLYGON].concat(
+ *          styles[GeometryType.POINT]
  *      );
  *```
  *

--- a/src/ol/style/index.jsdoc
+++ b/src/ol/style/index.jsdoc
@@ -28,16 +28,16 @@
  *  var white = [255, 255, 255, 1];
  *  var blue = [0, 153, 255, 1];
  *  var width = 3;
- *  styles[module:ol/geom/GeometryType~GeometryType.POLYGON] = [
+ *  styles[module:ol/geom/GeometryType.POLYGON] = [
  *    new ol.style.Style({
  *      fill: new ol.style.Fill({
  *        color: [255, 255, 255, 0.5]
  *      })
  *    })
  *  ];
- *  styles[module:ol/geom/GeometryType~GeometryType.MULTI_POLYGON] =
- *      styles[module:ol/geom/GeometryType~GeometryType.POLYGON];
- *  styles[module:ol/geom/GeometryType~GeometryType.LINE_STRING] = [
+ *  styles[module:ol/geom/GeometryType.MULTI_POLYGON] =
+ *      styles[module:ol/geom/GeometryType.POLYGON];
+ *  styles[module:ol/geom/GeometryType.LINE_STRING] = [
  *    new ol.style.Style({
  *      stroke: new ol.style.Stroke({
  *        color: white,
@@ -51,9 +51,9 @@
  *      })
  *    })
  *  ];
- *  styles[module:ol/geom/GeometryType~GeometryType.MULTI_LINE_STRING] =
- *      styles[module:ol/geom/GeometryType~GeometryType.LINE_STRING];
- *  styles[module:ol/geom/GeometryType~GeometryType.POINT] = [
+ *  styles[module:ol/geom/GeometryType.MULTI_LINE_STRING] =
+ *      styles[module:ol/geom/GeometryType.LINE_STRING];
+ *  styles[module:ol/geom/GeometryType.POINT] = [
  *    new ol.style.Style({
  *      image: new ol.style.Circle({
  *        radius: width * 2,
@@ -68,11 +68,11 @@
  *      zIndex: Infinity
  *    })
  *  ];
- *  styles[module:ol/geom/GeometryType~GeometryType.MULTI_POINT] =
- *      styles[module:ol/geom/GeometryType~GeometryType.POINT];
- *  styles[module:ol/geom/GeometryType~GeometryType.GEOMETRY_COLLECTION] =
- *      styles[module:ol/geom/GeometryType~GeometryType.POLYGON].concat(
- *          styles[module:ol/geom/GeometryType~GeometryType.POINT]
+ *  styles[module:ol/geom/GeometryType.MULTI_POINT] =
+ *      styles[module:ol/geom/GeometryType.POINT];
+ *  styles[module:ol/geom/GeometryType.GEOMETRY_COLLECTION] =
+ *      styles[module:ol/geom/GeometryType.POLYGON].concat(
+ *          styles[module:ol/geom/GeometryType.POINT]
  *      );
  *```
  *


### PR DESCRIPTION
The latest version of `babel-plugin-jsdoc-closure` (#8102) reveals a few path type conversion mistakes, which are fixed by this pull request.