### PR TITLE
Re-export format constructors from ol/format

### DIFF
--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -1,10 +1,6 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import GPX from '../src/ol/format/GPX.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import IGC from '../src/ol/format/IGC.js';
-import KML from '../src/ol/format/KML.js';
-import TopoJSON from '../src/ol/format/TopoJSON.js';
+import {GPX, GeoJSON, IGC, KML, TopoJSON} from '../src/ol/format.js';
 import {defaults as defaultInteractions} from '../src/ol/interaction.js';
 import DragAndDrop from '../src/ol/interaction/DragAndDrop.js';
 import VectorLayer from '../src/ol/layer/Vector.js';

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -1,10 +1,6 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import GPX from '../src/ol/format/GPX.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import IGC from '../src/ol/format/IGC.js';
-import KML from '../src/ol/format/KML.js';
-import TopoJSON from '../src/ol/format/TopoJSON.js';
+import {GPX, GeoJSON, IGC, KML, TopoJSON} from '../src/ol/format.js';
 import {defaults as defaultInteractions} from '../src/ol/interaction.js';
 import DragAndDrop from '../src/ol/interaction/DragAndDrop.js';
 import TileLayer from '../src/ol/layer/Tile.js';

--- a/examples/vector-wfs-getfeature.js
+++ b/examples/vector-wfs-getfeature.js
@@ -5,8 +5,7 @@ import {
   like as likeFilter,
   and as andFilter
 } from '../src/ol/format/filter.js';
-import WFS from '../src/ol/format/WFS.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
+import {WFS, GeoJSON} from '../src/ol/format.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import BingMaps from '../src/ol/source/BingMaps.js';

--- a/src/ol/format.js
+++ b/src/ol/format.js
@@ -1,0 +1,19 @@
+/**
+ * @module ol/format
+ */
+
+export {default as EsriJSON} from './format/EsriJSON.js';
+export {default as GeoJSON} from './format/GeoJSON.js';
+export {default as GML} from './format/GML.js';
+export {default as GPX} from './format/GPX.js';
+export {default as IGC} from './format/IGC.js';
+export {default as KML} from './format/KML.js';
+export {default as MVT} from './format/MVT.js';
+export {default as OWS} from './format/OWS.js';
+export {default as Polyline} from './format/Polyline.js';
+export {default as TopoJSON} from './format/TopoJSON.js';
+export {default as WFS} from './format/WFS.js';
+export {default as WKT} from './format/WKT.js';
+export {default as WMSCapabilities} from './format/WMSCapabilities.js';
+export {default as WMSGetFeatureInfo} from './format/WMSGetFeatureInfo.js';
+export {default as WMTSCapabilities} from './format/WMTSCapabilities.js';


### PR DESCRIPTION
This makes the format constructors available from the `ol/format` module.

See #8110.