### PR TITLE
Re-export style constructors from ol/style

### DIFF
--- a/examples/blend-modes.js
+++ b/examples/blend-modes.js
@@ -4,10 +4,7 @@ import View from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 // Create separate layers for red, green an blue circles.

--- a/examples/canvas-gradient-pattern.js
+++ b/examples/canvas-gradient-pattern.js
@@ -6,9 +6,7 @@ import {DEVICE_PIXEL_RATIO} from '../src/ol/has.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 
 const canvas = document.createElement('canvas');
 const context = canvas.getContext('2d');

--- a/examples/center.js
+++ b/examples/center.js
@@ -4,10 +4,7 @@ import {defaults as defaultControls} from '../src/ol/control.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 const source = new VectorSource({
   url: 'data/geojson/switzerland.geojson',

--- a/examples/cluster.js
+++ b/examples/cluster.js
@@ -4,11 +4,7 @@ import View from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {Cluster, OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Circle as CircleStyle, Fill, Stroke, Style, Text} from '../src/ol/style.js';
 
 
 const distance = document.getElementById('distance');

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -6,10 +6,7 @@ import {LineString, Point, Polygon} from '../src/ol/geom.js';
 import {defaults as defaultInteractions, Pointer as PointerInteraction} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {TileJSON, Vector as VectorSource} from '../src/ol/source.js';
-import Fill from '../src/ol/style/Fill.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Icon, Stroke, Style} from '../src/ol/style.js';
 
 
 /**

--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -4,10 +4,7 @@ import {GPX, GeoJSON, IGC, KML, TopoJSON} from '../src/ol/format.js';
 import {defaults as defaultInteractions, DragAndDrop} from '../src/ol/interaction.js';
 import {Vector as VectorLayer, Tile as TileLayer} from '../src/ol/layer.js';
 import {BingMaps, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const defaultStyle = {

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -4,10 +4,7 @@ import {GPX, GeoJSON, IGC, KML, TopoJSON} from '../src/ol/format.js';
 import {defaults as defaultInteractions, DragAndDrop} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {BingMaps, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const defaultStyle = {

--- a/examples/draw-and-modify-features.js
+++ b/examples/draw-and-modify-features.js
@@ -3,10 +3,7 @@ import View from '../src/ol/View.js';
 import {Draw, Modify, Snap} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/dynamic-data.js
+++ b/examples/dynamic-data.js
@@ -3,10 +3,7 @@ import View from '../src/ol/View.js';
 import {MultiPoint, Point} from '../src/ol/geom.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import OSM from '../src/ol/source/OSM.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const map = new Map({

--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -5,12 +5,7 @@ import KML from '../src/ol/format/KML.js';
 import {defaults as defaultInteractions, Select} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {Cluster, Stamen, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import RegularShape from '../src/ol/style/RegularShape.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Circle as CircleStyle, Fill, RegularShape, Stroke, Style, Text} from '../src/ol/style.js';
 
 
 const earthquakeFill = new Fill({

--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -6,10 +6,7 @@ import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {toContext} from '../src/ol/render.js';
 import Stamen from '../src/ol/source/Stamen.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Icon, Stroke, Style} from '../src/ol/style.js';
 
 
 const symbol = [[0, 0], [4, 2], [6, 0], [10, 5], [6, 3], [4, 5], [0, 0]];

--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -8,9 +8,7 @@ import Point from '../src/ol/geom/Point.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Stroke, Style} from '../src/ol/style.js';
 
 
 const map = new Map({

--- a/examples/feature-move-animation.js
+++ b/examples/feature-move-animation.js
@@ -6,11 +6,7 @@ import Point from '../src/ol/geom/Point.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import BingMaps from '../src/ol/source/BingMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Icon, Stroke, Style} from '../src/ol/style.js';
 
 // This long string is placed here due to jsFiddle limitations.
 // It is usually loaded with AJAX.

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -6,8 +6,7 @@ import LineString from '../src/ol/geom/LineString.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import Stamen from '../src/ol/source/Stamen.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Stroke, Style} from '../src/ol/style.js';
 
 const map = new Map({
   layers: [

--- a/examples/geojson.js
+++ b/examples/geojson.js
@@ -6,10 +6,7 @@ import GeoJSON from '../src/ol/format/GeoJSON.js';
 import Circle from '../src/ol/geom/Circle.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const image = new CircleStyle({

--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -6,10 +6,7 @@ import {defaults as defaultControls} from '../src/ol/control.js';
 import Point from '../src/ol/geom/Point.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 const view = new View({
   center: [0, 0],

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -4,10 +4,7 @@ import GPX from '../src/ol/format/GPX.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import BingMaps from '../src/ol/source/BingMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 const raster = new TileLayer({
   source: new BingMaps({

--- a/examples/hit-tolerance.js
+++ b/examples/hit-tolerance.js
@@ -4,8 +4,7 @@ import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
 import Feature from '../src/ol/Feature.js';
 import LineString from '../src/ol/geom/LineString.js';
-import Style from '../src/ol/style/Style.js';
-import Stroke from '../src/ol/style/Stroke.js';
+import {Stroke, Style} from '../src/ol/style.js';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -6,8 +6,7 @@ import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import TileJSON from '../src/ol/source/TileJSON.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Icon from '../src/ol/style/Icon.js';
-import Style from '../src/ol/style/Style.js';
+import {Icon, Style} from '../src/ol/style.js';
 
 
 const rome = new Feature({

--- a/examples/icon-negative.js
+++ b/examples/icon-negative.js
@@ -6,8 +6,7 @@ import Select from '../src/ol/interaction/Select.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import Stamen from '../src/ol/source/Stamen.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Icon from '../src/ol/style/Icon.js';
-import Style from '../src/ol/style/Style.js';
+import {Icon, Style} from '../src/ol/style.js';
 
 
 function createStyle(src, img) {

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -4,8 +4,7 @@ import View from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Icon from '../src/ol/style/Icon.js';
-import Style from '../src/ol/style/Style.js';
+import {Icon, Style} from '../src/ol/style.js';
 
 
 const iconInfo = [{

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -6,8 +6,7 @@ import Point from '../src/ol/geom/Point.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import TileJSON from '../src/ol/source/TileJSON.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Icon from '../src/ol/style/Icon.js';
-import Style from '../src/ol/style/Style.js';
+import {Icon, Style} from '../src/ol/style.js';
 
 
 const iconFeature = new Feature({

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -7,10 +7,7 @@ import {LineString, Point} from '../src/ol/geom.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import OSM, {ATTRIBUTION} from '../src/ol/source/OSM.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const colors = {

--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -3,10 +3,7 @@ import View from '../src/ol/View.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Stroke, Style, Text} from '../src/ol/style.js';
 
 
 const style = new Style({

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -4,10 +4,7 @@ import KML from '../src/ol/format/KML.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import Stamen from '../src/ol/source/Stamen.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const styleCache = {};

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -4,9 +4,7 @@ import KML from '../src/ol/format/KML.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import Stamen from '../src/ol/source/Stamen.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 /*

--- a/examples/layer-z-index.js
+++ b/examples/layer-z-index.js
@@ -4,10 +4,7 @@ import View from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import RegularShape from '../src/ol/style/RegularShape.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, RegularShape, Stroke, Style} from '../src/ol/style.js';
 
 
 const stroke = new Stroke({color: 'black', width: 1});

--- a/examples/line-arrows.js
+++ b/examples/line-arrows.js
@@ -4,9 +4,7 @@ import Point from '../src/ol/geom/Point.js';
 import Draw from '../src/ol/interaction/Draw.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Icon, Stroke, Style} from '../src/ol/style.js';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -4,11 +4,7 @@ import MVT from '../src/ol/format/MVT.js';
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import {get as getProjection} from '../src/ol/proj.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
-import Fill from '../src/ol/style/Fill.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Icon, Stroke, Style, Text} from '../src/ol/style.js';
 import TileGrid from '../src/ol/tilegrid/TileGrid.js';
 
 

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -3,11 +3,7 @@ import View from '../src/ol/View.js';
 import MVT from '../src/ol/format/MVT.js';
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
-import Fill from '../src/ol/style/Fill.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Icon, Stroke, Style, Text} from '../src/ol/style.js';
 
 
 const key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -7,10 +7,7 @@ import {LineString, Polygon} from '../src/ol/geom.js';
 import Draw from '../src/ol/interaction/Draw.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const raster = new TileLayer({

--- a/examples/modify-test.js
+++ b/examples/modify-test.js
@@ -4,10 +4,7 @@ import GeoJSON from '../src/ol/format/GeoJSON.js';
 import {defaults as defaultInteractions, Modify, Select} from '../src/ol/interaction.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const styleFunction = (function() {

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -4,9 +4,7 @@ import TopoJSON from '../src/ol/format/TopoJSON.js';
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 
 const key = 'vector-tiles-5eJz6JX';
 

--- a/examples/polygon-styles.js
+++ b/examples/polygon-styles.js
@@ -4,10 +4,7 @@ import GeoJSON from '../src/ol/format/GeoJSON.js';
 import MultiPoint from '../src/ol/geom/MultiPoint.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 const styles = [
   /* We are using two different styles for the polygons:

--- a/examples/regularshape.js
+++ b/examples/regularshape.js
@@ -4,10 +4,7 @@ import View from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import RegularShape from '../src/ol/style/RegularShape.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, RegularShape, Stroke, Style} from '../src/ol/style.js';
 
 
 const stroke = new Stroke({color: 'black', width: 2});

--- a/examples/render-geometry.js
+++ b/examples/render-geometry.js
@@ -1,9 +1,6 @@
 import {LineString, Point, Polygon} from '../src/ol/geom.js';
 import {toContext} from '../src/ol/render.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const canvas = document.getElementById('canvas');

--- a/examples/snap.js
+++ b/examples/snap.js
@@ -3,10 +3,7 @@ import View from '../src/ol/View.js';
 import {Draw, Modify, Select, Snap} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/street-labels.js
+++ b/examples/street-labels.js
@@ -5,9 +5,7 @@ import GeoJSON from '../src/ol/format/GeoJSON.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import BingMaps from '../src/ol/source/BingMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Style, Text} from '../src/ol/style.js';
 
 const style = new Style({
   text: new Text({

--- a/examples/symbol-atlas-webgl.js
+++ b/examples/symbol-atlas-webgl.js
@@ -4,12 +4,7 @@ import View from '../src/ol/View.js';
 import Point from '../src/ol/geom/Point.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import AtlasManager from '../src/ol/style/AtlasManager.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import RegularShape from '../src/ol/style/RegularShape.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {AtlasManager, Circle as CircleStyle, Fill, RegularShape, Stroke, Style} from '../src/ol/style.js';
 
 const atlasManager = new AtlasManager({
   // we increase the initial size so that all symbols fit into

--- a/examples/synthetic-lines.js
+++ b/examples/synthetic-lines.js
@@ -4,8 +4,7 @@ import View from '../src/ol/View.js';
 import LineString from '../src/ol/geom/LineString.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Stroke, Style} from '../src/ol/style.js';
 
 
 const count = 10000;

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -4,10 +4,7 @@ import View from '../src/ol/View.js';
 import {LineString, Point} from '../src/ol/geom.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const count = 20000;

--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -4,9 +4,7 @@ import TopoJSON from '../src/ol/format/TopoJSON.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import TileJSON from '../src/ol/source/TileJSON.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 
 
 const raster = new TileLayer({

--- a/examples/topolis.js
+++ b/examples/topolis.js
@@ -8,11 +8,7 @@ import {Point, LineString, Polygon} from '../src/ol/geom.js';
 import {Draw, Snap} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import Style from '../src/ol/style/Style.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Fill from '../src/ol/style/Fill.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Circle as CircleStyle, Stroke, Style, Text} from '../src/ol/style.js';
 import MousePosition from '../src/ol/control/MousePosition.js';
 
 const raster = new TileLayer({

--- a/examples/vector-esri.js
+++ b/examples/vector-esri.js
@@ -6,9 +6,7 @@ import {tile as tileStrategy} from '../src/ol/loadingstrategy.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import XYZ from '../src/ol/source/XYZ.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 import {createXYZ} from '../src/ol/tilegrid.js';
 
 

--- a/examples/vector-label-decluttering.js
+++ b/examples/vector-label-decluttering.js
@@ -4,10 +4,7 @@ import {getWidth} from '../src/ol/extent.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Stroke, Style, Text} from '../src/ol/style.js';
 
 const map = new Map({
   target: 'map',

--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -3,11 +3,7 @@ import View from '../src/ol/View.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Circle as CircleStyle, Fill, Stroke, Style, Text} from '../src/ol/style.js';
 
 let openSansAdded = false;
 

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -3,10 +3,7 @@ import View from '../src/ol/View.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
+import {Fill, Stroke, Style, Text} from '../src/ol/style.js';
 
 
 const style = new Style({

--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -7,10 +7,7 @@ import {bbox as bboxStrategy} from '../src/ol/loadingstrategy.js';
 import {transformExtent} from '../src/ol/proj.js';
 import BingMaps from '../src/ol/source/BingMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import CircleStyle from '../src/ol/style/Circle.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 
 let map = null;
 

--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -3,9 +3,7 @@ import View from '../src/ol/View.js';
 import MVT from '../src/ol/format/MVT.js';
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
-import Style from '../src/ol/style/Style.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
 
 // lookup for selection objects
 let selection = {};

--- a/examples/vector-wfs-getfeature.js
+++ b/examples/vector-wfs-getfeature.js
@@ -9,8 +9,7 @@ import {WFS, GeoJSON} from '../src/ol/format.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import BingMaps from '../src/ol/source/BingMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Stroke, Style} from '../src/ol/style.js';
 
 
 const vectorSource = new VectorSource();

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -5,8 +5,7 @@ import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {bbox as bboxStrategy} from '../src/ol/loadingstrategy.js';
 import BingMaps from '../src/ol/source/BingMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
+import {Stroke, Style} from '../src/ol/style.js';
 
 
 const vectorSource = new VectorSource({

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -9,7 +9,7 @@ import {getWidth} from '../extent.js';
 import {TRUE, UNDEFINED} from '../functions.js';
 import {visibleAtResolution} from '../layer/Layer.js';
 import {shared as iconImageCache} from '../style/IconImageCache.js';
-import {compose as composeTransform, invert as invertTransform, setFromArray as transformSetFromArray} from '../transform.js'; import IconImageCache from '../style/IconImageCache.js';
+import {compose as composeTransform, invert as invertTransform, setFromArray as transformSetFromArray} from '../transform.js';
 
 
 /**

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -8,8 +8,9 @@ import EventType from '../events/EventType.js';
 import {getWidth} from '../extent.js';
 import {TRUE, UNDEFINED} from '../functions.js';
 import {visibleAtResolution} from '../layer/Layer.js';
-import {iconImageCache} from '../style.js';
-import {compose as composeTransform, invert as invertTransform, setFromArray as transformSetFromArray} from '../transform.js';
+import {shared as iconImageCache} from '../style/IconImageCache.js';
+import {compose as composeTransform, invert as invertTransform, setFromArray as transformSetFromArray} from '../transform.js'; import IconImageCache from '../style/IconImageCache.js';
+
 
 /**
  * @constructor

--- a/src/ol/style.js
+++ b/src/ol/style.js
@@ -13,3 +13,15 @@
  *     (module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>)} StyleFunction
  * @api
  */
+
+export {default as Atlas} from './style/Atlas.js';
+export {default as AtlasManager} from './style/AtlasManager.js';
+export {default as Circle} from './style/Circle.js';
+export {default as Fill} from './style/Fill.js';
+export {default as Icon} from './style/Icon.js';
+export {default as IconImage} from './style/IconImage.js';
+export {default as Image} from './style/Image.js';
+export {default as RegularShape} from './style/RegularShape.js';
+export {default as Stroke} from './style/Stroke.js';
+export {default as Style} from './style/Style.js';
+export {default as Text} from './style/Text.js';

--- a/src/ol/style.js
+++ b/src/ol/style.js
@@ -13,13 +13,3 @@
  *     (module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>)} StyleFunction
  * @api
  */
-
-
-import IconImageCache from './style/IconImageCache.js';
-
-/**
- * The {@link module:ol/style/IconImageCache~IconImageCache} for
- * {@link module:ol/style/Icon~Icon} images.
- * @api
- */
-export const iconImageCache = new IconImageCache();

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -7,7 +7,7 @@ import {listenOnce, unlistenByKey} from '../events.js';
 import EventTarget from '../events/EventTarget.js';
 import EventType from '../events/EventType.js';
 import ImageState from '../ImageState.js';
-import {iconImageCache} from '../style.js';
+import {shared as iconImageCache} from '../style/IconImageCache.js';
 
 /**
  * @constructor

--- a/src/ol/style/IconImageCache.js
+++ b/src/ol/style/IconImageCache.js
@@ -4,7 +4,7 @@
 import {asString} from '../color.js';
 
 /**
- * Singleton class. Available through {@link ol.style.iconImageCache}.
+ * Singleton class. Available through {@link module:ol/style/IconImageCache~shared}.
  * @constructor
  */
 const IconImageCache = function() {
@@ -104,3 +104,11 @@ IconImageCache.prototype.setSize = function(maxCacheSize) {
   this.expire();
 };
 export default IconImageCache;
+
+
+/**
+ * The {@link module:ol/style/IconImageCache~IconImageCache} for
+ * {@link module:ol/style/Icon~Icon} images.
+ * @api
+ */
+export const shared = new IconImageCache();

--- a/test/spec/ol/style/icon.test.js
+++ b/test/spec/ol/style/icon.test.js
@@ -1,5 +1,5 @@
 import {getUid} from '../../../../src/ol/index.js';
-import {iconImageCache} from '../../../../src/ol/style.js';
+import {shared as iconImageCache} from '../../../../src/ol/style/IconImageCache.js';
 import Icon from '../../../../src/ol/style/Icon.js';
 import IconImage, {get as getIconImage} from '../../../../src/ol/style/IconImage.js';
 

--- a/test/spec/ol/style/iconimagecache.test.js
+++ b/test/spec/ol/style/iconimagecache.test.js
@@ -1,6 +1,6 @@
 import {UNDEFINED} from '../../../../src/ol/functions.js';
 import {listen} from '../../../../src/ol/events.js';
-import {iconImageCache} from '../../../../src/ol/style.js';
+import {shared as iconImageCache} from '../../../../src/ol/style/IconImageCache.js';
 import IconImage from '../../../../src/ol/style/IconImage.js';
 
 describe('ol.style.IconImageCache', function() {


### PR DESCRIPTION
This makes style constructors available from `ol/style`.

See #8110.