### PR TITLE
Shorter module paths for default exports

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -23,7 +23,7 @@ const Property = {
  * type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.CollectionEvent}
  * @param {module:ol/CollectionEventType} type Type.
  * @param {*=} opt_element Element.
@@ -59,7 +59,7 @@ inherits(CollectionEvent, Event);
  * Collection as a whole.
  *
  * @constructor
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @fires module:ol/Collection~CollectionEvent
  * @param {Array.<T>=} opt_array Array.
  * @param {module:ol/Collection~Options=} opt_options Collection options.
@@ -112,7 +112,7 @@ Collection.prototype.clear = function() {
  * Add elements to the collection.  This pushes each item in the provided array
  * to the end of the collection.
  * @param {!Array.<T>} arr Array.
- * @return {module:ol/Collection~Collection.<T>} This collection.
+ * @return {module:ol/Collection.<T>} This collection.
  * @api
  */
 Collection.prototype.extend = function(arr) {

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -18,7 +18,7 @@ import Style from './style/Style.js';
  * Features can be styled individually with `setStyle`; otherwise they use the
  * style of their vector layer.
  *
- * Note that attribute properties are set as {@link module:ol/Object~BaseObject} properties on
+ * Note that attribute properties are set as {@link module:ol/Object} properties on
  * the feature object, so they are observable, and have get/set accessors.
  *
  * Typically, a feature has a single geometry property. You can set the
@@ -52,8 +52,8 @@ import Style from './style/Style.js';
  * ```
  *
  * @constructor
- * @extends {module:ol/Object~BaseObject}
- * @param {module:ol/geom/Geometry~Geometry|Object.<string, *>=} opt_geometryOrProperties
+ * @extends {module:ol/Object}
+ * @param {module:ol/geom/Geometry|Object.<string, *>=} opt_geometryOrProperties
  * You may pass a Geometry object directly, or an object literal containing
  * properties. If you pass an object literal, you may include a Geometry
  * associated with a `geometry` key.
@@ -78,7 +78,7 @@ const Feature = function(opt_geometryOrProperties) {
   /**
    * User provided style.
    * @private
-   * @type {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction}
+   * @type {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction}
    */
   this.style_ = null;
 
@@ -117,7 +117,7 @@ inherits(Feature, BaseObject);
 /**
  * Clone this feature. If the original feature has a geometry it
  * is also cloned. The feature id is not set in the clone.
- * @return {module:ol/Feature~Feature} The clone.
+ * @return {module:ol/Feature} The clone.
  * @api
  */
 Feature.prototype.clone = function() {
@@ -139,13 +139,14 @@ Feature.prototype.clone = function() {
  * Get the feature's default geometry.  A feature may have any number of named
  * geometries.  The "default" geometry (the one that is rendered by default) is
  * set when calling {@link module:ol/Feature~Feature#setGeometry}.
- * @return {module:ol/geom/Geometry~Geometry|undefined} The default geometry for the feature.
+ * @return {module:ol/geom/Geometry|undefined} The default geometry for the feature.
  * @api
  * @observable
  */
 Feature.prototype.getGeometry = function() {
-  return /** @type {module:ol/geom/Geometry~Geometry|undefined} */ (
-    this.get(this.geometryName_));
+  return (
+    /** @type {module:ol/geom/Geometry|undefined} */ (this.get(this.geometryName_))
+  );
 };
 
 
@@ -176,7 +177,7 @@ Feature.prototype.getGeometryName = function() {
 /**
  * Get the feature's style. Will return what was provided to the
  * {@link module:ol/Feature~Feature#setStyle} method.
- * @return {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} The feature style.
+ * @return {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} The feature style.
  * @api
  */
 Feature.prototype.getStyle = function() {
@@ -223,7 +224,7 @@ Feature.prototype.handleGeometryChanged_ = function() {
 /**
  * Set the default geometry for the feature.  This will update the property
  * with the name returned by {@link module:ol/Feature~Feature#getGeometryName}.
- * @param {module:ol/geom/Geometry~Geometry|undefined} geometry The new geometry.
+ * @param {module:ol/geom/Geometry|undefined} geometry The new geometry.
  * @api
  * @observable
  */
@@ -236,7 +237,7 @@ Feature.prototype.setGeometry = function(geometry) {
  * Set the style for the feature.  This can be a single style object, an array
  * of styles, or a function that takes a resolution and returns an array of
  * styles. If it is `null` the feature has no style (a `null` style).
- * @param {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} style Style for this feature.
+ * @param {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} style Style for this feature.
  * @api
  * @fires module:ol/events/Event~Event#event:change
  */
@@ -283,9 +284,9 @@ Feature.prototype.setGeometryName = function(name) {
 
 /**
  * Convert the provided object into a feature style function.  Functions passed
- * through unchanged.  Arrays of module:ol/style/Style~Style or single style objects wrapped
+ * through unchanged.  Arrays of module:ol/style/Style or single style objects wrapped
  * in a new feature style function.
- * @param {module:ol/style~StyleFunction|!Array.<module:ol/style/Style~Style>|!module:ol/style/Style~Style} obj
+ * @param {module:ol/style~StyleFunction|!Array.<module:ol/style/Style>|!module:ol/style/Style} obj
  *     A feature style function, a single style, or an array of styles.
  * @return {module:ol/style~StyleFunction} A style function.
  */
@@ -294,7 +295,7 @@ export function createStyleFunction(obj) {
     return obj;
   } else {
     /**
-     * @type {Array.<module:ol/style/Style~Style>}
+     * @type {Array.<module:ol/style/Style>}
      */
     let styles;
     if (Array.isArray(obj)) {

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -45,7 +45,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
  *
  * @fires error
  * @constructor
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @param {module:ol/Geolocation~Options=} opt_options Options.
  * @api
  */
@@ -199,12 +199,14 @@ Geolocation.prototype.getAccuracy = function() {
 
 /**
  * Get a geometry of the position accuracy.
- * @return {?module:ol/geom/Polygon~Polygon} A geometry of the position accuracy.
+ * @return {?module:ol/geom/Polygon} A geometry of the position accuracy.
  * @observable
  * @api
  */
 Geolocation.prototype.getAccuracyGeometry = function() {
-  return /** @type {?module:ol/geom/Polygon~Polygon} */ (this.get(GeolocationProperty.ACCURACY_GEOMETRY) || null);
+  return (
+    /** @type {?module:ol/geom/Polygon} */ (this.get(GeolocationProperty.ACCURACY_GEOMETRY) || null)
+  );
 };
 
 
@@ -253,19 +255,23 @@ Geolocation.prototype.getHeading = function() {
  * @api
  */
 Geolocation.prototype.getPosition = function() {
-  return /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(GeolocationProperty.POSITION));
+  return (
+    /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(GeolocationProperty.POSITION))
+  );
 };
 
 
 /**
  * Get the projection associated with the position.
- * @return {module:ol/proj/Projection~Projection|undefined} The projection the position is
+ * @return {module:ol/proj/Projection|undefined} The projection the position is
  *     reported in.
  * @observable
  * @api
  */
 Geolocation.prototype.getProjection = function() {
-  return /** @type {module:ol/proj/Projection~Projection|undefined} */ (this.get(GeolocationProperty.PROJECTION));
+  return (
+    /** @type {module:ol/proj/Projection|undefined} */ (this.get(GeolocationProperty.PROJECTION))
+  );
 };
 
 

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -17,7 +17,7 @@ import Text from './style/Text.js';
 
 
 /**
- * @type {module:ol/style/Stroke~Stroke}
+ * @type {module:ol/style/Stroke}
  * @private
  * @const
  */
@@ -36,13 +36,13 @@ const INTERVALS = [
 
 /**
  * @typedef {Object} GraticuleLabelDataType
- * @property {module:ol/geom/Point~Point} geom
+ * @property {module:ol/geom/Point} geom
  * @property {string} text
  */
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/PluggableMap~PluggableMap} [map] Reference to an
+ * @property {module:ol/PluggableMap} [map] Reference to an
  * {@link module:ol/Map~Map} object.
  * @property {number} [maxLines=100] The maximum number of meridians and
  * parallels from the center of the map. The default value of 100 means that at
@@ -50,7 +50,7 @@ const INTERVALS = [
  * appropriate for conformal projections like Spherical Mercator. If you
  * increase the value, more lines will be drawn and the drawing performance will
  * decrease.
- * @property {module:ol/style/Stroke~Stroke} [strokeStyle='rgba(0,0,0,0.2)'] The
+ * @property {module:ol/style/Stroke} [strokeStyle='rgba(0,0,0,0.2)'] The
  * stroke style to use for drawing the graticule. If not provided, a not fully
  * opaque black will be used.
  * @property {number} [targetSize=100] The target size of the graticule cells,
@@ -67,7 +67,7 @@ const INTERVALS = [
  * @property {number} [latLabelPosition=1] Latitude label position in fractions
  * (0..1) of view extent. 0 means at the left of the viewport, 1 means at the
  * right.
- * @property {module:ol/style/Text~Text} [lonLabelStyle] Longitude label text
+ * @property {module:ol/style/Text} [lonLabelStyle] Longitude label text
  * style. If not provided, the following style will be used:
  * ```js
  * new Text({
@@ -85,7 +85,7 @@ const INTERVALS = [
  * Note that the default's `textBaseline` configuration will not work well for
  * `lonLabelPosition` configurations that position labels close to the top of
  * the viewport.
- * @param {module:ol/style/Text~Text} [latLabelStyle] Latitude label text style.
+ * @param {module:ol/style/Text} [latLabelStyle] Latitude label text style.
  * If not provided, the following style will be used:
  * ```js
  * new Text({
@@ -116,7 +116,7 @@ const Graticule = function(opt_options) {
   const options = opt_options || {};
 
   /**
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    * @private
    */
   this.map_ = null;
@@ -128,7 +128,7 @@ const Graticule = function(opt_options) {
   this.postcomposeListenerKey_ = null;
 
   /**
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.projection_ = null;
 
@@ -193,19 +193,19 @@ const Graticule = function(opt_options) {
   this.maxLines_ = options.maxLines !== undefined ? options.maxLines : 100;
 
   /**
-   * @type {Array.<module:ol/geom/LineString~LineString>}
+   * @type {Array.<module:ol/geom/LineString>}
    * @private
    */
   this.meridians_ = [];
 
   /**
-   * @type {Array.<module:ol/geom/LineString~LineString>}
+   * @type {Array.<module:ol/geom/LineString>}
    * @private
    */
   this.parallels_ = [];
 
   /**
-   * @type {module:ol/style/Stroke~Stroke}
+   * @type {module:ol/style/Stroke}
    * @private
    */
   this.strokeStyle_ = options.strokeStyle !== undefined ? options.strokeStyle : DEFAULT_STROKE_STYLE;
@@ -276,7 +276,7 @@ const Graticule = function(opt_options) {
       options.latLabelPosition;
 
     /**
-     * @type {module:ol/style/Text~Text}
+     * @type {module:ol/style/Text}
      * @private
      */
     this.lonLabelStyle_ = options.lonLabelStyle !== undefined ? options.lonLabelStyle :
@@ -293,7 +293,7 @@ const Graticule = function(opt_options) {
       });
 
     /**
-     * @type {module:ol/style/Text~Text}
+     * @type {module:ol/style/Text}
      * @private
      */
     this.latLabelStyle_ = options.latLabelStyle !== undefined ? options.latLabelStyle :
@@ -343,10 +343,10 @@ Graticule.prototype.addMeridian_ = function(lon, minLat, maxLat, squaredToleranc
 };
 
 /**
- * @param {module:ol/geom/LineString~LineString} lineString Meridian
+ * @param {module:ol/geom/LineString} lineString Meridian
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} index Index.
- * @return {module:ol/geom/Point~Point} Meridian point.
+ * @return {module:ol/geom/Point} Meridian point.
  * @private
  */
 Graticule.prototype.getMeridianPoint_ = function(lineString, extent, index) {
@@ -391,10 +391,10 @@ Graticule.prototype.addParallel_ = function(lat, minLon, maxLon, squaredToleranc
 
 
 /**
- * @param {module:ol/geom/LineString~LineString} lineString Parallels.
+ * @param {module:ol/geom/LineString} lineString Parallels.
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} index Index.
- * @return {module:ol/geom/Point~Point} Parallel point.
+ * @return {module:ol/geom/Point} Parallel point.
  * @private
  */
 Graticule.prototype.getParallelPoint_ = function(lineString, extent, index) {
@@ -542,7 +542,7 @@ Graticule.prototype.getInterval_ = function(resolution) {
 
 /**
  * Get the map associated with this graticule.
- * @return {module:ol/PluggableMap~PluggableMap} The map.
+ * @return {module:ol/PluggableMap} The map.
  * @api
  */
 Graticule.prototype.getMap = function() {
@@ -555,7 +555,7 @@ Graticule.prototype.getMap = function() {
  * @param {number} minLat Minimal latitude.
  * @param {number} maxLat Maximal latitude.
  * @param {number} squaredTolerance Squared tolerance.
- * @return {module:ol/geom/LineString~LineString} The meridian line string.
+ * @return {module:ol/geom/LineString} The meridian line string.
  * @param {number} index Index.
  * @private
  */
@@ -569,7 +569,7 @@ Graticule.prototype.getMeridian_ = function(lon, minLat, maxLat, squaredToleranc
 
 /**
  * Get the list of meridians.  Meridians are lines of equal longitude.
- * @return {Array.<module:ol/geom/LineString~LineString>} The meridians.
+ * @return {Array.<module:ol/geom/LineString>} The meridians.
  * @api
  */
 Graticule.prototype.getMeridians = function() {
@@ -582,7 +582,7 @@ Graticule.prototype.getMeridians = function() {
  * @param {number} minLon Minimal longitude.
  * @param {number} maxLon Maximal longitude.
  * @param {number} squaredTolerance Squared tolerance.
- * @return {module:ol/geom/LineString~LineString} The parallel line string.
+ * @return {module:ol/geom/LineString} The parallel line string.
  * @param {number} index Index.
  * @private
  */
@@ -596,7 +596,7 @@ Graticule.prototype.getParallel_ = function(lat, minLon, maxLon, squaredToleranc
 
 /**
  * Get the list of parallels.  Parallels are lines of equal latitude.
- * @return {Array.<module:ol/geom/LineString~LineString>} The parallels.
+ * @return {Array.<module:ol/geom/LineString>} The parallels.
  * @api
  */
 Graticule.prototype.getParallels = function() {
@@ -605,7 +605,7 @@ Graticule.prototype.getParallels = function() {
 
 
 /**
- * @param {module:ol/render/Event~RenderEvent} e Event.
+ * @param {module:ol/render/Event} e Event.
  * @private
  */
 Graticule.prototype.handlePostCompose_ = function(e) {
@@ -661,7 +661,7 @@ Graticule.prototype.handlePostCompose_ = function(e) {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @private
  */
 Graticule.prototype.updateProjectionInfo_ = function(projection) {
@@ -705,7 +705,7 @@ Graticule.prototype.updateProjectionInfo_ = function(projection) {
 /**
  * Set the map for this graticule.  The graticule will be rendered on the
  * provided map.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @api
  */
 Graticule.prototype.setMap = function(map) {

--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -30,7 +30,7 @@ import {getHeight} from './extent.js';
 
 /**
  * @constructor
- * @extends {module:ol/ImageBase~ImageBase}
+ * @extends {module:ol/ImageBase}
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number|undefined} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.

--- a/src/ol/ImageBase.js
+++ b/src/ol/ImageBase.js
@@ -8,7 +8,7 @@ import EventType from './events/EventType.js';
 /**
  * @constructor
  * @abstract
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number|undefined} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.

--- a/src/ol/ImageCanvas.js
+++ b/src/ol/ImageCanvas.js
@@ -18,7 +18,7 @@ import ImageState from './ImageState.js';
 
 /**
  * @constructor
- * @extends {module:ol/ImageBase~ImageBase}
+ * @extends {module:ol/ImageBase}
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -9,14 +9,14 @@ import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 
 /**
- * @typedef {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord,
+ * @typedef {function(new: module:ol/ImageTile, module:ol/tilecoord~TileCoord,
  * module:ol/TileState, string, ?string, module:ol/Tile~LoadFunction)} TileClass
  * @api
  */
 
 /**
  * @constructor
- * @extends {module:ol/Tile~Tile}
+ * @extends {module:ol/Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/TileState} state State.
  * @param {string} src Image source URI.

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -58,7 +58,7 @@ import CanvasVectorTileLayerRenderer from './renderer/canvas/VectorTileLayer.js'
  * groups, and so on.
  *
  * @constructor
- * @extends {module:ol/PluggableMap~PluggableMap}
+ * @extends {module:ol/PluggableMap}
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -10,10 +10,10 @@ import MapEvent from './MapEvent.js';
  * See {@link module:ol/Map~Map} for which events trigger a map browser event.
  *
  * @constructor
- * @extends {module:ol/MapEvent~MapEvent}
+ * @extends {module:ol/MapEvent}
  * @implements {oli.MapBrowserEvent}
  * @param {string} type Event type.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @param {Event} browserEvent Browser event.
  * @param {boolean=} opt_dragging Is the map currently being dragged?
  * @param {?module:ol/PluggableMap~FrameState=} opt_frameState Frame state.

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -11,12 +11,12 @@ import PointerEventType from './pointer/EventType.js';
 import PointerEventHandler from './pointer/PointerEventHandler.js';
 
 /**
- * @param {module:ol/PluggableMap~PluggableMap} map The map with the viewport to
+ * @param {module:ol/PluggableMap} map The map with the viewport to
  * listen to events on.
  * @param {number=} moveTolerance The minimal distance the pointer must travel
  * to trigger a move.
  * @constructor
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  */
 const MapBrowserEventHandler = function(map, moveTolerance) {
 
@@ -24,7 +24,7 @@ const MapBrowserEventHandler = function(map, moveTolerance) {
 
   /**
    * This is the element that we will listen to the real events on.
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    * @private
    */
   this.map_ = map;
@@ -57,7 +57,7 @@ const MapBrowserEventHandler = function(map, moveTolerance) {
   /**
    * The most recent "down" type event (or null if none have occurred).
    * Set on pointerdown.
-   * @type {module:ol/pointer/PointerEvent~PointerEvent}
+   * @type {module:ol/pointer/PointerEvent}
    * @private
    */
   this.down_ = null;
@@ -80,7 +80,7 @@ const MapBrowserEventHandler = function(map, moveTolerance) {
    * Event handler which generates pointer events for
    * the viewport element.
    *
-   * @type {module:ol/pointer/PointerEventHandler~PointerEventHandler}
+   * @type {module:ol/pointer/PointerEventHandler}
    * @private
    */
   this.pointerEventHandler_ = new PointerEventHandler(element);
@@ -89,7 +89,7 @@ const MapBrowserEventHandler = function(map, moveTolerance) {
    * Event handler which generates pointer events for
    * the document (used when dragging).
    *
-   * @type {module:ol/pointer/PointerEventHandler~PointerEventHandler}
+   * @type {module:ol/pointer/PointerEventHandler}
    * @private
    */
   this.documentPointerEventHandler_ = null;
@@ -116,7 +116,7 @@ inherits(MapBrowserEventHandler, EventTarget);
 
 
 /**
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @private
  */
@@ -146,7 +146,7 @@ MapBrowserEventHandler.prototype.emulateClick_ = function(pointerEvent) {
 /**
  * Keeps track on how many pointers are currently active.
  *
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @private
  */
@@ -164,7 +164,7 @@ MapBrowserEventHandler.prototype.updateActivePointers_ = function(pointerEvent) 
 
 
 /**
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @private
  */
@@ -196,7 +196,7 @@ MapBrowserEventHandler.prototype.handlePointerUp_ = function(pointerEvent) {
 
 
 /**
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @return {boolean} If the left mouse button was pressed.
  * @private
@@ -207,7 +207,7 @@ MapBrowserEventHandler.prototype.isMouseActionButton_ = function(pointerEvent) {
 
 
 /**
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @private
  */
@@ -256,7 +256,7 @@ MapBrowserEventHandler.prototype.handlePointerDown_ = function(pointerEvent) {
 
 
 /**
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @private
  */
@@ -283,7 +283,7 @@ MapBrowserEventHandler.prototype.handlePointerMove_ = function(pointerEvent) {
 /**
  * Wrap and relay a pointer event.  Note that this requires that the type
  * string for the MapBrowserPointerEvent matches the PointerEvent type.
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @private
  */
@@ -295,7 +295,7 @@ MapBrowserEventHandler.prototype.relayEvent_ = function(pointerEvent) {
 
 
 /**
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @return {boolean} Is moving.
  * @private

--- a/src/ol/MapBrowserPointerEvent.js
+++ b/src/ol/MapBrowserPointerEvent.js
@@ -6,10 +6,10 @@ import MapBrowserEvent from './MapBrowserEvent.js';
 
 /**
  * @constructor
- * @extends {module:ol/MapBrowserEvent~MapBrowserEvent}
+ * @extends {module:ol/MapBrowserEvent}
  * @param {string} type Event type.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
- * @param {module:ol/pointer/PointerEvent~PointerEvent} pointerEvent Pointer
+ * @param {module:ol/PluggableMap} map Map.
+ * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
  * event.
  * @param {boolean=} opt_dragging Is the map currently being dragged?
  * @param {?module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
@@ -22,7 +22,7 @@ const MapBrowserPointerEvent = function(type, map, pointerEvent, opt_dragging,
 
   /**
    * @const
-   * @type {module:ol/pointer/PointerEvent~PointerEvent}
+   * @type {module:ol/pointer/PointerEvent}
    */
   this.pointerEvent = pointerEvent;
 

--- a/src/ol/MapEvent.js
+++ b/src/ol/MapEvent.js
@@ -10,10 +10,10 @@ import Event from './events/Event.js';
  * See {@link module:ol/Map~Map} for which events trigger a map event.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.MapEvent}
  * @param {string} type Event type.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @param {?module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
  */
 const MapEvent = function(type, map, opt_frameState) {
@@ -22,7 +22,7 @@ const MapEvent = function(type, map, opt_frameState) {
 
   /**
    * The map where the event occurred.
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    * @api
    */
   this.map = map;

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -16,7 +16,7 @@ import {assign} from './obj.js';
  * @param {string} type The event type.
  * @param {string} key The property name.
  * @param {*} oldValue The old value for `key`.
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.Object.Event}
  * @constructor
  */
@@ -48,7 +48,7 @@ inherits(ObjectEvent, Event);
  * instantiated in apps.
  * Most non-trivial classes inherit from this.
  *
- * This extends {@link module:ol/Observable~Observable} with observable
+ * This extends {@link module:ol/Observable} with observable
  * properties, where each property is observable as well as the object as a
  * whole.
  *
@@ -83,7 +83,7 @@ inherits(ObjectEvent, Event);
  * object.unset('foo').
  *
  * @constructor
- * @extends {module:ol/Observable~Observable}
+ * @extends {module:ol/Observable}
  * @param {Object.<string, *>=} opt_values An object with key-value pairs.
  * @fires module:ol/Object~ObjectEvent
  * @api

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -15,7 +15,7 @@ import EventType from './events/EventType.js';
  * {@link module:ol/Observable~Observable#changed}.
  *
  * @constructor
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  * @fires module:ol/events/Event~Event
  * @struct
  * @api
@@ -68,8 +68,8 @@ Observable.prototype.changed = function() {
  * Object with a `type` property.
  *
  * @param {{type: string,
- *     target: (EventTarget|module:ol/events/EventTarget~EventTarget|undefined)}|
- *     module:ol/events/Event~Event|string} event Event object.
+ *     target: (EventTarget|module:ol/events/EventTarget|undefined)}|
+ *     module:ol/events/Event|string} event Event object.
  * @function
  * @api
  */

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -94,7 +94,7 @@ const Property = {
  *     map.addOverlay(popup);
  *
  * @constructor
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @param {module:ol/Overlay~Options} options Overlay options.
  * @api
  */
@@ -239,13 +239,15 @@ Overlay.prototype.getId = function() {
 
 /**
  * Get the map associated with this overlay.
- * @return {module:ol/PluggableMap~PluggableMap|undefined} The map that the
+ * @return {module:ol/PluggableMap|undefined} The map that the
  * overlay is part of.
  * @observable
  * @api
  */
 Overlay.prototype.getMap = function() {
-  return /** @type {module:ol/PluggableMap~PluggableMap|undefined} */ (this.get(Property.MAP));
+  return (
+    /** @type {module:ol/PluggableMap|undefined} */ (this.get(Property.MAP))
+  );
 };
 
 
@@ -268,7 +270,9 @@ Overlay.prototype.getOffset = function() {
  * @api
  */
 Overlay.prototype.getPosition = function() {
-  return /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(Property.POSITION));
+  return (
+    /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(Property.POSITION))
+  );
 };
 
 
@@ -280,7 +284,9 @@ Overlay.prototype.getPosition = function() {
  * @api
  */
 Overlay.prototype.getPositioning = function() {
-  return /** @type {module:ol/OverlayPositioning~OverlayPositioning} */ (this.get(Property.POSITIONING));
+  return (
+    /** @type {module:ol/OverlayPositioning~OverlayPositioning} */ (this.get(Property.POSITIONING))
+  );
 };
 
 
@@ -369,7 +375,7 @@ Overlay.prototype.setElement = function(element) {
 
 /**
  * Set the map to be associated with this overlay.
- * @param {module:ol/PluggableMap~PluggableMap|undefined} map The map that the
+ * @param {module:ol/PluggableMap|undefined} map The map that the
  * overlay is part of.
  * @observable
  * @api

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -47,23 +47,23 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {Array.<module:ol/PluggableMap~PostRenderFunction>} postRenderFunctions
  * @property {module:ol/size~Size} size
  * @property {!Object.<string, boolean>} skippedFeatureUids
- * @property {module:ol/TileQueue~TileQueue} tileQueue
- * @property {Object.<string, Object.<string, module:ol/TileRange~TileRange>>} usedTiles
+ * @property {module:ol/TileQueue} tileQueue
+ * @property {Object.<string, Object.<string, module:ol/TileRange>>} usedTiles
  * @property {Array.<number>} viewHints
  * @property {!Object.<string, Object.<string, boolean>>} wantedTiles
  */
 
 
 /**
- * @typedef {function(module:ol/PluggableMap~PluggableMap, ?module:ol/PluggableMap~FrameState): boolean} PostRenderFunction
+ * @typedef {function(module:ol/PluggableMap, ?module:ol/PluggableMap~FrameState): boolean} PostRenderFunction
  */
 
 
 /**
  * @typedef {Object} AtPixelOptions
- * @property {((function(module:ol/layer/Layer~Layer): boolean)|undefined)} layerFilter Layer filter
+ * @property {((function(module:ol/layer/Layer): boolean)|undefined)} layerFilter Layer filter
  * function. The filter function will receive one argument, the
- * {@link module:ol/layer/Layer~Layer layer-candidate} and it should return a boolean value.
+ * {@link module:ol/layer/Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
  * will be tested for features. By default, all visible layers will be tested.
  * @property {number} [hitTolerance=0] Hit-detection tolerance in pixels. Pixels
@@ -74,10 +74,10 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @typedef {Object} MapOptionsInternal
- * @property {module:ol/Collection~Collection.<module:ol/control/Control~Control>} [controls]
- * @property {module:ol/Collection~Collection.<module:ol/interaction/Interaction~Interaction>} [interactions]
+ * @property {module:ol/Collection.<module:ol/control/Control>} [controls]
+ * @property {module:ol/Collection.<module:ol/interaction/Interaction>} [interactions]
  * @property {Element|Document} keyboardEventTarget
- * @property {module:ol/Collection~Collection.<module:ol/Overlay~Overlay>} overlays
+ * @property {module:ol/Collection.<module:ol/Overlay>} overlays
  * @property {Object.<string, *>} values
  */
 
@@ -85,12 +85,12 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 /**
  * Object literal with config options for the map.
  * @typedef {Object} MapOptions
- * @property {module:ol/Collection~Collection.<module:ol/control/Control~Control>|Array.<module:ol/control/Control~Control>} [controls]
+ * @property {module:ol/Collection.<module:ol/control/Control>|Array.<module:ol/control/Control>} [controls]
  * Controls initially added to the map. If not specified,
  * {@link module:ol/control~defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
- * @property {module:ol/Collection~Collection.<module:ol/interaction/Interaction~Interaction>|Array.<module:ol/interaction/Interaction~Interaction>} [interactions]
+ * @property {module:ol/Collection.<module:ol/interaction/Interaction>|Array.<module:ol/interaction/Interaction>} [interactions]
  * Interactions that are initially added to the map. If not specified,
  * {@link module:ol/interaction~defaults} is used.
  * @property {Element|Document|string} [keyboardEventTarget] The element to
@@ -118,7 +118,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {number} [moveTolerance=1] The minimum distance in pixels the
  * cursor must move to be detected as a map move event instead of a click.
  * Increasing this value can make it easier to click on the map.
- * @property {module:ol/Collection~Collection.<module:ol/Overlay~Overlay>|Array.<module:ol/Overlay~Overlay>} [overlays]
+ * @property {module:ol/Collection.<module:ol/Overlay>|Array.<module:ol/Overlay>} [overlays]
  * Overlays initially added to the map. By default, no overlays are added.
  * @property {Element|string} [target] The container for the map, either the
  * element itself or the `id` of the element. If not specified at construction
@@ -132,7 +132,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @constructor
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent
@@ -283,7 +283,7 @@ const PluggableMap = function(options) {
 
   /**
    * @private
-   * @type {module:ol/MapBrowserEventHandler~MapBrowserEventHandler}
+   * @type {module:ol/MapBrowserEventHandler}
    */
   this.mapBrowserEventHandler_ = new MapBrowserEventHandler(this, options.moveTolerance);
   for (const key in MapBrowserEventType) {
@@ -311,19 +311,19 @@ const PluggableMap = function(options) {
     this.handleBrowserEvent, this);
 
   /**
-   * @type {module:ol/Collection~Collection.<module:ol/control/Control~Control>}
+   * @type {module:ol/Collection.<module:ol/control/Control>}
    * @protected
    */
   this.controls = optionsInternal.controls || new Collection();
 
   /**
-   * @type {module:ol/Collection~Collection.<module:ol/interaction/Interaction~Interaction>}
+   * @type {module:ol/Collection.<module:ol/interaction/Interaction>}
    * @protected
    */
   this.interactions = optionsInternal.interactions || new Collection();
 
   /**
-   * @type {module:ol/Collection~Collection.<module:ol/Overlay~Overlay>}
+   * @type {module:ol/Collection.<module:ol/Overlay>}
    * @private
    */
   this.overlays_ = optionsInternal.overlays;
@@ -331,7 +331,7 @@ const PluggableMap = function(options) {
   /**
    * A lookup of overlays by id.
    * @private
-   * @type {Object.<string, module:ol/Overlay~Overlay>}
+   * @type {Object.<string, module:ol/Overlay>}
    */
   this.overlayIdIndex_ = {};
 
@@ -361,7 +361,7 @@ const PluggableMap = function(options) {
 
   /**
    * @private
-   * @type {module:ol/TileQueue~TileQueue}
+   * @type {module:ol/TileQueue}
    */
   this.tileQueue_ = new TileQueue(
     this.getTilePriority.bind(this),
@@ -390,8 +390,8 @@ const PluggableMap = function(options) {
 
   this.controls.forEach(
     /**
-     * @param {module:ol/control/Control~Control} control Control.
-     * @this {module:ol/PluggableMap~PluggableMap}
+     * @param {module:ol/control/Control} control Control.
+     * @this {module:ol/PluggableMap}
      */
     function(control) {
       control.setMap(this);
@@ -415,8 +415,8 @@ const PluggableMap = function(options) {
 
   this.interactions.forEach(
     /**
-     * @param {module:ol/interaction/Interaction~Interaction} interaction Interaction.
-     * @this {module:ol/PluggableMap~PluggableMap}
+     * @param {module:ol/interaction/Interaction} interaction Interaction.
+     * @this {module:ol/PluggableMap}
      */
     function(interaction) {
       interaction.setMap(this);
@@ -445,7 +445,7 @@ const PluggableMap = function(options) {
      * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
      */
     function(event) {
-      this.addOverlayInternal_(/** @type {module:ol/Overlay~Overlay} */ (event.element));
+      this.addOverlayInternal_(/** @type {module:ol/Overlay} */ (event.element));
     }, this);
 
   listen(this.overlays_, CollectionEventType.REMOVE,
@@ -453,7 +453,7 @@ const PluggableMap = function(options) {
      * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
      */
     function(event) {
-      const overlay = /** @type {module:ol/Overlay~Overlay} */ (event.element);
+      const overlay = /** @type {module:ol/Overlay} */ (event.element);
       const id = overlay.getId();
       if (id !== undefined) {
         delete this.overlayIdIndex_[id.toString()];
@@ -473,7 +473,7 @@ PluggableMap.prototype.createRenderer = function() {
 
 /**
  * Add the given control to the map.
- * @param {module:ol/control/Control~Control} control Control.
+ * @param {module:ol/control/Control} control Control.
  * @api
  */
 PluggableMap.prototype.addControl = function(control) {
@@ -483,7 +483,7 @@ PluggableMap.prototype.addControl = function(control) {
 
 /**
  * Add the given interaction to the map.
- * @param {module:ol/interaction/Interaction~Interaction} interaction Interaction to add.
+ * @param {module:ol/interaction/Interaction} interaction Interaction to add.
  * @api
  */
 PluggableMap.prototype.addInteraction = function(interaction) {
@@ -506,7 +506,7 @@ PluggableMap.prototype.addLayer = function(layer) {
 
 /**
  * Add the given overlay to the map.
- * @param {module:ol/Overlay~Overlay} overlay Overlay.
+ * @param {module:ol/Overlay} overlay Overlay.
  * @api
  */
 PluggableMap.prototype.addOverlay = function(overlay) {
@@ -516,7 +516,7 @@ PluggableMap.prototype.addOverlay = function(overlay) {
 
 /**
  * This deals with map's overlay collection changes.
- * @param {module:ol/Overlay~Overlay} overlay Overlay.
+ * @param {module:ol/Overlay} overlay Overlay.
  * @private
  */
 PluggableMap.prototype.addOverlayInternal_ = function(overlay) {
@@ -555,12 +555,12 @@ PluggableMap.prototype.disposeInternal = function() {
  * callback with each intersecting feature. Layers included in the detection can
  * be configured through the `layerFilter` option in `opt_options`.
  * @param {module:ol~Pixel} pixel Pixel.
- * @param {function(this: S, (module:ol/Feature~Feature|module:ol/render/Feature~Feature),
- *     module:ol/layer/Layer~Layer): T} callback Feature callback. The callback will be
+ * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature~Feature),
+ *     module:ol/layer/Layer): T} callback Feature callback. The callback will be
  *     called with two arguments. The first argument is one
- *     {@link module:ol/Feature~Feature feature} or
+ *     {@link module:ol/Feature feature} or
  *     {@link module:ol/render/Feature~Feature render feature} at the pixel, the second is
- *     the {@link module:ol/layer/Layer~Layer layer} of the feature and will be null for
+ *     the {@link module:ol/layer/Layer layer} of the feature and will be null for
  *     unmanaged layers. To stop detection, callback functions can return a
  *     truthy value.
  * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
@@ -589,7 +589,7 @@ PluggableMap.prototype.forEachFeatureAtPixel = function(pixel, callback, opt_opt
  * Get all features that intersect a pixel on the viewport.
  * @param {module:ol~Pixel} pixel Pixel.
  * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
- * @return {Array.<module:ol/Feature~Feature|module:ol/render/Feature~Feature>} The detected features or
+ * @return {Array.<module:ol/Feature|module:ol/render/Feature~Feature>} The detected features or
  * `null` if none were found.
  * @api
  */
@@ -609,16 +609,16 @@ PluggableMap.prototype.getFeaturesAtPixel = function(pixel, opt_options) {
  * execute a callback with each matching layer. Layers included in the
  * detection can be configured through `opt_layerFilter`.
  * @param {module:ol~Pixel} pixel Pixel.
- * @param {function(this: S, module:ol/layer/Layer~Layer, (Uint8ClampedArray|Uint8Array)): T} callback
+ * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback
  *     Layer callback. This callback will receive two arguments: first is the
- *     {@link module:ol/layer/Layer~Layer layer}, second argument is an array representing
+ *     {@link module:ol/layer/Layer layer}, second argument is an array representing
  *     [R, G, B, A] pixel values (0 - 255) and will be `null` for layer types
  *     that do not currently support this argument. To stop detection, callback
  *     functions can return a truthy value.
  * @param {S=} opt_this Value to use as `this` when executing `callback`.
- * @param {(function(this: U, module:ol/layer/Layer~Layer): boolean)=} opt_layerFilter Layer
+ * @param {(function(this: U, module:ol/layer/Layer): boolean)=} opt_layerFilter Layer
  *     filter function. The filter function will receive one argument, the
- *     {@link module:ol/layer/Layer~Layer layer-candidate} and it should return a boolean
+ *     {@link module:ol/layer/Layer layer-candidate} and it should return a boolean
  *     value. Only layers which are visible and for which this function returns
  *     `true` will be tested for features. By default, all visible layers will
  *     be tested.
@@ -742,7 +742,7 @@ PluggableMap.prototype.getCoordinateFromPixel = function(pixel) {
 /**
  * Get the map controls. Modifying this collection changes the controls
  * associated with the map.
- * @return {module:ol/Collection~Collection.<module:ol/control/Control~Control>} Controls.
+ * @return {module:ol/Collection.<module:ol/control/Control>} Controls.
  * @api
  */
 PluggableMap.prototype.getControls = function() {
@@ -753,7 +753,7 @@ PluggableMap.prototype.getControls = function() {
 /**
  * Get the map overlays. Modifying this collection changes the overlays
  * associated with the map.
- * @return {module:ol/Collection~Collection.<module:ol/Overlay~Overlay>} Overlays.
+ * @return {module:ol/Collection.<module:ol/Overlay>} Overlays.
  * @api
  */
 PluggableMap.prototype.getOverlays = function() {
@@ -766,7 +766,7 @@ PluggableMap.prototype.getOverlays = function() {
  * Note that the index treats string and numeric identifiers as the same. So
  * `map.getOverlayById(2)` will return an overlay with id `'2'` or `2`.
  * @param {string|number} id Overlay identifier.
- * @return {module:ol/Overlay~Overlay} Overlay.
+ * @return {module:ol/Overlay} Overlay.
  * @api
  */
 PluggableMap.prototype.getOverlayById = function(id) {
@@ -780,7 +780,7 @@ PluggableMap.prototype.getOverlayById = function(id) {
  * associated with the map.
  *
  * Interactions are used for e.g. pan, zoom and rotate.
- * @return {module:ol/Collection~Collection.<module:ol/interaction/Interaction~Interaction>} Interactions.
+ * @return {module:ol/Collection.<module:ol/interaction/Interaction>} Interactions.
  * @api
  */
 PluggableMap.prototype.getInteractions = function() {
@@ -795,13 +795,15 @@ PluggableMap.prototype.getInteractions = function() {
  * @api
  */
 PluggableMap.prototype.getLayerGroup = function() {
-  return /** @type {module:ol/layer/Group~Group} */ (this.get(MapProperty.LAYERGROUP));
+  return (
+    /** @type {module:ol/layer/Group~Group} */ (this.get(MapProperty.LAYERGROUP))
+  );
 };
 
 
 /**
  * Get the collection of layers associated with this map.
- * @return {!module:ol/Collection~Collection.<module:ol/layer/Base~Base>} Layers.
+ * @return {!module:ol/Collection.<module:ol/layer/Base~Base>} Layers.
  * @api
  */
 PluggableMap.prototype.getLayers = function() {
@@ -843,19 +845,23 @@ PluggableMap.prototype.getRenderer = function() {
  * @api
  */
 PluggableMap.prototype.getSize = function() {
-  return /** @type {module:ol/size~Size|undefined} */ (this.get(MapProperty.SIZE));
+  return (
+    /** @type {module:ol/size~Size|undefined} */ (this.get(MapProperty.SIZE))
+  );
 };
 
 
 /**
  * Get the view associated with this map. A view manages properties such as
  * center and resolution.
- * @return {module:ol/View~View} The view that controls this map.
+ * @return {module:ol/View} The view that controls this map.
  * @observable
  * @api
  */
 PluggableMap.prototype.getView = function() {
-  return /** @type {module:ol/View~View} */ (this.get(MapProperty.VIEW));
+  return (
+    /** @type {module:ol/View} */ (this.get(MapProperty.VIEW))
+  );
 };
 
 
@@ -894,7 +900,7 @@ PluggableMap.prototype.getOverlayContainerStopEvent = function() {
 
 
 /**
- * @param {module:ol/Tile~Tile} tile Tile.
+ * @param {module:ol/Tile} tile Tile.
  * @param {string} tileSourceKey Tile source key.
  * @param {module:ol/coordinate~Coordinate} tileCenter Tile center.
  * @param {number} tileResolution Tile resolution.
@@ -935,7 +941,7 @@ PluggableMap.prototype.handleBrowserEvent = function(browserEvent, opt_type) {
 
 
 /**
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent The event to handle.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent The event to handle.
  */
 PluggableMap.prototype.handleMapBrowserEvent = function(mapBrowserEvent) {
   if (!this.frameState_) {
@@ -1162,8 +1168,8 @@ PluggableMap.prototype.render = function() {
 
 /**
  * Remove the given control from the map.
- * @param {module:ol/control/Control~Control} control Control.
- * @return {module:ol/control/Control~Control|undefined} The removed control (or undefined
+ * @param {module:ol/control/Control} control Control.
+ * @return {module:ol/control/Control|undefined} The removed control (or undefined
  *     if the control was not found).
  * @api
  */
@@ -1174,8 +1180,8 @@ PluggableMap.prototype.removeControl = function(control) {
 
 /**
  * Remove the given interaction from the map.
- * @param {module:ol/interaction/Interaction~Interaction} interaction Interaction to remove.
- * @return {module:ol/interaction/Interaction~Interaction|undefined} The removed interaction (or
+ * @param {module:ol/interaction/Interaction} interaction Interaction to remove.
+ * @return {module:ol/interaction/Interaction|undefined} The removed interaction (or
  *     undefined if the interaction was not found).
  * @api
  */
@@ -1199,8 +1205,8 @@ PluggableMap.prototype.removeLayer = function(layer) {
 
 /**
  * Remove the given overlay from the map.
- * @param {module:ol/Overlay~Overlay} overlay Overlay.
- * @return {module:ol/Overlay~Overlay|undefined} The removed overlay (or undefined
+ * @param {module:ol/Overlay} overlay Overlay.
+ * @return {module:ol/Overlay|undefined} The removed overlay (or undefined
  *     if the overlay was not found).
  * @api
  */
@@ -1339,7 +1345,7 @@ PluggableMap.prototype.setTarget = function(target) {
 
 /**
  * Set the view for this map.
- * @param {module:ol/View~View} view The view that controls this map.
+ * @param {module:ol/View} view The view that controls this map.
  * @observable
  * @api
  */
@@ -1349,7 +1355,7 @@ PluggableMap.prototype.setView = function(view) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  */
 PluggableMap.prototype.skipFeature = function(feature) {
   const featureUid = getUid(feature).toString();
@@ -1387,7 +1393,7 @@ PluggableMap.prototype.updateSize = function() {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  */
 PluggableMap.prototype.unskipFeature = function(feature) {
   const featureUid = getUid(feature).toString();

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -9,10 +9,10 @@ import EventType from './events/EventType.js';
 
 
 /**
- * A function that takes an {@link module:ol/Tile~Tile} for the tile and a
+ * A function that takes an {@link module:ol/Tile} for the tile and a
  * `{string}` for the url as arguments.
  *
- * @typedef {function(module:ol/Tile~Tile, string)} LoadFunction
+ * @typedef {function(module:ol/Tile, string)} LoadFunction
  * @api
  */
 
@@ -22,12 +22,12 @@ import EventType from './events/EventType.js';
  *
  * This function takes an {@link module:ol/tilecoord~TileCoord} for the tile
  * coordinate, a `{number}` representing the pixel ratio and a
- * {@link module:ol/proj/Projection~Projection} for the projection  as arguments
+ * {@link module:ol/proj/Projection} for the projection  as arguments
  * and returns a `{string}` representing the tile URL, or undefined if no tile
  * should be requested for the passed tile coordinate.
  *
  * @typedef {function(module:ol/tilecoord~TileCoord, number,
- *           module:ol/proj/Projection~Projection): (string|undefined)} UrlFunction
+ *           module:ol/proj/Projection): (string|undefined)} UrlFunction
  * @api
  */
 
@@ -46,7 +46,7 @@ import EventType from './events/EventType.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/TileState} state State.
  * @param {module:ol/Tile~Options=} opt_options Tile options.
@@ -71,7 +71,7 @@ const Tile = function(tileCoord, state, opt_options) {
    * An "interim" tile for this tile. The interim tile may be used while this
    * one is loading, for "smooth" transitions when changing params/dimensions
    * on the source.
-   * @type {module:ol/Tile~Tile}
+   * @type {module:ol/Tile}
    */
   this.interimTile = null;
 
@@ -120,7 +120,7 @@ Tile.prototype.getKey = function() {
  * Get the interim tile most suitable for rendering using the chain of interim
  * tiles. This corresponds to the  most recent tile that has been loaded, if no
  * such tile exists, the original tile is returned.
- * @return {!module:ol/Tile~Tile} Best tile for rendering.
+ * @return {!module:ol/Tile} Best tile for rendering.
  */
 Tile.prototype.getInterimTile = function() {
   if (!this.interimTile) {

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -7,7 +7,7 @@ import {fromKey, getKey} from './tilecoord.js';
 
 /**
  * @constructor
- * @extends {module:ol/structs/LRUCache~LRUCache.<module:ol/Tile~Tile>}
+ * @extends {module:ol/structs/LRUCache.<module:ol/Tile>}
  * @param {number=} opt_highWaterMark High water mark.
  * @struct
  */
@@ -21,7 +21,7 @@ inherits(TileCache, LRUCache);
 
 
 /**
- * @param {!Object.<string, module:ol/TileRange~TileRange>} usedTiles Used tiles.
+ * @param {!Object.<string, module:ol/TileRange>} usedTiles Used tiles.
  */
 TileCache.prototype.expireCache = function(usedTiles) {
   while (this.canExpireCache()) {

--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -9,13 +9,13 @@ import PriorityQueue from './structs/PriorityQueue.js';
 
 
 /**
- * @typedef {function(module:ol/Tile~Tile, string, module:ol/coordinate~Coordinate, number): number} PriorityFunction
+ * @typedef {function(module:ol/Tile, string, module:ol/coordinate~Coordinate, number): number} PriorityFunction
  */
 
 
 /**
  * @constructor
- * @extends {module:ol/structs/PriorityQueue~PriorityQueue.<Array>}
+ * @extends {module:ol/structs/PriorityQueue.<Array>}
  * @param {module:ol/TileQueue~PriorityFunction} tilePriorityFunction
  *     Tile priority function.
  * @param {function(): ?} tileChangeCallback
@@ -38,7 +38,9 @@ const TileQueue = function(tilePriorityFunction, tileChangeCallback) {
        * @return {string} Key.
        */
     function(element) {
-      return /** @type {module:ol/Tile~Tile} */ (element[0]).getKey();
+      return (
+        /** @type {module:ol/Tile} */ (element[0]).getKey()
+      );
     });
 
   /**
@@ -87,11 +89,11 @@ TileQueue.prototype.getTilesLoading = function() {
 
 
 /**
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  * @protected
  */
 TileQueue.prototype.handleTileChange = function(event) {
-  const tile = /** @type {module:ol/Tile~Tile} */ (event.target);
+  const tile = /** @type {module:ol/Tile} */ (event.target);
   const state = tile.getState();
   if (state === TileState.LOADED || state === TileState.ERROR ||
       state === TileState.EMPTY || state === TileState.ABORT) {
@@ -117,7 +119,7 @@ TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
   let state, tile, tileKey;
   while (this.tilesLoading_ < maxTotalLoading && newLoads < maxNewLoads &&
          this.getCount() > 0) {
-    tile = /** @type {module:ol/Tile~Tile} */ (this.dequeue()[0]);
+    tile = /** @type {module:ol/Tile} */ (this.dequeue()[0]);
     tileKey = tile.getKey();
     state = tile.getState();
     if (state === TileState.ABORT) {

--- a/src/ol/TileRange.js
+++ b/src/ol/TileRange.js
@@ -42,8 +42,8 @@ const TileRange = function(minX, maxX, minY, maxY) {
  * @param {number} maxX Maximum X.
  * @param {number} minY Minimum Y.
  * @param {number} maxY Maximum Y.
- * @param {module:ol/TileRange~TileRange=} tileRange TileRange.
- * @return {module:ol/TileRange~TileRange} Tile range.
+ * @param {module:ol/TileRange=} tileRange TileRange.
+ * @return {module:ol/TileRange} Tile range.
  */
 export function createOrUpdate(minX, maxX, minY, maxY, tileRange) {
   if (tileRange !== undefined) {
@@ -68,7 +68,7 @@ TileRange.prototype.contains = function(tileCoord) {
 
 
 /**
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+ * @param {module:ol/TileRange} tileRange Tile range.
  * @return {boolean} Contains.
  */
 TileRange.prototype.containsTileRange = function(tileRange) {
@@ -88,7 +88,7 @@ TileRange.prototype.containsXY = function(x, y) {
 
 
 /**
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+ * @param {module:ol/TileRange} tileRange Tile range.
  * @return {boolean} Equals.
  */
 TileRange.prototype.equals = function(tileRange) {
@@ -98,7 +98,7 @@ TileRange.prototype.equals = function(tileRange) {
 
 
 /**
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+ * @param {module:ol/TileRange} tileRange Tile range.
  */
 TileRange.prototype.extend = function(tileRange) {
   if (tileRange.minX < this.minX) {
@@ -141,7 +141,7 @@ TileRange.prototype.getWidth = function() {
 
 
 /**
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+ * @param {module:ol/TileRange} tileRange Tile range.
  * @return {boolean} Intersects.
  */
 TileRange.prototype.intersects = function(tileRange) {

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -22,23 +22,23 @@ import {loadFeaturesXhr} from './featureloader.js';
 
 /**
  * @constructor
- * @extends {module:ol/Tile~Tile}
+ * @extends {module:ol/Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/TileState} state State.
  * @param {number} sourceRevision Source revision.
- * @param {module:ol/format/Feature~FeatureFormat} format Feature format.
+ * @param {module:ol/format/Feature} format Feature format.
  * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
  * @param {module:ol/tilecoord~TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
  * @param {module:ol/Tile~UrlFunction} tileUrlFunction Tile url function.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} sourceTileGrid Tile grid of the source.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid of the renderer.
- * @param {Object.<string, module:ol/VectorTile~VectorTile>} sourceTiles Source tiles.
+ * @param {module:ol/tilegrid/TileGrid} sourceTileGrid Tile grid of the source.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid of the renderer.
+ * @param {Object.<string, module:ol/VectorTile>} sourceTiles Source tiles.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @param {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
- *     module:ol/format/Feature~FeatureFormat, module:ol/Tile~LoadFunction)} tileClass Class to
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @param {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
+ *     module:ol/format/Feature, module:ol/Tile~LoadFunction)} tileClass Class to
  *     instantiate for source tiles.
- * @param {function(this: module:ol/source/VectorTile~VectorTile, module:ol/events/Event~Event)} handleTileChange
+ * @param {function(this: module:ol/source/VectorTile, module:ol/events/Event)} handleTileChange
  *     Function to call when a source tile's state changes.
  * @param {module:ol/Tile~Options=} opt_options Tile options.
  */
@@ -68,7 +68,7 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
 
   /**
    * @private
-   * @type {Object.<string, module:ol/VectorTile~VectorTile>}
+   * @type {Object.<string, module:ol/VectorTile>}
    */
   this.sourceTiles_ = sourceTiles;
 
@@ -164,7 +164,7 @@ VectorImageTile.prototype.disposeInternal = function() {
 
 
 /**
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @return {CanvasRenderingContext2D} The rendering context.
  */
 VectorImageTile.prototype.getContext = function(layer) {
@@ -178,7 +178,7 @@ VectorImageTile.prototype.getContext = function(layer) {
 
 /**
  * Get the Canvas for this tile.
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @return {HTMLCanvasElement} Canvas.
  */
 VectorImageTile.prototype.getImage = function(layer) {
@@ -188,7 +188,7 @@ VectorImageTile.prototype.getImage = function(layer) {
 
 
 /**
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @return {module:ol/VectorImageTile~ReplayState} The replay state.
  */
 VectorImageTile.prototype.getReplayState = function(layer) {
@@ -215,7 +215,7 @@ VectorImageTile.prototype.getKey = function() {
 
 /**
  * @param {string} tileKey Key (tileCoord) of the source tile.
- * @return {module:ol/VectorTile~VectorTile} Source tile.
+ * @return {module:ol/VectorTile} Source tile.
  */
 VectorImageTile.prototype.getTile = function(tileKey) {
   return this.sourceTiles_[tileKey];
@@ -299,7 +299,7 @@ export default VectorImageTile;
 
 /**
  * Sets the loader for a tile.
- * @param {module:ol/VectorTile~VectorTile} tile Vector tile.
+ * @param {module:ol/VectorTile} tile Vector tile.
  * @param {string} url URL.
  */
 export function defaultLoadFunction(tile, url) {

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -6,18 +6,18 @@ import Tile from './Tile.js';
 import TileState from './TileState.js';
 
 /**
- * @typedef {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord,
+ * @typedef {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord,
  * module:ol/TileState, string, ?string, module:ol/Tile~LoadFunction)} TileClass
  * @api
  */
 
 /**
  * @constructor
- * @extends {module:ol/Tile~Tile}
+ * @extends {module:ol/Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/TileState} state State.
  * @param {string} src Data source url.
- * @param {module:ol/format/Feature~FeatureFormat} format Feature format.
+ * @param {module:ol/format/Feature} format Feature format.
  * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
  * @param {module:ol/Tile~Options=} opt_options Tile options.
  */
@@ -38,13 +38,13 @@ const VectorTile = function(tileCoord, state, src, format, tileLoadFunction, opt
 
   /**
    * @private
-   * @type {module:ol/format/Feature~FeatureFormat}
+   * @type {module:ol/format/Feature}
    */
   this.format_ = format;
 
   /**
    * @private
-   * @type {Array.<module:ol/Feature~Feature>}
+   * @type {Array.<module:ol/Feature>}
    */
   this.features_ = null;
 
@@ -57,13 +57,13 @@ const VectorTile = function(tileCoord, state, src, format, tileLoadFunction, opt
   /**
    * Data projection
    * @private
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.projection_;
 
   /**
    * @private
-   * @type {Object.<string, module:ol/render/ReplayGroup~ReplayGroup>}
+   * @type {Object.<string, module:ol/render/ReplayGroup>}
    */
   this.replayGroups_ = {};
 
@@ -114,7 +114,7 @@ VectorTile.prototype.getExtent = function() {
 
 /**
  * Get the feature format assigned for reading this tile's features.
- * @return {module:ol/format/Feature~FeatureFormat} Feature format.
+ * @return {module:ol/format/Feature} Feature format.
  * @api
  */
 VectorTile.prototype.getFormat = function() {
@@ -125,7 +125,7 @@ VectorTile.prototype.getFormat = function() {
 /**
  * Get the features for this tile. Geometries will be in the projection returned
  * by {@link module:ol/VectorTile~VectorTile#getProjection}.
- * @return {Array.<module:ol/Feature~Feature|module:ol/render/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature|module:ol/render/Feature~Feature>} Features.
  * @api
  */
 VectorTile.prototype.getFeatures = function() {
@@ -144,7 +144,7 @@ VectorTile.prototype.getKey = function() {
 /**
  * Get the feature projection of features returned by
  * {@link module:ol/VectorTile~VectorTile#getFeatures}.
- * @return {module:ol/proj/Projection~Projection} Feature projection.
+ * @return {module:ol/proj/Projection} Feature projection.
  * @api
  */
 VectorTile.prototype.getProjection = function() {
@@ -153,9 +153,9 @@ VectorTile.prototype.getProjection = function() {
 
 
 /**
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @param {string} key Key.
- * @return {module:ol/render/ReplayGroup~ReplayGroup} Replay group.
+ * @return {module:ol/render/ReplayGroup} Replay group.
  */
 VectorTile.prototype.getReplayGroup = function(layer, key) {
   return this.replayGroups_[getUid(layer) + ',' + key];
@@ -176,8 +176,8 @@ VectorTile.prototype.load = function() {
 
 /**
  * Handler for successful tile load.
- * @param {Array.<module:ol/Feature~Feature>} features The loaded features.
- * @param {module:ol/proj/Projection~Projection} dataProjection Data projection.
+ * @param {Array.<module:ol/Feature>} features The loaded features.
+ * @param {module:ol/proj/Projection} dataProjection Data projection.
  * @param {module:ol/extent~Extent} extent Extent.
  */
 VectorTile.prototype.onLoad = function(features, dataProjection, extent) {
@@ -215,7 +215,7 @@ VectorTile.prototype.setExtent = function(extent) {
 /**
  * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
  * Sets the features for the tile.
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @api
  */
 VectorTile.prototype.setFeatures = function(features) {
@@ -228,7 +228,7 @@ VectorTile.prototype.setFeatures = function(features) {
  * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
  * Sets the projection of the features that were added with
  * {@link module:ol/VectorTile~VectorTile#setFeatures}.
- * @param {module:ol/proj/Projection~Projection} projection Feature projection.
+ * @param {module:ol/proj/Projection} projection Feature projection.
  * @api
  */
 VectorTile.prototype.setProjection = function(projection) {
@@ -237,9 +237,9 @@ VectorTile.prototype.setProjection = function(projection) {
 
 
 /**
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @param {string} key Key.
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
  */
 VectorTile.prototype.setReplayGroup = function(layer, key, replayGroup) {
   this.replayGroups_[getUid(layer) + ',' + key] = replayGroup;

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -158,7 +158,7 @@ import Units from './proj/Units.js';
 /**
  * @typedef {Object} State
  * @property {module:ol/coordinate~Coordinate} center
- * @property {module:ol/proj/Projection~Projection} projection
+ * @property {module:ol/proj/Projection} projection
  * @property {number} resolution
  * @property {number} rotation
  * @property {number} zoom
@@ -225,7 +225,7 @@ const DEFAULT_MIN_ZOOM = 0;
  * default the center is not constrained at all.
  *
  * @constructor
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @param {module:ol/View~ViewOptions=} opt_options View options.
  * @api
  */
@@ -257,7 +257,7 @@ const View = function(opt_options) {
   /**
    * @private
    * @const
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.projection_ = createProjection(options.projection, 'EPSG:3857');
 
@@ -711,7 +711,9 @@ View.prototype.constrainRotation = function(rotation, opt_delta) {
  * @api
  */
 View.prototype.getCenter = function() {
-  return /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(ViewProperty.CENTER));
+  return (
+    /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(ViewProperty.CENTER))
+  );
 };
 
 
@@ -823,7 +825,7 @@ View.prototype.setMinZoom = function(zoom) {
 
 /**
  * Get the view projection.
- * @return {module:ol/proj/Projection~Projection} The projection of the view.
+ * @return {module:ol/proj/Projection} The projection of the view.
  * @api
  */
 View.prototype.getProjection = function() {
@@ -935,13 +937,15 @@ View.prototype.getState = function() {
   const projection = this.getProjection();
   const resolution = /** @type {number} */ (this.getResolution());
   const rotation = this.getRotation();
-  return /** @type {module:ol/View~State} */ ({
-    center: center.slice(),
-    projection: projection !== undefined ? projection : null,
-    resolution: resolution,
-    rotation: rotation,
-    zoom: this.getZoom()
-  });
+  return (
+    /** @type {module:ol/View~State} */ ({
+      center: center.slice(),
+      projection: projection !== undefined ? projection : null,
+      resolution: resolution,
+      rotation: rotation,
+      zoom: this.getZoom()
+    })
+  );
 };
 
 
@@ -1005,7 +1009,7 @@ View.prototype.getResolutionForZoom = function(zoom) {
  * The size is pixel dimensions of the box to fit the extent into.
  * In most cases you will want to use the map size, that is `map.getSize()`.
  * Takes care of the map angle.
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry|module:ol/extent~Extent} geometryOrExtent The geometry or
+ * @param {module:ol/geom/SimpleGeometry|module:ol/extent~Extent} geometryOrExtent The geometry or
  *     extent to fit the view to.
  * @param {module:ol/View~FitOptions=} opt_options Options.
  * @api
@@ -1016,7 +1020,7 @@ View.prototype.fit = function(geometryOrExtent, opt_options) {
   if (!size) {
     size = this.getSizeFromViewport_();
   }
-  /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */
+  /** @type {module:ol/geom/SimpleGeometry} */
   let geometry;
   if (!(geometryOrExtent instanceof SimpleGeometry)) {
     assert(Array.isArray(geometryOrExtent),

--- a/src/ol/WebGLMap.js
+++ b/src/ol/WebGLMap.js
@@ -58,7 +58,7 @@ import WebGLVectorLayerRenderer from './renderer/webgl/VectorLayer.js';
  * with `addLayer` can be groups, which can contain further groups, and so on.
  *
  * @constructor
- * @extends {module:ol/PluggableMap~PluggableMap}
+ * @extends {module:ol/PluggableMap}
  * @param {module:ol/PluggableMap~MapOptions} options Map options.
  * @fires module:ol/MapBrowserEvent~MapBrowserEvent
  * @fires module:ol/MapEvent~MapEvent

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -185,7 +185,9 @@ function fromStringInternal_(s) {
   } else {
     assert(false, 14); // Invalid color
   }
-  return /** @type {module:ol/color~Color} */ (color);
+  return (
+    /** @type {module:ol/color~Color} */ (color)
+  );
 }
 
 

--- a/src/ol/control.js
+++ b/src/ol/control.js
@@ -44,7 +44,7 @@ export {default as ZoomToExtent} from './control/ZoomToExtent.js';
  *
  * @param {module:ol/control~DefaultsOptions=} opt_options
  * Defaults options.
- * @return {module:ol/Collection~Collection.<module:ol/control/Control~Control>}
+ * @return {module:ol/Collection.<module:ol/control/Control>}
  * Controls.
  * @api
  */

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -29,7 +29,7 @@ import {visibleAtResolution} from '../layer/Layer.js';
  * @property {string|Element} [collapseLabel='»'] Text label to use
  * for the expanded attributions button.
  * Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when
+ * @property {function(module:ol/MapEvent)} [render] Function called when
  * the control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  */
@@ -43,7 +43,7 @@ import {visibleAtResolution} from '../layer/Layer.js';
  * be changed by using a css selector for `.ol-attribution`.
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/Attribution~Options=} opt_options Attribution options.
  * @api
  */
@@ -208,8 +208,8 @@ Attribution.prototype.getSourceAttributions_ = function(frameState) {
 
 /**
  * Update the attribution element.
- * @param {module:ol/MapEvent~MapEvent} mapEvent Map event.
- * @this {module:ol/control/Attribution~Attribution}
+ * @param {module:ol/MapEvent} mapEvent Map event.
+ * @this {module:ol/control/Attribution}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -14,7 +14,7 @@ import {listen, unlistenByKey} from '../events.js';
  * @property {Element} [element] The element is the control's
  * container element. This only needs to be specified if you're developing
  * a custom control.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when
+ * @property {function(module:ol/MapEvent)} [render] Function called when
  * the control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  * @property {Element|string} [target] Specify a target if you want
@@ -45,7 +45,7 @@ import {listen, unlistenByKey} from '../events.js';
  * examples/custom-controls for an example of how to do this.
  *
  * @constructor
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @implements {oli.control.Control}
  * @param {module:ol/control/Control~Options} options Control options.
  * @api
@@ -68,7 +68,7 @@ const Control = function(options) {
 
   /**
    * @private
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    */
   this.map_ = null;
 
@@ -79,7 +79,7 @@ const Control = function(options) {
   this.listenerKeys = [];
 
   /**
-   * @type {function(module:ol/MapEvent~MapEvent)}
+   * @type {function(module:ol/MapEvent)}
    */
   this.render = options.render ? options.render : UNDEFINED;
 
@@ -103,7 +103,7 @@ Control.prototype.disposeInternal = function() {
 
 /**
  * Get the map associated with this control.
- * @return {module:ol/PluggableMap~PluggableMap} Map.
+ * @return {module:ol/PluggableMap} Map.
  * @api
  */
 Control.prototype.getMap = function() {
@@ -115,7 +115,7 @@ Control.prototype.getMap = function() {
  * Remove the control from its current map and attach it to the new map.
  * Subclasses may set up event handlers to get notified about changes to
  * the map here.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @override
  * @api
  */

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -63,7 +63,7 @@ const getChangeType = (function() {
  *
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/FullScreen~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -26,7 +26,7 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * @property {string} [className='ol-mouse-position'] CSS class name.
  * @property {module:ol/coordinate~CoordinateFormat} [coordinateFormat] Coordinate format.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when the
+ * @property {function(module:ol/MapEvent)} [render] Function called when the
  * control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  * @property {Element|string} [target] Specify a target if you want the
@@ -47,7 +47,7 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * can be changed by using the css selector `.ol-mouse-position`.
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/MousePosition~Options=} opt_options Mouse position
  *     options.
  * @api
@@ -96,7 +96,7 @@ const MousePosition = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.mapProjection_ = null;
 
@@ -119,8 +119,8 @@ inherits(MousePosition, Control);
 
 /**
  * Update the mouseposition element.
- * @param {module:ol/MapEvent~MapEvent} mapEvent Map event.
- * @this {module:ol/control/MousePosition~MousePosition}
+ * @param {module:ol/MapEvent} mapEvent Map event.
+ * @this {module:ol/control/MousePosition}
  * @api
  */
 export function render(mapEvent) {
@@ -154,19 +154,23 @@ MousePosition.prototype.handleProjectionChanged_ = function() {
  * @api
  */
 MousePosition.prototype.getCoordinateFormat = function() {
-  return /** @type {module:ol/coordinate~CoordinateFormat|undefined} */ (this.get(COORDINATE_FORMAT));
+  return (
+    /** @type {module:ol/coordinate~CoordinateFormat|undefined} */ (this.get(COORDINATE_FORMAT))
+  );
 };
 
 
 /**
  * Return the projection that is used to report the mouse position.
- * @return {module:ol/proj/Projection~Projection|undefined} The projection to report mouse
+ * @return {module:ol/proj/Projection|undefined} The projection to report mouse
  *     position in.
  * @observable
  * @api
  */
 MousePosition.prototype.getProjection = function() {
-  return /** @type {module:ol/proj/Projection~Projection|undefined} */ (this.get(PROJECTION));
+  return (
+    /** @type {module:ol/proj/Projection|undefined} */ (this.get(PROJECTION))
+  );
 };
 
 

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -45,15 +45,15 @@ const MIN_RATIO = 0.1;
  * @property {boolean} [collapsible=true] Whether the control can be collapsed or not.
  * @property {string|Element} [label='»'] Text label to use for the collapsed
  * overviewmap button. Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {Array.<module:ol/layer/Layer~Layer>|module:ol/Collection~Collection.<module:ol/layer/Layer~Layer>} [layers]
+ * @property {Array.<module:ol/layer/Layer>|module:ol/Collection.<module:ol/layer/Layer>} [layers]
  * Layers for the overview map. If not set, then all main map layers are used
  * instead.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when the control
+ * @property {function(module:ol/MapEvent)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {Element|string} [target] Specify a target if you want the control
  * to be rendered outside of the map's viewport.
  * @property {string} [tipLabel='Overview map'] Text label to use for the button tip.
- * @property {module:ol/View~View} [view] Custom view for the overview map. If not provided,
+ * @property {module:ol/View} [view] Custom view for the overview map. If not provided,
  * a default view with an EPSG:3857 projection will be used.
  */
 
@@ -62,7 +62,7 @@ const MIN_RATIO = 0.1;
  * Create a new control with a map acting as an overview map for an other
  * defined map.
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/OverviewMap~Options=} opt_options OverviewMap options.
  * @api
  */
@@ -136,7 +136,7 @@ const OverviewMap = function(opt_options) {
   this.ovmapDiv_.className = 'ol-overviewmap-map';
 
   /**
-   * @type {module:ol/Map~Map}
+   * @type {module:ol/Map}
    * @private
    */
   this.ovmap_ = new Map({
@@ -149,7 +149,7 @@ const OverviewMap = function(opt_options) {
   if (options.layers) {
     options.layers.forEach(
       /**
-       * @param {module:ol/layer/Layer~Layer} layer Layer.
+       * @param {module:ol/layer/Layer} layer Layer.
        */
       function(layer) {
         ovmap.addLayer(layer);
@@ -161,7 +161,7 @@ const OverviewMap = function(opt_options) {
   box.style.boxSizing = 'border-box';
 
   /**
-   * @type {module:ol/Overlay~Overlay}
+   * @type {module:ol/Overlay}
    * @private
    */
   this.boxOverlay_ = new Overlay({
@@ -275,7 +275,7 @@ OverviewMap.prototype.setMap = function(map) {
  */
 OverviewMap.prototype.handleMapPropertyChange_ = function(event) {
   if (event.key === MapProperty.VIEW) {
-    const oldView = /** @type {module:ol/View~View} */ (event.oldValue);
+    const oldView = /** @type {module:ol/View} */ (event.oldValue);
     if (oldView) {
       this.unbindView_(oldView);
     }
@@ -287,7 +287,7 @@ OverviewMap.prototype.handleMapPropertyChange_ = function(event) {
 
 /**
  * Register listeners for view property changes.
- * @param {module:ol/View~View} view The view.
+ * @param {module:ol/View} view The view.
  * @private
  */
 OverviewMap.prototype.bindView_ = function(view) {
@@ -299,7 +299,7 @@ OverviewMap.prototype.bindView_ = function(view) {
 
 /**
  * Unregister listeners for view property changes.
- * @param {module:ol/View~View} view The view.
+ * @param {module:ol/View} view The view.
  * @private
  */
 OverviewMap.prototype.unbindView_ = function(view) {
@@ -322,8 +322,8 @@ OverviewMap.prototype.handleRotationChanged_ = function() {
 
 /**
  * Update the overview map element.
- * @param {module:ol/MapEvent~MapEvent} mapEvent Map event.
- * @this {module:ol/control/OverviewMap~OverviewMap}
+ * @param {module:ol/MapEvent} mapEvent Map event.
+ * @this {module:ol/control/OverviewMap}
  * @api
  */
 export function render(mapEvent) {
@@ -588,7 +588,7 @@ OverviewMap.prototype.getCollapsed = function() {
 
 /**
  * Return the overview map.
- * @return {module:ol/PluggableMap~PluggableMap} Overview map.
+ * @return {module:ol/PluggableMap} Overview map.
  * @api
  */
 OverviewMap.prototype.getOverviewMap = function() {

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -18,7 +18,7 @@ import {inherits} from '../index.js';
  * @property {string} [tipLabel='Reset rotation'] Text label to use for the rotate tip.
  * @property {number} [duration=250] Animation duration in milliseconds.
  * @property {boolean} [autoHide=true] Hide the control when rotation is 0.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when the control should
+ * @property {function(module:ol/MapEvent)} [render] Function called when the control should
  * be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {function()} [resetNorth] Function called when the control is clicked.
  * This will override the default `resetNorth`.
@@ -34,7 +34,7 @@ import {inherits} from '../index.js';
  * selector is added to the button when the rotation is 0.
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/Rotate~Options=} opt_options Rotate options.
  * @api
  */
@@ -153,8 +153,8 @@ Rotate.prototype.resetNorth_ = function() {
 
 /**
  * Update the rotate control element.
- * @param {module:ol/MapEvent~MapEvent} mapEvent Map event.
- * @this {module:ol/control/Rotate~Rotate}
+ * @param {module:ol/MapEvent} mapEvent Map event.
+ * @this {module:ol/control/Rotate}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -41,7 +41,7 @@ const LEADING_DIGITS = [1, 2, 5];
  * @typedef {Object} Options
  * @property {string} [className='ol-scale-line'] CSS Class name.
  * @property {number} [minWidth=64] Minimum width in pixels.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when the control
+ * @property {function(module:ol/MapEvent)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {Element|string} [target] Specify a target if you want the control
  * to be rendered outside of the map's viewport.
@@ -60,7 +60,7 @@ const LEADING_DIGITS = [1, 2, 5];
  * but this can be changed by using the css selector `.ol-scale-line`.
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/ScaleLine~Options=} opt_options Scale line options.
  * @api
  */
@@ -141,14 +141,16 @@ inherits(ScaleLine, Control);
  * @api
  */
 ScaleLine.prototype.getUnits = function() {
-  return /** @type {module:ol/control/ScaleLine~Units|undefined} */ (this.get(UNITS_PROP));
+  return (
+    /** @type {module:ol/control/ScaleLine~Units|undefined} */ (this.get(UNITS_PROP))
+  );
 };
 
 
 /**
  * Update the scale line element.
- * @param {module:ol/MapEvent~MapEvent} mapEvent Map event.
- * @this {module:ol/control/ScaleLine~ScaleLine}
+ * @param {module:ol/MapEvent} mapEvent Map event.
+ * @this {module:ol/control/ScaleLine}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -32,7 +32,7 @@ import {easeOut} from '../easing.js';
  * use css selectors `.ol-zoom-in` and `.ol-zoom-out`.
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/Zoom~Options=} opt_options Zoom options.
  * @api
  */

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -29,7 +29,7 @@ const Direction = {
  * @typedef {Object} Options
  * @property {string} [className='ol-zoomslider'] CSS class name.
  * @property {number} [duration=200] Animation duration in milliseconds.
- * @property {function(module:ol/MapEvent~MapEvent)} [render] Function called when the control
+ * @property {function(module:ol/MapEvent)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  */
 
@@ -43,7 +43,7 @@ const Direction = {
  *     map.addControl(new ZoomSlider());
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/ZoomSlider~Options=} opt_options Zoom slider options.
  * @api
  */
@@ -127,7 +127,7 @@ const ZoomSlider = function(opt_options) {
   containerElement.className = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL;
   containerElement.appendChild(thumbElement);
   /**
-   * @type {module:ol/pointer/PointerEventHandler~PointerEventHandler}
+   * @type {module:ol/pointer/PointerEventHandler}
    * @private
    */
   this.dragger_ = new PointerEventHandler(containerElement);
@@ -207,8 +207,8 @@ ZoomSlider.prototype.initSlider_ = function() {
 
 /**
  * Update the zoomslider element.
- * @param {module:ol/MapEvent~MapEvent} mapEvent Map event.
- * @this {module:ol/control/ZoomSlider~ZoomSlider}
+ * @param {module:ol/MapEvent} mapEvent Map event.
+ * @this {module:ol/control/ZoomSlider}
  * @api
  */
 export function render(mapEvent) {
@@ -249,7 +249,7 @@ ZoomSlider.prototype.handleContainerClick_ = function(event) {
 
 /**
  * Handle dragger start events.
- * @param {module:ol/pointer/PointerEvent~PointerEvent} event The drag event.
+ * @param {module:ol/pointer/PointerEvent} event The drag event.
  * @private
  */
 ZoomSlider.prototype.handleDraggerStart_ = function(event) {
@@ -265,7 +265,7 @@ ZoomSlider.prototype.handleDraggerStart_ = function(event) {
 /**
  * Handle dragger drag events.
  *
- * @param {module:ol/pointer/PointerEvent~PointerEvent|Event} event The drag event.
+ * @param {module:ol/pointer/PointerEvent|Event} event The drag event.
  * @private
  */
 ZoomSlider.prototype.handleDraggerDrag_ = function(event) {
@@ -285,7 +285,7 @@ ZoomSlider.prototype.handleDraggerDrag_ = function(event) {
 
 /**
  * Handle dragger end events.
- * @param {module:ol/pointer/PointerEvent~PointerEvent|Event} event The drag event.
+ * @param {module:ol/pointer/PointerEvent|Event} event The drag event.
  * @private
  */
 ZoomSlider.prototype.handleDraggerEnd_ = function(event) {

--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -27,7 +27,7 @@ import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
  * extent. To style this control use the css selector `.ol-zoom-extent`.
  *
  * @constructor
- * @extends {module:ol/control/Control~Control}
+ * @extends {module:ol/control/Control}
  * @param {module:ol/control/ZoomToExtent~Options=} opt_options Options.
  * @api
  */

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -50,7 +50,7 @@ export function add(coordinate, delta) {
  * Calculates the point closest to the passed coordinate on the passed circle.
  *
  * @param {module:ol/coordinate~Coordinate} coordinate The coordinate.
- * @param {module:ol/geom/Circle~Circle} circle The circle.
+ * @param {module:ol/geom/Circle} circle The circle.
  * @return {module:ol/coordinate~Coordinate} Closest point on the circumference.
  */
 export function closestOnCircle(coordinate, circle) {

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -12,7 +12,7 @@ import {clear} from './obj.js';
  * @property {boolean} callOnce
  * @property {number} [deleteIndex]
  * @property {module:ol/events~ListenerFunction} listener
- * @property {EventTarget|module:ol/events/EventTarget~EventTarget} target
+ * @property {EventTarget|module:ol/events/EventTarget} target
  * @property {string} type
  * @api
  */
@@ -22,7 +22,7 @@ import {clear} from './obj.js';
  * Listener function. This function is called with an event object as argument.
  * When the function returns `false`, event propagation will stop.
  *
- * @typedef {function(module:ol/events/Event~Event)|function(module:ol/events/Event~Event): boolean} ListenerFunction
+ * @typedef {function(module:ol/events/Event)|function(module:ol/events/Event): boolean} ListenerFunction
  * @api
  */
 

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -59,7 +59,7 @@ Event.prototype.preventDefault =
 
 
 /**
- * @param {Event|module:ol/events/Event~Event} evt Event
+ * @param {Event|module:ol/events/Event} evt Event
  */
 export function stopPropagation(evt) {
   evt.stopPropagation();
@@ -67,7 +67,7 @@ export function stopPropagation(evt) {
 
 
 /**
- * @param {Event|module:ol/events/Event~Event} evt Event
+ * @param {Event|module:ol/events/Event} evt Event
  */
 export function preventDefault(evt) {
   evt.preventDefault();

--- a/src/ol/events/EventTarget.js
+++ b/src/ol/events/EventTarget.js
@@ -9,7 +9,7 @@ import Event from '../events/Event.js';
 
 
 /**
- * @typedef {EventTarget|module:ol/events/EventTarget~EventTarget} EventTargetLike
+ * @typedef {EventTarget|module:ol/events/EventTarget} EventTargetLike
  */
 
 
@@ -29,7 +29,7 @@ import Event from '../events/Event.js';
  *    returns false.
  *
  * @constructor
- * @extends {module:ol/Disposable~Disposable}
+ * @extends {module:ol/Disposable}
  */
 const EventTarget = function() {
 
@@ -75,7 +75,7 @@ EventTarget.prototype.addEventListener = function(type, listener) {
 
 /**
  * @param {{type: string,
- *     target: (EventTarget|module:ol/events/EventTarget~EventTarget|undefined)}|module:ol/events/Event~Event|
+ *     target: (EventTarget|module:ol/events/EventTarget|undefined)}|module:ol/events/Event|
  *     string} event Event or event type.
  * @return {boolean|undefined} `false` if anyone called preventDefault on the
  *     event object or if any of the listeners returned false.

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -8,10 +8,10 @@ import {WEBKIT, MAC} from '../has.js';
 
 
 /**
- * A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
+ * A function that takes an {@link module:ol/MapBrowserEvent} and returns a
  * `{boolean}`. If the condition is met, true should be returned.
  *
- * @typedef {function(module:ol/MapBrowserEvent~MapBrowserEvent): boolean} Condition
+ * @typedef {function(module:ol/MapBrowserEvent): boolean} Condition
  */
 
 
@@ -19,7 +19,7 @@ import {WEBKIT, MAC} from '../has.js';
  * Return `true` if only the alt-key is pressed, `false` otherwise (e.g. when
  * additionally the shift-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the alt key is pressed.
  * @api
  */
@@ -36,7 +36,7 @@ export const altKeyOnly = function(mapBrowserEvent) {
  * Return `true` if only the alt-key and shift-key is pressed, `false` otherwise
  * (e.g. when additionally the platform-modifier-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the alt and shift keys are pressed.
  * @api
  */
@@ -53,7 +53,7 @@ export const altShiftKeysOnly = function(mapBrowserEvent) {
  * Return `true` if the map has the focus. This condition requires a map target
  * element with a `tabindex` attribute, e.g. `<div id="map" tabindex="1">`.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Map browser event.
+ * @param {module:ol/MapBrowserEvent} event Map browser event.
  * @return {boolean} The map has the focus.
  * @api
  */
@@ -65,7 +65,7 @@ export const focus = function(event) {
 /**
  * Return always true.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True.
  * @function
  * @api
@@ -76,7 +76,7 @@ export const always = TRUE;
 /**
  * Return `true` if the event is a `click` event, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `click` event.
  * @api
  */
@@ -91,7 +91,7 @@ export const click = function(mapBrowserEvent) {
  * By definition, this includes left-click on windows/linux, and left-click
  * without the ctrl key on Macs.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} The result.
  */
 export const mouseActionButton = function(mapBrowserEvent) {
@@ -104,7 +104,7 @@ export const mouseActionButton = function(mapBrowserEvent) {
 /**
  * Return always false.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} False.
  * @function
  * @api
@@ -116,7 +116,7 @@ export const never = FALSE;
  * Return `true` if the browser event is a `pointermove` event, `false`
  * otherwise.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the browser event is a `pointermove` event.
  * @api
  */
@@ -128,7 +128,7 @@ export const pointerMove = function(mapBrowserEvent) {
 /**
  * Return `true` if the event is a map `singleclick` event, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `singleclick` event.
  * @api
  */
@@ -140,7 +140,7 @@ export const singleClick = function(mapBrowserEvent) {
 /**
  * Return `true` if the event is a map `dblclick` event, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `dblclick` event.
  * @api
  */
@@ -153,7 +153,7 @@ export const doubleClick = function(mapBrowserEvent) {
  * Return `true` if no modifier key (alt-, shift- or platform-modifier-key) is
  * pressed.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True only if there no modifier keys are pressed.
  * @api
  */
@@ -171,7 +171,7 @@ export const noModifierKeys = function(mapBrowserEvent) {
  * ctrl-key otherwise) is pressed, `false` otherwise (e.g. when additionally
  * the shift-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the platform modifier key is pressed.
  * @api
  */
@@ -187,7 +187,7 @@ export const platformModifierKeyOnly = function(mapBrowserEvent) {
  * Return `true` if only the shift-key is pressed, `false` otherwise (e.g. when
  * additionally the alt-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the shift key is pressed.
  * @api
  */
@@ -204,7 +204,7 @@ export const shiftKeyOnly = function(mapBrowserEvent) {
  * Return `true` if the target element is not editable, i.e. not a `<input>`-,
  * `<select>`- or `<textarea>`-element, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True only if the target element is not editable.
  * @api
  */
@@ -221,14 +221,16 @@ export const targetNotEditable = function(mapBrowserEvent) {
 /**
  * Return `true` if the event originates from a mouse device.
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a mouse device.
  * @api
  */
 export const mouseOnly = function(mapBrowserEvent) {
   assert(mapBrowserEvent.pointerEvent, 56); // mapBrowserEvent must originate from a pointer event
   // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return /** @type {module:ol/MapBrowserEvent~MapBrowserEvent} */ (mapBrowserEvent).pointerEvent.pointerType == 'mouse';
+  return (
+    /** @type {module:ol/MapBrowserEvent} */ (mapBrowserEvent).pointerEvent.pointerType == 'mouse'
+  );
 };
 
 
@@ -237,7 +239,7 @@ export const mouseOnly = function(mapBrowserEvent) {
  * contact with the surface or if the left mouse button is pressed.
  * @see http://www.w3.org/TR/pointerevents/#button-states
  *
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a primary pointer.
  * @api
  */

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -494,7 +494,9 @@ export function getCorner(extent, corner) {
   } else {
     assert(false, 13); // Invalid corner
   }
-  return /** @type {!module:ol/coordinate~Coordinate} */ (coordinate);
+  return (
+    /** @type {!module:ol/coordinate~Coordinate} */ (coordinate)
+  );
 }
 
 

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -11,14 +11,14 @@ import FormatType from './format/FormatType.js';
  *
  * This function takes an {@link module:ol/extent~Extent} representing the area to be loaded,
  * a `{number}` representing the resolution (map units per pixel) and an
- * {@link module:ol/proj/Projection~Projection} for the projection  as
+ * {@link module:ol/proj/Projection} for the projection  as
  * arguments. `this` within the function is bound to the
  * {@link module:ol/source/Vector~Vector} it's called from.
  *
  * The function is responsible for loading the features and adding them to the
  * source.
  * @typedef {function(this:module:ol/source/Vector~Vector, module:ol/extent~Extent, number,
- *                    module:ol/proj/Projection~Projection)} FeatureLoader
+ *                    module:ol/proj/Projection)} FeatureLoader
  * @api
  */
 
@@ -29,20 +29,20 @@ import FormatType from './format/FormatType.js';
  *
  * This function takes an {@link module:ol/extent~Extent} representing the area
  * to be loaded, a `{number}` representing the resolution (map units per pixel)
- * and an {@link module:ol/proj/Projection~Projection} for the projection  as
+ * and an {@link module:ol/proj/Projection} for the projection  as
  * arguments and returns a `{string}` representing the URL.
- * @typedef {function(module:ol/extent~Extent, number, module:ol/proj/Projection~Projection): string} FeatureUrlFunction
+ * @typedef {function(module:ol/extent~Extent, number, module:ol/proj/Projection): string} FeatureUrlFunction
  * @api
  */
 
 
 /**
  * @param {string|module:ol/featureloader~FeatureUrlFunction} url Feature URL service.
- * @param {module:ol/format/Feature~FeatureFormat} format Feature format.
- * @param {function(this:module:ol/VectorTile~VectorTile, Array.<module:ol/Feature~Feature>, module:ol/proj/Projection~Projection, module:ol/extent~Extent)|function(this:module:ol/source/Vector~Vector, Array.<module:ol/Feature~Feature>)} success
+ * @param {module:ol/format/Feature} format Feature format.
+ * @param {function(this:module:ol/VectorTile, Array.<module:ol/Feature>, module:ol/proj/Projection, module:ol/extent~Extent)|function(this:module:ol/source/Vector~Vector, Array.<module:ol/Feature>)} success
  *     Function called with the loaded features and optionally with the data
  *     projection. Called with the vector tile or source as `this`.
- * @param {function(this:module:ol/VectorTile~VectorTile)|function(this:module:ol/source/Vector~Vector)} failure
+ * @param {function(this:module:ol/VectorTile)|function(this:module:ol/source/Vector~Vector)} failure
  *     Function called when loading failed. Called with the vector tile or
  *     source as `this`.
  * @return {module:ol/featureloader~FeatureLoader} The feature loader.
@@ -52,8 +52,8 @@ export function loadFeaturesXhr(url, format, success, failure) {
     /**
      * @param {module:ol/extent~Extent} extent Extent.
      * @param {number} resolution Resolution.
-     * @param {module:ol/proj/Projection~Projection} projection Projection.
-     * @this {module:ol/source/Vector~Vector|module:ol/VectorTile~VectorTile}
+     * @param {module:ol/proj/Projection} projection Projection.
+     * @this {module:ol/source/Vector~Vector|module:ol/VectorTile}
      */
     function(extent, resolution, projection) {
       const xhr = new XMLHttpRequest();
@@ -111,15 +111,15 @@ export function loadFeaturesXhr(url, format, success, failure) {
  * loads features (with XHR), parses the features, and adds them to the
  * vector source.
  * @param {string|module:ol/featureloader~FeatureUrlFunction} url Feature URL service.
- * @param {module:ol/format/Feature~FeatureFormat} format Feature format.
+ * @param {module:ol/format/Feature} format Feature format.
  * @return {module:ol/featureloader~FeatureLoader} The feature loader.
  * @api
  */
 export function xhr(url, format) {
   return loadFeaturesXhr(url, format,
     /**
-     * @param {Array.<module:ol/Feature~Feature>} features The loaded features.
-     * @param {module:ol/proj/Projection~Projection} dataProjection Data
+     * @param {Array.<module:ol/Feature>} features The loaded features.
+     * @param {module:ol/proj/Projection} dataProjection Data
      * projection.
      * @this {module:ol/source/Vector~Vector}
      */

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -24,7 +24,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @const
- * @type {Object.<module:ol/geom/GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry~Geometry>}
+ * @type {Object.<module:ol/geom/GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry>}
  */
 const GEOMETRY_READERS = {};
 GEOMETRY_READERS[GeometryType.POINT] = readPointGeometry;
@@ -37,7 +37,7 @@ GEOMETRY_READERS[GeometryType.MULTI_POLYGON] = readMultiPolygonGeometry;
 
 /**
  * @const
- * @type {Object.<string, function(module:ol/geom/Geometry~Geometry, module:ol/format/Feature~WriteOptions=): (EsriJSONGeometry)>}
+ * @type {Object.<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (EsriJSONGeometry)>}
  */
 const GEOMETRY_WRITERS = {};
 GEOMETRY_WRITERS[GeometryType.POINT] = writePointGeometry;
@@ -59,7 +59,7 @@ GEOMETRY_WRITERS[GeometryType.MULTI_POLYGON] = writeMultiPolygonGeometry;
  * Feature format for reading and writing data in the EsriJSON format.
  *
  * @constructor
- * @extends {module:ol/format/JSONFeature~JSONFeature}
+ * @extends {module:ol/format/JSONFeature}
  * @param {module:ol/format/EsriJSON~Options=} opt_options Options.
  * @api
  */
@@ -84,7 +84,7 @@ inherits(EsriJSON, JSONFeature);
 /**
  * @param {EsriJSONGeometry} object Object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 function readGeometry(object, opt_options) {
   if (!object) {
@@ -115,8 +115,8 @@ function readGeometry(object, opt_options) {
     }
   }
   const geometryReader = GEOMETRY_READERS[type];
-  return /** @type {module:ol/geom/Geometry~Geometry} */ (transformWithOptions(
-    geometryReader(object), false, opt_options)
+  return (
+    /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometryReader(object), false, opt_options))
   );
 }
 
@@ -176,7 +176,7 @@ function convertRings(rings, layout) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry~Geometry} Point.
+ * @return {module:ol/geom/Geometry} Point.
  */
 function readPointGeometry(object) {
   let point;
@@ -198,7 +198,7 @@ function readPointGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry~Geometry} LineString.
+ * @return {module:ol/geom/Geometry} LineString.
  */
 function readLineStringGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -208,7 +208,7 @@ function readLineStringGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry~Geometry} MultiLineString.
+ * @return {module:ol/geom/Geometry} MultiLineString.
  */
 function readMultiLineStringGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -235,7 +235,7 @@ function getGeometryLayout(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry~Geometry} MultiPoint.
+ * @return {module:ol/geom/Geometry} MultiPoint.
  */
 function readMultiPointGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -245,7 +245,7 @@ function readMultiPointGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry~Geometry} MultiPolygon.
+ * @return {module:ol/geom/Geometry} MultiPolygon.
  */
 function readMultiPolygonGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -257,7 +257,7 @@ function readMultiPolygonGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry~Geometry} Polygon.
+ * @return {module:ol/geom/Geometry} Polygon.
  */
 function readPolygonGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -266,14 +266,14 @@ function readPolygonGeometry(object) {
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONGeometry} EsriJSON geometry.
  */
 function writePointGeometry(geometry, opt_options) {
-  const coordinates = /** @type {module:ol/geom/Point~Point} */ (geometry).getCoordinates();
+  const coordinates = /** @type {module:ol/geom/Point} */ (geometry).getCoordinates();
   let esriJSON;
-  const layout = /** @type {module:ol/geom/Point~Point} */ (geometry).getLayout();
+  const layout = /** @type {module:ol/geom/Point} */ (geometry).getLayout();
   if (layout === GeometryLayout.XYZ) {
     esriJSON = /** @type {EsriJSONPoint} */ ({
       x: coordinates[0],
@@ -306,7 +306,7 @@ function writePointGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry Geometry.
+ * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
  * @return {Object} Object with boolean hasZ and hasM keys.
  */
 function getHasZM(geometry) {
@@ -321,76 +321,84 @@ function getHasZM(geometry) {
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolyline} EsriJSON geometry.
  */
 function writeLineStringGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/LineString~LineString} */(geometry));
-  return /** @type {EsriJSONPolyline} */ ({
-    hasZ: hasZM.hasZ,
-    hasM: hasZM.hasM,
-    paths: [
-      /** @type {module:ol/geom/LineString~LineString} */ (geometry).getCoordinates()
-    ]
-  });
+  const hasZM = getHasZM(/** @type {module:ol/geom/LineString} */(geometry));
+  return (
+    /** @type {EsriJSONPolyline} */ {
+      hasZ: hasZM.hasZ,
+      hasM: hasZM.hasM,
+      paths: [
+        /** @type {module:ol/geom/LineString} */ (geometry).getCoordinates()
+      ]
+    }
+  );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolygon} EsriJSON geometry.
  */
 function writePolygonGeometry(geometry, opt_options) {
   // Esri geometries use the left-hand rule
-  const hasZM = getHasZM(/** @type {module:ol/geom/Polygon~Polygon} */(geometry));
-  return /** @type {EsriJSONPolygon} */ ({
-    hasZ: hasZM.hasZ,
-    hasM: hasZM.hasM,
-    rings: /** @type {module:ol/geom/Polygon~Polygon} */ (geometry).getCoordinates(false)
-  });
+  const hasZM = getHasZM(/** @type {module:ol/geom/Polygon} */(geometry));
+  return (
+    /** @type {EsriJSONPolygon} */ {
+      hasZ: hasZM.hasZ,
+      hasM: hasZM.hasM,
+      rings: /** @type {module:ol/geom/Polygon} */ (geometry).getCoordinates(false)
+    }
+  );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolyline} EsriJSON geometry.
  */
 function writeMultiLineStringGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/MultiLineString~MultiLineString} */(geometry));
-  return /** @type {EsriJSONPolyline} */ ({
-    hasZ: hasZM.hasZ,
-    hasM: hasZM.hasM,
-    paths: /** @type {module:ol/geom/MultiLineString~MultiLineString} */ (geometry).getCoordinates()
-  });
+  const hasZM = getHasZM(/** @type {module:ol/geom/MultiLineString} */(geometry));
+  return (
+    /** @type {EsriJSONPolyline} */ {
+      hasZ: hasZM.hasZ,
+      hasM: hasZM.hasM,
+      paths: /** @type {module:ol/geom/MultiLineString} */ (geometry).getCoordinates()
+    }
+  );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONMultipoint} EsriJSON geometry.
  */
 function writeMultiPointGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/MultiPoint~MultiPoint} */(geometry));
-  return /** @type {EsriJSONMultipoint} */ ({
-    hasZ: hasZM.hasZ,
-    hasM: hasZM.hasM,
-    points: /** @type {module:ol/geom/MultiPoint~MultiPoint} */ (geometry).getCoordinates()
-  });
+  const hasZM = getHasZM(/** @type {module:ol/geom/MultiPoint} */(geometry));
+  return (
+    /** @type {EsriJSONMultipoint} */ {
+      hasZ: hasZM.hasZ,
+      hasM: hasZM.hasM,
+      points: /** @type {module:ol/geom/MultiPoint} */ (geometry).getCoordinates()
+    }
+  );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolygon} EsriJSON geometry.
  */
 function writeMultiPolygonGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/MultiPolygon~MultiPolygon} */(geometry));
-  const coordinates = /** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry).getCoordinates(false);
+  const hasZM = getHasZM(/** @type {module:ol/geom/MultiPolygon} */(geometry));
+  const coordinates = /** @type {module:ol/geom/MultiPolygon} */ (geometry).getCoordinates(false);
   const output = [];
   for (let i = 0; i < coordinates.length; i++) {
     for (let x = coordinates[i].length - 1; x >= 0; x--) {
@@ -412,7 +420,7 @@ function writeMultiPolygonGeometry(geometry, opt_options) {
  * @function
  * @param {ArrayBuffer|Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 EsriJSON.prototype.readFeature;
@@ -425,7 +433,7 @@ EsriJSON.prototype.readFeature;
  * @function
  * @param {ArrayBuffer|Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 EsriJSON.prototype.readFeatures;
@@ -461,7 +469,7 @@ EsriJSON.prototype.readFeaturesFromObject = function(object, opt_options) {
   const options = opt_options ? opt_options : {};
   if (esriJSONObject.features) {
     const esriJSONFeatureCollection = /** @type {EsriJSONFeatureCollection} */ (object);
-    /** @type {Array.<module:ol/Feature~Feature>} */
+    /** @type {Array.<module:ol/Feature>} */
     const features = [];
     const esriJSONFeatures = esriJSONFeatureCollection.features;
     options.idField = object.objectIdFieldName;
@@ -481,7 +489,7 @@ EsriJSON.prototype.readFeaturesFromObject = function(object, opt_options) {
  * @function
  * @param {ArrayBuffer|Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  * @api
  */
 EsriJSON.prototype.readGeometry;
@@ -500,7 +508,7 @@ EsriJSON.prototype.readGeometryFromObject = function(object, opt_options) {
  *
  * @function
  * @param {ArrayBuffer|Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 EsriJSON.prototype.readProjection;
@@ -521,13 +529,13 @@ EsriJSON.prototype.readProjectionFromObject = function(object) {
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONGeometry} EsriJSON geometry.
  */
 function writeGeometry(geometry, opt_options) {
   const geometryWriter = GEOMETRY_WRITERS[geometry.getType()];
-  return geometryWriter(/** @type {module:ol/geom/Geometry~Geometry} */(
+  return geometryWriter(/** @type {module:ol/geom/Geometry} */(
     transformWithOptions(geometry, true, opt_options)), opt_options);
 }
 
@@ -536,7 +544,7 @@ function writeGeometry(geometry, opt_options) {
  * Encode a geometry as a EsriJSON string.
  *
  * @function
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} EsriJSON.
  * @api
@@ -547,7 +555,7 @@ EsriJSON.prototype.writeGeometry;
 /**
  * Encode a geometry as a EsriJSON object.
  *
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {EsriJSONGeometry} Object.
  * @override
@@ -562,7 +570,7 @@ EsriJSON.prototype.writeGeometryObject = function(geometry, opt_options) {
  * Encode a feature as a EsriJSON Feature string.
  *
  * @function
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} EsriJSON.
  * @api
@@ -573,7 +581,7 @@ EsriJSON.prototype.writeFeature;
 /**
  * Encode a feature as a esriJSON Feature object.
  *
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  * @override
@@ -606,7 +614,7 @@ EsriJSON.prototype.writeFeatureObject = function(feature, opt_options) {
  * Encode an array of features as EsriJSON.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} EsriJSON.
  * @api
@@ -617,7 +625,7 @@ EsriJSON.prototype.writeFeatures;
 /**
  * Encode an array of features as a EsriJSON object.
  *
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {Object} EsriJSON Object.
  * @override

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -64,13 +64,13 @@ const FeatureFormat = function() {
 
   /**
    * @protected
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.defaultDataProjection = null;
 
   /**
    * @protected
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.defaultFeatureProjection = null;
 
@@ -136,7 +136,7 @@ FeatureFormat.prototype.getType = function() {};
  * @abstract
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 FeatureFormat.prototype.readFeature = function(source, opt_options) {};
 
@@ -147,7 +147,7 @@ FeatureFormat.prototype.readFeature = function(source, opt_options) {};
  * @abstract
  * @param {Document|Node|ArrayBuffer|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  */
 FeatureFormat.prototype.readFeatures = function(source, opt_options) {};
 
@@ -158,7 +158,7 @@ FeatureFormat.prototype.readFeatures = function(source, opt_options) {};
  * @abstract
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 FeatureFormat.prototype.readGeometry = function(source, opt_options) {};
 
@@ -168,7 +168,7 @@ FeatureFormat.prototype.readGeometry = function(source, opt_options) {};
  *
  * @abstract
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 FeatureFormat.prototype.readProjection = function(source) {};
 
@@ -177,7 +177,7 @@ FeatureFormat.prototype.readProjection = function(source) {};
  * Encode a feature in this format.
  *
  * @abstract
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} Result.
  */
@@ -188,7 +188,7 @@ FeatureFormat.prototype.writeFeature = function(feature, opt_options) {};
  * Encode an array of features in this format.
  *
  * @abstract
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} Result.
  */
@@ -199,7 +199,7 @@ FeatureFormat.prototype.writeFeatures = function(features, opt_options) {};
  * Write a single geometry in this format.
  *
  * @abstract
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} Result.
  */
@@ -208,11 +208,11 @@ FeatureFormat.prototype.writeGeometry = function(geometry, opt_options) {};
 export default FeatureFormat;
 
 /**
- * @param {module:ol/geom/Geometry~Geometry|module:ol/extent~Extent} geometry Geometry.
+ * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
  * @param {boolean} write Set to true for writing, false for reading.
  * @param {(module:ol/format/Feature~WriteOptions|module:ol/format/Feature~ReadOptions)=} opt_options
  *     Options.
- * @return {module:ol/geom/Geometry~Geometry|module:ol/extent~Extent} Transformed geometry.
+ * @return {module:ol/geom/Geometry|module:ol/extent~Extent} Transformed geometry.
  */
 export function transformWithOptions(geometry, write, opt_options) {
   const featureProjection = opt_options ?
@@ -220,7 +220,7 @@ export function transformWithOptions(geometry, write, opt_options) {
   const dataProjection = opt_options ?
     getProjection(opt_options.dataProjection) : null;
   /**
-   * @type {module:ol/geom/Geometry~Geometry|module:ol/extent~Extent}
+   * @type {module:ol/geom/Geometry|module:ol/extent~Extent}
    */
   let transformed;
   if (featureProjection && dataProjection &&

--- a/src/ol/format/GML.js
+++ b/src/ol/format/GML.js
@@ -12,7 +12,7 @@ import GML3 from '../format/GML3.js';
  * @constructor
  * @param {module:ol/format/GMLBase~Options=} opt_options
  *     Optional configuration object.
- * @extends {module:ol/format/GMLBase~GMLBase}
+ * @extends {module:ol/format/GMLBase}
  * @api
  */
 const GML = GML3;
@@ -22,7 +22,7 @@ const GML = GML3;
  * Encode an array of features in GML 3.1.1 Simple Features.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api
@@ -34,7 +34,7 @@ GML.prototype.writeFeatures;
  * Encode an array of features in the GML 3.1.1 format as an XML node.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @api

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -27,7 +27,7 @@ const schemaLocation = GMLNS + ' http://schemas.opengis.net/gml/2.1.2/feature.xs
  *
  * @constructor
  * @param {module:ol/format/GMLBase~Options=} opt_options Optional configuration object.
- * @extends {module:ol/format/GMLBase~GMLBase}
+ * @extends {module:ol/format/GMLBase}
  * @api
  */
 const GML2 = function(opt_options) {
@@ -150,7 +150,7 @@ GML2.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeNam
   const multiCurve = context['multiCurve'];
   let nodeName;
   if (!Array.isArray(value)) {
-    nodeName = /** @type {module:ol/geom/Geometry~Geometry} */ (value).getType();
+    nodeName = /** @type {module:ol/geom/Geometry} */ (value).getType();
     if (nodeName === 'MultiPolygon' && multiSurface === true) {
       nodeName = 'MultiSurface';
     } else if (nodeName === 'Polygon' && surface === true) {
@@ -168,7 +168,7 @@ GML2.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeNam
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Node stack.
  */
 GML2.prototype.writeFeatureElement = function(node, feature, objectStack) {
@@ -215,7 +215,7 @@ GML2.prototype.writeFeatureElement = function(node, feature, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} geometry LineString geometry.
+ * @param {module:ol/geom/LineString} geometry LineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -241,7 +241,7 @@ GML2.prototype.writeCurveOrLineString_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} line LineString geometry.
+ * @param {module:ol/geom/LineString} line LineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -256,7 +256,7 @@ GML2.prototype.writeLineStringOrCurveMember_ = function(node, line, objectStack)
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/MultiLineString~MultiLineString} geometry MultiLineString geometry.
+ * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -278,7 +278,7 @@ GML2.prototype.writeMultiCurveOrLineString_ = function(node, geometry, objectSta
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Geometry~Geometry|module:ol/extent~Extent} geometry Geometry.
+ * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
  * @param {Array.<*>} objectStack Node stack.
  */
 GML2.prototype.writeGeometryElement = function(node, geometry, objectStack) {
@@ -294,7 +294,7 @@ GML2.prototype.writeGeometryElement = function(node, geometry, objectStack) {
       value = geometry;
     }
   } else {
-    value = transformWithOptions(/** @type {module:ol/geom/Geometry~Geometry} */ (geometry), true, context);
+    value = transformWithOptions(/** @type {module:ol/geom/Geometry} */ (geometry), true, context);
   }
   pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
     (item), this.GEOMETRY_SERIALIZERS_,
@@ -320,7 +320,7 @@ GML2.prototype.createCoordinatesNode_ = function(namespaceURI) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString|module:ol/geom/LinearRing~LinearRing} value Geometry.
+ * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -342,7 +342,7 @@ GML2.prototype.writeCoordinates_ = function(node, value, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} line LineString geometry.
+ * @param {module:ol/geom/LineString} line LineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -355,7 +355,7 @@ GML2.prototype.writeCurveSegments_ = function(node, line, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} geometry Polygon geometry.
+ * @param {module:ol/geom/Polygon} geometry Polygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -403,7 +403,7 @@ GML2.prototype.RING_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon geometry.
+ * @param {module:ol/geom/Polygon} polygon Polygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -416,7 +416,7 @@ GML2.prototype.writeSurfacePatches_ = function(node, polygon, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LinearRing~LinearRing} ring LinearRing geometry.
+ * @param {module:ol/geom/LinearRing} ring LinearRing geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -454,7 +454,7 @@ GML2.prototype.getCoords_ = function(point, opt_srsName, opt_hasZ) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Point~Point} geometry Point geometry.
+ * @param {module:ol/geom/Point} geometry Point geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -475,7 +475,7 @@ GML2.prototype.writePoint_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/MultiPoint~MultiPoint} geometry MultiPoint geometry.
+ * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -496,7 +496,7 @@ GML2.prototype.writeMultiPoint_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Point~Point} point Point geometry.
+ * @param {module:ol/geom/Point} point Point geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -509,7 +509,7 @@ GML2.prototype.writePointMember_ = function(node, point, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LinearRing~LinearRing} geometry LinearRing geometry.
+ * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -527,7 +527,7 @@ GML2.prototype.writeLinearRing_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry MultiPolygon geometry.
+ * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -549,7 +549,7 @@ GML2.prototype.writeMultiSurfaceOrPolygon_ = function(node, geometry, objectStac
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon geometry.
+ * @param {module:ol/geom/Polygon} polygon Polygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -39,7 +39,7 @@ const schemaLocation = GMLNS +
  * @constructor
  * @param {module:ol/format/GMLBase~Options=} opt_options
  *     Optional configuration object.
- * @extends {module:ol/format/GMLBase~GMLBase}
+ * @extends {module:ol/format/GMLBase}
  * @api
  */
 const GML3 = function(opt_options) {
@@ -96,10 +96,10 @@ inherits(GML3, GMLBase);
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
- * @return {module:ol/geom/MultiLineString~MultiLineString|undefined} MultiLineString.
+ * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
  */
 GML3.prototype.readMultiCurve_ = function(node, objectStack) {
-  /** @type {Array.<module:ol/geom/LineString~LineString>} */
+  /** @type {Array.<module:ol/geom/LineString>} */
   const lineStrings = pushParseAndPop([],
     this.MULTICURVE_PARSERS_, node, objectStack, this);
   if (lineStrings) {
@@ -116,10 +116,10 @@ GML3.prototype.readMultiCurve_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
- * @return {module:ol/geom/MultiPolygon~MultiPolygon|undefined} MultiPolygon.
+ * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
  */
 GML3.prototype.readMultiSurface_ = function(node, objectStack) {
-  /** @type {Array.<module:ol/geom/Polygon~Polygon>} */
+  /** @type {Array.<module:ol/geom/Polygon>} */
   const polygons = pushParseAndPop([],
     this.MULTISURFACE_PARSERS_, node, objectStack, this);
   if (polygons) {
@@ -240,7 +240,7 @@ GML3.prototype.exteriorParser_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
- * @return {module:ol/geom/Polygon~Polygon|undefined} Polygon.
+ * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
 GML3.prototype.readSurface_ = function(node, objectStack) {
   /** @type {Array.<Array.<number>>} */
@@ -268,7 +268,7 @@ GML3.prototype.readSurface_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
- * @return {module:ol/geom/LineString~LineString|undefined} LineString.
+ * @return {module:ol/geom/LineString|undefined} LineString.
  */
 GML3.prototype.readCurve_ = function(node, objectStack) {
   /** @type {Array.<number>} */
@@ -573,7 +573,7 @@ GML3.prototype.SEGMENTS_PARSERS_ = {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Point~Point} value Point geometry.
+ * @param {module:ol/geom/Point} value Point geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -631,7 +631,7 @@ GML3.prototype.getCoords_ = function(point, opt_srsName, opt_hasZ) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString|module:ol/geom/LinearRing~LinearRing} value Geometry.
+ * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -656,7 +656,7 @@ GML3.prototype.writePosList_ = function(node, value, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Point~Point} geometry Point geometry.
+ * @param {module:ol/geom/Point} geometry Point geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -695,7 +695,7 @@ GML3.prototype.writeEnvelope = function(node, extent, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LinearRing~LinearRing} geometry LinearRing geometry.
+ * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -732,7 +732,7 @@ GML3.prototype.RING_NODE_FACTORY_ = function(value, objectStack, opt_nodeName) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} geometry Polygon geometry.
+ * @param {module:ol/geom/Polygon} geometry Polygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -761,7 +761,7 @@ GML3.prototype.writeSurfaceOrPolygon_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} geometry LineString geometry.
+ * @param {module:ol/geom/LineString} geometry LineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -787,7 +787,7 @@ GML3.prototype.writeCurveOrLineString_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry MultiPolygon geometry.
+ * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -809,7 +809,7 @@ GML3.prototype.writeMultiSurfaceOrPolygon_ = function(node, geometry, objectStac
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/MultiPoint~MultiPoint} geometry MultiPoint geometry.
+ * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -830,7 +830,7 @@ GML3.prototype.writeMultiPoint_ = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/MultiLineString~MultiLineString} geometry MultiLineString geometry.
+ * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -852,7 +852,7 @@ GML3.prototype.writeMultiCurveOrLineString_ = function(node, geometry, objectSta
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LinearRing~LinearRing} ring LinearRing geometry.
+ * @param {module:ol/geom/LinearRing} ring LinearRing geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -865,7 +865,7 @@ GML3.prototype.writeRing_ = function(node, ring, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon geometry.
+ * @param {module:ol/geom/Polygon} polygon Polygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -881,7 +881,7 @@ GML3.prototype.writeSurfaceOrPolygonMember_ = function(node, polygon, objectStac
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Point~Point} point Point geometry.
+ * @param {module:ol/geom/Point} point Point geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -894,7 +894,7 @@ GML3.prototype.writePointMember_ = function(node, point, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} line LineString geometry.
+ * @param {module:ol/geom/LineString} line LineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -909,7 +909,7 @@ GML3.prototype.writeLineStringOrCurveMember_ = function(node, line, objectStack)
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon geometry.
+ * @param {module:ol/geom/Polygon} polygon Polygon geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -922,7 +922,7 @@ GML3.prototype.writeSurfacePatches_ = function(node, polygon, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} line LineString geometry.
+ * @param {module:ol/geom/LineString} line LineString geometry.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -936,7 +936,7 @@ GML3.prototype.writeCurveSegments_ = function(node, line, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Geometry~Geometry|module:ol/extent~Extent} geometry Geometry.
+ * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
  * @param {Array.<*>} objectStack Node stack.
  */
 GML3.prototype.writeGeometryElement = function(node, geometry, objectStack) {
@@ -952,7 +952,7 @@ GML3.prototype.writeGeometryElement = function(node, geometry, objectStack) {
       value = geometry;
     }
   } else {
-    value = transformWithOptions(/** @type {module:ol/geom/Geometry~Geometry} */ (geometry), true, context);
+    value = transformWithOptions(/** @type {module:ol/geom/Geometry} */ (geometry), true, context);
   }
   pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
     (item), this.GEOMETRY_SERIALIZERS_,
@@ -963,7 +963,7 @@ GML3.prototype.writeGeometryElement = function(node, geometry, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Node stack.
  */
 GML3.prototype.writeFeatureElement = function(node, feature, objectStack) {
@@ -1010,7 +1010,7 @@ GML3.prototype.writeFeatureElement = function(node, feature, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {Array.<*>} objectStack Node stack.
  * @private
  */
@@ -1075,7 +1075,7 @@ GML3.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeNam
   const multiCurve = context['multiCurve'];
   let nodeName;
   if (!Array.isArray(value)) {
-    nodeName = /** @type {module:ol/geom/Geometry~Geometry} */ (value).getType();
+    nodeName = /** @type {module:ol/geom/Geometry} */ (value).getType();
     if (nodeName === 'MultiPolygon' && multiSurface === true) {
       nodeName = 'MultiSurface';
     } else if (nodeName === 'Polygon' && surface === true) {
@@ -1096,7 +1096,7 @@ GML3.prototype.GEOMETRY_NODE_FACTORY_ = function(value, objectStack, opt_nodeNam
 /**
  * Encode a geometry in GML 3.1.1 Simple Features.
  *
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @override
@@ -1120,7 +1120,7 @@ GML3.prototype.writeGeometryNode = function(geometry, opt_options) {
  * Encode an array of features in GML 3.1.1 Simple Features.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api
@@ -1131,7 +1131,7 @@ GML3.prototype.writeFeatures;
 /**
  * Encode an array of features in the GML 3.1.1 format as an XML node.
  *
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @override

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -74,7 +74,7 @@ export const GMLNS = 'http://www.opengis.net/gml';
  * @abstract
  * @param {module:ol/format/GMLBase~Options=} opt_options
  *     Optional configuration object.
- * @extends {module:ol/format/XMLFeature~XMLFeature}
+ * @extends {module:ol/format/XMLFeature}
  */
 const GMLBase = function(opt_options) {
   const options = /** @type {module:ol/format/GMLBase~Options} */ (opt_options ? opt_options : {});
@@ -135,7 +135,7 @@ const ONLY_WHITESPACE_RE = /^[\s\xa0]*$/;
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<module:ol/Feature~Feature> | undefined} Features.
+ * @return {Array.<module:ol/Feature> | undefined} Features.
  */
 GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
   const localName = node.localName;
@@ -224,16 +224,18 @@ GMLBase.prototype.readFeaturesInternal = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Geometry~Geometry|undefined} Geometry.
+ * @return {module:ol/geom/Geometry|undefined} Geometry.
  */
 GMLBase.prototype.readGeometryElement = function(node, objectStack) {
   const context = /** @type {Object} */ (objectStack[0]);
   context['srsName'] = node.firstElementChild.getAttribute('srsName');
   context['srsDimension'] = node.firstElementChild.getAttribute('srsDimension');
-  /** @type {module:ol/geom/Geometry~Geometry} */
+  /** @type {module:ol/geom/Geometry} */
   const geometry = pushParseAndPop(null, this.GEOMETRY_PARSERS_, node, objectStack, this);
   if (geometry) {
-    return /** @type {module:ol/geom/Geometry~Geometry} */ (transformWithOptions(geometry, false, context));
+    return (
+      /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometry, false, context))
+    );
   } else {
     return undefined;
   }
@@ -243,7 +245,7 @@ GMLBase.prototype.readGeometryElement = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 GMLBase.prototype.readFeatureElement = function(node, objectStack) {
   let n;
@@ -285,7 +287,7 @@ GMLBase.prototype.readFeatureElement = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Point~Point|undefined} Point.
+ * @return {module:ol/geom/Point|undefined} Point.
  */
 GMLBase.prototype.readPoint = function(node, objectStack) {
   const flatCoordinates = this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -300,7 +302,7 @@ GMLBase.prototype.readPoint = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/MultiPoint~MultiPoint|undefined} MultiPoint.
+ * @return {module:ol/geom/MultiPoint|undefined} MultiPoint.
  */
 GMLBase.prototype.readMultiPoint = function(node, objectStack) {
   /** @type {Array.<Array.<number>>} */
@@ -317,10 +319,10 @@ GMLBase.prototype.readMultiPoint = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/MultiLineString~MultiLineString|undefined} MultiLineString.
+ * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
  */
 GMLBase.prototype.readMultiLineString = function(node, objectStack) {
-  /** @type {Array.<module:ol/geom/LineString~LineString>} */
+  /** @type {Array.<module:ol/geom/LineString>} */
   const lineStrings = pushParseAndPop([],
     this.MULTILINESTRING_PARSERS_, node, objectStack, this);
   if (lineStrings) {
@@ -336,10 +338,10 @@ GMLBase.prototype.readMultiLineString = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/MultiPolygon~MultiPolygon|undefined} MultiPolygon.
+ * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
  */
 GMLBase.prototype.readMultiPolygon = function(node, objectStack) {
-  /** @type {Array.<module:ol/geom/Polygon~Polygon>} */
+  /** @type {Array.<module:ol/geom/Polygon>} */
   const polygons = pushParseAndPop([], this.MULTIPOLYGON_PARSERS_, node, objectStack, this);
   if (polygons) {
     const multiPolygon = new MultiPolygon(null);
@@ -384,7 +386,7 @@ GMLBase.prototype.polygonMemberParser_ = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/LineString~LineString|undefined} LineString.
+ * @return {module:ol/geom/LineString|undefined} LineString.
  */
 GMLBase.prototype.readLineString = function(node, objectStack) {
   const flatCoordinates = this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -419,7 +421,7 @@ GMLBase.prototype.readFlatLinearRing_ = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/LinearRing~LinearRing|undefined} LinearRing.
+ * @return {module:ol/geom/LinearRing|undefined} LinearRing.
  */
 GMLBase.prototype.readLinearRing = function(node, objectStack) {
   const flatCoordinates = this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -436,7 +438,7 @@ GMLBase.prototype.readLinearRing = function(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Polygon~Polygon|undefined} Polygon.
+ * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
 GMLBase.prototype.readPolygon = function(node, objectStack) {
   /** @type {Array.<Array.<number>>} */
@@ -573,7 +575,7 @@ GMLBase.prototype.readGeometryFromNode = function(node, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 GMLBase.prototype.readFeatures;

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -20,7 +20,7 @@ import {createElementNS, makeArrayPusher, makeArraySerializer, makeChildAppender
 
 /**
  * @typedef {Object} Options
- * @property {function(module:ol/Feature~Feature, Node)} [readExtensions] Callback function
+ * @property {function(module:ol/Feature, Node)} [readExtensions] Callback function
  * to process `extensions` nodes. To prevent memory leaks, this callback function must
  * not store any references to the node. Note that the `extensions`
  * node is not allowed in GPX 1.0. Moreover, only `extensions`
@@ -39,7 +39,7 @@ import {createElementNS, makeArrayPusher, makeArraySerializer, makeChildAppender
  * Feature format for reading and writing data in the GPX format.
  *
  * @constructor
- * @extends {module:ol/format/XMLFeature~XMLFeature}
+ * @extends {module:ol/format/XMLFeature}
  * @param {module:ol/format/GPX~Options=} opt_options Options.
  * @api
  */
@@ -55,7 +55,7 @@ const GPX = function(opt_options) {
   this.defaultDataProjection = getProjection('EPSG:4326');
 
   /**
-   * @type {function(module:ol/Feature~Feature, Node)|undefined}
+   * @type {function(module:ol/Feature, Node)|undefined}
    * @private
    */
   this.readExtensions_ = options.readExtensions;
@@ -85,7 +85,7 @@ const SCHEMA_LOCATION = 'http://www.topografix.com/GPX/1/1 ' +
 
 /**
  * @const
- * @type {Object.<string, function(Node, Array.<*>): (module:ol/Feature~Feature|undefined)>}
+ * @type {Object.<string, function(Node, Array.<*>): (module:ol/Feature|undefined)>}
  */
 const FEATURE_READER = {
   'rte': readRte,
@@ -369,7 +369,7 @@ const GEOMETRY_TYPE_TO_NODENAME = {
  * @return {Node|undefined} Node.
  */
 function GPX_NODE_FACTORY(value, objectStack, opt_nodeName) {
-  const geometry = /** @type {module:ol/Feature~Feature} */ (value).getGeometry();
+  const geometry = /** @type {module:ol/Feature} */ (value).getGeometry();
   if (geometry) {
     const nodeName = GEOMETRY_TYPE_TO_NODENAME[geometry.getType()];
     if (nodeName) {
@@ -536,7 +536,7 @@ function parseTrkSeg(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/Feature~Feature|undefined} Track.
+ * @return {module:ol/Feature|undefined} Track.
  */
 function readRte(node, objectStack) {
   const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
@@ -565,7 +565,7 @@ function readRte(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/Feature~Feature|undefined} Track.
+ * @return {module:ol/Feature|undefined} Track.
  */
 function readTrk(node, objectStack) {
   const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
@@ -597,7 +597,7 @@ function readTrk(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/Feature~Feature|undefined} Waypoint.
+ * @return {module:ol/Feature|undefined} Waypoint.
  */
 function readWpt(node, objectStack) {
   const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
@@ -617,7 +617,7 @@ function readWpt(node, objectStack) {
 
 
 /**
- * @param {Array.<module:ol/Feature~Feature>} features List of features.
+ * @param {Array.<module:ol/Feature>} features List of features.
  * @private
  */
 GPX.prototype.handleReadExtensions_ = function(features) {
@@ -643,7 +643,7 @@ GPX.prototype.handleReadExtensions_ = function(features) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 GPX.prototype.readFeature;
@@ -677,7 +677,7 @@ GPX.prototype.readFeatureFromNode = function(node, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 GPX.prototype.readFeatures;
@@ -691,7 +691,7 @@ GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
     return [];
   }
   if (node.localName == 'gpx') {
-    /** @type {Array.<module:ol/Feature~Feature>} */
+    /** @type {Array.<module:ol/Feature>} */
     const features = pushParseAndPop([], GPX_PARSERS,
       node, [this.getReadOptions(node, opt_options)]);
     if (features) {
@@ -710,7 +710,7 @@ GPX.prototype.readFeaturesFromNode = function(node, opt_options) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 GPX.prototype.readProjection;
@@ -781,7 +781,7 @@ function writeWptType(node, coordinate, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeRte(node, feature, objectStack) {
@@ -790,7 +790,7 @@ function writeRte(node, feature, objectStack) {
   const context = {node: node, 'properties': properties};
   let geometry = feature.getGeometry();
   if (geometry) {
-    geometry = /** @type {module:ol/geom/LineString~LineString} */ (transformWithOptions(geometry, true, options));
+    geometry = /** @type {module:ol/geom/LineString} */ (transformWithOptions(geometry, true, options));
     context['geometryLayout'] = geometry.getLayout();
     properties['rtept'] = geometry.getCoordinates();
   }
@@ -805,7 +805,7 @@ function writeRte(node, feature, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeTrk(node, feature, objectStack) {
@@ -815,7 +815,7 @@ function writeTrk(node, feature, objectStack) {
   const context = {node: node, 'properties': properties};
   let geometry = feature.getGeometry();
   if (geometry) {
-    geometry = /** @type {module:ol/geom/MultiLineString~MultiLineString} */
+    geometry = /** @type {module:ol/geom/MultiLineString} */
       (transformWithOptions(geometry, true, options));
     properties['trkseg'] = geometry.getLineStrings();
   }
@@ -830,7 +830,7 @@ function writeTrk(node, feature, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString~LineString} lineString LineString.
+ * @param {module:ol/geom/LineString} lineString LineString.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeTrkSeg(node, lineString, objectStack) {
@@ -845,7 +845,7 @@ function writeTrkSeg(node, lineString, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeWpt(node, feature, objectStack) {
@@ -854,7 +854,7 @@ function writeWpt(node, feature, objectStack) {
   context['properties'] = feature.getProperties();
   let geometry = feature.getGeometry();
   if (geometry) {
-    geometry = /** @type {module:ol/geom/Point~Point} */
+    geometry = /** @type {module:ol/geom/Point} */
       (transformWithOptions(geometry, true, options));
     context['geometryLayout'] = geometry.getLayout();
     writeWptType(node, geometry.getCoordinates(), objectStack);
@@ -868,7 +868,7 @@ function writeWpt(node, feature, objectStack) {
  * as tracks (`<trk>`).
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} Result.
  * @api
@@ -881,7 +881,7 @@ GPX.prototype.writeFeatures;
  * LineString geometries are output as routes (`<rte>`), and MultiLineString
  * as tracks (`<trk>`).
  *
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @override

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -38,7 +38,7 @@ import {get as getProjection} from '../proj.js';
  * Feature format for reading and writing data in the GeoJSON format.
  *
  * @constructor
- * @extends {module:ol/format/JSONFeature~JSONFeature}
+ * @extends {module:ol/format/JSONFeature}
  * @param {module:ol/format/GeoJSON~Options=} opt_options Options.
  * @api
  */
@@ -81,7 +81,7 @@ inherits(GeoJSON, JSONFeature);
 
 /**
  * @const
- * @type {Object.<string, function(GeoJSONObject): module:ol/geom/Geometry~Geometry>}
+ * @type {Object.<string, function(GeoJSONObject): module:ol/geom/Geometry>}
  */
 const GEOMETRY_READERS = {
   'Point': readPointGeometry,
@@ -96,7 +96,7 @@ const GEOMETRY_READERS = {
 
 /**
  * @const
- * @type {Object.<string, function(module:ol/geom/Geometry~Geometry, module:ol/format/Feature~WriteOptions=): (GeoJSONGeometry|GeoJSONGeometryCollection)>}
+ * @type {Object.<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (GeoJSONGeometry|GeoJSONGeometryCollection)>}
  */
 const GEOMETRY_WRITERS = {
   'Point': writePointGeometry,
@@ -113,15 +113,15 @@ const GEOMETRY_WRITERS = {
 /**
  * @param {GeoJSONGeometry|GeoJSONGeometryCollection} object Object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 function readGeometry(object, opt_options) {
   if (!object) {
     return null;
   }
   const geometryReader = GEOMETRY_READERS[object.type];
-  return /** @type {module:ol/geom/Geometry~Geometry} */ (transformWithOptions(
-    geometryReader(object), false, opt_options)
+  return (
+    /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometryReader(object), false, opt_options))
   );
 }
 
@@ -129,13 +129,13 @@ function readGeometry(object, opt_options) {
 /**
  * @param {GeoJSONGeometryCollection} object Object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/GeometryCollection~GeometryCollection} Geometry collection.
+ * @return {module:ol/geom/GeometryCollection} Geometry collection.
  */
 function readGeometryCollectionGeometry(object, opt_options) {
   const geometries = object.geometries.map(
     /**
      * @param {GeoJSONGeometry} geometry Geometry.
-     * @return {module:ol/geom/Geometry~Geometry} geometry Geometry.
+     * @return {module:ol/geom/Geometry} geometry Geometry.
      */
     function(geometry) {
       return readGeometry(geometry, opt_options);
@@ -146,7 +146,7 @@ function readGeometryCollectionGeometry(object, opt_options) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/Point~Point} Point.
+ * @return {module:ol/geom/Point} Point.
  */
 function readPointGeometry(object) {
   return new Point(object.coordinates);
@@ -155,7 +155,7 @@ function readPointGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/LineString~LineString} LineString.
+ * @return {module:ol/geom/LineString} LineString.
  */
 function readLineStringGeometry(object) {
   return new LineString(object.coordinates);
@@ -164,7 +164,7 @@ function readLineStringGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/MultiLineString~MultiLineString} MultiLineString.
+ * @return {module:ol/geom/MultiLineString} MultiLineString.
  */
 function readMultiLineStringGeometry(object) {
   return new MultiLineString(object.coordinates);
@@ -173,7 +173,7 @@ function readMultiLineStringGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/MultiPoint~MultiPoint} MultiPoint.
+ * @return {module:ol/geom/MultiPoint} MultiPoint.
  */
 function readMultiPointGeometry(object) {
   return new MultiPoint(object.coordinates);
@@ -182,7 +182,7 @@ function readMultiPointGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/MultiPolygon~MultiPolygon} MultiPolygon.
+ * @return {module:ol/geom/MultiPolygon} MultiPolygon.
  */
 function readMultiPolygonGeometry(object) {
   return new MultiPolygon(object.coordinates);
@@ -191,7 +191,7 @@ function readMultiPolygonGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/Polygon~Polygon} Polygon.
+ * @return {module:ol/geom/Polygon} Polygon.
  */
 function readPolygonGeometry(object) {
   return new Polygon(object.coordinates);
@@ -199,19 +199,19 @@ function readPolygonGeometry(object) {
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry|GeoJSONGeometryCollection} GeoJSON geometry.
  */
 function writeGeometry(geometry, opt_options) {
   const geometryWriter = GEOMETRY_WRITERS[geometry.getType()];
-  return geometryWriter(/** @type {module:ol/geom/Geometry~Geometry} */ (
+  return geometryWriter(/** @type {module:ol/geom/Geometry} */ (
     transformWithOptions(geometry, true, opt_options)), opt_options);
 }
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @return {GeoJSONGeometryCollection} Empty GeoJSON geometry collection.
  */
 function writeEmptyGeometryCollectionGeometry(geometry) {
@@ -223,7 +223,7 @@ function writeEmptyGeometryCollectionGeometry(geometry) {
 
 
 /**
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geometry Geometry.
+ * @param {module:ol/geom/GeometryCollection} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometryCollection} GeoJSON geometry collection.
  */
@@ -241,7 +241,7 @@ function writeGeometryCollectionGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/LineString~LineString} geometry Geometry.
+ * @param {module:ol/geom/LineString} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
@@ -254,7 +254,7 @@ function writeLineStringGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/MultiLineString~MultiLineString} geometry Geometry.
+ * @param {module:ol/geom/MultiLineString} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
@@ -267,7 +267,7 @@ function writeMultiLineStringGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/MultiPoint~MultiPoint} geometry Geometry.
+ * @param {module:ol/geom/MultiPoint} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
@@ -280,7 +280,7 @@ function writeMultiPointGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry Geometry.
+ * @param {module:ol/geom/MultiPolygon} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
@@ -297,7 +297,7 @@ function writeMultiPolygonGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Point~Point} geometry Geometry.
+ * @param {module:ol/geom/Point} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
@@ -310,7 +310,7 @@ function writePointGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Polygon~Polygon} geometry Geometry.
+ * @param {module:ol/geom/Polygon} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
@@ -330,12 +330,12 @@ function writePolygonGeometry(geometry, opt_options) {
  * Read a feature from a GeoJSON Feature source.  Only works for Feature or
  * geometry types.  Use {@link ol.format.GeoJSON#readFeatures} to read
  * FeatureCollection source. If feature at source has an id, it will be used
- * as Feature id by calling {@link module:ol/Feature~Feature#setId} internally.
+ * as Feature id by calling {@link module:ol/Feature#setId} internally.
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 GeoJSON.prototype.readFeature;
@@ -349,7 +349,7 @@ GeoJSON.prototype.readFeature;
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 GeoJSON.prototype.readFeatures;
@@ -395,7 +395,7 @@ GeoJSON.prototype.readFeatureFromObject = function(object, opt_options) {
  */
 GeoJSON.prototype.readFeaturesFromObject = function(object, opt_options) {
   const geoJSONObject = /** @type {GeoJSONObject} */ (object);
-  /** @type {Array.<module:ol/Feature~Feature>} */
+  /** @type {Array.<module:ol/Feature>} */
   let features = null;
   if (geoJSONObject.type === 'FeatureCollection') {
     const geoJSONFeatureCollection = /** @type {GeoJSONFeatureCollection} */ (object);
@@ -417,7 +417,7 @@ GeoJSON.prototype.readFeaturesFromObject = function(object, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  * @api
  */
 GeoJSON.prototype.readGeometry;
@@ -436,7 +436,7 @@ GeoJSON.prototype.readGeometryFromObject = function(object, opt_options) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 GeoJSON.prototype.readProjection;
@@ -458,7 +458,9 @@ GeoJSON.prototype.readProjectionFromObject = function(object) {
   } else {
     projection = this.defaultDataProjection;
   }
-  return /** @type {module:ol/proj/Projection~Projection} */ (projection);
+  return (
+    /** @type {module:ol/proj/Projection} */ (projection)
+  );
 };
 
 
@@ -466,7 +468,7 @@ GeoJSON.prototype.readProjectionFromObject = function(object) {
  * Encode a feature as a GeoJSON Feature string.
  *
  * @function
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} GeoJSON.
  * @override
@@ -478,7 +480,7 @@ GeoJSON.prototype.writeFeature;
 /**
  * Encode a feature as a GeoJSON Feature object.
  *
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONFeature} Object.
  * @override
@@ -515,7 +517,7 @@ GeoJSON.prototype.writeFeatureObject = function(feature, opt_options) {
  * Encode an array of features as GeoJSON.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} GeoJSON.
  * @api
@@ -526,7 +528,7 @@ GeoJSON.prototype.writeFeatures;
 /**
  * Encode an array of features as a GeoJSON object.
  *
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONFeatureCollection} GeoJSON Object.
  * @override
@@ -549,7 +551,7 @@ GeoJSON.prototype.writeFeaturesObject = function(features, opt_options) {
  * Encode a geometry as a GeoJSON string.
  *
  * @function
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} GeoJSON.
  * @api
@@ -560,7 +562,7 @@ GeoJSON.prototype.writeGeometry;
 /**
  * Encode a geometry as a GeoJSON object.
  *
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry|GeoJSONGeometryCollection} Object.
  * @override

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -32,7 +32,7 @@ const IGCZ = {
  * Feature format for `*.igc` flight recording files.
  *
  * @constructor
- * @extends {module:ol/format/TextFeature~TextFeature}
+ * @extends {module:ol/format/TextFeature}
  * @param {module:ol/format/IGC~Options=} opt_options Options.
  * @api
  */
@@ -94,7 +94,7 @@ const NEWLINE_RE = /\r\n|\r|\n/;
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 IGC.prototype.readFeature;
@@ -184,7 +184,7 @@ IGC.prototype.readFeatureFromText = function(text, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 IGC.prototype.readFeatures;
@@ -208,7 +208,7 @@ IGC.prototype.readFeaturesFromText = function(text, opt_options) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 IGC.prototype.readProjection;

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -13,7 +13,7 @@ import FormatType from '../format/FormatType.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/format/Feature~FeatureFormat}
+ * @extends {module:ol/format/Feature}
  */
 const JSONFeature = function() {
   FeatureFormat.call(this);
@@ -69,7 +69,7 @@ JSONFeature.prototype.readFeatures = function(source, opt_options) {
  * @param {Object} object Object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
  * @protected
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 JSONFeature.prototype.readFeatureFromObject = function(object, opt_options) {};
 
@@ -79,7 +79,7 @@ JSONFeature.prototype.readFeatureFromObject = function(object, opt_options) {};
  * @param {Object} object Object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
  * @protected
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  */
 JSONFeature.prototype.readFeaturesFromObject = function(object, opt_options) {};
 
@@ -98,7 +98,7 @@ JSONFeature.prototype.readGeometry = function(source, opt_options) {
  * @param {Object} object Object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
  * @protected
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 JSONFeature.prototype.readGeometryFromObject = function(object, opt_options) {};
 
@@ -115,7 +115,7 @@ JSONFeature.prototype.readProjection = function(source) {
  * @abstract
  * @param {Object} object Object.
  * @protected
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 JSONFeature.prototype.readProjectionFromObject = function(object) {};
 
@@ -130,7 +130,7 @@ JSONFeature.prototype.writeFeature = function(feature, opt_options) {
 
 /**
  * @abstract
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  */
@@ -147,7 +147,7 @@ JSONFeature.prototype.writeFeatures = function(features, opt_options) {
 
 /**
  * @abstract
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  */
@@ -164,7 +164,7 @@ JSONFeature.prototype.writeGeometry = function(geometry, opt_options) {
 
 /**
  * @abstract
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {Object} Object.
  */

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -54,13 +54,13 @@ import {createElementNS, getAllTextContent, isDocument, isNode, makeArrayExtende
 let DEFAULT_COLOR;
 
 /**
- * @type {module:ol/style/Fill~Fill}
+ * @type {module:ol/style/Fill}
  */
 let DEFAULT_FILL_STYLE = null;
 
 /**
  * Get the default fill style (or null if not yet set).
- * @return {module:ol/style/Fill~Fill} The default fill style.
+ * @return {module:ol/style/Fill} The default fill style.
  */
 export function getDefaultFillStyle() {
   return DEFAULT_FILL_STYLE;
@@ -97,13 +97,13 @@ let DEFAULT_IMAGE_STYLE_SRC;
 let DEFAULT_IMAGE_SCALE_MULTIPLIER;
 
 /**
- * @type {module:ol/style/Image~ImageStyle}
+ * @type {module:ol/style/Image}
  */
 let DEFAULT_IMAGE_STYLE = null;
 
 /**
  * Get the default image style (or null if not yet set).
- * @return {module:ol/style/Image~ImageStyle} The default image style.
+ * @return {module:ol/style/Image} The default image style.
  */
 export function getDefaultImageStyle() {
   return DEFAULT_IMAGE_STYLE;
@@ -115,57 +115,57 @@ export function getDefaultImageStyle() {
 let DEFAULT_NO_IMAGE_STYLE;
 
 /**
- * @type {module:ol/style/Stroke~Stroke}
+ * @type {module:ol/style/Stroke}
  */
 let DEFAULT_STROKE_STYLE = null;
 
 /**
  * Get the default stroke style (or null if not yet set).
- * @return {module:ol/style/Stroke~Stroke} The default stroke style.
+ * @return {module:ol/style/Stroke} The default stroke style.
  */
 export function getDefaultStrokeStyle() {
   return DEFAULT_STROKE_STYLE;
 }
 
 /**
- * @type {module:ol/style/Stroke~Stroke}
+ * @type {module:ol/style/Stroke}
  */
 let DEFAULT_TEXT_STROKE_STYLE;
 
 /**
- * @type {module:ol/style/Text~Text}
+ * @type {module:ol/style/Text}
  */
 let DEFAULT_TEXT_STYLE = null;
 
 /**
  * Get the default text style (or null if not yet set).
- * @return {module:ol/style/Text~Text} The default text style.
+ * @return {module:ol/style/Text} The default text style.
  */
 export function getDefaultTextStyle() {
   return DEFAULT_TEXT_STYLE;
 }
 
 /**
- * @type {module:ol/style/Style~Style}
+ * @type {module:ol/style/Style}
  */
 let DEFAULT_STYLE = null;
 
 /**
  * Get the default style (or null if not yet set).
- * @return {module:ol/style/Style~Style} The default style.
+ * @return {module:ol/style/Style} The default style.
  */
 export function getDefaultStyle() {
   return DEFAULT_STYLE;
 }
 
 /**
- * @type {Array.<module:ol/style/Style~Style>}
+ * @type {Array.<module:ol/style/Style>}
  */
 let DEFAULT_STYLE_ARRAY = null;
 
 /**
  * Get the default style array (or null if not yet set).
- * @return {Array.<module:ol/style/Style~Style>} The default style.
+ * @return {Array.<module:ol/style/Style>} The default style.
  */
 export function getDefaultStyleArray() {
   return DEFAULT_STYLE_ARRAY;
@@ -234,7 +234,7 @@ function createStyleDefaults() {
 
   /**
    * @const
-   * @type {Array.<module:ol/style/Style~Style>}
+   * @type {Array.<module:ol/style/Style>}
    * @private
    */
   DEFAULT_STYLE_ARRAY = [DEFAULT_STYLE];
@@ -246,7 +246,7 @@ function createStyleDefaults() {
  * @typedef {Object} Options
  * @property {boolean} [extractStyles=true] Extract styles from the KML.
  * @property {boolean} [showPointNames=true] Show names as labels for placemarks which contain points.
- * @property {Array.<module:ol/style/Style~Style>} [defaultStyle] Default style. The
+ * @property {Array.<module:ol/style/Style>} [defaultStyle] Default style. The
  * default default style is the same as Google Earth.
  * @property {boolean} [writeStyles=true] Write styles into KML.
  */
@@ -260,7 +260,7 @@ function createStyleDefaults() {
  * which do not support this will need a URL polyfill to be loaded before use.
  *
  * @constructor
- * @extends {module:ol/format/XMLFeature~XMLFeature}
+ * @extends {module:ol/format/XMLFeature}
  * @param {module:ol/format/KML~Options=} opt_options Options.
  * @api
  */
@@ -281,7 +281,7 @@ const KML = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<module:ol/style/Style~Style>}
+   * @type {Array.<module:ol/style/Style>}
    */
   this.defaultStyle_ = options.defaultStyle ?
     options.defaultStyle : DEFAULT_STYLE_ARRAY;
@@ -302,7 +302,7 @@ const KML = function(opt_options) {
 
   /**
    * @private
-   * @type {!Object.<string, (Array.<module:ol/style/Style~Style>|string)>}
+   * @type {!Object.<string, (Array.<module:ol/style/Style>|string)>}
    */
   this.sharedStyles_ = {};
 
@@ -359,9 +359,9 @@ const ICON_ANCHOR_UNITS_MAP = {
 
 
 /**
- * @param {module:ol/style/Style~Style|undefined} foundStyle Style.
+ * @param {module:ol/style/Style|undefined} foundStyle Style.
  * @param {string} name Name.
- * @return {module:ol/style/Style~Style} style Style.
+ * @return {module:ol/style/Style} style Style.
  */
 function createNameStyleFunction(foundStyle, name) {
   let textStyle = null;
@@ -406,10 +406,10 @@ function createNameStyleFunction(foundStyle, name) {
 
 
 /**
- * @param {Array.<module:ol/style/Style~Style>|undefined} style Style.
+ * @param {Array.<module:ol/style/Style>|undefined} style Style.
  * @param {string} styleUrl Style URL.
- * @param {Array.<module:ol/style/Style~Style>} defaultStyle Default style.
- * @param {!Object.<string, (Array.<module:ol/style/Style~Style>|string)>} sharedStyles Shared styles.
+ * @param {Array.<module:ol/style/Style>} defaultStyle Default style.
+ * @param {!Object.<string, (Array.<module:ol/style/Style>|string)>} sharedStyles Shared styles.
  * @param {boolean|undefined} showPointNames true to show names for point placemarks.
  * @return {module:ol/style~StyleFunction} Feature style function.
  */
@@ -417,13 +417,13 @@ function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles,
 
   return (
     /**
-     * @param {module:ol/Feature~Feature} feature feature.
+     * @param {module:ol/Feature} feature feature.
      * @param {number} resolution Resolution.
-     * @return {Array.<module:ol/style/Style~Style>} Style.
+     * @return {Array.<module:ol/style/Style>} Style.
      */
     function(feature, resolution) {
       let drawName = showPointNames;
-      /** @type {module:ol/style/Style~Style|undefined} */
+      /** @type {module:ol/style/Style|undefined} */
       let nameStyle;
       let name = '';
       if (drawName) {
@@ -464,11 +464,11 @@ function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles,
 
 
 /**
- * @param {Array.<module:ol/style/Style~Style>|string|undefined} styleValue Style value.
- * @param {Array.<module:ol/style/Style~Style>} defaultStyle Default style.
- * @param {!Object.<string, (Array.<module:ol/style/Style~Style>|string)>} sharedStyles
+ * @param {Array.<module:ol/style/Style>|string|undefined} styleValue Style value.
+ * @param {Array.<module:ol/style/Style>} defaultStyle Default style.
+ * @param {!Object.<string, (Array.<module:ol/style/Style>|string)>} sharedStyles
  * Shared styles.
- * @return {Array.<module:ol/style/Style~Style>} Style.
+ * @return {Array.<module:ol/style/Style>} Style.
  */
 function findStyle(styleValue, defaultStyle, sharedStyles) {
   if (Array.isArray(styleValue)) {
@@ -609,7 +609,7 @@ const STYLE_MAP_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<module:ol/style/Style~Style>|string|undefined} StyleMap.
+ * @return {Array.<module:ol/style/Style>|string|undefined} StyleMap.
  */
 function readStyleMapValue(node, objectStack) {
   return pushParseAndPop(undefined,
@@ -901,7 +901,7 @@ const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/MultiLineString~MultiLineString|undefined} MultiLineString.
+ * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
  */
 function readGxMultiTrack(node, objectStack) {
   const lineStrings = pushParseAndPop([],
@@ -931,7 +931,7 @@ const GX_TRACK_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/LineString~LineString|undefined} LineString.
+ * @return {module:ol/geom/LineString|undefined} LineString.
  */
 function readGxTrack(node, objectStack) {
   const gxTrackObject = pushParseAndPop(
@@ -1021,7 +1021,7 @@ const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/LineString~LineString|undefined} LineString.
+ * @return {module:ol/geom/LineString|undefined} LineString.
  */
 function readLineString(node, objectStack) {
   const properties = pushParseAndPop({},
@@ -1043,7 +1043,7 @@ function readLineString(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Polygon~Polygon|undefined} Polygon.
+ * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
 function readLinearRing(node, objectStack) {
   const properties = pushParseAndPop({},
@@ -1080,7 +1080,7 @@ const MULTI_GEOMETRY_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 function readMultiGeometry(node, objectStack) {
   const geometries = pushParseAndPop([],
@@ -1091,7 +1091,7 @@ function readMultiGeometry(node, objectStack) {
   if (geometries.length === 0) {
     return new GeometryCollection(geometries);
   }
-  /** @type {module:ol/geom/Geometry~Geometry} */
+  /** @type {module:ol/geom/Geometry} */
   let multiGeometry;
   let homogeneous = true;
   const type = geometries[0].getType();
@@ -1133,14 +1133,16 @@ function readMultiGeometry(node, objectStack) {
   } else {
     multiGeometry = new GeometryCollection(geometries);
   }
-  return /** @type {module:ol/geom/Geometry~Geometry} */ (multiGeometry);
+  return (
+    /** @type {module:ol/geom/Geometry} */ (multiGeometry)
+  );
 }
 
 
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Point~Point|undefined} Point.
+ * @return {module:ol/geom/Point|undefined} Point.
  */
 function readPoint(node, objectStack) {
   const properties = pushParseAndPop({},
@@ -1173,7 +1175,7 @@ const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {module:ol/geom/Polygon~Polygon|undefined} Polygon.
+ * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
 function readPolygon(node, objectStack) {
   const properties = pushParseAndPop(/** @type {Object<string,*>} */ ({}),
@@ -1214,7 +1216,7 @@ const STYLE_PARSERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<module:ol/style/Style~Style>} Style.
+ * @return {Array.<module:ol/style/Style>} Style.
  */
 function readStyle(node, objectStack) {
   const styleObject = pushParseAndPop(
@@ -1222,23 +1224,23 @@ function readStyle(node, objectStack) {
   if (!styleObject) {
     return null;
   }
-  let fillStyle = /** @type {module:ol/style/Fill~Fill} */
+  let fillStyle = /** @type {module:ol/style/Fill} */
       ('fillStyle' in styleObject ?
         styleObject['fillStyle'] : DEFAULT_FILL_STYLE);
   const fill = /** @type {boolean|undefined} */ (styleObject['fill']);
   if (fill !== undefined && !fill) {
     fillStyle = null;
   }
-  let imageStyle = /** @type {module:ol/style/Image~ImageStyle} */
+  let imageStyle = /** @type {module:ol/style/Image} */
       ('imageStyle' in styleObject ?
         styleObject['imageStyle'] : DEFAULT_IMAGE_STYLE);
   if (imageStyle == DEFAULT_NO_IMAGE_STYLE) {
     imageStyle = undefined;
   }
-  const textStyle = /** @type {module:ol/style/Text~Text} */
+  const textStyle = /** @type {module:ol/style/Text} */
       ('textStyle' in styleObject ?
         styleObject['textStyle'] : DEFAULT_TEXT_STYLE);
-  let strokeStyle = /** @type {module:ol/style/Stroke~Stroke} */
+  let strokeStyle = /** @type {module:ol/style/Stroke} */
       ('strokeStyle' in styleObject ?
         styleObject['strokeStyle'] : DEFAULT_STROKE_STYLE);
   const outline = /** @type {boolean|undefined} */
@@ -1259,9 +1261,9 @@ function readStyle(node, objectStack) {
 /**
  * Reads an array of geometries and creates arrays for common geometry
  * properties. Then sets them to the multi geometry.
- * @param {module:ol/geom/MultiPoint~MultiPoint|module:ol/geom/MultiLineString~MultiLineString|module:ol/geom/MultiPolygon~MultiPolygon}
+ * @param {module:ol/geom/MultiPoint|module:ol/geom/MultiLineString|module:ol/geom/MultiPolygon}
  *     multiGeometry A multi-geometry.
- * @param {Array.<module:ol/geom/Geometry~Geometry>} geometries List of geometries.
+ * @param {Array.<module:ol/geom/Geometry>} geometries List of geometries.
  */
 function setCommonGeometryProperties(multiGeometry, geometries) {
   const ii = geometries.length;
@@ -1387,7 +1389,7 @@ function pairDataParser(node, objectStack) {
     if (styleUrl) {
       objectStack[objectStack.length - 1] = styleUrl;
     }
-    const Style = /** @type {module:ol/style/Style~Style} */
+    const Style = /** @type {module:ol/style/Style} */
         (pairObject['Style']);
     if (Style) {
       objectStack[objectStack.length - 1] = Style;
@@ -1662,7 +1664,7 @@ const PLACEMARK_PARSERS = makeStructureNS(
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
- * @return {Array.<module:ol/Feature~Feature>|undefined} Features.
+ * @return {Array.<module:ol/Feature>|undefined} Features.
  */
 KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
   // FIXME use scope somehow
@@ -1674,7 +1676,7 @@ KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
       'Style': this.readSharedStyle_.bind(this),
       'StyleMap': this.readSharedStyleMap_.bind(this)
     });
-  /** @type {Array.<module:ol/Feature~Feature>} */
+  /** @type {Array.<module:ol/Feature>} */
   const features = pushParseAndPop([], parsersNS, node, objectStack, this);
   if (features) {
     return features;
@@ -1688,7 +1690,7 @@ KML.prototype.readDocumentOrFolder_ = function(node, objectStack) {
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
  * @private
- * @return {module:ol/Feature~Feature|undefined} Feature.
+ * @return {module:ol/Feature|undefined} Feature.
  */
 KML.prototype.readPlacemark_ = function(node, objectStack) {
   const object = pushParseAndPop({'geometry': null},
@@ -1792,7 +1794,7 @@ KML.prototype.readSharedStyleMap_ = function(node, objectStack) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 KML.prototype.readFeature;
@@ -1823,7 +1825,7 @@ KML.prototype.readFeatureFromNode = function(node, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 KML.prototype.readFeatures;
@@ -2071,7 +2073,7 @@ KML.prototype.readRegionFromNode = function(node) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 KML.prototype.readProjection;
@@ -2215,9 +2217,9 @@ const DOCUMENT_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {Array.<*>} objectStack Object stack.
- * @this {module:ol/format/KML~KML}
+ * @this {module:ol/format/KML}
  */
 function writeDocument(node, features, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2341,7 +2343,7 @@ const ICON_STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Icon~Icon} style Icon style.
+ * @param {module:ol/style/Icon} style Icon style.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeIconStyle(node, style, objectStack) {
@@ -2419,7 +2421,7 @@ const LABEL_STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Text~Text} style style.
+ * @param {module:ol/style/Text} style style.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeLabelStyle(node, style, objectStack) {
@@ -2465,7 +2467,7 @@ const LINE_STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Stroke~Stroke} style style.
+ * @param {module:ol/style/Stroke} style style.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeLineStyle(node, style, objectStack) {
@@ -2509,7 +2511,7 @@ const GEOMETRY_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
   if (value) {
     const parentNode = objectStack[objectStack.length - 1].node;
     return createElementNS(parentNode.namespaceURI,
-      GEOMETRY_TYPE_TO_NODENAME[/** @type {module:ol/geom/Geometry~Geometry} */ (value).getType()]);
+      GEOMETRY_TYPE_TO_NODENAME[/** @type {module:ol/geom/Geometry} */ (value).getType()]);
   }
 };
 
@@ -2564,30 +2566,30 @@ const MULTI_GEOMETRY_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeMultiGeometry(node, geometry, objectStack) {
   /** @type {module:ol/xml~NodeStackItem} */
   const context = {node: node};
   const type = geometry.getType();
-  /** @type {Array.<module:ol/geom/Geometry~Geometry>} */
+  /** @type {Array.<module:ol/geom/Geometry>} */
   let geometries;
   /** @type {function(*, Array.<*>, string=): (Node|undefined)} */
   let factory;
   if (type == GeometryType.GEOMETRY_COLLECTION) {
-    geometries = /** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry).getGeometries();
+    geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
     factory = GEOMETRY_NODE_FACTORY;
   } else if (type == GeometryType.MULTI_POINT) {
-    geometries = /** @type {module:ol/geom/MultiPoint~MultiPoint} */ (geometry).getPoints();
+    geometries = /** @type {module:ol/geom/MultiPoint} */ (geometry).getPoints();
     factory = POINT_NODE_FACTORY;
   } else if (type == GeometryType.MULTI_LINE_STRING) {
     geometries =
-        (/** @type {module:ol/geom/MultiLineString~MultiLineString} */ (geometry)).getLineStrings();
+        (/** @type {module:ol/geom/MultiLineString} */ (geometry)).getLineStrings();
     factory = LINE_STRING_NODE_FACTORY;
   } else if (type == GeometryType.MULTI_POLYGON) {
     geometries =
-        (/** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry)).getPolygons();
+        (/** @type {module:ol/geom/MultiPolygon} */ (geometry)).getPolygons();
     factory = POLYGON_NODE_FACTORY;
   } else {
     assert(false, 39); // Unknown geometry type
@@ -2611,7 +2613,7 @@ const BOUNDARY_IS_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LinearRing~LinearRing} linearRing Linear ring.
+ * @param {module:ol/geom/LinearRing} linearRing Linear ring.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeBoundaryIs(node, linearRing, objectStack) {
@@ -2668,9 +2670,9 @@ const EXTENDEDDATA_NODE_FACTORY = makeSimpleNodeFactory('ExtendedData');
  * FIXME currently we do serialize arbitrary/custom feature properties
  * (ExtendedData).
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Object stack.
- * @this {module:ol/format/KML~KML}
+ * @this {module:ol/format/KML}
  */
 function writePlacemark(node, feature, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2756,7 +2758,7 @@ const PRIMITIVE_GEOMETRY_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry Geometry.
+ * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writePrimitiveGeometry(node, geometry, objectStack) {
@@ -2808,7 +2810,7 @@ const OUTER_BOUNDARY_NODE_FACTORY = makeSimpleNodeFactory('outerBoundaryIs');
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon.
+ * @param {module:ol/geom/Polygon} polygon Polygon.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writePolygon(node, polygon, objectStack) {
@@ -2848,7 +2850,7 @@ const COLOR_NODE_FACTORY = makeSimpleNodeFactory('color');
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Fill~Fill} style Style.
+ * @param {module:ol/style/Fill} style Style.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writePolyStyle(node, style, objectStack) {
@@ -2894,7 +2896,7 @@ const STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Style~Style} style Style.
+ * @param {module:ol/style/Style} style Style.
  * @param {Array.<*>} objectStack Object stack.
  */
 function writeStyle(node, style, objectStack) {
@@ -2962,7 +2964,7 @@ const KML_SERIALIZERS = makeStructureNS(
  * MultiLineStrings, and MultiPolygons are output as MultiGeometries.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api
@@ -2974,7 +2976,7 @@ KML.prototype.writeFeatures;
  * Encode an array of features in the KML format as an XML node. GeometryCollections,
  * MultiPoints, MultiLineStrings, and MultiPolygons are output as MultiGeometries.
  *
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @override

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -24,7 +24,7 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {function((module:ol/geom/Geometry~Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType,Array.<number>,(Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)} [featureClass]
+ * @property {function((module:ol/geom/Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType,Array.<number>,(Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)} [featureClass]
  * Class for features returned by {@link ol.format.MVT#readFeatures}. Set to
  * {@link module:ol/Feature~Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link module:ol/render/Feature~RenderFeature},
@@ -43,7 +43,7 @@ import RenderFeature from '../render/Feature.js';
  * Feature format for reading data in the Mapbox MVT format.
  *
  * @constructor
- * @extends {module:ol/format/Feature~FeatureFormat}
+ * @extends {module:ol/format/Feature}
  * @param {module:ol/format/MVT~Options=} opt_options Options.
  * @api
  */
@@ -54,7 +54,7 @@ const MVT = function(opt_options) {
   const options = opt_options ? opt_options : {};
 
   /**
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.defaultDataProjection = new Projection({
     code: '',
@@ -63,7 +63,7 @@ const MVT = function(opt_options) {
 
   /**
    * @private
-   * @type {function((module:ol/geom/Geometry~Geometry|Object.<string,*>)=)|
+   * @type {function((module:ol/geom/Geometry|Object.<string,*>)=)|
    *     function(module:ol/geom/GeometryType,Array.<number>,
    *         (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
    */
@@ -297,7 +297,7 @@ function getGeometryType(type, numEnds) {
  * @param {ol.ext.PBF} pbf PBF
  * @param {Object} rawFeature Raw Mapbox feature.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} Feature.
+ * @return {module:ol/Feature|module:ol/render/Feature} Feature.
  */
 MVT.prototype.createFeature_ = function(pbf, rawFeature, opt_options) {
   const type = rawFeature.type;
@@ -387,7 +387,7 @@ MVT.prototype.readFeatures = function(source, opt_options) {
 
   const pbf = new PBF(/** @type {ArrayBuffer} */ (source));
   const pbfLayers = pbf.readFields(layersPBFReader, {});
-  /** @type {Array.<module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature>} */
+  /** @type {Array.<module:ol/Feature|module:ol/render/Feature>} */
   const features = [];
   for (const name in pbfLayers) {
     if (layers && layers.indexOf(name) == -1) {

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -21,7 +21,7 @@ import {pushParseAndPop, makeStructureNS} from '../xml.js';
  * [OSMXML format](http://wiki.openstreetmap.org/wiki/OSM_XML).
  *
  * @constructor
- * @extends {module:ol/format/XMLFeature~XMLFeature}
+ * @extends {module:ol/format/XMLFeature}
  * @api
  */
 const OSMXML = function() {
@@ -146,7 +146,7 @@ function readTag(node, objectStack) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 OSMXML.prototype.readFeatures;
@@ -201,7 +201,7 @@ OSMXML.prototype.readFeaturesFromNode = function(node, opt_options) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 OSMXML.prototype.readProjection;

--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -9,7 +9,7 @@ import {makeObjectPropertyPusher, makeObjectPropertySetter, makeStructureNS, pus
 
 /**
  * @constructor
- * @extends {module:ol/format/XML~XML}
+ * @extends {module:ol/format/XML}
  */
 const OWS = function() {
   XML.call(this);

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -28,7 +28,7 @@ import {get as getProjection} from '../proj.js';
  * Polyline Algorithm Format.
  *
  * @constructor
- * @extends {module:ol/format/TextFeature~TextFeature}
+ * @extends {module:ol/format/TextFeature}
  * @param {module:ol/format/Polyline~Options=} opt_options Optional configuration object.
  * @api
  */
@@ -271,7 +271,7 @@ export function encodeUnsignedInteger(num) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 Polyline.prototype.readFeature;
@@ -293,7 +293,7 @@ Polyline.prototype.readFeatureFromText = function(text, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 Polyline.prototype.readFeatures;
@@ -314,7 +314,7 @@ Polyline.prototype.readFeaturesFromText = function(text, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  * @api
  */
 Polyline.prototype.readGeometry;
@@ -329,9 +329,12 @@ Polyline.prototype.readGeometryFromText = function(text, opt_options) {
   flipXY(flatCoordinates, 0, flatCoordinates.length, stride, flatCoordinates);
   const coordinates = inflateCoordinates(flatCoordinates, 0, flatCoordinates.length, stride);
 
-  return /** @type {module:ol/geom/Geometry~Geometry} */ (transformWithOptions(
-    new LineString(coordinates, this.geometryLayout_), false,
-    this.adaptOptions(opt_options))
+  return (
+    /** @type {module:ol/geom/Geometry} */ (transformWithOptions(
+      new LineString(coordinates, this.geometryLayout_),
+      false,
+      this.adaptOptions(opt_options)
+    ))
   );
 };
 
@@ -341,7 +344,7 @@ Polyline.prototype.readGeometryFromText = function(text, opt_options) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 Polyline.prototype.readProjection;
@@ -373,7 +376,7 @@ Polyline.prototype.writeFeaturesText = function(features, opt_options) {
  * Write a single geometry in Polyline format.
  *
  * @function
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} Geometry.
  * @api
@@ -385,7 +388,7 @@ Polyline.prototype.writeGeometry;
  * @inheritDoc
  */
 Polyline.prototype.writeGeometryText = function(geometry, opt_options) {
-  geometry = /** @type {module:ol/geom/LineString~LineString} */
+  geometry = /** @type {module:ol/geom/LineString} */
     (transformWithOptions(geometry, true, this.adaptOptions(opt_options)));
   const flatCoordinates = geometry.getFlatCoordinates();
   const stride = geometry.getStride();

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -13,7 +13,7 @@ import FormatType from '../format/FormatType.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/format/Feature~FeatureFormat}
+ * @extends {module:ol/format/Feature}
  */
 const TextFeature = function() {
   FeatureFormat.call(this);
@@ -56,7 +56,7 @@ TextFeature.prototype.readFeature = function(source, opt_options) {
  * @param {string} text Text.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
  * @protected
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 TextFeature.prototype.readFeatureFromText = function(text, opt_options) {};
 
@@ -74,7 +74,7 @@ TextFeature.prototype.readFeatures = function(source, opt_options) {
  * @param {string} text Text.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
  * @protected
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  */
 TextFeature.prototype.readFeaturesFromText = function(text, opt_options) {};
 
@@ -92,7 +92,7 @@ TextFeature.prototype.readGeometry = function(source, opt_options) {
  * @param {string} text Text.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
  * @protected
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 TextFeature.prototype.readGeometryFromText = function(text, opt_options) {};
 
@@ -108,7 +108,7 @@ TextFeature.prototype.readProjection = function(source) {
 /**
  * @param {string} text Text.
  * @protected
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 TextFeature.prototype.readProjectionFromText = function(text) {
   return this.defaultDataProjection;
@@ -125,7 +125,7 @@ TextFeature.prototype.writeFeature = function(feature, opt_options) {
 
 /**
  * @abstract
- * @param {module:ol/Feature~Feature} feature Features.
+ * @param {module:ol/Feature} feature Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @protected
  * @return {string} Text.
@@ -143,7 +143,7 @@ TextFeature.prototype.writeFeatures = function(features, opt_options) {
 
 /**
  * @abstract
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @protected
  * @return {string} Text.
@@ -161,7 +161,7 @@ TextFeature.prototype.writeGeometry = function(geometry, opt_options) {
 
 /**
  * @abstract
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @protected
  * @return {string} Text.

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -44,7 +44,7 @@ import {get as getProjection} from '../proj.js';
  * Feature format for reading data in the TopoJSON format.
  *
  * @constructor
- * @extends {module:ol/format/JSONFeature~JSONFeature}
+ * @extends {module:ol/format/JSONFeature}
  * @param {module:ol/format/TopoJSON~Options=} opt_options Options.
  * @api
  */
@@ -80,7 +80,7 @@ inherits(TopoJSON, JSONFeature);
 
 /**
  * @const
- * @type {Object.<string, function(TopoJSONGeometry, Array, ...Array): module:ol/geom/Geometry~Geometry>}
+ * @type {Object.<string, function(TopoJSONGeometry, Array, ...Array): module:ol/geom/Geometry>}
  */
 const GEOMETRY_READERS = {
   'Point': readPointGeometry,
@@ -133,7 +133,7 @@ function concatenateArcs(indices, arcs) {
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array.<number>} scale Scale for each dimension.
  * @param {Array.<number>} translate Translation for each dimension.
- * @return {module:ol/geom/Point~Point} Geometry.
+ * @return {module:ol/geom/Point} Geometry.
  */
 function readPointGeometry(object, scale, translate) {
   const coordinates = object.coordinates;
@@ -150,7 +150,7 @@ function readPointGeometry(object, scale, translate) {
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array.<number>} scale Scale for each dimension.
  * @param {Array.<number>} translate Translation for each dimension.
- * @return {module:ol/geom/MultiPoint~MultiPoint} Geometry.
+ * @return {module:ol/geom/MultiPoint} Geometry.
  */
 function readMultiPointGeometry(object, scale, translate) {
   const coordinates = object.coordinates;
@@ -168,7 +168,7 @@ function readMultiPointGeometry(object, scale, translate) {
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/LineString~LineString} Geometry.
+ * @return {module:ol/geom/LineString} Geometry.
  */
 function readLineStringGeometry(object, arcs) {
   const coordinates = concatenateArcs(object.arcs, arcs);
@@ -181,7 +181,7 @@ function readLineStringGeometry(object, arcs) {
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/MultiLineString~MultiLineString} Geometry.
+ * @return {module:ol/geom/MultiLineString} Geometry.
  */
 function readMultiLineStringGeometry(object, arcs) {
   const coordinates = [];
@@ -197,7 +197,7 @@ function readMultiLineStringGeometry(object, arcs) {
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/Polygon~Polygon} Geometry.
+ * @return {module:ol/geom/Polygon} Geometry.
  */
 function readPolygonGeometry(object, arcs) {
   const coordinates = [];
@@ -213,7 +213,7 @@ function readPolygonGeometry(object, arcs) {
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/MultiPolygon~MultiPolygon} Geometry.
+ * @return {module:ol/geom/MultiPolygon} Geometry.
  */
 function readMultiPolygonGeometry(object, arcs) {
   const coordinates = [];
@@ -243,7 +243,7 @@ function readMultiPolygonGeometry(object, arcs) {
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Array of features.
+ * @return {Array.<module:ol/Feature>} Array of features.
  */
 function readFeaturesFromGeometryCollection(collection, arcs, scale, translate, property, name, opt_options) {
   const geometries = collection.geometries;
@@ -267,7 +267,7 @@ function readFeaturesFromGeometryCollection(collection, arcs, scale, translate, 
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 function readFeatureFromGeometry(object, arcs, scale, translate, property, name, opt_options) {
   let geometry;
@@ -279,7 +279,7 @@ function readFeatureFromGeometry(object, arcs, scale, translate, property, name,
     geometry = geometryReader(object, arcs);
   }
   const feature = new Feature();
-  feature.setGeometry(/** @type {module:ol/geom/Geometry~Geometry} */ (
+  feature.setGeometry(/** @type {module:ol/geom/Geometry} */ (
     transformWithOptions(geometry, false, opt_options)));
   if (object.id !== undefined) {
     feature.setId(object.id);
@@ -303,7 +303,7 @@ function readFeatureFromGeometry(object, arcs, scale, translate, property, name,
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 TopoJSON.prototype.readFeatures;
@@ -325,7 +325,7 @@ TopoJSON.prototype.readFeaturesFromObject = function(object, opt_options) {
     if (transform) {
       transformArcs(arcs, scale, translate);
     }
-    /** @type {Array.<module:ol/Feature~Feature>} */
+    /** @type {Array.<module:ol/Feature>} */
     const features = [];
     const topoJSONFeatures = topoJSONTopology.objects;
     const property = this.layerName_;
@@ -405,7 +405,7 @@ function transformVertex(vertex, scale, translate) {
  * Read the projection from a TopoJSON source.
  *
  * @param {Document|Node|Object|string} object Source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @override
  * @api
  */

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -21,7 +21,7 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
  * @typedef {Object} Options
  * @property {Object.<string, string>|string} [featureNS] The namespace URI used for features.
  * @property {Array.<string>|string} [featureType] The feature type to parse. Only used for read operations.
- * @property {module:ol/format/GMLBase~GMLBase} [gmlFormat] The GML format to use to parse the response. Default is `ol.format.GML3`.
+ * @property {module:ol/format/GMLBase} [gmlFormat] The GML format to use to parse the response. Default is `ol.format.GML3`.
  * @property {string} [schemaLocation] Optional schemaLocation to use for serialization, this will override the default.
  */
 
@@ -44,7 +44,7 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
  * WFS 2.0 feature backported to WFS 1.1.0 by some Web Feature Services. Please note that some
  * Web Feature Services have repurposed `maxfeatures` instead.
  * @property {module:ol/extent~Extent} [bbox] Extent to use for the BBOX filter.
- * @property {module:ol/format/filter/Filter~Filter} [filter] Filter condition. See
+ * @property {module:ol/format/filter/Filter} [filter] Filter condition. See
  * {@link ol.format.filter} for more information.
  * @property {string} [resultType] Indicates what response should be returned,
  * E.g. `hits` only includes the `numberOfFeatures` attribute in the response and no features.
@@ -140,7 +140,7 @@ const DEFAULT_VERSION = '1.1.0';
  *
  * @constructor
  * @param {module:ol/format/WFS~Options=} opt_options Optional configuration object.
- * @extends {module:ol/format/XMLFeature~XMLFeature}
+ * @extends {module:ol/format/XMLFeature}
  * @api
  */
 const WFS = function(opt_options) {
@@ -160,7 +160,7 @@ const WFS = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/format/GMLBase~GMLBase}
+   * @type {module:ol/format/GMLBase}
    */
   this.gmlFormat_ = options.gmlFormat ?
     options.gmlFormat : new GML3();
@@ -200,7 +200,7 @@ WFS.prototype.setFeatureType = function(featureType) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 WFS.prototype.readFeatures;
@@ -437,7 +437,7 @@ const QUERY_SERIALIZERS = {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeFeature(node, feature, objectStack) {
@@ -488,7 +488,7 @@ function getTypeName(featurePrefix, featureType) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeDelete(node, feature, objectStack) {
@@ -523,7 +523,7 @@ const TRANSACTION_SERIALIZERS = {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeUpdate(node, feature, objectStack) {
@@ -680,7 +680,7 @@ function writeQuery(node, featureType, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Filter~Filter} filter Filter.
+ * @param {module:ol/format/filter/Filter} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeFilterCondition(node, filter, objectStack) {
@@ -695,7 +695,7 @@ function writeFilterCondition(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Bbox~Bbox} filter Filter.
+ * @param {module:ol/format/filter/Bbox} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeBboxFilter(node, filter, objectStack) {
@@ -709,7 +709,7 @@ function writeBboxFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Contains~Contains} filter Filter.
+ * @param {module:ol/format/filter/Contains} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeContainsFilter(node, filter, objectStack) {
@@ -723,7 +723,7 @@ function writeContainsFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Intersects~Intersects} filter Filter.
+ * @param {module:ol/format/filter/Intersects} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeIntersectsFilter(node, filter, objectStack) {
@@ -737,7 +737,7 @@ function writeIntersectsFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Within~Within} filter Filter.
+ * @param {module:ol/format/filter/Within} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeWithinFilter(node, filter, objectStack) {
@@ -751,7 +751,7 @@ function writeWithinFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/During~During} filter Filter.
+ * @param {module:ol/format/filter/During} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeDuringFilter(node, filter, objectStack) {
@@ -776,7 +776,7 @@ function writeDuringFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/LogicalNary~LogicalNary} filter Filter.
+ * @param {module:ol/format/filter/LogicalNary} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeLogicalFilter(node, filter, objectStack) {
@@ -795,7 +795,7 @@ function writeLogicalFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Not~Not} filter Filter.
+ * @param {module:ol/format/filter/Not} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeNotFilter(node, filter, objectStack) {
@@ -811,7 +811,7 @@ function writeNotFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/ComparisonBinary~ComparisonBinary} filter Filter.
+ * @param {module:ol/format/filter/ComparisonBinary} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeComparisonFilter(node, filter, objectStack) {
@@ -825,7 +825,7 @@ function writeComparisonFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/IsNull~IsNull} filter Filter.
+ * @param {module:ol/format/filter/IsNull} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeIsNullFilter(node, filter, objectStack) {
@@ -835,7 +835,7 @@ function writeIsNullFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/IsBetween~IsBetween} filter Filter.
+ * @param {module:ol/format/filter/IsBetween} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeIsBetweenFilter(node, filter, objectStack) {
@@ -853,7 +853,7 @@ function writeIsBetweenFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/IsLike~IsLike} filter Filter.
+ * @param {module:ol/format/filter/IsLike} filter Filter.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeIsLikeFilter(node, filter, objectStack) {
@@ -915,7 +915,7 @@ function writeTimeInstant(node, time) {
 /**
  * Encode filter as WFS `Filter` and return the Node.
  *
- * @param {module:ol/format/filter/Filter~Filter} filter Filter.
+ * @param {module:ol/format/filter/Filter} filter Filter.
  * @return {Node} Result.
  * @api
  */
@@ -1008,9 +1008,9 @@ WFS.prototype.writeGetFeature = function(options) {
 /**
  * Encode format as WFS `Transaction` and return the Node.
  *
- * @param {Array.<module:ol/Feature~Feature>} inserts The features to insert.
- * @param {Array.<module:ol/Feature~Feature>} updates The features to update.
- * @param {Array.<module:ol/Feature~Feature>} deletes The features to delete.
+ * @param {Array.<module:ol/Feature>} inserts The features to insert.
+ * @param {Array.<module:ol/Feature>} updates The features to update.
+ * @param {Array.<module:ol/Feature>} deletes The features to delete.
  * @param {module:ol/format/WFS~WriteTransactionOptions} options Write options.
  * @return {Node} Result.
  * @api
@@ -1079,7 +1079,7 @@ WFS.prototype.writeTransaction = function(inserts, updates, deletes, options) {
  *
  * @function
  * @param {Document|Node|Object|string} source Source.
- * @return {?module:ol/proj/Projection~Projection} Projection.
+ * @return {?module:ol/proj/Projection} Projection.
  * @api
  */
 WFS.prototype.readProjection;

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -271,7 +271,7 @@ Parser.prototype.match = function(type) {
 
 /**
  * Try to parse the tokens provided by the lexer.
- * @return {module:ol/geom/Geometry~Geometry} The geometry.
+ * @return {module:ol/geom/Geometry} The geometry.
  */
 Parser.prototype.parse = function() {
   this.consume_();
@@ -306,7 +306,7 @@ Parser.prototype.parseGeometryLayout_ = function() {
 
 
 /**
- * @return {!Array.<module:ol/geom/Geometry~Geometry>} A collection of geometries.
+ * @return {!Array.<module:ol/geom/Geometry>} A collection of geometries.
  * @private
  */
 Parser.prototype.parseGeometryCollectionText_ = function() {
@@ -538,7 +538,7 @@ Parser.prototype.formatErrorMessage_ = function() {
  * format.
  *
  * @constructor
- * @extends {module:ol/format/TextFeature~TextFeature}
+ * @extends {module:ol/format/TextFeature}
  * @param {module:ol/format/WKT~Options=} opt_options Options.
  * @api
  */
@@ -562,7 +562,7 @@ inherits(WKT, TextFeature);
 
 
 /**
- * @param {module:ol/geom/Point~Point} geom Point geometry.
+ * @param {module:ol/geom/Point} geom Point geometry.
  * @return {string} Coordinates part of Point as WKT.
  */
 function encodePointGeometry(geom) {
@@ -575,7 +575,7 @@ function encodePointGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/MultiPoint~MultiPoint} geom MultiPoint geometry.
+ * @param {module:ol/geom/MultiPoint} geom MultiPoint geometry.
  * @return {string} Coordinates part of MultiPoint as WKT.
  */
 function encodeMultiPointGeometry(geom) {
@@ -589,7 +589,7 @@ function encodeMultiPointGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geom GeometryCollection geometry.
+ * @param {module:ol/geom/GeometryCollection} geom GeometryCollection geometry.
  * @return {string} Coordinates part of GeometryCollection as WKT.
  */
 function encodeGeometryCollectionGeometry(geom) {
@@ -603,7 +603,7 @@ function encodeGeometryCollectionGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/LineString~LineString|module:ol/geom/LinearRing~LinearRing} geom LineString geometry.
+ * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} geom LineString geometry.
  * @return {string} Coordinates part of LineString as WKT.
  */
 function encodeLineStringGeometry(geom) {
@@ -617,7 +617,7 @@ function encodeLineStringGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/MultiLineString~MultiLineString} geom MultiLineString geometry.
+ * @param {module:ol/geom/MultiLineString} geom MultiLineString geometry.
  * @return {string} Coordinates part of MultiLineString as WKT.
  */
 function encodeMultiLineStringGeometry(geom) {
@@ -631,7 +631,7 @@ function encodeMultiLineStringGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/Polygon~Polygon} geom Polygon geometry.
+ * @param {module:ol/geom/Polygon} geom Polygon geometry.
  * @return {string} Coordinates part of Polygon as WKT.
  */
 function encodePolygonGeometry(geom) {
@@ -645,7 +645,7 @@ function encodePolygonGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geom MultiPolygon geometry.
+ * @param {module:ol/geom/MultiPolygon} geom MultiPolygon geometry.
  * @return {string} Coordinates part of MultiPolygon as WKT.
  */
 function encodeMultiPolygonGeometry(geom) {
@@ -658,7 +658,7 @@ function encodeMultiPolygonGeometry(geom) {
 }
 
 /**
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} geom SimpleGeometry geometry.
+ * @param {module:ol/geom/SimpleGeometry} geom SimpleGeometry geometry.
  * @return {string} Potential dimensional information for WKT type.
  */
 function encodeGeometryLayout(geom) {
@@ -676,7 +676,7 @@ function encodeGeometryLayout(geom) {
 
 /**
  * @const
- * @type {Object.<string, function(module:ol/geom/Geometry~Geometry): string>}
+ * @type {Object.<string, function(module:ol/geom/Geometry): string>}
  */
 const GeometryEncoder = {
   'Point': encodePointGeometry,
@@ -691,7 +691,7 @@ const GeometryEncoder = {
 
 /**
  * Encode a geometry as WKT.
- * @param {module:ol/geom/Geometry~Geometry} geom The geometry to encode.
+ * @param {module:ol/geom/Geometry} geom The geometry to encode.
  * @return {string} WKT string for the geometry.
  */
 function encode(geom) {
@@ -715,7 +715,7 @@ function encode(geom) {
 /**
  * Parse a WKT string.
  * @param {string} wkt WKT string.
- * @return {module:ol/geom/Geometry~Geometry|undefined}
+ * @return {module:ol/geom/Geometry|undefined}
  *     The geometry created.
  * @private
  */
@@ -732,7 +732,7 @@ WKT.prototype.parse_ = function(wkt) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  * @api
  */
 WKT.prototype.readFeature;
@@ -758,7 +758,7 @@ WKT.prototype.readFeatureFromText = function(text, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 WKT.prototype.readFeatures;
@@ -772,7 +772,7 @@ WKT.prototype.readFeaturesFromText = function(text, opt_options) {
   const geometry = this.readGeometryFromText(text, opt_options);
   if (this.splitCollection_ &&
       geometry.getType() == GeometryType.GEOMETRY_COLLECTION) {
-    geometries = (/** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry))
+    geometries = (/** @type {module:ol/geom/GeometryCollection} */ (geometry))
       .getGeometriesArray();
   } else {
     geometries = [geometry];
@@ -793,7 +793,7 @@ WKT.prototype.readFeaturesFromText = function(text, opt_options) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  * @api
  */
 WKT.prototype.readGeometry;
@@ -805,7 +805,9 @@ WKT.prototype.readGeometry;
 WKT.prototype.readGeometryFromText = function(text, opt_options) {
   const geometry = this.parse_(text);
   if (geometry) {
-    return /** @type {module:ol/geom/Geometry~Geometry} */ (transformWithOptions(geometry, false, opt_options));
+    return (
+      /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometry, false, opt_options))
+    );
   } else {
     return null;
   }
@@ -813,7 +815,7 @@ WKT.prototype.readGeometryFromText = function(text, opt_options) {
 
 
 /**
- * @enum {function (new:module:ol/geom/Geometry~Geometry, Array, module:ol/geom/GeometryLayout~GeometryLayout)}
+ * @enum {function (new:module:ol/geom/Geometry, Array, module:ol/geom/GeometryLayout~GeometryLayout)}
  */
 const GeometryConstructor = {
   'POINT': Point,
@@ -839,7 +841,7 @@ const GeometryParser = {
 
 
 /**
- * @return {!module:ol/geom/Geometry~Geometry} The geometry.
+ * @return {!module:ol/geom/Geometry} The geometry.
  * @private
  */
 Parser.prototype.parseGeometry_ = function() {
@@ -868,7 +870,7 @@ Parser.prototype.parseGeometry_ = function() {
  * Encode a feature as a WKT string.
  *
  * @function
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} WKT string.
  * @api
@@ -892,7 +894,7 @@ WKT.prototype.writeFeatureText = function(feature, opt_options) {
  * Encode an array of features as a WKT string.
  *
  * @function
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} WKT string.
  * @api
@@ -920,7 +922,7 @@ WKT.prototype.writeFeaturesText = function(features, opt_options) {
  * Write a single geometry as a WKT string.
  *
  * @function
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
  * @return {string} WKT string.
  * @api
@@ -932,7 +934,7 @@ WKT.prototype.writeGeometry;
  * @inheritDoc
  */
 WKT.prototype.writeGeometryText = function(geometry, opt_options) {
-  return encode(/** @type {module:ol/geom/Geometry~Geometry} */ (
+  return encode(/** @type {module:ol/geom/Geometry} */ (
     transformWithOptions(geometry, true, opt_options)));
 };
 

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -14,7 +14,7 @@ import {makeArrayPusher, makeObjectPropertyPusher, makeObjectPropertySetter,
  * Format for reading WMS capabilities data
  *
  * @constructor
- * @extends {module:ol/format/XML~XML}
+ * @extends {module:ol/format/XML}
  * @api
  */
 const WMSCapabilities = function() {

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -21,7 +21,7 @@ import {makeArrayPusher, makeStructureNS, pushParseAndPop} from '../xml.js';
  * {@link module:ol/format/GML2~GML2} to read features.
  *
  * @constructor
- * @extends {module:ol/format/XMLFeature~XMLFeature}
+ * @extends {module:ol/format/XMLFeature}
  * @param {module:ol/format/WMSGetFeatureInfo~Options=} opt_options Options.
  * @api
  */
@@ -38,7 +38,7 @@ const WMSGetFeatureInfo = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/format/GML2~GML2}
+   * @type {module:ol/format/GML2}
    */
   this.gmlFormat_ = new GML2();
 
@@ -88,13 +88,13 @@ WMSGetFeatureInfo.prototype.setLayers = function(layers) {
 /**
  * @param {Node} node Node.
  * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @private
  */
 WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack) {
   node.setAttribute('namespaceURI', this.featureNS_);
   const localName = node.localName;
-  /** @type {Array.<module:ol/Feature~Feature>} */
+  /** @type {Array.<module:ol/Feature>} */
   let features = [];
   if (node.childNodes.length === 0) {
     return features;
@@ -151,7 +151,7 @@ WMSGetFeatureInfo.prototype.readFeatures_ = function(node, objectStack) {
  * @function
  * @param {Document|Node|Object|string} source Source.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 WMSGetFeatureInfo.prototype.readFeatures;

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -15,14 +15,14 @@ import {pushParseAndPop, makeStructureNS,
  * Format for reading WMTS capabilities data.
  *
  * @constructor
- * @extends {module:ol/format/XML~XML}
+ * @extends {module:ol/format/XML}
  * @api
  */
 const WMTSCapabilities = function() {
   XML.call(this);
 
   /**
-   * @type {module:ol/format/OWS~OWS}
+   * @type {module:ol/format/OWS}
    * @private
    */
   this.owsParser_ = new OWS();

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -15,7 +15,7 @@ import {isDocument, isNode, parse} from '../xml.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/format/Feature~FeatureFormat}
+ * @extends {module:ol/format/Feature}
  */
 const XMLFeature = function() {
 
@@ -59,7 +59,7 @@ XMLFeature.prototype.readFeature = function(source, opt_options) {
 /**
  * @param {Document} doc Document.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 XMLFeature.prototype.readFeatureFromDocument = function(doc, opt_options) {
   const features = this.readFeaturesFromDocument(doc, opt_options);
@@ -74,7 +74,7 @@ XMLFeature.prototype.readFeatureFromDocument = function(doc, opt_options) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
- * @return {module:ol/Feature~Feature} Feature.
+ * @return {module:ol/Feature} Feature.
  */
 XMLFeature.prototype.readFeatureFromNode = function(node, opt_options) {
   return null; // not implemented
@@ -103,10 +103,10 @@ XMLFeature.prototype.readFeatures = function(source, opt_options) {
  * @param {Document} doc Document.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
  * @protected
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  */
 XMLFeature.prototype.readFeaturesFromDocument = function(doc, opt_options) {
-  /** @type {Array.<module:ol/Feature~Feature>} */
+  /** @type {Array.<module:ol/Feature>} */
   const features = [];
   for (let n = doc.firstChild; n; n = n.nextSibling) {
     if (n.nodeType == Node.ELEMENT_NODE) {
@@ -122,7 +122,7 @@ XMLFeature.prototype.readFeaturesFromDocument = function(doc, opt_options) {
  * @param {Node} node Node.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
  * @protected
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  */
 XMLFeature.prototype.readFeaturesFromNode = function(node, opt_options) {};
 
@@ -149,7 +149,7 @@ XMLFeature.prototype.readGeometry = function(source, opt_options) {
  * @param {Document} doc Document.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
  * @protected
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 XMLFeature.prototype.readGeometryFromDocument = function(doc, opt_options) {
   return null; // not implemented
@@ -160,7 +160,7 @@ XMLFeature.prototype.readGeometryFromDocument = function(doc, opt_options) {
  * @param {Node} node Node.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
  * @protected
- * @return {module:ol/geom/Geometry~Geometry} Geometry.
+ * @return {module:ol/geom/Geometry} Geometry.
  */
 XMLFeature.prototype.readGeometryFromNode = function(node, opt_options) {
   return null; // not implemented
@@ -187,7 +187,7 @@ XMLFeature.prototype.readProjection = function(source) {
 /**
  * @param {Document} doc Document.
  * @protected
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 XMLFeature.prototype.readProjectionFromDocument = function(doc) {
   return this.defaultDataProjection;
@@ -197,7 +197,7 @@ XMLFeature.prototype.readProjectionFromDocument = function(doc) {
 /**
  * @param {Node} node Node.
  * @protected
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 XMLFeature.prototype.readProjectionFromNode = function(node) {
   return this.defaultDataProjection;
@@ -214,7 +214,7 @@ XMLFeature.prototype.writeFeature = function(feature, opt_options) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @protected
  * @return {Node} Node.
@@ -234,7 +234,7 @@ XMLFeature.prototype.writeFeatures = function(features, opt_options) {
 
 
 /**
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  */
@@ -253,7 +253,7 @@ XMLFeature.prototype.writeGeometry = function(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  */

--- a/src/ol/format/filter.js
+++ b/src/ol/format/filter.js
@@ -23,8 +23,8 @@ import Within from '../format/filter/Within.js';
 /**
  * Create a logical `<And>` operator between two or more filter conditions.
  *
- * @param {...module:ol/format/filter/Filter~Filter} conditions Filter conditions.
- * @returns {!module:ol/format/filter/And~And} `<And>` operator.
+ * @param {...module:ol/format/filter/Filter} conditions Filter conditions.
+ * @returns {!module:ol/format/filter/And} `<And>` operator.
  * @api
  */
 export function and(conditions) {
@@ -36,8 +36,8 @@ export function and(conditions) {
 /**
  * Create a logical `<Or>` operator between two or more filter conditions.
  *
- * @param {...module:ol/format/filter/Filter~Filter} conditions Filter conditions.
- * @returns {!module:ol/format/filter/Or~Or} `<Or>` operator.
+ * @param {...module:ol/format/filter/Filter} conditions Filter conditions.
+ * @returns {!module:ol/format/filter/Or} `<Or>` operator.
  * @api
  */
 export function or(conditions) {
@@ -49,8 +49,8 @@ export function or(conditions) {
 /**
  * Represents a logical `<Not>` operator for a filter condition.
  *
- * @param {!module:ol/format/filter/Filter~Filter} condition Filter condition.
- * @returns {!module:ol/format/filter/Not~Not} `<Not>` operator.
+ * @param {!module:ol/format/filter/Filter} condition Filter condition.
+ * @returns {!module:ol/format/filter/Not} `<Not>` operator.
  * @api
  */
 export function not(condition) {
@@ -66,7 +66,7 @@ export function not(condition) {
  * @param {!module:ol/extent~Extent} extent Extent.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Bbox~Bbox} `<BBOX>` operator.
+ * @returns {!module:ol/format/filter/Bbox} `<BBOX>` operator.
  * @api
  */
 export function bbox(geometryName, extent, opt_srsName) {
@@ -78,10 +78,10 @@ export function bbox(geometryName, extent, opt_srsName) {
  * contains a given geometry.
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Contains~Contains} `<Contains>` operator.
+ * @returns {!module:ol/format/filter/Contains} `<Contains>` operator.
  * @api
  */
 export function contains(geometryName, geometry, opt_srsName) {
@@ -93,10 +93,10 @@ export function contains(geometryName, geometry, opt_srsName) {
  * intersects a given geometry.
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Intersects~Intersects} `<Intersects>` operator.
+ * @returns {!module:ol/format/filter/Intersects} `<Intersects>` operator.
  * @api
  */
 export function intersects(geometryName, geometry, opt_srsName) {
@@ -108,10 +108,10 @@ export function intersects(geometryName, geometry, opt_srsName) {
  * is within a given geometry.
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Within~Within} `<Within>` operator.
+ * @returns {!module:ol/format/filter/Within} `<Within>` operator.
  * @api
  */
 export function within(geometryName, geometry, opt_srsName) {
@@ -125,7 +125,7 @@ export function within(geometryName, geometry, opt_srsName) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!module:ol/format/filter/EqualTo~EqualTo} `<PropertyIsEqualTo>` operator.
+ * @returns {!module:ol/format/filter/EqualTo} `<PropertyIsEqualTo>` operator.
  * @api
  */
 export function equalTo(propertyName, expression, opt_matchCase) {
@@ -139,7 +139,7 @@ export function equalTo(propertyName, expression, opt_matchCase) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!module:ol/format/filter/NotEqualTo~NotEqualTo} `<PropertyIsNotEqualTo>` operator.
+ * @returns {!module:ol/format/filter/NotEqualTo} `<PropertyIsNotEqualTo>` operator.
  * @api
  */
 export function notEqualTo(propertyName, expression, opt_matchCase) {
@@ -152,7 +152,7 @@ export function notEqualTo(propertyName, expression, opt_matchCase) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/LessThan~LessThan} `<PropertyIsLessThan>` operator.
+ * @returns {!module:ol/format/filter/LessThan} `<PropertyIsLessThan>` operator.
  * @api
  */
 export function lessThan(propertyName, expression) {
@@ -165,7 +165,7 @@ export function lessThan(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/LessThanOrEqualTo~LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
+ * @returns {!module:ol/format/filter/LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
  * @api
  */
 export function lessThanOrEqualTo(propertyName, expression) {
@@ -178,7 +178,7 @@ export function lessThanOrEqualTo(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/GreaterThan~GreaterThan} `<PropertyIsGreaterThan>` operator.
+ * @returns {!module:ol/format/filter/GreaterThan} `<PropertyIsGreaterThan>` operator.
  * @api
  */
 export function greaterThan(propertyName, expression) {
@@ -191,7 +191,7 @@ export function greaterThan(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/GreaterThanOrEqualTo~GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
+ * @returns {!module:ol/format/filter/GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
  * @api
  */
 export function greaterThanOrEqualTo(propertyName, expression) {
@@ -204,7 +204,7 @@ export function greaterThanOrEqualTo(propertyName, expression) {
  * is null.
  *
  * @param {!string} propertyName Name of the context property to compare.
- * @returns {!module:ol/format/filter/IsNull~IsNull} `<PropertyIsNull>` operator.
+ * @returns {!module:ol/format/filter/IsNull} `<PropertyIsNull>` operator.
  * @api
  */
 export function isNull(propertyName) {
@@ -219,7 +219,7 @@ export function isNull(propertyName) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} lowerBoundary The lower bound of the range.
  * @param {!number} upperBoundary The upper bound of the range.
- * @returns {!module:ol/format/filter/IsBetween~IsBetween} `<PropertyIsBetween>` operator.
+ * @returns {!module:ol/format/filter/IsBetween} `<PropertyIsBetween>` operator.
  * @api
  */
 export function between(propertyName, lowerBoundary, upperBoundary) {
@@ -240,7 +240,7 @@ export function between(propertyName, lowerBoundary, upperBoundary) {
  * @param {string=} opt_escapeChar Escape character which can be used to escape
  *    the pattern characters. Default is '!'.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!module:ol/format/filter/IsLike~IsLike} `<PropertyIsLike>` operator.
+ * @returns {!module:ol/format/filter/IsLike} `<PropertyIsLike>` operator.
  * @api
  */
 export function like(propertyName, pattern,
@@ -256,7 +256,7 @@ export function like(propertyName, pattern,
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!string} begin The begin date in ISO-8601 format.
  * @param {!string} end The end date in ISO-8601 format.
- * @returns {!module:ol/format/filter/During~During} `<During>` operator.
+ * @returns {!module:ol/format/filter/During} `<During>` operator.
  * @api
  */
 export function during(propertyName, begin, end) {

--- a/src/ol/format/filter/And.js
+++ b/src/ol/format/filter/And.js
@@ -10,8 +10,8 @@ import LogicalNary from '../filter/LogicalNary.js';
  *
  * @constructor
  * @abstract
- * @param {...module:ol/format/filter/Filter~Filter} conditions Conditions.
- * @extends {module:ol/format/filter/LogicalNary~LogicalNary}
+ * @param {...module:ol/format/filter/Filter} conditions Conditions.
+ * @extends {module:ol/format/filter/LogicalNary}
  */
 const And = function(conditions) {
   const params = ['And'].concat(Array.prototype.slice.call(arguments));

--- a/src/ol/format/filter/Bbox.js
+++ b/src/ol/format/filter/Bbox.js
@@ -14,7 +14,7 @@ import Filter from '../filter/Filter.js';
  * @param {!module:ol/extent~Extent} extent Extent.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @extends {module:ol/format/filter/Filter~Filter}
+ * @extends {module:ol/format/filter/Filter}
  * @api
  */
 const Bbox = function(geometryName, extent, opt_srsName) {

--- a/src/ol/format/filter/Comparison.js
+++ b/src/ol/format/filter/Comparison.js
@@ -13,7 +13,7 @@ import Filter from '../filter/Filter.js';
  * @abstract
  * @param {!string} tagName The XML tag name for this filter.
  * @param {!string} propertyName Name of the context property to compare.
- * @extends {module:ol/format/filter/Filter~Filter}
+ * @extends {module:ol/format/filter/Filter}
  */
 const Comparison = function(tagName, propertyName) {
 

--- a/src/ol/format/filter/ComparisonBinary.js
+++ b/src/ol/format/filter/ComparisonBinary.js
@@ -15,7 +15,7 @@ import Comparison from '../filter/Comparison.js';
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @extends {module:ol/format/filter/Comparison~Comparison}
+ * @extends {module:ol/format/filter/Comparison}
  */
 const ComparisonBinary = function(tagName, propertyName, expression, opt_matchCase) {
 

--- a/src/ol/format/filter/Contains.js
+++ b/src/ol/format/filter/Contains.js
@@ -11,10 +11,10 @@ import Spatial from '../filter/Spatial.js';
  *
  * @constructor
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @extends {module:ol/format/filter/Spatial~Spatial}
+ * @extends {module:ol/format/filter/Spatial}
  * @api
  */
 const Contains = function(geometryName, geometry, opt_srsName) {

--- a/src/ol/format/filter/During.js
+++ b/src/ol/format/filter/During.js
@@ -12,7 +12,7 @@ import Comparison from '../filter/Comparison.js';
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!string} begin The begin date in ISO-8601 format.
  * @param {!string} end The end date in ISO-8601 format.
- * @extends {module:ol/format/filter/Comparison~Comparison}
+ * @extends {module:ol/format/filter/Comparison}
  * @api
  */
 const During = function(propertyName, begin, end) {

--- a/src/ol/format/filter/EqualTo.js
+++ b/src/ol/format/filter/EqualTo.js
@@ -12,7 +12,7 @@ import ComparisonBinary from '../filter/ComparisonBinary.js';
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @extends {module:ol/format/filter/ComparisonBinary~ComparisonBinary}
+ * @extends {module:ol/format/filter/ComparisonBinary}
  * @api
  */
 const EqualTo = function(propertyName, expression, opt_matchCase) {

--- a/src/ol/format/filter/GreaterThan.js
+++ b/src/ol/format/filter/GreaterThan.js
@@ -11,7 +11,7 @@ import ComparisonBinary from '../filter/ComparisonBinary.js';
  * @constructor
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @extends {module:ol/format/filter/ComparisonBinary~ComparisonBinary}
+ * @extends {module:ol/format/filter/ComparisonBinary}
  * @api
  */
 const GreaterThan = function(propertyName, expression) {

--- a/src/ol/format/filter/GreaterThanOrEqualTo.js
+++ b/src/ol/format/filter/GreaterThanOrEqualTo.js
@@ -11,7 +11,7 @@ import ComparisonBinary from '../filter/ComparisonBinary.js';
  * @constructor
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @extends {module:ol/format/filter/ComparisonBinary~ComparisonBinary}
+ * @extends {module:ol/format/filter/ComparisonBinary}
  * @api
  */
 const GreaterThanOrEqualTo = function(propertyName, expression) {

--- a/src/ol/format/filter/Intersects.js
+++ b/src/ol/format/filter/Intersects.js
@@ -11,10 +11,10 @@ import Spatial from '../filter/Spatial.js';
  *
  * @constructor
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @extends {module:ol/format/filter/Spatial~Spatial}
+ * @extends {module:ol/format/filter/Spatial}
  * @api
  */
 const Intersects = function(geometryName, geometry, opt_srsName) {

--- a/src/ol/format/filter/IsBetween.js
+++ b/src/ol/format/filter/IsBetween.js
@@ -12,7 +12,7 @@ import Comparison from '../filter/Comparison.js';
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} lowerBoundary The lower bound of the range.
  * @param {!number} upperBoundary The upper bound of the range.
- * @extends {module:ol/format/filter/Comparison~Comparison}
+ * @extends {module:ol/format/filter/Comparison}
  * @api
  */
 const IsBetween = function(propertyName, lowerBoundary, upperBoundary) {

--- a/src/ol/format/filter/IsLike.js
+++ b/src/ol/format/filter/IsLike.js
@@ -18,7 +18,7 @@ import Comparison from '../filter/Comparison.js';
  * @param {string=} opt_escapeChar Escape character which can be used to escape
  *    the pattern characters. Default is '!'.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @extends {module:ol/format/filter/Comparison~Comparison}
+ * @extends {module:ol/format/filter/Comparison}
  * @api
  */
 const IsLike = function(propertyName, pattern, opt_wildCard, opt_singleChar, opt_escapeChar, opt_matchCase) {

--- a/src/ol/format/filter/IsNull.js
+++ b/src/ol/format/filter/IsNull.js
@@ -10,7 +10,7 @@ import Comparison from '../filter/Comparison.js';
  *
  * @constructor
  * @param {!string} propertyName Name of the context property to compare.
- * @extends {module:ol/format/filter/Comparison~Comparison}
+ * @extends {module:ol/format/filter/Comparison}
  * @api
  */
 const IsNull = function(propertyName) {

--- a/src/ol/format/filter/LessThan.js
+++ b/src/ol/format/filter/LessThan.js
@@ -11,7 +11,7 @@ import ComparisonBinary from '../filter/ComparisonBinary.js';
  * @constructor
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @extends {module:ol/format/filter/ComparisonBinary~ComparisonBinary}
+ * @extends {module:ol/format/filter/ComparisonBinary}
  * @api
  */
 const LessThan = function(propertyName, expression) {

--- a/src/ol/format/filter/LessThanOrEqualTo.js
+++ b/src/ol/format/filter/LessThanOrEqualTo.js
@@ -11,7 +11,7 @@ import ComparisonBinary from '../filter/ComparisonBinary.js';
  * @constructor
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @extends {module:ol/format/filter/ComparisonBinary~ComparisonBinary}
+ * @extends {module:ol/format/filter/ComparisonBinary}
  * @api
  */
 const LessThanOrEqualTo = function(propertyName, expression) {

--- a/src/ol/format/filter/LogicalNary.js
+++ b/src/ol/format/filter/LogicalNary.js
@@ -13,15 +13,15 @@ import Filter from '../filter/Filter.js';
  * @constructor
  * @abstract
  * @param {!string} tagName The XML tag name for this filter.
- * @param {...module:ol/format/filter/Filter~Filter} conditions Conditions.
- * @extends {module:ol/format/filter/Filter~Filter}
+ * @param {...module:ol/format/filter/Filter} conditions Conditions.
+ * @extends {module:ol/format/filter/Filter}
  */
 const LogicalNary = function(tagName, conditions) {
 
   Filter.call(this, tagName);
 
   /**
-   * @type {Array.<module:ol/format/filter/Filter~Filter>}
+   * @type {Array.<module:ol/format/filter/Filter>}
    */
   this.conditions = Array.prototype.slice.call(arguments, 1);
   assert(this.conditions.length >= 2, 57); // At least 2 conditions are required.

--- a/src/ol/format/filter/Not.js
+++ b/src/ol/format/filter/Not.js
@@ -9,8 +9,8 @@ import Filter from '../filter/Filter.js';
  * Represents a logical `<Not>` operator for a filter condition.
  *
  * @constructor
- * @param {!module:ol/format/filter/Filter~Filter} condition Filter condition.
- * @extends {module:ol/format/filter/Filter~Filter}
+ * @param {!module:ol/format/filter/Filter} condition Filter condition.
+ * @extends {module:ol/format/filter/Filter}
  * @api
  */
 const Not = function(condition) {
@@ -18,7 +18,7 @@ const Not = function(condition) {
   Filter.call(this, 'Not');
 
   /**
-   * @type {!module:ol/format/filter/Filter~Filter}
+   * @type {!module:ol/format/filter/Filter}
    */
   this.condition = condition;
 };

--- a/src/ol/format/filter/NotEqualTo.js
+++ b/src/ol/format/filter/NotEqualTo.js
@@ -12,7 +12,7 @@ import ComparisonBinary from '../filter/ComparisonBinary.js';
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @extends {module:ol/format/filter/ComparisonBinary~ComparisonBinary}
+ * @extends {module:ol/format/filter/ComparisonBinary}
  * @api
  */
 const NotEqualTo = function(propertyName, expression, opt_matchCase) {

--- a/src/ol/format/filter/Or.js
+++ b/src/ol/format/filter/Or.js
@@ -9,8 +9,8 @@ import LogicalNary from '../filter/LogicalNary.js';
  * Represents a logical `<Or>` operator between two ore more filter conditions.
  *
  * @constructor
- * @param {...module:ol/format/filter/Filter~Filter} conditions Conditions.
- * @extends {module:ol/format/filter/LogicalNary~LogicalNary}
+ * @param {...module:ol/format/filter/Filter} conditions Conditions.
+ * @extends {module:ol/format/filter/LogicalNary}
  * @api
  */
 const Or = function(conditions) {

--- a/src/ol/format/filter/Spatial.js
+++ b/src/ol/format/filter/Spatial.js
@@ -14,10 +14,10 @@ import Filter from '../filter/Filter.js';
  * @abstract
  * @param {!string} tagName The XML tag name for this filter.
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @extends {module:ol/format/filter/Filter~Filter}
+ * @extends {module:ol/format/filter/Filter}
  */
 const Spatial = function(tagName, geometryName, geometry, opt_srsName) {
 
@@ -29,7 +29,7 @@ const Spatial = function(tagName, geometryName, geometry, opt_srsName) {
   this.geometryName = geometryName || 'the_geom';
 
   /**
-   * @type {module:ol/geom/Geometry~Geometry}
+   * @type {module:ol/geom/Geometry}
    */
   this.geometry = geometry;
 

--- a/src/ol/format/filter/Within.js
+++ b/src/ol/format/filter/Within.js
@@ -11,10 +11,10 @@ import Spatial from '../filter/Spatial.js';
  *
  * @constructor
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry~Geometry} geometry Geometry.
+ * @param {!module:ol/geom/Geometry} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @extends {module:ol/format/filter/Spatial~Spatial}
+ * @extends {module:ol/format/filter/Spatial}
  * @api
  */
 const Within = function(geometryName, geometry, opt_srsName) {

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -13,7 +13,7 @@ import {deflateCoordinate} from '../geom/flat/deflate.js';
  * Circle geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number=} opt_radius Radius.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
@@ -30,7 +30,7 @@ inherits(Circle, SimpleGeometry);
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/Circle~Circle} Clone.
+ * @return {!module:ol/geom/Circle} Clone.
  * @override
  * @api
  */
@@ -254,7 +254,7 @@ Circle.prototype.setRadius = function(radius) {
  *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
  * @param {module:ol/proj~ProjectionLike} destination The desired projection.  Can be a
  *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
- * @return {module:ol/geom/Circle~Circle} This geometry.  Note that original geometry is
+ * @return {module:ol/geom/Circle} This geometry.  Note that original geometry is
  *     modified in place.
  * @function
  * @api

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -22,7 +22,7 @@ import {create as createTransform, compose as composeTransform} from '../transfo
  *
  * @constructor
  * @abstract
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @api
  */
 const Geometry = function() {
@@ -43,7 +43,7 @@ const Geometry = function() {
 
   /**
    * @protected
-   * @type {Object.<string, module:ol/geom/Geometry~Geometry>}
+   * @type {Object.<string, module:ol/geom/Geometry>}
    */
   this.simplifiedGeometryCache = {};
 
@@ -73,7 +73,7 @@ const tmpTransform = createTransform();
 /**
  * Make a complete copy of the geometry.
  * @abstract
- * @return {!module:ol/geom/Geometry~Geometry} Clone.
+ * @return {!module:ol/geom/Geometry} Clone.
  */
 Geometry.prototype.clone = function() {};
 
@@ -181,7 +181,7 @@ Geometry.prototype.scale = function(sx, opt_sy, opt_anchor) {};
  * simplification is used to preserve topology.
  * @function
  * @param {number} tolerance The tolerance distance for simplification.
- * @return {module:ol/geom/Geometry~Geometry} A new, simplified version of the original
+ * @return {module:ol/geom/Geometry} A new, simplified version of the original
  *     geometry.
  * @api
  */
@@ -196,7 +196,7 @@ Geometry.prototype.simplify = function(tolerance) {
  * @see https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
  * @abstract
  * @param {number} squaredTolerance Squared tolerance.
- * @return {module:ol/geom/Geometry~Geometry} Simplified geometry.
+ * @return {module:ol/geom/Geometry} Simplified geometry.
  */
 Geometry.prototype.getSimplifiedGeometry = function(squaredTolerance) {};
 
@@ -250,7 +250,7 @@ Geometry.prototype.translate = function(deltaX, deltaY) {};
  *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
  * @param {module:ol/proj~ProjectionLike} destination The desired projection.  Can be a
  *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
- * @return {module:ol/geom/Geometry~Geometry} This geometry.  Note that original geometry is
+ * @return {module:ol/geom/Geometry} This geometry.  Note that original geometry is
  *     modified in place.
  * @api
  */

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -11,11 +11,11 @@ import {clear} from '../obj.js';
 
 /**
  * @classdesc
- * An array of {@link module:ol/geom/Geometry~Geometry} objects.
+ * An array of {@link module:ol/geom/Geometry} objects.
  *
  * @constructor
- * @extends {module:ol/geom/Geometry~Geometry}
- * @param {Array.<module:ol/geom/Geometry~Geometry>=} opt_geometries Geometries.
+ * @extends {module:ol/geom/Geometry}
+ * @param {Array.<module:ol/geom/Geometry>=} opt_geometries Geometries.
  * @api
  */
 const GeometryCollection = function(opt_geometries) {
@@ -24,7 +24,7 @@ const GeometryCollection = function(opt_geometries) {
 
   /**
    * @private
-   * @type {Array.<module:ol/geom/Geometry~Geometry>}
+   * @type {Array.<module:ol/geom/Geometry>}
    */
   this.geometries_ = opt_geometries ? opt_geometries : null;
 
@@ -35,8 +35,8 @@ inherits(GeometryCollection, Geometry);
 
 
 /**
- * @param {Array.<module:ol/geom/Geometry~Geometry>} geometries Geometries.
- * @return {Array.<module:ol/geom/Geometry~Geometry>} Cloned geometries.
+ * @param {Array.<module:ol/geom/Geometry>} geometries Geometries.
+ * @return {Array.<module:ol/geom/Geometry>} Cloned geometries.
  */
 function cloneGeometries(geometries) {
   const clonedGeometries = [];
@@ -79,7 +79,7 @@ GeometryCollection.prototype.listenGeometriesChange_ = function() {
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/GeometryCollection~GeometryCollection} Clone.
+ * @return {!module:ol/geom/GeometryCollection} Clone.
  * @override
  * @api
  */
@@ -135,7 +135,7 @@ GeometryCollection.prototype.computeExtent = function(extent) {
 
 /**
  * Return the geometries that make up this geometry collection.
- * @return {Array.<module:ol/geom/Geometry~Geometry>} Geometries.
+ * @return {Array.<module:ol/geom/Geometry>} Geometries.
  * @api
  */
 GeometryCollection.prototype.getGeometries = function() {
@@ -144,7 +144,7 @@ GeometryCollection.prototype.getGeometries = function() {
 
 
 /**
- * @return {Array.<module:ol/geom/Geometry~Geometry>} Geometries.
+ * @return {Array.<module:ol/geom/Geometry>} Geometries.
  */
 GeometryCollection.prototype.getGeometriesArray = function() {
   return this.geometries_;
@@ -257,7 +257,7 @@ GeometryCollection.prototype.scale = function(sx, opt_sy, opt_anchor) {
 
 /**
  * Set the geometries that make up this geometry collection.
- * @param {Array.<module:ol/geom/Geometry~Geometry>} geometries Geometries.
+ * @param {Array.<module:ol/geom/Geometry>} geometries Geometries.
  * @api
  */
 GeometryCollection.prototype.setGeometries = function(geometries) {
@@ -266,7 +266,7 @@ GeometryCollection.prototype.setGeometries = function(geometries) {
 
 
 /**
- * @param {Array.<module:ol/geom/Geometry~Geometry>} geometries Geometries.
+ * @param {Array.<module:ol/geom/Geometry>} geometries Geometries.
  */
 GeometryCollection.prototype.setGeometriesArray = function(geometries) {
   this.unlistenGeometriesChange_();

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -21,7 +21,7 @@ import {douglasPeucker} from '../geom/flat/simplify.js';
  * Linestring geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
  * @api
@@ -78,7 +78,7 @@ LineString.prototype.appendCoordinate = function(coordinate) {
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/LineString~LineString} Clone.
+ * @return {!module:ol/geom/LineString} Clone.
  * @override
  * @api
  */

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -18,7 +18,7 @@ import {douglasPeucker} from '../geom/flat/simplify.js';
  * on its own.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
  * @api
@@ -48,7 +48,7 @@ inherits(LinearRing, SimpleGeometry);
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/LinearRing~LinearRing} Clone.
+ * @return {!module:ol/geom/LinearRing} Clone.
  * @override
  * @api
  */

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -20,7 +20,7 @@ import {douglasPeuckerArray} from '../geom/flat/simplify.js';
  * Multi-linestring geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
  * @api
@@ -56,7 +56,7 @@ inherits(MultiLineString, SimpleGeometry);
 
 /**
  * Append the passed linestring to the multilinestring.
- * @param {module:ol/geom/LineString~LineString} lineString LineString.
+ * @param {module:ol/geom/LineString} lineString LineString.
  * @api
  */
 MultiLineString.prototype.appendLineString = function(lineString) {
@@ -72,7 +72,7 @@ MultiLineString.prototype.appendLineString = function(lineString) {
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/MultiLineString~MultiLineString} Clone.
+ * @return {!module:ol/geom/MultiLineString} Clone.
  * @override
  * @api
  */
@@ -160,7 +160,7 @@ MultiLineString.prototype.getEnds = function() {
 /**
  * Return the linestring at the specified index.
  * @param {number} index Index.
- * @return {module:ol/geom/LineString~LineString} LineString.
+ * @return {module:ol/geom/LineString} LineString.
  * @api
  */
 MultiLineString.prototype.getLineString = function(index) {
@@ -176,14 +176,14 @@ MultiLineString.prototype.getLineString = function(index) {
 
 /**
  * Return the linestrings of this multilinestring.
- * @return {Array.<module:ol/geom/LineString~LineString>} LineStrings.
+ * @return {Array.<module:ol/geom/LineString>} LineStrings.
  * @api
  */
 MultiLineString.prototype.getLineStrings = function() {
   const flatCoordinates = this.flatCoordinates;
   const ends = this.ends_;
   const layout = this.layout;
-  /** @type {Array.<module:ol/geom/LineString~LineString>} */
+  /** @type {Array.<module:ol/geom/LineString>} */
   const lineStrings = [];
   let offset = 0;
   for (let i = 0, ii = ends.length; i < ii; ++i) {
@@ -288,7 +288,7 @@ MultiLineString.prototype.setFlatCoordinates = function(layout, flatCoordinates,
 
 
 /**
- * @param {Array.<module:ol/geom/LineString~LineString>} lineStrings LineStrings.
+ * @param {Array.<module:ol/geom/LineString>} lineStrings LineStrings.
  */
 MultiLineString.prototype.setLineStrings = function(lineStrings) {
   let layout = this.getLayout();

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -17,7 +17,7 @@ import {squaredDistance as squaredDx} from '../math.js';
  * Multi-point geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
  * @api
@@ -32,7 +32,7 @@ inherits(MultiPoint, SimpleGeometry);
 
 /**
  * Append the passed point to this multipoint.
- * @param {module:ol/geom/Point~Point} point Point.
+ * @param {module:ol/geom/Point} point Point.
  * @api
  */
 MultiPoint.prototype.appendPoint = function(point) {
@@ -47,7 +47,7 @@ MultiPoint.prototype.appendPoint = function(point) {
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/MultiPoint~MultiPoint} Clone.
+ * @return {!module:ol/geom/MultiPoint} Clone.
  * @override
  * @api
  */
@@ -97,7 +97,7 @@ MultiPoint.prototype.getCoordinates = function() {
 /**
  * Return the point at the specified index.
  * @param {number} index Index.
- * @return {module:ol/geom/Point~Point} Point.
+ * @return {module:ol/geom/Point} Point.
  * @api
  */
 MultiPoint.prototype.getPoint = function(index) {
@@ -114,14 +114,14 @@ MultiPoint.prototype.getPoint = function(index) {
 
 /**
  * Return the points of this multipoint.
- * @return {Array.<module:ol/geom/Point~Point>} Points.
+ * @return {Array.<module:ol/geom/Point>} Points.
  * @api
  */
 MultiPoint.prototype.getPoints = function() {
   const flatCoordinates = this.flatCoordinates;
   const layout = this.layout;
   const stride = this.stride;
-  /** @type {Array.<module:ol/geom/Point~Point>} */
+  /** @type {Array.<module:ol/geom/Point>} */
   const points = [];
   for (let i = 0, ii = flatCoordinates.length; i < ii; i += stride) {
     const point = new Point(null);

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -25,7 +25,7 @@ import {quantizeMultiArray} from '../geom/flat/simplify.js';
  * Multi-polygon geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>} coordinates Coordinates.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
  * @api
@@ -85,7 +85,7 @@ inherits(MultiPolygon, SimpleGeometry);
 
 /**
  * Append the passed polygon to this multipolygon.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon.
+ * @param {module:ol/geom/Polygon} polygon Polygon.
  * @api
  */
 MultiPolygon.prototype.appendPolygon = function(polygon) {
@@ -110,7 +110,7 @@ MultiPolygon.prototype.appendPolygon = function(polygon) {
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/MultiPolygon~MultiPolygon} Clone.
+ * @return {!module:ol/geom/MultiPolygon} Clone.
  * @override
  * @api
  */
@@ -219,8 +219,8 @@ MultiPolygon.prototype.getFlatInteriorPoints = function() {
 
 
 /**
- * Return the interior points as {@link module:ol/geom/MultiPoint~MultiPoint multipoint}.
- * @return {module:ol/geom/MultiPoint~MultiPoint} Interior points as XYM coordinates, where M is
+ * Return the interior points as {@link module:ol/geom/MultiPoint multipoint}.
+ * @return {module:ol/geom/MultiPoint} Interior points as XYM coordinates, where M is
  * the length of the horizontal intersection that the point belongs to.
  * @api
  */
@@ -273,7 +273,7 @@ MultiPolygon.prototype.getSimplifiedGeometryInternal = function(squaredTolerance
 /**
  * Return the polygon at the specified index.
  * @param {number} index Index.
- * @return {module:ol/geom/Polygon~Polygon} Polygon.
+ * @return {module:ol/geom/Polygon} Polygon.
  * @api
  */
 MultiPolygon.prototype.getPolygon = function(index) {
@@ -303,7 +303,7 @@ MultiPolygon.prototype.getPolygon = function(index) {
 
 /**
  * Return the polygons of this multipolygon.
- * @return {Array.<module:ol/geom/Polygon~Polygon>} Polygons.
+ * @return {Array.<module:ol/geom/Polygon>} Polygons.
  * @api
  */
 MultiPolygon.prototype.getPolygons = function() {
@@ -391,7 +391,7 @@ MultiPolygon.prototype.setFlatCoordinates = function(layout, flatCoordinates, en
 
 
 /**
- * @param {Array.<module:ol/geom/Polygon~Polygon>} polygons Polygons.
+ * @param {Array.<module:ol/geom/Polygon>} polygons Polygons.
  */
 MultiPolygon.prototype.setPolygons = function(polygons) {
   let layout = this.getLayout();

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -14,7 +14,7 @@ import {squaredDistance as squaredDx} from '../math.js';
  * Point geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {module:ol/coordinate~Coordinate} coordinates Coordinates.
  * @param {module:ol/geom/GeometryLayout~GeometryLayout=} opt_layout Layout.
  * @api
@@ -29,7 +29,7 @@ inherits(Point, SimpleGeometry);
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/Point~Point} Clone.
+ * @return {!module:ol/geom/Point} Clone.
  * @override
  * @api
  */

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -26,7 +26,7 @@ import {modulo} from '../math.js';
  * Polygon geometry.
  *
  * @constructor
- * @extends {module:ol/geom/SimpleGeometry~SimpleGeometry}
+ * @extends {module:ol/geom/SimpleGeometry}
  * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} coordinates Array of linear
  *     rings that define the polygon. The first linear ring of the array
  *     defines the outer-boundary or surface of the polygon. Each subsequent
@@ -91,7 +91,7 @@ inherits(Polygon, SimpleGeometry);
 
 /**
  * Append the passed linear ring to this polygon.
- * @param {module:ol/geom/LinearRing~LinearRing} linearRing Linear ring.
+ * @param {module:ol/geom/LinearRing} linearRing Linear ring.
  * @api
  */
 Polygon.prototype.appendLinearRing = function(linearRing) {
@@ -107,7 +107,7 @@ Polygon.prototype.appendLinearRing = function(linearRing) {
 
 /**
  * Make a complete copy of the geometry.
- * @return {!module:ol/geom/Polygon~Polygon} Clone.
+ * @return {!module:ol/geom/Polygon} Clone.
  * @override
  * @api
  */
@@ -209,7 +209,7 @@ Polygon.prototype.getFlatInteriorPoint = function() {
 
 /**
  * Return an interior point of the polygon.
- * @return {module:ol/geom/Point~Point} Interior point as XYM coordinate, where M is the
+ * @return {module:ol/geom/Point} Interior point as XYM coordinate, where M is the
  * length of the horizontal intersection that the point belongs to.
  * @api
  */
@@ -237,7 +237,7 @@ Polygon.prototype.getLinearRingCount = function() {
  * at index `1` and beyond.
  *
  * @param {number} index Index.
- * @return {module:ol/geom/LinearRing~LinearRing} Linear ring.
+ * @return {module:ol/geom/LinearRing} Linear ring.
  * @api
  */
 Polygon.prototype.getLinearRing = function(index) {
@@ -253,7 +253,7 @@ Polygon.prototype.getLinearRing = function(index) {
 
 /**
  * Return the linear rings of the polygon.
- * @return {Array.<module:ol/geom/LinearRing~LinearRing>} Linear rings.
+ * @return {Array.<module:ol/geom/LinearRing>} Linear rings.
  * @api
  */
 Polygon.prototype.getLinearRings = function() {
@@ -376,7 +376,7 @@ export default Polygon;
  *     polygon. Default is `32`.
  * @param {number=} opt_sphereRadius Optional radius for the sphere (defaults to
  *     the Earth's mean radius using the WGS84 ellipsoid).
- * @return {module:ol/geom/Polygon~Polygon} The "circular" polygon.
+ * @return {module:ol/geom/Polygon} The "circular" polygon.
  * @api
  */
 export function circular(center, radius, opt_n, opt_sphereRadius) {
@@ -396,7 +396,7 @@ export function circular(center, radius, opt_n, opt_sphereRadius) {
 /**
  * Create a polygon from an extent. The layout used is `XY`.
  * @param {module:ol/extent~Extent} extent The extent.
- * @return {module:ol/geom/Polygon~Polygon} The polygon.
+ * @return {module:ol/geom/Polygon} The polygon.
  * @api
  */
 export function fromExtent(extent) {
@@ -415,11 +415,11 @@ export function fromExtent(extent) {
 
 /**
  * Create a regular polygon from a circle.
- * @param {module:ol/geom/Circle~Circle} circle Circle geometry.
+ * @param {module:ol/geom/Circle} circle Circle geometry.
  * @param {number=} opt_sides Number of sides of the polygon. Default is 32.
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in
  *     radians. Default is 0.
- * @return {module:ol/geom/Polygon~Polygon} Polygon geometry.
+ * @return {module:ol/geom/Polygon} Polygon geometry.
  * @api
  */
 export function fromCircle(circle, opt_sides, opt_angle) {
@@ -441,7 +441,7 @@ export function fromCircle(circle, opt_sides, opt_angle) {
 
 /**
  * Modify the coordinates of a polygon to make it a regular polygon.
- * @param {module:ol/geom/Polygon~Polygon} polygon Polygon geometry.
+ * @param {module:ol/geom/Polygon} polygon Polygon geometry.
  * @param {module:ol/coordinate~Coordinate} center Center of the regular polygon.
  * @param {number} radius Radius of the regular polygon.
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -16,7 +16,7 @@ import {clear} from '../obj.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/geom/Geometry~Geometry}
+ * @extends {module:ol/geom/Geometry}
  * @api
  */
 const SimpleGeometry = function() {
@@ -59,7 +59,9 @@ function getLayoutForStride(stride) {
   } else if (stride == 4) {
     layout = GeometryLayout.XYZM;
   }
-  return /** @type {module:ol/geom/GeometryLayout~GeometryLayout} */ (layout);
+  return (
+    /** @type {module:ol/geom/GeometryLayout~GeometryLayout} */ (layout)
+  );
 }
 
 
@@ -182,7 +184,7 @@ SimpleGeometry.prototype.getSimplifiedGeometry = function(squaredTolerance) {
 
 /**
  * @param {number} squaredTolerance Squared tolerance.
- * @return {module:ol/geom/SimpleGeometry~SimpleGeometry} Simplified geometry.
+ * @return {module:ol/geom/SimpleGeometry} Simplified geometry.
  * @protected
  */
 SimpleGeometry.prototype.getSimplifiedGeometryInternal = function(squaredTolerance) {
@@ -316,7 +318,7 @@ SimpleGeometry.prototype.translate = function(deltaX, deltaY) {
 
 
 /**
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} simpleGeometry Simple geometry.
+ * @param {module:ol/geom/SimpleGeometry} simpleGeometry Simple geometry.
  * @param {module:ol/transform~Transform} transform Transform.
  * @param {Array.<number>=} opt_dest Destination.
  * @return {Array.<number>} Transformed flat coordinates.

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -84,7 +84,7 @@ function line(interpolate, transform, squaredTolerance) {
  * @param {number} lat1 Latitude 1 in degrees.
  * @param {number} lon2 Longitude 2 in degrees.
  * @param {number} lat2 Latitude 2 in degrees.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array.<number>} Flat coordinates.
  */
@@ -128,7 +128,7 @@ export function greatCircleArc(lon1, lat1, lon2, lat2, projection, squaredTolera
  * @param {number} lon Longitude.
  * @param {number} lat1 Latitude 1.
  * @param {number} lat2 Latitude 2.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array.<number>} Flat coordinates.
  */
@@ -151,7 +151,7 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
  * @param {number} lat Latitude.
  * @param {number} lon1 Longitude 1.
  * @param {number} lon2 Longitude 2.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array.<number>} Flat coordinates.
  */

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -61,8 +61,8 @@ export {default as Translate} from './interaction/Translate.js';
  * excluded by setting the appropriate option to false in the constructor
  * options, but the order of the interactions is fixed.  If you want to specify
  * a different order for interactions, you will need to create your own
- * {@link module:ol/interaction/Interaction~Interaction} instances and insert
- * them into a {@link module:ol/Collection~Collection} in the order you want
+ * {@link module:ol/interaction/Interaction} instances and insert
+ * them into a {@link module:ol/Collection} in the order you want
  * before creating your {@link module:ol/Map~Map} instance. The default set of
  * interactions, in sequence, is:
  * * {@link module:ol/interaction/DragRotate~DragRotate}
@@ -77,7 +77,7 @@ export {default as Translate} from './interaction/Translate.js';
  *
  * @param {module:ol/interaction/Interaction~DefaultsOptions=} opt_options
  * Defaults options.
- * @return {module:ol/Collection~Collection.<module:ol/interaction/Interaction~Interaction>}
+ * @return {module:ol/Collection.<module:ol/interaction/Interaction>}
  * A collection of interactions to be used with the {@link module:ol/Map~Map}
  * constructor's `interactions` option.
  * @api

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -18,7 +18,7 @@ import Interaction, {zoomByDelta} from '../interaction/Interaction.js';
  * Allows the user to zoom by double-clicking on the map.
  *
  * @constructor
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @param {module:ol/interaction/DoubleClickZoom~Options=} opt_options Options.
  * @api
  */
@@ -48,11 +48,11 @@ inherits(DoubleClickZoom, Interaction);
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} (if it was a
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
  * doubleclick) and eventually zooms the map.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/DoubleClickZoom~DoubleClickZoom}
+ * @this {module:ol/interaction/DoubleClickZoom}
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -14,8 +14,8 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @typedef {Object} Options
- * @property {Array.<function(new: module:ol/format/Feature~FeatureFormat)>} [formatConstructors] Format constructors.
- * @property {module:ol/source/Vector~VectorSource} [source] Optional vector source where features will be added.  If a source is provided
+ * @property {Array.<function(new: module:ol/format/Feature)>} [formatConstructors] Format constructors.
+ * @property {module:ol/source/Vector} [source] Optional vector source where features will be added.  If a source is provided
  * all existing features will be removed and new features will be added when
  * they are dropped on the target.  If you want to add features to a vector
  * source without removing the existing features (append only), instead of
@@ -44,12 +44,12 @@ const DragAndDropEventType = {
  * of this type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.interaction.DragAndDropEvent}
  * @param {module:ol/interaction/DragAndDrop~DragAndDropEventType} type Type.
  * @param {File} file File.
- * @param {Array.<module:ol/Feature~Feature>=} opt_features Features.
- * @param {module:ol/proj/Projection~Projection=} opt_projection Projection.
+ * @param {Array.<module:ol/Feature>=} opt_features Features.
+ * @param {module:ol/proj/Projection=} opt_projection Projection.
  */
 const DragAndDropEvent = function(type, file, opt_features, opt_projection) {
 
@@ -57,7 +57,7 @@ const DragAndDropEvent = function(type, file, opt_features, opt_projection) {
 
   /**
    * The features parsed from dropped data.
-   * @type {Array.<module:ol/Feature~Feature>|undefined}
+   * @type {Array.<module:ol/Feature>|undefined}
    * @api
    */
   this.features = opt_features;
@@ -71,7 +71,7 @@ const DragAndDropEvent = function(type, file, opt_features, opt_projection) {
 
   /**
    * The feature projection.
-   * @type {module:ol/proj/Projection~Projection|undefined}
+   * @type {module:ol/proj/Projection|undefined}
    * @api
    */
   this.projection = opt_projection;
@@ -85,7 +85,7 @@ inherits(DragAndDropEvent, Event);
  * Handles input of vector data by drag and drop.
  *
  * @constructor
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @fires module:ol/interaction/DragAndDrop~DragAndDropEvent
  * @param {module:ol/interaction/DragAndDrop~Options=} opt_options Options.
  * @api
@@ -100,14 +100,14 @@ const DragAndDrop = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<function(new: module:ol/format/Feature~FeatureFormat)>}
+   * @type {Array.<function(new: module:ol/format/Feature)>}
    */
   this.formatConstructors_ = options.formatConstructors ?
     options.formatConstructors : [];
 
   /**
    * @private
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.projection_ = options.projection ?
     getProjection(options.projection) : null;
@@ -120,7 +120,7 @@ const DragAndDrop = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/source/Vector~VectorSource}
+   * @type {module:ol/source/Vector}
    */
   this.source_ = options.source || null;
 
@@ -137,7 +137,7 @@ inherits(DragAndDrop, Interaction);
 
 /**
  * @param {Event} event Event.
- * @this {module:ol/interaction/DragAndDrop~DragAndDrop}
+ * @this {module:ol/interaction/DragAndDrop}
  */
 function handleDrop(event) {
   const files = event.dataTransfer.files;
@@ -183,7 +183,7 @@ DragAndDrop.prototype.handleResult_ = function(file, event) {
      */
     const formatConstructor = formatConstructors[i];
     /**
-     * @type {module:ol/format/Feature~FeatureFormat}
+     * @type {module:ol/format/Feature}
      */
     const format = new formatConstructor();
     features = this.tryReadFeatures_(format, result, {
@@ -247,11 +247,11 @@ DragAndDrop.prototype.setMap = function(map) {
 
 
 /**
- * @param {module:ol/format/Feature~FeatureFormat} format Format.
+ * @param {module:ol/format/Feature} format Format.
  * @param {string} text Text.
  * @param {module:ol/format/Feature~ReadOptions} options Read options.
  * @private
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  */
 DragAndDrop.prototype.tryReadFeatures_ = function(format, text, options) {
   try {

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -11,10 +11,10 @@ import RenderBox from '../render/Box.js';
 
 
 /**
- * A function that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and two
+ * A function that takes a {@link module:ol/MapBrowserEvent} and two
  * {@link module:ol~Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
- * @typedef {function(module:ol/MapBrowserEvent~MapBrowserEvent, module:ol~Pixel, module:ol~Pixel):boolean} EndCondition
+ * @typedef {function(module:ol/MapBrowserEvent, module:ol~Pixel, module:ol~Pixel):boolean} EndCondition
  */
 
 
@@ -66,8 +66,8 @@ const DragBoxEventType = {
  *
  * @param {string} type The event type.
  * @param {module:ol/coordinate~Coordinate} coordinate The event coordinate.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Originating event.
- * @extends {module:ol/events/Event~Event}
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Originating event.
+ * @extends {module:ol/events/Event}
  * @constructor
  * @implements {oli.DragBoxEvent}
  */
@@ -84,7 +84,7 @@ const DragBoxEvent = function(type, coordinate, mapBrowserEvent) {
 
   /**
    * @const
-   * @type {module:ol/MapBrowserEvent~MapBrowserEvent}
+   * @type {module:ol/MapBrowserEvent}
    * @api
    */
   this.mapBrowserEvent = mapBrowserEvent;
@@ -106,7 +106,7 @@ inherits(DragBoxEvent, Event);
  * This interaction is only supported for mouse devices.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @fires module:ol/interaction/DragBox~DragBoxEvent
  * @param {module:ol/interaction/DragBox~Options=} opt_options Options.
  * @api
@@ -159,12 +159,12 @@ inherits(DragBox, PointerInteraction);
 /**
  * The default condition for determining whether the boxend event
  * should fire.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent The originating MapBrowserEvent
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent The originating MapBrowserEvent
  *     leading to the box end.
  * @param {module:ol~Pixel} startPixel The starting pixel of the box.
  * @param {module:ol~Pixel} endPixel The end pixel of the box.
  * @return {boolean} Whether or not the boxend condition should be fired.
- * @this {module:ol/interaction/DragBox~DragBox}
+ * @this {module:ol/interaction/DragBox}
  */
 function defaultBoxEndCondition(mapBrowserEvent, startPixel, endPixel) {
   const width = endPixel[0] - startPixel[0];
@@ -174,8 +174,8 @@ function defaultBoxEndCondition(mapBrowserEvent, startPixel, endPixel) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragBox~DragBox}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/DragBox}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -191,7 +191,7 @@ function handleDragEvent(mapBrowserEvent) {
 
 /**
  * Returns geometry of last drawn box.
- * @return {module:ol/geom/Polygon~Polygon} Geometry.
+ * @return {module:ol/geom/Polygon} Geometry.
  * @api
  */
 DragBox.prototype.getGeometry = function() {
@@ -202,16 +202,16 @@ DragBox.prototype.getGeometry = function() {
 /**
  * To be overridden by child classes.
  * FIXME: use constructor option instead of relying on overriding.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @protected
  */
 DragBox.prototype.onBoxEnd = UNDEFINED;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragBox~DragBox}
+ * @this {module:ol/interaction/DragBox}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -231,9 +231,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragBox~DragBox}
+ * @this {module:ol/interaction/DragBox}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -15,7 +15,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  * @property {module:ol/events/condition~Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link module:ol/events/condition~noModifierKeys}.
- * @property {module:ol/Kinetic~Kinetic} [kinetic] Kinetic inertia to apply to the pan.
+ * @property {module:ol/Kinetic} [kinetic] Kinetic inertia to apply to the pan.
  */
 
 
@@ -24,7 +24,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  * Allows the user to pan the map by dragging the map.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/DragPan~Options=} opt_options Options.
  * @api
  */
@@ -40,7 +40,7 @@ const DragPan = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/Kinetic~Kinetic|undefined}
+   * @type {module:ol/Kinetic|undefined}
    */
   this.kinetic_ = options.kinetic;
 
@@ -72,8 +72,8 @@ inherits(DragPan, PointerInteraction);
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragPan~DragPan}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/DragPan}
  */
 function handleDragEvent(mapBrowserEvent) {
   const targetPointers = this.targetPointers;
@@ -105,9 +105,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragPan~DragPan}
+ * @this {module:ol/interaction/DragPan}
  */
 function handleUpEvent(mapBrowserEvent) {
   const map = mapBrowserEvent.map;
@@ -143,9 +143,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragPan~DragPan}
+ * @this {module:ol/interaction/DragPan}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (this.targetPointers.length > 0 && this.condition_(mapBrowserEvent)) {

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -29,7 +29,7 @@ import PointerInteraction from '../interaction/Pointer.js';
  * This interaction is only supported for mouse devices.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/DragRotate~Options=} opt_options Options.
  * @api
  */
@@ -66,8 +66,8 @@ inherits(DragRotate, PointerInteraction);
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragRotate~DragRotate}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/DragRotate}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -93,9 +93,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragRotate~DragRotate}
+ * @this {module:ol/interaction/DragRotate}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -112,9 +112,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragRotate~DragRotate}
+ * @this {module:ol/interaction/DragRotate}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -30,7 +30,7 @@ import PointerInteraction from '../interaction/Pointer.js';
  * And this interaction is not included in the default interactions.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/DragRotateAndZoom~Options=} opt_options Options.
  * @api
  */
@@ -80,8 +80,8 @@ inherits(DragRotateAndZoom, PointerInteraction);
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragRotateAndZoom~DragRotateAndZoom}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/DragRotateAndZoom}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -113,9 +113,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragRotateAndZoom~DragRotateAndZoom}
+ * @this {module:ol/interaction/DragRotateAndZoom}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -134,9 +134,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragRotateAndZoom~DragRotateAndZoom}
+ * @this {module:ol/interaction/DragRotateAndZoom}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -31,7 +31,7 @@ import DragBox from '../interaction/DragBox.js';
  * your custom one configured with `className`.
  *
  * @constructor
- * @extends {module:ol/interaction/DragBox~DragBox}
+ * @extends {module:ol/interaction/DragBox}
  * @param {module:ol/interaction/DragZoom~Options=} opt_options Options.
  * @api
  */
@@ -68,7 +68,7 @@ inherits(DragZoom, DragBox);
 DragZoom.prototype.onBoxEnd = function() {
   const map = this.getMap();
 
-  const view = /** @type {!module:ol/View~View} */ (map.getView());
+  const view = /** @type {!module:ol/View} */ (map.getView());
 
   const size = /** @type {!module:ol/size~Size} */ (map.getSize());
 

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -38,7 +38,7 @@ import {createEditingStyle} from '../style/Style.js';
  * actually add a point/vertex to the geometry being drawn.  The default of `6`
  * was chosen for the draw interaction to behave correctly on mouse as well as
  * on touch devices.
- * @property {module:ol/Collection~Collection.<module:ol/Feature~Feature>} [features]
+ * @property {module:ol/Collection.<module:ol/Feature>} [features]
  * Destination collection for the drawn features.
  * @property {module:ol/source/Vector~Vector} [source] Destination source for
  * the drawn features.
@@ -57,7 +57,7 @@ import {createEditingStyle} from '../style/Style.js';
  * @property {module:ol/events/condition~Condition} [finishCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether the drawing can be finished.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [style]
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [style]
  * Style for sketch features.
  * @property {module:ol/interaction/Draw~GeometryFunction} [geometryFunction]
  * Function that is called when a geometry's coordinates are updated.
@@ -87,8 +87,8 @@ import {createEditingStyle} from '../style/Style.js';
  * arguments, and returns a geometry. The optional existing geometry is the
  * geometry that is returned when the function is called without a second
  * argument.
- * @typedef {function(!Array.<module:ol/coordinate~Coordinate>, module:ol/geom/SimpleGeometry~SimpleGeometry=):
- *     module:ol/geom/SimpleGeometry~SimpleGeometry} GeometryFunction
+ * @typedef {function(!Array.<module:ol/coordinate~Coordinate>, module:ol/geom/SimpleGeometry=):
+ *     module:ol/geom/SimpleGeometry} GeometryFunction
  */
 
 
@@ -130,10 +130,10 @@ const DrawEventType = {
  * instances of this type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.DrawEvent}
  * @param {module:ol/interaction/Draw~DrawEventType} type Type.
- * @param {module:ol/Feature~Feature} feature The feature drawn.
+ * @param {module:ol/Feature} feature The feature drawn.
  */
 const DrawEvent = function(type, feature) {
 
@@ -141,7 +141,7 @@ const DrawEvent = function(type, feature) {
 
   /**
    * The feature being drawn.
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @api
    */
   this.feature = feature;
@@ -156,7 +156,7 @@ inherits(DrawEvent, Event);
  * Interaction for drawing feature geometries.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @fires module:ol/interaction/Draw~DrawEvent
  * @param {module:ol/interaction/Draw~Options} options Options.
  * @api
@@ -208,7 +208,7 @@ const Draw = function(options) {
 
   /**
    * Target collection for drawn features.
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    * @private
    */
   this.features_ = options.features ? options.features : null;
@@ -274,11 +274,11 @@ const Draw = function(options) {
       /**
        * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates
        *     The coordinates.
-       * @param {module:ol/geom/SimpleGeometry~SimpleGeometry=} opt_geometry Optional geometry.
-       * @return {module:ol/geom/SimpleGeometry~SimpleGeometry} A geometry.
+       * @param {module:ol/geom/SimpleGeometry=} opt_geometry Optional geometry.
+       * @return {module:ol/geom/SimpleGeometry} A geometry.
        */
       geometryFunction = function(coordinates, opt_geometry) {
-        const circle = opt_geometry ? /** @type {module:ol/geom/Circle~Circle} */ (opt_geometry) :
+        const circle = opt_geometry ? /** @type {module:ol/geom/Circle} */ (opt_geometry) :
           new Circle([NaN, NaN]);
         const squaredLength = squaredCoordinateDistance(
           coordinates[0], coordinates[1]);
@@ -298,8 +298,8 @@ const Draw = function(options) {
       /**
        * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates
        *     The coordinates.
-       * @param {module:ol/geom/SimpleGeometry~SimpleGeometry=} opt_geometry Optional geometry.
-       * @return {module:ol/geom/SimpleGeometry~SimpleGeometry} A geometry.
+       * @param {module:ol/geom/SimpleGeometry=} opt_geometry Optional geometry.
+       * @return {module:ol/geom/SimpleGeometry} A geometry.
        */
       geometryFunction = function(coordinates, opt_geometry) {
         let geometry = opt_geometry;
@@ -344,14 +344,14 @@ const Draw = function(options) {
 
   /**
    * Sketch feature.
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.sketchFeature_ = null;
 
   /**
    * Sketch point.
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.sketchPoint_ = null;
@@ -365,7 +365,7 @@ const Draw = function(options) {
 
   /**
    * Sketch line. Used when drawing polygon.
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.sketchLine_ = null;
@@ -457,11 +457,11 @@ Draw.prototype.setMap = function(map) {
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may actually
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} and may actually
  * draw or finish the drawing.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Map browser event.
+ * @param {module:ol/MapBrowserEvent} event Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Draw~Draw}
+ * @this {module:ol/interaction/Draw}
  * @api
  */
 export function handleEvent(event) {
@@ -511,9 +511,9 @@ export function handleEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} event Event.
+ * @param {module:ol/MapBrowserPointerEvent} event Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/Draw~Draw}
+ * @this {module:ol/interaction/Draw}
  */
 function handleDownEvent(event) {
   this.shouldHandle_ = !this.freehand_;
@@ -539,9 +539,9 @@ function handleDownEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} event Event.
+ * @param {module:ol/MapBrowserPointerEvent} event Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Draw~Draw}
+ * @this {module:ol/interaction/Draw}
  */
 function handleUpEvent(event) {
   let pass = true;
@@ -584,7 +584,7 @@ function handleUpEvent(event) {
 
 /**
  * Handle move events.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event A move event.
+ * @param {module:ol/MapBrowserEvent} event A move event.
  * @return {boolean} Pass the event to other interactions.
  * @private
  */
@@ -616,7 +616,7 @@ Draw.prototype.handlePointerMove_ = function(event) {
 
 /**
  * Determine if an event is within the snapping tolerance of the start coord.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Event.
+ * @param {module:ol/MapBrowserEvent} event Event.
  * @return {boolean} The event is within the snapping tolerance of the start.
  * @private
  */
@@ -655,7 +655,7 @@ Draw.prototype.atFinish_ = function(event) {
 
 
 /**
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Event.
+ * @param {module:ol/MapBrowserEvent} event Event.
  * @private
  */
 Draw.prototype.createOrUpdateSketchPoint_ = function(event) {
@@ -664,7 +664,7 @@ Draw.prototype.createOrUpdateSketchPoint_ = function(event) {
     this.sketchPoint_ = new Feature(new Point(coordinates));
     this.updateSketchFeatures_();
   } else {
-    const sketchPointGeom = /** @type {module:ol/geom/Point~Point} */ (this.sketchPoint_.getGeometry());
+    const sketchPointGeom = /** @type {module:ol/geom/Point} */ (this.sketchPoint_.getGeometry());
     sketchPointGeom.setCoordinates(coordinates);
   }
 };
@@ -672,7 +672,7 @@ Draw.prototype.createOrUpdateSketchPoint_ = function(event) {
 
 /**
  * Start the drawing.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Event.
+ * @param {module:ol/MapBrowserEvent} event Event.
  * @private
  */
 Draw.prototype.startDrawing_ = function(event) {
@@ -703,12 +703,12 @@ Draw.prototype.startDrawing_ = function(event) {
 
 /**
  * Modify the drawing.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Event.
+ * @param {module:ol/MapBrowserEvent} event Event.
  * @private
  */
 Draw.prototype.modifyDrawing_ = function(event) {
   let coordinate = event.coordinate;
-  const geometry = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (this.sketchFeature_.getGeometry());
+  const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (this.sketchFeature_.getGeometry());
   let coordinates, last;
   if (this.mode_ === Mode.POINT) {
     last = this.sketchCoords_;
@@ -727,7 +727,7 @@ Draw.prototype.modifyDrawing_ = function(event) {
   last[1] = coordinate[1];
   this.geometryFunction_(/** @type {!Array.<module:ol/coordinate~Coordinate>} */ (this.sketchCoords_), geometry);
   if (this.sketchPoint_) {
-    const sketchPointGeom = /** @type {module:ol/geom/Point~Point} */ (this.sketchPoint_.getGeometry());
+    const sketchPointGeom = /** @type {module:ol/geom/Point} */ (this.sketchPoint_.getGeometry());
     sketchPointGeom.setCoordinates(coordinate);
   }
   let sketchLineGeom;
@@ -737,11 +737,11 @@ Draw.prototype.modifyDrawing_ = function(event) {
       this.sketchLine_ = new Feature(new LineString(null));
     }
     const ring = geometry.getLinearRing(0);
-    sketchLineGeom = /** @type {module:ol/geom/LineString~LineString} */ (this.sketchLine_.getGeometry());
+    sketchLineGeom = /** @type {module:ol/geom/LineString} */ (this.sketchLine_.getGeometry());
     sketchLineGeom.setFlatCoordinates(
       ring.getLayout(), ring.getFlatCoordinates());
   } else if (this.sketchLineCoords_) {
-    sketchLineGeom = /** @type {module:ol/geom/LineString~LineString} */ (this.sketchLine_.getGeometry());
+    sketchLineGeom = /** @type {module:ol/geom/LineString} */ (this.sketchLine_.getGeometry());
     sketchLineGeom.setCoordinates(this.sketchLineCoords_);
   }
   this.updateSketchFeatures_();
@@ -750,12 +750,12 @@ Draw.prototype.modifyDrawing_ = function(event) {
 
 /**
  * Add a new coordinate to the drawing.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Event.
+ * @param {module:ol/MapBrowserEvent} event Event.
  * @private
  */
 Draw.prototype.addToDrawing_ = function(event) {
   const coordinate = event.coordinate;
-  const geometry = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (this.sketchFeature_.getGeometry());
+  const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (this.sketchFeature_.getGeometry());
   let done;
   let coordinates;
   if (this.mode_ === Mode.LINE_STRING) {
@@ -800,7 +800,7 @@ Draw.prototype.removeLastPoint = function() {
   if (!this.sketchFeature_) {
     return;
   }
-  const geometry = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (this.sketchFeature_.getGeometry());
+  const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (this.sketchFeature_.getGeometry());
   let coordinates, sketchLineGeom;
   if (this.mode_ === Mode.LINE_STRING) {
     coordinates = this.sketchCoords_;
@@ -812,7 +812,7 @@ Draw.prototype.removeLastPoint = function() {
   } else if (this.mode_ === Mode.POLYGON) {
     coordinates = this.sketchCoords_[0];
     coordinates.splice(-2, 1);
-    sketchLineGeom = /** @type {module:ol/geom/LineString~LineString} */ (this.sketchLine_.getGeometry());
+    sketchLineGeom = /** @type {module:ol/geom/LineString} */ (this.sketchLine_.getGeometry());
     sketchLineGeom.setCoordinates(coordinates);
     this.geometryFunction_(this.sketchCoords_, geometry);
   }
@@ -837,7 +837,7 @@ Draw.prototype.finishDrawing = function() {
     return;
   }
   let coordinates = this.sketchCoords_;
-  const geometry = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (sketchFeature.getGeometry());
+  const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (sketchFeature.getGeometry());
   if (this.mode_ === Mode.LINE_STRING) {
     // remove the redundant last point
     coordinates.pop();
@@ -873,7 +873,7 @@ Draw.prototype.finishDrawing = function() {
 
 /**
  * Stop drawing without adding the sketch feature to the target layer.
- * @return {module:ol/Feature~Feature} The sketch feature (or null if none).
+ * @return {module:ol/Feature} The sketch feature (or null if none).
  * @private
  */
 Draw.prototype.abortDrawing_ = function() {
@@ -893,12 +893,12 @@ Draw.prototype.abortDrawing_ = function() {
  * Extend an existing geometry by adding additional points. This only works
  * on features with `LineString` geometries, where the interaction will
  * extend lines by adding points to the end of the coordinates array.
- * @param {!module:ol/Feature~Feature} feature Feature to be extended.
+ * @param {!module:ol/Feature} feature Feature to be extended.
  * @api
  */
 Draw.prototype.extend = function(feature) {
   const geometry = feature.getGeometry();
-  const lineString = /** @type {module:ol/geom/LineString~LineString} */ (geometry);
+  const lineString = /** @type {module:ol/geom/LineString} */ (geometry);
   this.sketchFeature_ = feature;
   this.sketchCoords_ = lineString.getCoordinates();
   const last = this.sketchCoords_[this.sketchCoords_.length - 1];
@@ -963,20 +963,18 @@ Draw.prototype.updateState_ = function() {
  * @api
  */
 export function createRegularPolygon(opt_sides, opt_angle) {
-  return (
-    function(coordinates, opt_geometry) {
-      const center = coordinates[0];
-      const end = coordinates[1];
-      const radius = Math.sqrt(
-        squaredCoordinateDistance(center, end));
-      const geometry = opt_geometry ? /** @type {module:ol/geom/Polygon~Polygon} */ (opt_geometry) :
-        fromCircle(new Circle(center), opt_sides);
-      const angle = opt_angle ? opt_angle :
-        Math.atan((end[1] - center[1]) / (end[0] - center[0]));
-      makeRegular(geometry, center, radius, angle);
-      return geometry;
-    }
-  );
+  return function(coordinates, opt_geometry) {
+    const center = coordinates[0];
+    const end = coordinates[1];
+    const radius = Math.sqrt(
+      squaredCoordinateDistance(center, end));
+    const geometry = opt_geometry ? /** @type {module:ol/geom/Polygon} */ (opt_geometry) :
+      fromCircle(new Circle(center), opt_sides);
+    const angle = opt_angle ? opt_angle :
+      Math.atan((end[1] - center[1]) / (end[0] - center[0]));
+    makeRegular(geometry, center, radius, angle);
+    return geometry;
+  };
 }
 
 
@@ -1025,7 +1023,9 @@ function getMode(type) {
   } else if (type === GeometryType.CIRCLE) {
     mode = Mode.CIRCLE;
   }
-  return /** @type {!module:ol/interaction/Draw~Mode} */ (mode);
+  return (
+    /** @type {!module:ol/interaction/Draw~Mode} */ (mode)
+  );
 }
 
 

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -21,12 +21,12 @@ import {createEditingStyle} from '../style/Style.js';
  * @typedef {Object} Options
  * @property {module:ol/extent~Extent} [extent] Initial extent. Defaults to no
  * initial extent.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [boxStyle]
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [boxStyle]
  * Style for the drawn extent box. Defaults to
  * {@link module:ol/style/Style~createEditing()['Polygon']}
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [pointerStyle]
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [pointerStyle]
  * Style for the cursor used to draw the extent. Defaults to
  * {@link module:ol/style/Style~createEditing()['Point']}
  * @property {boolean} [wrapX=false] Wrap the drawn extent across multiple maps
@@ -55,7 +55,7 @@ const ExtentEventType = {
  * @constructor
  * @implements {oli.ExtentEvent}
  * @param {module:ol/extent~Extent} extent the new extent
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  */
 const ExtentInteractionEvent = function(extent) {
   Event.call(this, ExtentEventType.EXTENTCHANGED);
@@ -78,7 +78,7 @@ inherits(ExtentInteractionEvent, Event);
  * This interaction is only supported for mouse devices.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @fires module:ol/interaction/Extent~Event
  * @param {module:ol/interaction/Extent~Options=} opt_options Options.
  * @api
@@ -118,14 +118,14 @@ const ExtentInteraction = function(opt_options) {
 
   /**
    * Feature for displaying the visible extent
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.extentFeature_ = null;
 
   /**
    * Feature for displaying the visible pointer
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.vertexFeature_ = null;
@@ -179,7 +179,7 @@ const ExtentInteraction = function(opt_options) {
 inherits(ExtentInteraction, PointerInteraction);
 
 /**
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Event.
  * @return {boolean} Propagate event?
  * @this {module:ol/interaction/Extent~Extent}
  */
@@ -198,7 +198,7 @@ function handleEvent(mapBrowserEvent) {
 }
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Event handled?
  * @this {module:ol/interaction/Extent~Extent}
  */
@@ -257,7 +257,7 @@ function handleDownEvent(mapBrowserEvent) {
 }
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Event handled?
  * @this {module:ol/interaction/Extent~Extent}
  */
@@ -271,7 +271,7 @@ function handleDragEvent(mapBrowserEvent) {
 }
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
  * @this {module:ol/interaction/Extent~Extent}
  */
@@ -353,7 +353,7 @@ function getSegments(extent) {
 
 /**
  * @param {module:ol~Pixel} pixel cursor location
- * @param {module:ol/PluggableMap~PluggableMap} map map
+ * @param {module:ol/PluggableMap} map map
  * @returns {module:ol/coordinate~Coordinate|null} snapped vertex on extent
  * @private
  */
@@ -394,7 +394,7 @@ ExtentInteraction.prototype.snapToVertex_ = function(pixel, map) {
 };
 
 /**
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent pointer move event
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent pointer move event
  * @private
  */
 ExtentInteraction.prototype.handlePointerMove_ = function(mapBrowserEvent) {
@@ -410,7 +410,7 @@ ExtentInteraction.prototype.handlePointerMove_ = function(mapBrowserEvent) {
 
 /**
  * @param {module:ol/extent~Extent} extent extent
- * @returns {module:ol/Feature~Feature} extent as featrue
+ * @returns {module:ol/Feature} extent as featrue
  * @private
  */
 ExtentInteraction.prototype.createOrUpdateExtentFeature_ = function(extent) {
@@ -437,7 +437,7 @@ ExtentInteraction.prototype.createOrUpdateExtentFeature_ = function(extent) {
 
 /**
  * @param {module:ol/coordinate~Coordinate} vertex location of feature
- * @returns {module:ol/Feature~Feature} vertex as feature
+ * @returns {module:ol/Feature} vertex as feature
  * @private
  */
 ExtentInteraction.prototype.createOrUpdatePointerFeature_ = function(vertex) {
@@ -447,7 +447,7 @@ ExtentInteraction.prototype.createOrUpdatePointerFeature_ = function(vertex) {
     this.vertexFeature_ = vertexFeature;
     this.vertexOverlay_.getSource().addFeature(vertexFeature);
   } else {
-    const geometry = /** @type {module:ol/geom/Point~Point} */ (vertexFeature.getGeometry());
+    const geometry = /** @type {module:ol/geom/Point} */ (vertexFeature.getGeometry());
     geometry.setCoordinates(vertex);
   }
   return vertexFeature;

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -11,7 +11,7 @@ import {clamp} from '../math.js';
 /**
  * Object literal with config options for interactions.
  * @typedef {Object} InteractionOptions
- * @property {function(module:ol/MapBrowserEvent~MapBrowserEvent):boolean} handleEvent
+ * @property {function(module:ol/MapBrowserEvent):boolean} handleEvent
  * Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. If the function returns a falsy value, propagation of
  * the event to other interactions in the map's interactions chain will be
@@ -33,7 +33,7 @@ import {clamp} from '../math.js';
  *
  * @constructor
  * @param {module:ol/interaction/Interaction~InteractionOptions} options Options.
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @api
  */
 const Interaction = function(options) {
@@ -42,14 +42,14 @@ const Interaction = function(options) {
 
   /**
    * @private
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    */
   this.map_ = null;
 
   this.setActive(true);
 
   /**
-   * @type {function(module:ol/MapBrowserEvent~MapBrowserEvent):boolean}
+   * @type {function(module:ol/MapBrowserEvent):boolean}
    */
   this.handleEvent = options.handleEvent;
 
@@ -71,7 +71,7 @@ Interaction.prototype.getActive = function() {
 
 /**
  * Get the map associated with this interaction.
- * @return {module:ol/PluggableMap~PluggableMap} Map.
+ * @return {module:ol/PluggableMap} Map.
  * @api
  */
 Interaction.prototype.getMap = function() {
@@ -94,7 +94,7 @@ Interaction.prototype.setActive = function(active) {
  * Remove the interaction from its current map and attach it to the new map.
  * Subclasses may set up event handlers to get notified about changes to
  * the map here.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  */
 Interaction.prototype.setMap = function(map) {
   this.map_ = map;
@@ -102,7 +102,7 @@ Interaction.prototype.setMap = function(map) {
 
 
 /**
- * @param {module:ol/View~View} view View.
+ * @param {module:ol/View} view View.
  * @param {module:ol/coordinate~Coordinate} delta Delta.
  * @param {number=} opt_duration Duration.
  */
@@ -125,7 +125,7 @@ export function pan(view, delta, opt_duration) {
 
 
 /**
- * @param {module:ol/View~View} view View.
+ * @param {module:ol/View} view View.
  * @param {number|undefined} rotation Rotation.
  * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
@@ -137,7 +137,7 @@ export function rotate(view, rotation, opt_anchor, opt_duration) {
 
 
 /**
- * @param {module:ol/View~View} view View.
+ * @param {module:ol/View} view View.
  * @param {number|undefined} rotation Rotation.
  * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
@@ -161,7 +161,7 @@ export function rotateWithoutConstraints(view, rotation, opt_anchor, opt_duratio
 
 
 /**
- * @param {module:ol/View~View} view View.
+ * @param {module:ol/View} view View.
  * @param {number|undefined} resolution Resolution to go to.
  * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
@@ -181,7 +181,7 @@ export function zoom(view, resolution, opt_anchor, opt_duration, opt_direction) 
 
 
 /**
- * @param {module:ol/View~View} view View.
+ * @param {module:ol/View} view View.
  * @param {number} delta Delta from previous zoom level.
  * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
@@ -219,7 +219,7 @@ export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
 
 
 /**
- * @param {module:ol/View~View} view View.
+ * @param {module:ol/View} view View.
  * @param {number|undefined} resolution Resolution to go to.
  * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -35,7 +35,7 @@ import Interaction, {pan} from '../interaction/Interaction.js';
  * See also {@link module:ol/interaction/KeyboardZoom~KeyboardZoom}.
  *
  * @constructor
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @param {module:ol/interaction/KeyboardPan~Options=} opt_options Options.
  * @api
  */
@@ -49,7 +49,7 @@ const KeyboardPan = function(opt_options) {
 
   /**
    * @private
-   * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Browser event.
+   * @param {module:ol/MapBrowserEvent} mapBrowserEvent Browser event.
    * @return {boolean} Combined condition result.
    */
   this.defaultCondition_ = function(mapBrowserEvent) {
@@ -82,12 +82,12 @@ const KeyboardPan = function(opt_options) {
 inherits(KeyboardPan, Interaction);
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} if it was a
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
  * `KeyEvent`, and decides the direction to pan to (if an arrow key was
  * pressed).
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/KeyboardPan~KeyboardPan}
+ * @this {module:ol/interaction/KeyboardPan}
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -32,7 +32,7 @@ import Interaction, {zoomByDelta} from '../interaction/Interaction.js';
  *
  * @constructor
  * @param {module:ol/interaction/KeyboardZoom~Options=} opt_options Options.
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @api
  */
 const KeyboardZoom = function(opt_options) {
@@ -67,12 +67,12 @@ inherits(KeyboardZoom, Interaction);
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} if it was a
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
  * `KeyEvent`, and decides whether to zoom in or out (depending on whether the
  * key pressed was '+' or '-').
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/KeyboardZoom~KeyboardZoom}
+ * @this {module:ol/interaction/KeyboardZoom}
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -46,8 +46,8 @@ const ModifyEventType = {
 /**
  * @typedef {Object} SegmentData
  * @property {Array.<number>} [depth]
- * @property {module:ol/Feature~Feature} feature
- * @property {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry
+ * @property {module:ol/Feature} feature
+ * @property {module:ol/geom/SimpleGeometry} geometry
  * @property {number} index
  * @property {Array.<module:ol/extent~Extent>} segment
  * @property {Array.<module:ol/interaction/Modify~SegmentData>} [featureSegments]
@@ -72,13 +72,13 @@ const ModifyEventType = {
  * features. Default is {@link module:ol/events/condition~always}.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [style]
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [style]
  * Style used for the features being modified. By default the default edit
  * style is used (see {@link module:ol/style}).
  * @property {module:ol/source/Vector~Vector} [source] The vector source with
  * features to modify.  If a vector source is not provided, a feature collection
  * must be provided with the features option.
- * @property {module:ol/Collection~Collection.<module:ol/Feature~Feature>} [features]
+ * @property {module:ol/Collection.<module:ol/Feature>} [features]
  * The features the interaction works on.  If a feature collection is not
  * provided, a vector source must be provided with the source option.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
@@ -92,13 +92,13 @@ const ModifyEventType = {
  * instances of this type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.ModifyEvent}
  * @param {ModifyEventType} type Type.
- * @param {module:ol/Collection~Collection.<module:ol/Feature~Feature>} features
+ * @param {module:ol/Collection.<module:ol/Feature>} features
  * The features modified.
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserPointerEvent
- * Associated {@link module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent}.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserPointerEvent
+ * Associated {@link module:ol/MapBrowserPointerEvent}.
  */
 export const ModifyEvent = function(type, features, mapBrowserPointerEvent) {
 
@@ -106,14 +106,14 @@ export const ModifyEvent = function(type, features, mapBrowserPointerEvent) {
 
   /**
    * The features being modified.
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    * @api
    */
   this.features = features;
 
   /**
-   * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
-   * @type {module:ol/MapBrowserEvent~MapBrowserEvent}
+   * Associated {@link module:ol/MapBrowserEvent}.
+   * @type {module:ol/MapBrowserEvent}
    * @api
    */
   this.mapBrowserEvent = mapBrowserPointerEvent;
@@ -136,7 +136,7 @@ inherits(ModifyEvent, Event);
  * for deletion, use the `deleteCondition` option.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/Modify~Options} options Options.
  * @fires module:ol/interaction/Modify~ModifyEvent
  * @api
@@ -159,7 +159,7 @@ const Modify = function(options) {
 
   /**
    * @private
-   * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Browser event.
+   * @param {module:ol/MapBrowserEvent} mapBrowserEvent Browser event.
    * @return {boolean} Combined condition result.
    */
   this.defaultDeleteCondition_ = function(mapBrowserEvent) {
@@ -182,7 +182,7 @@ const Modify = function(options) {
 
   /**
    * Editing vertex.
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.vertexFeature_ = null;
@@ -216,7 +216,7 @@ const Modify = function(options) {
 
   /**
    * Segment RTree for each layer
-   * @type {module:ol/structs/RBush~RBush.<module:ol/interaction/Modify~SegmentData>}
+   * @type {module:ol/structs/RBush.<module:ol/interaction/Modify~SegmentData>}
    * @private
    */
   this.rBush_ = new RBush();
@@ -265,10 +265,10 @@ const Modify = function(options) {
   });
 
   /**
-  * @const
-  * @private
-  * @type {!Object.<string, function(module:ol/Feature~Feature, module:ol/geom/Geometry~Geometry)>}
-  */
+   * @const
+   * @private
+   * @type {!Object.<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
+   */
   this.SEGMENT_WRITERS_ = {
     'Point': this.writePointGeometry_,
     'LineString': this.writeLineStringGeometry_,
@@ -304,7 +304,7 @@ const Modify = function(options) {
   }
 
   /**
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    * @private
    */
   this.features_ = features;
@@ -316,7 +316,7 @@ const Modify = function(options) {
     this.handleFeatureRemove_, this);
 
   /**
-   * @type {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent}
+   * @type {module:ol/MapBrowserPointerEvent}
    * @private
    */
   this.lastPointerEvent_ = null;
@@ -342,7 +342,7 @@ const CIRCLE_CIRCUMFERENCE_INDEX = 1;
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @private
  */
 Modify.prototype.addFeature_ = function(feature) {
@@ -360,7 +360,7 @@ Modify.prototype.addFeature_ = function(feature) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} evt Map browser event
+ * @param {module:ol/MapBrowserPointerEvent} evt Map browser event
  * @private
  */
 Modify.prototype.willModifyFeatures_ = function(evt) {
@@ -373,7 +373,7 @@ Modify.prototype.willModifyFeatures_ = function(evt) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @private
  */
 Modify.prototype.removeFeature_ = function(feature) {
@@ -390,7 +390,7 @@ Modify.prototype.removeFeature_ = function(feature) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @private
  */
 Modify.prototype.removeFeatureSegmentData_ = function(feature) {
@@ -459,17 +459,17 @@ Modify.prototype.handleSourceRemove_ = function(event) {
  * @private
  */
 Modify.prototype.handleFeatureAdd_ = function(evt) {
-  this.addFeature_(/** @type {module:ol/Feature~Feature} */ (evt.element));
+  this.addFeature_(/** @type {module:ol/Feature} */ (evt.element));
 };
 
 
 /**
- * @param {module:ol/events/Event~Event} evt Event.
+ * @param {module:ol/events/Event} evt Event.
  * @private
  */
 Modify.prototype.handleFeatureChange_ = function(evt) {
   if (!this.changingFeature_) {
-    const feature = /** @type {module:ol/Feature~Feature} */ (evt.target);
+    const feature = /** @type {module:ol/Feature} */ (evt.target);
     this.removeFeature_(feature);
     this.addFeature_(feature);
   }
@@ -481,14 +481,14 @@ Modify.prototype.handleFeatureChange_ = function(evt) {
  * @private
  */
 Modify.prototype.handleFeatureRemove_ = function(evt) {
-  const feature = /** @type {module:ol/Feature~Feature} */ (evt.element);
+  const feature = /** @type {module:ol/Feature} */ (evt.element);
   this.removeFeature_(feature);
 };
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/Point~Point} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/Point} geometry Geometry.
  * @private
  */
 Modify.prototype.writePointGeometry_ = function(feature, geometry) {
@@ -503,8 +503,8 @@ Modify.prototype.writePointGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/MultiPoint~MultiPoint} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/MultiPoint} geometry Geometry.
  * @private
  */
 Modify.prototype.writeMultiPointGeometry_ = function(feature, geometry) {
@@ -524,8 +524,8 @@ Modify.prototype.writeMultiPointGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/LineString~LineString} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/LineString} geometry Geometry.
  * @private
  */
 Modify.prototype.writeLineStringGeometry_ = function(feature, geometry) {
@@ -544,8 +544,8 @@ Modify.prototype.writeLineStringGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/MultiLineString~MultiLineString} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/MultiLineString} geometry Geometry.
  * @private
  */
 Modify.prototype.writeMultiLineStringGeometry_ = function(feature, geometry) {
@@ -568,8 +568,8 @@ Modify.prototype.writeMultiLineStringGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/Polygon~Polygon} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/Polygon} geometry Geometry.
  * @private
  */
 Modify.prototype.writePolygonGeometry_ = function(feature, geometry) {
@@ -592,8 +592,8 @@ Modify.prototype.writePolygonGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/MultiPolygon} geometry Geometry.
  * @private
  */
 Modify.prototype.writeMultiPolygonGeometry_ = function(feature, geometry) {
@@ -625,8 +625,8 @@ Modify.prototype.writeMultiPolygonGeometry_ = function(feature, geometry) {
  * {@link CIRCLE_CIRCUMFERENCE_INDEX} is
  * the circumference, and is not a line segment.
  *
- * @param {module:ol/Feature~Feature} feature Feature.
- * @param {module:ol/geom/Circle~Circle} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature.
+ * @param {module:ol/geom/Circle} geometry Geometry.
  * @private
  */
 Modify.prototype.writeCircleGeometry_ = function(feature, geometry) {
@@ -651,8 +651,8 @@ Modify.prototype.writeCircleGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/GeometryCollection} geometry Geometry.
  * @private
  */
 Modify.prototype.writeGeometryCollectionGeometry_ = function(feature, geometry) {
@@ -665,7 +665,7 @@ Modify.prototype.writeGeometryCollectionGeometry_ = function(feature, geometry) 
 
 /**
  * @param {module:ol/coordinate~Coordinate} coordinates Coordinates.
- * @return {module:ol/Feature~Feature} Vertex feature.
+ * @return {module:ol/Feature} Vertex feature.
  * @private
  */
 Modify.prototype.createOrUpdateVertexFeature_ = function(coordinates) {
@@ -675,7 +675,7 @@ Modify.prototype.createOrUpdateVertexFeature_ = function(coordinates) {
     this.vertexFeature_ = vertexFeature;
     this.overlay_.getSource().addFeature(vertexFeature);
   } else {
-    const geometry = /** @type {module:ol/geom/Point~Point} */ (vertexFeature.getGeometry());
+    const geometry = /** @type {module:ol/geom/Point} */ (vertexFeature.getGeometry());
     geometry.setCoordinates(coordinates);
   }
   return vertexFeature;
@@ -693,9 +693,9 @@ function compareIndexes(a, b) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} evt Event.
+ * @param {module:ol/MapBrowserPointerEvent} evt Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/Modify~Modify}
+ * @this {module:ol/interaction/Modify}
  */
 function handleDownEvent(evt) {
   if (!this.condition_(evt)) {
@@ -708,7 +708,7 @@ function handleDownEvent(evt) {
   const vertexFeature = this.vertexFeature_;
   if (vertexFeature) {
     const insertVertices = [];
-    const geometry = /** @type {module:ol/geom/Point~Point} */ (vertexFeature.getGeometry());
+    const geometry = /** @type {module:ol/geom/Point} */ (vertexFeature.getGeometry());
     const vertex = geometry.getCoordinates();
     const vertexExtent = boundingExtent([vertex]);
     const segmentDataMatches = this.rBush_.getInExtent(vertexExtent);
@@ -769,8 +769,8 @@ function handleDownEvent(evt) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} evt Event.
- * @this {module:ol/interaction/Modify~Modify}
+ * @param {module:ol/MapBrowserPointerEvent} evt Event.
+ * @this {module:ol/interaction/Modify}
  */
 function handleDragEvent(evt) {
   this.ignoreNextSingleClick_ = false;
@@ -845,9 +845,9 @@ function handleDragEvent(evt) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} evt Event.
+ * @param {module:ol/MapBrowserPointerEvent} evt Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Modify~Modify}
+ * @this {module:ol/interaction/Modify}
  */
 function handleUpEvent(evt) {
   for (let i = this.dragSegments_.length - 1; i >= 0; --i) {
@@ -875,11 +875,11 @@ function handleUpEvent(evt) {
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may modify the
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} and may modify the
  * geometry.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Modify~Modify}
+ * @this {module:ol/interaction/Modify}
  */
 function handleEvent(mapBrowserEvent) {
   if (!(mapBrowserEvent instanceof MapBrowserPointerEvent)) {
@@ -910,7 +910,7 @@ function handleEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} evt Event.
+ * @param {module:ol/MapBrowserEvent} evt Event.
  * @private
  */
 Modify.prototype.handlePointerMove_ = function(evt) {
@@ -921,7 +921,7 @@ Modify.prototype.handlePointerMove_ = function(evt) {
 
 /**
  * @param {module:ol~Pixel} pixel Pixel
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @private
  */
 Modify.prototype.handlePointerAtPixel_ = function(pixel, map) {
@@ -1000,7 +1000,7 @@ function pointDistanceToSegmentDataSquared(pointCoordinates, segmentData) {
   const geometry = segmentData.geometry;
 
   if (geometry.getType() === GeometryType.CIRCLE) {
-    const circleGeometry = /** @type {module:ol/geom/Circle~Circle} */ (geometry);
+    const circleGeometry = /** @type {module:ol/geom/Circle} */ (geometry);
 
     if (segmentData.index === CIRCLE_CIRCUMFERENCE_INDEX) {
       const distanceToCenterSquared =
@@ -1235,7 +1235,7 @@ Modify.prototype.removeVertex_ = function() {
 
 
 /**
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry Geometry.
+ * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
  * @param {Array} coordinates Coordinates.
  * @private
  */
@@ -1247,7 +1247,7 @@ Modify.prototype.setGeometryCoordinates_ = function(geometry, coordinates) {
 
 
 /**
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry Geometry.
+ * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
  * @param {number} index Index.
  * @param {Array.<number>|undefined} depth Depth.
  * @param {number} delta Delta (1 or -1).

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -49,7 +49,7 @@ export const Mode = {
  * Allows the user to zoom the map by scrolling the mouse wheel.
  *
  * @constructor
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @param {module:ol/interaction/MouseWheelZoom~Options=} opt_options Options.
  * @api
  */
@@ -153,11 +153,11 @@ inherits(MouseWheelZoom, Interaction);
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} (if it was a
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
  * mousewheel-event) and eventually zooms the map.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} Allow event propagation.
- * @this {module:ol/interaction/MouseWheelZoom~MouseWheelZoom}
+ * @this {module:ol/interaction/MouseWheelZoom}
  */
 function handleEvent(mapBrowserEvent) {
   if (!this.condition_(mapBrowserEvent)) {
@@ -288,7 +288,7 @@ MouseWheelZoom.prototype.decrementInteractingHint_ = function() {
 
 /**
  * @private
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  */
 MouseWheelZoom.prototype.handleWheelZoom_ = function(map) {
   const view = map.getView();

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -23,7 +23,7 @@ import {disable} from '../rotationconstraint.js';
  * on a touch screen.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/PinchRotate~Options=} opt_options Options.
  * @api
  */
@@ -79,8 +79,8 @@ inherits(PinchRotate, PointerInteraction);
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/PinchRotate~PinchRotate}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/PinchRotate}
  */
 function handleDragEvent(mapBrowserEvent) {
   let rotationDelta = 0.0;
@@ -129,9 +129,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/PinchRotate~PinchRotate}
+ * @this {module:ol/interaction/PinchRotate}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (this.targetPointers.length < 2) {
@@ -150,9 +150,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/PinchRotate~PinchRotate}
+ * @this {module:ol/interaction/PinchRotate}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (this.targetPointers.length >= 2) {

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -22,7 +22,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  * on a touch screen.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/PinchZoom~Options=} opt_options Options.
  * @api
  */
@@ -72,8 +72,8 @@ inherits(PinchZoom, PointerInteraction);
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/PinchZoom~PinchZoom}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/PinchZoom}
  */
 function handleDragEvent(mapBrowserEvent) {
   let scaleDelta = 1.0;
@@ -124,9 +124,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/PinchZoom~PinchZoom}
+ * @this {module:ol/interaction/PinchZoom}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (this.targetPointers.length < 2) {
@@ -151,9 +151,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/PinchZoom~PinchZoom}
+ * @this {module:ol/interaction/PinchZoom}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (this.targetPointers.length >= 2) {

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -10,53 +10,53 @@ import {getValues} from '../obj.js';
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/Pointer~PointerInteraction}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/Pointer}
  */
 const handleDragEvent = UNDEFINED;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Capture dragging.
- * @this {module:ol/interaction/Pointer~PointerInteraction}
+ * @this {module:ol/interaction/Pointer}
  */
 const handleUpEvent = FALSE;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Capture dragging.
- * @this {module:ol/interaction/Pointer~PointerInteraction}
+ * @this {module:ol/interaction/Pointer}
  */
 const handleDownEvent = FALSE;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/Pointer~PointerInteraction}
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @this {module:ol/interaction/Pointer}
  */
 const handleMoveEvent = UNDEFINED;
 
 
 /**
  * @typedef {Object} Options
- * @property {(function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent):boolean)} [handleDownEvent]
+ * @property {(function(module:ol/MapBrowserPointerEvent):boolean)} [handleDownEvent]
  * Function handling "down" events. If the function returns `true` then a drag
  * sequence is started.
- * @property {(function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent))} [handleDragEvent]
+ * @property {(function(module:ol/MapBrowserPointerEvent))} [handleDragEvent]
  * Function handling "drag" events. This function is called on "move" events
  * during a drag sequence.
- * @property {(function(module:ol/MapBrowserEvent~MapBrowserEvent):boolean)} [handleEvent]
+ * @property {(function(module:ol/MapBrowserEvent):boolean)} [handleEvent]
  * Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. The function may return `false` to prevent the
  * propagation of the event to other interactions in the map's interactions
  * chain.
- * @property {(function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent))} [handleMoveEvent]
+ * @property {(function(module:ol/MapBrowserPointerEvent))} [handleMoveEvent]
  * Function handling "move" events. This function is called on "move" events,
  * also during a drag sequence (so during a drag sequence both the
  * `handleDragEvent` function and this function are called).
- * @property {(function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent):boolean)} [handleUpEvent]
+ * @property {(function(module:ol/MapBrowserPointerEvent):boolean)} [handleUpEvent]
  *  Function handling "up" events. If the function returns `false` then the
  * current drag sequence is stopped.
  */
@@ -74,7 +74,7 @@ const handleMoveEvent = UNDEFINED;
  *
  * @constructor
  * @param {module:ol/interaction/Pointer~Options=} opt_options Options.
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @api
  */
 const PointerInteraction = function(opt_options) {
@@ -86,28 +86,28 @@ const PointerInteraction = function(opt_options) {
   });
 
   /**
-   * @type {function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent):boolean}
+   * @type {function(module:ol/MapBrowserPointerEvent):boolean}
    * @private
    */
   this.handleDownEvent_ = options.handleDownEvent ?
     options.handleDownEvent : handleDownEvent;
 
   /**
-   * @type {function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent)}
+   * @type {function(module:ol/MapBrowserPointerEvent)}
    * @private
    */
   this.handleDragEvent_ = options.handleDragEvent ?
     options.handleDragEvent : handleDragEvent;
 
   /**
-   * @type {function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent)}
+   * @type {function(module:ol/MapBrowserPointerEvent)}
    * @private
    */
   this.handleMoveEvent_ = options.handleMoveEvent ?
     options.handleMoveEvent : handleMoveEvent;
 
   /**
-   * @type {function(module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent):boolean}
+   * @type {function(module:ol/MapBrowserPointerEvent):boolean}
    * @private
    */
   this.handleUpEvent_ = options.handleUpEvent ?
@@ -120,13 +120,13 @@ const PointerInteraction = function(opt_options) {
   this.handlingDownUpSequence = false;
 
   /**
-   * @type {!Object.<string, module:ol/pointer/PointerEvent~PointerEvent>}
+   * @type {!Object.<string, module:ol/pointer/PointerEvent>}
    * @private
    */
   this.trackedPointers_ = {};
 
   /**
-   * @type {Array.<module:ol/pointer/PointerEvent~PointerEvent>}
+   * @type {Array.<module:ol/pointer/PointerEvent>}
    * @protected
    */
   this.targetPointers = [];
@@ -137,7 +137,7 @@ inherits(PointerInteraction, Interaction);
 
 
 /**
- * @param {Array.<module:ol/pointer/PointerEvent~PointerEvent>} pointerEvents List of events.
+ * @param {Array.<module:ol/pointer/PointerEvent>} pointerEvents List of events.
  * @return {module:ol~Pixel} Centroid pixel.
  */
 export function centroid(pointerEvents) {
@@ -153,7 +153,7 @@ export function centroid(pointerEvents) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Whether the event is a pointerdown, pointerdrag
  *     or pointerup event.
  */
@@ -166,7 +166,7 @@ function isPointerDraggingEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @private
  */
 PointerInteraction.prototype.updateTrackedPointers_ = function(mapBrowserEvent) {
@@ -189,12 +189,12 @@ PointerInteraction.prototype.updateTrackedPointers_ = function(mapBrowserEvent) 
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may call into
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} and may call into
  * other functions, if event sequences like e.g. 'drag' or 'down-up' etc. are
  * detected.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Pointer~PointerInteraction}
+ * @this {module:ol/interaction/Pointer}
  * @api
  */
 export function handleEvent(mapBrowserEvent) {

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -30,11 +30,11 @@ const SelectEventType = {
 
 
 /**
- * A function that takes an {@link module:ol/Feature~Feature} or
+ * A function that takes an {@link module:ol/Feature} or
  * {@link module:ol/render/Feature~Feature} and an
- * {@link module:ol/layer/Layer~Layer} and returns `true` if the feature may be
+ * {@link module:ol/layer/Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
- * @typedef {function((module:ol/Feature~Feature|module:ol/render/Feature~Feature), module:ol/layer/Layer~Layer):
+ * @typedef {function((module:ol/Feature|module:ol/render/Feature~Feature), module:ol/layer/Layer):
  *     boolean} FilterFunction
  */
 
@@ -55,13 +55,13 @@ const SelectEventType = {
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- * @property {Array.<module:ol/layer/Layer~Layer>|function(module:ol/layer/Layer~Layer): boolean} [layers]
+ * @property {Array.<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers]
  * A list of layers from which features should be selected. Alternatively, a
  * filter function can be provided. The function will be called for each layer
  * in the map and should return `true` for layers that you want to be
  * selectable. If the option is absent, all visible layers will be considered
  * selectable.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [style]
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [style]
  * Style for the selected features. By default the default edit style is used
  * (see {@link module:ol/style}).
  * @property {module:ol/events/condition~Condition} [removeCondition] A function
@@ -80,14 +80,14 @@ const SelectEventType = {
  * @property {boolean} [multi=false] A boolean that determines if the default
  * behaviour should select only single features or all (overlapping) features at
  * the clicked map position. The default of `false` means single select.
- * @property {module:ol/Collection~Collection.<module:ol/Feature~Feature>} [features]
+ * @property {module:ol/Collection.<module:ol/Feature>} [features]
  * Collection where the interaction will place selected features. Optional. If
  * not set the interaction will create a collection. In any case the collection
  * used by the interaction is returned by
  * {@link module:ol/interaction/Select~Select#getFeatures}.
  * @property {module:ol/interaction/Select~FilterFunction} [filter] A function
- * that takes an {@link module:ol/Feature~Feature} and an
- * {@link module:ol/layer/Layer~Layer} and returns `true` if the feature may be
+ * that takes an {@link module:ol/Feature} and an
+ * {@link module:ol/layer/Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
  * @property {boolean} [wrapX=true] Wrap the world horizontally on the selection
  * overlay.
@@ -103,12 +103,12 @@ const SelectEventType = {
  * this type.
  *
  * @param {SelectEventType} type The event type.
- * @param {Array.<module:ol/Feature~Feature>} selected Selected features.
- * @param {Array.<module:ol/Feature~Feature>} deselected Deselected features.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Associated
- *     {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
+ * @param {Array.<module:ol/Feature>} selected Selected features.
+ * @param {Array.<module:ol/Feature>} deselected Deselected features.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Associated
+ *     {@link module:ol/MapBrowserEvent}.
  * @implements {oli.SelectEvent}
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @constructor
  */
 const SelectEvent = function(type, selected, deselected, mapBrowserEvent) {
@@ -116,21 +116,21 @@ const SelectEvent = function(type, selected, deselected, mapBrowserEvent) {
 
   /**
    * Selected features array.
-   * @type {Array.<module:ol/Feature~Feature>}
+   * @type {Array.<module:ol/Feature>}
    * @api
    */
   this.selected = selected;
 
   /**
    * Deselected features array.
-   * @type {Array.<module:ol/Feature~Feature>}
+   * @type {Array.<module:ol/Feature>}
    * @api
    */
   this.deselected = deselected;
 
   /**
-   * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
-   * @type {module:ol/MapBrowserEvent~MapBrowserEvent}
+   * Associated {@link module:ol/MapBrowserEvent}.
+   * @type {module:ol/MapBrowserEvent}
    * @api
    */
   this.mapBrowserEvent = mapBrowserEvent;
@@ -152,7 +152,7 @@ inherits(SelectEvent, Event);
  * Selected features are added to an internal unmanaged layer.
  *
  * @constructor
- * @extends {module:ol/interaction/Interaction~Interaction}
+ * @extends {module:ol/interaction/Interaction}
  * @param {module:ol/interaction/Select~Options=} opt_options Options.
  * @fires SelectEvent
  * @api
@@ -225,7 +225,7 @@ const Select = function(opt_options) {
    */
   this.featureOverlay_ = featureOverlay;
 
-  /** @type {function(module:ol/layer/Layer~Layer): boolean} */
+  /** @type {function(module:ol/layer/Layer): boolean} */
   let layerFilter;
   if (options.layers) {
     if (typeof options.layers === 'function') {
@@ -242,7 +242,7 @@ const Select = function(opt_options) {
 
   /**
    * @private
-   * @type {function(module:ol/layer/Layer~Layer): boolean}
+   * @type {function(module:ol/layer/Layer): boolean}
    */
   this.layerFilter_ = layerFilter;
 
@@ -250,7 +250,7 @@ const Select = function(opt_options) {
    * An association between selected feature (key)
    * and layer (value)
    * @private
-   * @type {Object.<number, module:ol/layer/Layer~Layer>}
+   * @type {Object.<number, module:ol/layer/Layer>}
    */
   this.featureLayerAssociation_ = {};
 
@@ -266,8 +266,8 @@ inherits(Select, Interaction);
 
 
 /**
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~Feature} feature Feature.
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/Feature|module:ol/render/Feature~Feature} feature Feature.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @private
  */
 Select.prototype.addFeatureLayerAssociation_ = function(feature, layer) {
@@ -278,7 +278,7 @@ Select.prototype.addFeatureLayerAssociation_ = function(feature, layer) {
 
 /**
  * Get the selected features.
- * @return {module:ol/Collection~Collection.<module:ol/Feature~Feature>} Features collection.
+ * @return {module:ol/Collection.<module:ol/Feature>} Features collection.
  * @api
  */
 Select.prototype.getFeatures = function() {
@@ -301,22 +301,24 @@ Select.prototype.getHitTolerance = function() {
  * the (last) selected feature. Note that this will not work with any
  * programmatic method like pushing features to
  * {@link module:ol/interaction/Select~Select#getFeatures collection}.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~Feature} feature Feature
+ * @param {module:ol/Feature|module:ol/render/Feature~Feature} feature Feature
  * @return {module:ol/layer/Vector~Vector} Layer.
  * @api
  */
 Select.prototype.getLayer = function(feature) {
   const key = getUid(feature);
-  return /** @type {module:ol/layer/Vector~Vector} */ (this.featureLayerAssociation_[key]);
+  return (
+    /** @type {module:ol/layer/Vector~Vector} */ (this.featureLayerAssociation_[key])
+  );
 };
 
 
 /**
- * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may change the
+ * Handles the {@link module:ol/MapBrowserEvent map browser event} and may change the
  * selected state of features.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Select~Select}
+ * @this {module:ol/interaction/Select}
  */
 function handleEvent(mapBrowserEvent) {
   if (!this.condition_(mapBrowserEvent)) {
@@ -338,8 +340,8 @@ function handleEvent(mapBrowserEvent) {
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
       (
         /**
-         * @param {module:ol/Feature~Feature|module:ol/render/Feature~Feature} feature Feature.
-         * @param {module:ol/layer/Layer~Layer} layer Layer.
+         * @param {module:ol/Feature|module:ol/render/Feature~Feature} feature Feature.
+         * @param {module:ol/layer/Layer} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
@@ -371,8 +373,8 @@ function handleEvent(mapBrowserEvent) {
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
       (
         /**
-         * @param {module:ol/Feature~Feature|module:ol/render/Feature~Feature} feature Feature.
-         * @param {module:ol/layer/Layer~Layer} layer Layer.
+         * @param {module:ol/Feature|module:ol/render/Feature~Feature} feature Feature.
+         * @param {module:ol/layer/Layer} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
@@ -419,7 +421,7 @@ Select.prototype.setHitTolerance = function(hitTolerance) {
 /**
  * Remove the interaction from its current map, if any,  and attach it to a new
  * map, if any. Pass `null` to just remove the interaction from the current map.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @override
  * @api
  */
@@ -462,7 +464,7 @@ function getDefaultStyleFunction() {
 Select.prototype.addFeature_ = function(evt) {
   const map = this.getMap();
   if (map) {
-    map.skipFeature(/** @type {module:ol/Feature~Feature} */ (evt.element));
+    map.skipFeature(/** @type {module:ol/Feature} */ (evt.element));
   }
 };
 
@@ -474,13 +476,13 @@ Select.prototype.addFeature_ = function(evt) {
 Select.prototype.removeFeature_ = function(evt) {
   const map = this.getMap();
   if (map) {
-    map.unskipFeature(/** @type {module:ol/Feature~Feature} */ (evt.element));
+    map.unskipFeature(/** @type {module:ol/Feature} */ (evt.element));
   }
 };
 
 
 /**
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature|module:ol/render/Feature~Feature} feature Feature.
  * @private
  */
 Select.prototype.removeFeatureLayerAssociation_ = function(feature) {

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -28,14 +28,14 @@ import RBush from '../structs/RBush.js';
 
 /**
  * @typedef {Object} SegmentData
- * @property {module:ol/Feature~Feature} feature
+ * @property {module:ol/Feature} feature
  * @property {Array.<module:ol/coordinate~Coordinate>} segment
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/Collection~Collection.<module:ol/Feature~Feature>} [features] Snap to these features. Either this option or source should be provided.
+ * @property {module:ol/Collection.<module:ol/Feature>} [features] Snap to these features. Either this option or source should be provided.
  * @property {boolean} [edge=true] Snap to edges.
  * @property {boolean} [vertex=true] Snap to vertices.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the pointer close enough to a segment or
@@ -64,7 +64,7 @@ import RBush from '../structs/RBush.js';
  *     });
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @param {module:ol/interaction/Snap~Options=} opt_options Options.
  * @api
  */
@@ -97,7 +97,7 @@ const Snap = function(opt_options) {
   this.edge_ = options.edge !== undefined ? options.edge : true;
 
   /**
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    * @private
    */
   this.features_ = options.features ? options.features : null;
@@ -126,7 +126,7 @@ const Snap = function(opt_options) {
    * If a feature geometry changes while a pointer drag|move event occurs, the
    * feature doesn't get updated right away.  It will be at the next 'pointerup'
    * event fired.
-   * @type {!Object.<number, module:ol/Feature~Feature>}
+   * @type {!Object.<number, module:ol/Feature>}
    * @private
    */
   this.pendingFeatures_ = {};
@@ -154,7 +154,7 @@ const Snap = function(opt_options) {
 
   /**
   * Segment RTree for each layer
-  * @type {module:ol/structs/RBush~RBush.<module:ol/interaction/Snap~SegmentData>}
+  * @type {module:ol/structs/RBush.<module:ol/interaction/Snap~SegmentData>}
   * @private
   */
   this.rBush_ = new RBush();
@@ -163,7 +163,7 @@ const Snap = function(opt_options) {
   /**
   * @const
   * @private
-  * @type {Object.<string, function(module:ol/Feature~Feature, module:ol/geom/Geometry~Geometry)>}
+  * @type {Object.<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
   */
   this.SEGMENT_WRITERS_ = {
     'Point': this.writePointGeometry_,
@@ -183,7 +183,7 @@ inherits(Snap, PointerInteraction);
 
 /**
  * Add a feature to the collection of features that we may snap to.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {boolean=} opt_listen Whether to listen to the feature change or not
  *     Defaults to `true`.
  * @api
@@ -210,7 +210,7 @@ Snap.prototype.addFeature = function(feature, opt_listen) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @private
  */
 Snap.prototype.forEachFeatureAdd_ = function(feature) {
@@ -219,7 +219,7 @@ Snap.prototype.forEachFeatureAdd_ = function(feature) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @private
  */
 Snap.prototype.forEachFeatureRemove_ = function(feature) {
@@ -228,7 +228,7 @@ Snap.prototype.forEachFeatureRemove_ = function(feature) {
 
 
 /**
- * @return {module:ol/Collection~Collection.<module:ol/Feature~Feature>|Array.<module:ol/Feature~Feature>} Features.
+ * @return {module:ol/Collection.<module:ol/Feature>|Array.<module:ol/Feature>} Features.
  * @private
  */
 Snap.prototype.getFeatures_ = function() {
@@ -238,12 +238,14 @@ Snap.prototype.getFeatures_ = function() {
   } else if (this.source_) {
     features = this.source_.getFeatures();
   }
-  return /** @type {!Array.<module:ol/Feature~Feature>|!module:ol/Collection~Collection.<module:ol/Feature~Feature>} */ (features);
+  return (
+    /** @type {!Array.<module:ol/Feature>|!module:ol/Collection.<module:ol/Feature>} */ (features)
+  );
 };
 
 
 /**
- * @param {module:ol/source/Vector~Vector.Event|module:ol/Collection~CollectionEvent} evt Event.
+ * @param {module:ol/source/Vector~Vector|module:ol/Collection~CollectionEvent} evt Event.
  * @private
  */
 Snap.prototype.handleFeatureAdd_ = function(evt) {
@@ -253,12 +255,12 @@ Snap.prototype.handleFeatureAdd_ = function(evt) {
   } else if (evt instanceof CollectionEvent) {
     feature = evt.element;
   }
-  this.addFeature(/** @type {module:ol/Feature~Feature} */ (feature));
+  this.addFeature(/** @type {module:ol/Feature} */ (feature));
 };
 
 
 /**
- * @param {module:ol/source/Vector~Vector.Event|module:ol/Collection~CollectionEvent} evt Event.
+ * @param {module:ol/source/Vector~Vector|module:ol/Collection~CollectionEvent} evt Event.
  * @private
  */
 Snap.prototype.handleFeatureRemove_ = function(evt) {
@@ -268,16 +270,16 @@ Snap.prototype.handleFeatureRemove_ = function(evt) {
   } else if (evt instanceof CollectionEvent) {
     feature = evt.element;
   }
-  this.removeFeature(/** @type {module:ol/Feature~Feature} */ (feature));
+  this.removeFeature(/** @type {module:ol/Feature} */ (feature));
 };
 
 
 /**
- * @param {module:ol/events/Event~Event} evt Event.
+ * @param {module:ol/events/Event} evt Event.
  * @private
  */
 Snap.prototype.handleFeatureChange_ = function(evt) {
-  const feature = /** @type {module:ol/Feature~Feature} */ (evt.target);
+  const feature = /** @type {module:ol/Feature} */ (evt.target);
   if (this.handlingDownUpSequence) {
     const uid = getUid(feature);
     if (!(uid in this.pendingFeatures_)) {
@@ -291,7 +293,7 @@ Snap.prototype.handleFeatureChange_ = function(evt) {
 
 /**
  * Remove a feature from the collection of features that we may snap to.
- * @param {module:ol/Feature~Feature} feature Feature
+ * @param {module:ol/Feature} feature Feature
  * @param {boolean=} opt_unlisten Whether to unlisten to the feature change
  *     or not. Defaults to `true`.
  * @api
@@ -365,7 +367,7 @@ Snap.prototype.shouldStopEvent = FALSE;
 /**
  * @param {module:ol~Pixel} pixel Pixel
  * @param {module:ol/coordinate~Coordinate} pixelCoordinate Coordinate
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @return {module:ol/interaction/Snap~Result} Snap result
  */
 Snap.prototype.snapTo = function(pixel, pixelCoordinate, map) {
@@ -412,7 +414,7 @@ Snap.prototype.snapTo = function(pixel, pixelCoordinate, map) {
     } else if (this.edge_) {
       if (isCircle) {
         vertex = closestOnCircle(pixelCoordinate,
-          /** @type {module:ol/geom/Circle~Circle} */ (segments[0].feature.getGeometry()));
+          /** @type {module:ol/geom/Circle} */ (segments[0].feature.getGeometry()));
       } else {
         vertex = closestOnSegment(pixelCoordinate, closestSegment);
       }
@@ -437,16 +439,18 @@ Snap.prototype.snapTo = function(pixel, pixelCoordinate, map) {
       vertexPixel = [Math.round(vertexPixel[0]), Math.round(vertexPixel[1])];
     }
   }
-  return /** @type {module:ol/interaction/Snap~Result} */ ({
-    snapped: snapped,
-    vertex: vertex,
-    vertexPixel: vertexPixel
-  });
+  return (
+    /** @type {module:ol/interaction/Snap~Result} */ ({
+      snapped: snapped,
+      vertex: vertex,
+      vertexPixel: vertexPixel
+    })
+  );
 };
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
+ * @param {module:ol/Feature} feature Feature
  * @private
  */
 Snap.prototype.updateFeature_ = function(feature) {
@@ -456,8 +460,8 @@ Snap.prototype.updateFeature_ = function(feature) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/Circle~Circle} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/Circle} geometry Geometry.
  * @private
  */
 Snap.prototype.writeCircleGeometry_ = function(feature, geometry) {
@@ -475,8 +479,8 @@ Snap.prototype.writeCircleGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/GeometryCollection} geometry Geometry.
  * @private
  */
 Snap.prototype.writeGeometryCollectionGeometry_ = function(feature, geometry) {
@@ -491,8 +495,8 @@ Snap.prototype.writeGeometryCollectionGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/LineString~LineString} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/LineString} geometry Geometry.
  * @private
  */
 Snap.prototype.writeLineStringGeometry_ = function(feature, geometry) {
@@ -509,8 +513,8 @@ Snap.prototype.writeLineStringGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/MultiLineString~MultiLineString} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/MultiLineString} geometry Geometry.
  * @private
  */
 Snap.prototype.writeMultiLineStringGeometry_ = function(feature, geometry) {
@@ -530,8 +534,8 @@ Snap.prototype.writeMultiLineStringGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/MultiPoint~MultiPoint} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/MultiPoint} geometry Geometry.
  * @private
  */
 Snap.prototype.writeMultiPointGeometry_ = function(feature, geometry) {
@@ -548,8 +552,8 @@ Snap.prototype.writeMultiPointGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/MultiPolygon} geometry Geometry.
  * @private
  */
 Snap.prototype.writeMultiPolygonGeometry_ = function(feature, geometry) {
@@ -572,8 +576,8 @@ Snap.prototype.writeMultiPolygonGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/Point~Point} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/Point} geometry Geometry.
  * @private
  */
 Snap.prototype.writePointGeometry_ = function(feature, geometry) {
@@ -587,8 +591,8 @@ Snap.prototype.writePointGeometry_ = function(feature, geometry) {
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature
- * @param {module:ol/geom/Polygon~Polygon} geometry Geometry.
+ * @param {module:ol/Feature} feature Feature
+ * @param {module:ol/geom/Polygon} geometry Geometry.
  * @private
  */
 Snap.prototype.writePolygonGeometry_ = function(feature, geometry) {
@@ -609,9 +613,9 @@ Snap.prototype.writePolygonGeometry_ = function(feature, geometry) {
 
 /**
  * Handle all pointer events events.
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} evt A move event.
+ * @param {module:ol/MapBrowserEvent} evt A move event.
  * @return {boolean} Pass the event to other interactions.
- * @this {module:ol/interaction/Snap~Snap}
+ * @this {module:ol/interaction/Snap}
  */
 export function handleEvent(evt) {
   const result = this.snapTo(evt.pixel, evt.coordinate, evt.map);
@@ -624,9 +628,9 @@ export function handleEvent(evt) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} evt Event.
+ * @param {module:ol/MapBrowserPointerEvent} evt Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Snap~Snap}
+ * @this {module:ol/interaction/Snap}
  */
 function handleUpEvent(evt) {
   const featuresToUpdate = getValues(this.pendingFeatures_);
@@ -643,7 +647,7 @@ function handleUpEvent(evt) {
  * @param {module:ol/interaction/Snap~SegmentData} a The first segment data.
  * @param {module:ol/interaction/Snap~SegmentData} b The second segment data.
  * @return {number} The difference in distance.
- * @this {module:ol/interaction/Snap~Snap}
+ * @this {module:ol/interaction/Snap}
  */
 function sortByDistance(a, b) {
   const deltaA = squaredDistanceToSegment(this.pixelCoordinate_, a.segment);

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -39,9 +39,9 @@ const TranslateEventType = {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/Collection~Collection.<module:ol/Feature~Feature>} [features] Only features contained in this collection will be able to be translated. If
+ * @property {module:ol/Collection.<module:ol/Feature>} [features] Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
- * @property {Array.<module:ol/layer/Layer~Layer>|function(module:ol/layer/Layer~Layer): boolean} [layers] A list of layers from which features should be
+ * @property {Array.<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers] A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be translatable. If the option is
@@ -58,10 +58,10 @@ const TranslateEventType = {
  * are instances of this type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.interaction.TranslateEvent}
  * @param {module:ol/interaction/Translate~TranslateEventType} type Type.
- * @param {module:ol/Collection~Collection.<module:ol/Feature~Feature>} features The features translated.
+ * @param {module:ol/Collection.<module:ol/Feature>} features The features translated.
  * @param {module:ol/coordinate~Coordinate} coordinate The event coordinate.
  */
 export const TranslateEvent = function(type, features, coordinate) {
@@ -70,7 +70,7 @@ export const TranslateEvent = function(type, features, coordinate) {
 
   /**
    * The features being translated.
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    * @api
    */
   this.features = features;
@@ -92,7 +92,7 @@ inherits(TranslateEvent, Event);
  * Interaction for translating (moving) features.
  *
  * @constructor
- * @extends {module:ol/interaction/Pointer~PointerInteraction}
+ * @extends {module:ol/interaction/Pointer}
  * @fires module:ol/interaction/Translate~TranslateEvent
  * @param {module:ol/interaction/Translate~Options=} opt_options Options.
  * @api
@@ -116,12 +116,12 @@ const Translate = function(opt_options) {
 
 
   /**
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    * @private
    */
   this.features_ = options.features !== undefined ? options.features : null;
 
-  /** @type {function(module:ol/layer/Layer~Layer): boolean} */
+  /** @type {function(module:ol/layer/Layer): boolean} */
   let layerFilter;
   if (options.layers) {
     if (typeof options.layers === 'function') {
@@ -138,7 +138,7 @@ const Translate = function(opt_options) {
 
   /**
    * @private
-   * @type {function(module:ol/layer/Layer~Layer): boolean}
+   * @type {function(module:ol/layer/Layer): boolean}
    */
   this.layerFilter_ = layerFilter;
 
@@ -149,7 +149,7 @@ const Translate = function(opt_options) {
   this.hitTolerance_ = options.hitTolerance ? options.hitTolerance : 0;
 
   /**
-   * @type {module:ol/Feature~Feature}
+   * @type {module:ol/Feature}
    * @private
    */
   this.lastFeature_ = null;
@@ -164,9 +164,9 @@ inherits(Translate, PointerInteraction);
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} event Event.
+ * @param {module:ol/MapBrowserPointerEvent} event Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/Translate~Translate}
+ * @this {module:ol/interaction/Translate}
  */
 function handleDownEvent(event) {
   this.lastFeature_ = this.featuresAtPixel_(event.pixel, event.map);
@@ -187,9 +187,9 @@ function handleDownEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} event Event.
+ * @param {module:ol/MapBrowserPointerEvent} event Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Translate~Translate}
+ * @this {module:ol/interaction/Translate}
  */
 function handleUpEvent(event) {
   if (this.lastCoordinate_) {
@@ -209,8 +209,8 @@ function handleUpEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent~MapBrowserPointerEvent} event Event.
- * @this {module:ol/interaction/Translate~Translate}
+ * @param {module:ol/MapBrowserPointerEvent} event Event.
+ * @this {module:ol/interaction/Translate}
  */
 function handleDragEvent(event) {
   if (this.lastCoordinate_) {
@@ -236,8 +236,8 @@ function handleDragEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserEvent~MapBrowserEvent} event Event.
- * @this {module:ol/interaction/Translate~Translate}
+ * @param {module:ol/MapBrowserEvent} event Event.
+ * @this {module:ol/interaction/Translate}
  */
 function handleMoveEvent(event) {
   const elem = event.map.getViewport();
@@ -257,8 +257,8 @@ function handleMoveEvent(event) {
  * Tests to see if the given coordinates intersects any of our selected
  * features.
  * @param {module:ol~Pixel} pixel Pixel coordinate to test for intersection.
- * @param {module:ol/PluggableMap~PluggableMap} map Map to test the intersection on.
- * @return {module:ol/Feature~Feature} Returns the feature found at the specified pixel
+ * @param {module:ol/PluggableMap} map Map to test the intersection on.
+ * @return {module:ol/Feature} Returns the feature found at the specified pixel
  * coordinates.
  * @private
  */
@@ -316,7 +316,7 @@ Translate.prototype.handleActiveChanged_ = function() {
 
 
 /**
- * @param {module:ol/PluggableMap~PluggableMap} oldMap Old map.
+ * @param {module:ol/PluggableMap} oldMap Old map.
  * @private
  */
 Translate.prototype.updateState_ = function(oldMap) {

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -28,12 +28,12 @@ import {assign} from '../obj.js';
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
  * Note that with `module:ol/layer/Base~BaseLayer` and all its subclasses, any property set in
- * the options is set as a {@link module:ol/Object~BaseObject property on the layer object, so
+ * the options is set as a {@link module:ol/Object property on the layer object, so
  * is observable, and has get/set accessors.
  *
  * @constructor
  * @abstract
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @param {module:ol/layer/Base~Options} options Layer options.
  * @api
  */
@@ -63,7 +63,7 @@ const BaseLayer = function(options) {
    * @private
    */
   this.state_ = /** @type {module:ol/layer/Layer~State} */ ({
-    layer: /** @type {module:ol/layer/Layer~Layer} */ (this),
+    layer: /** @type {module:ol/layer/Layer} */ (this),
     managed: true
   });
 
@@ -106,9 +106,9 @@ BaseLayer.prototype.getLayerState = function() {
 
 /**
  * @abstract
- * @param {Array.<module:ol/layer/Layer~Layer>=} opt_array Array of layers (to be
+ * @param {Array.<module:ol/layer/Layer>=} opt_array Array of layers (to be
  *     modified in place).
- * @return {Array.<module:ol/layer/Layer~Layer>} Array of layers.
+ * @return {Array.<module:ol/layer/Layer>} Array of layers.
  */
 BaseLayer.prototype.getLayersArray = function(opt_array) {};
 
@@ -130,7 +130,9 @@ BaseLayer.prototype.getLayerStatesArray = function(opt_states) {};
  * @api
  */
 BaseLayer.prototype.getExtent = function() {
-  return /** @type {module:ol/extent~Extent|undefined} */ (this.get(LayerProperty.EXTENT));
+  return (
+    /** @type {module:ol/extent~Extent|undefined} */ (this.get(LayerProperty.EXTENT))
+  );
 };
 
 

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -27,7 +27,7 @@ import SourceState from '../source/State.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {(Array.<module:ol/layer/Base~BaseLayer>|module:ol/Collection~Collection.<module:ol/layer/Base~BaseLayer>)} [layers] Child layers.
+ * @property {(Array.<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>)} [layers] Child layers.
  */
 
 
@@ -47,7 +47,7 @@ const Property = {
  * A generic `change` event is triggered when the group/Collection changes.
  *
  * @constructor
- * @extends {module:ol/layer/Base~BaseLayer}
+ * @extends {module:ol/layer/Base}
  * @param {module:ol/layer/Group~Options=} opt_options Layer options.
  * @api
  */
@@ -105,7 +105,7 @@ LayerGroup.prototype.handleLayerChange_ = function() {
 
 
 /**
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  * @private
  */
 LayerGroup.prototype.handleLayersChanged_ = function(event) {
@@ -141,7 +141,7 @@ LayerGroup.prototype.handleLayersChanged_ = function(event) {
  * @private
  */
 LayerGroup.prototype.handleLayersAdd_ = function(collectionEvent) {
-  const layer = /** @type {module:ol/layer/Base~BaseLayer} */ (collectionEvent.element);
+  const layer = /** @type {module:ol/layer/Base} */ (collectionEvent.element);
   const key = getUid(layer).toString();
   this.listenerKeys_[key] = [
     listen(layer, ObjectEventType.PROPERTYCHANGE, this.handleLayerChange_, this),
@@ -156,7 +156,7 @@ LayerGroup.prototype.handleLayersAdd_ = function(collectionEvent) {
  * @private
  */
 LayerGroup.prototype.handleLayersRemove_ = function(collectionEvent) {
-  const layer = /** @type {module:ol/layer/Base~BaseLayer} */ (collectionEvent.element);
+  const layer = /** @type {module:ol/layer/Base} */ (collectionEvent.element);
   const key = getUid(layer).toString();
   this.listenerKeys_[key].forEach(unlistenByKey);
   delete this.listenerKeys_[key];
@@ -165,23 +165,25 @@ LayerGroup.prototype.handleLayersRemove_ = function(collectionEvent) {
 
 
 /**
- * Returns the {@link module:ol/Collection~Collection collection} of {@link module:ol/layer/Layer~Layer layers}
+ * Returns the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
  * in this group.
- * @return {!module:ol/Collection~Collection.<module:ol/layer/Base~BaseLayer>} Collection of
- *   {@link module:ol/layer/Base~BaseLayer layers} that are part of this group.
+ * @return {!module:ol/Collection.<module:ol/layer/Base>} Collection of
+ *   {@link module:ol/layer/Base layers} that are part of this group.
  * @observable
  * @api
  */
 LayerGroup.prototype.getLayers = function() {
-  return /** @type {!module:ol/Collection~Collection.<module:ol/layer/Base~BaseLayer>} */ (this.get(Property.LAYERS));
+  return (
+    /** @type {!module:ol/Collection.<module:ol/layer/Base>} */ (this.get(Property.LAYERS))
+  );
 };
 
 
 /**
- * Set the {@link module:ol/Collection~Collection collection} of {@link module:ol/layer/Layer~Layer layers}
+ * Set the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
  * in this group.
- * @param {!module:ol/Collection~Collection.<module:ol/layer/Base~BaseLayer>} layers Collection of
- *   {@link module:ol/layer/Base~BaseLayer layers} that are part of this group.
+ * @param {!module:ol/Collection.<module:ol/layer/Base>} layers Collection of
+ *   {@link module:ol/layer/Base layers} that are part of this group.
  * @observable
  * @api
  */

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -30,10 +30,10 @@ import Style from '../style/Style.js';
  * @property {number} [radius=8] Radius size in pixels.
  * @property {number} [blur=15] Blur size in pixels.
  * @property {number} [shadow=250] Shadow size in pixels.
- * @property {string|function(module:ol/Feature~Feature):number} [weight='weight'] The feature
+ * @property {string|function(module:ol/Feature):number} [weight='weight'] The feature
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
- * @property {module:ol/source/Vector~VectorSource} [source] Source.
+ * @property {module:ol/source/Vector} [source] Source.
  */
 
 
@@ -63,7 +63,7 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  * options means that `title` is observable, and has get/set accessors.
  *
  * @constructor
- * @extends {module:ol/layer/Vector~VectorLayer}
+ * @extends {module:ol/layer/Vector}
  * @fires module:ol/render/Event~RenderEvent
  * @param {module:ol/layer/Heatmap~Options=} opt_options Options.
  * @api
@@ -100,7 +100,7 @@ const Heatmap = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<Array.<module:ol/style/Style~Style>>}
+   * @type {Array.<Array.<module:ol/style/Style>>}
    */
   this.styleCache_ = null;
 
@@ -259,7 +259,7 @@ Heatmap.prototype.handleStyleChanged_ = function() {
 
 
 /**
- * @param {module:ol/render/Event~RenderEvent} event Post compose event
+ * @param {module:ol/render/Event} event Post compose event
  * @private
  */
 Heatmap.prototype.handleRender_ = function(event) {

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -18,11 +18,11 @@ import Layer from '../layer/Layer.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {module:ol/PluggableMap~PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link ol.Map#addLayer}.
- * @property {module:ol/source/Image~ImageSource} [source] Source for this layer.
+ * @property {module:ol/source/Image} [source] Source for this layer.
  */
 
 
@@ -35,7 +35,7 @@ import Layer from '../layer/Layer.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @constructor
- * @extends {module:ol/layer/Layer~Layer}
+ * @extends {module:ol/layer/Layer}
  * @fires module:ol/render/Event~RenderEvent
  * @param {module:ol/layer/Image~Options=} opt_options Layer options.
  * @api
@@ -57,9 +57,9 @@ inherits(ImageLayer, Layer);
 
 
 /**
- * Return the associated {@link module:ol/source/Image~ImageSource source} of the image layer.
+ * Return the associated {@link module:ol/source/Image source} of the image layer.
  * @function
- * @return {module:ol/source/Image~ImageSource} Source.
+ * @return {module:ol/source/Image} Source.
  * @api
  */
 ImageLayer.prototype.getSource;

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -24,7 +24,7 @@ import SourceState from '../source/State.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {module:ol/source/Source~Source} [source] Source for this layer.  If not provided to the constructor,
+ * @property {module:ol/source/Source} [source] Source for this layer.  If not provided to the constructor,
  * the source can be set by calling {@link ol.layer.Layer#setSource layer.setSource(source)} after
  * construction.
  */
@@ -32,7 +32,7 @@ import SourceState from '../source/State.js';
 
 /**
  * @typedef {Object} State
- * @property {module:ol/layer/Layer~Layer} layer
+ * @property {module:ol/layer/Layer} layer
  * @property {number} opacity
  * @property {module:ol/source/Source~State} sourceState
  * @property {boolean} visible
@@ -61,7 +61,7 @@ import SourceState from '../source/State.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/layer/Base~BaseLayer}
+ * @extends {module:ol/layer/Base}
  * @fires module:ol/render/Event~RenderEvent
  * @param {module:ol/layer/Layer~Options} options Layer options.
  * @api
@@ -142,13 +142,15 @@ Layer.prototype.getLayerStatesArray = function(opt_states) {
 
 /**
  * Get the layer source.
- * @return {module:ol/source/Source~Source} The layer source (or `null` if not yet set).
+ * @return {module:ol/source/Source} The layer source (or `null` if not yet set).
  * @observable
  * @api
  */
 Layer.prototype.getSource = function() {
   const source = this.get(LayerProperty.SOURCE);
-  return /** @type {module:ol/source/Source~Source} */ (source) || null;
+  return (
+    /** @type {module:ol/source/Source} */ (source) || null
+  );
 };
 
 
@@ -195,7 +197,7 @@ Layer.prototype.handleSourcePropertyChange_ = function() {
  *
  * To add the layer to a map and have it managed by the map, use
  * {@link ol.Map#addLayer} instead.
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @api
  */
 Layer.prototype.setMap = function(map) {
@@ -226,7 +228,7 @@ Layer.prototype.setMap = function(map) {
 
 /**
  * Set the layer source.
- * @param {module:ol/source/Source~Source} source The layer source.
+ * @param {module:ol/source/Source} source The layer source.
  * @observable
  * @api
  */

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -22,8 +22,8 @@ import {assign} from '../obj.js';
  * be visible.
  * @property {number} [preload=0] Preload. Load low-resolution tiles up to `preload` levels. `0`
  * means no preloading.
- * @property {module:ol/source/Tile~TileSource} [source] Source for this layer.
- * @property {module:ol/PluggableMap~PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {module:ol/source/Tile} [source] Source for this layer.
+ * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link ol.Map#addLayer}.
@@ -40,7 +40,7 @@ import {assign} from '../obj.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @constructor
- * @extends {module:ol/layer/Layer~Layer}
+ * @extends {module:ol/layer/Layer}
  * @fires module:ol/render/Event~RenderEvent
  * @param {module:ol/layer/Tile~Options=} opt_options Tile layer options.
  * @api
@@ -84,7 +84,7 @@ TileLayer.prototype.getPreload = function() {
 /**
  * Return the associated {@link ol.source.Tile tilesource} of the layer.
  * @function
- * @return {module:ol/source/Tile~TileSource} Source.
+ * @return {module:ol/source/Tile} Source.
  * @api
  */
 TileLayer.prototype.getSource;

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -32,15 +32,15 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  *    texts are always rotated with the view and pixels are scaled during zoom animations.
  *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering even during
  *    animations, but slower performance.
- * @property {module:ol/source/Vector~VectorSource} [source] Source.
- * @property {module:ol/PluggableMap~PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {module:ol/source/Vector} [source] Source.
+ * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link ol.Map#addLayer}.
  * @property {boolean} [declutter=false] Declutter images and text. Decluttering is applied to all
  * image and text styles, and the priority is defined by the z-index of the style. Lower z-index
  * means higher priority.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [style] Layer style. See
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [style] Layer style. See
  * {@link ol.style} for default style which will be used if this is not defined.
  * @property {number} [maxTilesLoading=16] Maximum number tiles to load simultaneously.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
@@ -85,7 +85,7 @@ const Property = {
  * options means that `title` is observable, and has get/set accessors.
  *
  * @constructor
- * @extends {module:ol/layer/Layer~Layer}
+ * @extends {module:ol/layer/Layer}
  * @fires module:ol/render/Event~RenderEvent
  * @param {module:ol/layer/Vector~Options=} opt_options Options.
  * @api
@@ -117,7 +117,7 @@ const VectorLayer = function(opt_options) {
 
   /**
    * User provided style.
-   * @type {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction}
+   * @type {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction}
    * @private
    */
   this.style_ = null;
@@ -188,18 +188,20 @@ VectorLayer.prototype.getRenderBuffer = function() {
 
 
 /**
- * @return {function(module:ol/Feature~Feature, module:ol/Feature~Feature): number|null|undefined} Render
+ * @return {function(module:ol/Feature, module:ol/Feature): number|null|undefined} Render
  *     order.
  */
 VectorLayer.prototype.getRenderOrder = function() {
-  return /** @type {module:ol/render~OrderFunction|null|undefined} */ (this.get(Property.RENDER_ORDER));
+  return (
+    /** @type {module:ol/render~OrderFunction|null|undefined} */ (this.get(Property.RENDER_ORDER))
+  );
 };
 
 
 /**
- * Return the associated {@link module:ol/source/Vector~VectorSource vectorsource} of the layer.
+ * Return the associated {@link module:ol/source/Vector vectorsource} of the layer.
  * @function
- * @return {module:ol/source/Vector~VectorSource} Source.
+ * @return {module:ol/source/Vector} Source.
  * @api
  */
 VectorLayer.prototype.getSource;
@@ -208,7 +210,7 @@ VectorLayer.prototype.getSource;
 /**
  * Get the style for features.  This returns whatever was passed to the `style`
  * option at construction or to the `setStyle` method.
- * @return {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction}
+ * @return {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction}
  *     Layer style.
  * @api
  */
@@ -261,7 +263,7 @@ VectorLayer.prototype.setRenderOrder = function(renderOrder) {
  * it is `null` the layer has no style (a `null` style), so only features
  * that have their own styles will be rendered in the layer. See
  * {@link ol.style} for information on the default style.
- * @param {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction|null|undefined}
+ * @param {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction|null|undefined}
  *     style Layer style.
  * @api
  */

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -60,8 +60,8 @@ export const RenderType = {
  *    animations, but slower performance than the other options.
  *
  * When `declutter` is set to `true`, `'hybrid'` will be used instead of `'image'`.
- * @property {module:ol/source/VectorTile~VectorTile} [source] Source.
- * @property {module:ol/PluggableMap~PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {module:ol/source/VectorTile} [source] Source.
+ * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link ol.Map#addLayer}.
@@ -69,7 +69,7 @@ export const RenderType = {
  * image and text styles, and the priority is defined by the z-index of the style. Lower z-index
  * means higher priority. When set to `true`, a `renderMode` of `'image'` will be overridden with
  * `'hybrid'`.
- * @property {module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction} [style] Layer style. See
+ * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction} [style] Layer style. See
  * {@link ol.style} for default style which will be used if this is not defined.
  * @property {number} [maxTilesLoading=16] Maximum number tiles to load simultaneously.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
@@ -82,7 +82,7 @@ export const RenderType = {
  * means no preloading.
  * @property {module:ol/render~OrderFunction} [renderOrder] Render order. Function to be used when sorting
  * features before rendering. By default features are drawn in the order that they are created.
- * @property {(module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>|module:ol/style~StyleFunction)} [style] Layer style. See
+ * @property {(module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style~StyleFunction)} [style] Layer style. See
  * {@link ol.style} for default style which will be used if this is not defined.
  * @property {boolean} [useInterimTilesOnError=true] Use interim tiles on error.
  */
@@ -96,7 +96,7 @@ export const RenderType = {
  * options means that `title` is observable, and has get/set accessors.
  *
  * @constructor
- * @extends {module:ol/layer/Vector~VectorLayer}
+ * @extends {module:ol/layer/Vector}
  * @param {module:ol/layer/VectorTile~Options=} opt_options Options.
  * @api
  */
@@ -181,9 +181,9 @@ VectorTileLayer.prototype.setUseInterimTilesOnError = function(useInterimTilesOn
 
 
 /**
- * Return the associated {@link module:ol/source/VectorTile~VectorTile vectortilesource} of the layer.
+ * Return the associated {@link module:ol/source/VectorTile vectortilesource} of the layer.
  * @function
- * @return {module:ol/source/VectorTile~VectorTile} Source.
+ * @return {module:ol/source/VectorTile} Source.
  * @api
  */
 VectorTileLayer.prototype.getSource;

--- a/src/ol/loadingstrategy.js
+++ b/src/ol/loadingstrategy.js
@@ -30,7 +30,7 @@ export function bbox(extent, resolution) {
 
 /**
  * Creates a strategy function for loading features based on a tile grid.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @return {function(module:ol/extent~Extent, number): Array.<module:ol/extent~Extent>} Loading strategy.
  * @api
  */
@@ -54,5 +54,6 @@ export function tile(tileGrid) {
         }
       }
       return extents;
-    });
+    }
+  );
 }

--- a/src/ol/pointer/EventSource.js
+++ b/src/ol/pointer/EventSource.js
@@ -2,13 +2,13 @@
  * @module ol/pointer/EventSource
  */
 /**
- * @param {module:ol/pointer/PointerEventHandler~PointerEventHandler} dispatcher Event handler.
+ * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
  * @param {!Object.<string, function(Event)>} mapping Event mapping.
  * @constructor
  */
 const EventSource = function(dispatcher, mapping) {
   /**
-   * @type {module:ol/pointer/PointerEventHandler~PointerEventHandler}
+   * @type {module:ol/pointer/PointerEventHandler}
    */
   this.dispatcher = dispatcher;
 

--- a/src/ol/pointer/MouseSource.js
+++ b/src/ol/pointer/MouseSource.js
@@ -35,9 +35,9 @@ import {inherits} from '../index.js';
 import EventSource from '../pointer/EventSource.js';
 
 /**
- * @param {module:ol/pointer/PointerEventHandler~PointerEventHandler} dispatcher Event handler.
+ * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
  * @constructor
- * @extends {module:ol/pointer/EventSource~EventSource}
+ * @extends {module:ol/pointer/EventSource}
  */
 const MouseSource = function(dispatcher) {
   const mapping = {
@@ -131,7 +131,7 @@ MouseSource.prototype.isEventSimulatedFromTouch_ = function(inEvent) {
  * for the fake pointer event.
  *
  * @param {Event} inEvent The in event.
- * @param {module:ol/pointer/PointerEventHandler~PointerEventHandler} dispatcher Event handler.
+ * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
  * @return {Object} The copied event.
  */
 function prepareEvent(inEvent, dispatcher) {

--- a/src/ol/pointer/MsSource.js
+++ b/src/ol/pointer/MsSource.js
@@ -35,9 +35,9 @@ import {inherits} from '../index.js';
 import EventSource from '../pointer/EventSource.js';
 
 /**
- * @param {module:ol/pointer/PointerEventHandler~PointerEventHandler} dispatcher Event handler.
+ * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
  * @constructor
- * @extends {module:ol/pointer/EventSource~EventSource}
+ * @extends {module:ol/pointer/EventSource}
  */
 const MsSource = function(dispatcher) {
   const mapping = {

--- a/src/ol/pointer/NativeSource.js
+++ b/src/ol/pointer/NativeSource.js
@@ -35,9 +35,9 @@ import {inherits} from '../index.js';
 import EventSource from '../pointer/EventSource.js';
 
 /**
- * @param {module:ol/pointer/PointerEventHandler~PointerEventHandler} dispatcher Event handler.
+ * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
  * @constructor
- * @extends {module:ol/pointer/EventSource~EventSource}
+ * @extends {module:ol/pointer/EventSource}
  */
 const NativeSource = function(dispatcher) {
   const mapping = {

--- a/src/ol/pointer/PointerEvent.js
+++ b/src/ol/pointer/PointerEvent.js
@@ -41,7 +41,7 @@ import Event from '../events/Event.js';
  * touch events and even native pointer events.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @param {string} type The type of the event to create.
  * @param {Event} originalEvent The event.
  * @param {Object.<string, ?>=} opt_eventDict An optional dictionary of

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -44,7 +44,7 @@ import TouchSource from '../pointer/TouchSource.js';
 
 /**
  * @constructor
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  * @param {Element|HTMLDocument} element Viewport element.
  */
 const PointerEventHandler = function(element) {
@@ -70,7 +70,7 @@ const PointerEventHandler = function(element) {
   this.eventMap_ = {};
 
   /**
-   * @type {Array.<module:ol/pointer/EventSource~EventSource>}
+   * @type {Array.<module:ol/pointer/EventSource>}
    * @private
    */
   this.eventSourceList_ = [];
@@ -147,7 +147,7 @@ PointerEventHandler.prototype.registerSources = function() {
  * Add a new event source that will generate pointer events.
  *
  * @param {string} name A name for the event source
- * @param {module:ol/pointer/EventSource~EventSource} source The source event.
+ * @param {module:ol/pointer/EventSource} source The source event.
  */
 PointerEventHandler.prototype.registerSource = function(name, source) {
   const s = source;
@@ -388,7 +388,7 @@ PointerEventHandler.prototype.contains_ = function(container, contained) {
  * @param {string} inType A string representing the type of event to create.
  * @param {Object} data Pointer event data.
  * @param {Event} event The event.
- * @return {module:ol/pointer/PointerEvent~PointerEvent} A PointerEvent of type `inType`.
+ * @return {module:ol/pointer/PointerEvent} A PointerEvent of type `inType`.
  */
 PointerEventHandler.prototype.makeEvent = function(inType, data, event) {
   return new PointerEvent(inType, event, data);
@@ -423,7 +423,7 @@ PointerEventHandler.prototype.fireNativeEvent = function(event) {
  * This proxy method is required for the legacy IE support.
  * @param {string} eventType The pointer event type.
  * @param {Event} event The event.
- * @return {module:ol/pointer/PointerEvent~PointerEvent} The wrapped event.
+ * @return {module:ol/pointer/PointerEvent} The wrapped event.
  */
 PointerEventHandler.prototype.wrapMouseEvent = function(eventType, event) {
   const pointerEvent = this.makeEvent(

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -39,9 +39,9 @@ import {POINTER_ID} from '../pointer/MouseSource.js';
 
 /**
  * @constructor
- * @param {module:ol/pointer/PointerEventHandler~PointerEventHandler} dispatcher The event handler.
- * @param {module:ol/pointer/MouseSource~MouseSource} mouseSource Mouse source.
- * @extends {module:ol/pointer/EventSource~EventSource}
+ * @param {module:ol/pointer/PointerEventHandler} dispatcher The event handler.
+ * @param {module:ol/pointer/MouseSource} mouseSource Mouse source.
+ * @extends {module:ol/pointer/EventSource}
  */
 const TouchSource = function(dispatcher, mouseSource) {
   const mapping = {
@@ -60,7 +60,7 @@ const TouchSource = function(dispatcher, mouseSource) {
 
   /**
    * @const
-   * @type {module:ol/pointer/MouseSource~MouseSource}
+   * @type {module:ol/pointer/MouseSource}
    */
   this.mouseSource = mouseSource;
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -13,9 +13,9 @@ import {add as addTransformFunc, clear as clearTransformFuncs, get as getTransfo
 
 
 /**
- * A projection as {@link module:ol/proj/Projection~Projection}, SRS identifier
+ * A projection as {@link module:ol/proj/Projection}, SRS identifier
  * string or undefined.
- * @typedef {module:ol/proj/Projection~Projection|string|undefined} ProjectionLike
+ * @typedef {module:ol/proj/Projection|string|undefined} ProjectionLike
  * @api
  */
 
@@ -34,7 +34,7 @@ import {add as addTransformFunc, clear as clearTransformFuncs, get as getTransfo
 /**
  * Meters per unit lookup table.
  * @const
- * @type {Object.<module:ol/proj/Units~Units, number>}
+ * @type {Object.<module:ol/proj/Units, number>}
  * @api
  */
 export {METERS_PER_UNIT};
@@ -82,7 +82,7 @@ export function identityTransform(input, opt_output, opt_dimension) {
  * Add a Projection object to the list of supported projections that can be
  * looked up by their code.
  *
- * @param {module:ol/proj/Projection~Projection} projection Projection instance.
+ * @param {module:ol/proj/Projection} projection Projection instance.
  * @api
  */
 export function addProjection(projection) {
@@ -92,7 +92,7 @@ export function addProjection(projection) {
 
 
 /**
- * @param {Array.<module:ol/proj/Projection~Projection>} projections Projections.
+ * @param {Array.<module:ol/proj/Projection>} projections Projections.
  */
 export function addProjections(projections) {
   projections.forEach(addProjection);
@@ -105,7 +105,7 @@ export function addProjections(projections) {
  * @param {module:ol/proj~ProjectionLike} projectionLike Either a code string which is
  *     a combination of authority and identifier such as "EPSG:4326", or an
  *     existing projection object, or undefined.
- * @return {module:ol/proj/Projection~Projection} Projection object, or null if not in list.
+ * @return {module:ol/proj/Projection} Projection object, or null if not in list.
  * @api
  */
 export function get(projectionLike) {
@@ -135,7 +135,7 @@ export function get(projectionLike) {
  * @param {module:ol/proj~ProjectionLike} projection The projection.
  * @param {number} resolution Nominal resolution in projection units.
  * @param {module:ol/coordinate~Coordinate} point Point to find adjusted resolution at.
- * @param {module:ol/proj/Units~Units=} opt_units Units to get the point resolution in.
+ * @param {module:ol/proj/Units=} opt_units Units to get the point resolution in.
  * Default is the projection's units.
  * @return {number} Point resolution.
  * @api
@@ -181,7 +181,7 @@ export function getPointResolution(projection, resolution, point, opt_units) {
  * Registers transformation functions that don't alter coordinates. Those allow
  * to transform between projections with equal meaning.
  *
- * @param {Array.<module:ol/proj/Projection~Projection>} projections Projections.
+ * @param {Array.<module:ol/proj/Projection>} projections Projections.
  * @api
  */
 export function addEquivalentProjections(projections) {
@@ -200,9 +200,9 @@ export function addEquivalentProjections(projections) {
  * Registers transformation functions to convert coordinates in any projection
  * in projection1 to any projection in projection2.
  *
- * @param {Array.<module:ol/proj/Projection~Projection>} projections1 Projections with equal
+ * @param {Array.<module:ol/proj/Projection>} projections1 Projections with equal
  *     meaning.
- * @param {Array.<module:ol/proj/Projection~Projection>} projections2 Projections with equal
+ * @param {Array.<module:ol/proj/Projection>} projections2 Projections with equal
  *     meaning.
  * @param {module:ol/proj~TransformFunction} forwardTransform Transformation from any
  *   projection in projection1 to any projection in projection2.
@@ -229,9 +229,9 @@ export function clearAllProjections() {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection|string|undefined} projection Projection.
+ * @param {module:ol/proj/Projection|string|undefined} projection Projection.
  * @param {string} defaultCode Default code.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 export function createProjection(projection, defaultCode) {
   if (!projection) {
@@ -239,7 +239,9 @@ export function createProjection(projection, defaultCode) {
   } else if (typeof projection === 'string') {
     return get(projection);
   } else {
-    return /** @type {module:ol/proj/Projection~Projection} */ (projection);
+    return (
+      /** @type {module:ol/proj/Projection} */ (projection)
+    );
   }
 }
 
@@ -344,8 +346,8 @@ export function toLonLat(coordinate, opt_projection) {
  * projection does represent the same geographic point as the same coordinate in
  * the other projection.
  *
- * @param {module:ol/proj/Projection~Projection} projection1 Projection 1.
- * @param {module:ol/proj/Projection~Projection} projection2 Projection 2.
+ * @param {module:ol/proj/Projection} projection1 Projection 1.
+ * @param {module:ol/proj/Projection} projection2 Projection 2.
  * @return {boolean} Equivalent.
  * @api
  */
@@ -367,8 +369,8 @@ export function equivalent(projection1, projection2) {
  * Searches in the list of transform functions for the function for converting
  * coordinates from the source projection to the destination projection.
  *
- * @param {module:ol/proj/Projection~Projection} sourceProjection Source Projection object.
- * @param {module:ol/proj/Projection~Projection} destinationProjection Destination Projection
+ * @param {module:ol/proj/Projection} sourceProjection Source Projection object.
+ * @param {module:ol/proj/Projection} destinationProjection Destination Projection
  *     object.
  * @return {module:ol/proj~TransformFunction} Transform function.
  */
@@ -440,8 +442,8 @@ export function transformExtent(extent, source, destination) {
  * Transforms the given point to the destination projection.
  *
  * @param {module:ol/coordinate~Coordinate} point Point.
- * @param {module:ol/proj/Projection~Projection} sourceProjection Source projection.
- * @param {module:ol/proj/Projection~Projection} destinationProjection Destination projection.
+ * @param {module:ol/proj/Projection} sourceProjection Source projection.
+ * @param {module:ol/proj/Projection} destinationProjection Destination projection.
  * @return {module:ol/coordinate~Coordinate} Point.
  */
 export function transformWithProjections(point, sourceProjection, destinationProjection) {

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -7,7 +7,7 @@ import {METERS_PER_UNIT} from '../proj/Units.js';
 /**
  * @typedef {Object} Options
  * @property {string} code The SRS identifier code, e.g. `EPSG:4326`.
- * @property {module:ol/proj/Units~Units|string} [units] Units. Required unless a
+ * @property {module:ol/proj/Units|string} [units] Units. Required unless a
  * proj4 projection is defined for `code`.
  * @property {module:ol/extent~Extent} [extent] The validity extent for the SRS.
  * @property {string} [axisOrientation='enu'] The axis orientation as specified in Proj4.
@@ -66,9 +66,9 @@ const Projection = function(options) {
    * `this.extent_` and `this.worldExtent_` must be configured properly for each
    * tile.
    * @private
-   * @type {module:ol/proj/Units~Units}
+   * @type {module:ol/proj/Units}
    */
-  this.units_ = /** @type {module:ol/proj/Units~Units} */ (options.units);
+  this.units_ = /** @type {module:ol/proj/Units} */ (options.units);
 
   /**
    * Validity extent of the projection in projected coordinates. For projections
@@ -116,7 +116,7 @@ const Projection = function(options) {
 
   /**
    * @private
-   * @type {module:ol/tilegrid/TileGrid~TileGrid}
+   * @type {module:ol/tilegrid/TileGrid}
    */
   this.defaultTileGrid_ = null;
 
@@ -158,7 +158,7 @@ Projection.prototype.getExtent = function() {
 
 /**
  * Get the units of this projection.
- * @return {module:ol/proj/Units~Units} Units.
+ * @return {module:ol/proj/Units} Units.
  * @api
  */
 Projection.prototype.getUnits = function() {
@@ -226,7 +226,7 @@ Projection.prototype.setGlobal = function(global) {
 
 
 /**
- * @return {module:ol/tilegrid/TileGrid~TileGrid} The default tile grid.
+ * @return {module:ol/tilegrid/TileGrid} The default tile grid.
  */
 Projection.prototype.getDefaultTileGrid = function() {
   return this.defaultTileGrid_;
@@ -234,7 +234,7 @@ Projection.prototype.getDefaultTileGrid = function() {
 
 
 /**
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid The default tile grid.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid The default tile grid.
  */
 Projection.prototype.setDefaultTileGrid = function(tileGrid) {
   this.defaultTileGrid_ = tileGrid;

--- a/src/ol/proj/Units.js
+++ b/src/ol/proj/Units.js
@@ -20,7 +20,7 @@ const Units = {
 /**
  * Meters per unit lookup table.
  * @const
- * @type {Object.<module:ol/proj/Units~Units, number>}
+ * @type {Object.<module:ol/proj/Units, number>}
  * @api
  */
 export const METERS_PER_UNIT = {};

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -45,7 +45,7 @@ export const WORLD_EXTENT = [-180, -85, 180, 85];
  * Projection object for web/spherical Mercator (EPSG:3857).
  *
  * @constructor
- * @extends {module:ol/proj/Projection~Projection}
+ * @extends {module:ol/proj/Projection}
  * @param {string} code Code.
  */
 function EPSG3857Projection(code) {
@@ -67,7 +67,7 @@ inherits(EPSG3857Projection, Projection);
  * Projections equal to EPSG:3857.
  *
  * @const
- * @type {Array.<module:ol/proj/Projection~Projection>}
+ * @type {Array.<module:ol/proj/Projection>}
  */
 export const PROJECTIONS = [
   new EPSG3857Projection('EPSG:3857'),

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -40,7 +40,7 @@ export const METERS_PER_UNIT = Math.PI * RADIUS / 180;
  * OpenLayers treats EPSG:4326 as a pseudo-projection, with x,y coordinates.
  *
  * @constructor
- * @extends {module:ol/proj/Projection~Projection}
+ * @extends {module:ol/proj/Projection}
  * @param {string} code Code.
  * @param {string=} opt_axisOrientation Axis orientation.
  */
@@ -62,7 +62,7 @@ inherits(EPSG4326Projection, Projection);
  * Projections equal to EPSG:4326.
  *
  * @const
- * @type {Array.<module:ol/proj/Projection~Projection>}
+ * @type {Array.<module:ol/proj/Projection>}
  */
 export const PROJECTIONS = [
   new EPSG4326Projection('CRS:84'),

--- a/src/ol/proj/projections.js
+++ b/src/ol/proj/projections.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @type {Object.<string, module:ol/proj/Projection~Projection>}
+ * @type {Object.<string, module:ol/proj/Projection>}
  */
 let cache = {};
 
@@ -20,7 +20,7 @@ export function clear() {
 /**
  * Get a cached projection by code.
  * @param {string} code The code for the projection.
- * @return {module:ol/proj/Projection~Projection} The projection (if cached).
+ * @return {module:ol/proj/Projection} The projection (if cached).
  */
 export function get(code) {
   return cache[code] || null;
@@ -30,7 +30,7 @@ export function get(code) {
 /**
  * Add a projection to the cache.
  * @param {string} code The projection code.
- * @param {module:ol/proj/Projection~Projection} projection The projection to cache.
+ * @param {module:ol/proj/Projection} projection The projection to cache.
  */
 export function add(code, projection) {
   cache[code] = projection;

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -23,8 +23,8 @@ export function clear() {
  * Registers a conversion function to convert coordinates from the source
  * projection to the destination projection.
  *
- * @param {module:ol/proj/Projection~Projection} source Source.
- * @param {module:ol/proj/Projection~Projection} destination Destination.
+ * @param {module:ol/proj/Projection} source Source.
+ * @param {module:ol/proj/Projection} destination Destination.
  * @param {module:ol/proj~TransformFunction} transformFn Transform.
  */
 export function add(source, destination, transformFn) {
@@ -42,8 +42,8 @@ export function add(source, destination, transformFn) {
  * projection to the destination projection.  This method is used to clean up
  * cached transforms during testing.
  *
- * @param {module:ol/proj/Projection~Projection} source Source projection.
- * @param {module:ol/proj/Projection~Projection} destination Destination projection.
+ * @param {module:ol/proj/Projection} source Source projection.
+ * @param {module:ol/proj/Projection} destination Destination projection.
  * @return {module:ol/proj~TransformFunction} transformFn The unregistered transform.
  */
 export function remove(source, destination) {

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -9,8 +9,8 @@ import CanvasImmediateRenderer from './render/canvas/Immediate.js';
 /**
  * @typedef {Object} State
  * @property {CanvasRenderingContext2D} context Canvas context that the layer is being rendered to.
- * @property {module:ol/Feature~Feature|module:ol/render/Feature~Feature} feature
- * @property {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry
+ * @property {module:ol/Feature|module:ol/render/Feature~Feature} feature
+ * @property {module:ol/geom/SimpleGeometry} geometry
  * @property {number} pixelRatio Pixel ratio used by the layer renderer.
  * @property {number} resolution Resolution that the render batch was created and optimized for.
  * This is not the view's resolution that is being rendered.
@@ -23,8 +23,8 @@ import CanvasImmediateRenderer from './render/canvas/Immediate.js';
  * It takes two instances of {@link module:ol/Feature} or
  * {@link module:ol/render/Feature} and returns a `{number}`.
  *
- * @typedef {function((module:ol/Feature~Feature|module:ol/render/Feature~Feature),
- *           (module:ol/Feature~Feature|module:ol/render/Feature~Feature)):number} OrderFunction
+ * @typedef {function((module:ol/Feature|module:ol/render/Feature~Feature),
+ *           (module:ol/Feature|module:ol/render/Feature~Feature)):number} OrderFunction
  */
 
 

--- a/src/ol/render/Box.js
+++ b/src/ol/render/Box.js
@@ -9,13 +9,13 @@ import Polygon from '../geom/Polygon.js';
 
 /**
  * @constructor
- * @extends {module:ol/Disposable~Disposable}
+ * @extends {module:ol/Disposable}
  * @param {string} className CSS class name.
  */
 const RenderBox = function(className) {
 
   /**
-   * @type {module:ol/geom/Polygon~Polygon}
+   * @type {module:ol/geom/Polygon}
    * @private
    */
   this.geometry_ = null;
@@ -30,7 +30,7 @@ const RenderBox = function(className) {
 
   /**
    * @private
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    */
   this.map_ = null;
 
@@ -75,7 +75,7 @@ RenderBox.prototype.render_ = function() {
 
 
 /**
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  */
 RenderBox.prototype.setMap = function(map) {
   if (this.map_) {
@@ -126,7 +126,7 @@ RenderBox.prototype.createOrUpdateGeometry = function() {
 
 
 /**
- * @return {module:ol/geom/Polygon~Polygon} Geometry.
+ * @return {module:ol/geom/Polygon} Geometry.
  */
 RenderBox.prototype.getGeometry = function() {
   return this.geometry_;

--- a/src/ol/render/Event.js
+++ b/src/ol/render/Event.js
@@ -6,13 +6,13 @@ import Event from '../events/Event.js';
 
 /**
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.render.Event}
  * @param {module:ol/render/EventType~EventType} type Type.
- * @param {module:ol/render/VectorContext~VectorContext=} opt_vectorContext Vector context.
+ * @param {module:ol/render/VectorContext=} opt_vectorContext Vector context.
  * @param {module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
  * @param {?CanvasRenderingContext2D=} opt_context Context.
- * @param {?module:ol/webgl/Context~WebGLContext=} opt_glContext WebGL Context.
+ * @param {?module:ol/webgl/Context=} opt_glContext WebGL Context.
  */
 const RenderEvent = function(
   type, opt_vectorContext, opt_frameState, opt_context,
@@ -22,7 +22,7 @@ const RenderEvent = function(
 
   /**
    * For canvas, this is an instance of {@link ol.render.canvas.Immediate}.
-   * @type {module:ol/render/VectorContext~VectorContext|undefined}
+   * @type {module:ol/render/VectorContext|undefined}
    * @api
    */
   this.vectorContext = opt_vectorContext;
@@ -45,7 +45,7 @@ const RenderEvent = function(
   /**
    * WebGL context. Only available when a WebGL renderer is used, null
    * otherwise.
-   * @type {module:ol/webgl/Context~WebGLContext|null|undefined}
+   * @type {module:ol/webgl/Context|null|undefined}
    * @api
    */
   this.glContext = opt_glContext;

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -207,7 +207,7 @@ RenderFeature.prototype.getFlatCoordinates =
 /**
  * For API compatibility with {@link module:ol/Feature~Feature}, this method is useful when
  * determining the geometry type in style function (see {@link #getType}).
- * @return {module:ol/render/Feature~RenderFeature} Feature.
+ * @return {module:ol/render/Feature} Feature.
  * @api
  */
 RenderFeature.prototype.getGeometry = function() {
@@ -227,7 +227,7 @@ RenderFeature.prototype.getProperties = function() {
 
 /**
  * Get the feature for working with its geometry.
- * @return {module:ol/render/Feature~RenderFeature} Feature.
+ * @return {module:ol/render/Feature} Feature.
  */
 RenderFeature.prototype.getSimplifiedGeometry =
     RenderFeature.prototype.getGeometry;

--- a/src/ol/render/ReplayGroup.js
+++ b/src/ol/render/ReplayGroup.js
@@ -13,7 +13,7 @@ const ReplayGroup = function() {};
  * @abstract
  * @param {number|undefined} zIndex Z index.
  * @param {module:ol/render/ReplayType~ReplayType} replayType Replay type.
- * @return {module:ol/render/VectorContext~VectorContext} Replay.
+ * @return {module:ol/render/VectorContext} Replay.
  */
 ReplayGroup.prototype.getReplay = function(zIndex, replayType) {};
 

--- a/src/ol/render/VectorContext.js
+++ b/src/ol/render/VectorContext.js
@@ -16,8 +16,8 @@ const VectorContext = function() {
 /**
  * Render a geometry with a custom renderer.
  *
- * @param {module:ol/geom/SimpleGeometry~SimpleGeometry} geometry Geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  * @param {Function} renderer Renderer.
  */
 VectorContext.prototype.drawCustom = function(geometry, feature, renderer) {};
@@ -26,7 +26,7 @@ VectorContext.prototype.drawCustom = function(geometry, feature, renderer) {};
 /**
  * Render a geometry.
  *
- * @param {module:ol/geom/Geometry~Geometry} geometry The geometry to render.
+ * @param {module:ol/geom/Geometry} geometry The geometry to render.
  */
 VectorContext.prototype.drawGeometry = function(geometry) {};
 
@@ -34,98 +34,98 @@ VectorContext.prototype.drawGeometry = function(geometry) {};
 /**
  * Set the rendering style.
  *
- * @param {module:ol/style/Style~Style} style The rendering style.
+ * @param {module:ol/style/Style} style The rendering style.
  */
 VectorContext.prototype.setStyle = function(style) {};
 
 
 /**
- * @param {module:ol/geom/Circle~Circle} circleGeometry Circle geometry.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/geom/Circle} circleGeometry Circle geometry.
+ * @param {module:ol/Feature} feature Feature.
  */
 VectorContext.prototype.drawCircle = function(circleGeometry, feature) {};
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
- * @param {module:ol/style/Style~Style} style Style.
+ * @param {module:ol/Feature} feature Feature.
+ * @param {module:ol/style/Style} style Style.
  */
 VectorContext.prototype.drawFeature = function(feature, style) {};
 
 
 /**
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geometryCollectionGeometry Geometry
+ * @param {module:ol/geom/GeometryCollection} geometryCollectionGeometry Geometry
  *     collection.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  */
 VectorContext.prototype.drawGeometryCollection = function(geometryCollectionGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/LineString~LineString|module:ol/render/Feature~RenderFeature} lineStringGeometry Line string geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/LineString|module:ol/render/Feature} lineStringGeometry Line string geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawLineString = function(lineStringGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/MultiLineString~MultiLineString|module:ol/render/Feature~RenderFeature} multiLineStringGeometry MultiLineString geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/MultiLineString|module:ol/render/Feature} multiLineStringGeometry MultiLineString geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawMultiLineString = function(multiLineStringGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/MultiPoint~MultiPoint|module:ol/render/Feature~RenderFeature} multiPointGeometry MultiPoint geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/MultiPoint|module:ol/render/Feature} multiPointGeometry MultiPoint geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawMultiPoint = function(multiPointGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} multiPolygonGeometry MultiPolygon geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/MultiPolygon} multiPolygonGeometry MultiPolygon geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawMultiPolygon = function(multiPolygonGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/Point~Point|module:ol/render/Feature~RenderFeature} pointGeometry Point geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/Point|module:ol/render/Feature} pointGeometry Point geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawPoint = function(pointGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/Polygon~Polygon|module:ol/render/Feature~RenderFeature} polygonGeometry Polygon geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/Polygon|module:ol/render/Feature} polygonGeometry Polygon geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawPolygon = function(polygonGeometry, feature) {};
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 VectorContext.prototype.drawText = function(geometry, feature) {};
 
 
 /**
- * @param {module:ol/style/Fill~Fill} fillStyle Fill style.
- * @param {module:ol/style/Stroke~Stroke} strokeStyle Stroke style.
+ * @param {module:ol/style/Fill} fillStyle Fill style.
+ * @param {module:ol/style/Stroke} strokeStyle Stroke style.
  */
 VectorContext.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {};
 
 
 /**
- * @param {module:ol/style/Image~ImageStyle} imageStyle Image style.
+ * @param {module:ol/style/Image} imageStyle Image style.
  * @param {module:ol/render/canvas~DeclutterGroup=} opt_declutterGroup Declutter.
  */
 VectorContext.prototype.setImageStyle = function(imageStyle, opt_declutterGroup) {};
 
 
 /**
- * @param {module:ol/style/Text~Text} textStyle Text style.
+ * @param {module:ol/style/Text} textStyle Text style.
  * @param {module:ol/render/canvas~DeclutterGroup=} opt_declutterGroup Declutter.
  */
 VectorContext.prototype.setTextStyle = function(textStyle, opt_declutterGroup) {};

--- a/src/ol/render/canvas/ImageReplay.js
+++ b/src/ol/render/canvas/ImageReplay.js
@@ -7,7 +7,7 @@ import CanvasReplay from '../canvas/Replay.js';
 
 /**
  * @constructor
- * @extends {module:ol/render/canvas/Replay~CanvasReplay}
+ * @extends {module:ol/render/canvas/Replay}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Maximum extent.
  * @param {number} resolution Resolution.

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -19,7 +19,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 
 /**
  * @classdesc
- * A concrete subclass of {@link module:ol/render/VectorContext~VectorContext} that implements
+ * A concrete subclass of {@link module:ol/render/VectorContext} that implements
  * direct rendering of features and geometries to an HTML5 Canvas context.
  * Instances of this class are created internally by the library and
  * provided to application code as vectorContext member of the
@@ -27,7 +27,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
  * render events emitted by layers and maps.
  *
  * @constructor
- * @extends {module:ol/render/VectorContext~VectorContext}
+ * @extends {module:ol/render/VectorContext}
  * @param {CanvasRenderingContext2D} context Context.
  * @param {number} pixelRatio Pixel ratio.
  * @param {module:ol/extent~Extent} extent Extent.
@@ -394,7 +394,7 @@ CanvasImmediateRenderer.prototype.drawRings_ = function(flatCoordinates, offset,
  * Render a circle geometry into the canvas.  Rendering is immediate and uses
  * the current fill and stroke styles.
  *
- * @param {module:ol/geom/Circle~Circle} geometry Circle geometry.
+ * @param {module:ol/geom/Circle} geometry Circle geometry.
  * @override
  * @api
  */
@@ -435,7 +435,7 @@ CanvasImmediateRenderer.prototype.drawCircle = function(geometry) {
  * Set the rendering style.  Note that since this is an immediate rendering API,
  * any `zIndex` on the provided style will be ignored.
  *
- * @param {module:ol/style/Style~Style} style The rendering style.
+ * @param {module:ol/style/Style} style The rendering style.
  * @override
  * @api
  */
@@ -450,7 +450,7 @@ CanvasImmediateRenderer.prototype.setStyle = function(style) {
  * Render a geometry into the canvas.  Call
  * {@link ol.render.canvas.Immediate#setStyle} first to set the rendering style.
  *
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry The geometry to render.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry The geometry to render.
  * @override
  * @api
  */
@@ -458,28 +458,28 @@ CanvasImmediateRenderer.prototype.drawGeometry = function(geometry) {
   const type = geometry.getType();
   switch (type) {
     case GeometryType.POINT:
-      this.drawPoint(/** @type {module:ol/geom/Point~Point} */ (geometry));
+      this.drawPoint(/** @type {module:ol/geom/Point} */ (geometry));
       break;
     case GeometryType.LINE_STRING:
-      this.drawLineString(/** @type {module:ol/geom/LineString~LineString} */ (geometry));
+      this.drawLineString(/** @type {module:ol/geom/LineString} */ (geometry));
       break;
     case GeometryType.POLYGON:
-      this.drawPolygon(/** @type {module:ol/geom/Polygon~Polygon} */ (geometry));
+      this.drawPolygon(/** @type {module:ol/geom/Polygon} */ (geometry));
       break;
     case GeometryType.MULTI_POINT:
-      this.drawMultiPoint(/** @type {module:ol/geom/MultiPoint~MultiPoint} */ (geometry));
+      this.drawMultiPoint(/** @type {module:ol/geom/MultiPoint} */ (geometry));
       break;
     case GeometryType.MULTI_LINE_STRING:
-      this.drawMultiLineString(/** @type {module:ol/geom/MultiLineString~MultiLineString} */ (geometry));
+      this.drawMultiLineString(/** @type {module:ol/geom/MultiLineString} */ (geometry));
       break;
     case GeometryType.MULTI_POLYGON:
-      this.drawMultiPolygon(/** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry));
+      this.drawMultiPolygon(/** @type {module:ol/geom/MultiPolygon} */ (geometry));
       break;
     case GeometryType.GEOMETRY_COLLECTION:
-      this.drawGeometryCollection(/** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry));
+      this.drawGeometryCollection(/** @type {module:ol/geom/GeometryCollection} */ (geometry));
       break;
     case GeometryType.CIRCLE:
-      this.drawCircle(/** @type {module:ol/geom/Circle~Circle} */ (geometry));
+      this.drawCircle(/** @type {module:ol/geom/Circle} */ (geometry));
       break;
     default:
   }
@@ -492,8 +492,8 @@ CanvasImmediateRenderer.prototype.drawGeometry = function(geometry) {
  * this method is called.  If you need `zIndex` support, you should be using an
  * {@link module:ol/layer/Vector~VectorLayer} instead.
  *
- * @param {module:ol/Feature~Feature} feature Feature.
- * @param {module:ol/style/Style~Style} style Style.
+ * @param {module:ol/Feature} feature Feature.
+ * @param {module:ol/style/Style} style Style.
  * @override
  * @api
  */
@@ -511,7 +511,7 @@ CanvasImmediateRenderer.prototype.drawFeature = function(feature, style) {
  * Render a GeometryCollection to the canvas.  Rendering is immediate and
  * uses the current styles appropriate for each geometry in the collection.
  *
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geometry Geometry collection.
+ * @param {module:ol/geom/GeometryCollection} geometry Geometry collection.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawGeometryCollection = function(geometry) {
@@ -526,7 +526,7 @@ CanvasImmediateRenderer.prototype.drawGeometryCollection = function(geometry) {
  * Render a Point geometry into the canvas.  Rendering is immediate and uses
  * the current style.
  *
- * @param {module:ol/geom/Point~Point|module:ol/render/Feature~RenderFeature} geometry Point geometry.
+ * @param {module:ol/geom/Point|module:ol/render/Feature} geometry Point geometry.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawPoint = function(geometry) {
@@ -545,7 +545,7 @@ CanvasImmediateRenderer.prototype.drawPoint = function(geometry) {
  * Render a MultiPoint geometry  into the canvas.  Rendering is immediate and
  * uses the current style.
  *
- * @param {module:ol/geom/MultiPoint~MultiPoint|module:ol/render/Feature~RenderFeature} geometry MultiPoint geometry.
+ * @param {module:ol/geom/MultiPoint|module:ol/render/Feature} geometry MultiPoint geometry.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawMultiPoint = function(geometry) {
@@ -564,7 +564,7 @@ CanvasImmediateRenderer.prototype.drawMultiPoint = function(geometry) {
  * Render a LineString into the canvas.  Rendering is immediate and uses
  * the current style.
  *
- * @param {module:ol/geom/LineString~LineString|module:ol/render/Feature~RenderFeature} geometry LineString geometry.
+ * @param {module:ol/geom/LineString|module:ol/render/Feature} geometry LineString geometry.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawLineString = function(geometry) {
@@ -591,7 +591,7 @@ CanvasImmediateRenderer.prototype.drawLineString = function(geometry) {
  * Render a MultiLineString geometry into the canvas.  Rendering is immediate
  * and uses the current style.
  *
- * @param {module:ol/geom/MultiLineString~MultiLineString|module:ol/render/Feature~RenderFeature} geometry MultiLineString geometry.
+ * @param {module:ol/geom/MultiLineString|module:ol/render/Feature} geometry MultiLineString geometry.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawMultiLineString = function(geometry) {
@@ -623,7 +623,7 @@ CanvasImmediateRenderer.prototype.drawMultiLineString = function(geometry) {
  * Render a Polygon geometry into the canvas.  Rendering is immediate and uses
  * the current style.
  *
- * @param {module:ol/geom/Polygon~Polygon|module:ol/render/Feature~RenderFeature} geometry Polygon geometry.
+ * @param {module:ol/geom/Polygon|module:ol/render/Feature} geometry Polygon geometry.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawPolygon = function(geometry) {
@@ -658,7 +658,7 @@ CanvasImmediateRenderer.prototype.drawPolygon = function(geometry) {
 /**
  * Render MultiPolygon geometry into the canvas.  Rendering is immediate and
  * uses the current style.
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry MultiPolygon geometry.
+ * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
  * @override
  */
 CanvasImmediateRenderer.prototype.drawMultiPolygon = function(geometry) {
@@ -810,8 +810,8 @@ CanvasImmediateRenderer.prototype.setContextTextState_ = function(textState) {
  * Set the fill and stroke style for subsequent draw operations.  To clear
  * either fill or stroke styles, pass null for the appropriate parameter.
  *
- * @param {module:ol/style/Fill~Fill} fillStyle Fill style.
- * @param {module:ol/style/Stroke~Stroke} strokeStyle Stroke style.
+ * @param {module:ol/style/Fill} fillStyle Fill style.
+ * @param {module:ol/style/Stroke} strokeStyle Stroke style.
  * @override
  */
 CanvasImmediateRenderer.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
@@ -858,7 +858,7 @@ CanvasImmediateRenderer.prototype.setFillStrokeStyle = function(fillStyle, strok
  * Set the image style for subsequent draw operations.  Pass null to remove
  * the image style.
  *
- * @param {module:ol/style/Image~ImageStyle} imageStyle Image style.
+ * @param {module:ol/style/Image} imageStyle Image style.
  * @override
  */
 CanvasImmediateRenderer.prototype.setImageStyle = function(imageStyle) {
@@ -890,7 +890,7 @@ CanvasImmediateRenderer.prototype.setImageStyle = function(imageStyle) {
  * Set the text style for subsequent draw operations.  Pass null to
  * remove the text style.
  *
- * @param {module:ol/style/Text~Text} textStyle Text style.
+ * @param {module:ol/style/Text} textStyle Text style.
  * @override
  */
 CanvasImmediateRenderer.prototype.setTextStyle = function(textStyle) {

--- a/src/ol/render/canvas/LineStringReplay.js
+++ b/src/ol/render/canvas/LineStringReplay.js
@@ -7,7 +7,7 @@ import CanvasReplay from '../canvas/Replay.js';
 
 /**
  * @constructor
- * @extends {module:ol/render/canvas/Replay~CanvasReplay}
+ * @extends {module:ol/render/canvas/Replay}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Maximum extent.
  * @param {number} resolution Resolution.

--- a/src/ol/render/canvas/PolygonReplay.js
+++ b/src/ol/render/canvas/PolygonReplay.js
@@ -13,7 +13,7 @@ import CanvasReplay from '../canvas/Replay.js';
 
 /**
  * @constructor
- * @extends {module:ol/render/canvas/Replay~CanvasReplay}
+ * @extends {module:ol/render/canvas/Replay}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Maximum extent.
  * @param {number} resolution Resolution.
@@ -201,7 +201,7 @@ CanvasPolygonReplay.prototype.finish = function() {
 
 /**
  * @private
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
  */
 CanvasPolygonReplay.prototype.setFillStrokeStyles_ = function(geometry) {
   const state = this.state;

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -30,7 +30,7 @@ import {
 
 /**
  * @constructor
- * @extends {module:ol/render/VectorContext~VectorContext}
+ * @extends {module:ol/render/VectorContext}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Maximum extent.
  * @param {number} resolution Resolution.
@@ -398,7 +398,7 @@ CanvasReplay.prototype.drawCustom = function(geometry, feature, renderer) {
   let flatCoordinates, replayEnd, replayEnds, replayEndss;
   let offset;
   if (type == GeometryType.MULTI_POLYGON) {
-    geometry = /** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry);
+    geometry = /** @type {module:ol/geom/MultiPolygon} */ (geometry);
     flatCoordinates = geometry.getOrientedFlatCoordinates();
     replayEndss = [];
     const endss = geometry.getEndss();
@@ -413,10 +413,10 @@ CanvasReplay.prototype.drawCustom = function(geometry, feature, renderer) {
   } else if (type == GeometryType.POLYGON || type == GeometryType.MULTI_LINE_STRING) {
     replayEnds = [];
     flatCoordinates = (type == GeometryType.POLYGON) ?
-      /** @type {module:ol/geom/Polygon~Polygon} */ (geometry).getOrientedFlatCoordinates() :
+      /** @type {module:ol/geom/Polygon} */ (geometry).getOrientedFlatCoordinates() :
       geometry.getFlatCoordinates();
     offset = this.drawCustomCoordinates_(flatCoordinates, 0,
-      /** @type {module:ol/geom/Polygon~Polygon|module:ol/geom/MultiLineString~MultiLineString} */ (geometry).getEnds(),
+      /** @type {module:ol/geom/Polygon|module:ol/geom/MultiLineString} */ (geometry).getEnds(),
       stride, replayEnds);
     this.instructions.push([CanvasInstruction.CUSTOM,
       replayBegin, replayEnds, geometry, renderer, inflateCoordinatesArray]);
@@ -439,8 +439,8 @@ CanvasReplay.prototype.drawCustom = function(geometry, feature, renderer) {
 
 /**
  * @protected
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 CanvasReplay.prototype.beginGeometry = function(geometry, feature) {
   this.beginGeometryInstruction1_ = [CanvasInstruction.BEGIN_GEOMETRY, feature, 0];
@@ -487,7 +487,7 @@ CanvasReplay.prototype.setStrokeStyle_ = function(context, instruction) {
 
 /**
  * @param {module:ol/render/canvas~DeclutterGroup} declutterGroup Declutter group.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 CanvasReplay.prototype.renderDeclutter_ = function(declutterGroup, feature) {
   if (declutterGroup && declutterGroup.length > 5) {
@@ -529,7 +529,7 @@ CanvasReplay.prototype.renderDeclutter_ = function(declutterGroup, feature) {
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
  *     to skip.
  * @param {Array.<*>} instructions Instructions array.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined}
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined}
  *     featureCallback Feature callback.
  * @param {module:ol/extent~Extent=} opt_hitExtent Only check features that intersect this
  *     extent.
@@ -575,14 +575,14 @@ CanvasReplay.prototype.replay_ = function(
   // When the batch size gets too big, performance decreases. 200 is a good
   // balance between batch size and number of fill/stroke instructions.
   const batchSize = this.instructions != instructions || this.overlaps ? 0 : 200;
-  let /** @type {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} */ feature;
+  let /** @type {module:ol/Feature|module:ol/render/Feature} */ feature;
   let x, y;
   while (i < ii) {
     const instruction = instructions[i];
-    const type = /** @type {module:ol/render/canvas/Instruction~Instruction} */ (instruction[0]);
+    const type = /** @type {module:ol/render/canvas/Instruction} */ (instruction[0]);
     switch (type) {
       case CanvasInstruction.BEGIN_GEOMETRY:
-        feature = /** @type {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} */ (instruction[1]);
+        feature = /** @type {module:ol/Feature|module:ol/render/Feature} */ (instruction[1]);
         if ((skipFeatures &&
             skippedFeaturesHash[getUid(feature).toString()]) ||
             !feature.getGeometry()) {
@@ -629,7 +629,7 @@ CanvasReplay.prototype.replay_ = function(
       case CanvasInstruction.CUSTOM:
         d = /** @type {number} */ (instruction[1]);
         dd = instruction[2];
-        const geometry = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (instruction[3]);
+        const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (instruction[3]);
         const renderer = instruction[4];
         const fn = instruction.length == 6 ? instruction[5] : undefined;
         state.geometry = geometry;
@@ -710,7 +710,7 @@ CanvasReplay.prototype.replay_ = function(
         const pathLength = lineStringLength(pixelCoordinates, begin, end, 2);
         const textLength = measure(text);
         if (overflow || textLength <= pathLength) {
-          const textAlign = /** @type {module:ol.render.canvas.TextReplay~CanvasTextReplay} */ (this).textStates[textKey].textAlign;
+          const textAlign = /** @type {module:ol~render} */ (this).textStates[textKey].textAlign;
           const startM = (pathLength - textLength) * TEXT_ALIGN[textAlign];
           const parts = drawTextOnPath(
             pixelCoordinates, begin, end, 2, text, measure, startM, maxAngle);
@@ -720,7 +720,7 @@ CanvasReplay.prototype.replay_ = function(
               for (c = 0, cc = parts.length; c < cc; ++c) {
                 part = parts[c]; // x, y, anchorX, rotation, chunk
                 chars = /** @type {string} */ (part[4]);
-                label = /** @type {module:ol.render.canvas.TextReplay~CanvasTextReplay} */ (this).getImage(chars, textKey, '', strokeKey);
+                label = /** @type {module:ol~render} */ (this).getImage(chars, textKey, '', strokeKey);
                 anchorX = /** @type {number} */ (part[2]) + strokeWidth;
                 anchorY = baseline * label.height + (0.5 - baseline) * 2 * strokeWidth - offsetY;
                 this.replayImage_(context,
@@ -734,7 +734,7 @@ CanvasReplay.prototype.replay_ = function(
               for (c = 0, cc = parts.length; c < cc; ++c) {
                 part = parts[c]; // x, y, anchorX, rotation, chunk
                 chars = /** @type {string} */ (part[4]);
-                label = /** @type {module:ol.render.canvas.TextReplay~CanvasTextReplay} */ (this).getImage(chars, textKey, fillKey, '');
+                label = /** @type {module:ol~render} */ (this).getImage(chars, textKey, fillKey, '');
                 anchorX = /** @type {number} */ (part[2]);
                 anchorY = baseline * label.height - offsetY;
                 this.replayImage_(context,
@@ -751,7 +751,7 @@ CanvasReplay.prototype.replay_ = function(
         break;
       case CanvasInstruction.END_GEOMETRY:
         if (featureCallback !== undefined) {
-          feature = /** @type {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} */ (instruction[1]);
+          feature = /** @type {module:ol/Feature|module:ol/render/Feature} */ (instruction[1]);
           const result = featureCallback(feature);
           if (result) {
             return result;
@@ -861,7 +861,7 @@ CanvasReplay.prototype.replay = function(
  * @param {number} viewRotation View rotation.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
  *     to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T=} opt_featureCallback
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T=} opt_featureCallback
  *     Feature callback.
  * @param {module:ol/extent~Extent=} opt_hitExtent Only check features that intersect this
  *     extent.
@@ -892,7 +892,7 @@ CanvasReplay.prototype.reverseHitDetectionInstructions = function() {
   let begin = -1;
   for (i = 0; i < n; ++i) {
     instruction = hitDetectionInstructions[i];
-    type = /** @type {module:ol/render/canvas/Instruction~Instruction} */ (instruction[0]);
+    type = /** @type {module:ol/render/canvas/Instruction} */ (instruction[0]);
     if (type == CanvasInstruction.END_GEOMETRY) {
       begin = i;
     } else if (type == CanvasInstruction.BEGIN_GEOMETRY) {
@@ -958,7 +958,7 @@ CanvasReplay.prototype.setFillStrokeStyle = function(fillStyle, strokeStyle) {
 
 /**
  * @param {module:ol/render/canvas~FillStrokeState} state State.
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
  * @return {Array.<*>} Fill instruction.
  */
 CanvasReplay.prototype.createFill = function(state, geometry) {
@@ -996,8 +996,8 @@ CanvasReplay.prototype.createStroke = function(state) {
 
 /**
  * @param {module:ol/render/canvas~FillStrokeState} state State.
- * @param {function(this:module:ol/render/canvas/Replay~CanvasReplay, module:ol/render/canvas~FillStrokeState, (module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature)):Array.<*>} createFill Create fill.
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
+ * @param {function(this:module:ol/render/canvas/Replay, module:ol/render/canvas~FillStrokeState, (module:ol/geom/Geometry|module:ol/render/Feature)):Array.<*>} createFill Create fill.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
  */
 CanvasReplay.prototype.updateFillStyle = function(state, createFill, geometry) {
   const fillStyle = state.fillStyle;
@@ -1012,7 +1012,7 @@ CanvasReplay.prototype.updateFillStyle = function(state, createFill, geometry) {
 
 /**
  * @param {module:ol/render/canvas~FillStrokeState} state State.
- * @param {function(this:module:ol/render/canvas/Replay~CanvasReplay, module:ol/render/canvas~FillStrokeState)} applyStroke Apply stroke.
+ * @param {function(this:module:ol/render/canvas/Replay, module:ol/render/canvas~FillStrokeState)} applyStroke Apply stroke.
  */
 CanvasReplay.prototype.updateStrokeStyle = function(state, applyStroke) {
   const strokeStyle = state.strokeStyle;
@@ -1044,8 +1044,8 @@ CanvasReplay.prototype.updateStrokeStyle = function(state, applyStroke) {
 
 
 /**
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 CanvasReplay.prototype.endGeometry = function(geometry, feature) {
   this.beginGeometryInstruction1_[2] = this.instructions.length;

--- a/src/ol/render/canvas/ReplayGroup.js
+++ b/src/ol/render/canvas/ReplayGroup.js
@@ -20,7 +20,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 
 /**
  * @type {Object.<module:ol/render/ReplayType~ReplayType,
- *                function(new: module:ol/render/canvas/Replay~CanvasReplay, number, module:ol/extent~Extent,
+ *                function(new: module:ol/render/canvas/Replay, number, module:ol/extent~Extent,
  *                number, number, boolean, Array.<module:ol/render/canvas~DeclutterGroup>)>}
  */
 const BATCH_CONSTRUCTORS = {
@@ -35,7 +35,7 @@ const BATCH_CONSTRUCTORS = {
 
 /**
  * @constructor
- * @extends {module:ol/render/ReplayGroup~ReplayGroup}
+ * @extends {module:ol/render/ReplayGroup}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Max extent.
  * @param {number} resolution Resolution.
@@ -100,7 +100,7 @@ const CanvasReplayGroup = function(
 
   /**
    * @private
-   * @type {!Object.<string, !Object.<module:ol/render/ReplayType~ReplayType, module:ol/render/canvas/Replay~CanvasReplay>>}
+   * @type {!Object.<string, !Object.<module:ol/render/ReplayType~ReplayType, module:ol/render/canvas/Replay>>}
    */
   this.replaysByZIndex_ = {};
 
@@ -287,7 +287,7 @@ CanvasReplayGroup.prototype.finish = function() {
  * @param {number} rotation Rotation.
  * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T} callback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
  * @param {Object.<string, module:ol/render/canvas~DeclutterGroup>} declutterReplays Declutter replays.
  * @return {T|undefined} Callback result.
  * @template T
@@ -332,7 +332,7 @@ CanvasReplayGroup.prototype.forEachFeatureAtCoordinate = function(
   let replayType;
 
   /**
-   * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
    * @return {?} Callback result.
    */
   function featureCallback(feature) {
@@ -431,7 +431,7 @@ CanvasReplayGroup.prototype.getReplay = function(zIndex, replayType) {
 
 
 /**
- * @return {Object.<string, Object.<module:ol/render/ReplayType~ReplayType, module:ol/render/canvas/Replay~CanvasReplay>>} Replays.
+ * @return {Object.<string, Object.<module:ol/render/ReplayType~ReplayType, module:ol/render/canvas/Replay>>} Replays.
  */
 CanvasReplayGroup.prototype.getReplays = function() {
   return this.replaysByZIndex_;

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -16,7 +16,7 @@ import TextPlacement from '../../style/TextPlacement.js';
 
 /**
  * @constructor
- * @extends {module:ol/render/canvas/Replay~CanvasReplay}
+ * @extends {module:ol/render/canvas/Replay}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Maximum extent.
  * @param {number} resolution Resolution.
@@ -226,24 +226,24 @@ CanvasTextReplay.prototype.drawText = function(geometry, feature) {
         end = flatCoordinates.length;
         break;
       case GeometryType.LINE_STRING:
-        flatCoordinates = /** @type {module:ol/geom/LineString~LineString} */ (geometry).getFlatMidpoint();
+        flatCoordinates = /** @type {module:ol/geom/LineString} */ (geometry).getFlatMidpoint();
         break;
       case GeometryType.CIRCLE:
-        flatCoordinates = /** @type {module:ol/geom/Circle~Circle} */ (geometry).getCenter();
+        flatCoordinates = /** @type {module:ol/geom/Circle} */ (geometry).getCenter();
         break;
       case GeometryType.MULTI_LINE_STRING:
-        flatCoordinates = /** @type {module:ol/geom/MultiLineString~MultiLineString} */ (geometry).getFlatMidpoints();
+        flatCoordinates = /** @type {module:ol/geom/MultiLineString} */ (geometry).getFlatMidpoints();
         end = flatCoordinates.length;
         break;
       case GeometryType.POLYGON:
-        flatCoordinates = /** @type {module:ol/geom/Polygon~Polygon} */ (geometry).getFlatInteriorPoint();
+        flatCoordinates = /** @type {module:ol/geom/Polygon} */ (geometry).getFlatInteriorPoint();
         if (!textState.overflow && flatCoordinates[2] / this.resolution < width) {
           return;
         }
         stride = 3;
         break;
       case GeometryType.MULTI_POLYGON:
-        const interiorPoints = /** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry).getFlatInteriorPoints();
+        const interiorPoints = /** @type {module:ol/geom/MultiPolygon} */ (geometry).getFlatInteriorPoints();
         flatCoordinates = [];
         for (i = 0, ii = interiorPoints.length; i < ii; i += 3) {
           if (textState.overflow || interiorPoints[i + 2] / this.resolution >= width) {

--- a/src/ol/render/webgl/CircleReplay.js
+++ b/src/ol/render/webgl/CircleReplay.js
@@ -311,7 +311,7 @@ WebGLCircleReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, contex
 /**
  * @private
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object} skippedFeaturesHash Ids of features to skip.
  */
 WebGLCircleReplay.prototype.drawReplaySkipping_ = function(gl, context, skippedFeaturesHash) {

--- a/src/ol/render/webgl/Immediate.js
+++ b/src/ol/render/webgl/Immediate.js
@@ -10,8 +10,8 @@ import WebGLReplayGroup from '../webgl/ReplayGroup.js';
 
 /**
  * @constructor
- * @extends {module:ol/render/VectorContext~VectorContext}
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @extends {module:ol/render/VectorContext}
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
@@ -60,25 +60,25 @@ const WebGLImmediateRenderer = function(context, center, resolution, rotation, s
 
   /**
    * @private
-   * @type {module:ol/style/Image~ImageStyle}
+   * @type {module:ol/style/Image}
    */
   this.imageStyle_ = null;
 
   /**
    * @private
-   * @type {module:ol/style/Fill~Fill}
+   * @type {module:ol/style/Fill}
    */
   this.fillStyle_ = null;
 
   /**
    * @private
-   * @type {module:ol/style/Stroke~Stroke}
+   * @type {module:ol/style/Stroke}
    */
   this.strokeStyle_ = null;
 
   /**
    * @private
-   * @type {module:ol/style/Text~Text}
+   * @type {module:ol/style/Text}
    */
   this.textStyle_ = null;
 
@@ -89,7 +89,7 @@ inherits(WebGLImmediateRenderer, VectorContext);
 
 /**
  * @param {ol.render.webgl.ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry Geometry.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
  * @private
  */
 WebGLImmediateRenderer.prototype.drawText_ = function(replayGroup, geometry) {
@@ -115,7 +115,7 @@ WebGLImmediateRenderer.prototype.drawText_ = function(replayGroup, geometry) {
  * Set the rendering style.  Note that since this is an immediate rendering API,
  * any `zIndex` on the provided style will be ignored.
  *
- * @param {module:ol/style/Style~Style} style The rendering style.
+ * @param {module:ol/style/Style} style The rendering style.
  * @override
  * @api
  */
@@ -130,7 +130,7 @@ WebGLImmediateRenderer.prototype.setStyle = function(style) {
  * Render a geometry into the canvas.  Call
  * {@link ol.render.webgl.Immediate#setStyle} first to set the rendering style.
  *
- * @param {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature} geometry The geometry to render.
+ * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry The geometry to render.
  * @override
  * @api
  */
@@ -138,28 +138,28 @@ WebGLImmediateRenderer.prototype.drawGeometry = function(geometry) {
   const type = geometry.getType();
   switch (type) {
     case GeometryType.POINT:
-      this.drawPoint(/** @type {module:ol/geom/Point~Point} */ (geometry), null);
+      this.drawPoint(/** @type {module:ol/geom/Point} */ (geometry), null);
       break;
     case GeometryType.LINE_STRING:
-      this.drawLineString(/** @type {module:ol/geom/LineString~LineString} */ (geometry), null);
+      this.drawLineString(/** @type {module:ol/geom/LineString} */ (geometry), null);
       break;
     case GeometryType.POLYGON:
-      this.drawPolygon(/** @type {module:ol/geom/Polygon~Polygon} */ (geometry), null);
+      this.drawPolygon(/** @type {module:ol/geom/Polygon} */ (geometry), null);
       break;
     case GeometryType.MULTI_POINT:
-      this.drawMultiPoint(/** @type {module:ol/geom/MultiPoint~MultiPoint} */ (geometry), null);
+      this.drawMultiPoint(/** @type {module:ol/geom/MultiPoint} */ (geometry), null);
       break;
     case GeometryType.MULTI_LINE_STRING:
-      this.drawMultiLineString(/** @type {module:ol/geom/MultiLineString~MultiLineString} */ (geometry), null);
+      this.drawMultiLineString(/** @type {module:ol/geom/MultiLineString} */ (geometry), null);
       break;
     case GeometryType.MULTI_POLYGON:
-      this.drawMultiPolygon(/** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry), null);
+      this.drawMultiPolygon(/** @type {module:ol/geom/MultiPolygon} */ (geometry), null);
       break;
     case GeometryType.GEOMETRY_COLLECTION:
-      this.drawGeometryCollection(/** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry), null);
+      this.drawGeometryCollection(/** @type {module:ol/geom/GeometryCollection} */ (geometry), null);
       break;
     case GeometryType.CIRCLE:
-      this.drawCircle(/** @type {module:ol/geom/Circle~Circle} */ (geometry), null);
+      this.drawCircle(/** @type {module:ol/geom/Circle} */ (geometry), null);
       break;
     default:
       // pass

--- a/src/ol/render/webgl/LineStringReplay.js
+++ b/src/ol/render/webgl/LineStringReplay.js
@@ -396,7 +396,7 @@ WebGLLineStringReplay.prototype.drawPolygonCoordinates = function(
 
 
 /**
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  * @param {number=} opt_index Index count.
  */
 WebGLLineStringReplay.prototype.setPolygonStyle = function(feature, opt_index) {
@@ -549,7 +549,7 @@ WebGLLineStringReplay.prototype.drawReplay = function(gl, context, skippedFeatur
 /**
  * @private
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object} skippedFeaturesHash Ids of features to skip.
  */
 WebGLLineStringReplay.prototype.drawReplaySkipping_ = function(gl, context, skippedFeaturesHash) {

--- a/src/ol/render/webgl/PolygonReplay.js
+++ b/src/ol/render/webgl/PolygonReplay.js
@@ -1002,7 +1002,7 @@ WebGLPolygonReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, conte
 /**
  * @private
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object} skippedFeaturesHash Ids of features to skip.
  */
 WebGLPolygonReplay.prototype.drawReplaySkipping_ = function(gl, context, skippedFeaturesHash) {

--- a/src/ol/render/webgl/Replay.js
+++ b/src/ol/render/webgl/Replay.js
@@ -18,7 +18,7 @@ import {ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, TRIANGLES,
 /**
  * @constructor
  * @abstract
- * @extends {module:ol/render/VectorContext~VectorContext}
+ * @extends {module:ol/render/VectorContext}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Max extent.
  * @struct
@@ -81,7 +81,7 @@ const WebGLReplay = function(tolerance, maxExtent) {
 
   /**
    * @protected
-   * @type {?module:ol/webgl/Buffer~WebGLBuffer}
+   * @type {?module:ol/webgl/Buffer}
    */
   this.indicesBuffer = null;
 
@@ -95,7 +95,7 @@ const WebGLReplay = function(tolerance, maxExtent) {
   /**
    * Start index per feature (the feature).
    * @protected
-   * @type {Array.<module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature>}
+   * @type {Array.<module:ol/Feature|module:ol/render/Feature>}
    */
   this.startIndicesFeature = [];
 
@@ -107,7 +107,7 @@ const WebGLReplay = function(tolerance, maxExtent) {
 
   /**
    * @protected
-   * @type {?module:ol/webgl/Buffer~WebGLBuffer}
+   * @type {?module:ol/webgl/Buffer}
    */
   this.verticesBuffer = null;
 
@@ -125,7 +125,7 @@ inherits(WebGLReplay, VectorContext);
 
 /**
  * @abstract
- * @param {module:ol/webgl/Context~WebGLContext} context WebGL context.
+ * @param {module:ol/webgl/Context} context WebGL context.
  * @return {function()} Delete resources function.
  */
 WebGLReplay.prototype.getDeleteResourcesFunction = function(context) {};
@@ -133,7 +133,7 @@ WebGLReplay.prototype.getDeleteResourcesFunction = function(context) {};
 
 /**
  * @abstract
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  */
 WebGLReplay.prototype.finish = function(context) {};
 
@@ -142,7 +142,7 @@ WebGLReplay.prototype.finish = function(context) {};
  * @abstract
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/size~Size} size Size.
  * @param {number} pixelRatio Pixel ratio.
  * @return {ol.render.webgl.circlereplay.defaultshader.Locations|
@@ -169,7 +169,7 @@ WebGLReplay.prototype.shutDownProgram = function(gl, locations) {};
  * @abstract
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
  * @param {boolean} hitDetection Hit detection mode.
  */
@@ -180,9 +180,9 @@ WebGLReplay.prototype.drawReplay = function(gl, context, skippedFeaturesHash, hi
  * @abstract
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined} featureCallback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
  * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
  * @return {T|undefined} Callback result.
  * @template T
@@ -193,9 +193,9 @@ WebGLReplay.prototype.drawHitDetectionReplayOneByOne = function(gl, context, ski
 /**
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined} featureCallback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
  * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
  * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting
  *  this extent are checked.
@@ -219,9 +219,9 @@ WebGLReplay.prototype.drawHitDetectionReplay = function(gl, context, skippedFeat
 /**
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined} featureCallback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
  * @return {T|undefined} Callback result.
  * @template T
  */
@@ -240,7 +240,7 @@ WebGLReplay.prototype.drawHitDetectionReplayAll = function(gl, context, skippedF
 
 
 /**
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
@@ -248,7 +248,7 @@ WebGLReplay.prototype.drawHitDetectionReplayAll = function(gl, context, skippedF
  * @param {number} pixelRatio Pixel ratio.
  * @param {number} opacity Global opacity.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined} featureCallback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
  * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
  * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting
  *  this extent are checked.
@@ -347,7 +347,7 @@ WebGLReplay.prototype.replay = function(context,
 /**
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {number} start Start index.
  * @param {number} end End index.
  */

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -34,7 +34,7 @@ const BATCH_CONSTRUCTORS = {
 
 /**
  * @constructor
- * @extends {module:ol/render/ReplayGroup~ReplayGroup}
+ * @extends {module:ol/render/ReplayGroup}
  * @param {number} tolerance Tolerance.
  * @param {module:ol/extent~Extent} maxExtent Max extent.
  * @param {number=} opt_renderBuffer Render buffer.
@@ -74,14 +74,14 @@ inherits(WebGLReplayGroup, ReplayGroup);
 
 
 /**
- * @param {module:ol/style/Style~Style} style Style.
+ * @param {module:ol/style/Style} style Style.
  * @param {boolean} group Group with previous replay.
  */
 WebGLReplayGroup.prototype.addDeclutter = function(style, group) {};
 
 
 /**
- * @param {module:ol/webgl/Context~WebGLContext} context WebGL context.
+ * @param {module:ol/webgl/Context} context WebGL context.
  * @return {function()} Delete resources function.
  */
 WebGLReplayGroup.prototype.getDeleteResourcesFunction = function(context) {
@@ -106,7 +106,7 @@ WebGLReplayGroup.prototype.getDeleteResourcesFunction = function(context) {
 
 
 /**
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  */
 WebGLReplayGroup.prototype.finish = function(context) {
   let zKey;
@@ -151,7 +151,7 @@ WebGLReplayGroup.prototype.isEmpty = function() {
 
 
 /**
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
@@ -185,7 +185,7 @@ WebGLReplayGroup.prototype.replay = function(context,
 
 /**
  * @private
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
@@ -193,7 +193,7 @@ WebGLReplayGroup.prototype.replay = function(context,
  * @param {number} pixelRatio Pixel ratio.
  * @param {number} opacity Global opacity.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined} featureCallback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
  * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
  * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting
  *  this extent are checked.
@@ -230,7 +230,7 @@ WebGLReplayGroup.prototype.replayHitDetection_ = function(context,
 
 /**
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
@@ -238,7 +238,7 @@ WebGLReplayGroup.prototype.replayHitDetection_ = function(context,
  * @param {number} pixelRatio Pixel ratio.
  * @param {number} opacity Global opacity.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T|undefined} callback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} callback Feature callback.
  * @return {T|undefined} Callback result.
  * @template T
  */
@@ -265,7 +265,7 @@ WebGLReplayGroup.prototype.forEachFeatureAtCoordinate = function(
     coordinate, resolution, rotation, HIT_DETECTION_SIZE,
     pixelRatio, opacity, skippedFeaturesHash,
     /**
-     * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
      * @return {?} Callback result.
      */
     function(feature) {
@@ -284,7 +284,7 @@ WebGLReplayGroup.prototype.forEachFeatureAtCoordinate = function(
 
 /**
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {module:ol/coordinate~Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
@@ -305,7 +305,7 @@ WebGLReplayGroup.prototype.hasFeatureAtCoordinate = function(
     coordinate, resolution, rotation, HIT_DETECTION_SIZE,
     pixelRatio, opacity, skippedFeaturesHash,
     /**
-     * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
      * @return {boolean} Is there a feature?
      */
     function(feature) {

--- a/src/ol/render/webgl/TextReplay.js
+++ b/src/ol/render/webgl/TextReplay.js
@@ -16,7 +16,7 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 
 /**
  * @typedef {Object} GlyphAtlas
- * @property {module:ol/style/AtlasManager~AtlasManager} atlas
+ * @property {module:ol/style/AtlasManager} atlas
  * @property {Object.<string, number>} width
  * @property {number} height
  */
@@ -144,20 +144,20 @@ WebGLTextReplay.prototype.drawText = function(geometry, feature) {
         stride = geometry.getStride();
         break;
       case GeometryType.CIRCLE:
-        flatCoordinates = /** @type {module:ol/geom/Circle~Circle} */ (geometry).getCenter();
+        flatCoordinates = /** @type {module:ol/geom/Circle} */ (geometry).getCenter();
         break;
       case GeometryType.LINE_STRING:
-        flatCoordinates = /** @type {module:ol/geom/LineString~LineString} */ (geometry).getFlatMidpoint();
+        flatCoordinates = /** @type {module:ol/geom/LineString} */ (geometry).getFlatMidpoint();
         break;
       case GeometryType.MULTI_LINE_STRING:
-        flatCoordinates = /** @type {module:ol/geom/MultiLineString~MultiLineString} */ (geometry).getFlatMidpoints();
+        flatCoordinates = /** @type {module:ol/geom/MultiLineString} */ (geometry).getFlatMidpoints();
         end = flatCoordinates.length;
         break;
       case GeometryType.POLYGON:
-        flatCoordinates = /** @type {module:ol/geom/Polygon~Polygon} */ (geometry).getFlatInteriorPoint();
+        flatCoordinates = /** @type {module:ol/geom/Polygon} */ (geometry).getFlatInteriorPoint();
         break;
       case GeometryType.MULTI_POLYGON:
-        flatCoordinates = /** @type {module:ol/geom/MultiPolygon~MultiPolygon} */ (geometry).getFlatInteriorPoints();
+        flatCoordinates = /** @type {module:ol/geom/MultiPolygon} */ (geometry).getFlatInteriorPoints();
         end = flatCoordinates.length;
         break;
       default:

--- a/src/ol/render/webgl/TextureReplay.js
+++ b/src/ol/render/webgl/TextureReplay.js
@@ -362,7 +362,7 @@ WebGLTextureReplay.prototype.drawReplay = function(gl, context, skippedFeaturesH
  *
  * @protected
  * @param {WebGLRenderingContext} gl gl.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
  *  to skip.
  * @param {Array.<WebGLTexture>} textures Textures.

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -12,8 +12,8 @@ import SourceState from '../source/State.js';
 
 /**
  * @constructor
- * @extends {module:ol/Observable~Observable}
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @extends {module:ol/Observable}
+ * @param {module:ol/layer/Layer} layer Layer.
  * @struct
  */
 const LayerRenderer = function(layer) {
@@ -22,7 +22,7 @@ const LayerRenderer = function(layer) {
 
   /**
    * @private
-   * @type {module:ol/layer/Layer~Layer}
+   * @type {module:ol/layer/Layer}
    */
   this.layer_ = layer;
 
@@ -36,7 +36,7 @@ inherits(LayerRenderer, Observable);
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @param {number} hitTolerance Hit tolerance in pixels.
- * @param {function(this: S, (module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature), module:ol/layer/Layer~Layer): T}
+ * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature), module:ol/layer/Layer): T}
  *     callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|undefined} Callback result.
@@ -55,10 +55,10 @@ LayerRenderer.prototype.hasFeatureAtCoordinate = FALSE;
 
 /**
  * Create a function that adds loaded tiles to the tile lookup.
- * @param {module:ol/source/Tile~TileSource} source Tile source.
- * @param {module:ol/proj/Projection~Projection} projection Projection of the tiles.
- * @param {Object.<number, Object.<string, module:ol/Tile~Tile>>} tiles Lookup of loaded tiles by zoom level.
- * @return {function(number, module:ol/TileRange~TileRange):boolean} A function that can be
+ * @param {module:ol/source/Tile} source Tile source.
+ * @param {module:ol/proj/Projection} projection Projection of the tiles.
+ * @param {Object.<number, Object.<string, module:ol/Tile>>} tiles Lookup of loaded tiles by zoom level.
+ * @return {function(number, module:ol/TileRange):boolean} A function that can be
  *     called with a zoom level and a tile range to add loaded tiles to the lookup.
  * @protected
  */
@@ -66,7 +66,7 @@ LayerRenderer.prototype.createLoadedTileFinder = function(source, projection, ti
   return (
     /**
      * @param {number} zoom Zoom level.
-     * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+     * @param {module:ol/TileRange} tileRange Tile range.
      * @return {boolean} The tile range is fully loaded.
      */
     function(zoom, tileRange) {
@@ -77,12 +77,13 @@ LayerRenderer.prototype.createLoadedTileFinder = function(source, projection, ti
         tiles[zoom][tile.tileCoord.toString()] = tile;
       }
       return source.forEachLoadedTile(projection, zoom, tileRange, callback);
-    });
+    }
+  );
 };
 
 
 /**
- * @return {module:ol/layer/Layer~Layer} Layer.
+ * @return {module:ol/layer/Layer} Layer.
  */
 LayerRenderer.prototype.getLayer = function() {
   return this.layer_;
@@ -91,7 +92,7 @@ LayerRenderer.prototype.getLayer = function() {
 
 /**
  * Handle changes in image state.
- * @param {module:ol/events/Event~Event} event Image change event.
+ * @param {module:ol/events/Event} event Image change event.
  * @private
  */
 LayerRenderer.prototype.handleImageChange_ = function(event) {
@@ -105,7 +106,7 @@ LayerRenderer.prototype.handleImageChange_ = function(event) {
 /**
  * Load the image if not already loaded, and register the image change
  * listener if needed.
- * @param {module:ol/ImageBase~ImageBase} image Image.
+ * @param {module:ol/ImageBase} image Image.
  * @return {boolean} `true` if the image is already loaded, `false` otherwise.
  * @protected
  */
@@ -135,14 +136,14 @@ LayerRenderer.prototype.renderIfReadyAndVisible = function() {
 
 /**
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
- * @param {module:ol/source/Tile~TileSource} tileSource Tile source.
+ * @param {module:ol/source/Tile} tileSource Tile source.
  * @protected
  */
 LayerRenderer.prototype.scheduleExpireCache = function(frameState, tileSource) {
   if (tileSource.canExpireCache()) {
     /**
-     * @param {module:ol/source/Tile~TileSource} tileSource Tile source.
-     * @param {module:ol/PluggableMap~PluggableMap} map Map.
+     * @param {module:ol/source/Tile} tileSource Tile source.
+     * @param {module:ol/PluggableMap} map Map.
      * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
      */
     const postRenderFunction = function(tileSource, map, frameState) {
@@ -161,10 +162,10 @@ LayerRenderer.prototype.scheduleExpireCache = function(frameState, tileSource) {
 
 
 /**
- * @param {!Object.<string, !Object.<string, module:ol/TileRange~TileRange>>} usedTiles Used tiles.
- * @param {module:ol/source/Tile~TileSource} tileSource Tile source.
+ * @param {!Object.<string, !Object.<string, module:ol/TileRange>>} usedTiles Used tiles.
+ * @param {module:ol/source/Tile} tileSource Tile source.
  * @param {number} z Z.
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+ * @param {module:ol/TileRange} tileRange Tile range.
  * @protected
  */
 LayerRenderer.prototype.updateUsedTiles = function(usedTiles, tileSource, z, tileRange) {
@@ -192,14 +193,14 @@ LayerRenderer.prototype.updateUsedTiles = function(usedTiles, tileSource, z, til
  *   discarded by the tile queue
  * - enqueues missing tiles
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
- * @param {module:ol/source/Tile~TileSource} tileSource Tile source.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid.
+ * @param {module:ol/source/Tile} tileSource Tile source.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} currentZ Current Z.
  * @param {number} preload Load low resolution tiles up to 'preload' levels.
- * @param {function(this: T, module:ol/Tile~Tile)=} opt_tileCallback Tile callback.
+ * @param {function(this: T, module:ol/Tile)=} opt_tileCallback Tile callback.
  * @param {T=} opt_this Object to use as `this` in `opt_tileCallback`.
  * @protected
  * @template T

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -15,8 +15,8 @@ import {compose as composeTransform, invert as invertTransform, setFromArray as 
 /**
  * @constructor
  * @abstract
- * @extends {module:ol/Disposable~Disposable}
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @extends {module:ol/Disposable}
+ * @param {module:ol/PluggableMap} map Map.
  * @struct
  */
 const MapRenderer = function(map) {
@@ -24,7 +24,7 @@ const MapRenderer = function(map) {
 
   /**
    * @private
-   * @type {module:ol/PluggableMap~PluggableMap}
+   * @type {module:ol/PluggableMap}
    */
   this.map_ = map;
 
@@ -42,7 +42,7 @@ const MapRenderer = function(map) {
 
   /**
    * @private
-   * @type {Array.<module:ol/renderer/Layer~LayerRenderer>}
+   * @type {Array.<module:ol/renderer/Layer>}
    */
   this.layerRendererConstructors_ = [];
 
@@ -53,7 +53,7 @@ inherits(MapRenderer, Disposable);
 
 /**
  * Register layer renderer constructors.
- * @param {Array.<module:ol/renderer/Layer~LayerRenderer>} constructors Layer renderers.
+ * @param {Array.<module:ol/renderer/Layer>} constructors Layer renderers.
  */
 MapRenderer.prototype.registerLayerRenderers = function(constructors) {
   this.layerRendererConstructors_.push.apply(this.layerRendererConstructors_, constructors);
@@ -62,7 +62,7 @@ MapRenderer.prototype.registerLayerRenderers = function(constructors) {
 
 /**
  * Get the registered layer renderer constructors.
- * @return {Array.<module:ol/renderer/Layer~LayerRenderer>} Registered layer renderers.
+ * @return {Array.<module:ol/renderer/Layer>} Registered layer renderers.
  */
 MapRenderer.prototype.getLayerRendererConstructors = function() {
   return this.layerRendererConstructors_;
@@ -100,7 +100,7 @@ MapRenderer.prototype.removeLayerRenderers = function() {
 
 
 /**
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  */
 function expireIconCache(map, frameState) {
@@ -112,10 +112,10 @@ function expireIconCache(map, frameState) {
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
  * @param {number} hitTolerance Hit tolerance in pixels.
- * @param {function(this: S, (module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature),
- *     module:ol/layer/Layer~Layer): T} callback Feature callback.
+ * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature),
+ *     module:ol/layer/Layer): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
- * @param {function(this: U, module:ol/layer/Layer~Layer): boolean} layerFilter Layer filter
+ * @param {function(this: U, module:ol/layer/Layer): boolean} layerFilter Layer filter
  *     function, only layers which are visible and for which this function
  *     returns `true` will be tested for features.  By default, all visible
  *     layers will be tested.
@@ -130,8 +130,8 @@ MapRenderer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameSta
   const viewResolution = viewState.resolution;
 
   /**
-   * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
-   * @param {module:ol/layer/Layer~Layer} layer Layer.
+   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {module:ol/layer/Layer} layer Layer.
    * @return {?} Callback result.
    */
   function forEachFeatureAtCoordinate(feature, layer) {
@@ -181,10 +181,10 @@ MapRenderer.prototype.forEachFeatureAtCoordinate = function(coordinate, frameSta
  * @abstract
  * @param {module:ol~Pixel} pixel Pixel.
  * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
- * @param {function(this: S, module:ol/layer/Layer~Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+ * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
  *     callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
- * @param {function(this: U, module:ol/layer/Layer~Layer): boolean} layerFilter Layer filter
+ * @param {function(this: U, module:ol/layer/Layer): boolean} layerFilter Layer filter
  *     function, only layers which are visible and for which this function
  *     returns `true` will be tested for features.  By default, all visible
  *     layers will be tested.
@@ -200,7 +200,7 @@ MapRenderer.prototype.forEachLayerAtPixel = function(pixel, frameState, callback
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
  * @param {number} hitTolerance Hit tolerance in pixels.
- * @param {function(this: U, module:ol/layer/Layer~Layer): boolean} layerFilter Layer filter
+ * @param {function(this: U, module:ol/layer/Layer): boolean} layerFilter Layer filter
  *     function, only layers which are visible and for which this function
  *     returns `true` will be tested for features.  By default, all visible
  *     layers will be tested.
@@ -217,7 +217,7 @@ MapRenderer.prototype.hasFeatureAtCoordinate = function(coordinate, frameState, 
 
 
 /**
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  * @protected
  * @return {ol.renderer.Layer} Layer renderer.
  */
@@ -266,7 +266,7 @@ MapRenderer.prototype.getLayerRenderers = function() {
 
 
 /**
- * @return {module:ol/PluggableMap~PluggableMap} Map.
+ * @return {module:ol/PluggableMap} Map.
  */
 MapRenderer.prototype.getMap = function() {
   return this.map_;
@@ -306,7 +306,7 @@ MapRenderer.prototype.renderFrame = UNDEFINED;
 
 
 /**
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @private
  */

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -16,7 +16,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 /**
  * @constructor
  * @extends {ol.renderer.canvas.IntermediateCanvas}
- * @param {module:ol/layer/Image~ImageLayer} imageLayer Single image layer.
+ * @param {module:ol/layer/Image} imageLayer Single image layer.
  * @api
  */
 const CanvasImageLayerRenderer = function(imageLayer) {
@@ -25,7 +25,7 @@ const CanvasImageLayerRenderer = function(imageLayer) {
 
   /**
    * @private
-   * @type {?module:ol/ImageBase~ImageBase}
+   * @type {?module:ol/ImageBase}
    */
   this.image_ = null;
 
@@ -53,24 +53,24 @@ inherits(CanvasImageLayerRenderer, IntermediateCanvasRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasImageLayerRenderer['handles'] = function(layer) {
   return layer.getType() === LayerType.IMAGE ||
     layer.getType() === LayerType.VECTOR &&
-    /** @type {module:ol/layer/Vector~VectorLayer} */ (layer).getRenderMode() === VectorRenderType.IMAGE;
+    /** @type {module:ol/layer/Vector} */ (layer).getRenderMode() === VectorRenderType.IMAGE;
 };
 
 
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.canvas.ImageLayer} The layer renderer.
  */
 CanvasImageLayerRenderer['create'] = function(mapRenderer, layer) {
-  const renderer = new CanvasImageLayerRenderer(/** @type {module:ol/layer/Image~ImageLayer} */ (layer));
+  const renderer = new CanvasImageLayerRenderer(/** @type {module:ol/layer/Image} */ (layer));
   if (layer.getType() === LayerType.VECTOR) {
     const candidates = mapRenderer.getLayerRendererConstructors();
     for (let i = 0, ii = candidates.length; i < ii; ++i) {
@@ -124,7 +124,7 @@ CanvasImageLayerRenderer.prototype.prepareFrame = function(frameState, layerStat
   const viewResolution = viewState.resolution;
 
   let image;
-  const imageLayer = /** @type {module:ol/layer/Image~ImageLayer} */ (this.getLayer());
+  const imageLayer = /** @type {module:ol/layer/Image} */ (this.getLayer());
   const imageSource = imageLayer.getSource();
 
   const hints = frameState.viewHints;

--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -13,7 +13,7 @@ import {create as createTransform, apply as applyTransform} from '../../transfor
  * @constructor
  * @abstract
  * @extends {ol.renderer.canvas.Layer}
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  */
 const IntermediateCanvasRenderer = function(layer) {
 
@@ -107,7 +107,7 @@ IntermediateCanvasRenderer.prototype.forEachFeatureAtCoordinate = function(coord
   return source.forEachFeatureAtCoordinate(
     coordinate, resolution, rotation, hitTolerance, skippedFeatureUids,
     /**
-     * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
      * @return {?} Callback result.
      */
     function(feature) {

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -15,7 +15,7 @@ import {create as createTransform, apply as applyTransform, compose as composeTr
  * @constructor
  * @abstract
  * @extends {ol.renderer.Layer}
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  */
 const CanvasLayerRenderer = function(layer) {
 
@@ -101,7 +101,7 @@ CanvasLayerRenderer.prototype.dispatchComposeEvent_ = function(type, context, fr
 /**
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
- * @param {function(this: S, module:ol/layer/Layer~Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+ * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
  *     callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|undefined} Callback result.

--- a/src/ol/renderer/canvas/Map.js
+++ b/src/ol/renderer/canvas/Map.js
@@ -17,7 +17,7 @@ import SourceState from '../../source/State.js';
 /**
  * @constructor
  * @extends {ol.renderer.Map}
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @api
  */
 const CanvasMapRenderer = function(map) {

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -14,7 +14,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 /**
  * @constructor
  * @extends {ol.renderer.canvas.IntermediateCanvas}
- * @param {module:ol/layer/Tile~TileLayer|module:ol/layer/VectorTile~VectorTile} tileLayer Tile layer.
+ * @param {module:ol/layer/Tile|module:ol/layer/VectorTile~VectorTile} tileLayer Tile layer.
  * @api
  */
 const CanvasTileLayerRenderer = function(tileLayer) {
@@ -47,7 +47,7 @@ const CanvasTileLayerRenderer = function(tileLayer) {
 
   /**
    * @protected
-   * @type {!Array.<module:ol/Tile~Tile>}
+   * @type {!Array.<module:ol/Tile>}
    */
   this.renderedTiles = [];
 
@@ -59,7 +59,7 @@ const CanvasTileLayerRenderer = function(tileLayer) {
 
   /**
    * @private
-   * @type {module:ol/TileRange~TileRange}
+   * @type {module:ol/TileRange}
    */
   this.tmpTileRange_ = new TileRange(0, 0, 0, 0);
 
@@ -82,7 +82,7 @@ inherits(CanvasTileLayerRenderer, IntermediateCanvasRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasTileLayerRenderer['handles'] = function(layer) {
@@ -93,17 +93,17 @@ CanvasTileLayerRenderer['handles'] = function(layer) {
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.canvas.TileLayer} The layer renderer.
  */
 CanvasTileLayerRenderer['create'] = function(mapRenderer, layer) {
-  return new CanvasTileLayerRenderer(/** @type {module:ol/layer/Tile~TileLayer} */ (layer));
+  return new CanvasTileLayerRenderer(/** @type {module:ol/layer/Tile} */ (layer));
 };
 
 
 /**
  * @private
- * @param {module:ol/Tile~Tile} tile Tile.
+ * @param {module:ol/Tile} tile Tile.
  * @return {boolean} Tile is drawable.
  */
 CanvasTileLayerRenderer.prototype.isDrawableTile_ = function(tile) {
@@ -127,7 +127,7 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
   const viewCenter = viewState.center;
 
   const tileLayer = this.getLayer();
-  const tileSource = /** @type {module:ol/source/Tile~TileSource} */ (tileLayer.getSource());
+  const tileSource = /** @type {module:ol/source/Tile} */ (tileLayer.getSource());
   const sourceRevision = tileSource.getRevision();
   const tileGrid = tileSource.getTileGridForProjection(projection);
   const z = tileGrid.getZForResolution(viewResolution, this.zDirection);
@@ -149,7 +149,7 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
   const tilePixelRatio = tileSource.getTilePixelRatio(pixelRatio);
 
   /**
-   * @type {Object.<number, Object.<string, module:ol/Tile~Tile>>}
+   * @type {Object.<number, Object.<string, module:ol/Tile>>}
    */
   const tilesToDrawByZ = {};
   tilesToDrawByZ[z] = {};
@@ -296,7 +296,7 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
 
 
 /**
- * @param {module:ol/Tile~Tile} tile Tile.
+ * @param {module:ol/Tile} tile Tile.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @param {module:ol/layer/Layer~State} layerState Layer state.
  * @param {number} x Left of the tile.
@@ -346,7 +346,7 @@ CanvasTileLayerRenderer.prototype.getImage = function() {
 
 /**
  * @function
- * @return {module:ol/layer/Tile~TileLayer|module:ol/layer/VectorTile~VectorTile}
+ * @return {module:ol/layer/Tile|module:ol/layer/VectorTile~VectorTile}
  */
 CanvasTileLayerRenderer.prototype.getLayer;
 

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -18,7 +18,7 @@ import {defaultOrder as defaultRenderOrder, getTolerance as getRenderTolerance, 
 /**
  * @constructor
  * @extends {ol.renderer.canvas.Layer}
- * @param {module:ol/layer/Vector~VectorLayer} vectorLayer Vector layer.
+ * @param {module:ol/layer/Vector} vectorLayer Vector layer.
  * @api
  */
 const CanvasVectorLayerRenderer = function(vectorLayer) {
@@ -57,13 +57,13 @@ const CanvasVectorLayerRenderer = function(vectorLayer) {
 
   /**
    * @private
-   * @type {function(module:ol/Feature~Feature, module:ol/Feature~Feature): number|null}
+   * @type {function(module:ol/Feature, module:ol/Feature): number|null}
    */
   this.renderedRenderOrder_ = null;
 
   /**
    * @private
-   * @type {module:ol/render/canvas/ReplayGroup~CanvasReplayGroup}
+   * @type {module:ol/render/canvas/ReplayGroup}
    */
   this.replayGroup_ = null;
 
@@ -87,7 +87,7 @@ inherits(CanvasVectorLayerRenderer, CanvasLayerRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasVectorLayerRenderer['handles'] = function(layer) {
@@ -98,11 +98,11 @@ CanvasVectorLayerRenderer['handles'] = function(layer) {
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.canvas.VectorLayer} The layer renderer.
  */
 CanvasVectorLayerRenderer['create'] = function(mapRenderer, layer) {
-  return new CanvasVectorLayerRenderer(/** @type {module:ol/layer/Vector~VectorLayer} */ (layer));
+  return new CanvasVectorLayerRenderer(/** @type {module:ol/layer/Vector} */ (layer));
 };
 
 
@@ -128,7 +128,7 @@ CanvasVectorLayerRenderer.prototype.composeFrame = function(frameState, layerSta
   const projection = viewState.projection;
   const rotation = viewState.rotation;
   const projectionExtent = projection.getExtent();
-  const vectorSource = /** @type {module:ol/source/Vector~VectorSource} */ (this.getLayer().getSource());
+  const vectorSource = /** @type {module:ol/source/Vector} */ (this.getLayer().getSource());
 
   let transform = this.getTransform(frameState, 0);
 
@@ -145,7 +145,7 @@ CanvasVectorLayerRenderer.prototype.composeFrame = function(frameState, layerSta
     if (this.declutterTree_) {
       this.declutterTree_.clear();
     }
-    const layer = /** @type {module:ol/layer/Vector~VectorLayer} */ (this.getLayer());
+    const layer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
     let drawOffsetX = 0;
     let drawOffsetY = 0;
     let replayContext;
@@ -250,12 +250,12 @@ CanvasVectorLayerRenderer.prototype.forEachFeatureAtCoordinate = function(coordi
   } else {
     const resolution = frameState.viewState.resolution;
     const rotation = frameState.viewState.rotation;
-    const layer = /** @type {module:ol/layer/Vector~VectorLayer} */ (this.getLayer());
+    const layer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
     /** @type {!Object.<string, boolean>} */
     const features = {};
     const result = this.replayGroup_.forEachFeatureAtCoordinate(coordinate, resolution, rotation, hitTolerance, {},
       /**
-       * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
        * @return {?} Callback result.
        */
       function(feature) {
@@ -271,7 +271,7 @@ CanvasVectorLayerRenderer.prototype.forEachFeatureAtCoordinate = function(coordi
 
 
 /**
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  */
 CanvasVectorLayerRenderer.prototype.handleFontsChanged_ = function(event) {
   const layer = this.getLayer();
@@ -283,7 +283,7 @@ CanvasVectorLayerRenderer.prototype.handleFontsChanged_ = function(event) {
 
 /**
  * Handle changes in image style state.
- * @param {module:ol/events/Event~Event} event Image style change event.
+ * @param {module:ol/events/Event} event Image style change event.
  * @private
  */
 CanvasVectorLayerRenderer.prototype.handleStyleImageChange_ = function(event) {
@@ -295,7 +295,7 @@ CanvasVectorLayerRenderer.prototype.handleStyleImageChange_ = function(event) {
  * @inheritDoc
  */
 CanvasVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerState) {
-  const vectorLayer = /** @type {module:ol/layer/Vector~VectorLayer} */ (this.getLayer());
+  const vectorLayer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
   const vectorSource = vectorLayer.getSource();
 
   const animating = frameState.viewHints[ViewHint.ANIMATING];
@@ -356,7 +356,7 @@ CanvasVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerSta
     pixelRatio, vectorSource.getOverlaps(), this.declutterTree_, vectorLayer.getRenderBuffer());
   vectorSource.loadFeatures(extent, resolution, projection);
   /**
-   * @param {module:ol/Feature~Feature} feature Feature.
+   * @param {module:ol/Feature} feature Feature.
    * @this {ol.renderer.canvas.VectorLayer}
    */
   const render = function(feature) {
@@ -372,11 +372,11 @@ CanvasVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerSta
     }
   }.bind(this);
   if (vectorLayerRenderOrder) {
-    /** @type {Array.<module:ol/Feature~Feature>} */
+    /** @type {Array.<module:ol/Feature>} */
     const features = [];
     vectorSource.forEachFeatureInExtent(extent,
       /**
-       * @param {module:ol/Feature~Feature} feature Feature.
+       * @param {module:ol/Feature} feature Feature.
        */
       function(feature) {
         features.push(feature);
@@ -402,11 +402,11 @@ CanvasVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerSta
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {(module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>)} styles The style or array of styles.
- * @param {module:ol/render/canvas/ReplayGroup~CanvasReplayGroup} replayGroup Replay group.
+ * @param {(module:ol/style/Style|Array.<module:ol/style/Style>)} styles The style or array of styles.
+ * @param {module:ol/render/canvas/ReplayGroup} replayGroup Replay group.
  * @return {boolean} `true` if an image is loading.
  */
 CanvasVectorLayerRenderer.prototype.renderFeature = function(feature, resolution, pixelRatio, styles, replayGroup) {

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -98,7 +98,7 @@ inherits(CanvasVectorTileLayerRenderer, CanvasTileLayerRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasVectorTileLayerRenderer['handles'] = function(layer) {
@@ -109,7 +109,7 @@ CanvasVectorTileLayerRenderer['handles'] = function(layer) {
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.canvas.VectorTileLayer} The layer renderer.
  */
 CanvasVectorTileLayerRenderer['create'] = function(mapRenderer, layer) {
@@ -148,7 +148,7 @@ CanvasVectorTileLayerRenderer.prototype.prepareFrame = function(frameState, laye
 
 
 /**
- * @param {module:ol/VectorImageTile~VectorImageTile} tile Tile.
+ * @param {module:ol/VectorImageTile} tile Tile.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @private
  */
@@ -165,7 +165,7 @@ CanvasVectorTileLayerRenderer.prototype.createReplayGroup_ = function(tile, fram
     return;
   }
 
-  const source = /** @type {module:ol/source/VectorTile~VectorTile} */ (layer.getSource());
+  const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
   const sourceTileGrid = source.getTileGrid();
   const tileGrid = source.getTileGridForProjection(projection);
   const resolution = tileGrid.getResolution(tile.tileCoord[0]);
@@ -195,7 +195,7 @@ CanvasVectorTileLayerRenderer.prototype.createReplayGroup_ = function(tile, fram
     const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
 
     /**
-     * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
      * @this {ol.renderer.canvas.VectorTileLayer}
      */
     const render = function(feature) {
@@ -246,7 +246,7 @@ CanvasVectorTileLayerRenderer.prototype.createReplayGroup_ = function(tile, fram
  */
 CanvasVectorTileLayerRenderer.prototype.drawTileImage = function(
   tile, frameState, layerState, x, y, w, h, gutter, transition) {
-  const vectorImageTile = /** @type {module:ol/VectorImageTile~VectorImageTile} */ (tile);
+  const vectorImageTile = /** @type {module:ol/VectorImageTile} */ (tile);
   this.createReplayGroup_(vectorImageTile, frameState);
   if (this.context) {
     this.renderTileImage_(vectorImageTile, frameState, layerState);
@@ -266,10 +266,10 @@ CanvasVectorTileLayerRenderer.prototype.forEachFeatureAtCoordinate = function(co
   /** @type {!Object.<string, boolean>} */
   const features = {};
 
-  /** @type {Array.<module:ol/VectorImageTile~VectorImageTile>} */
+  /** @type {Array.<module:ol/VectorImageTile>} */
   const renderedTiles = this.renderedTiles;
 
-  const source = /** @type {module:ol/source/VectorTile~VectorTile} */ (layer.getSource());
+  const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
   const tileGrid = source.getTileGridForProjection(frameState.viewState.projection);
   let bufferedExtent, found;
   let i, ii, replayGroup;
@@ -290,7 +290,7 @@ CanvasVectorTileLayerRenderer.prototype.forEachFeatureAtCoordinate = function(co
       replayGroup = sourceTile.getReplayGroup(layer, tile.tileCoord.toString());
       found = found || replayGroup.forEachFeatureAtCoordinate(coordinate, resolution, rotation, hitTolerance, {},
         /**
-         * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+         * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
          * @return {?} Callback result.
          */
         function(feature) {
@@ -307,14 +307,14 @@ CanvasVectorTileLayerRenderer.prototype.forEachFeatureAtCoordinate = function(co
 
 
 /**
- * @param {module:ol/VectorTile~VectorTile} tile Tile.
+ * @param {module:ol/VectorTile} tile Tile.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @return {module:ol/transform~Transform} transform Transform.
  * @private
  */
 CanvasVectorTileLayerRenderer.prototype.getReplayTransform_ = function(tile, frameState) {
   const layer = this.getLayer();
-  const source = /** @type {module:ol/source/VectorTile~VectorTile} */ (layer.getSource());
+  const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
   const tileGrid = source.getTileGrid();
   const tileCoord = tile.tileCoord;
   const tileResolution = tileGrid.getResolution(tileCoord[0]);
@@ -337,7 +337,7 @@ CanvasVectorTileLayerRenderer.prototype.getReplayTransform_ = function(tile, fra
 
 
 /**
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  */
 CanvasVectorTileLayerRenderer.prototype.handleFontsChanged_ = function(event) {
   const layer = this.getLayer();
@@ -349,7 +349,7 @@ CanvasVectorTileLayerRenderer.prototype.handleFontsChanged_ = function(event) {
 
 /**
  * Handle changes in image style state.
- * @param {module:ol/events/Event~Event} event Image style change event.
+ * @param {module:ol/events/Event} event Image style change event.
  * @private
  */
 CanvasVectorTileLayerRenderer.prototype.handleStyleImageChange_ = function(event) {
@@ -363,7 +363,7 @@ CanvasVectorTileLayerRenderer.prototype.handleStyleImageChange_ = function(event
 CanvasVectorTileLayerRenderer.prototype.postCompose = function(context, frameState, layerState) {
   const layer = this.getLayer();
   const declutterReplays = layer.getDeclutter() ? {} : null;
-  const source = /** @type {module:ol/source/VectorTile~VectorTile} */ (layer.getSource());
+  const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
   const renderMode = layer.getRenderMode();
   const replayTypes = VECTOR_REPLAYS[renderMode];
   const pixelRatio = frameState.pixelRatio;
@@ -383,7 +383,7 @@ CanvasVectorTileLayerRenderer.prototype.postCompose = function(context, frameSta
   const clips = [];
   const zs = [];
   for (let i = tiles.length - 1; i >= 0; --i) {
-    const tile = /** @type {module:ol/VectorImageTile~VectorImageTile} */ (tiles[i]);
+    const tile = /** @type {module:ol/VectorImageTile} */ (tiles[i]);
     if (tile.getState() == TileState.ABORT) {
       continue;
     }
@@ -444,10 +444,10 @@ CanvasVectorTileLayerRenderer.prototype.postCompose = function(context, frameSta
 
 
 /**
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {(module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>)} styles The style or array of styles.
- * @param {module:ol/render/canvas/ReplayGroup~CanvasReplayGroup} replayGroup Replay group.
+ * @param {(module:ol/style/Style|Array.<module:ol/style/Style>)} styles The style or array of styles.
+ * @param {module:ol/render/canvas/ReplayGroup} replayGroup Replay group.
  * @return {boolean} `true` if an image is loading.
  */
 CanvasVectorTileLayerRenderer.prototype.renderFeature = function(feature, squaredTolerance, styles, replayGroup) {
@@ -471,7 +471,7 @@ CanvasVectorTileLayerRenderer.prototype.renderFeature = function(feature, square
 
 
 /**
- * @param {module:ol/VectorImageTile~VectorImageTile} tile Tile.
+ * @param {module:ol/VectorImageTile} tile Tile.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @param {module:ol/layer/Layer~State} layerState Layer state.
  * @private
@@ -487,7 +487,7 @@ CanvasVectorTileLayerRenderer.prototype.renderTileImage_ = function(
     const tileCoord = tile.wrappedTileCoord;
     const z = tileCoord[0];
     const pixelRatio = frameState.pixelRatio;
-    const source = /** @type {module:ol/source/VectorTile~VectorTile} */ (layer.getSource());
+    const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
     const tileGrid = source.getTileGridForProjection(frameState.viewState.projection);
     const resolution = tileGrid.getResolution(z);
     const context = tile.getContext(layer);

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -17,8 +17,8 @@ const SIMPLIFY_TOLERANCE = 0.5;
 /**
  * @const
  * @type {Object.<module:ol/geom/GeometryType,
- *                function(module:ol/render/ReplayGroup~ReplayGroup, module:ol/geom/Geometry~Geometry,
- *                         module:ol/style/Style~Style, Object)>}
+ *                function(module:ol/render/ReplayGroup, module:ol/geom/Geometry,
+ *                         module:ol/style/Style, Object)>}
  */
 const GEOMETRY_RENDERERS = {
   'Point': renderPointGeometry,
@@ -33,8 +33,8 @@ const GEOMETRY_RENDERERS = {
 
 
 /**
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature1 Feature 1.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature2 Feature 2.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature1 Feature 1.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature2 Feature 2.
  * @return {number} Order.
  */
 export function defaultOrder(feature1, feature2) {
@@ -64,10 +64,10 @@ export function getTolerance(resolution, pixelRatio) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Circle~Circle} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/Circle} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature} feature Feature.
  */
 function renderCircleGeometry(replayGroup, geometry, style, feature) {
   const fillStyle = style.getFill();
@@ -87,11 +87,11 @@ function renderCircleGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
- * @param {module:ol/style/Style~Style} style Style.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {module:ol/style/Style} style Style.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {function(this: T, module:ol/events/Event~Event)} listener Listener function.
+ * @param {function(this: T, module:ol/events/Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {boolean} `true` if style is loading.
  * @template T
@@ -119,9 +119,9 @@ export function renderFeature(replayGroup, feature, style, squaredTolerance, lis
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
- * @param {module:ol/style/Style~Style} style Style.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {module:ol/style/Style} style Style.
  * @param {number} squaredTolerance Squared tolerance.
  */
 function renderFeatureInternal(replayGroup, feature, style, squaredTolerance) {
@@ -141,29 +141,29 @@ function renderFeatureInternal(replayGroup, feature, style, squaredTolerance) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Geometry~Geometry} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/Geometry} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 function renderGeometry(replayGroup, geometry, style, feature) {
   if (geometry.getType() == GeometryType.GEOMETRY_COLLECTION) {
-    const geometries = /** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry).getGeometries();
+    const geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
     for (let i = 0, ii = geometries.length; i < ii; ++i) {
       renderGeometry(replayGroup, geometries[i], style, feature);
     }
     return;
   }
   const replay = replayGroup.getReplay(style.getZIndex(), ReplayType.DEFAULT);
-  replay.drawCustom(/** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (geometry), feature, style.getRenderer());
+  replay.drawCustom(/** @type {module:ol/geom/SimpleGeometry} */ (geometry), feature, style.getRenderer());
 }
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/GeometryCollection~GeometryCollection} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/GeometryCollection} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature} feature Feature.
  */
 function renderGeometryCollectionGeometry(replayGroup, geometry, style, feature) {
   const geometries = geometry.getGeometriesArray();
@@ -177,10 +177,10 @@ function renderGeometryCollectionGeometry(replayGroup, geometry, style, feature)
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/LineString~LineString|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/LineString|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 function renderLineStringGeometry(replayGroup, geometry, style, feature) {
   const strokeStyle = style.getStroke();
@@ -199,10 +199,10 @@ function renderLineStringGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/MultiLineString~MultiLineString|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/MultiLineString|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 function renderMultiLineStringGeometry(replayGroup, geometry, style, feature) {
   const strokeStyle = style.getStroke();
@@ -221,10 +221,10 @@ function renderMultiLineStringGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/MultiPolygon~MultiPolygon} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/MultiPolygon} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature} feature Feature.
  */
 function renderMultiPolygonGeometry(replayGroup, geometry, style, feature) {
   const fillStyle = style.getFill();
@@ -244,10 +244,10 @@ function renderMultiPolygonGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Point~Point|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/Point|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 function renderPointGeometry(replayGroup, geometry, style, feature) {
   const imageStyle = style.getImage();
@@ -269,10 +269,10 @@ function renderPointGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/MultiPoint~MultiPoint|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/MultiPoint|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 function renderMultiPointGeometry(replayGroup, geometry, style, feature) {
   const imageStyle = style.getImage();
@@ -294,10 +294,10 @@ function renderMultiPointGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup~ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Polygon~Polygon|module:ol/render/Feature~RenderFeature} geometry Geometry.
- * @param {module:ol/style/Style~Style} style Style.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+ * @param {module:ol/geom/Polygon|module:ol/render/Feature} geometry Geometry.
+ * @param {module:ol/style/Style} style Style.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  */
 function renderPolygonGeometry(replayGroup, geometry, style, feature) {
   const fillStyle = style.getFill();

--- a/src/ol/renderer/webgl/ImageLayer.js
+++ b/src/ol/renderer/webgl/ImageLayer.js
@@ -26,7 +26,7 @@ import {createTexture} from '../../webgl/Context.js';
  * @constructor
  * @extends {ol.renderer.webgl.Layer}
  * @param {ol.renderer.webgl.Map} mapRenderer Map renderer.
- * @param {module:ol/layer/Image~ImageLayer} imageLayer Tile layer.
+ * @param {module:ol/layer/Image} imageLayer Tile layer.
  * @api
  */
 const WebGLImageLayerRenderer = function(mapRenderer, imageLayer) {
@@ -36,7 +36,7 @@ const WebGLImageLayerRenderer = function(mapRenderer, imageLayer) {
   /**
    * The last rendered image.
    * @private
-   * @type {?module:ol/ImageBase~ImageBase}
+   * @type {?module:ol/ImageBase}
    */
   this.image_ = null;
 
@@ -59,7 +59,7 @@ inherits(WebGLImageLayerRenderer, WebGLLayerRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 WebGLImageLayerRenderer['handles'] = function(layer) {
@@ -70,19 +70,19 @@ WebGLImageLayerRenderer['handles'] = function(layer) {
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.webgl.ImageLayer} The layer renderer.
  */
 WebGLImageLayerRenderer['create'] = function(mapRenderer, layer) {
   return new WebGLImageLayerRenderer(
     /** @type {ol.renderer.webgl.Map} */ (mapRenderer),
-    /** @type {module:ol/layer/Image~ImageLayer} */ (layer)
+    /** @type {module:ol/layer/Image} */ (layer)
   );
 };
 
 
 /**
- * @param {module:ol/ImageBase~ImageBase} image Image.
+ * @param {module:ol/ImageBase} image Image.
  * @private
  * @return {WebGLTexture} Texture.
  */
@@ -113,9 +113,9 @@ WebGLImageLayerRenderer.prototype.forEachFeatureAtCoordinate = function(coordina
     coordinate, resolution, rotation, hitTolerance, skippedFeatureUids,
 
     /**
-       * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
-       * @return {?} Callback result.
-       */
+     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+     * @return {?} Callback result.
+     */
     function(feature) {
       return callback.call(thisArg, feature, layer);
     });
@@ -137,7 +137,7 @@ WebGLImageLayerRenderer.prototype.prepareFrame = function(frameState, layerState
 
   let image = this.image_;
   let texture = this.texture;
-  const imageLayer = /** @type {module:ol/layer/Image~ImageLayer} */ (this.getLayer());
+  const imageLayer = /** @type {module:ol/layer/Image} */ (this.getLayer());
   const imageSource = imageLayer.getSource();
 
   const hints = frameState.viewHints;

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -20,7 +20,7 @@ import {createEmptyTexture} from '../../webgl/Context.js';
  * @abstract
  * @extends {ol.renderer.Layer}
  * @param {ol.renderer.webgl.Map} mapRenderer Map renderer.
- * @param {module:ol/layer/Layer~Layer} layer Layer.
+ * @param {module:ol/layer/Layer} layer Layer.
  */
 const WebGLLayerRenderer = function(mapRenderer, layer) {
 
@@ -34,7 +34,7 @@ const WebGLLayerRenderer = function(mapRenderer, layer) {
 
   /**
    * @private
-   * @type {module:ol/webgl/Buffer~WebGLBuffer}
+   * @type {module:ol/webgl/Buffer}
    */
   this.arrayBuffer_ = new WebGLBuffer([
     -1, -1, 0, 0,
@@ -139,7 +139,7 @@ WebGLLayerRenderer.prototype.bindFramebuffer = function(frameState, framebufferD
 /**
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @param {module:ol/layer/Layer~State} layerState Layer state.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  */
 WebGLLayerRenderer.prototype.composeFrame = function(frameState, layerState, context) {
 
@@ -183,7 +183,7 @@ WebGLLayerRenderer.prototype.composeFrame = function(frameState, layerState, con
 
 /**
  * @param {module:ol/render/EventType~EventType} type Event type.
- * @param {module:ol/webgl/Context~WebGLContext} context WebGL context.
+ * @param {module:ol/webgl/Context} context WebGL context.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @private
  */
@@ -245,7 +245,7 @@ WebGLLayerRenderer.prototype.handleWebGLContextLost = function() {
  * @abstract
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @param {module:ol/layer/Layer~State} layerState Layer state.
- * @param {module:ol/webgl/Context~WebGLContext} context Context.
+ * @param {module:ol/webgl/Context} context Context.
  * @return {boolean} whether composeFrame should be called.
  */
 WebGLLayerRenderer.prototype.prepareFrame = function(frameState, layerState, context) {};
@@ -255,7 +255,7 @@ WebGLLayerRenderer.prototype.prepareFrame = function(frameState, layerState, con
  * @abstract
  * @param {module:ol~Pixel} pixel Pixel.
  * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
- * @param {function(this: S, module:ol/layer/Layer~Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+ * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
  *     callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|undefined} Callback result.

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -41,7 +41,7 @@ const WEBGL_TEXTURE_CACHE_HIGH_WATER_MARK = 1024;
 /**
  * @constructor
  * @extends {ol.renderer.Map}
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @api
  */
 const WebGLMapRenderer = function(map) {
@@ -99,7 +99,7 @@ const WebGLMapRenderer = function(map) {
 
   /**
    * @private
-   * @type {module:ol/webgl/Context~WebGLContext}
+   * @type {module:ol/webgl/Context}
    */
   this.context_ = new WebGLContext(this.canvas_, this.gl_);
 
@@ -126,29 +126,31 @@ const WebGLMapRenderer = function(map) {
    */
   this.tileTextureQueue_ = new PriorityQueue(
     /**
-       * @param {Array.<*>} element Element.
-       * @return {number} Priority.
-       * @this {ol.renderer.webgl.Map}
-       */
-    (function(element) {
+     * @param {Array.<*>} element Element.
+     * @return {number} Priority.
+     * @this {ol.renderer.webgl.Map}
+     */
+    function(element) {
       const tileCenter = /** @type {module:ol/coordinate~Coordinate} */ (element[1]);
       const tileResolution = /** @type {number} */ (element[2]);
       const deltaX = tileCenter[0] - this.focus_[0];
       const deltaY = tileCenter[1] - this.focus_[1];
       return 65536 * Math.log(tileResolution) +
             Math.sqrt(deltaX * deltaX + deltaY * deltaY) / tileResolution;
-    }).bind(this),
+    }.bind(this),
     /**
-       * @param {Array.<*>} element Element.
-       * @return {string} Key.
-       */
+     * @param {Array.<*>} element Element.
+     * @return {string} Key.
+     */
     function(element) {
-      return /** @type {module:ol/Tile~Tile} */ (element[0]).getKey();
+      return (
+        /** @type {module:ol/Tile} */ (element[0]).getKey()
+      );
     });
 
 
   /**
-   * @param {module:ol/PluggableMap~PluggableMap} map Map.
+   * @param {module:ol/PluggableMap} map Map.
    * @param {?module:ol/PluggableMap~FrameState} frameState Frame state.
    * @return {boolean} false.
    * @this {ol.renderer.webgl.Map}
@@ -158,7 +160,7 @@ const WebGLMapRenderer = function(map) {
         if (!this.tileTextureQueue_.isEmpty()) {
           this.tileTextureQueue_.reprioritize();
           const element = this.tileTextureQueue_.dequeue();
-          const tile = /** @type {module:ol/Tile~Tile} */ (element[0]);
+          const tile = /** @type {module:ol/Tile} */ (element[0]);
           const tileSize = /** @type {module:ol/size~Size} */ (element[3]);
           const tileGutter = /** @type {number} */ (element[4]);
           this.bindTileTexture(
@@ -296,7 +298,7 @@ WebGLMapRenderer.prototype.disposeInternal = function() {
 
 
 /**
- * @param {module:ol/PluggableMap~PluggableMap} map Map.
+ * @param {module:ol/PluggableMap} map Map.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @private
  */
@@ -321,7 +323,7 @@ WebGLMapRenderer.prototype.expireCache_ = function(map, frameState) {
 
 
 /**
- * @return {module:ol/webgl/Context~WebGLContext} The context.
+ * @return {module:ol/webgl/Context} The context.
  */
 WebGLMapRenderer.prototype.getContext = function() {
   return this.context_;
@@ -345,7 +347,7 @@ WebGLMapRenderer.prototype.getTileTextureQueue = function() {
 
 
 /**
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  * @protected
  */
 WebGLMapRenderer.prototype.handleWebGLContextLost = function(event) {
@@ -387,7 +389,7 @@ WebGLMapRenderer.prototype.initializeGL_ = function() {
 
 
 /**
- * @param {module:ol/Tile~Tile} tile Tile.
+ * @param {module:ol/Tile} tile Tile.
  * @return {boolean} Is tile texture loaded.
  */
 WebGLMapRenderer.prototype.isTileTextureLoaded = function(tile) {

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -29,7 +29,7 @@ import WebGLBuffer from '../../webgl/Buffer.js';
  * @constructor
  * @extends {ol.renderer.webgl.Layer}
  * @param {ol.renderer.webgl.Map} mapRenderer Map renderer.
- * @param {module:ol/layer/Tile~TileLayer} tileLayer Tile layer.
+ * @param {module:ol/layer/Tile} tileLayer Tile layer.
  * @api
  */
 const WebGLTileLayerRenderer = function(mapRenderer, tileLayer) {
@@ -38,13 +38,13 @@ const WebGLTileLayerRenderer = function(mapRenderer, tileLayer) {
 
   /**
    * @private
-   * @type {module:ol/webgl/Fragment~WebGLFragment}
+   * @type {module:ol/webgl/Fragment}
    */
   this.fragmentShader_ = fragment;
 
   /**
    * @private
-   * @type {module:ol/webgl/Vertex~WebGLVertex}
+   * @type {module:ol/webgl/Vertex}
    */
   this.vertexShader_ = vertex;
 
@@ -56,7 +56,7 @@ const WebGLTileLayerRenderer = function(mapRenderer, tileLayer) {
 
   /**
    * @private
-   * @type {module:ol/webgl/Buffer~WebGLBuffer}
+   * @type {module:ol/webgl/Buffer}
    */
   this.renderArrayBuffer_ = new WebGLBuffer([
     0, 0, 0, 1,
@@ -67,7 +67,7 @@ const WebGLTileLayerRenderer = function(mapRenderer, tileLayer) {
 
   /**
    * @private
-   * @type {module:ol/TileRange~TileRange}
+   * @type {module:ol/TileRange}
    */
   this.renderedTileRange_ = null;
 
@@ -96,7 +96,7 @@ inherits(WebGLTileLayerRenderer, WebGLLayerRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 WebGLTileLayerRenderer['handles'] = function(layer) {
@@ -107,13 +107,13 @@ WebGLTileLayerRenderer['handles'] = function(layer) {
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.webgl.TileLayer} The layer renderer.
  */
 WebGLTileLayerRenderer['create'] = function(mapRenderer, layer) {
   return new WebGLTileLayerRenderer(
     /** @type {ol.renderer.webgl.Map} */ (mapRenderer),
-    /** @type {module:ol/layer/Tile~TileLayer} */ (layer)
+    /** @type {module:ol/layer/Tile} */ (layer)
   );
 };
 
@@ -137,7 +137,7 @@ WebGLTileLayerRenderer.prototype.createLoadedTileFinder = function(source, proje
   return (
     /**
      * @param {number} zoom Zoom level.
-     * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+     * @param {module:ol/TileRange} tileRange Tile range.
      * @return {boolean} The tile range is fully loaded.
      */
     function(zoom, tileRange) {
@@ -152,7 +152,8 @@ WebGLTileLayerRenderer.prototype.createLoadedTileFinder = function(source, proje
         return loaded;
       }
       return source.forEachLoadedTile(projection, zoom, tileRange, callback);
-    });
+    }
+  );
 };
 
 
@@ -176,7 +177,7 @@ WebGLTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState,
   const viewState = frameState.viewState;
   const projection = viewState.projection;
 
-  const tileLayer = /** @type {module:ol/layer/Tile~TileLayer} */ (this.getLayer());
+  const tileLayer = /** @type {module:ol/layer/Tile} */ (this.getLayer());
   const tileSource = tileLayer.getSource();
   const tileGrid = tileSource.getTileGridForProjection(projection);
   const z = tileGrid.getZForResolution(viewState.resolution);
@@ -240,7 +241,7 @@ WebGLTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState,
     gl.uniform1i(this.locations_.u_texture, 0);
 
     /**
-     * @type {Object.<number, Object.<string, module:ol/Tile~Tile>>}
+     * @type {Object.<number, Object.<string, module:ol/Tile>>}
      */
     const tilesToDrawByZ = {};
     tilesToDrawByZ[z] = {};
@@ -342,8 +343,8 @@ WebGLTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState,
     frameState, tileSource, tileGrid, pixelRatio, projection, extent, z,
     tileLayer.getPreload(),
     /**
-       * @param {module:ol/Tile~Tile} tile Tile.
-       */
+     * @param {module:ol/Tile} tile Tile.
+     */
     function(tile) {
       if (tile.getState() == TileState.LOADED &&
             !mapRenderer.isTileTextureLoaded(tile) &&

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -14,7 +14,7 @@ import {apply as applyTransform} from '../../transform.js';
  * @constructor
  * @extends {ol.renderer.webgl.Layer}
  * @param {ol.renderer.webgl.Map} mapRenderer Map renderer.
- * @param {module:ol/layer/Vector~VectorLayer} vectorLayer Vector layer.
+ * @param {module:ol/layer/Vector} vectorLayer Vector layer.
  * @api
  */
 const WebGLVectorLayerRenderer = function(mapRenderer, vectorLayer) {
@@ -47,7 +47,7 @@ const WebGLVectorLayerRenderer = function(mapRenderer, vectorLayer) {
 
   /**
    * @private
-   * @type {function(module:ol/Feature~Feature, module:ol/Feature~Feature): number|null}
+   * @type {function(module:ol/Feature, module:ol/Feature): number|null}
    */
   this.renderedRenderOrder_ = null;
 
@@ -71,7 +71,7 @@ inherits(WebGLVectorLayerRenderer, WebGLLayerRenderer);
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer~Layer} layer The candidate layer.
+ * @param {module:ol/layer/Layer} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 WebGLVectorLayerRenderer['handles'] = function(layer) {
@@ -82,13 +82,13 @@ WebGLVectorLayerRenderer['handles'] = function(layer) {
 /**
  * Create a layer renderer.
  * @param {ol.renderer.Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer~Layer} layer The layer to be rendererd.
+ * @param {module:ol/layer/Layer} layer The layer to be rendererd.
  * @return {ol.renderer.webgl.VectorLayer} The layer renderer.
  */
 WebGLVectorLayerRenderer['create'] = function(mapRenderer, layer) {
   return new WebGLVectorLayerRenderer(
     /** @type {ol.renderer.webgl.Map} */ (mapRenderer),
-    /** @type {module:ol/layer/Vector~VectorLayer} */ (layer)
+    /** @type {module:ol/layer/Vector} */ (layer)
   );
 };
 
@@ -148,7 +148,7 @@ WebGLVectorLayerRenderer.prototype.forEachFeatureAtCoordinate = function(coordin
       frameState.size, frameState.pixelRatio, layerState.opacity,
       {},
       /**
-       * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
        * @return {?} Callback result.
        */
       function(feature) {
@@ -198,7 +198,7 @@ WebGLVectorLayerRenderer.prototype.forEachLayerAtPixel = function(pixel, frameSt
 
 /**
  * Handle changes in image style state.
- * @param {module:ol/events/Event~Event} event Image style change event.
+ * @param {module:ol/events/Event} event Image style change event.
  * @private
  */
 WebGLVectorLayerRenderer.prototype.handleStyleImageChange_ = function(event) {
@@ -210,7 +210,7 @@ WebGLVectorLayerRenderer.prototype.handleStyleImageChange_ = function(event) {
  * @inheritDoc
  */
 WebGLVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerState, context) {
-  const vectorLayer = /** @type {module:ol/layer/Vector~VectorLayer} */ (this.getLayer());
+  const vectorLayer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
   const vectorSource = vectorLayer.getSource();
 
   const animating = frameState.viewHints[ViewHint.ANIMATING];
@@ -259,7 +259,7 @@ WebGLVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerStat
     extent, vectorLayer.getRenderBuffer());
   vectorSource.loadFeatures(extent, resolution, projection);
   /**
-   * @param {module:ol/Feature~Feature} feature Feature.
+   * @param {module:ol/Feature} feature Feature.
    * @this {ol.renderer.webgl.VectorLayer}
    */
   const render = function(feature) {
@@ -275,11 +275,11 @@ WebGLVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerStat
     }
   };
   if (vectorLayerRenderOrder) {
-    /** @type {Array.<module:ol/Feature~Feature>} */
+    /** @type {Array.<module:ol/Feature>} */
     const features = [];
     vectorSource.forEachFeatureInExtent(extent,
       /**
-       * @param {module:ol/Feature~Feature} feature Feature.
+       * @param {module:ol/Feature} feature Feature.
        */
       function(feature) {
         features.push(feature);
@@ -302,10 +302,10 @@ WebGLVectorLayerRenderer.prototype.prepareFrame = function(frameState, layerStat
 
 
 /**
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {(module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>)} styles The style or array of
+ * @param {(module:ol/style/Style|Array.<module:ol/style/Style>)} styles The style or array of
  *     styles.
  * @param {ol.render.webgl.ReplayGroup} replayGroup Replay group.
  * @return {boolean} `true` if an image is loading.

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -13,8 +13,8 @@ import {getPointResolution, transform} from './proj.js';
  * The resolution is calculated regardless of what resolutions
  * are actually available in the dataset (TileGrid, Image, ...).
  *
- * @param {module:ol/proj/Projection~Projection} sourceProj Source projection.
- * @param {module:ol/proj/Projection~Projection} targetProj Target projection.
+ * @param {module:ol/proj/Projection} sourceProj Source projection.
+ * @param {module:ol/proj/Projection} targetProj Target projection.
  * @param {module:ol/coordinate~Coordinate} targetCenter Target center.
  * @param {number} targetResolution Target resolution.
  * @return {number} The best resolution to use. Can be +-Infinity, NaN or 0.
@@ -81,7 +81,7 @@ function enlargeClipPoint(centroidX, centroidY, x, y) {
  * @param {module:ol/extent~Extent} sourceExtent Extent of the data source.
  * @param {number} targetResolution Target resolution.
  * @param {module:ol/extent~Extent} targetExtent Target extent.
- * @param {module:ol/reproj/Triangulation~Triangulation} triangulation
+ * @param {module:ol/reproj/Triangulation} triangulation
  * Calculated triangulation.
  * @param {Array.<{extent: module:ol/extent~Extent,
  *                 image: (HTMLCanvasElement|Image|HTMLVideoElement)}>} sources

--- a/src/ol/reproj/Image.js
+++ b/src/ol/reproj/Image.js
@@ -13,7 +13,7 @@ import Triangulation from '../reproj/Triangulation.js';
 
 
 /**
- * @typedef {function(module:ol/extent~Extent, number, number) : module:ol/ImageBase~ImageBase} FunctionType
+ * @typedef {function(module:ol/extent~Extent, number, number) : module:ol/ImageBase} FunctionType
  */
 
 
@@ -23,9 +23,9 @@ import Triangulation from '../reproj/Triangulation.js';
  * See {@link module:ol/source/Image~ImageSource}.
  *
  * @constructor
- * @extends {module:ol/ImageBase~ImageBase}
- * @param {module:ol/proj/Projection~Projection} sourceProj Source projection (of the data).
- * @param {module:ol/proj/Projection~Projection} targetProj Target projection.
+ * @extends {module:ol/ImageBase}
+ * @param {module:ol/proj/Projection} sourceProj Source projection (of the data).
+ * @param {module:ol/proj/Projection} targetProj Target projection.
  * @param {module:ol/extent~Extent} targetExtent Target extent.
  * @param {number} targetResolution Target resolution.
  * @param {number} pixelRatio Pixel ratio.
@@ -37,7 +37,7 @@ const ReprojImage = function(sourceProj, targetProj,
 
   /**
    * @private
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.targetProj_ = targetProj;
 
@@ -59,7 +59,7 @@ const ReprojImage = function(sourceProj, targetProj,
 
   /**
    * @private
-   * @type {!module:ol/reproj/Triangulation~Triangulation}
+   * @type {!module:ol/reproj/Triangulation}
    */
   this.triangulation_ = new Triangulation(
     sourceProj, targetProj, limitedTargetExtent, this.maxSourceExtent_,
@@ -81,7 +81,7 @@ const ReprojImage = function(sourceProj, targetProj,
 
   /**
    * @private
-   * @type {module:ol/ImageBase~ImageBase}
+   * @type {module:ol/ImageBase}
    */
   this.sourceImage_ =
       getImageFunction(sourceExtent, sourceResolution, pixelRatio);
@@ -138,7 +138,7 @@ ReprojImage.prototype.getImage = function() {
 
 
 /**
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  */
 ReprojImage.prototype.getProjection = function() {
   return this.targetProj_;

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -14,7 +14,7 @@ import Triangulation from '../reproj/Triangulation.js';
 
 
 /**
- * @typedef {function(number, number, number, number) : module:ol/Tile~Tile} FunctionType
+ * @typedef {function(number, number, number, number) : module:ol/Tile} FunctionType
  */
 
 
@@ -24,11 +24,11 @@ import Triangulation from '../reproj/Triangulation.js';
  * See {@link module:ol/source/TileImage~TileImage}.
  *
  * @constructor
- * @extends {module:ol/Tile~Tile}
- * @param {module:ol/proj/Projection~Projection} sourceProj Source projection.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} sourceTileGrid Source tile grid.
- * @param {module:ol/proj/Projection~Projection} targetProj Target projection.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} targetTileGrid Target tile grid.
+ * @extends {module:ol/Tile}
+ * @param {module:ol/proj/Projection} sourceProj Source projection.
+ * @param {module:ol/tilegrid/TileGrid} sourceTileGrid Source tile grid.
+ * @param {module:ol/proj/Projection} targetProj Target projection.
+ * @param {module:ol/tilegrid/TileGrid} targetTileGrid Target tile grid.
  * @param {module:ol/tilecoord~TileCoord} tileCoord Coordinate of the tile.
  * @param {module:ol/tilecoord~TileCoord} wrappedTileCoord Coordinate of the tile wrapped in X.
  * @param {number} pixelRatio Pixel ratio.
@@ -70,13 +70,13 @@ const ReprojTile = function(sourceProj, sourceTileGrid,
 
   /**
    * @private
-   * @type {module:ol/tilegrid/TileGrid~TileGrid}
+   * @type {module:ol/tilegrid/TileGrid}
    */
   this.sourceTileGrid_ = sourceTileGrid;
 
   /**
    * @private
-   * @type {module:ol/tilegrid/TileGrid~TileGrid}
+   * @type {module:ol/tilegrid/TileGrid}
    */
   this.targetTileGrid_ = targetTileGrid;
 
@@ -88,7 +88,7 @@ const ReprojTile = function(sourceProj, sourceTileGrid,
 
   /**
    * @private
-   * @type {!Array.<module:ol/Tile~Tile>}
+   * @type {!Array.<module:ol/Tile>}
    */
   this.sourceTiles_ = [];
 
@@ -146,7 +146,7 @@ const ReprojTile = function(sourceProj, sourceTileGrid,
 
   /**
    * @private
-   * @type {!module:ol/reproj/Triangulation~Triangulation}
+   * @type {!module:ol/reproj/Triangulation}
    */
   this.triangulation_ = new Triangulation(
     sourceProj, targetProj, limitedTargetExtent, maxSourceExtent,

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -41,8 +41,8 @@ const MAX_TRIANGLE_WIDTH = 0.25;
  * Class containing triangulation of the given target extent.
  * Used for determining source data and the reprojection itself.
  *
- * @param {module:ol/proj/Projection~Projection} sourceProj Source projection.
- * @param {module:ol/proj/Projection~Projection} targetProj Target projection.
+ * @param {module:ol/proj/Projection} sourceProj Source projection.
+ * @param {module:ol/proj/Projection} targetProj Target projection.
  * @param {module:ol/extent~Extent} targetExtent Target extent to triangulate.
  * @param {module:ol/extent~Extent} maxSourceExtent Maximal source extent that can be used.
  * @param {number} errorThreshold Acceptable error (in source units).
@@ -52,13 +52,13 @@ const Triangulation = function(sourceProj, targetProj, targetExtent,
   maxSourceExtent, errorThreshold) {
 
   /**
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    * @private
    */
   this.sourceProj_ = sourceProj;
 
   /**
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    * @private
    */
   this.targetProj_ = targetProj;

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -37,7 +37,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * Layer source for Bing Maps tile data.
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/BingMaps~Options=} options Bing Maps options.
  * @api
  */
@@ -169,12 +169,12 @@ BingMaps.prototype.handleImageryMetadataResponse = function(response) {
         .replace('{subdomain}', subdomain)
         .replace('{culture}', culture);
       return (
-      /**
-           * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-           * @param {number} pixelRatio Pixel ratio.
-           * @param {module:ol/proj/Projection~Projection} projection Projection.
-           * @return {string|undefined} Tile URL.
-           */
+        /**
+         * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
+         * @param {number} pixelRatio Pixel ratio.
+         * @param {module:ol/proj/Projection} projection Projection.
+         * @return {string|undefined} Tile URL.
+         */
         function(tileCoord, pixelRatio, projection) {
           if (!tileCoord) {
             return undefined;

--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -36,7 +36,7 @@ import XYZ from '../source/XYZ.js';
  * Layer source for the CartoDB Maps API.
  *
  * @constructor
- * @extends {module:ol/source/XYZ~XYZ}
+ * @extends {module:ol/source/XYZ}
  * @param {module:ol/source/CartoDB~Options=} options CartoDB options.
  * @api
  */

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -17,9 +17,9 @@ import VectorSource from '../source/Vector.js';
  * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [distance=20] Minimum distance in pixels between clusters.
  * @property {module:ol/extent~Extent} [extent] Extent.
- * @property {function(module:ol/Feature~Feature):module:ol/geom/Point~Point} [geometryFunction]
- * Function that takes an {@link module:ol/Feature~Feature} as argument and returns an
- * {@link module:ol/geom/Point~Point} as cluster calculation point for the feature. When a
+ * @property {function(module:ol/Feature):module:ol/geom/Point} [geometryFunction]
+ * Function that takes an {@link module:ol/Feature} as argument and returns an
+ * {@link module:ol/geom/Point} as cluster calculation point for the feature. When a
  * feature should not be considered for clustering, the function should return
  * `null`. The default, which works when the underyling source contains point
  * features only, is
@@ -31,7 +31,7 @@ import VectorSource from '../source/Vector.js';
  * See {@link module:ol/geom/Polygon~Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {module:ol/source/Vector~VectorSource} source Source.
+ * @property {module:ol/source/Vector} source Source.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  */
 
@@ -44,7 +44,7 @@ import VectorSource from '../source/Vector.js';
  *
  * @constructor
  * @param {module:ol/source/Cluster~Options=} options Cluster options.
- * @extends {module:ol/source/Vector~VectorSource}
+ * @extends {module:ol/source/Vector}
  * @api
  */
 const Cluster = function(options) {
@@ -68,25 +68,25 @@ const Cluster = function(options) {
   this.distance = options.distance !== undefined ? options.distance : 20;
 
   /**
-   * @type {Array.<module:ol/Feature~Feature>}
+   * @type {Array.<module:ol/Feature>}
    * @protected
    */
   this.features = [];
 
   /**
-   * @param {module:ol/Feature~Feature} feature Feature.
-   * @return {module:ol/geom/Point~Point} Cluster calculation point.
+   * @param {module:ol/Feature} feature Feature.
+   * @return {module:ol/geom/Point} Cluster calculation point.
    * @protected
    */
   this.geometryFunction = options.geometryFunction || function(feature) {
-    const geometry = /** @type {module:ol/geom/Point~Point} */ (feature.getGeometry());
+    const geometry = /** @type {module:ol/geom/Point} */ (feature.getGeometry());
     assert(geometry instanceof Point,
       10); // The default `geometryFunction` can only handle `module:ol/geom/Point~Point` geometries
     return geometry;
   };
 
   /**
-   * @type {module:ol/source/Vector~VectorSource}
+   * @type {module:ol/source/Vector}
    * @protected
    */
   this.source = options.source;
@@ -109,7 +109,7 @@ Cluster.prototype.getDistance = function() {
 
 /**
  * Get a reference to the wrapped source.
- * @return {module:ol/source/Vector~VectorSource} Source.
+ * @return {module:ol/source/Vector} Source.
  * @api
  */
 Cluster.prototype.getSource = function() {
@@ -198,8 +198,8 @@ Cluster.prototype.cluster = function() {
 
 
 /**
- * @param {Array.<module:ol/Feature~Feature>} features Features
- * @return {module:ol/Feature~Feature} The cluster feature.
+ * @param {Array.<module:ol/Feature>} features Features
+ * @return {module:ol/Feature} The cluster feature.
  * @protected
  */
 Cluster.prototype.createCluster = function(features) {

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -47,7 +47,7 @@ const ImageSourceEventType = {
  * type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.source.ImageEvent}
  * @param {string} type Type.
  * @param {module:ol/Image~Image} image The image.
@@ -85,7 +85,7 @@ inherits(ImageSourceEvent, Event);
  *
  * @constructor
  * @abstract
- * @extends {module:ol/source/Source~Source}
+ * @extends {module:ol/source/Source}
  * @param {module:ol/source/Image~Options} options Single image source options.
  * @api
  */
@@ -149,8 +149,8 @@ ImageSource.prototype.findNearestResolution = function(resolution) {
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @return {module:ol/ImageBase~ImageBase} Single image.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {module:ol/ImageBase} Single image.
  */
 ImageSource.prototype.getImage = function(extent, resolution, pixelRatio, projection) {
   const sourceProjection = this.getProjection();
@@ -193,8 +193,8 @@ ImageSource.prototype.getImage = function(extent, resolution, pixelRatio, projec
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} resolution Resolution.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @return {module:ol/ImageBase~ImageBase} Single image.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {module:ol/ImageBase} Single image.
  * @protected
  */
 ImageSource.prototype.getImageInternal = function(extent, resolution, pixelRatio, projection) {};
@@ -202,7 +202,7 @@ ImageSource.prototype.getImageInternal = function(extent, resolution, pixelRatio
 
 /**
  * Handle image change events.
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  * @protected
  */
 ImageSource.prototype.handleImageChange = function(event) {

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -50,7 +50,7 @@ import {appendParams} from '../uri.js';
  *
  * @constructor
  * @fires ol.source.Image.Event
- * @extends {module:ol/source/Image~ImageSource}
+ * @extends {module:ol/source/Image}
  * @param {module:ol/source/ImageArcGISRest~Options=} opt_options Image ArcGIS Rest Options.
  * @api
  */
@@ -223,7 +223,7 @@ ImageArcGISRest.prototype.getImageLoadFunction = function() {
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {module:ol/size~Size} size Size.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {Object} params Params.
  * @return {string} Request URL.
  * @private

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -12,12 +12,12 @@ import ImageSource from '../source/Image.js';
  * used by the source as an image. The arguments passed to the function are:
  * {@link module:ol/extent~Extent} the image extent, `{number}` the image resolution,
  * `{number}` the device pixel ratio, {@link module:ol/size~Size} the image size, and
- * {@link module:ol/proj/Projection~Projection} the image projection. The canvas returned by
+ * {@link module:ol/proj/Projection} the image projection. The canvas returned by
  * this function is cached by the source. The this keyword inside the function
  * references the {@link module:ol/source/ImageCanvas}.
  *
- * @typedef {function(this:module:ol/ImageCanvas~ImageCanvas, module:ol/extent~Extent, number,
- *     number, module:ol/size~Size, module:ol/proj/Projection~Projection): HTMLCanvasElement} FunctionType
+ * @typedef {function(this:module:ol/ImageCanvas, module:ol/extent~Extent, number,
+ *     number, module:ol/size~Size, module:ol/proj/Projection): HTMLCanvasElement} FunctionType
  */
 
 
@@ -47,7 +47,7 @@ import ImageSource from '../source/Image.js';
  * Base class for image sources where a canvas element is the image.
  *
  * @constructor
- * @extends {module:ol/source/Image~ImageSource}
+ * @extends {module:ol/source/Image}
  * @param {module:ol/source/ImageCanvas~Options=} options ImageCanvas options.
  * @api
  */
@@ -68,7 +68,7 @@ const ImageCanvasSource = function(options) {
 
   /**
    * @private
-   * @type {module:ol/ImageCanvas~ImageCanvas}
+   * @type {module:ol/ImageCanvas}
    */
   this.canvas_ = null;
 

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -34,7 +34,7 @@ import {appendParams} from '../uri.js';
  *
  * @constructor
  * @fires ol.source.Image.Event
- * @extends {module:ol/source/Image~ImageSource}
+ * @extends {module:ol/source/Image}
  * @param {module:ol/source/ImageMapGuide~Options=} options ImageMapGuide options.
  * @api
  */
@@ -221,7 +221,7 @@ ImageMapGuide.prototype.updateParams = function(params) {
  * @param {Object.<string, string|number>} params Request parameters.
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {module:ol/size~Size} size Size.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @return {string} The mapagent map image request URL.
  */
 ImageMapGuide.prototype.getUrl = function(baseUrl, params, extent, size, projection) {

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -33,7 +33,7 @@ import ImageSource, {defaultImageLoadFunction} from '../source/Image.js';
  * A layer source for displaying a single, static image.
  *
  * @constructor
- * @extends {module:ol/source/Image~ImageSource}
+ * @extends {module:ol/source/Image}
  * @param {module:ol/source/ImageStatic~Options=} options ImageStatic options.
  * @api
  */

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -49,7 +49,7 @@ import {appendParams} from '../uri.js';
  *
  * @constructor
  * @fires ol.source.Image.Event
- * @extends {module:ol/source/Image~ImageSource}
+ * @extends {module:ol/source/Image}
  * @param {module:ol/source/ImageWMS~Options=} [opt_options] ImageWMS options.
  * @api
  */
@@ -283,7 +283,7 @@ ImageWMS.prototype.getImageLoadFunction = function() {
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {module:ol/size~Size} size Size.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {Object} params Params.
  * @return {string} Request URL.
  * @private

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -46,7 +46,7 @@ export const ATTRIBUTION = '&copy; ' +
  * Layer source for the OpenStreetMap tile server.
  *
  * @constructor
- * @extends {module:ol/source/XYZ~XYZ}
+ * @extends {module:ol/source/XYZ}
  * @param {module:ol/source/OSM~Options=} [opt_options] Open Street Map options.
  * @api
  */

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -67,7 +67,7 @@ const RasterEventType = {
  * type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.source.RasterEvent}
  * @param {string} type Type.
  * @param {module:ol/PluggableMap~FrameState} frameState The frame state.
@@ -103,7 +103,7 @@ inherits(RasterSourceEvent, Event);
 
 /**
  * @typedef {Object} Options
- * @property {Array.<module:ol/source/Source~Source>} sources Input sources.
+ * @property {Array.<module:ol/source/Source>} sources Input sources.
  * @property {module:ol/source/Raster~Operation} [operation] Raster operation.
  * The operation will be called with data from input sources
  * and the output will be assigned to the raster source.
@@ -128,7 +128,7 @@ inherits(RasterSourceEvent, Event);
  * output pixel values.
  *
  * @constructor
- * @extends {module:ol/source/Image~ImageSource}
+ * @extends {module:ol/source/Image}
  * @fires ol.source.Raster.Event
  * @param {module:ol/source/Raster~Options=} options Options.
  * @api
@@ -167,7 +167,7 @@ const RasterSource = function(options) {
 
   /**
    * @private
-   * @type {module:ol/TileQueue~TileQueue}
+   * @type {module:ol/TileQueue}
    */
   this.tileQueue_ = new TileQueue(
     function() {
@@ -190,7 +190,7 @@ const RasterSource = function(options) {
 
   /**
    * The most recently rendered image canvas.
-   * @type {module:ol/ImageCanvas~ImageCanvas}
+   * @type {module:ol/ImageCanvas}
    * @private
    */
   this.renderedImageCanvas_ = null;
@@ -262,7 +262,7 @@ RasterSource.prototype.setOperation = function(operation, opt_lib) {
  * Update the stored frame state.
  * @param {module:ol/extent~Extent} extent The view extent (in map units).
  * @param {number} resolution The view resolution.
- * @param {module:ol/proj/Projection~Projection} projection The view projection.
+ * @param {module:ol/proj/Projection} projection The view projection.
  * @return {module:ol/PluggableMap~FrameState} The updated frame state.
  * @private
  */
@@ -455,7 +455,7 @@ function getLayerStatesArray(renderers) {
 
 /**
  * Create renderers for all sources.
- * @param {Array.<module:ol/source/Source~Source>} sources The sources.
+ * @param {Array.<module:ol/source/Source>} sources The sources.
  * @return {Array.<ol.renderer.canvas.Layer>} Array of layer renderers.
  */
 function createRenderers(sources) {
@@ -470,7 +470,7 @@ function createRenderers(sources) {
 
 /**
  * Create a renderer for the provided source.
- * @param {module:ol/source/Source~Source} source The source.
+ * @param {module:ol/source/Source} source The source.
  * @return {ol.renderer.canvas.Layer} The renderer.
  */
 function createRenderer(source) {
@@ -486,7 +486,7 @@ function createRenderer(source) {
 
 /**
  * Create an image renderer for the provided source.
- * @param {module:ol/source/Image~ImageSource} source The source.
+ * @param {module:ol/source/Image} source The source.
  * @return {ol.renderer.canvas.Layer} The renderer.
  */
 function createImageRenderer(source) {
@@ -497,7 +497,7 @@ function createImageRenderer(source) {
 
 /**
  * Create a tile renderer for the provided source.
- * @param {module:ol/source/Tile~TileSource} source The source.
+ * @param {module:ol/source/Tile} source The source.
  * @return {ol.renderer.canvas.Layer} The renderer.
  */
 function createTileRenderer(source) {

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -47,7 +47,7 @@ import SourceState from '../source/State.js';
  *
  * @constructor
  * @abstract
- * @extends {module:ol/Object~BaseObject}
+ * @extends {module:ol/Object}
  * @param {module:ol/source/Source~Options} options Source options.
  * @api
  */
@@ -57,7 +57,7 @@ const Source = function(options) {
 
   /**
    * @private
-   * @type {module:ol/proj/Projection~Projection}
+   * @type {module:ol/proj/Projection}
    */
   this.projection_ = getProjection(options.projection);
 
@@ -114,7 +114,7 @@ Source.prototype.adaptAttributions_ = function(attributionLike) {
  * @param {number} rotation Rotation.
  * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {Object.<string, boolean>} skippedFeatureUids Skipped feature uids.
- * @param {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)): T} callback Feature callback.
+ * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
  * @return {T|undefined} Callback result.
  * @template T
  */
@@ -132,7 +132,7 @@ Source.prototype.getAttributions = function() {
 
 /**
  * Get the projection of the source.
- * @return {module:ol/proj/Projection~Projection} Projection.
+ * @return {module:ol/proj/Projection} Projection.
  * @api
  */
 Source.prototype.getProjection = function() {

--- a/src/ol/source/Stamen.js
+++ b/src/ol/source/Stamen.js
@@ -114,7 +114,7 @@ const ProviderConfig = {
  * Layer source for the Stamen tile server.
  *
  * @constructor
- * @extends {module:ol/source/XYZ~XYZ}
+ * @extends {module:ol/source/XYZ}
  * @param {module:ol/source/Stamen~Options=} options Stamen options.
  * @api
  */

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -21,7 +21,7 @@ import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.j
  * @property {number} [tilePixelRatio]
  * @property {module:ol/proj~ProjectionLike} [projection]
  * @property {module:ol/source/State~State} [state]
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid]
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid]
  * @property {boolean} [wrapX=true]
  * @property {number} [transition]
  */
@@ -35,7 +35,7 @@ import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.j
  *
  * @constructor
  * @abstract
- * @extends {module:ol/source/Source~Source}
+ * @extends {module:ol/source/Source}
  * @param {module:ol/source/Tile~Options=} options SourceTile source options.
  * @api
  */
@@ -64,13 +64,13 @@ const TileSource = function(options) {
 
   /**
    * @protected
-   * @type {module:ol/tilegrid/TileGrid~TileGrid}
+   * @type {module:ol/tilegrid/TileGrid}
    */
   this.tileGrid = options.tileGrid !== undefined ? options.tileGrid : null;
 
   /**
    * @protected
-   * @type {module:ol/TileCache~TileCache}
+   * @type {module:ol/TileCache}
    */
   this.tileCache = new TileCache(options.cacheSize);
 
@@ -106,8 +106,8 @@ TileSource.prototype.canExpireCache = function() {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @param {Object.<string, module:ol/TileRange~TileRange>} usedTiles Used tiles.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @param {Object.<string, module:ol/TileRange>} usedTiles Used tiles.
  */
 TileSource.prototype.expireCache = function(projection, usedTiles) {
   const tileCache = this.getTileCacheForProjection(projection);
@@ -118,10 +118,10 @@ TileSource.prototype.expireCache = function(projection, usedTiles) {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} z Zoom level.
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
- * @param {function(module:ol/Tile~Tile):(boolean|undefined)} callback Called with each
+ * @param {module:ol/TileRange} tileRange Tile range.
+ * @param {function(module:ol/Tile):(boolean|undefined)} callback Called with each
  *     loaded tile.  If the callback returns `false`, the tile will not be
  *     considered loaded.
  * @return {boolean} The tile range is fully covered with loaded tiles.
@@ -139,7 +139,7 @@ TileSource.prototype.forEachLoadedTile = function(projection, z, tileRange, call
       tileCoordKey = getKeyZXY(z, x, y);
       loaded = false;
       if (tileCache.containsKey(tileCoordKey)) {
-        tile = /** @type {!module:ol/Tile~Tile} */ (tileCache.get(tileCoordKey));
+        tile = /** @type {!module:ol/Tile} */ (tileCache.get(tileCoordKey));
         loaded = tile.getState() === TileState.LOADED;
         if (loaded) {
           loaded = (callback(tile) !== false);
@@ -155,7 +155,7 @@ TileSource.prototype.forEachLoadedTile = function(projection, z, tileRange, call
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @return {number} Gutter.
  */
 TileSource.prototype.getGutter = function(projection) {
@@ -187,7 +187,7 @@ TileSource.prototype.setKey = function(key) {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @return {boolean} Opaque.
  */
 TileSource.prototype.getOpaque = function(projection) {
@@ -209,15 +209,15 @@ TileSource.prototype.getResolutions = function() {
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @return {!module:ol/Tile~Tile} Tile.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {!module:ol/Tile} Tile.
  */
 TileSource.prototype.getTile = function(z, x, y, pixelRatio, projection) {};
 
 
 /**
  * Return the tile grid of the tile source.
- * @return {module:ol/tilegrid/TileGrid~TileGrid} Tile grid.
+ * @return {module:ol/tilegrid/TileGrid} Tile grid.
  * @api
  */
 TileSource.prototype.getTileGrid = function() {
@@ -226,8 +226,8 @@ TileSource.prototype.getTileGrid = function() {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @return {!module:ol/tilegrid/TileGrid~TileGrid} Tile grid.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {!module:ol/tilegrid/TileGrid} Tile grid.
  */
 TileSource.prototype.getTileGridForProjection = function(projection) {
   if (!this.tileGrid) {
@@ -239,8 +239,8 @@ TileSource.prototype.getTileGridForProjection = function(projection) {
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @return {module:ol/TileCache~TileCache} Tile cache.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {module:ol/TileCache} Tile cache.
  * @protected
  */
 TileSource.prototype.getTileCacheForProjection = function(projection) {
@@ -268,7 +268,7 @@ TileSource.prototype.getTilePixelRatio = function(pixelRatio) {
 /**
  * @param {number} z Z.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @return {module:ol/size~Size} Tile size.
  */
 TileSource.prototype.getTilePixelSize = function(z, pixelRatio, projection) {
@@ -288,7 +288,7 @@ TileSource.prototype.getTilePixelSize = function(z, pixelRatio, projection) {
  * is outside the resolution and extent range of the tile grid, `null` will be
  * returned.
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/proj/Projection~Projection=} opt_projection Projection.
+ * @param {module:ol/proj/Projection=} opt_projection Projection.
  * @return {module:ol/tilecoord~TileCoord} Tile coordinate to be passed to the tileUrlFunction or
  *     null if no tile URL should be created for the passed `tileCoord`.
  */
@@ -317,7 +317,7 @@ TileSource.prototype.refresh = function() {
  * @param {number} z Tile coordinate z.
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  */
 TileSource.prototype.useTile = UNDEFINED;
 
@@ -328,10 +328,10 @@ TileSource.prototype.useTile = UNDEFINED;
  * type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.source.Tile.Event}
  * @param {string} type Type.
- * @param {module:ol/Tile~Tile} tile The tile.
+ * @param {module:ol/Tile} tile The tile.
  */
 export const TileSourceEvent = function(type, tile) {
 
@@ -339,7 +339,7 @@ export const TileSourceEvent = function(type, tile) {
 
   /**
    * The tile related to the event.
-   * @type {module:ol/Tile~Tile}
+   * @type {module:ol/Tile}
    * @api
    */
   this.tile = tile;

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -60,7 +60,7 @@ import {appendParams} from '../uri.js';
  * {@link module:ol/source/XYZ~XYZ} data source.
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/TileArcGISRest~Options=} opt_options Tile ArcGIS Rest options.
  * @api
  */
@@ -130,7 +130,7 @@ TileArcGISRest.prototype.getParams = function() {
  * @param {module:ol/size~Size} tileSize Tile size.
  * @param {module:ol/extent~Extent} tileExtent Tile extent.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {Object} params Params.
  * @return {string|undefined} Request URL.
  * @private

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -12,7 +12,7 @@ import {getKeyZXY} from '../tilecoord.js';
 
 /**
  * @constructor
- * @extends {module:ol/Tile~Tile}
+ * @extends {module:ol/Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/size~Size} tileSize Tile size.
  * @param {string} text Text.
@@ -78,7 +78,7 @@ LabeledTile.prototype.load = function() {};
 /**
  * @typedef {Object} Options
  * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid.
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  */
 
@@ -92,7 +92,7 @@ LabeledTile.prototype.load = function() {};
  * Uses Canvas context2d, so requires Canvas support.
  *
  * @constructor
- * @extends {module:ol/source/Tile~TileSource}
+ * @extends {module:ol/source/Tile}
  * @param {module:ol/source/TileDebug~Options=} options Debug tile options.
  * @api
  */

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -29,7 +29,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * @property {module:ol/source/State~State} [state] Source state.
  * @property {module:ol/ImageTile~TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/ImageTile~ImageTile}.
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid.
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
  * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
@@ -93,7 +93,7 @@ const TileImage = function(options) {
 
   /**
    * @protected
-   * @type {function(new: module:ol/ImageTile~ImageTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
+   * @type {function(new: module:ol/ImageTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
    *        ?string, module:ol/Tile~LoadFunction, module:ol/Tile~Options=)}
    */
   this.tileClass = options.tileClass !== undefined ?
@@ -101,13 +101,13 @@ const TileImage = function(options) {
 
   /**
    * @protected
-   * @type {!Object.<string, module:ol/TileCache~TileCache>}
+   * @type {!Object.<string, module:ol/TileCache>}
    */
   this.tileCacheForProjection = {};
 
   /**
    * @protected
-   * @type {!Object.<string, module:ol/tilegrid/TileGrid~TileGrid>}
+   * @type {!Object.<string, module:ol/tilegrid/TileGrid>}
    */
   this.tileGridForProjection = {};
 
@@ -215,7 +215,9 @@ TileImage.prototype.getTileGridForProjection = function(projection) {
     if (!(projKey in this.tileGridForProjection)) {
       this.tileGridForProjection[projKey] = getTileGridForProjection(projection);
     }
-    return /** @type {!module:ol/tilegrid/TileGrid~TileGrid} */ (this.tileGridForProjection[projKey]);
+    return (
+      /** @type {!module:ol/tilegrid/TileGrid} */ (this.tileGridForProjection[projKey])
+    );
   }
 };
 
@@ -244,9 +246,9 @@ TileImage.prototype.getTileCacheForProjection = function(projection) {
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {string} key The key set on the tile.
- * @return {!module:ol/Tile~Tile} Tile.
+ * @return {!module:ol/Tile} Tile.
  * @private
  */
 TileImage.prototype.createTile_ = function(z, x, y, pixelRatio, projection, key) {
@@ -273,7 +275,7 @@ TileImage.prototype.createTile_ = function(z, x, y, pixelRatio, projection, key)
  * @inheritDoc
  */
 TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection) {
-  const sourceProjection = /** @type {!module:ol/proj/Projection~Projection} */ (this.getProjection());
+  const sourceProjection = /** @type {!module:ol/proj/Projection} */ (this.getProjection());
   if (!ENABLE_RASTER_REPROJECTION ||
       !sourceProjection || !projection || equivalent(sourceProjection, projection)) {
     return this.getTileInternal(z, x, y, pixelRatio, sourceProjection || projection);
@@ -283,7 +285,7 @@ TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection) {
     let tile;
     const tileCoordKey = getKey(tileCoord);
     if (cache.containsKey(tileCoordKey)) {
-      tile = /** @type {!module:ol/Tile~Tile} */ (cache.get(tileCoordKey));
+      tile = /** @type {!module:ol/Tile} */ (cache.get(tileCoordKey));
     }
     const key = this.getKey();
     if (tile && tile.key == key) {
@@ -322,8 +324,8 @@ TileImage.prototype.getTile = function(z, x, y, pixelRatio, projection) {
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
  * @param {number} pixelRatio Pixel ratio.
- * @param {!module:ol/proj/Projection~Projection} projection Projection.
- * @return {!module:ol/Tile~Tile} Tile.
+ * @param {!module:ol/proj/Projection} projection Projection.
+ * @return {!module:ol/Tile} Tile.
  * @protected
  */
 TileImage.prototype.getTileInternal = function(z, x, y, pixelRatio, projection) {
@@ -384,7 +386,7 @@ TileImage.prototype.setRenderReprojectionEdges = function(render) {
  * for optimization reasons (custom tile size, resolutions, ...).
  *
  * @param {module:ol/proj~ProjectionLike} projection Projection.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tilegrid Tile grid to use for the projection.
+ * @param {module:ol/tilegrid/TileGrid} tilegrid Tile grid to use for the projection.
  * @api
  */
 TileImage.prototype.setTileGridForProjection = function(projection, tilegrid) {
@@ -401,7 +403,7 @@ TileImage.prototype.setTileGridForProjection = function(projection, tilegrid) {
 
 
 /**
- * @param {module:ol/ImageTile~ImageTile} imageTile Image tile.
+ * @param {module:ol/ImageTile} imageTile Image tile.
  * @param {string} src Source.
  */
 function defaultTileLoadFunction(imageTile, src) {

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -49,7 +49,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * Layer source for tile data in TileJSON format.
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/TileJSON~Options=} options TileJSON options.
  * @api
  */

--- a/src/ol/source/TileUTFGrid.js
+++ b/src/ol/source/TileUTFGrid.js
@@ -19,7 +19,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 /**
  * @constructor
- * @extends {module:ol/Tile~Tile}
+ * @extends {module:ol/Tile}
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/TileState} state State.
  * @param {string} src Image source URI.
@@ -271,7 +271,7 @@ CustomTile.prototype.load = function() {
  * Layer source for UTFGrid interaction data loaded from TileJSON format.
  *
  * @constructor
- * @extends {module:ol/source/Tile~TileSource}
+ * @extends {module:ol/source/Tile}
  * @param {module:ol/source/TileUTFGrid~Options=} options Source options.
  * @api
  */
@@ -466,7 +466,9 @@ UTFGrid.prototype.handleTileJSONResponse = function(tileJSON) {
 UTFGrid.prototype.getTile = function(z, x, y, pixelRatio, projection) {
   const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
-    return /** @type {!module:ol/Tile~Tile} */ (this.tileCache.get(tileCoordKey));
+    return (
+      /** @type {!module:ol/Tile} */ (this.tileCache.get(tileCoordKey))
+    );
   } else {
     const tileCoord = [z, x, y];
     const urlTileCoord =

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -45,7 +45,7 @@ import {appendParams} from '../uri.js';
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {module:ol/ImageTile~TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/ImageTile~TileClass}.
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid. Base this on the resolutions,
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid. Base this on the resolutions,
  * tilesize and extent supported by the server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
@@ -76,7 +76,7 @@ import {appendParams} from '../uri.js';
  * Layer source for tile data from WMS servers.
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/TileWMS~Options=} [opt_options] Tile WMS options.
  * @api
  */
@@ -239,7 +239,7 @@ TileWMS.prototype.getParams = function() {
  * @param {module:ol/size~Size} tileSize Tile size.
  * @param {module:ol/extent~Extent} tileExtent Tile extent.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @param {Object} params Params.
  * @return {string|undefined} Request URL.
  * @private

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -16,7 +16,7 @@ import {getKeyZXY} from '../tilecoord.js';
  * @property {boolean} [opaque]
  * @property {module:ol/proj~ProjectionLike} [projection]
  * @property {module:ol/source/State~State} [state]
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid]
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid]
  * @property {module:ol/Tile~LoadFunction} tileLoadFunction
  * @property {number} [tilePixelRatio]
  * @property {module:ol/Tile~UrlFunction} [tileUrlFunction]
@@ -33,8 +33,8 @@ import {getKeyZXY} from '../tilecoord.js';
  *
  * @constructor
  * @abstract
- * @fires module:ol/source/Tile~TileSourceEvent
- * @extends {module:ol/source/Tile~TileSource}
+ * @fires module:ol/source/TileEvent
+ * @extends {module:ol/source/Tile}
  * @param {module:ol/source/UrlTile~Options=} options Image tile options.
  */
 const UrlTile = function(options) {
@@ -131,11 +131,11 @@ UrlTile.prototype.getUrls = function() {
 
 /**
  * Handle tile change events.
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  * @protected
  */
 UrlTile.prototype.handleTileChange = function(event) {
-  const tile = /** @type {module:ol/Tile~Tile} */ (event.target);
+  const tile = /** @type {module:ol/Tile} */ (event.target);
   const uid = getUid(tile);
   const tileState = tile.getState();
   let type;

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -37,10 +37,10 @@ import RBush from '../structs/RBush.js';
  * type.
  *
  * @constructor
- * @extends {module:ol/events/Event~Event}
+ * @extends {module:ol/events/Event}
  * @implements {oli.source.Vector.Event}
  * @param {string} type Type.
- * @param {module:ol/Feature~Feature=} opt_feature Feature.
+ * @param {module:ol/Feature=} opt_feature Feature.
  */
 export const VectorSourceEvent = function(type, opt_feature) {
 
@@ -48,7 +48,7 @@ export const VectorSourceEvent = function(type, opt_feature) {
 
   /**
    * The feature being added or removed.
-   * @type {module:ol/Feature~Feature|undefined}
+   * @type {module:ol/Feature|undefined}
    * @api
    */
   this.feature = opt_feature;
@@ -60,10 +60,10 @@ inherits(VectorSourceEvent, Event);
 /**
  * @typedef {Object} Options
  * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
- * @property {Array.<module:ol/Feature~Feature>|module:ol/Collection~Collection.<module:ol/Feature~Feature>} [features]
- * Features. If provided as {@link module:ol/Collection~Collection}, the features in the source
+ * @property {Array.<module:ol/Feature>|module:ol/Collection.<module:ol/Feature>} [features]
+ * Features. If provided as {@link module:ol/Collection}, the features in the source
  * and the collection will stay in sync.
- * @property {module:ol/format/Feature~FeatureFormat} [format] The feature format used by the XHR
+ * @property {module:ol/format/Feature} [format] The feature format used by the XHR
  * feature loader when `url` is set. Required if `url` is set, otherwise ignored.
  * @property {module:ol/Feature~FeatureLoader} [loader]
  * The loader function used to load features, from a remote source for example.
@@ -135,7 +135,7 @@ inherits(VectorSourceEvent, Event);
  * through all features.
  *
  * When set to `false`, the features will be maintained in an
- * {@link module:ol/Collection~Collection}, which can be retrieved through
+ * {@link module:ol/Collection}, which can be retrieved through
  * {@link module:ol/source/Vector~VectorSource#getFeaturesCollection}.
  * @property {boolean} [wrapX=true] Wrap the world horizontally. For vector editing across the
  * -180° and 180° meridians to work properly, this should be set to `false`. The
@@ -150,7 +150,7 @@ inherits(VectorSourceEvent, Event);
  * vector data that is optimized for rendering.
  *
  * @constructor
- * @extends {module:ol/source/Source~Source}
+ * @extends {module:ol/source/Source}
  * @fires ol.source.Vector.Event
  * @param {module:ol/source/Vector~Options=} opt_options Vector source options.
  * @api
@@ -174,7 +174,7 @@ const VectorSource = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/format/Feature~FeatureFormat|undefined}
+   * @type {module:ol/format/Feature|undefined}
    */
   this.format_ = options.format;
 
@@ -195,7 +195,7 @@ const VectorSource = function(opt_options) {
   } else if (this.url_ !== undefined) {
     assert(this.format_, 7); // `format` must be set when `url` is set
     // create a XHR feature loader for "url" and "format"
-    this.loader_ = xhr(this.url_, /** @type {module:ol/format/Feature~FeatureFormat} */ (this.format_));
+    this.loader_ = xhr(this.url_, /** @type {module:ol/format/Feature} */ (this.format_));
   }
 
   /**
@@ -209,7 +209,7 @@ const VectorSource = function(opt_options) {
 
   /**
    * @private
-   * @type {ol.structs.RBush.<module:ol/Feature~Feature>}
+   * @type {ol.structs.RBush.<module:ol/Feature>}
    */
   this.featuresRtree_ = useSpatialIndex ? new RBush() : null;
 
@@ -221,21 +221,21 @@ const VectorSource = function(opt_options) {
 
   /**
    * @private
-   * @type {!Object.<string, module:ol/Feature~Feature>}
+   * @type {!Object.<string, module:ol/Feature>}
    */
   this.nullGeometryFeatures_ = {};
 
   /**
    * A lookup of features by id (the return from feature.getId()).
    * @private
-   * @type {!Object.<string, module:ol/Feature~Feature>}
+   * @type {!Object.<string, module:ol/Feature>}
    */
   this.idIndex_ = {};
 
   /**
    * A lookup of features without id (keyed by ol.getUid(feature)).
    * @private
-   * @type {!Object.<string, module:ol/Feature~Feature>}
+   * @type {!Object.<string, module:ol/Feature>}
    */
   this.undefIdIndex_ = {};
 
@@ -247,7 +247,7 @@ const VectorSource = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/Collection~Collection.<module:ol/Feature~Feature>}
+   * @type {module:ol/Collection.<module:ol/Feature>}
    */
   this.featuresCollection_ = null;
 
@@ -279,7 +279,7 @@ inherits(VectorSource, Source);
  * instead. A feature will not be added to the source if feature with
  * the same id is already there. The reason for this behavior is to avoid
  * feature duplication when using bbox or tile loading strategies.
- * @param {module:ol/Feature~Feature} feature Feature to add.
+ * @param {module:ol/Feature} feature Feature to add.
  * @api
  */
 VectorSource.prototype.addFeature = function(feature) {
@@ -290,7 +290,7 @@ VectorSource.prototype.addFeature = function(feature) {
 
 /**
  * Add a feature without firing a `change` event.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @protected
  */
 VectorSource.prototype.addFeatureInternal = function(feature) {
@@ -319,7 +319,7 @@ VectorSource.prototype.addFeatureInternal = function(feature) {
 
 /**
  * @param {string} featureKey Unique identifier for the feature.
- * @param {module:ol/Feature~Feature} feature The feature.
+ * @param {module:ol/Feature} feature The feature.
  * @private
  */
 VectorSource.prototype.setupChangeEvents_ = function(featureKey, feature) {
@@ -334,7 +334,7 @@ VectorSource.prototype.setupChangeEvents_ = function(featureKey, feature) {
 
 /**
  * @param {string} featureKey Unique identifier for the feature.
- * @param {module:ol/Feature~Feature} feature The feature.
+ * @param {module:ol/Feature} feature The feature.
  * @return {boolean} The feature is "valid", in the sense that it is also a
  *     candidate for insertion into the Rtree.
  * @private
@@ -359,7 +359,7 @@ VectorSource.prototype.addToIndex_ = function(featureKey, feature) {
 
 /**
  * Add a batch of features to the source.
- * @param {Array.<module:ol/Feature~Feature>} features Features to add.
+ * @param {Array.<module:ol/Feature>} features Features to add.
  * @api
  */
 VectorSource.prototype.addFeatures = function(features) {
@@ -370,7 +370,7 @@ VectorSource.prototype.addFeatures = function(features) {
 
 /**
  * Add features without firing a `change` event.
- * @param {Array.<module:ol/Feature~Feature>} features Features.
+ * @param {Array.<module:ol/Feature>} features Features.
  * @protected
  */
 VectorSource.prototype.addFeaturesInternal = function(features) {
@@ -411,7 +411,7 @@ VectorSource.prototype.addFeaturesInternal = function(features) {
 
 
 /**
- * @param {!module:ol/Collection~Collection.<module:ol/Feature~Feature>} collection Collection.
+ * @param {!module:ol/Collection.<module:ol/Feature>} collection Collection.
  * @private
  */
 VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
@@ -436,7 +436,7 @@ VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
     function(evt) {
       if (!modifyingCollection) {
         modifyingCollection = true;
-        this.addFeature(/** @type {module:ol/Feature~Feature} */ (evt.element));
+        this.addFeature(/** @type {module:ol/Feature} */ (evt.element));
         modifyingCollection = false;
       }
     }, this);
@@ -444,7 +444,7 @@ VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
     function(evt) {
       if (!modifyingCollection) {
         modifyingCollection = true;
-        this.removeFeature(/** @type {module:ol/Feature~Feature} */ (evt.element));
+        this.removeFeature(/** @type {module:ol/Feature} */ (evt.element));
         modifyingCollection = false;
       }
     }, this);
@@ -498,7 +498,7 @@ VectorSource.prototype.clear = function(opt_fast) {
  * stop and the function will return the same value.
  * Note: this function only iterate through the feature that have a defined geometry.
  *
- * @param {function(module:ol/Feature~Feature): T} callback Called with each feature
+ * @param {function(module:ol/Feature): T} callback Called with each feature
  *     on the source.  Return a truthy value to stop iteration.
  * @return {T|undefined} The return value from the last call to the callback.
  * @template T
@@ -520,7 +520,7 @@ VectorSource.prototype.forEachFeature = function(callback) {
  * value.
  *
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {function(module:ol/Feature~Feature): T} callback Called with each feature
+ * @param {function(module:ol/Feature): T} callback Called with each feature
  *     whose goemetry contains the provided coordinate.
  * @return {T|undefined} The return value from the last call to the callback.
  * @template T
@@ -552,7 +552,7 @@ VectorSource.prototype.forEachFeatureAtCoordinateDirect = function(coordinate, c
  * features, equivalent to {@link module:ol/source/Vector~VectorSource#forEachFeature}.
  *
  * @param {module:ol/extent~Extent} extent Extent.
- * @param {function(module:ol/Feature~Feature): T} callback Called with each feature
+ * @param {function(module:ol/Feature): T} callback Called with each feature
  *     whose bounding box intersects the provided extent.
  * @return {T|undefined} The return value from the last call to the callback.
  * @template T
@@ -577,7 +577,7 @@ VectorSource.prototype.forEachFeatureInExtent = function(extent, callback) {
  * source.forEachFeatureInExtent()} method instead.
  *
  * @param {module:ol/extent~Extent} extent Extent.
- * @param {function(module:ol/Feature~Feature): T} callback Called with each feature
+ * @param {function(module:ol/Feature): T} callback Called with each feature
  *     whose geometry intersects the provided extent.
  * @return {T|undefined} The return value from the last call to the callback.
  * @template T
@@ -586,7 +586,7 @@ VectorSource.prototype.forEachFeatureInExtent = function(extent, callback) {
 VectorSource.prototype.forEachFeatureIntersectingExtent = function(extent, callback) {
   return this.forEachFeatureInExtent(extent,
     /**
-     * @param {module:ol/Feature~Feature} feature Feature.
+     * @param {module:ol/Feature} feature Feature.
      * @return {T|undefined} The return value from the last call to the callback.
      * @template T
      */
@@ -605,8 +605,8 @@ VectorSource.prototype.forEachFeatureIntersectingExtent = function(extent, callb
 /**
  * Get the features collection associated with this source. Will be `null`
  * unless the source was configured with `useSpatialIndex` set to `false`, or
- * with an {@link module:ol/Collection~Collection} as `features`.
- * @return {module:ol/Collection~Collection.<module:ol/Feature~Feature>} The collection of features.
+ * with an {@link module:ol/Collection} as `features`.
+ * @return {module:ol/Collection.<module:ol/Feature>} The collection of features.
  * @api
  */
 VectorSource.prototype.getFeaturesCollection = function() {
@@ -616,7 +616,7 @@ VectorSource.prototype.getFeaturesCollection = function() {
 
 /**
  * Get all features on the source in random order.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 VectorSource.prototype.getFeatures = function() {
@@ -629,14 +629,16 @@ VectorSource.prototype.getFeatures = function() {
       extend(features, getValues(this.nullGeometryFeatures_));
     }
   }
-  return /** @type {Array.<module:ol/Feature~Feature>} */ (features);
+  return (
+    /** @type {Array.<module:ol/Feature>} */ (features)
+  );
 };
 
 
 /**
  * Get all features whose geometry intersects the provided coordinate.
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 VectorSource.prototype.getFeaturesAtCoordinate = function(coordinate) {
@@ -656,7 +658,7 @@ VectorSource.prototype.getFeaturesAtCoordinate = function(coordinate) {
  * This method is not available when the source is configured with
  * `useSpatialIndex` set to `false`.
  * @param {module:ol/extent~Extent} extent Extent.
- * @return {Array.<module:ol/Feature~Feature>} Features.
+ * @return {Array.<module:ol/Feature>} Features.
  * @api
  */
 VectorSource.prototype.getFeaturesInExtent = function(extent) {
@@ -670,10 +672,10 @@ VectorSource.prototype.getFeaturesInExtent = function(extent) {
  * This method is not available when the source is configured with
  * `useSpatialIndex` set to `false`.
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {function(module:ol/Feature~Feature):boolean=} opt_filter Feature filter function.
- *     The filter function will receive one argument, the {@link module:ol/Feature~Feature feature}
+ * @param {function(module:ol/Feature):boolean=} opt_filter Feature filter function.
+ *     The filter function will receive one argument, the {@link module:ol/Feature feature}
  *     and it should return a boolean value. By default, no filtering is made.
- * @return {module:ol/Feature~Feature} Closest feature.
+ * @return {module:ol/Feature} Closest feature.
  * @api
  */
 VectorSource.prototype.getClosestFeatureToCoordinate = function(coordinate, opt_filter) {
@@ -693,8 +695,8 @@ VectorSource.prototype.getClosestFeatureToCoordinate = function(coordinate, opt_
   const filter = opt_filter ? opt_filter : TRUE;
   this.featuresRtree_.forEachInExtent(extent,
     /**
-       * @param {module:ol/Feature~Feature} feature Feature.
-       */
+     * @param {module:ol/Feature} feature Feature.
+     */
     function(feature) {
       if (filter(feature)) {
         const geometry = feature.getGeometry();
@@ -740,7 +742,7 @@ VectorSource.prototype.getExtent = function(opt_extent) {
  * `source.getFeatureById(2)` will return a feature with id `'2'` or `2`.
  *
  * @param {string|number} id Feature identifier.
- * @return {module:ol/Feature~Feature} The feature (or `null` if not found).
+ * @return {module:ol/Feature} The feature (or `null` if not found).
  * @api
  */
 VectorSource.prototype.getFeatureById = function(id) {
@@ -752,7 +754,7 @@ VectorSource.prototype.getFeatureById = function(id) {
 /**
  * Get the format associated with this source.
  *
- * @return {module:ol/format/Feature~FeatureFormat|undefined} The feature format.
+ * @return {module:ol/format/Feature|undefined} The feature format.
  * @api
  */
 VectorSource.prototype.getFormat = function() {
@@ -786,11 +788,11 @@ VectorSource.prototype.getUrl = function() {
 
 
 /**
- * @param {module:ol/events/Event~Event} event Event.
+ * @param {module:ol/events/Event} event Event.
  * @private
  */
 VectorSource.prototype.handleFeatureChange_ = function(event) {
-  const feature = /** @type {module:ol/Feature~Feature} */ (event.target);
+  const feature = /** @type {module:ol/Feature} */ (event.target);
   const featureKey = getUid(feature).toString();
   const geometry = feature.getGeometry();
   if (!geometry) {
@@ -863,7 +865,7 @@ VectorSource.prototype.isEmpty = function() {
 /**
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} resolution Resolution.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  */
 VectorSource.prototype.loadFeatures = function(extent, resolution, projection) {
   const loadedExtentsRtree = this.loadedExtentsRtree_;
@@ -910,7 +912,7 @@ VectorSource.prototype.removeLoadedExtent = function(extent) {
  * Remove a single feature from the source.  If you want to remove all features
  * at once, use the {@link module:ol/source/Vector~VectorSource#clear source.clear()} method
  * instead.
- * @param {module:ol/Feature~Feature} feature Feature to remove.
+ * @param {module:ol/Feature} feature Feature to remove.
  * @api
  */
 VectorSource.prototype.removeFeature = function(feature) {
@@ -929,7 +931,7 @@ VectorSource.prototype.removeFeature = function(feature) {
 
 /**
  * Remove feature without firing a `change` event.
- * @param {module:ol/Feature~Feature} feature Feature.
+ * @param {module:ol/Feature} feature Feature.
  * @protected
  */
 VectorSource.prototype.removeFeatureInternal = function(feature) {
@@ -950,7 +952,7 @@ VectorSource.prototype.removeFeatureInternal = function(feature) {
 /**
  * Remove a feature from the id index.  Called internally when the feature id
  * may have changed.
- * @param {module:ol/Feature~Feature} feature The feature.
+ * @param {module:ol/Feature} feature The feature.
  * @return {boolean} Removed the feature from the index.
  * @private
  */

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -14,7 +14,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * @typedef {Object} Options
  * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=128] Cache size.
- * @property {module:ol/format/Feature~FeatureFormat} [format] Feature format for tiles. Used and required by the default.
+ * @property {module:ol/format/Feature} [format] Feature format for tiles. Used and required by the default.
  * @property {boolean} [overlaps=true] This source may have overlapping geometries. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
@@ -23,7 +23,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * @property {module:ol/source/State~State} [state] Source state.
  * @property {module:ol/VectorTile~TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link ol.VectorTile}.
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid.
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
  * @property {module:ol/Tile~LoadFunction} [tileLoadFunction]
  * Optional function to load a tile given a URL. Could look like this:
  * ```js
@@ -98,14 +98,14 @@ const VectorTile = function(options) {
 
   /**
    * @private
-   * @type {module:ol/format/Feature~FeatureFormat}
+   * @type {module:ol/format/Feature}
    */
   this.format_ = options.format ? options.format : null;
 
   /**
-   * @private
-   * @type {Object.<string, module:ol/VectorTile~VectorTile>}
-   */
+     * @private
+     * @type {Object.<string, module:ol/VectorTile>}
+     */
   this.sourceTiles_ = {};
 
   /**
@@ -115,15 +115,15 @@ const VectorTile = function(options) {
   this.overlaps_ = options.overlaps == undefined ? true : options.overlaps;
 
   /**
-   * @protected
-   * @type {function(new: module:ol/VectorTile~VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
-   *        module:ol/format/Feature~FeatureFormat, module:ol/Tile~LoadFunction)}
-   */
+     * @protected
+     * @type {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
+     *        module:ol/format/Feature, module:ol/Tile~LoadFunction)}
+     */
   this.tileClass = options.tileClass ? options.tileClass : Tile;
 
   /**
    * @private
-   * @type {Object.<string, module:ol/tilegrid/TileGrid~TileGrid>}
+   * @type {Object.<string, module:ol/tilegrid/TileGrid>}
    */
   this.tileGrids_ = {};
 
@@ -154,7 +154,9 @@ VectorTile.prototype.clear = function() {
 VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projection) {
   const tileCoordKey = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(tileCoordKey)) {
-    return /** @type {!module:ol/Tile~Tile} */ (this.tileCache.get(tileCoordKey));
+    return (
+      /** @type {!module:ol/Tile} */ (this.tileCache.get(tileCoordKey))
+    );
   } else {
     const tileCoord = [z, x, y];
     const urlTileCoord = this.getTileCoordForTileUrlFunction(

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -20,7 +20,7 @@ import {appendParams} from '../uri.js';
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
- * @property {module:ol/tilegrid/WMTS~WMTSTileGrid} tileGrid Tile grid.
+ * @property {module:ol/tilegrid/WMTS} tileGrid Tile grid.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {boolean} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
@@ -61,7 +61,7 @@ import {appendParams} from '../uri.js';
  * Layer source for tile data from WMTS servers.
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/WMTS~Options=} options WMTS options.
  * @api
  */
@@ -167,7 +167,7 @@ const WMTS = function(options) {
       /**
        * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
        * @param {number} pixelRatio Pixel ratio.
-       * @param {module:ol/proj/Projection~Projection} projection Projection.
+       * @param {module:ol/proj/Projection} projection Projection.
        * @return {string|undefined} Tile URL.
        */
       function(tileCoord, pixelRatio, projection) {

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -19,7 +19,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {number} [maxZoom=18] Optional max zoom level.
  * @property {number} [maxZoom=0] Optional min zoom level.
- * @property {module:ol/tilegrid/TileGrid~TileGrid} [tileGrid] Tile grid.
+ * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
  * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
@@ -52,7 +52,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * TMS where `x` 0 and `y` 0 are in the bottom left can be used by
  * using the `{-y}` placeholder in the URL template, so long as the
  * source does not have a custom tile grid. In this case,
- * {@link module:ol/source/TileImage~TileImage} can be used with a `tileUrlFunction`
+ * {@link module:ol/source/TileImage} can be used with a `tileUrlFunction`
  * such as:
  *
  *  tileUrlFunction: function(coordinate) {
@@ -62,7 +62,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  *
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/XYZ~Options=} opt_options XYZ options.
  * @api
  */

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -25,8 +25,8 @@ const TierSizeCalculation = {
 
 /**
  * @constructor
- * @extends {module:ol/ImageTile~ImageTile}
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid TileGrid that the tile belongs to.
+ * @extends {module:ol/ImageTile}
+ * @param {module:ol/tilegrid/TileGrid} tileGrid TileGrid that the tile belongs to.
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {module:ol/TileState} state State.
  * @param {string} src Image source URI.
@@ -120,7 +120,7 @@ CustomTile.prototype.getImage = function() {
  * Imaging Protocol are supported).
  *
  * @constructor
- * @extends {module:ol/source/TileImage~TileImage}
+ * @extends {module:ol/source/TileImage}
  * @param {module:ol/source/Zoomify~Options=} opt_options Options.
  * @api
  */
@@ -204,7 +204,7 @@ const Zoomify = function(opt_options) {
       /**
        * @param {module:ol/tilecoord~TileCoord} tileCoord Tile Coordinate.
        * @param {number} pixelRatio Pixel ratio.
-       * @param {module:ol/proj/Projection~Projection} projection Projection.
+       * @param {module:ol/proj/Projection} projection Projection.
        * @return {string|undefined} Tile URL.
        */
       function(tileCoord, pixelRatio, projection) {
@@ -230,7 +230,8 @@ const Zoomify = function(opt_options) {
             return localContext[p];
           });
         }
-      });
+      }
+    );
   }
 
   const tileUrlFunction = createFromTileUrlFunctions(urls.map(createFromTemplate));

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -74,7 +74,7 @@ function getLengthInternal(coordinates, radius) {
  * great circle distances between coordinates.  For polygons, the length is
  * the sum of all rings.  For points, the length is zero.  For multi-part
  * geometries, the length is the sum of the length of each part.
- * @param {module:ol/geom/Geometry~Geometry} geometry A geometry.
+ * @param {module:ol/geom/Geometry} geometry A geometry.
  * @param {module:ol/sphere~SphereMetricOptions=} opt_options Options for the
  * length calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  * You can change this by providing a `projection` option.
@@ -98,20 +98,20 @@ export function getLength(geometry, opt_options) {
     }
     case GeometryType.LINE_STRING:
     case GeometryType.LINEAR_RING: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
       length = getLengthInternal(coordinates, radius);
       break;
     }
     case GeometryType.MULTI_LINE_STRING:
     case GeometryType.POLYGON: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         length += getLengthInternal(coordinates[i], radius);
       }
       break;
     }
     case GeometryType.MULTI_POLYGON: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         coords = coordinates[i];
         for (j = 0, jj = coords.length; j < jj; ++j) {
@@ -121,7 +121,7 @@ export function getLength(geometry, opt_options) {
       break;
     }
     case GeometryType.GEOMETRY_COLLECTION: {
-      const geometries = /** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry).getGeometries();
+      const geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
       for (i = 0, ii = geometries.length; i < ii; ++i) {
         length += getLength(geometries[i], opt_options);
       }
@@ -170,7 +170,7 @@ function getAreaInternal(coordinates, radius) {
 /**
  * Get the spherical area of a geometry.  This is the area (in meters) assuming
  * that polygon edges are segments of great circles on a sphere.
- * @param {module:ol/geom/Geometry~Geometry} geometry A geometry.
+ * @param {module:ol/geom/Geometry} geometry A geometry.
  * @param {module:ol/sphere~SphereMetricOptions=} opt_options Options for the area
  *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  *     You can change this by providing a `projection` option.
@@ -196,7 +196,7 @@ export function getArea(geometry, opt_options) {
       break;
     }
     case GeometryType.POLYGON: {
-      coordinates = /** @type {module:ol/geom/Polygon~Polygon} */ (geometry).getCoordinates();
+      coordinates = /** @type {module:ol/geom/Polygon} */ (geometry).getCoordinates();
       area = Math.abs(getAreaInternal(coordinates[0], radius));
       for (i = 1, ii = coordinates.length; i < ii; ++i) {
         area -= Math.abs(getAreaInternal(coordinates[i], radius));
@@ -204,7 +204,7 @@ export function getArea(geometry, opt_options) {
       break;
     }
     case GeometryType.MULTI_POLYGON: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry~SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         coords = coordinates[i];
         area += Math.abs(getAreaInternal(coords[0], radius));
@@ -215,7 +215,7 @@ export function getArea(geometry, opt_options) {
       break;
     }
     case GeometryType.GEOMETRY_COLLECTION: {
-      const geometries = /** @type {module:ol/geom/GeometryCollection~GeometryCollection} */ (geometry).getGeometries();
+      const geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
       for (i = 0, ii = geometries.length; i < ii; ++i) {
         area += getArea(geometries[i], opt_options);
       }

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -21,7 +21,7 @@ import EventType from '../events/EventType.js';
  * Object's properties (e.g. 'hasOwnProperty' is not allowed as a key). Expiring
  * items from the cache is the responsibility of the user.
  * @constructor
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  * @fires module:ol/events/Event~Event
  * @struct
  * @template T

--- a/src/ol/style.js
+++ b/src/ol/style.js
@@ -4,13 +4,13 @@
 
 
 /**
- * A function that takes an {@link module:ol/Feature~Feature} and a `{number}`
+ * A function that takes an {@link module:ol/Feature} and a `{number}`
  * representing the view's resolution. The function should return a
- * {@link module:ol/style/Style~Style} or an array of them. This way e.g. a
+ * {@link module:ol/style/Style} or an array of them. This way e.g. a
  * vector layer can be styled.
  *
- * @typedef {function((module:ol/Feature~Feature|module:ol/render/Feature~Feature), number):
- *     (module:ol/style/Style~Style|Array.<module:ol/style/Style~Style>)} StyleFunction
+ * @typedef {function((module:ol/Feature|module:ol/render/Feature~Feature), number):
+ *     (module:ol/style/Style|Array.<module:ol/style/Style>)} StyleFunction
  * @api
  */
 

--- a/src/ol/style/AtlasManager.js
+++ b/src/ol/style/AtlasManager.js
@@ -89,7 +89,7 @@ const AtlasManager = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<module:ol/style/Atlas~Atlas>}
+   * @type {Array.<module:ol/style/Atlas>}
    */
   this.atlases_ = [new Atlas(this.currentSize_, this.space_)];
 
@@ -102,7 +102,7 @@ const AtlasManager = function(opt_options) {
 
   /**
    * @private
-   * @type {Array.<module:ol/style/Atlas~Atlas>}
+   * @type {Array.<module:ol/style/Atlas>}
    */
   this.hitAtlases_ = [new Atlas(this.currentHitSize_, this.space_)];
 };
@@ -128,7 +128,7 @@ AtlasManager.prototype.getInfo = function(id) {
 
 /**
  * @private
- * @param {Array.<module:ol/style/Atlas~Atlas>} atlases The atlases to search.
+ * @param {Array.<module:ol/style/Atlas>} atlases The atlases to search.
  * @param {string} id The identifier of the entry to check.
  * @return {?module:ol/style/Atlas~AtlasInfo} The position and atlas image for the entry,
  *    or `null` if the entry is not part of the atlases.
@@ -154,12 +154,14 @@ AtlasManager.prototype.getInfo_ = function(atlases, id) {
  *    entry, or `null` if the entry is not part of the atlases.
  */
 AtlasManager.prototype.mergeInfos_ = function(info, hitInfo) {
-  return /** @type {module:ol/style/AtlasManager~AtlasManagerInfo} */ ({
-    offsetX: info.offsetX,
-    offsetY: info.offsetY,
-    image: info.image,
-    hitImage: hitInfo.image
-  });
+  return (
+    /** @type {module:ol/style/AtlasManager~AtlasManagerInfo} */ ({
+      offsetX: info.offsetX,
+      offsetY: info.offsetY,
+      image: info.image,
+      hitImage: hitInfo.image
+    })
+  );
 };
 
 

--- a/src/ol/style/Circle.js
+++ b/src/ol/style/Circle.js
@@ -7,14 +7,14 @@ import RegularShape from '../style/RegularShape.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/style/Fill~Fill} [fill] Fill style.
+ * @property {module:ol/style/Fill} [fill] Fill style.
  * @property {number} radius Circle radius.
  * @property {boolean} [snapToPixel=true] If `true` integral numbers of pixels are used as the X and Y pixel coordinate
  * when drawing the circle in the output canvas. If `false` fractional numbers may be used. Using `true` allows for
  * "sharp" rendering (no blur), while using `false` allows for "accurate" rendering. Note that accuracy is important if
  * the circle's position is animated. Without it, the circle may jitter noticeably.
- * @property {module:ol/style/Stroke~Stroke} [stroke] Stroke style.
- * @property {module:ol/style/AtlasManager~AtlasManager} [atlasManager] The atlas manager to use for this circle.
+ * @property {module:ol/style/Stroke} [stroke] Stroke style.
+ * @property {module:ol/style/AtlasManager} [atlasManager] The atlas manager to use for this circle.
  * When using WebGL it is recommended to use an atlas manager to avoid texture switching. If an atlas manager is given,
  * the circle is added to an atlas. By default no atlas manager is used.
  */
@@ -26,7 +26,7 @@ import RegularShape from '../style/RegularShape.js';
  *
  * @constructor
  * @param {module:ol/style/Circle~Options=} opt_options Options.
- * @extends {module:ol/style/RegularShape~RegularShape}
+ * @extends {module:ol/style/RegularShape}
  * @api
  */
 const CircleStyle = function(opt_options) {
@@ -49,7 +49,7 @@ inherits(CircleStyle, RegularShape);
 
 /**
  * Clones the style.  If an atlasmanager was provided to the original style it will be used in the cloned style, too.
- * @return {module:ol/style/Circle~CircleStyle} The cloned style.
+ * @return {module:ol/style/Circle} The cloned style.
  * @override
  * @api
  */

--- a/src/ol/style/Fill.js
+++ b/src/ol/style/Fill.js
@@ -41,7 +41,7 @@ const Fill = function(opt_options) {
 
 /**
  * Clones the style. The color is not cloned if it is an {@link module:ol/colorlike~ColorLike}.
- * @return {module:ol/style/Fill~Fill} The cloned style.
+ * @return {module:ol/style/Fill} The cloned style.
  * @api
  */
 Fill.prototype.clone = function() {

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -58,7 +58,7 @@ import ImageStyle from '../style/Image.js';
  *
  * @constructor
  * @param {module:ol/style/Icon~Options=} opt_options Options.
- * @extends {module:ol/style/Image~ImageStyle}
+ * @extends {module:ol/style/Image}
  * @api
  */
 const Icon = function(opt_options) {
@@ -145,7 +145,7 @@ const Icon = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/style/IconImage~IconImage}
+   * @type {module:ol/style/IconImage}
    */
   this.iconImage_ = getIconImage(
     image, /** @type {string} */ (src), imgSize, this.crossOrigin_, imageState, this.color_);
@@ -217,7 +217,7 @@ inherits(Icon, ImageStyle);
 
 /**
  * Clones the style. The underlying Image/HTMLCanvasElement is not cloned.
- * @return {module:ol/style/Icon~Icon} The cloned style.
+ * @return {module:ol/style/Icon} The cloned style.
  * @api
  */
 Icon.prototype.clone = function() {

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -17,7 +17,7 @@ import {shared as iconImageCache} from '../style/IconImageCache.js';
  * @param {?string} crossOrigin Cross origin.
  * @param {module:ol/ImageState~ImageState} imageState Image state.
  * @param {module:ol/color~Color} color Color.
- * @extends {module:ol/events/EventTarget~EventTarget}
+ * @extends {module:ol/events/EventTarget}
  */
 const IconImage = function(image, src, size, crossOrigin, imageState, color) {
 
@@ -98,7 +98,7 @@ inherits(IconImage, EventTarget);
  * @param {?string} crossOrigin Cross origin.
  * @param {module:ol/ImageState~ImageState} imageState Image state.
  * @param {module:ol/color~Color} color Color.
- * @return {module:ol/style/IconImage~IconImage} Icon image.
+ * @return {module:ol/style/IconImage} Icon image.
  */
 export function get(image, src, size, crossOrigin, imageState, color) {
   let iconImage = iconImageCache.get(src, crossOrigin, color);

--- a/src/ol/style/IconImageCache.js
+++ b/src/ol/style/IconImageCache.js
@@ -10,7 +10,7 @@ import {asString} from '../color.js';
 const IconImageCache = function() {
 
   /**
-   * @type {!Object.<string, module:ol/style/IconImage~IconImage>}
+   * @type {!Object.<string, module:ol/style/IconImage>}
    * @private
    */
   this.cache_ = {};
@@ -71,7 +71,7 @@ IconImageCache.prototype.expire = function() {
  * @param {string} src Src.
  * @param {?string} crossOrigin Cross origin.
  * @param {module:ol/color~Color} color Color.
- * @return {module:ol/style/IconImage~IconImage} Icon image.
+ * @return {module:ol/style/IconImage} Icon image.
  */
 IconImageCache.prototype.get = function(src, crossOrigin, color) {
   const key = getKey(src, crossOrigin, color);
@@ -83,7 +83,7 @@ IconImageCache.prototype.get = function(src, crossOrigin, color) {
  * @param {string} src Src.
  * @param {?string} crossOrigin Cross origin.
  * @param {module:ol/color~Color} color Color.
- * @param {module:ol/style/IconImage~IconImage} iconImage Icon image.
+ * @param {module:ol/style/IconImage} iconImage Icon image.
  */
 IconImageCache.prototype.set = function(src, crossOrigin, color, iconImage) {
   const key = getKey(src, crossOrigin, color);

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -229,7 +229,7 @@ ImageStyle.prototype.setSnapToPixel = function(snapToPixel) {
 
 /**
  * @abstract
- * @param {function(this: T, module:ol/events/Event~Event)} listener Listener function.
+ * @param {function(this: T, module:ol/events/Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {module:ol/events~EventsKey|undefined} Listener key.
  * @template T
@@ -246,7 +246,7 @@ ImageStyle.prototype.load = function() {};
 
 /**
  * @abstract
- * @param {function(this: T, module:ol/events/Event~Event)} listener Listener function.
+ * @param {function(this: T, module:ol/events/Event)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @template T
  */

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -13,7 +13,7 @@ import ImageStyle from '../style/Image.js';
 /**
  * Specify radius for regular polygons, or radius1 and radius2 for stars.
  * @typedef {Object} Options
- * @property {module:ol/style/Fill~Fill} [fill] Fill style.
+ * @property {module:ol/style/Fill} [fill] Fill style.
  * @property {number} points Number of points for stars and regular polygons. In case of a polygon, the number of points
  * is the number of sides.
  * @property {number} [radius] Radius of a regular polygon.
@@ -24,10 +24,10 @@ import ImageStyle from '../style/Image.js';
  * when drawing the shape in the output canvas. If `false` fractional numbers may be used. Using `true` allows for
  * "sharp" rendering (no blur), while using `false` allows for "accurate" rendering. Note that accuracy is important if
  * the shape's position is animated. Without it, the shape may jitter noticeably.
- * @property {module:ol/style/Stroke~Stroke} [stroke] Stroke style.
+ * @property {module:ol/style/Stroke} [stroke] Stroke style.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {boolean} [rotateWithView=false] Whether to rotate the shape with the view.
- * @property {module:ol/style/AtlasManager~AtlasManager} [atlasManager] The atlas manager to use for this symbol. When
+ * @property {module:ol/style/AtlasManager} [atlasManager] The atlas manager to use for this symbol. When
  * using WebGL it is recommended to use an atlas manager to avoid texture switching. If an atlas manager is given, the
  * symbol is added to an atlas. By default no atlas manager is used.
  */
@@ -53,7 +53,7 @@ import ImageStyle from '../style/Image.js';
  *
  * @constructor
  * @param {module:ol/style/RegularShape~Options} options Options.
- * @extends {module:ol/style/Image~ImageStyle}
+ * @extends {module:ol/style/Image}
  * @api
  */
 const RegularShape = function(options) {
@@ -77,7 +77,7 @@ const RegularShape = function(options) {
 
   /**
    * @private
-   * @type {module:ol/style/Fill~Fill}
+   * @type {module:ol/style/Fill}
    */
   this.fill_ = options.fill !== undefined ? options.fill : null;
 
@@ -114,7 +114,7 @@ const RegularShape = function(options) {
 
   /**
    * @private
-   * @type {module:ol/style/Stroke~Stroke}
+   * @type {module:ol/style/Stroke}
    */
   this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
@@ -144,7 +144,7 @@ const RegularShape = function(options) {
 
   /**
    * @protected
-   * @type {module:ol/style/AtlasManager~AtlasManager|undefined}
+   * @type {module:ol/style/AtlasManager|undefined}
    */
   this.atlasManager_ = options.atlasManager;
 
@@ -176,7 +176,7 @@ inherits(RegularShape, ImageStyle);
 
 /**
  * Clones the style. If an atlasmanager was provided to the original style it will be used in the cloned style, too.
- * @return {module:ol/style/RegularShape~RegularShape} The cloned style.
+ * @return {module:ol/style/RegularShape} The cloned style.
  * @api
  */
 RegularShape.prototype.clone = function() {
@@ -219,7 +219,7 @@ RegularShape.prototype.getAngle = function() {
 
 /**
  * Get the fill style for the shape.
- * @return {module:ol/style/Fill~Fill} Fill style.
+ * @return {module:ol/style/Fill} Fill style.
  * @api
  */
 RegularShape.prototype.getFill = function() {
@@ -318,7 +318,7 @@ RegularShape.prototype.getSize = function() {
 
 /**
  * Get the stroke style for the shape.
- * @return {module:ol/style/Stroke~Stroke} Stroke style.
+ * @return {module:ol/style/Stroke} Stroke style.
  * @api
  */
 RegularShape.prototype.getStroke = function() {
@@ -346,7 +346,7 @@ RegularShape.prototype.unlistenImageChange = function(listener, thisArg) {};
 
 /**
  * @protected
- * @param {module:ol/style/AtlasManager~AtlasManager|undefined} atlasManager An atlas manager.
+ * @param {module:ol/style/AtlasManager|undefined} atlasManager An atlas manager.
  */
 RegularShape.prototype.render_ = function(atlasManager) {
   let imageSize;

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -87,7 +87,7 @@ const Stroke = function(opt_options) {
 
 /**
  * Clones the style.
- * @return {module:ol/style/Stroke~Stroke} The cloned style.
+ * @return {module:ol/style/Stroke} The cloned style.
  * @api
  */
 Stroke.prototype.clone = function() {

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -8,11 +8,11 @@ import Fill from '../style/Fill.js';
 import Stroke from '../style/Stroke.js';
 
 /**
- * A function that takes an {@link module:ol/Feature~Feature} as argument and returns an
- * {@link module:ol/geom/Geometry~Geometry} that will be rendered and styled for the feature.
+ * A function that takes an {@link module:ol/Feature} as argument and returns an
+ * {@link module:ol/geom/Geometry} that will be rendered and styled for the feature.
  *
- * @typedef {function((module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature)):
- *     (module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature|undefined)} GeometryFunction
+ * @typedef {function((module:ol/Feature|module:ol/render/Feature)):
+ *     (module:ol/geom/Geometry|module:ol/render/Feature|undefined)} GeometryFunction
  */
 
 
@@ -29,14 +29,14 @@ import Stroke from '../style/Stroke.js';
 
 /**
  * @typedef {Object} Options
- * @property {string|module:ol/geom/Geometry~Geometry|module:ol/style/Style~GeometryFunction} [geometry] Feature property or geometry
+ * @property {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction} [geometry] Feature property or geometry
  * or function returning a geometry to render for this style.
- * @property {module:ol/style/Fill~Fill} [fill] Fill style.
- * @property {module:ol/style/Image~ImageStyle} [image] Image style.
+ * @property {module:ol/style/Fill} [fill] Fill style.
+ * @property {module:ol/style/Image} [image] Image style.
  * @property {module:ol/style/Style~RenderFunction} [renderer] Custom renderer. When configured, `fill`, `stroke` and `image` will be
  * ignored, and the provided function will be called with each render frame for each geometry.
- * @property {module:ol/style/Stroke~Stroke} [stroke] Stroke style.
- * @property {module:ol/style/Text~Text} [text] Text style.
+ * @property {module:ol/style/Stroke} [stroke] Stroke style.
+ * @property {module:ol/style/Text} [text] Text style.
  * @property {number} [zIndex] Z index.
  */
 
@@ -58,7 +58,7 @@ const Style = function(opt_options) {
 
   /**
    * @private
-   * @type {string|module:ol/geom/Geometry~Geometry|module:ol/style/Style~GeometryFunction}
+   * @type {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction}
    */
   this.geometry_ = null;
 
@@ -74,14 +74,14 @@ const Style = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/style/Fill~Fill}
+   * @type {module:ol/style/Fill}
    */
   this.fill_ = options.fill !== undefined ? options.fill : null;
 
   /**
-   * @private
-   * @type {module:ol/style/Image~ImageStyle}
-   */
+     * @private
+     * @type {module:ol/style/Image}
+     */
   this.image_ = options.image !== undefined ? options.image : null;
 
   /**
@@ -92,13 +92,13 @@ const Style = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/style/Stroke~Stroke}
+   * @type {module:ol/style/Stroke}
    */
   this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
   /**
    * @private
-   * @type {module:ol/style/Text~Text}
+   * @type {module:ol/style/Text}
    */
   this.text_ = options.text !== undefined ? options.text : null;
 
@@ -113,7 +113,7 @@ const Style = function(opt_options) {
 
 /**
  * Clones the style.
- * @return {module:ol/style/Style~Style} The cloned style.
+ * @return {module:ol/style/Style} The cloned style.
  * @api
  */
 Style.prototype.clone = function() {
@@ -156,7 +156,7 @@ Style.prototype.setRenderer = function(renderer) {
 
 /**
  * Get the geometry to be rendered.
- * @return {string|module:ol/geom/Geometry~Geometry|module:ol/style/Style~GeometryFunction}
+ * @return {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction}
  * Feature property or geometry or function that returns the geometry that will
  * be rendered with this style.
  * @api
@@ -179,7 +179,7 @@ Style.prototype.getGeometryFunction = function() {
 
 /**
  * Get the fill style.
- * @return {module:ol/style/Fill~Fill} Fill style.
+ * @return {module:ol/style/Fill} Fill style.
  * @api
  */
 Style.prototype.getFill = function() {
@@ -189,7 +189,7 @@ Style.prototype.getFill = function() {
 
 /**
  * Set the fill style.
- * @param {module:ol/style/Fill~Fill} fill Fill style.
+ * @param {module:ol/style/Fill} fill Fill style.
  * @api
  */
 Style.prototype.setFill = function(fill) {
@@ -199,7 +199,7 @@ Style.prototype.setFill = function(fill) {
 
 /**
  * Get the image style.
- * @return {module:ol/style/Image~ImageStyle} Image style.
+ * @return {module:ol/style/Image} Image style.
  * @api
  */
 Style.prototype.getImage = function() {
@@ -209,7 +209,7 @@ Style.prototype.getImage = function() {
 
 /**
  * Set the image style.
- * @param {module:ol/style/Image~ImageStyle} image Image style.
+ * @param {module:ol/style/Image} image Image style.
  * @api
  */
 Style.prototype.setImage = function(image) {
@@ -219,7 +219,7 @@ Style.prototype.setImage = function(image) {
 
 /**
  * Get the stroke style.
- * @return {module:ol/style/Stroke~Stroke} Stroke style.
+ * @return {module:ol/style/Stroke} Stroke style.
  * @api
  */
 Style.prototype.getStroke = function() {
@@ -229,7 +229,7 @@ Style.prototype.getStroke = function() {
 
 /**
  * Set the stroke style.
- * @param {module:ol/style/Stroke~Stroke} stroke Stroke style.
+ * @param {module:ol/style/Stroke} stroke Stroke style.
  * @api
  */
 Style.prototype.setStroke = function(stroke) {
@@ -239,7 +239,7 @@ Style.prototype.setStroke = function(stroke) {
 
 /**
  * Get the text style.
- * @return {module:ol/style/Text~Text} Text style.
+ * @return {module:ol/style/Text} Text style.
  * @api
  */
 Style.prototype.getText = function() {
@@ -249,7 +249,7 @@ Style.prototype.getText = function() {
 
 /**
  * Set the text style.
- * @param {module:ol/style/Text~Text} text Text style.
+ * @param {module:ol/style/Text} text Text style.
  * @api
  */
 Style.prototype.setText = function(text) {
@@ -270,7 +270,7 @@ Style.prototype.getZIndex = function() {
 /**
  * Set a geometry that is rendered instead of the feature's geometry.
  *
- * @param {string|module:ol/geom/Geometry~Geometry|module:ol/style/Style~GeometryFunction} geometry
+ * @param {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction} geometry
  *     Feature property or geometry or function returning a geometry to render
  *     for this style.
  * @api
@@ -280,13 +280,17 @@ Style.prototype.setGeometry = function(geometry) {
     this.geometryFunction_ = geometry;
   } else if (typeof geometry === 'string') {
     this.geometryFunction_ = function(feature) {
-      return /** @type {module:ol/geom/Geometry~Geometry} */ (feature.get(geometry));
+      return (
+        /** @type {module:ol/geom/Geometry} */ (feature.get(geometry))
+      );
     };
   } else if (!geometry) {
     this.geometryFunction_ = defaultGeometryFunction;
   } else if (geometry !== undefined) {
     this.geometryFunction_ = function() {
-      return /** @type {module:ol/geom/Geometry~Geometry} */ (geometry);
+      return (
+        /** @type {module:ol/geom/Geometry} */ (geometry)
+      );
     };
   }
   this.geometry_ = geometry;
@@ -306,9 +310,9 @@ Style.prototype.setZIndex = function(zIndex) {
 
 /**
  * Convert the provided object into a style function.  Functions passed through
- * unchanged.  Arrays of module:ol/style/Style~Style or single style objects wrapped in a
+ * unchanged.  Arrays of module:ol/style/Style or single style objects wrapped in a
  * new style function.
- * @param {module:ol/style~StyleFunction|Array.<module:ol/style/Style~Style>|module:ol/style/Style~Style} obj
+ * @param {module:ol/style~StyleFunction|Array.<module:ol/style/Style>|module:ol/style/Style} obj
  *     A style function, a single style, or an array of styles.
  * @return {module:ol/style~StyleFunction} A style function.
  */
@@ -319,7 +323,7 @@ export function toFunction(obj) {
     styleFunction = obj;
   } else {
     /**
-     * @type {Array.<module:ol/style/Style~Style>}
+     * @type {Array.<module:ol/style/Style>}
      */
     let styles;
     if (Array.isArray(obj)) {
@@ -338,15 +342,15 @@ export function toFunction(obj) {
 
 
 /**
- * @type {Array.<module:ol/style/Style~Style>}
+ * @type {Array.<module:ol/style/Style>}
  */
 let defaultStyles = null;
 
 
 /**
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  * @param {number} resolution Resolution.
- * @return {Array.<module:ol/style/Style~Style>} Style.
+ * @return {Array.<module:ol/style/Style>} Style.
  */
 export function createDefaultStyle(feature, resolution) {
   // We don't use an immediately-invoked function
@@ -380,10 +384,10 @@ export function createDefaultStyle(feature, resolution) {
 
 /**
  * Default styles for editing features.
- * @return {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style~Style>>} Styles
+ * @return {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style>>} Styles
  */
 export function createEditingStyle() {
-  /** @type {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style~Style>>} */
+  /** @type {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style>>} */
   const styles = {};
   const white = [255, 255, 255, 1];
   const blue = [0, 153, 255, 1];
@@ -451,8 +455,8 @@ export function createEditingStyle() {
 
 /**
  * Function that is called with a feature and returns its default geometry.
- * @param {module:ol/Feature~Feature|module:ol/render/Feature~RenderFeature} feature Feature to get the geometry for.
- * @return {module:ol/geom/Geometry~Geometry|module:ol/render/Feature~RenderFeature|undefined} Geometry to render.
+ * @param {module:ol/Feature|module:ol/render/Feature} feature Feature to get the geometry for.
+ * @return {module:ol/geom/Geometry|module:ol/render/Feature|undefined} Geometry to render.
  */
 function defaultGeometryFunction(feature) {
   return feature.getGeometry();

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -34,11 +34,11 @@ const DEFAULT_FILL_COLOR = '#333';
  * placement where `maxAngle` is not exceeded.
  * @property {string} [textBaseline='middle'] Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
  * 'hanging', 'ideographic'.
- * @property {module:ol/style/Fill~Fill} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
- * @property {module:ol/style/Stroke~Stroke} [stroke] Stroke style.
- * @property {module:ol/style/Fill~Fill} [backgroundFill] Fill style for the text background when `placement` is
+ * @property {module:ol/style/Fill} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
+ * @property {module:ol/style/Stroke} [stroke] Stroke style.
+ * @property {module:ol/style/Fill} [backgroundFill] Fill style for the text background when `placement` is
  * `'point'`. Default is no fill.
- * @property {module:ol/style/Stroke~Stroke} [backgroundStroke] Stroke style for the text background  when `placement`
+ * @property {module:ol/style/Stroke} [backgroundStroke] Stroke style for the text background  when `placement`
  * is `'point'`. Default is no stroke.
  * @property {Array.<number>} [padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
  * values in the array is `[top, right, bottom, left]`.
@@ -101,7 +101,7 @@ const Text = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/style/Fill~Fill}
+   * @type {module:ol/style/Fill}
    */
   this.fill_ = options.fill !== undefined ? options.fill :
     new Fill({color: DEFAULT_FILL_COLOR});
@@ -126,7 +126,7 @@ const Text = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/style/Stroke~Stroke}
+   * @type {module:ol/style/Stroke}
    */
   this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
@@ -144,13 +144,13 @@ const Text = function(opt_options) {
 
   /**
    * @private
-   * @type {module:ol/style/Fill~Fill}
+   * @type {module:ol/style/Fill}
    */
   this.backgroundFill_ = options.backgroundFill ? options.backgroundFill : null;
 
   /**
    * @private
-   * @type {module:ol/style/Stroke~Stroke}
+   * @type {module:ol/style/Stroke}
    */
   this.backgroundStroke_ = options.backgroundStroke ? options.backgroundStroke : null;
 
@@ -164,7 +164,7 @@ const Text = function(opt_options) {
 
 /**
  * Clones the style.
- * @return {module:ol/style/Text~Text} The cloned style.
+ * @return {module:ol/style/Text} The cloned style.
  * @api
  */
 Text.prototype.clone = function() {
@@ -251,7 +251,7 @@ Text.prototype.getOffsetY = function() {
 
 /**
  * Get the fill style for the text.
- * @return {module:ol/style/Fill~Fill} Fill style.
+ * @return {module:ol/style/Fill} Fill style.
  * @api
  */
 Text.prototype.getFill = function() {
@@ -291,7 +291,7 @@ Text.prototype.getScale = function() {
 
 /**
  * Get the stroke style for the text.
- * @return {module:ol/style/Stroke~Stroke} Stroke style.
+ * @return {module:ol/style/Stroke} Stroke style.
  * @api
  */
 Text.prototype.getStroke = function() {
@@ -331,7 +331,7 @@ Text.prototype.getTextBaseline = function() {
 
 /**
  * Get the background fill style for the text.
- * @return {module:ol/style/Fill~Fill} Fill style.
+ * @return {module:ol/style/Fill} Fill style.
  * @api
  */
 Text.prototype.getBackgroundFill = function() {
@@ -341,7 +341,7 @@ Text.prototype.getBackgroundFill = function() {
 
 /**
  * Get the background stroke style for the text.
- * @return {module:ol/style/Stroke~Stroke} Stroke style.
+ * @return {module:ol/style/Stroke} Stroke style.
  * @api
  */
 Text.prototype.getBackgroundStroke = function() {
@@ -428,7 +428,7 @@ Text.prototype.setPlacement = function(placement) {
 /**
  * Set the fill.
  *
- * @param {module:ol/style/Fill~Fill} fill Fill style.
+ * @param {module:ol/style/Fill} fill Fill style.
  * @api
  */
 Text.prototype.setFill = function(fill) {
@@ -461,7 +461,7 @@ Text.prototype.setScale = function(scale) {
 /**
  * Set the stroke.
  *
- * @param {module:ol/style/Stroke~Stroke} stroke Stroke style.
+ * @param {module:ol/style/Stroke} stroke Stroke style.
  * @api
  */
 Text.prototype.setStroke = function(stroke) {
@@ -505,7 +505,7 @@ Text.prototype.setTextBaseline = function(textBaseline) {
 /**
  * Set the background fill.
  *
- * @param {module:ol/style/Fill~Fill} fill Fill style.
+ * @param {module:ol/style/Fill} fill Fill style.
  * @api
  */
 Text.prototype.setBackgroundFill = function(fill) {
@@ -516,7 +516,7 @@ Text.prototype.setBackgroundFill = function(fill) {
 /**
  * Set the background stroke.
  *
- * @param {module:ol/style/Stroke~Stroke} stroke Stroke style.
+ * @param {module:ol/style/Stroke} stroke Stroke style.
  * @api
  */
 Text.prototype.setBackgroundStroke = function(stroke) {

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -97,7 +97,7 @@ export function quadKey(tileCoord) {
 
 /**
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {!module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid.
+ * @param {!module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @return {boolean} Tile coordinate is within extent and zoom level range.
  */
 export function withinExtentAndZ(tileCoord, tileGrid) {

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -12,8 +12,8 @@ import TileGrid from './tilegrid/TileGrid.js';
 
 
 /**
- * @param {module:ol/proj/Projection~Projection} projection Projection.
- * @return {!module:ol/tilegrid/TileGrid~TileGrid} Default tile grid for the
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {!module:ol/tilegrid/TileGrid} Default tile grid for the
  * passed projection.
  */
 export function getForProjection(projection) {
@@ -27,9 +27,9 @@ export function getForProjection(projection) {
 
 
 /**
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
  */
 export function wrapX(tileGrid, tileCoord, projection) {
@@ -54,7 +54,7 @@ export function wrapX(tileGrid, tileCoord, projection) {
  * @param {number|module:ol/size~Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
  * @param {module:ol/extent/Corner~Corner=} opt_corner Extent corner (default is `'top-left'`).
- * @return {!module:ol/tilegrid/TileGrid~TileGrid} TileGrid instance.
+ * @return {!module:ol/tilegrid/TileGrid} TileGrid instance.
  */
 export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
   const corner = opt_corner !== undefined ? opt_corner : Corner.TOP_LEFT;
@@ -85,7 +85,7 @@ export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
 /**
  * Creates a tile grid with a standard XYZ tiling scheme.
  * @param {module:ol/tilegrid~XYZOptions=} opt_options Tile grid options.
- * @return {!module:ol/tilegrid/TileGrid~TileGrid} Tile grid instance.
+ * @return {!module:ol/tilegrid/TileGrid} Tile grid instance.
  * @api
  */
 export function createXYZ(opt_options) {
@@ -140,7 +140,7 @@ function resolutionsFromExtent(extent, opt_maxZoom, opt_tileSize) {
  * @param {number|module:ol/size~Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
  * @param {module:ol/extent/Corner~Corner=} opt_corner Extent corner (default is `'top-left'`).
- * @return {!module:ol/tilegrid/TileGrid~TileGrid} TileGrid instance.
+ * @return {!module:ol/tilegrid/TileGrid} TileGrid instance.
  */
 export function createForProjection(projection, opt_maxZoom, opt_tileSize, opt_corner) {
   const extent = extentFromProjection(projection);

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -154,7 +154,7 @@ const TileGrid = function(options) {
 
   /**
    * @private
-   * @type {Array.<module:ol/TileRange~TileRange>}
+   * @type {Array.<module:ol/TileRange>}
    */
   this.fullTileRanges_ = null;
 
@@ -205,9 +205,9 @@ TileGrid.prototype.forEachTileCoord = function(extent, zoom, callback) {
 
 /**
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {function(this: T, number, module:ol/TileRange~TileRange): boolean} callback Callback.
+ * @param {function(this: T, number, module:ol/TileRange): boolean} callback Callback.
  * @param {T=} opt_this The object to use as `this` in `callback`.
- * @param {module:ol/TileRange~TileRange=} opt_tileRange Temporary module:ol/TileRange~TileRange object.
+ * @param {module:ol/TileRange=} opt_tileRange Temporary module:ol/TileRange object.
  * @param {module:ol/extent~Extent=} opt_extent Temporary module:ol/extent~Extent object.
  * @return {boolean} Callback succeeded.
  * @template T
@@ -306,9 +306,9 @@ TileGrid.prototype.getResolutions = function() {
 
 /**
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/TileRange~TileRange=} opt_tileRange Temporary module:ol/TileRange~TileRange object.
+ * @param {module:ol/TileRange=} opt_tileRange Temporary module:ol/TileRange object.
  * @param {module:ol/extent~Extent=} opt_extent Temporary module:ol/extent~Extent object.
- * @return {module:ol/TileRange~TileRange} Tile range.
+ * @return {module:ol/TileRange} Tile range.
  */
 TileGrid.prototype.getTileCoordChildTileRange = function(tileCoord, opt_tileRange, opt_extent) {
   if (tileCoord[0] < this.maxZoom) {
@@ -328,7 +328,7 @@ TileGrid.prototype.getTileCoordChildTileRange = function(tileCoord, opt_tileRang
 /**
  * Get the extent for a tile range.
  * @param {number} z Integer zoom level.
- * @param {module:ol/TileRange~TileRange} tileRange Tile range.
+ * @param {module:ol/TileRange} tileRange Tile range.
  * @param {module:ol/extent~Extent=} opt_extent Temporary module:ol/extent~Extent object.
  * @return {module:ol/extent~Extent} Extent.
  */
@@ -348,8 +348,8 @@ TileGrid.prototype.getTileRangeExtent = function(z, tileRange, opt_extent) {
  * Get a tile range for the given extent and integer zoom level.
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} z Integer zoom level.
- * @param {module:ol/TileRange~TileRange=} opt_tileRange Temporary tile range object.
- * @return {module:ol/TileRange~TileRange} Tile range.
+ * @param {module:ol/TileRange=} opt_tileRange Temporary tile range object.
+ * @return {module:ol/TileRange} Tile range.
  */
 TileGrid.prototype.getTileRangeForExtentAndZ = function(extent, z, opt_tileRange) {
   const tileCoord = tmpTileCoord;
@@ -533,7 +533,7 @@ TileGrid.prototype.getTileSize = function(z) {
 
 /**
  * @param {number} z Zoom level.
- * @return {module:ol/TileRange~TileRange} Extent tile range for the specified zoom level.
+ * @return {module:ol/TileRange} Extent tile range for the specified zoom level.
  */
 TileGrid.prototype.getFullTileRange = function(z) {
   if (!this.fullTileRanges_) {

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -50,7 +50,7 @@ import TileGrid from '../tilegrid/TileGrid.js';
  * Set the grid pattern for sources accessing WMTS tiled-image servers.
  *
  * @constructor
- * @extends {module:ol/tilegrid/TileGrid~TileGrid}
+ * @extends {module:ol/tilegrid/TileGrid}
  * @param {module:ol/tilegrid/WMTS~Options} options WMTS options.
  * @struct
  * @api
@@ -106,7 +106,7 @@ export default WMTSTileGrid;
  *     ranges the server provides.
  * @param {Array.<Object>=} opt_matrixLimits An optional object representing
  *     the available matrices for tileGrid.
- * @return {module:ol/tilegrid/WMTS~WMTSTileGrid} WMTS tileGrid instance.
+ * @return {module:ol/tilegrid/WMTS} WMTS tileGrid instance.
  * @api
  */
 export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matrixLimits) {

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -8,7 +8,7 @@ import {hash as tileCoordHash} from './tilecoord.js';
 
 /**
  * @param {string} template Template.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @return {module:ol/Tile~UrlFunction} Tile URL function.
  */
 export function createFromTemplate(template, tileGrid) {
@@ -20,7 +20,7 @@ export function createFromTemplate(template, tileGrid) {
     /**
      * @param {module:ol/tilecoord~TileCoord} tileCoord Tile Coordinate.
      * @param {number} pixelRatio Pixel ratio.
-     * @param {module:ol/proj/Projection~Projection} projection Projection.
+     * @param {module:ol/proj/Projection} projection Projection.
      * @return {string|undefined} Tile URL.
      */
     function(tileCoord, pixelRatio, projection) {
@@ -48,7 +48,7 @@ export function createFromTemplate(template, tileGrid) {
 
 /**
  * @param {Array.<string>} templates Templates.
- * @param {module:ol/tilegrid/TileGrid~TileGrid} tileGrid Tile grid.
+ * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @return {module:ol/Tile~UrlFunction} Tile URL function.
  */
 export function createFromTemplates(templates, tileGrid) {
@@ -73,7 +73,7 @@ export function createFromTileUrlFunctions(tileUrlFunctions) {
     /**
      * @param {module:ol/tilecoord~TileCoord} tileCoord Tile Coordinate.
      * @param {number} pixelRatio Pixel ratio.
-     * @param {module:ol/proj/Projection~Projection} projection Projection.
+     * @param {module:ol/proj/Projection} projection Projection.
      * @return {string|undefined} Tile URL.
      */
     function(tileCoord, pixelRatio, projection) {
@@ -92,7 +92,7 @@ export function createFromTileUrlFunctions(tileUrlFunctions) {
 /**
  * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection~Projection} projection Projection.
+ * @param {module:ol/proj/Projection} projection Projection.
  * @return {string|undefined} Tile URL.
  */
 export function nullTileUrlFunction(tileCoord, pixelRatio, projection) {

--- a/src/ol/webgl/Context.js
+++ b/src/ol/webgl/Context.js
@@ -12,7 +12,7 @@ import ContextEventType from '../webgl/ContextEventType.js';
 
 /**
  * @typedef {Object} BufferCacheEntry
- * @property {module:ol/webgl/Buffer~WebGLBuffer} buf
+ * @property {module:ol/webgl/Buffer} buf
  * @property {WebGLBuffer} buffer
  */
 
@@ -22,7 +22,7 @@ import ContextEventType from '../webgl/ContextEventType.js';
  * A WebGL context for accessing low-level WebGL capabilities.
  *
  * @constructor
- * @extends {module:ol/Disposable~Disposable}
+ * @extends {module:ol/Disposable}
  * @param {HTMLCanvasElement} canvas Canvas.
  * @param {WebGLRenderingContext} gl GL.
  */
@@ -107,7 +107,7 @@ inherits(WebGLContext, Disposable);
  * the WebGL buffer, bind it, populate it, and add an entry to
  * the cache.
  * @param {number} target Target.
- * @param {module:ol/webgl/Buffer~WebGLBuffer} buf Buffer.
+ * @param {module:ol/webgl/Buffer} buf Buffer.
  */
 WebGLContext.prototype.bindBuffer = function(target, buf) {
   const gl = this.getGL();
@@ -136,7 +136,7 @@ WebGLContext.prototype.bindBuffer = function(target, buf) {
 
 
 /**
- * @param {module:ol/webgl/Buffer~WebGLBuffer} buf Buffer.
+ * @param {module:ol/webgl/Buffer} buf Buffer.
  */
 WebGLContext.prototype.deleteBuffer = function(buf) {
   const gl = this.getGL();
@@ -206,7 +206,7 @@ WebGLContext.prototype.getHitDetectionFramebuffer = function() {
 /**
  * Get shader from the cache if it's in the cache. Otherwise, create
  * the WebGL shader, compile it, and add entry to cache.
- * @param {module:ol/webgl/Shader~WebGLShader} shaderObject Shader object.
+ * @param {module:ol/webgl/Shader} shaderObject Shader object.
  * @return {WebGLShader} Shader.
  */
 WebGLContext.prototype.getShader = function(shaderObject) {
@@ -228,8 +228,8 @@ WebGLContext.prototype.getShader = function(shaderObject) {
  * Get the program from the cache if it's in the cache. Otherwise create
  * the WebGL program, attach the shaders to it, and add an entry to the
  * cache.
- * @param {module:ol/webgl/Fragment~WebGLFragment} fragmentShaderObject Fragment shader.
- * @param {module:ol/webgl/Vertex~WebGLVertex} vertexShaderObject Vertex shader.
+ * @param {module:ol/webgl/Fragment} fragmentShaderObject Fragment shader.
+ * @param {module:ol/webgl/Vertex} vertexShaderObject Vertex shader.
  * @return {WebGLProgram} Program.
  */
 WebGLContext.prototype.getProgram = function(fragmentShaderObject, vertexShaderObject) {

--- a/src/ol/webgl/Fragment.js
+++ b/src/ol/webgl/Fragment.js
@@ -7,7 +7,7 @@ import WebGLShader from '../webgl/Shader.js';
 
 /**
  * @constructor
- * @extends {module:ol/webgl/Shader~WebGLShader}
+ * @extends {module:ol/webgl/Shader}
  * @param {string} source Source.
  * @struct
  */

--- a/src/ol/webgl/Vertex.js
+++ b/src/ol/webgl/Vertex.js
@@ -7,7 +7,7 @@ import WebGLShader from '../webgl/Shader.js';
 
 /**
  * @constructor
- * @extends {module:ol/webgl/Shader~WebGLShader}
+ * @extends {module:ol/webgl/Shader}
  * @param {string} source Source.
  * @struct
  */


### PR DESCRIPTION
This implements the change suggested in https://github.com/openlayers/openlayers/pull/8103#issuecomment-383634301. To still get a link to the named export in JSDoc, we can use a simple plugin like the one introduced in https://github.com/openlayers/closure-es-modules/commit/d94d144ecd353847b5d9085f52f96a3a6582b208#diff-28a8c6de8bfb580271ebed73a8a9ae25.