### PR TITLE
Update tasks to use native async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "rbush": "2.0.2"
   },
   "devDependencies": {
-    "async": "2.6.0",
     "babel-cli": "6.26.0",
     "babel-minify-webpack-plugin": "^0.3.0",
     "babel-plugin-jsdoc-closure": "1.5.1",
@@ -55,7 +54,7 @@
     "eslint-config-openlayers": "^9.0.0",
     "expect.js": "0.3.1",
     "front-matter": "^2.1.2",
-    "fs-extra": "5.0.0",
+    "fs-extra": "^5.0.0",
     "google-closure-compiler": "20180402.0.0",
     "handlebars": "4.0.11",
     "html-webpack-plugin": "^3.0.1",


### PR DESCRIPTION
This removes the dependency on `async` in favor of native `async/await`.