### PR TITLE
Fix skipping of texts with background

### DIFF
--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -258,14 +258,18 @@ CanvasTextReplay.prototype.drawText = function(geometry, feature) {
       default:
     }
     end = this.appendFlatCoordinates(flatCoordinates, 0, end, stride, false, false);
-    this.beginGeometry(geometry, feature);
     if (textState.backgroundFill || textState.backgroundStroke) {
       this.setFillStrokeStyle(textState.backgroundFill, textState.backgroundStroke);
-      this.updateFillStyle(this.state, this.createFill, geometry);
-      this.hitDetectionInstructions.push(this.createFill(this.state, geometry));
-      this.updateStrokeStyle(this.state, this.applyStroke);
-      this.hitDetectionInstructions.push(this.createStroke(this.state));
+      if (textState.backgroundFill) {
+        this.updateFillStyle(this.state, this.createFill, geometry);
+        this.hitDetectionInstructions.push(this.createFill(this.state, geometry));
+      }
+      if (textState.backgroundStroke) {
+        this.updateStrokeStyle(this.state, this.applyStroke);
+        this.hitDetectionInstructions.push(this.createStroke(this.state));
+      }
     }
+    this.beginGeometry(geometry, feature);
     this.drawTextImage_(label, begin, end);
     this.endGeometry(geometry, feature);
   }


### PR DESCRIPTION
Fill and stroke instructions need to be added before `beginGeometry` so they can be skipped by the select interaction. This change also reveals another issue: background fill and stroke instructions for hit detection should only be created when there actually is a background to fill or stroke.

Fixes #8150.