### PR TITLE
Update linter config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "copy-webpack-plugin": "^4.0.1",
     "coveralls": "3.0.0",
     "eslint": "4.19.1",
-    "eslint-config-openlayers": "^9.0.0",
+    "eslint-config-openlayers": "^9.2.0",
     "expect.js": "0.3.1",
     "front-matter": "^2.1.2",
     "fs-extra": "^5.0.0",

--- a/tasks/.eslintrc
+++ b/tasks/.eslintrc
@@ -2,7 +2,7 @@
   "env": {
     "node": true
   },
-  parserOptions: {
-    ecmaVersion: '2017'
+  "parserOptions": {
+    "ecmaVersion": 2017
   }
 }


### PR DESCRIPTION
This brings in `eslint-config-openlayers@9.2` primarily for writing tasks with async arrow functions.  The `tasks/.eslintrc` change makes the file valid JSON and corrects the type for the `ecmaVersion` value.