### PR TITLE
Ignore 'this' type in function typedef

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -11,7 +11,7 @@ import {WEBKIT, MAC} from '../has.js';
  * A function that takes an {@link module:ol/MapBrowserEvent} and returns a
  * `{boolean}`. If the condition is met, true should be returned.
  *
- * @typedef {function(module:ol/MapBrowserEvent): boolean} Condition
+ * @typedef {function(this: ?, module:ol/MapBrowserEvent): boolean} Condition
  */
 
 

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -14,7 +14,7 @@ import RenderBox from '../render/Box.js';
  * A function that takes a {@link module:ol/MapBrowserEvent} and two
  * {@link module:ol~Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
- * @typedef {function(module:ol/MapBrowserEvent, module:ol~Pixel, module:ol~Pixel):boolean} EndCondition
+ * @typedef {function(this: ?, module:ol/MapBrowserEvent, module:ol~Pixel, module:ol~Pixel):boolean} EndCondition
  */
 
 


### PR DESCRIPTION
The condition functions are not bound, `this` type can be ignored