### PR TITLE
Hide attribution control if there are no attributions

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -231,6 +231,13 @@ Attribution.prototype.updateElement_ = function(frameState) {
   }
 
   const attributions = this.getSourceAttributions_(frameState);
+
+  const visible = attributions.length > 0;
+  if (this.renderedVisible_ != visible) {
+    this.element.style.display = visible ? '' : 'none';
+    this.renderedVisible_ = visible;
+  }
+
   if (equals(attributions, this.renderedAttributions_)) {
     return;
   }
@@ -242,13 +249,6 @@ Attribution.prototype.updateElement_ = function(frameState) {
     const element = document.createElement('LI');
     element.innerHTML = attributions[i];
     this.ulElement_.appendChild(element);
-  }
-
-
-  const visible = attributions.length > 0;
-  if (this.renderedVisible_ != visible) {
-    this.element.style.display = visible ? '' : 'none';
-    this.renderedVisible_ = visible;
   }
 
   this.renderedAttributions_ = attributions;


### PR DESCRIPTION
Currently, if no sources have any attribution to show, we still display the attribution control.  With this change, we hide the control if there are no attributions.

Before:
![image](https://user-images.githubusercontent.com/41094/39957913-0e6c8c06-55b8-11e8-971f-c339a623a529.png)

After:
![image](https://user-images.githubusercontent.com/41094/39957905-f5210ad8-55b7-11e8-9316-baed4499362a.png)
