### PR TITLE
More apidoc fixes

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -10,7 +10,7 @@
     "includePattern": ".+\\.js(doc)?$",
     "excludePattern": "(^|\\/|\\\\)_",
     "include": [
-      "src"
+      "src/ol"
     ]
   },
   "plugins": [

--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -15,7 +15,8 @@
   },
   "plugins": [
     "plugins/markdown",
-    "config/jsdoc/api/plugins/default-export",
+    "config/jsdoc/api/plugins/normalize-exports",
+    "config/jsdoc/api/plugins/inline-options",
     "config/jsdoc/api/plugins/events",
     "config/jsdoc/api/plugins/observable",
     "config/jsdoc/api/plugins/api"

--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -82,6 +82,9 @@ function includeTypes(doclet) {
   if (doclet.returns) {
     doclet.returns.forEach(extractTypes);
   }
+  if (doclet.properties) {
+    doclet.properties.forEach(extractTypes);
+  }
   if (doclet.type && doclet.meta.code.type == 'MemberExpression') {
     extractTypes(doclet);
   }
@@ -131,7 +134,7 @@ exports.handlers = {
         // Document all modules that are referenced by the API
         continue;
       }
-      if (doclet.isEnum) {
+      if (doclet.isEnum || doclet.kind == 'typedef') {
         continue;
       }
       if (doclet.kind == 'class' && api.some(hasApiMembers, doclet)) {

--- a/config/jsdoc/api/plugins/inline-options.js
+++ b/config/jsdoc/api/plugins/inline-options.js
@@ -1,0 +1,49 @@
+/**
+ * @filedesc
+ * Inlines option params from typedefs
+ */
+
+const properties = {};
+
+exports.handlers = {
+
+  /**
+   * Collects all typedefs, keyed by longname
+   * @param {Object} e Event object.
+   */
+  newDoclet: function(e) {
+    if (e.doclet.kind == 'typedef' && e.doclet.properties) {
+      properties[e.doclet.longname] = e.doclet.properties;
+    }
+  },
+
+  /**
+   * Adds `options.*` params for options that match the longname of one of the
+   * collected typedefs.
+   * @param {Object} e Event object.
+   */
+  parseComplete: function(e) {
+    const doclets = e.doclets;
+    for (let i = 0, ii = doclets.length; i < ii; ++i) {
+      const doclet = doclets[i];
+      if (doclet.params) {
+        const params = doclet.params;
+        for (let j = 0, jj = params.length; j < jj; ++j) {
+          const param = params[j];
+          if (param.type && param.type.names) {
+            const type = param.type.names[0];
+            if (type in properties) {
+              param.type.names[0] = type;
+              params.push.apply(params, properties[type].map(p => {
+                const property = Object.assign({}, p);
+                property.name = `${param.name}.${property.name}`;
+                return property;
+              }));
+            }
+          }
+        }
+      }
+    }
+  }
+
+};

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -85,7 +85,7 @@ $(function () {
     var srcLinks = $('div.tag-source');
     srcLinks.each(function(i, el) {
       var textParts = el.innerHTML.trim().split(', ');
-      var link = 'https://github.com/openlayers/openlayers/blob/v' + currentVersion + '/' +
+      var link = 'https://github.com/openlayers/openlayers/blob/v' + currentVersion + '/src/ol/' +
           textParts[0];
       el.innerHTML = '<a href="' + link + '">' + textParts[0] + '</a>, ' +
           '<a href="' + link + textParts[1].replace('line ', '#L') + '">' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayers",
-  "version": "4.6.5",
+  "version": "5.0.0-beta.12",
   "description": "Build tools and sources for developing OpenLayers based mapping applications",
   "keywords": [
     "map",
@@ -23,7 +23,7 @@
     "src-closure": "babel -q --out-dir build/src-closure src/",
     "pretypecheck": "npm run src-closure",
     "typecheck": "node tasks/typecheck",
-    "apidoc": "jsdoc config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -d build/apidoc"
+    "apidoc": "jsdoc config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -P package.json -d build/apidoc"
   },
   "main": "src/ol/index.js",
   "repository": {

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -35,7 +35,7 @@ import CanvasVectorTileLayerRenderer from './renderer/canvas/VectorTileLayer.js'
  *       target: 'map'
  *     });
  *
- * The above snippet creates a map using a {@link module:ol/layer/Tile~Tile} to
+ * The above snippet creates a map using a {@link module:ol/layer/Tile} to
  * display {@link module:ol/source/OSM~OSM} OSM data and render it to a DOM
  * element with the id `map`.
  *

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -87,7 +87,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @typedef {Object} MapOptions
  * @property {module:ol/Collection.<module:ol/control/Control>|Array.<module:ol/control/Control>} [controls]
  * Controls initially added to the map. If not specified,
- * {@link module:ol/control~defaults} is used.
+ * {@link module:ol/control/util~defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
  * @property {module:ol/Collection.<module:ol/interaction/Interaction>|Array.<module:ol/interaction/Interaction>} [interactions]

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -59,7 +59,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * with vector features from the server, it is not meant for feature editing.
  * Features are optimized for rendering, their geometries are clipped at or near
  * tile boundaries and simplified for a view resolution. See
- * {@link module:ol/source/VectorSource} for vector sources that are suitable for feature
+ * {@link module:ol/source/Vector} for vector sources that are suitable for feature
  * editing.
  *
  * @constructor


### PR DESCRIPTION
This pull request makes further improvements to the generated JSDocs:

 * Replaces path types for default export in `@link` annotations in descriptions
 * Unifies type paths (instead of random `.` or `~` for members, we now always get `~`)
 * Document al typedefs