### PR TITLE
Remove babelrc, transform using babel-core

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "plugins": ["jsdoc-closure"],
-  "parserOpts": {
-    "parser": "recast"
-  },
-  "generatorOpts": {
-    "generator": "recast"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "karma": "karma start test/karma.config.js",
     "serve-examples": "mkdir -p build/examples && webpack --config examples/webpack/config.js --watch & serve build/examples",
     "build-examples": "webpack --config examples/webpack/config.js --env=prod",
-    "build-index": "node tasks/generate-index.js",
+    "build-index": "node tasks/generate-index",
     "prebuild": "npm run build-index",
     "build": "webpack --config config/webpack.js",
     "presrc-closure": "npm run prebuild",
-    "src-closure": "babel -q --out-dir build/src-closure src/",
+    "src-closure": "node tasks/transform-types",
     "pretypecheck": "npm run src-closure",
     "typecheck": "node tasks/typecheck",
     "apidoc": "jsdoc config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -P package.json -d build/apidoc"
@@ -44,7 +44,6 @@
     "rbush": "2.0.2"
   },
   "devDependencies": {
-    "babel-cli": "6.26.0",
     "babel-minify-webpack-plugin": "^0.3.0",
     "babel-plugin-jsdoc-closure": "1.5.1",
     "chaikin-smooth": "1.0.4",
@@ -56,6 +55,7 @@
     "expect.js": "0.3.1",
     "front-matter": "^2.1.2",
     "fs-extra": "^6.0.0",
+    "glob": "^7.1.2",
     "google-closure-compiler": "20180506.0.0",
     "handlebars": "4.0.11",
     "html-webpack-plugin": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "rbush": "2.0.2"
   },
   "devDependencies": {
+    "babel-core": "^6.26.3",
     "babel-minify-webpack-plugin": "^0.3.0",
     "babel-plugin-jsdoc-closure": "1.5.1",
     "chaikin-smooth": "1.0.4",

--- a/tasks/transform-types.js
+++ b/tasks/transform-types.js
@@ -1,0 +1,31 @@
+/**
+ * @filedesc
+ * Transforms type comments in all source files to types that Closure Compiler
+ * understands.
+ */
+
+const glob = require('glob');
+const mkdirp = require('mkdirp').sync;
+const fs = require('fs');
+const path = require('path');
+const transform = require('babel-core').transformFileSync;
+
+const options = {
+  plugins: 'jsdoc-closure',
+  parserOpts: {
+    parser: 'recast'
+  },
+  generatorOpts: {
+    generator: 'recast'
+  }
+};
+
+const outDir = path.join('build', 'src-closure');
+
+glob('src/**/*.js', (err, matches) => {
+  matches.forEach(match => {
+    const out = path.join(outDir, path.relative('src', match));
+    mkdirp(path.dirname(out));
+    fs.writeFileSync(out, transform(match, options).code, 'utf-8');
+  });
+});


### PR DESCRIPTION
We should not have a `.babelrc` file in the root of our repo. When using babel-core instead of babel-cli to transform the code for type checking, we do not need that file.