### PR TITLE
Document ol/control~defaults in the right place

### DIFF
--- a/src/ol/control/util.js
+++ b/src/ol/control/util.js
@@ -36,6 +36,7 @@ import Zoom from './Zoom.js';
  * Defaults options.
  * @return {module:ol/Collection.<module:ol/control/Control>}
  * Controls.
+ * @function module:ol/control.defaults
  * @api
  */
 export function defaults(opt_options) {


### PR DESCRIPTION
This change moves the documentation of the control defaults to the right place. It also fixes the namespace in the full build from `ol.control.util.defaults` to `ol.control.defaults`.