### PR TITLE
Re-enable type checking

### DIFF
--- a/tasks/typecheck.js
+++ b/tasks/typecheck.js
@@ -13,6 +13,7 @@ const compiler = new Compiler({
   dependency_mode: 'STRICT',
   checks_only: true,
   jscomp_error: ['newCheckTypes'],
+  compilation_level: 'ADVANCED',
   // Options to make dependencies work
   process_common_js_modules: true,
   hide_warnings_for: 'node_modules'


### PR DESCRIPTION
Looks like the recent Closure Compiler update changed things so type checking the way we want it now requires `compilation_level: 'ADVANCED'`.

With this change, we're back at >2000 warnings.

@fredj, maybe you want to take a look at those? I've pushed this branch to openlayers if you want to add commits.