### PR TITLE
Better vectortile experience

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next release
 
+#### `transition` option of `ol/source/VectorTile` is ignored
+
+The `transition` option to get an opacity transition to fade in tiles has been  disabled for `ol/source/VectorTile`. Vector tiles are now always rendered without an opacity transition.
+
 #### `ol/style/Fill` with `CanvasGradient` or `CanvasPattern`
 
 The origin for gradients and patterns has changed from the top-left corner of the extent of the geometry being filled to 512 css pixel increments from map coordinate `[0, 0]`. This allows repeat patterns to be aligned properly with vector tiles. For seamless repeat patterns, width and height of the pattern image must be a factor of two (2, 4, 8, ..., 512).

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -46,7 +46,7 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
   tileLoadFunction, urlTileCoord, tileUrlFunction, sourceTileGrid, tileGrid,
   sourceTiles, pixelRatio, projection, tileClass, handleTileChange, opt_options) {
 
-  Tile.call(this, tileCoord, state, opt_options);
+  Tile.call(this, tileCoord, state, {transition: 0});
 
   /**
    * @private

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -79,6 +79,11 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
   this.tileKeys = [];
 
   /**
+   * @type {module:ol/extent~Extent}
+   */
+  this.extent = null;
+
+  /**
    * @type {number}
    */
   this.sourceRevision_ = sourceRevision;
@@ -99,7 +104,7 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
   this.sourceTileListenerKeys_ = [];
 
   if (urlTileCoord) {
-    const extent = tileGrid.getTileCoordExtent(urlTileCoord);
+    const extent = this.extent = tileGrid.getTileCoordExtent(urlTileCoord);
     const resolution = tileGrid.getResolution(tileCoord[0]);
     const sourceZ = sourceTileGrid.getZForResolution(resolution);
     sourceTileGrid.forEachTileCoord(extent, sourceZ, function(sourceTileCoord) {

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -9,6 +9,7 @@ import {listen, unlistenByKey} from './events.js';
 import {getHeight, getIntersection, getWidth} from './extent.js';
 import EventType from './events/EventType.js';
 import {loadFeaturesXhr} from './featureloader.js';
+import {UNDEFINED} from './functions.js';
 
 
 /**
@@ -40,11 +41,11 @@ import {loadFeaturesXhr} from './featureloader.js';
  *     instantiate for source tiles.
  * @param {function(this: module:ol/source/VectorTile, module:ol/events/Event)} handleTileChange
  *     Function to call when a source tile's state changes.
- * @param {module:ol/Tile~Options=} opt_options Tile options.
+ * @param {number} zoom Integer zoom to render the tile for.
  */
 const VectorImageTile = function(tileCoord, state, sourceRevision, format,
   tileLoadFunction, urlTileCoord, tileUrlFunction, sourceTileGrid, tileGrid,
-  sourceTiles, pixelRatio, projection, tileClass, handleTileChange, opt_options) {
+  sourceTiles, pixelRatio, projection, tileClass, handleTileChange, zoom) {
 
   Tile.call(this, tileCoord, state, {transition: 0});
 
@@ -105,8 +106,10 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
 
   if (urlTileCoord) {
     const extent = this.extent = tileGrid.getTileCoordExtent(urlTileCoord);
-    const resolution = tileGrid.getResolution(tileCoord[0]);
+    const resolution = tileGrid.getResolution(zoom);
     const sourceZ = sourceTileGrid.getZForResolution(resolution);
+    const useLoadedOnly = zoom != tileCoord[0];
+    let loadCount = 0;
     sourceTileGrid.forEachTileCoord(extent, sourceZ, function(sourceTileCoord) {
       let sharedExtent = getIntersection(extent,
         sourceTileGrid.getTileCoordExtent(sourceTileCoord));
@@ -117,9 +120,10 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
       if (getWidth(sharedExtent) / resolution >= 0.5 &&
           getHeight(sharedExtent) / resolution >= 0.5) {
         // only include source tile if overlap is at least 1 pixel
+        ++loadCount;
         const sourceTileKey = sourceTileCoord.toString();
         let sourceTile = sourceTiles[sourceTileKey];
-        if (!sourceTile) {
+        if (!sourceTile && !useLoadedOnly) {
           const tileUrl = tileUrlFunction(sourceTileCoord, pixelRatio, projection);
           sourceTile = sourceTiles[sourceTileKey] = new tileClass(sourceTileCoord,
             tileUrl == undefined ? TileState.EMPTY : TileState.IDLE,
@@ -128,10 +132,29 @@ const VectorImageTile = function(tileCoord, state, sourceRevision, format,
           this.sourceTileListenerKeys_.push(
             listen(sourceTile, EventType.CHANGE, handleTileChange));
         }
-        sourceTile.consumers++;
-        this.tileKeys.push(sourceTileKey);
+        if (sourceTile && (!useLoadedOnly || sourceTile.getState() == TileState.LOADED)) {
+          sourceTile.consumers++;
+          this.tileKeys.push(sourceTileKey);
+        }
       }
     }.bind(this));
+
+    if (useLoadedOnly && loadCount == this.tileKeys.length) {
+      this.finishLoading_();
+    }
+
+    if (zoom <= tileCoord[0] && this.state != TileState.LOADED) {
+      while (zoom > tileGrid.getMinZoom()) {
+        const tile = new VectorImageTile(tileCoord, state, sourceRevision,
+          format, tileLoadFunction, urlTileCoord, tileUrlFunction,
+          sourceTileGrid, tileGrid, sourceTiles, pixelRatio, projection,
+          tileClass, UNDEFINED, --zoom);
+        if (tile.state == TileState.LOADED) {
+          this.interimTile = tile;
+          break;
+        }
+      }
+    }
   }
 
 };

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -52,6 +52,12 @@ const CanvasTileLayerRenderer = function(tileLayer) {
   this.renderedTiles = [];
 
   /**
+   * @private
+   * @type {boolean}
+   */
+  this.newTiles_ = false;
+
+  /**
    * @protected
    * @type {module:ol/extent~Extent}
    */
@@ -114,6 +120,34 @@ CanvasTileLayerRenderer.prototype.isDrawableTile_ = function(tile) {
       tileState == TileState.ERROR && !useInterimTilesOnError;
 };
 
+
+/**
+ * @param {number} z Tile coordinate z.
+ * @param {number} x Tile coordinate x.
+ * @param {number} y Tile coordinate y.
+ * @param {number} pixelRatio Pixel ratio.
+ * @param {module:ol/proj/Projection} projection Projection.
+ * @return {!module:ol/Tile} Tile.
+ */
+CanvasTileLayerRenderer.prototype.getTile = function(z, x, y, pixelRatio, projection) {
+  const layer = this.getLayer();
+  const source = /** @type {module:ol/source/Tile} */ (layer.getSource());
+  let tile = source.getTile(z, x, y, pixelRatio, projection);
+  if (tile.getState() == TileState.ERROR) {
+    if (!layer.getUseInterimTilesOnError()) {
+      // When useInterimTilesOnError is false, we consider the error tile as loaded.
+      tile.setState(TileState.LOADED);
+    } else if (layer.getPreload() > 0) {
+      // Preloaded tiles for lower resolutions might have finished loading.
+      this.newTiles_ = true;
+    }
+  }
+  if (!this.isDrawableTile_(tile)) {
+    tile = tile.getInterimTile();
+  }
+  return tile;
+};
+
 /**
  * @inheritDoc
  */
@@ -159,30 +193,19 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
 
   const tmpExtent = this.tmpExtent;
   const tmpTileRange = this.tmpTileRange_;
-  let newTiles = false;
+  this.newTiles_ = false;
   let tile, x, y;
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
-      tile = tileSource.getTile(z, x, y, pixelRatio, projection);
-      if (tile.getState() == TileState.ERROR) {
-        if (!tileLayer.getUseInterimTilesOnError()) {
-          // When useInterimTilesOnError is false, we consider the error tile as loaded.
-          tile.setState(TileState.LOADED);
-        } else if (tileLayer.getPreload() > 0) {
-          // Preloaded tiles for lower resolutions might have finished loading.
-          newTiles = true;
-        }
       }
-      if (!this.isDrawableTile_(tile)) {
-        tile = tile.getInterimTile();
-      }
+      tile = this.getTile(z, x, y, pixelRatio, projection);
       if (this.isDrawableTile_(tile)) {
         const uid = getUid(this);
         if (tile.getState() == TileState.LOADED) {
           tilesToDrawByZ[z][tile.tileCoord.toString()] = tile;
           const inTransition = tile.inTransition(uid);
-          if (!newTiles && (inTransition || this.renderedTiles.indexOf(tile) === -1)) {
-            newTiles = true;
+          if (!this.newTiles_ && (inTransition || this.renderedTiles.indexOf(tile) === -1)) {
+            this.newTiles_ = true;
           }
         }
         if (tile.getAlpha(uid, frameState.time) === 1) {
@@ -209,7 +232,7 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
   const hints = frameState.viewHints;
   const animatingOrInteracting = hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING];
   if (!(this.renderedResolution && Date.now() - frameState.time > 16 && animatingOrInteracting) && (
-    newTiles ||
+    this.newTiles_ ||
         !(this.renderedExtent_ && containsExtent(this.renderedExtent_, extent)) ||
         this.renderedRevision != sourceRevision ||
         oversampling != this.oversampling_ ||

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -191,12 +191,17 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
   const findLoadedTiles = this.createLoadedTileFinder(
     tileSource, projection, tilesToDrawByZ);
 
+  const hints = frameState.viewHints;
+  const animatingOrInteracting = hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING];
+
   const tmpExtent = this.tmpExtent;
   const tmpTileRange = this.tmpTileRange_;
   this.newTiles_ = false;
   let tile, x, y;
   for (x = tileRange.minX; x <= tileRange.maxX; ++x) {
     for (y = tileRange.minY; y <= tileRange.maxY; ++y) {
+      if (Date.now() - frameState.time > 16 && animatingOrInteracting) {
+        continue;
       }
       tile = this.getTile(z, x, y, pixelRatio, projection);
       if (this.isDrawableTile_(tile)) {
@@ -229,8 +234,6 @@ CanvasTileLayerRenderer.prototype.prepareFrame = function(frameState, layerState
   }
 
   const renderedResolution = tileResolution * pixelRatio / tilePixelRatio * oversampling;
-  const hints = frameState.viewHints;
-  const animatingOrInteracting = hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING];
   if (!(this.renderedResolution && Date.now() - frameState.time > 16 && animatingOrInteracting) && (
     this.newTiles_ ||
         !(this.renderedExtent_ && containsExtent(this.renderedExtent_, extent)) ||

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -169,7 +169,7 @@ CanvasVectorTileLayerRenderer.prototype.createReplayGroup_ = function(tile, fram
   const sourceTileGrid = source.getTileGrid();
   const tileGrid = source.getTileGridForProjection(projection);
   const resolution = tileGrid.getResolution(tile.tileCoord[0]);
-  const tileExtent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
+  const tileExtent = tile.extent;
 
   const zIndexKeys = {};
   for (let t = 0, tt = tile.tileKeys.length; t < tt; ++t) {
@@ -269,16 +269,11 @@ CanvasVectorTileLayerRenderer.prototype.forEachFeatureAtCoordinate = function(co
   /** @type {Array.<module:ol/VectorImageTile>} */
   const renderedTiles = this.renderedTiles;
 
-  const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
-  const tileGrid = source.getTileGridForProjection(frameState.viewState.projection);
   let bufferedExtent, found;
   let i, ii, replayGroup;
-  let tile, tileCoord, tileExtent;
   for (i = 0, ii = renderedTiles.length; i < ii; ++i) {
-    tile = renderedTiles[i];
-    tileCoord = tile.wrappedTileCoord;
-    tileExtent = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent);
-    bufferedExtent = buffer(tileExtent, hitTolerance * resolution, bufferedExtent);
+    const tile = renderedTiles[i];
+    bufferedExtent = buffer(tile.extent, hitTolerance * resolution, bufferedExtent);
     if (!containsCoordinate(bufferedExtent, coordinate)) {
       continue;
     }
@@ -388,8 +383,7 @@ CanvasVectorTileLayerRenderer.prototype.postCompose = function(context, frameSta
       continue;
     }
     const tileCoord = tile.tileCoord;
-    const worldOffset = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent)[0] -
-        tileGrid.getTileCoordExtent(tile.wrappedTileCoord, this.tmpExtent)[0];
+    const worldOffset = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent)[0] - tile.extent[0];
     let transform = undefined;
     for (let t = 0, tt = tile.tileKeys.length; t < tt; ++t) {
       const sourceTile = tile.getTile(tile.tileKeys[t]);

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -47,8 +47,6 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * When set to `false`, only one world
  * will be rendered. When set to `true`, tiles will be wrapped horizontally to
  * render multiple worlds.
- * @property {number} [transition] Duration of the opacity transition for rendering.
- * To disable the opacity transition, pass `transition: 0`.
  */
 
 
@@ -168,8 +166,7 @@ VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projection) {
       this.format_, this.tileLoadFunction, urlTileCoord, this.tileUrlFunction,
       this.tileGrid, this.getTileGridForProjection(projection),
       this.sourceTiles_, pixelRatio, projection, this.tileClass,
-      this.handleTileChange.bind(this),
-      this.tileOptions);
+      this.handleTileChange.bind(this));
 
     this.tileCache.set(tileCoordKey, tile);
     return tile;

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -166,7 +166,7 @@ VectorTile.prototype.getTile = function(z, x, y, pixelRatio, projection) {
       this.format_, this.tileLoadFunction, urlTileCoord, this.tileUrlFunction,
       this.tileGrid, this.getTileGridForProjection(projection),
       this.sourceTiles_, pixelRatio, projection, this.tileClass,
-      this.handleTileChange.bind(this));
+      this.handleTileChange.bind(this), tileCoord[0]);
 
     this.tileCache.set(tileCoordKey, tile);
     return tile;

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -251,7 +251,9 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       sourceTile.getImage = function() {
         return document.createElement('canvas');
       };
-      const tile = new VectorImageTile([0, 0, 0]);
+      const tile = new VectorImageTile([0, 0, 0], undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, 0);
       tile.transition_ = 0;
       tile.wrappedTileCoord = [0, 0, 0];
       tile.setState(TileState.LOADED);
@@ -262,7 +264,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         return tile;
       };
       const renderer = new CanvasVectorTileLayerRenderer(layer);
-      renderer.renderTileImage_ = sinon.spy();
       const proj = getProjection('EPSG:3857');
       const frameState = {
         extent: proj.getExtent(),
@@ -279,12 +280,13 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         wantedTiles: {}
       };
       renderer.prepareFrame(frameState, {});
-      expect(renderer.renderTileImage_.getCalls().length).to.be(1);
+      const replayState = renderer.renderedTiles[0].getReplayState(layer);
+      const revision = replayState.renderedTileRevision;
       renderer.prepareFrame(frameState, {});
-      expect(renderer.renderTileImage_.getCalls().length).to.be(1);
+      expect(replayState.renderedTileRevision).to.be(revision);
       layer.changed();
       renderer.prepareFrame(frameState, {});
-      expect(renderer.renderTileImage_.getCalls().length).to.be(2);
+      expect(replayState.renderedTileRevision).to.be(revision + 1);
     });
   });
 
@@ -292,6 +294,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     let layer, renderer, replayGroup;
     const TileClass = function() {
       VectorImageTile.apply(this, arguments);
+      this.extent = [-Infinity, -Infinity, Infinity, Infinity];
       this.setState(TileState.LOADED);
       const sourceTile = new VectorTile([0, 0, 0]);
       sourceTile.setState(TileState.LOADED);

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -17,7 +17,7 @@ describe('ol.VectorImageTile', function() {
       defaultLoadFunction, [0, 0, -1], function() {
         return url;
       }, createXYZ(), createXYZ(), {},
-      1, getProjection('EPSG:3857'), VectorTile, function() {});
+      1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
     tile.load();
     const sourceTile = tile.getTile(tile.tileKeys[0]);
@@ -41,7 +41,7 @@ describe('ol.VectorImageTile', function() {
       }, [0, 0, -1], function() {
         return url;
       }, createXYZ(), createXYZ(), {},
-      1, getProjection('EPSG:3857'), VectorTile, function() {});
+      1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
     tile.load();
     let calls = 0;
@@ -65,7 +65,7 @@ describe('ol.VectorImageTile', function() {
       defaultLoadFunction, [0, 0, -1], function() {
         return url;
       }, createXYZ(), createXYZ(), {},
-      1, getProjection('EPSG:3857'), VectorTile, function() {});
+      1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
     tile.load();
 
@@ -81,7 +81,7 @@ describe('ol.VectorImageTile', function() {
     const tile = new VectorImageTile([0, 0, -1], 0, url, format,
       defaultLoadFunction, [0, 0, -1], function() {},
       createXYZ(), createXYZ(), {},
-      1, getProjection('EPSG:3857'), VectorTile, function() {});
+      1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
     tile.load();
 
@@ -105,7 +105,7 @@ describe('ol.VectorImageTile', function() {
         return url;
       }, tileGrid,
       createXYZ({extent: [-180, -90, 180, 90], tileSize: 512}),
-      sourceTiles, 1, getProjection('EPSG:4326'), VectorTile, function() {});
+      sourceTiles, 1, getProjection('EPSG:4326'), VectorTile, function() {}, 1);
     tile.load();
     expect(tile.tileKeys.length).to.be(1);
     expect(tile.getTile(tile.tileKeys[0]).tileCoord).to.eql([0, 16, -10]);
@@ -118,7 +118,7 @@ describe('ol.VectorImageTile', function() {
       defaultLoadFunction, [0, 0, -1], function() {
         return url;
       }, createXYZ(), createXYZ({tileSize: 512}), {},
-      1, getProjection('EPSG:3857'), VectorTile, function() {});
+      1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
     tile.load();
     expect(tile.loadListenerKeys_.length).to.be(4);
@@ -138,7 +138,7 @@ describe('ol.VectorImageTile', function() {
       defaultLoadFunction, [0, 0, -1], function() {
         return url;
       }, createXYZ(), createXYZ({tileSize: 512}), {},
-      1, getProjection('EPSG:3857'), VectorTile, function() {});
+      1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
     tile.load();
     listenOnce(tile, 'change', function() {


### PR DESCRIPTION
This change brings interim tiles to vector image tiles. So when e.g. zooming in or panning, vector tile data from lower resolutions can be used and rendered. Users no langer have to stare at blurry lines and polygons while waiting for the tiles to load. The upscaled images are now only used when the frame time budget is exceed, so they are either not shown at all, or only for a very short time.

Overall performance also improves with this change, because the frame time budget is exceeded less often, so animations are more likely to finish within the scheduled time.

**Before**
![may-24-2018 17-04-28](https://user-images.githubusercontent.com/211514/40494544-635ba596-5f75-11e8-91ce-79c1a70f47e9.gif)

**After**
![may-24-2018 17-04-17](https://user-images.githubusercontent.com/211514/40494559-6e02751a-5f75-11e8-9156-3dd1622aab0f.gif)
