### PR TITLE
Improve source maps for tests

### DIFF
--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -54,6 +54,9 @@ module.exports = function(karma) {
       '**/*.js': ['webpack']
     },
     reporters: ['progress'],
+    webpack: {
+      devtool: 'eval'
+    },
     webpackMiddleware: {
       noInfo: true
     }


### PR DESCRIPTION
Currently, our tests have lines-only source maps. With this change, the test files show up more or less correctly (but still not perfect) in the dev tools.