### PR TITLE
Remove non-functional type checks from testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "lint": "eslint tasks test src/ol examples config",
     "pretest": "npm run lint",
-    "posttest": "npm run typecheck",
     "test": "npm run karma -- --single-run",
     "karma": "karma start test/karma.config.js",
     "serve-examples": "mkdir -p build/examples && webpack --config examples/webpack/config.js --mode development --watch & serve build/examples",


### PR DESCRIPTION
Until #8217 is fixed, it makes no sense to run type checks as part of the test suite.