### PR TITLE
Do not render vectors in image mode

### DIFF
--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -132,7 +132,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     });
 
     it('renders replays with custom renderers as direct replays', function() {
-      layer.renderMode_ = 'image';
       layer.setStyle(new Style({
         renderer: function() {}
       }));


### PR DESCRIPTION
This pull request improves performance for `"image"` render mode with vector tiles, by not trying to render vectors at all.