### PR TITLE
Ignore node_modules everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /build/
 /coverage/
 /dist/
-/node_modules/
+node_modules/
 src/index.js


### PR DESCRIPTION
This allows users to use npm link directly from src/ol, without risiking to commit the src/ol/node_modules directory.
