### PR TITLE
Set sideEffects: false flag

### DIFF
--- a/src/ol/package.json
+++ b/src/ol/package.json
@@ -9,5 +9,6 @@
     "pbf": "3.1.0",
     "pixelworks": "1.1.0",
     "rbush": "2.0.2"
-  }
+  },
+  "sideEffects": "false"
 }


### PR DESCRIPTION
Bundlers start looking for a `"sideEffects": "false"` property in `package.json` for more aggressive tree shaking. By setting this flag, we help users get smaller bundle sizes.

Example: with the [Webpack example project](https://gist.github.com/tschaub/79025aef325cd2837364400a105405b8), this change reduces the bundle size from ~440kB to ~225kB.

Fixes #8337.