### PR TITLE
Updated issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,9 @@
+<!--
 Thank you for your interest in making OpenLayers better!
 
-To keep this project manageable for maintainers, we ask you to please check all boxes below before submitting an issue.
+If you are reporting a bug, please link to an example that reproduces the problem.  This will make it easier for people who may want to help you debug.
 
-- [ ] I am submitting a bug or feature request, not a usage question. Go to https://stackoverflow.com/questions/tagged/openlayers for questions.
-- [ ] I have searched GitHub to see if a similar bug or feature request has already been reported.
-- [ ] I have verified that the issue is present in the latest version of OpenLayers (see 'LATEST' on https://openlayers.org/).
-- [ ] If reporting a bug, I have created a [CodePen](https://codepen.io) or prepared a stack trace (using the latest version and unminified code, so e.g. `ol-debug.js`, not `ol.js`) that shows the issue.
+If you have a usage question, you might want to try Stack Overflow first: https://stackoverflow.com/questions/tagged/openlayers
+
+Thanks
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,13 @@
+<!--
 Thank you for your interest in making OpenLayers better!
 
-In order to get your proposed changes merged into the master branch, we ask you to please make sure the following boxes are checked *before* submitting your pull request.
+Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.
 
-- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
-- [ ] It contains one or more small, incremental, logically separate commits, with no merge commits.
-- [ ] I have used clear commit messages.
-- [ ] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
+Here are some other tips that make pull requests easier to review:
+
+ * Commits in the branch are small and logically separated (with no unnecessary merge commits).
+ * Commit messages are clear.
+ * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.
+
+Thanks
+-->


### PR DESCRIPTION
This proposes reworking our issue and pull request templates a bit.  Personally, I've never checked all of the existing checkboxes and delete the whole block upon opening a pr.  Since it gets in the way of the description when rendered, I think the template text should be wrapped as a comment.  At best, we can hope that people skim it before continuing on.