### PR TITLE
TypeScript (1/n)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "rbush": "2.0.2"
   },
   "devDependencies": {
+    "@openlayers/eslint-plugin": "^4.0.0-beta.1",
     "buble": "^0.19.3",
     "buble-loader": "^0.5.1",
     "chaikin-smooth": "^1.0.4",
@@ -84,7 +85,19 @@
     "webpack-dev-server": "^3.1.4"
   },
   "eslintConfig": {
-    "extends": "openlayers"
+    "extends": "openlayers",
+    "plugins": [
+      "@openlayers"
+    ],
+    "rules": {
+      "valid-jsdoc": "off",
+      "@openlayers/valid-tsdoc": [
+        "error",
+        {
+          "requireReturn": false
+        }
+      ]
+    }
   },
   "sideEffects": [
     "ol.css"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build-legacy": "rm -rf build && npm run build-index && rollup --config config/rollup.js && cleancss --source-map src/ol/ol.css -o build/ol.css",
     "copy-css": "cp src/ol/ol.css build/ol/ol.css",
     "transpile": "rm -rf build/ol && mkdir -p build && buble --input src/ol --output build/ol --no modules --sourcemap",
+    "typecheck": "tsc --pretty",
     "apidoc": "jsdoc config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -P package.json -d build/apidoc"
   },
   "main": "index.js",
@@ -74,6 +75,7 @@
     "rollup-plugin-sourcemaps": "0.4.2",
     "rollup-plugin-uglify": "5.0.2",
     "sinon": "^6.0.0",
+    "typescript": "^3.1.0-dev.20180905",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "url-polyfill": "^1.0.13",
     "walk": "^2.3.9",

--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -24,7 +24,7 @@ const Property = {
 export class CollectionEvent extends Event {
 
   /**
-   * @param {module:ol/CollectionEventType} type Type.
+   * @param {import("./CollectionEventType.js").default} type Type.
    * @param {*=} opt_element Element.
    */
   constructor(type, opt_element) {
@@ -63,7 +63,7 @@ class Collection extends BaseObject {
 
   /**
    * @param {Array<T>=} opt_array Array.
-   * @param {module:ol/Collection~Options=} opt_options Collection options.
+   * @param {Options=} opt_options Collection options.
    */
   constructor(opt_array, opt_options) {
 
@@ -107,7 +107,7 @@ class Collection extends BaseObject {
    * Add elements to the collection.  This pushes each item in the provided array
    * to the end of the collection.
    * @param {!Array<T>} arr Array.
-   * @return {module:ol/Collection<T>} This collection.
+   * @return {import("./Collection.js").default<T>} This collection.
    * @api
    */
   extend(arr) {

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -54,7 +54,7 @@ import Style from './style/Style.js';
  */
 class Feature extends BaseObject {
   /**
-   * @param {module:ol/geom/Geometry|Object<string, *>=} opt_geometryOrProperties
+   * @param {import("./geom/Geometry.js").default|Object<string, *>=} opt_geometryOrProperties
    *     You may pass a Geometry object directly, or an object literal containing
    *     properties. If you pass an object literal, you may include a Geometry
    *     associated with a `geometry` key.
@@ -78,19 +78,19 @@ class Feature extends BaseObject {
     /**
      * User provided style.
      * @private
-     * @type {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
+     * @type {import("./style/Style.js").default|Array<import("./style/Style.js").default>|import("./style/Style.js").StyleFunction}
      */
     this.style_ = null;
 
     /**
      * @private
-     * @type {module:ol/style/Style~StyleFunction|undefined}
+     * @type {import("./style/Style.js").StyleFunction|undefined}
      */
     this.styleFunction_ = undefined;
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      */
     this.geometryChangeKey_ = null;
 
@@ -114,7 +114,7 @@ class Feature extends BaseObject {
   /**
    * Clone this feature. If the original feature has a geometry it
    * is also cloned. The feature id is not set in the clone.
-   * @return {module:ol/Feature} The clone.
+   * @return {import("./Feature.js").default} The clone.
    * @api
    */
   clone() {
@@ -135,13 +135,13 @@ class Feature extends BaseObject {
    * Get the feature's default geometry.  A feature may have any number of named
    * geometries.  The "default" geometry (the one that is rendered by default) is
    * set when calling {@link module:ol/Feature~Feature#setGeometry}.
-   * @return {module:ol/geom/Geometry|undefined} The default geometry for the feature.
+   * @return {import("./geom/Geometry.js").default|undefined} The default geometry for the feature.
    * @api
    * @observable
    */
   getGeometry() {
     return (
-      /** @type {module:ol/geom/Geometry|undefined} */ (this.get(this.geometryName_))
+      /** @type {import("./geom/Geometry.js").default|undefined} */ (this.get(this.geometryName_))
     );
   }
 
@@ -170,7 +170,7 @@ class Feature extends BaseObject {
   /**
    * Get the feature's style. Will return what was provided to the
    * {@link module:ol/Feature~Feature#setStyle} method.
-   * @return {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} The feature style.
+   * @return {import("./style/Style.js").default|Array<import("./style/Style.js").default>|import("./style/Style.js").StyleFunction} The feature style.
    * @api
    */
   getStyle() {
@@ -179,7 +179,7 @@ class Feature extends BaseObject {
 
   /**
    * Get the feature's style function.
-   * @return {module:ol/style/Style~StyleFunction|undefined} Return a function
+   * @return {import("./style/Style.js").StyleFunction|undefined} Return a function
    * representing the current style of this feature.
    * @api
    */
@@ -213,7 +213,7 @@ class Feature extends BaseObject {
   /**
    * Set the default geometry for the feature.  This will update the property
    * with the name returned by {@link module:ol/Feature~Feature#getGeometryName}.
-   * @param {module:ol/geom/Geometry|undefined} geometry The new geometry.
+   * @param {import("./geom/Geometry.js").default|undefined} geometry The new geometry.
    * @api
    * @observable
    */
@@ -225,7 +225,7 @@ class Feature extends BaseObject {
    * Set the style for the feature.  This can be a single style object, an array
    * of styles, or a function that takes a resolution and returns an array of
    * styles. If it is `null` the feature has no style (a `null` style).
-   * @param {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} style Style for this feature.
+   * @param {import("./style/Style.js").default|Array<import("./style/Style.js").default>|import("./style/Style.js").StyleFunction} style Style for this feature.
    * @api
    * @fires module:ol/events/Event~Event#event:change
    */
@@ -271,25 +271,25 @@ class Feature extends BaseObject {
 
 /**
  * Convert the provided object into a feature style function.  Functions passed
- * through unchanged.  Arrays of module:ol/style/Style or single style objects wrapped
+ * through unchanged.  Arrays of import("./style/Style.js").default or single style objects wrapped
  * in a new feature style function.
- * @param {module:ol/style/Style~StyleFunction|!Array<module:ol/style/Style>|!module:ol/style/Style} obj
+ * @param {import("./style/Style.js").StyleFunction|!Array<import("./style/Style.js").default>|!import("./style/Style.js").default} obj
  *     A feature style function, a single style, or an array of styles.
- * @return {module:ol/style/Style~StyleFunction} A style function.
+ * @return {import("./style/Style.js").StyleFunction} A style function.
  */
 export function createStyleFunction(obj) {
   if (typeof obj === 'function') {
     return obj;
   } else {
     /**
-     * @type {Array<module:ol/style/Style>}
+     * @type {Array<import("./style/Style.js").default>}
      */
     let styles;
     if (Array.isArray(obj)) {
       styles = obj;
     } else {
       assert(obj instanceof Style,
-        41); // Expected an `module:ol/style/Style~Style` or an array of `module:ol/style/Style~Style`
+        41); // Expected an `import("./style/Style.js").Style` or an array of `import("./style/Style.js").Style`
       styles = [obj];
     }
     return function() {

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -17,7 +17,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
  * instantiation.
  * @property {PositionOptions} [trackingOptions] Tracking options.
  * See http://www.w3.org/TR/geolocation-API/#position_options_interface.
- * @property {module:ol/proj~ProjectionLike} [projection] The projection the position
+ * @property {import("./proj.js").ProjectionLike} [projection] The projection the position
  * is reported in.
  */
 
@@ -48,7 +48,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
 class Geolocation extends BaseObject {
 
   /**
-   * @param {module:ol/Geolocation~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -59,13 +59,13 @@ class Geolocation extends BaseObject {
     /**
      * The unprojected (EPSG:4326) device position.
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("./coordinate.js").Coordinate}
      */
     this.position_ = null;
 
     /**
      * @private
-     * @type {module:ol/proj~TransformFunction}
+     * @type {import("./proj.js").TransformFunction}
      */
     this.transform_ = identityTransform;
 
@@ -192,13 +192,13 @@ class Geolocation extends BaseObject {
 
   /**
    * Get a geometry of the position accuracy.
-   * @return {?module:ol/geom/Polygon} A geometry of the position accuracy.
+   * @return {?import("./geom/Polygon.js").default} A geometry of the position accuracy.
    * @observable
    * @api
    */
   getAccuracyGeometry() {
     return (
-      /** @type {?module:ol/geom/Polygon} */ (this.get(GeolocationProperty.ACCURACY_GEOMETRY) || null)
+      /** @type {?import("./geom/Polygon.js").default} */ (this.get(GeolocationProperty.ACCURACY_GEOMETRY) || null)
     );
   }
 
@@ -238,27 +238,27 @@ class Geolocation extends BaseObject {
 
   /**
    * Get the position of the device.
-   * @return {module:ol/coordinate~Coordinate|undefined} The current position of the device reported
+   * @return {import("./coordinate.js").Coordinate|undefined} The current position of the device reported
    *     in the current projection.
    * @observable
    * @api
    */
   getPosition() {
     return (
-      /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(GeolocationProperty.POSITION))
+      /** @type {import("./coordinate.js").Coordinate|undefined} */ (this.get(GeolocationProperty.POSITION))
     );
   }
 
   /**
    * Get the projection associated with the position.
-   * @return {module:ol/proj/Projection|undefined} The projection the position is
+   * @return {import("./proj/Projection.js").default|undefined} The projection the position is
    *     reported in.
    * @observable
    * @api
    */
   getProjection() {
     return (
-      /** @type {module:ol/proj/Projection|undefined} */ (this.get(GeolocationProperty.PROJECTION))
+      /** @type {import("./proj/Projection.js").default|undefined} */ (this.get(GeolocationProperty.PROJECTION))
     );
   }
 
@@ -298,7 +298,7 @@ class Geolocation extends BaseObject {
 
   /**
    * Set the projection to use for transforming the coordinates.
-   * @param {module:ol/proj~ProjectionLike} projection The projection the position is
+   * @param {import("./proj.js").ProjectionLike} projection The projection the position is
    *     reported in.
    * @observable
    * @api

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -17,7 +17,7 @@ import Text from './style/Text.js';
 
 
 /**
- * @type {module:ol/style/Stroke}
+ * @type {import("./style/Stroke.js").default}
  * @private
  * @const
  */
@@ -36,13 +36,13 @@ const INTERVALS = [
 
 /**
  * @typedef {Object} GraticuleLabelDataType
- * @property {module:ol/geom/Point} geom
+ * @property {import("./geom/Point.js").default} geom
  * @property {string} text
  */
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/PluggableMap} [map] Reference to an
+ * @property {import("./PluggableMap.js").default} [map] Reference to an
  * {@link module:ol/Map~Map} object.
  * @property {number} [maxLines=100] The maximum number of meridians and
  * parallels from the center of the map. The default value of 100 means that at
@@ -50,7 +50,7 @@ const INTERVALS = [
  * appropriate for conformal projections like Spherical Mercator. If you
  * increase the value, more lines will be drawn and the drawing performance will
  * decrease.
- * @property {module:ol/style/Stroke} [strokeStyle='rgba(0,0,0,0.2)'] The
+ * @property {import("./style/Stroke.js").default} [strokeStyle='rgba(0,0,0,0.2)'] The
  * stroke style to use for drawing the graticule. If not provided, a not fully
  * opaque black will be used.
  * @property {number} [targetSize=100] The target size of the graticule cells,
@@ -71,7 +71,7 @@ const INTERVALS = [
  * @property {number} [latLabelPosition=1] Latitude label position in fractions
  * (0..1) of view extent. 0 means at the left of the viewport, 1 means at the
  * right.
- * @property {module:ol/style/Text} [lonLabelStyle] Longitude label text
+ * @property {import("./style/Text.js").default} [lonLabelStyle] Longitude label text
  * style. If not provided, the following style will be used:
  * ```js
  * new Text({
@@ -89,7 +89,7 @@ const INTERVALS = [
  * Note that the default's `textBaseline` configuration will not work well for
  * `lonLabelPosition` configurations that position labels close to the top of
  * the viewport.
- * @property {module:ol/style/Text} [latLabelStyle] Latitude label text style.
+ * @property {import("./style/Text.js").default} [latLabelStyle] Latitude label text style.
  * If not provided, the following style will be used:
  * ```js
  * new Text({
@@ -117,25 +117,25 @@ const INTERVALS = [
 class Graticule {
 
   /**
-   * @param {module:ol/Graticule~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};
 
     /**
-     * @type {module:ol/PluggableMap}
+     * @type {import("./PluggableMap.js").default}
      * @private
      */
     this.map_ = null;
 
     /**
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      * @private
      */
     this.postcomposeListenerKey_ = null;
 
     /**
-     * @type {module:ol/proj/Projection}
+     * @type {import("./proj/Projection.js").default}
      */
     this.projection_ = null;
 
@@ -200,49 +200,49 @@ class Graticule {
     this.maxLines_ = options.maxLines !== undefined ? options.maxLines : 100;
 
     /**
-     * @type {Array<module:ol/geom/LineString>}
+     * @type {Array<import("./geom/LineString.js").default>}
      * @private
      */
     this.meridians_ = [];
 
     /**
-     * @type {Array<module:ol/geom/LineString>}
+     * @type {Array<import("./geom/LineString.js").default>}
      * @private
      */
     this.parallels_ = [];
 
     /**
-     * @type {module:ol/style/Stroke}
+     * @type {import("./style/Stroke.js").default}
      * @private
      */
     this.strokeStyle_ = options.strokeStyle !== undefined ? options.strokeStyle : DEFAULT_STROKE_STYLE;
 
     /**
-     * @type {module:ol/proj~TransformFunction|undefined}
+     * @type {import("./proj.js").TransformFunction|undefined}
      * @private
      */
     this.fromLonLatTransform_ = undefined;
 
     /**
-     * @type {module:ol/proj~TransformFunction|undefined}
+     * @type {import("./proj.js").TransformFunction|undefined}
      * @private
      */
     this.toLonLatTransform_ = undefined;
 
     /**
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("./coordinate.js").Coordinate}
      * @private
      */
     this.projectionCenterLonLat_ = null;
 
     /**
-     * @type {Array<module:ol/Graticule~GraticuleLabelDataType>}
+     * @type {Array<GraticuleLabelDataType>}
      * @private
      */
     this.meridiansLabels_ = null;
 
     /**
-     * @type {Array<module:ol/Graticule~GraticuleLabelDataType>}
+     * @type {Array<GraticuleLabelDataType>}
      * @private
      */
     this.parallelsLabels_ = null;
@@ -282,7 +282,7 @@ class Graticule {
         options.latLabelPosition;
 
       /**
-       * @type {module:ol/style/Text}
+       * @type {import("./style/Text.js").default}
        * @private
        */
       this.lonLabelStyle_ = options.lonLabelStyle !== undefined ? options.lonLabelStyle :
@@ -299,7 +299,7 @@ class Graticule {
         });
 
       /**
-       * @type {module:ol/style/Text}
+       * @type {import("./style/Text.js").default}
        * @private
        */
       this.latLabelStyle_ = options.latLabelStyle !== undefined ? options.latLabelStyle :
@@ -327,7 +327,7 @@ class Graticule {
    * @param {number} minLat Minimal latitude.
    * @param {number} maxLat Maximal latitude.
    * @param {number} squaredTolerance Squared tolerance.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number} index Index.
    * @return {number} Index.
    * @private
@@ -348,10 +348,10 @@ class Graticule {
   }
 
   /**
-   * @param {module:ol/geom/LineString} lineString Meridian
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./geom/LineString.js").default} lineString Meridian
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number} index Index.
-   * @return {module:ol/geom/Point} Meridian point.
+   * @return {import("./geom/Point.js").default} Meridian point.
    * @private
    */
   getMeridianPoint_(lineString, extent, index) {
@@ -377,7 +377,7 @@ class Graticule {
    * @param {number} minLon Minimal longitude.
    * @param {number} maxLon Maximal longitude.
    * @param {number} squaredTolerance Squared tolerance.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number} index Index.
    * @return {number} Index.
    * @private
@@ -398,10 +398,10 @@ class Graticule {
   }
 
   /**
-   * @param {module:ol/geom/LineString} lineString Parallels.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./geom/LineString.js").default} lineString Parallels.
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number} index Index.
-   * @return {module:ol/geom/Point} Parallel point.
+   * @return {import("./geom/Point.js").default} Parallel point.
    * @private
    */
   getParallelPoint_(lineString, extent, index) {
@@ -423,8 +423,8 @@ class Graticule {
   }
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("./extent.js").Extent} extent Extent.
+   * @param {import("./coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} squaredTolerance Squared tolerance.
    * @private
@@ -549,7 +549,7 @@ class Graticule {
 
   /**
    * Get the map associated with this graticule.
-   * @return {module:ol/PluggableMap} The map.
+   * @return {import("./PluggableMap.js").default} The map.
    * @api
    */
   getMap() {
@@ -561,7 +561,7 @@ class Graticule {
    * @param {number} minLat Minimal latitude.
    * @param {number} maxLat Maximal latitude.
    * @param {number} squaredTolerance Squared tolerance.
-   * @return {module:ol/geom/LineString} The meridian line string.
+   * @return {import("./geom/LineString.js").default} The meridian line string.
    * @param {number} index Index.
    * @private
    */
@@ -579,7 +579,7 @@ class Graticule {
 
   /**
    * Get the list of meridians.  Meridians are lines of equal longitude.
-   * @return {Array<module:ol/geom/LineString>} The meridians.
+   * @return {Array<import("./geom/LineString.js").default>} The meridians.
    * @api
    */
   getMeridians() {
@@ -591,7 +591,7 @@ class Graticule {
    * @param {number} minLon Minimal longitude.
    * @param {number} maxLon Maximal longitude.
    * @param {number} squaredTolerance Squared tolerance.
-   * @return {module:ol/geom/LineString} The parallel line string.
+   * @return {import("./geom/LineString.js").default} The parallel line string.
    * @param {number} index Index.
    * @private
    */
@@ -609,7 +609,7 @@ class Graticule {
 
   /**
    * Get the list of parallels.  Parallels are lines of equal latitude.
-   * @return {Array<module:ol/geom/LineString>} The parallels.
+   * @return {Array<import("./geom/LineString.js").default>} The parallels.
    * @api
    */
   getParallels() {
@@ -617,7 +617,7 @@ class Graticule {
   }
 
   /**
-   * @param {module:ol/render/Event} e Event.
+   * @param {import("./render/Event.js").default} e Event.
    * @private
    */
   handlePostCompose_(e) {
@@ -672,7 +672,7 @@ class Graticule {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("./proj/Projection.js").default} projection Projection.
    * @private
    */
   updateProjectionInfo_(projection) {
@@ -703,7 +703,7 @@ class Graticule {
   /**
    * Set the map for this graticule.  The graticule will be rendered on the
    * provided map.
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("./PluggableMap.js").default} map Map.
    * @api
    */
   setMap(map) {

--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -22,7 +22,7 @@ import {getHeight} from './extent.js';
  * post requests or - in general - through XHR requests, where the src of the
  * image element would be set to a data URI when the content is loaded.
  *
- * @typedef {function(module:ol/Image, string)} LoadFunction
+ * @typedef {function(import("./Image.js").default, string)} LoadFunction
  * @api
  */
 
@@ -30,12 +30,12 @@ import {getHeight} from './extent.js';
 class ImageWrapper extends ImageBase {
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number|undefined} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
-   * @param {module:ol/Image~LoadFunction} imageLoadFunction Image load function.
+   * @param {LoadFunction} imageLoadFunction Image load function.
    */
   constructor(extent, resolution, pixelRatio, src, crossOrigin, imageLoadFunction) {
 
@@ -58,19 +58,19 @@ class ImageWrapper extends ImageBase {
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("./events.js").EventsKey>}
      */
     this.imageListenerKeys_ = null;
 
     /**
      * @protected
-     * @type {module:ol/ImageState}
+     * @type {import("./ImageState.js").default}
      */
     this.state = ImageState.IDLE;
 
     /**
      * @private
-     * @type {module:ol/Image~LoadFunction}
+     * @type {LoadFunction}
      */
     this.imageLoadFunction_ = imageLoadFunction;
 

--- a/src/ol/ImageBase.js
+++ b/src/ol/ImageBase.js
@@ -10,10 +10,10 @@ import EventType from './events/EventType.js';
 class ImageBase extends EventTarget {
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number|undefined} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/ImageState} state State.
+   * @param {import("./ImageState.js").default} state State.
    */
   constructor(extent, resolution, pixelRatio, state) {
 
@@ -21,7 +21,7 @@ class ImageBase extends EventTarget {
 
     /**
      * @protected
-     * @type {module:ol/extent~Extent}
+     * @type {import("./extent.js").Extent}
      */
     this.extent = extent;
 
@@ -39,7 +39,7 @@ class ImageBase extends EventTarget {
 
     /**
      * @protected
-     * @type {module:ol/ImageState}
+     * @type {import("./ImageState.js").default}
      */
     this.state = state;
 
@@ -53,7 +53,7 @@ class ImageBase extends EventTarget {
   }
 
   /**
-   * @return {module:ol/extent~Extent} Extent.
+   * @return {import("./extent.js").Extent} Extent.
    */
   getExtent() {
     return this.extent;
@@ -80,7 +80,7 @@ class ImageBase extends EventTarget {
   }
 
   /**
-   * @return {module:ol/ImageState} State.
+   * @return {import("./ImageState.js").default} State.
    */
   getState() {
     return this.state;

--- a/src/ol/ImageCanvas.js
+++ b/src/ol/ImageCanvas.js
@@ -18,11 +18,11 @@ import ImageState from './ImageState.js';
 class ImageCanvas extends ImageBase {
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("./extent.js").Extent} extent Extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {HTMLCanvasElement} canvas Canvas.
-   * @param {module:ol/ImageCanvas~Loader=} opt_loader Optional loader function to
+   * @param {Loader=} opt_loader Optional loader function to
    *     support asynchronous canvas drawing.
    */
   constructor(extent, resolution, pixelRatio, canvas, opt_loader) {
@@ -33,7 +33,7 @@ class ImageCanvas extends ImageBase {
 
     /**
      * Optional canvas loader function.
-     * @type {?module:ol/ImageCanvas~Loader}
+     * @type {?Loader}
      * @private
      */
     this.loader_ = opt_loader !== undefined ? opt_loader : null;

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -8,20 +8,20 @@ import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 
 /**
- * @typedef {function(new: module:ol/ImageTile, module:ol/tilecoord~TileCoord,
- * module:ol/TileState, string, ?string, module:ol/Tile~LoadFunction)} TileClass
+ * @typedef {function(new: import("./ImageTile.js").default, import("./tilecoord.js").TileCoord,
+ * import("./TileState.js").default, string, ?string, import("./Tile.js").LoadFunction)} TileClass
  * @api
  */
 
 class ImageTile extends Tile {
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileState} state State.
+   * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("./TileState.js").default} state State.
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
-   * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
-   * @param {module:ol/Tile~Options=} opt_options Tile options.
+   * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
+   * @param {import("./Tile.js").Options=} opt_options Tile options.
    */
   constructor(tileCoord, state, src, crossOrigin, tileLoadFunction, opt_options) {
 
@@ -52,13 +52,13 @@ class ImageTile extends Tile {
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("./events.js").EventsKey>}
      */
     this.imageListenerKeys_ = null;
 
     /**
      * @private
-     * @type {module:ol/Tile~LoadFunction}
+     * @type {import("./Tile.js").LoadFunction}
      */
     this.tileLoadFunction_ = tileLoadFunction;
 

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -56,8 +56,8 @@ import CanvasVectorTileLayerRenderer from './renderer/canvas/VectorTileLayer.js'
  * options or added with `addLayer` can be groups, which can contain further
  * groups, and so on.
  *
- * @fires module:ol/MapBrowserEvent~MapBrowserEvent
- * @fires module:ol/MapEvent~MapEvent
+ * @fires import("./MapBrowserEvent.js").MapBrowserEvent
+ * @fires import("./MapEvent.js").MapEvent
  * @fires module:ol/render/Event~RenderEvent#postcompose
  * @fires module:ol/render/Event~RenderEvent#precompose
  * @api
@@ -65,7 +65,7 @@ import CanvasVectorTileLayerRenderer from './renderer/canvas/VectorTileLayer.js'
 class Map extends PluggableMap {
 
   /**
-   * @param {module:ol/PluggableMap~MapOptions} options Map options.
+   * @param {import("./PluggableMap.js").MapOptions} options Map options.
    */
   constructor(options) {
     options = assign({}, options);

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -12,10 +12,10 @@ class MapBrowserEvent extends MapEvent {
 
   /**
    * @param {string} type Event type.
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("./PluggableMap.js").default} map Map.
    * @param {Event} browserEvent Browser event.
    * @param {boolean=} opt_dragging Is the map currently being dragged?
-   * @param {?module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
+   * @param {?import("./PluggableMap.js").FrameState=} opt_frameState Frame state.
    */
   constructor(type, map, browserEvent, opt_dragging, opt_frameState) {
 
@@ -31,14 +31,14 @@ class MapBrowserEvent extends MapEvent {
 
     /**
      * The map pixel relative to the viewport corresponding to the original browser event.
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("./pixel.js").Pixel}
      * @api
      */
     this.pixel = map.getEventPixel(browserEvent);
 
     /**
      * The coordinate in view projection corresponding to the original browser event.
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("./coordinate.js").Coordinate}
      * @api
      */
     this.coordinate = map.getCoordinateFromPixel(this.pixel);

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -12,7 +12,7 @@ import PointerEventHandler from './pointer/PointerEventHandler.js';
 class MapBrowserEventHandler extends EventTarget {
 
   /**
-   * @param {module:ol/PluggableMap} map The map with the viewport to listen to events on.
+   * @param {import("./PluggableMap.js").default} map The map with the viewport to listen to events on.
    * @param {number=} moveTolerance The minimal distance the pointer must travel to trigger a move.
    */
   constructor(map, moveTolerance) {
@@ -21,7 +21,7 @@ class MapBrowserEventHandler extends EventTarget {
 
     /**
      * This is the element that we will listen to the real events on.
-     * @type {module:ol/PluggableMap}
+     * @type {import("./PluggableMap.js").default}
      * @private
      */
     this.map_ = map;
@@ -39,7 +39,7 @@ class MapBrowserEventHandler extends EventTarget {
     this.dragging_ = false;
 
     /**
-     * @type {!Array<module:ol/events~EventsKey>}
+     * @type {!Array<import("./events.js").EventsKey>}
      * @private
      */
     this.dragListenerKeys_ = [];
@@ -54,7 +54,7 @@ class MapBrowserEventHandler extends EventTarget {
     /**
      * The most recent "down" type event (or null if none have occurred).
      * Set on pointerdown.
-     * @type {module:ol/pointer/PointerEvent}
+     * @type {import("./pointer/PointerEvent.js").default}
      * @private
      */
     this.down_ = null;
@@ -77,7 +77,7 @@ class MapBrowserEventHandler extends EventTarget {
      * Event handler which generates pointer events for
      * the viewport element.
      *
-     * @type {module:ol/pointer/PointerEventHandler}
+     * @type {import("./pointer/PointerEventHandler.js").default}
      * @private
      */
     this.pointerEventHandler_ = new PointerEventHandler(element);
@@ -86,13 +86,13 @@ class MapBrowserEventHandler extends EventTarget {
      * Event handler which generates pointer events for
      * the document (used when dragging).
      *
-     * @type {module:ol/pointer/PointerEventHandler}
+     * @type {import("./pointer/PointerEventHandler.js").default}
      * @private
      */
     this.documentPointerEventHandler_ = null;
 
     /**
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      * @private
      */
     this.pointerdownListenerKey_ = listen(this.pointerEventHandler_,
@@ -100,7 +100,7 @@ class MapBrowserEventHandler extends EventTarget {
       this.handlePointerDown_, this);
 
     /**
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      * @private
      */
     this.relayedListenerKey_ = listen(this.pointerEventHandler_,
@@ -110,7 +110,7 @@ class MapBrowserEventHandler extends EventTarget {
   }
 
   /**
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @private
    */
@@ -139,7 +139,7 @@ class MapBrowserEventHandler extends EventTarget {
   /**
    * Keeps track on how many pointers are currently active.
    *
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @private
    */
@@ -156,7 +156,7 @@ class MapBrowserEventHandler extends EventTarget {
   }
 
   /**
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @private
    */
@@ -187,7 +187,7 @@ class MapBrowserEventHandler extends EventTarget {
   }
 
   /**
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @return {boolean} If the left mouse button was pressed.
    * @private
@@ -197,7 +197,7 @@ class MapBrowserEventHandler extends EventTarget {
   }
 
   /**
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @private
    */
@@ -245,7 +245,7 @@ class MapBrowserEventHandler extends EventTarget {
   }
 
   /**
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @private
    */
@@ -271,7 +271,7 @@ class MapBrowserEventHandler extends EventTarget {
   /**
    * Wrap and relay a pointer event.  Note that this requires that the type
    * string for the MapBrowserPointerEvent matches the PointerEvent type.
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @private
    */
@@ -282,7 +282,7 @@ class MapBrowserEventHandler extends EventTarget {
   }
 
   /**
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer
    * event.
    * @return {boolean} Is moving.
    * @private

--- a/src/ol/MapBrowserPointerEvent.js
+++ b/src/ol/MapBrowserPointerEvent.js
@@ -7,10 +7,10 @@ class MapBrowserPointerEvent extends MapBrowserEvent {
 
   /**
    * @param {string} type Event type.
-   * @param {module:ol/PluggableMap} map Map.
-   * @param {module:ol/pointer/PointerEvent} pointerEvent Pointer event.
+   * @param {import("./PluggableMap.js").default} map Map.
+   * @param {import("./pointer/PointerEvent.js").default} pointerEvent Pointer event.
    * @param {boolean=} opt_dragging Is the map currently being dragged?
-   * @param {?module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
+   * @param {?import("./PluggableMap.js").FrameState=} opt_frameState Frame state.
    */
   constructor(type, map, pointerEvent, opt_dragging, opt_frameState) {
 
@@ -18,7 +18,7 @@ class MapBrowserPointerEvent extends MapBrowserEvent {
 
     /**
      * @const
-     * @type {module:ol/pointer/PointerEvent}
+     * @type {import("./pointer/PointerEvent.js").default}
      */
     this.pointerEvent = pointerEvent;
 

--- a/src/ol/MapEvent.js
+++ b/src/ol/MapEvent.js
@@ -12,8 +12,8 @@ class MapEvent extends Event {
 
   /**
    * @param {string} type Event type.
-   * @param {module:ol/PluggableMap} map Map.
-   * @param {?module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
+   * @param {import("./PluggableMap.js").default} map Map.
+   * @param {?import("./PluggableMap.js").FrameState=} opt_frameState Frame state.
    */
   constructor(type, map, opt_frameState) {
 
@@ -21,14 +21,14 @@ class MapEvent extends Event {
 
     /**
      * The map where the event occurred.
-     * @type {module:ol/PluggableMap}
+     * @type {import("./PluggableMap.js").default}
      * @api
      */
     this.map = map;
 
     /**
      * The frame state at the time of the event.
-     * @type {?module:ol/PluggableMap~FrameState}
+     * @type {?import("./PluggableMap.js").FrameState}
      * @api
      */
     this.frameState = opt_frameState !== undefined ? opt_frameState : null;

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -82,7 +82,7 @@ class ObjectEvent extends Event {
  * Properties can be deleted by using the unset method. E.g.
  * object.unset('foo').
  *
- * @fires module:ol/Object~ObjectEvent
+ * @fires ObjectEvent
  * @api
  */
 class BaseObject extends Observable {

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -13,7 +13,7 @@ import EventType from './events/EventType.js';
  * and unregistration. A generic `change` event is always available through
  * {@link module:ol/Observable~Observable#changed}.
  *
- * @fires module:ol/events/Event~Event
+ * @fires import("./events/Event.js").Event
  * @api
  */
 class Observable extends EventTarget {
@@ -52,7 +52,7 @@ class Observable extends EventTarget {
    * Listen for a certain type of event.
    * @param {string|Array<string>} type The event type or array of event types.
    * @param {function(?): ?} listener The listener function.
-   * @return {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} Unique key for the listener. If
+   * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Unique key for the listener. If
    *     called with an array of event types as the first argument, the return
    *     will be an array of keys.
    * @api
@@ -74,7 +74,7 @@ class Observable extends EventTarget {
    * Listen once for a certain type of event.
    * @param {string|Array<string>} type The event type or array of event types.
    * @param {function(?): ?} listener The listener function.
-   * @return {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} Unique key for the listener. If
+   * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Unique key for the listener. If
    *     called with an array of event types as the first argument, the return
    *     will be an array of keys.
    * @api
@@ -113,7 +113,7 @@ class Observable extends EventTarget {
 
 /**
  * Removes an event listener using the key returned by `on()` or `once()`.
- * @param {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} key The key returned by `on()`
+ * @param {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} key The key returned by `on()`
  *     or `once()` (or an array of keys).
  * @api
  */
@@ -123,7 +123,7 @@ export function unByKey(key) {
       unlistenByKey(key[i]);
     }
   } else {
-    unlistenByKey(/** @type {module:ol/events~EventsKey} */ (key));
+    unlistenByKey(/** @type {import("./events.js").EventsKey} */ (key));
   }
 }
 

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -20,9 +20,9 @@ import {containsExtent} from './extent.js';
  * array is the horizontal offset. A positive value shifts the overlay right.
  * The second element in the array is the vertical offset. A positive value
  * shifts the overlay down.
- * @property {module:ol/coordinate~Coordinate} [position] The overlay position
+ * @property {import("./coordinate.js").Coordinate} [position] The overlay position
  * in map projection.
- * @property {module:ol/OverlayPositioning} [positioning='top-left'] Defines how
+ * @property {import("./OverlayPositioning.js").default} [positioning='top-left'] Defines how
  * the overlay is actually positioned with respect to its `position` property.
  * Possible values are `'bottom-left'`, `'bottom-center'`, `'bottom-right'`,
  * `'center-left'`, `'center-center'`, `'center-right'`, `'top-left'`,
@@ -40,7 +40,7 @@ import {containsExtent} from './extent.js';
  * @property {boolean} [autoPan=false] If set to `true` the map is panned when
  * calling `setPosition`, so that the overlay is entirely visible in the current
  * viewport.
- * @property {module:ol/Overlay~PanOptions} [autoPanAnimation] The
+ * @property {PanOptions} [autoPanAnimation] The
  * animation options used to pan the overlay into view. This animation is only
  * used when `autoPan` is enabled. A `duration` and `easing` may be provided to
  * customize the animation.
@@ -97,7 +97,7 @@ const Property = {
 class Overlay extends BaseObject {
 
   /**
-   * @param {module:ol/Overlay~Options} options Overlay options.
+   * @param {Options} options Overlay options.
    */
   constructor(options) {
 
@@ -105,7 +105,7 @@ class Overlay extends BaseObject {
 
     /**
      * @protected
-     * @type {module:ol/Overlay~Options}
+     * @type {Options}
      */
     this.options = options;
 
@@ -145,9 +145,9 @@ class Overlay extends BaseObject {
 
     /**
      * @protected
-     * @type {module:ol/Overlay~PanOptions}
+     * @type {PanOptions}
      */
-    this.autoPanAnimation = options.autoPanAnimation || /** @type {module:ol/Overlay~PanOptions} */ ({});
+    this.autoPanAnimation = options.autoPanAnimation || /** @type {PanOptions} */ ({});
 
     /**
      * @protected
@@ -174,7 +174,7 @@ class Overlay extends BaseObject {
 
     /**
      * @protected
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      */
     this.mapPostrenderListenerKey = null;
 
@@ -205,7 +205,7 @@ class Overlay extends BaseObject {
     this.setOffset(options.offset !== undefined ? options.offset : [0, 0]);
 
     this.setPositioning(options.positioning !== undefined ?
-      /** @type {module:ol/OverlayPositioning} */ (options.positioning) :
+      /** @type {import("./OverlayPositioning.js").default} */ (options.positioning) :
       OverlayPositioning.TOP_LEFT);
 
     if (options.position !== undefined) {
@@ -235,14 +235,14 @@ class Overlay extends BaseObject {
 
   /**
    * Get the map associated with this overlay.
-   * @return {module:ol/PluggableMap|undefined} The map that the
+   * @return {import("./PluggableMap.js").default|undefined} The map that the
    * overlay is part of.
    * @observable
    * @api
    */
   getMap() {
     return (
-      /** @type {module:ol/PluggableMap|undefined} */ (this.get(Property.MAP))
+      /** @type {import("./PluggableMap.js").default|undefined} */ (this.get(Property.MAP))
     );
   }
 
@@ -258,27 +258,27 @@ class Overlay extends BaseObject {
 
   /**
    * Get the current position of this overlay.
-   * @return {module:ol/coordinate~Coordinate|undefined} The spatial point that the overlay is
+   * @return {import("./coordinate.js").Coordinate|undefined} The spatial point that the overlay is
    *     anchored at.
    * @observable
    * @api
    */
   getPosition() {
     return (
-      /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(Property.POSITION))
+      /** @type {import("./coordinate.js").Coordinate|undefined} */ (this.get(Property.POSITION))
     );
   }
 
   /**
    * Get the current positioning of this overlay.
-   * @return {module:ol/OverlayPositioning} How the overlay is positioned
+   * @return {import("./OverlayPositioning.js").default} How the overlay is positioned
    *     relative to its point on the map.
    * @observable
    * @api
    */
   getPositioning() {
     return (
-      /** @type {module:ol/OverlayPositioning} */ (this.get(Property.POSITIONING))
+      /** @type {import("./OverlayPositioning.js").default} */ (this.get(Property.POSITIONING))
     );
   }
 
@@ -360,7 +360,7 @@ class Overlay extends BaseObject {
 
   /**
    * Set the map to be associated with this overlay.
-   * @param {module:ol/PluggableMap|undefined} map The map that the
+   * @param {import("./PluggableMap.js").default|undefined} map The map that the
    * overlay is part of.
    * @observable
    * @api
@@ -382,7 +382,7 @@ class Overlay extends BaseObject {
   /**
    * Set the position for this overlay. If the position is `undefined` the
    * overlay is hidden.
-   * @param {module:ol/coordinate~Coordinate|undefined} position The spatial point that the overlay
+   * @param {import("./coordinate.js").Coordinate|undefined} position The spatial point that the overlay
    *     is anchored at.
    * @observable
    * @api
@@ -432,7 +432,7 @@ class Overlay extends BaseObject {
       }
 
       if (delta[0] !== 0 || delta[1] !== 0) {
-        const center = /** @type {module:ol/coordinate~Coordinate} */ (map.getView().getCenter());
+        const center = /** @type {import("./coordinate.js").Coordinate} */ (map.getView().getCenter());
         const centerPx = map.getPixelFromCoordinate(center);
         const newCenterPx = [
           centerPx[0] + delta[0],
@@ -451,8 +451,8 @@ class Overlay extends BaseObject {
   /**
    * Get the extent of an element relative to the document
    * @param {HTMLElement|undefined} element The element.
-   * @param {module:ol/size~Size|undefined} size The size of the element.
-   * @return {module:ol/extent~Extent} The extent.
+   * @param {import("./size.js").Size|undefined} size The size of the element.
+   * @return {import("./extent.js").Extent} The extent.
    * @protected
    */
   getRect(element, size) {
@@ -469,7 +469,7 @@ class Overlay extends BaseObject {
 
   /**
    * Set the positioning for this overlay.
-   * @param {module:ol/OverlayPositioning} positioning how the overlay is
+   * @param {import("./OverlayPositioning.js").default} positioning how the overlay is
    *     positioned relative to its point on the map.
    * @observable
    * @api
@@ -508,8 +508,8 @@ class Overlay extends BaseObject {
   }
 
   /**
-   * @param {module:ol/pixel~Pixel} pixel The pixel location.
-   * @param {module:ol/size~Size|undefined} mapSize The map size.
+   * @param {import("./pixel.js").Pixel} pixel The pixel location.
+   * @param {import("./size.js").Size|undefined} mapSize The map size.
    * @protected
    */
   updateRenderedPosition(pixel, mapSize) {
@@ -574,7 +574,7 @@ class Overlay extends BaseObject {
 
   /**
    * returns the options this Overlay has been created with
-   * @return {module:ol/Overlay~Options} overlay options
+   * @return {Options} overlay options
    */
   getOptions() {
     return this.options;

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -36,33 +36,33 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @typedef {Object} FrameState
  * @property {number} pixelRatio The pixel ratio of the frame.
  * @property {number} time The time when rendering of the frame was requested.
- * @property {module:ol/View~State} viewState The state of the current view.
+ * @property {import("./View.js").State} viewState The state of the current view.
  * @property {boolean} animate
- * @property {module:ol/transform~Transform} coordinateToPixelTransform
- * @property {null|module:ol/extent~Extent} extent
- * @property {module:ol/coordinate~Coordinate} focus
+ * @property {import("./transform.js").Transform} coordinateToPixelTransform
+ * @property {null|import("./extent.js").Extent} extent
+ * @property {import("./coordinate.js").Coordinate} focus
  * @property {number} index
- * @property {Object<number, module:ol/layer/Layer~State>} layerStates
- * @property {Array<module:ol/layer/Layer~State>} layerStatesArray
- * @property {module:ol/transform~Transform} pixelToCoordinateTransform
- * @property {Array<module:ol/PluggableMap~PostRenderFunction>} postRenderFunctions
- * @property {module:ol/size~Size} size
+ * @property {Object<number, import("./layer/Layer.js").State>} layerStates
+ * @property {Array<import("./layer/Layer.js").State>} layerStatesArray
+ * @property {import("./transform.js").Transform} pixelToCoordinateTransform
+ * @property {Array<PostRenderFunction>} postRenderFunctions
+ * @property {import("./size.js").Size} size
  * @property {!Object<string, boolean>} skippedFeatureUids
- * @property {module:ol/TileQueue} tileQueue
- * @property {Object<string, Object<string, module:ol/TileRange>>} usedTiles
+ * @property {import("./TileQueue.js").default} tileQueue
+ * @property {Object<string, Object<string, import("./TileRange.js").default>>} usedTiles
  * @property {Array<number>} viewHints
  * @property {!Object<string, Object<string, boolean>>} wantedTiles
  */
 
 
 /**
- * @typedef {function(module:ol/PluggableMap, ?module:ol/PluggableMap~FrameState): boolean} PostRenderFunction
+ * @typedef {function(import("./PluggableMap.js").default, ?FrameState): boolean} PostRenderFunction
  */
 
 
 /**
  * @typedef {Object} AtPixelOptions
- * @property {undefined|function(module:ol/layer/Layer): boolean} layerFilter Layer filter
+ * @property {undefined|function(import("./layer/Layer.js").default): boolean} layerFilter Layer filter
  * function. The filter function will receive one argument, the
  * {@link module:ol/layer/Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
@@ -75,10 +75,10 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @typedef {Object} MapOptionsInternal
- * @property {module:ol/Collection<module:ol/control/Control>} [controls]
- * @property {module:ol/Collection<module:ol/interaction/Interaction>} [interactions]
+ * @property {import("./Collection.js").default<import("./control/Control.js").default>} [controls]
+ * @property {import("./Collection.js").default<import("./interaction/Interaction.js").default>} [interactions]
  * @property {HTMLElement|Document} keyboardEventTarget
- * @property {module:ol/Collection<module:ol/Overlay>} overlays
+ * @property {import("./Collection.js").default<import("./Overlay.js").default>} overlays
  * @property {Object<string, *>} values
  */
 
@@ -86,12 +86,12 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 /**
  * Object literal with config options for the map.
  * @typedef {Object} MapOptions
- * @property {module:ol/Collection<module:ol/control/Control>|Array<module:ol/control/Control>} [controls]
+ * @property {import("./Collection.js").default<import("./control/Control.js").default>|Array<import("./control/Control.js").default>} [controls]
  * Controls initially added to the map. If not specified,
  * {@link module:ol/control/util~defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
- * @property {module:ol/Collection<module:ol/interaction/Interaction>|Array<module:ol/interaction/Interaction>} [interactions]
+ * @property {import("./Collection.js").default<import("./interaction/Interaction.js").default>|Array<import("./interaction/Interaction.js").default>} [interactions]
  * Interactions that are initially added to the map. If not specified,
  * {@link module:ol/interaction~defaults} is used.
  * @property {HTMLElement|Document|string} [keyboardEventTarget] The element to
@@ -102,7 +102,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * map target (i.e. the user-provided div for the map). If this is not
  * `document`, the target element needs to be focused for key events to be
  * emitted, requiring that the target element has a `tabindex` attribute.
- * @property {Array<module:ol/layer/Base>|module:ol/Collection<module:ol/layer/Base>} [layers]
+ * @property {Array<import("./layer/Base.js").default>|import("./Collection.js").default<import("./layer/Base.js").default>} [layers]
  * Layers. If this is not defined, a map with no layers will be rendered. Note
  * that layers are rendered in the order supplied, so if you want, for example,
  * a vector layer to appear on top of a tile layer, it must come after the tile
@@ -119,21 +119,21 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {number} [moveTolerance=1] The minimum distance in pixels the
  * cursor must move to be detected as a map move event instead of a click.
  * Increasing this value can make it easier to click on the map.
- * @property {module:ol/Collection<module:ol/Overlay>|Array<module:ol/Overlay>} [overlays]
+ * @property {import("./Collection.js").default<import("./Overlay.js").default>|Array<import("./Overlay.js").default>} [overlays]
  * Overlays initially added to the map. By default, no overlays are added.
  * @property {HTMLElement|string} [target] The container for the map, either the
  * element itself or the `id` of the element. If not specified at construction
  * time, {@link module:ol/Map~Map#setTarget} must be called for the map to be
  * rendered.
- * @property {module:ol/View} [view] The map's view.  No layer sources will be
+ * @property {import("./View.js").default} [view] The map's view.  No layer sources will be
  * fetched unless this is specified at construction time or through
  * {@link module:ol/Map~Map#setView}.
  */
 
 
 /**
- * @fires module:ol/MapBrowserEvent~MapBrowserEvent
- * @fires module:ol/MapEvent~MapEvent
+ * @fires import("./MapBrowserEvent.js").MapBrowserEvent
+ * @fires import("./MapEvent.js").MapEvent
  * @fires module:ol/render/Event~RenderEvent#postcompose
  * @fires module:ol/render/Event~RenderEvent#precompose
  * @fires module:ol/render/Event~RenderEvent#rendercomplete
@@ -142,7 +142,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 class PluggableMap extends BaseObject {
 
   /**
-   * @param {module:ol/PluggableMap~MapOptions} options Map options.
+   * @param {MapOptions} options Map options.
    */
   constructor(options) {
 
@@ -195,13 +195,13 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("./transform.js").Transform}
      */
     this.coordinateToPixelTransform_ = createTransform();
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("./transform.js").Transform}
      */
     this.pixelToCoordinateTransform_ = createTransform();
 
@@ -213,32 +213,32 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {?module:ol/PluggableMap~FrameState}
+     * @type {?FrameState}
      */
     this.frameState_ = null;
 
     /**
      * The extent at the previous 'moveend' event.
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("./extent.js").Extent}
      */
     this.previousExtent_ = null;
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      */
     this.viewPropertyListenerKey_ = null;
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("./events.js").EventsKey}
      */
     this.viewChangeListenerKey_ = null;
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("./events.js").EventsKey>}
      */
     this.layerGroupPropertyListenerKeys_ = null;
 
@@ -287,7 +287,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/MapBrowserEventHandler}
+     * @type {import("./MapBrowserEventHandler.js").default}
      */
     this.mapBrowserEventHandler_ = new MapBrowserEventHandler(this, options.moveTolerance);
     for (const key in MapBrowserEventType) {
@@ -303,7 +303,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("./events.js").EventsKey>}
      */
     this.keyHandlerKeys_ = null;
 
@@ -312,19 +312,19 @@ class PluggableMap extends BaseObject {
     listen(this.viewport_, EventType.MOUSEWHEEL, this.handleBrowserEvent, this);
 
     /**
-     * @type {module:ol/Collection<module:ol/control/Control>}
+     * @type {import("./Collection.js").default<import("./control/Control.js").default>}
      * @protected
      */
     this.controls = optionsInternal.controls || new Collection();
 
     /**
-     * @type {module:ol/Collection<module:ol/interaction/Interaction>}
+     * @type {import("./Collection.js").default<import("./interaction/Interaction.js").default>}
      * @protected
      */
     this.interactions = optionsInternal.interactions || new Collection();
 
     /**
-     * @type {module:ol/Collection<module:ol/Overlay>}
+     * @type {import("./Collection.js").default<import("./Overlay.js").default>}
      * @private
      */
     this.overlays_ = optionsInternal.overlays;
@@ -332,12 +332,12 @@ class PluggableMap extends BaseObject {
     /**
      * A lookup of overlays by id.
      * @private
-     * @type {Object<string, module:ol/Overlay>}
+     * @type {Object<string, import("./Overlay.js").default>}
      */
     this.overlayIdIndex_ = {};
 
     /**
-     * @type {module:ol/renderer/Map}
+     * @type {import("./renderer/Map.js").default}
      * @private
      */
     this.renderer_ = this.createRenderer();
@@ -350,19 +350,19 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("./coordinate.js").Coordinate}
      */
     this.focus_ = null;
 
     /**
      * @private
-     * @type {!Array<module:ol/PluggableMap~PostRenderFunction>}
+     * @type {!Array<PostRenderFunction>}
      */
     this.postRenderFunctions_ = [];
 
     /**
      * @private
-     * @type {module:ol/TileQueue}
+     * @type {import("./TileQueue.js").default}
      */
     this.tileQueue_ = new TileQueue(
       this.getTilePriority.bind(this),
@@ -391,8 +391,8 @@ class PluggableMap extends BaseObject {
 
     this.controls.forEach(
       /**
-       * @param {module:ol/control/Control} control Control.
-       * @this {module:ol/PluggableMap}
+       * @param {import("./control/Control.js").default} control Control.
+       * @this {import("./PluggableMap.js").default}
        */
       (function(control) {
         control.setMap(this);
@@ -400,7 +400,7 @@ class PluggableMap extends BaseObject {
 
     listen(this.controls, CollectionEventType.ADD,
       /**
-       * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
+       * @param {import("./Collection.js").CollectionEvent} event CollectionEvent.
        */
       function(event) {
         event.element.setMap(this);
@@ -408,7 +408,7 @@ class PluggableMap extends BaseObject {
 
     listen(this.controls, CollectionEventType.REMOVE,
       /**
-       * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
+       * @param {import("./Collection.js").CollectionEvent} event CollectionEvent.
        */
       function(event) {
         event.element.setMap(null);
@@ -416,8 +416,8 @@ class PluggableMap extends BaseObject {
 
     this.interactions.forEach(
       /**
-       * @param {module:ol/interaction/Interaction} interaction Interaction.
-       * @this {module:ol/PluggableMap}
+       * @param {import("./interaction/Interaction.js").default} interaction Interaction.
+       * @this {import("./PluggableMap.js").default}
        */
       (function(interaction) {
         interaction.setMap(this);
@@ -425,7 +425,7 @@ class PluggableMap extends BaseObject {
 
     listen(this.interactions, CollectionEventType.ADD,
       /**
-       * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
+       * @param {import("./Collection.js").CollectionEvent} event CollectionEvent.
        */
       function(event) {
         event.element.setMap(this);
@@ -433,7 +433,7 @@ class PluggableMap extends BaseObject {
 
     listen(this.interactions, CollectionEventType.REMOVE,
       /**
-       * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
+       * @param {import("./Collection.js").CollectionEvent} event CollectionEvent.
        */
       function(event) {
         event.element.setMap(null);
@@ -443,18 +443,18 @@ class PluggableMap extends BaseObject {
 
     listen(this.overlays_, CollectionEventType.ADD,
       /**
-       * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
+       * @param {import("./Collection.js").CollectionEvent} event CollectionEvent.
        */
       function(event) {
-        this.addOverlayInternal_(/** @type {module:ol/Overlay} */ (event.element));
+        this.addOverlayInternal_(/** @type {import("./Overlay.js").default} */ (event.element));
       }, this);
 
     listen(this.overlays_, CollectionEventType.REMOVE,
       /**
-       * @param {module:ol/Collection~CollectionEvent} event CollectionEvent.
+       * @param {import("./Collection.js").CollectionEvent} event CollectionEvent.
        */
       function(event) {
-        const overlay = /** @type {module:ol/Overlay} */ (event.element);
+        const overlay = /** @type {import("./Overlay.js").default} */ (event.element);
         const id = overlay.getId();
         if (id !== undefined) {
           delete this.overlayIdIndex_[id.toString()];
@@ -470,7 +470,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Add the given control to the map.
-   * @param {module:ol/control/Control} control Control.
+   * @param {import("./control/Control.js").default} control Control.
    * @api
    */
   addControl(control) {
@@ -479,7 +479,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Add the given interaction to the map.
-   * @param {module:ol/interaction/Interaction} interaction Interaction to add.
+   * @param {import("./interaction/Interaction.js").default} interaction Interaction to add.
    * @api
    */
   addInteraction(interaction) {
@@ -490,7 +490,7 @@ class PluggableMap extends BaseObject {
    * Adds the given layer to the top of this map. If you want to add a layer
    * elsewhere in the stack, use `getLayers()` and the methods available on
    * {@link module:ol/Collection~Collection}.
-   * @param {module:ol/layer/Base} layer Layer.
+   * @param {import("./layer/Base.js").default} layer Layer.
    * @api
    */
   addLayer(layer) {
@@ -500,7 +500,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Add the given overlay to the map.
-   * @param {module:ol/Overlay} overlay Overlay.
+   * @param {import("./Overlay.js").default} overlay Overlay.
    * @api
    */
   addOverlay(overlay) {
@@ -509,7 +509,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * This deals with map's overlay collection changes.
-   * @param {module:ol/Overlay} overlay Overlay.
+   * @param {import("./Overlay.js").default} overlay Overlay.
    * @private
    */
   addOverlayInternal_(overlay) {
@@ -545,16 +545,16 @@ class PluggableMap extends BaseObject {
    * Detect features that intersect a pixel on the viewport, and execute a
    * callback with each intersecting feature. Layers included in the detection can
    * be configured through the `layerFilter` option in `opt_options`.
-   * @param {module:ol/pixel~Pixel} pixel Pixel.
-   * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature),
-   *     module:ol/layer/Layer): T} callback Feature callback. The callback will be
+   * @param {import("./pixel.js").Pixel} pixel Pixel.
+   * @param {function(this: S, (import("./Feature.js").default|import("./render/Feature.js").default),
+   *     import("./layer/Layer.js").default): T} callback Feature callback. The callback will be
    *     called with two arguments. The first argument is one
    *     {@link module:ol/Feature feature} or
    *     {@link module:ol/render/Feature render feature} at the pixel, the second is
    *     the {@link module:ol/layer/Layer layer} of the feature and will be null for
    *     unmanaged layers. To stop detection, callback functions can return a
    *     truthy value.
-   * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
+   * @param {AtPixelOptions=} opt_options Optional options.
    * @return {T|undefined} Callback result, i.e. the return value of last
    * callback execution, or the first truthy callback return value.
    * @template S,T
@@ -577,9 +577,9 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get all features that intersect a pixel on the viewport.
-   * @param {module:ol/pixel~Pixel} pixel Pixel.
-   * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
-   * @return {Array<module:ol/Feature|module:ol/render/Feature>} The detected features or
+   * @param {import("./pixel.js").Pixel} pixel Pixel.
+   * @param {AtPixelOptions=} opt_options Optional options.
+   * @return {Array<import("./Feature.js").default|import("./render/Feature.js").default>} The detected features or
    * `null` if none were found.
    * @api
    */
@@ -598,14 +598,14 @@ class PluggableMap extends BaseObject {
    * Detect layers that have a color value at a pixel on the viewport, and
    * execute a callback with each matching layer. Layers included in the
    * detection can be configured through `opt_layerFilter`.
-   * @param {module:ol/pixel~Pixel} pixel Pixel.
-   * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback
+   * @param {import("./pixel.js").Pixel} pixel Pixel.
+   * @param {function(this: S, import("./layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback
    *     Layer callback. This callback will receive two arguments: first is the
    *     {@link module:ol/layer/Layer layer}, second argument is an array representing
    *     [R, G, B, A] pixel values (0 - 255) and will be `null` for layer types
    *     that do not currently support this argument. To stop detection, callback
    *     functions can return a truthy value.
-   * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Configuration options.
+   * @param {AtPixelOptions=} opt_options Configuration options.
    * @return {T|undefined} Callback result, i.e. the return value of last
    * callback execution, or the first truthy callback return value.
    * @template S,T
@@ -615,7 +615,7 @@ class PluggableMap extends BaseObject {
     if (!this.frameState_) {
       return;
     }
-    const options = opt_options || /** @type {module:ol/PluggableMap~AtPixelOptions} */ ({});
+    const options = opt_options || /** @type {AtPixelOptions} */ ({});
     const hitTolerance = options.hitTolerance !== undefined ?
       opt_options.hitTolerance * this.frameState_.pixelRatio : 0;
     const layerFilter = options.layerFilter || TRUE;
@@ -626,8 +626,8 @@ class PluggableMap extends BaseObject {
   /**
    * Detect if features intersect a pixel on the viewport. Layers included in the
    * detection can be configured through `opt_layerFilter`.
-   * @param {module:ol/pixel~Pixel} pixel Pixel.
-   * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
+   * @param {import("./pixel.js").Pixel} pixel Pixel.
+   * @param {AtPixelOptions=} opt_options Optional options.
    * @return {boolean} Is there a feature at the given pixel?
    * @template U
    * @api
@@ -648,7 +648,7 @@ class PluggableMap extends BaseObject {
   /**
    * Returns the coordinate in view projection for a browser event.
    * @param {Event} event Event.
-   * @return {module:ol/coordinate~Coordinate} Coordinate.
+   * @return {import("./coordinate.js").Coordinate} Coordinate.
    * @api
    */
   getEventCoordinate(event) {
@@ -658,7 +658,7 @@ class PluggableMap extends BaseObject {
   /**
    * Returns the map pixel position for a browser event relative to the viewport.
    * @param {Event} event Event.
-   * @return {module:ol/pixel~Pixel} Pixel.
+   * @return {import("./pixel.js").Pixel} Pixel.
    * @api
    */
   getEventPixel(event) {
@@ -702,8 +702,8 @@ class PluggableMap extends BaseObject {
   /**
    * Get the coordinate for a given pixel.  This returns a coordinate in the
    * map view projection.
-   * @param {module:ol/pixel~Pixel} pixel Pixel position in the map viewport.
-   * @return {module:ol/coordinate~Coordinate} The coordinate for the pixel position.
+   * @param {import("./pixel.js").Pixel} pixel Pixel position in the map viewport.
+   * @return {import("./coordinate.js").Coordinate} The coordinate for the pixel position.
    * @api
    */
   getCoordinateFromPixel(pixel) {
@@ -718,7 +718,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the map controls. Modifying this collection changes the controls
    * associated with the map.
-   * @return {module:ol/Collection<module:ol/control/Control>} Controls.
+   * @return {import("./Collection.js").default<import("./control/Control.js").default>} Controls.
    * @api
    */
   getControls() {
@@ -728,7 +728,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the map overlays. Modifying this collection changes the overlays
    * associated with the map.
-   * @return {module:ol/Collection<module:ol/Overlay>} Overlays.
+   * @return {import("./Collection.js").default<import("./Overlay.js").default>} Overlays.
    * @api
    */
   getOverlays() {
@@ -740,7 +740,7 @@ class PluggableMap extends BaseObject {
    * Note that the index treats string and numeric identifiers as the same. So
    * `map.getOverlayById(2)` will return an overlay with id `'2'` or `2`.
    * @param {string|number} id Overlay identifier.
-   * @return {module:ol/Overlay} Overlay.
+   * @return {import("./Overlay.js").default} Overlay.
    * @api
    */
   getOverlayById(id) {
@@ -753,7 +753,7 @@ class PluggableMap extends BaseObject {
    * associated with the map.
    *
    * Interactions are used for e.g. pan, zoom and rotate.
-   * @return {module:ol/Collection<module:ol/interaction/Interaction>} Interactions.
+   * @return {import("./Collection.js").default<import("./interaction/Interaction.js").default>} Interactions.
    * @api
    */
   getInteractions() {
@@ -762,19 +762,19 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get the layergroup associated with this map.
-   * @return {module:ol/layer/Group} A layer group containing the layers in this map.
+   * @return {import("./layer/Group.js").default} A layer group containing the layers in this map.
    * @observable
    * @api
    */
   getLayerGroup() {
     return (
-      /** @type {module:ol/layer/Group} */ (this.get(MapProperty.LAYERGROUP))
+      /** @type {import("./layer/Group.js").default} */ (this.get(MapProperty.LAYERGROUP))
     );
   }
 
   /**
    * Get the collection of layers associated with this map.
-   * @return {!module:ol/Collection<module:ol/layer/Base>} Layers.
+   * @return {!import("./Collection.js").default<import("./layer/Base.js").default>} Layers.
    * @api
    */
   getLayers() {
@@ -785,8 +785,8 @@ class PluggableMap extends BaseObject {
   /**
    * Get the pixel for a coordinate.  This takes a coordinate in the map view
    * projection and returns the corresponding pixel.
-   * @param {module:ol/coordinate~Coordinate} coordinate A map coordinate.
-   * @return {module:ol/pixel~Pixel} A pixel position in the map viewport.
+   * @param {import("./coordinate.js").Coordinate} coordinate A map coordinate.
+   * @return {import("./pixel.js").Pixel} A pixel position in the map viewport.
    * @api
    */
   getPixelFromCoordinate(coordinate) {
@@ -800,7 +800,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get the map renderer.
-   * @return {module:ol/renderer/Map} Renderer
+   * @return {import("./renderer/Map.js").default} Renderer
    */
   getRenderer() {
     return this.renderer_;
@@ -808,26 +808,26 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get the size of this map.
-   * @return {module:ol/size~Size|undefined} The size in pixels of the map in the DOM.
+   * @return {import("./size.js").Size|undefined} The size in pixels of the map in the DOM.
    * @observable
    * @api
    */
   getSize() {
     return (
-      /** @type {module:ol/size~Size|undefined} */ (this.get(MapProperty.SIZE))
+      /** @type {import("./size.js").Size|undefined} */ (this.get(MapProperty.SIZE))
     );
   }
 
   /**
    * Get the view associated with this map. A view manages properties such as
    * center and resolution.
-   * @return {module:ol/View} The view that controls this map.
+   * @return {import("./View.js").default} The view that controls this map.
    * @observable
    * @api
    */
   getView() {
     return (
-      /** @type {module:ol/View} */ (this.get(MapProperty.VIEW))
+      /** @type {import("./View.js").default} */ (this.get(MapProperty.VIEW))
     );
   }
 
@@ -863,9 +863,9 @@ class PluggableMap extends BaseObject {
   }
 
   /**
-   * @param {module:ol/Tile} tile Tile.
+   * @param {import("./Tile.js").default} tile Tile.
    * @param {string} tileSourceKey Tile source key.
-   * @param {module:ol/coordinate~Coordinate} tileCenter Tile center.
+   * @param {import("./coordinate.js").Coordinate} tileCenter Tile center.
    * @param {number} tileResolution Tile resolution.
    * @return {number} Tile priority.
    */
@@ -902,7 +902,7 @@ class PluggableMap extends BaseObject {
   }
 
   /**
-   * @param {module:ol/MapBrowserEvent} mapBrowserEvent The event to handle.
+   * @param {import("./MapBrowserEvent.js").default} mapBrowserEvent The event to handle.
    */
   handleMapBrowserEvent(mapBrowserEvent) {
     if (!this.frameState_) {
@@ -1122,8 +1122,8 @@ class PluggableMap extends BaseObject {
 
   /**
    * Remove the given control from the map.
-   * @param {module:ol/control/Control} control Control.
-   * @return {module:ol/control/Control|undefined} The removed control (or undefined
+   * @param {import("./control/Control.js").default} control Control.
+   * @return {import("./control/Control.js").default|undefined} The removed control (or undefined
    *     if the control was not found).
    * @api
    */
@@ -1133,8 +1133,8 @@ class PluggableMap extends BaseObject {
 
   /**
    * Remove the given interaction from the map.
-   * @param {module:ol/interaction/Interaction} interaction Interaction to remove.
-   * @return {module:ol/interaction/Interaction|undefined} The removed interaction (or
+   * @param {import("./interaction/Interaction.js").default} interaction Interaction to remove.
+   * @return {import("./interaction/Interaction.js").default|undefined} The removed interaction (or
    *     undefined if the interaction was not found).
    * @api
    */
@@ -1144,8 +1144,8 @@ class PluggableMap extends BaseObject {
 
   /**
    * Removes the given layer from the map.
-   * @param {module:ol/layer/Base} layer Layer.
-   * @return {module:ol/layer/Base|undefined} The removed layer (or undefined if the
+   * @param {import("./layer/Base.js").default} layer Layer.
+   * @return {import("./layer/Base.js").default|undefined} The removed layer (or undefined if the
    *     layer was not found).
    * @api
    */
@@ -1156,8 +1156,8 @@ class PluggableMap extends BaseObject {
 
   /**
    * Remove the given overlay from the map.
-   * @param {module:ol/Overlay} overlay Overlay.
-   * @return {module:ol/Overlay|undefined} The removed overlay (or undefined
+   * @param {import("./Overlay.js").default} overlay Overlay.
+   * @return {import("./Overlay.js").default|undefined} The removed overlay (or undefined
    *     if the overlay was not found).
    * @api
    */
@@ -1176,7 +1176,7 @@ class PluggableMap extends BaseObject {
     const view = this.getView();
     const extent = createEmpty();
     const previousFrameState = this.frameState_;
-    /** @type {?module:ol/PluggableMap~FrameState} */
+    /** @type {?FrameState} */
     let frameState = null;
     if (size !== undefined && hasArea(size) && view && view.isDef()) {
       const viewHints = view.getHints(this.frameState_ ? this.frameState_.viewHints : undefined);
@@ -1186,7 +1186,7 @@ class PluggableMap extends BaseObject {
         layerStates[getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
       }
       viewState = view.getState(this.pixelRatio_);
-      frameState = /** @type {module:ol/PluggableMap~FrameState} */ ({
+      frameState = /** @type {FrameState} */ ({
         animate: false,
         coordinateToPixelTransform: this.coordinateToPixelTransform_,
         extent: extent,
@@ -1252,7 +1252,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Sets the layergroup of this map.
-   * @param {module:ol/layer/Group} layerGroup A layer group containing the layers in this map.
+   * @param {import("./layer/Group.js").default} layerGroup A layer group containing the layers in this map.
    * @observable
    * @api
    */
@@ -1262,7 +1262,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Set the size of this map.
-   * @param {module:ol/size~Size|undefined} size The size in pixels of the map in the DOM.
+   * @param {import("./size.js").Size|undefined} size The size in pixels of the map in the DOM.
    * @observable
    * @api
    */
@@ -1283,7 +1283,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Set the view for this map.
-   * @param {module:ol/View} view The view that controls this map.
+   * @param {import("./View.js").default} view The view that controls this map.
    * @observable
    * @api
    */
@@ -1292,7 +1292,7 @@ class PluggableMap extends BaseObject {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("./Feature.js").default} feature Feature.
    */
   skipFeature(feature) {
     const featureUid = getUid(feature).toString();
@@ -1328,7 +1328,7 @@ class PluggableMap extends BaseObject {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("./Feature.js").default} feature Feature.
    */
   unskipFeature(feature) {
     const featureUid = getUid(feature).toString();
@@ -1340,7 +1340,7 @@ class PluggableMap extends BaseObject {
 
 /**
  * @param {MapOptions} options Map options.
- * @return {module:ol/PluggableMap~MapOptionsInternal} Internal map options.
+ * @return {MapOptionsInternal} Internal map options.
  */
 function createOptionsInternal(options) {
 
@@ -1374,7 +1374,7 @@ function createOptionsInternal(options) {
       controls = new Collection(options.controls.slice());
     } else {
       assert(options.controls instanceof Collection,
-        47); // Expected `controls` to be an array or an `module:ol/Collection~Collection`
+        47); // Expected `controls` to be an array or an `import("./Collection.js").Collection`
       controls = options.controls;
     }
   }
@@ -1385,7 +1385,7 @@ function createOptionsInternal(options) {
       interactions = new Collection(options.interactions.slice());
     } else {
       assert(options.interactions instanceof Collection,
-        48); // Expected `interactions` to be an array or an `module:ol/Collection~Collection`
+        48); // Expected `interactions` to be an array or an `import("./Collection.js").Collection`
       interactions = options.interactions;
     }
   }
@@ -1396,7 +1396,7 @@ function createOptionsInternal(options) {
       overlays = new Collection(options.overlays.slice());
     } else {
       assert(options.overlays instanceof Collection,
-        49); // Expected `overlays` to be an array or an `module:ol/Collection~Collection`
+        49); // Expected `overlays` to be an array or an `import("./Collection.js").Collection`
       overlays = options.overlays;
     }
   } else {
@@ -1415,7 +1415,7 @@ function createOptionsInternal(options) {
 export default PluggableMap;
 
 /**
- * @param  {Array<module:ol/layer/Base>} layers Layers.
+ * @param  {Array<import("./layer/Base.js").default>} layers Layers.
  * @return {boolean} Layers have sources that are still loading.
  */
 function getLoading(layers) {

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -40,7 +40,7 @@ import EventType from './events/EventType.js';
  * });
  * ```
  *
- * @typedef {function(module:ol/Tile, string)} LoadFunction
+ * @typedef {function(import("./Tile.js").default, string)} LoadFunction
  * @api
  */
 
@@ -54,8 +54,8 @@ import EventType from './events/EventType.js';
  * and returns a `{string}` representing the tile URL, or undefined if no tile
  * should be requested for the passed tile coordinate.
  *
- * @typedef {function(module:ol/tilecoord~TileCoord, number,
- *           module:ol/proj/Projection): (string|undefined)} UrlFunction
+ * @typedef {function(import("./tilecoord.js").TileCoord, number,
+ *           import("./proj/Projection.js").default): (string|undefined)} UrlFunction
  * @api
  */
 
@@ -77,9 +77,9 @@ import EventType from './events/EventType.js';
 class Tile extends EventTarget {
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileState} state State.
-   * @param {module:ol/Tile~Options=} opt_options Tile options.
+   * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("./TileState.js").default} state State.
+   * @param {Options=} opt_options Tile options.
    */
   constructor(tileCoord, state, opt_options) {
     super();
@@ -87,13 +87,13 @@ class Tile extends EventTarget {
     const options = opt_options ? opt_options : {};
 
     /**
-     * @type {module:ol/tilecoord~TileCoord}
+     * @type {import("./tilecoord.js").TileCoord}
      */
     this.tileCoord = tileCoord;
 
     /**
      * @protected
-     * @type {module:ol/TileState}
+     * @type {import("./TileState.js").default}
      */
     this.state = state;
 
@@ -101,7 +101,7 @@ class Tile extends EventTarget {
      * An "interim" tile for this tile. The interim tile may be used while this
      * one is loading, for "smooth" transitions when changing params/dimensions
      * on the source.
-     * @type {module:ol/Tile}
+     * @type {import("./Tile.js").default}
      */
     this.interimTile = null;
 
@@ -146,7 +146,7 @@ class Tile extends EventTarget {
    * Get the interim tile most suitable for rendering using the chain of interim
    * tiles. This corresponds to the  most recent tile that has been loaded, if no
    * such tile exists, the original tile is returned.
-   * @return {!module:ol/Tile} Best tile for rendering.
+   * @return {!import("./Tile.js").default} Best tile for rendering.
    */
   getInterimTile() {
     if (!this.interimTile) {
@@ -206,7 +206,7 @@ class Tile extends EventTarget {
 
   /**
    * Get the tile coordinate for this tile.
-   * @return {module:ol/tilecoord~TileCoord} The tile coordinate.
+   * @return {import("./tilecoord.js").TileCoord} The tile coordinate.
    * @api
    */
   getTileCoord() {
@@ -214,7 +214,7 @@ class Tile extends EventTarget {
   }
 
   /**
-   * @return {module:ol/TileState} State.
+   * @return {import("./TileState.js").default} State.
    */
   getState() {
     return this.state;
@@ -225,7 +225,7 @@ class Tile extends EventTarget {
    * it is important to set the state correctly to {@link module:ol/TileState~ERROR}
    * when the tile cannot be loaded. Otherwise the tile cannot be removed from
    * the tile queue and will block other requests.
-   * @param {module:ol/TileState} state State.
+   * @param {import("./TileState.js").default} state State.
    * @api
    */
   setState(state) {

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -16,7 +16,7 @@ class TileCache extends LRUCache {
   }
 
   /**
-   * @param {!Object<string, module:ol/TileRange>} usedTiles Used tiles.
+   * @param {!Object<string, import("./TileRange.js").default>} usedTiles Used tiles.
    */
   expireCache(usedTiles) {
     while (this.canExpireCache()) {

--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -8,14 +8,14 @@ import PriorityQueue from './structs/PriorityQueue.js';
 
 
 /**
- * @typedef {function(module:ol/Tile, string, module:ol/coordinate~Coordinate, number): number} PriorityFunction
+ * @typedef {function(import("./Tile.js").default, string, import("./coordinate.js").Coordinate, number): number} PriorityFunction
  */
 
 
 class TileQueue extends PriorityQueue {
 
   /**
-   * @param {module:ol/TileQueue~PriorityFunction} tilePriorityFunction Tile priority function.
+   * @param {PriorityFunction} tilePriorityFunction Tile priority function.
    * @param {function(): ?} tileChangeCallback Function called on each tile change event.
    */
   constructor(tilePriorityFunction, tileChangeCallback) {
@@ -33,7 +33,7 @@ class TileQueue extends PriorityQueue {
        * @return {string} Key.
        */
       function(element) {
-        return (/** @type {module:ol/Tile} */ (element[0]).getKey());
+        return (/** @type {import("./Tile.js").default} */ (element[0]).getKey());
       });
 
     /**
@@ -76,11 +76,11 @@ class TileQueue extends PriorityQueue {
   }
 
   /**
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("./events/Event.js").default} event Event.
    * @protected
    */
   handleTileChange(event) {
-    const tile = /** @type {module:ol/Tile} */ (event.target);
+    const tile = /** @type {import("./Tile.js").default} */ (event.target);
     const state = tile.getState();
     if (state === TileState.LOADED || state === TileState.ERROR ||
         state === TileState.EMPTY || state === TileState.ABORT) {
@@ -104,7 +104,7 @@ class TileQueue extends PriorityQueue {
     let state, tile, tileKey;
     while (this.tilesLoading_ < maxTotalLoading && newLoads < maxNewLoads &&
            this.getCount() > 0) {
-      tile = /** @type {module:ol/Tile} */ (this.dequeue()[0]);
+      tile = /** @type {import("./Tile.js").default} */ (this.dequeue()[0]);
       tileKey = tile.getKey();
       state = tile.getState();
       if (state === TileState.ABORT) {

--- a/src/ol/TileRange.js
+++ b/src/ol/TileRange.js
@@ -39,7 +39,7 @@ class TileRange {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
+   * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @return {boolean} Contains tile coordinate.
    */
   contains(tileCoord) {
@@ -47,7 +47,7 @@ class TileRange {
   }
 
   /**
-   * @param {module:ol/TileRange} tileRange Tile range.
+   * @param {import("./TileRange.js").default} tileRange Tile range.
    * @return {boolean} Contains.
    */
   containsTileRange(tileRange) {
@@ -65,7 +65,7 @@ class TileRange {
   }
 
   /**
-   * @param {module:ol/TileRange} tileRange Tile range.
+   * @param {import("./TileRange.js").default} tileRange Tile range.
    * @return {boolean} Equals.
    */
   equals(tileRange) {
@@ -74,7 +74,7 @@ class TileRange {
   }
 
   /**
-   * @param {module:ol/TileRange} tileRange Tile range.
+   * @param {import("./TileRange.js").default} tileRange Tile range.
    */
   extend(tileRange) {
     if (tileRange.minX < this.minX) {
@@ -99,7 +99,7 @@ class TileRange {
   }
 
   /**
-  * @return {module:ol/size~Size} Size.
+  * @return {import("./size.js").Size} Size.
   */
   getSize() {
     return [this.getWidth(), this.getHeight()];
@@ -113,7 +113,7 @@ class TileRange {
   }
 
   /**
-  * @param {module:ol/TileRange} tileRange Tile range.
+  * @param {import("./TileRange.js").default} tileRange Tile range.
   * @return {boolean} Intersects.
   */
   intersects(tileRange) {
@@ -130,8 +130,8 @@ class TileRange {
  * @param {number} maxX Maximum X.
  * @param {number} minY Minimum Y.
  * @param {number} maxY Maximum Y.
- * @param {module:ol/TileRange=} tileRange TileRange.
- * @return {module:ol/TileRange} Tile range.
+ * @param {import("./TileRange.js").default=} tileRange TileRange.
+ * @return {import("./TileRange.js").default} Tile range.
  */
 export function createOrUpdate(minX, maxX, minY, maxY, tileRange) {
   if (tileRange !== undefined) {

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -15,7 +15,7 @@ import {VOID} from './functions.js';
 /**
  * @typedef {Object} ReplayState
  * @property {boolean} dirty
- * @property {null|module:ol/render~OrderFunction} renderedRenderOrder
+ * @property {null|import("./render.js").OrderFunction} renderedRenderOrder
  * @property {number} renderedTileRevision
  * @property {number} renderedRevision
  */
@@ -24,22 +24,22 @@ import {VOID} from './functions.js';
 class VectorImageTile extends Tile {
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileState} state State.
+   * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("./TileState.js").default} state State.
    * @param {number} sourceRevision Source revision.
-   * @param {module:ol/format/Feature} format Feature format.
-   * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
-   * @param {module:ol/tilecoord~TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
-   * @param {module:ol/Tile~UrlFunction} tileUrlFunction Tile url function.
-   * @param {module:ol/tilegrid/TileGrid} sourceTileGrid Tile grid of the source.
-   * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid of the renderer.
-   * @param {Object<string, module:ol/VectorTile>} sourceTiles Source tiles.
+   * @param {import("./format/Feature.js").default} format Feature format.
+   * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
+   * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
+   * @param {import("./Tile.js").UrlFunction} tileUrlFunction Tile url function.
+   * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
+   * @param {import("./tilegrid/TileGrid.js").default} tileGrid Tile grid of the renderer.
+   * @param {Object<string, import("./VectorTile.js").default>} sourceTiles Source tiles.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @param {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
-   *     module:ol/format/Feature, module:ol/Tile~LoadFunction)} tileClass Class to
+   * @param {import("./proj/Projection.js").default} projection Projection.
+   * @param {function(new: import("./VectorTile.js").default, import("./tilecoord.js").TileCoord, import("./TileState.js").default, string,
+   *     import("./format/Feature.js").default, import("./Tile.js").LoadFunction)} tileClass Class to
    *     instantiate for source tiles.
-   * @param {function(this: module:ol/source/VectorTile, module:ol/events/Event)} handleTileChange
+   * @param {function(this: import("./source/VectorTile.js").default, import("./events/Event.js").default)} handleTileChange
    *     Function to call when a source tile's state changes.
    * @param {number} zoom Integer zoom to render the tile for.
    */
@@ -57,19 +57,19 @@ class VectorImageTile extends Tile {
 
     /**
      * @private
-     * @type {module:ol/featureloader~FeatureLoader}
+     * @type {import("./featureloader.js").FeatureLoader}
      */
     this.loader_;
 
     /**
      * @private
-     * @type {!Object<string, module:ol/VectorImageTile~ReplayState>}
+     * @type {!Object<string, ReplayState>}
      */
     this.replayState_ = {};
 
     /**
      * @private
-     * @type {Object<string, module:ol/VectorTile>}
+     * @type {Object<string, import("./VectorTile.js").default>}
      */
     this.sourceTiles_ = sourceTiles;
 
@@ -80,7 +80,7 @@ class VectorImageTile extends Tile {
     this.tileKeys = [];
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("./extent.js").Extent}
      */
     this.extent = null;
 
@@ -90,17 +90,17 @@ class VectorImageTile extends Tile {
     this.sourceRevision_ = sourceRevision;
 
     /**
-     * @type {module:ol/tilecoord~TileCoord}
+     * @type {import("./tilecoord.js").TileCoord}
      */
     this.wrappedTileCoord = urlTileCoord;
 
     /**
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("./events.js").EventsKey>}
      */
     this.loadListenerKeys_ = [];
 
     /**
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("./events.js").EventsKey>}
      */
     this.sourceTileListenerKeys_ = [];
 
@@ -188,7 +188,7 @@ class VectorImageTile extends Tile {
   }
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("./layer/Layer.js").default} layer Layer.
    * @return {CanvasRenderingContext2D} The rendering context.
    */
   getContext(layer) {
@@ -201,7 +201,7 @@ class VectorImageTile extends Tile {
 
   /**
    * Get the Canvas for this tile.
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("./layer/Layer.js").default} layer Layer.
    * @return {HTMLCanvasElement} Canvas.
    */
   getImage(layer) {
@@ -210,8 +210,8 @@ class VectorImageTile extends Tile {
   }
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
-   * @return {module:ol/VectorImageTile~ReplayState} The replay state.
+   * @param {import("./layer/Layer.js").default} layer Layer.
+   * @return {ReplayState} The replay state.
    */
   getReplayState(layer) {
     const key = getUid(layer).toString();
@@ -235,7 +235,7 @@ class VectorImageTile extends Tile {
 
   /**
    * @param {string} tileKey Key (tileCoord) of the source tile.
-   * @return {module:ol/VectorTile} Source tile.
+   * @return {import("./VectorTile.js").default} Source tile.
    */
   getTile(tileKey) {
     return this.sourceTiles_[tileKey];
@@ -319,7 +319,7 @@ export default VectorImageTile;
 
 /**
  * Sets the loader for a tile.
- * @param {module:ol/VectorTile} tile Vector tile.
+ * @param {import("./VectorTile.js").default} tile Vector tile.
  * @param {string} url URL.
  */
 export function defaultLoadFunction(tile, url) {

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -7,26 +7,26 @@ import TileState from './TileState.js';
 
 /**
  * @const
- * @type {module:ol/extent~Extent}
+ * @type {import("./extent.js").Extent}
  */
 const DEFAULT_EXTENT = [0, 0, 4096, 4096];
 
 
 /**
- * @typedef {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord,
- * module:ol/TileState, string, ?string, module:ol/Tile~LoadFunction)} TileClass
+ * @typedef {function(new: import("./VectorTile.js").default, import("./tilecoord.js").TileCoord,
+ * import("./TileState.js").default, string, ?string, import("./Tile.js").LoadFunction)} TileClass
  * @api
  */
 
 class VectorTile extends Tile {
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileState} state State.
+   * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("./TileState.js").default} state State.
    * @param {string} src Data source url.
-   * @param {module:ol/format/Feature} format Feature format.
-   * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
-   * @param {module:ol/Tile~Options=} opt_options Tile options.
+   * @param {import("./format/Feature.js").default} format Feature format.
+   * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
+   * @param {import("./Tile.js").Options=} opt_options Tile options.
    */
   constructor(tileCoord, state, src, format, tileLoadFunction, opt_options) {
 
@@ -39,44 +39,44 @@ class VectorTile extends Tile {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("./extent.js").Extent}
      */
     this.extent_ = null;
 
     /**
      * @private
-     * @type {module:ol/format/Feature}
+     * @type {import("./format/Feature.js").default}
      */
     this.format_ = format;
 
     /**
      * @private
-     * @type {Array<module:ol/Feature>}
+     * @type {Array<import("./Feature.js").default>}
      */
     this.features_ = null;
 
     /**
      * @private
-     * @type {module:ol/featureloader~FeatureLoader}
+     * @type {import("./featureloader.js").FeatureLoader}
      */
     this.loader_;
 
     /**
      * Data projection
      * @private
-     * @type {module:ol/proj/Projection}
+     * @type {import("./proj/Projection.js").default}
      */
     this.projection_ = null;
 
     /**
      * @private
-     * @type {Object<string, module:ol/render/ReplayGroup>}
+     * @type {Object<string, import("./render/ReplayGroup.js").default>}
      */
     this.replayGroups_ = {};
 
     /**
      * @private
-     * @type {module:ol/Tile~LoadFunction}
+     * @type {import("./Tile.js").LoadFunction}
      */
     this.tileLoadFunction_ = tileLoadFunction;
 
@@ -101,7 +101,7 @@ class VectorTile extends Tile {
 
   /**
    * Gets the extent of the vector tile.
-   * @return {module:ol/extent~Extent} The extent.
+   * @return {import("./extent.js").Extent} The extent.
    * @api
    */
   getExtent() {
@@ -110,7 +110,7 @@ class VectorTile extends Tile {
 
   /**
    * Get the feature format assigned for reading this tile's features.
-   * @return {module:ol/format/Feature} Feature format.
+   * @return {import("./format/Feature.js").default} Feature format.
    * @api
    */
   getFormat() {
@@ -120,7 +120,7 @@ class VectorTile extends Tile {
   /**
    * Get the features for this tile. Geometries will be in the projection returned
    * by {@link module:ol/VectorTile~VectorTile#getProjection}.
-   * @return {Array<module:ol/Feature|module:ol/render/Feature>} Features.
+   * @return {Array<import("./Feature.js").default|import("./render/Feature.js").default>} Features.
    * @api
    */
   getFeatures() {
@@ -137,7 +137,7 @@ class VectorTile extends Tile {
   /**
    * Get the feature projection of features returned by
    * {@link module:ol/VectorTile~VectorTile#getFeatures}.
-   * @return {module:ol/proj/Projection} Feature projection.
+   * @return {import("./proj/Projection.js").default} Feature projection.
    * @api
    */
   getProjection() {
@@ -145,9 +145,9 @@ class VectorTile extends Tile {
   }
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("./layer/Layer.js").default} layer Layer.
    * @param {string} key Key.
-   * @return {module:ol/render/ReplayGroup} Replay group.
+   * @return {import("./render/ReplayGroup.js").default} Replay group.
    */
   getReplayGroup(layer, key) {
     return this.replayGroups_[getUid(layer) + ',' + key];
@@ -166,9 +166,9 @@ class VectorTile extends Tile {
 
   /**
    * Handler for successful tile load.
-   * @param {Array<module:ol/Feature>} features The loaded features.
-   * @param {module:ol/proj/Projection} dataProjection Data projection.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {Array<import("./Feature.js").default>} features The loaded features.
+   * @param {import("./proj/Projection.js").default} dataProjection Data projection.
+   * @param {import("./extent.js").Extent} extent Extent.
    */
   onLoad(features, dataProjection, extent) {
     this.setProjection(dataProjection);
@@ -192,7 +192,7 @@ class VectorTile extends Tile {
    * sources using {@link module:ol/format/MVT~MVT} as feature format, the
    * {@link module:ol/format/MVT~MVT#getLastExtent} method will return the correct
    * extent. The default is `[0, 0, 4096, 4096]`.
-   * @param {module:ol/extent~Extent} extent The extent.
+   * @param {import("./extent.js").Extent} extent The extent.
    * @api
    */
   setExtent(extent) {
@@ -202,7 +202,7 @@ class VectorTile extends Tile {
   /**
    * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
    * Sets the features for the tile.
-   * @param {Array<module:ol/Feature>} features Features.
+   * @param {Array<import("./Feature.js").default>} features Features.
    * @api
    */
   setFeatures(features) {
@@ -214,7 +214,7 @@ class VectorTile extends Tile {
    * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
    * Sets the projection of the features that were added with
    * {@link module:ol/VectorTile~VectorTile#setFeatures}.
-   * @param {module:ol/proj/Projection} projection Feature projection.
+   * @param {import("./proj/Projection.js").default} projection Feature projection.
    * @api
    */
   setProjection(projection) {
@@ -222,9 +222,9 @@ class VectorTile extends Tile {
   }
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("./layer/Layer.js").default} layer Layer.
    * @param {string} key Key.
-   * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
+   * @param {import("./render/ReplayGroup.js").default} replayGroup Replay group.
    */
   setReplayGroup(layer, key, replayGroup) {
     this.replayGroups_[getUid(layer) + ',' + key] = replayGroup;
@@ -232,7 +232,7 @@ class VectorTile extends Tile {
 
   /**
    * Set the feature loader for reading this tile's features.
-   * @param {module:ol/featureloader~FeatureLoader} loader Feature loader.
+   * @param {import("./featureloader.js").FeatureLoader} loader Feature loader.
    * @api
    */
   setLoader(loader) {

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -28,13 +28,13 @@ import Units from './proj/Units.js';
  * An animation configuration
  *
  * @typedef {Object} Animation
- * @property {module:ol/coordinate~Coordinate} [sourceCenter]
- * @property {module:ol/coordinate~Coordinate} [targetCenter]
+ * @property {import("./coordinate.js").Coordinate} [sourceCenter]
+ * @property {import("./coordinate.js").Coordinate} [targetCenter]
  * @property {number} [sourceResolution]
  * @property {number} [targetResolution]
  * @property {number} [sourceRotation]
  * @property {number} [targetRotation]
- * @property {module:ol/coordinate~Coordinate} [anchor]
+ * @property {import("./coordinate.js").Coordinate} [anchor]
  * @property {number} start
  * @property {number} duration
  * @property {boolean} complete
@@ -45,15 +45,15 @@ import Units from './proj/Units.js';
 
 /**
  * @typedef {Object} Constraints
- * @property {module:ol/centerconstraint~Type} center
- * @property {module:ol/resolutionconstraint~Type} resolution
- * @property {module:ol/rotationconstraint~Type} rotation
+ * @property {import("./centerconstraint.js").Type} center
+ * @property {import("./resolutionconstraint.js").Type} resolution
+ * @property {import("./rotationconstraint.js").Type} rotation
  */
 
 
 /**
  * @typedef {Object} FitOptions
- * @property {module:ol/size~Size} [size] The size in pixels of the box to fit
+ * @property {import("./size.js").Size} [size] The size in pixels of the box to fit
  * the extent into. Default is the current size of the first map in the DOM that
  * uses this view, or `[100, 100]` if no such map is found.
  * @property {!Array<number>} [padding=[0, 0, 0, 0]] Padding (in pixels) to be
@@ -80,7 +80,7 @@ import Units from './proj/Units.js';
 
 /**
  * @typedef {Object} ViewOptions
- * @property {module:ol/coordinate~Coordinate} [center] The initial center for
+ * @property {import("./coordinate.js").Coordinate} [center] The initial center for
  * the view. The coordinate system for the center is specified with the
  * `projection` option. Layer sources will not be fetched if this is not set,
  * but the center can be set later with {@link #setCenter}.
@@ -92,7 +92,7 @@ import Units from './proj/Units.js';
  * If `false`, a rotation constraint that always sets the rotation to zero is
  * used. The `constrainRotation` option has no effect if `enableRotation` is
  * `false`.
- * @property {module:ol/extent~Extent} [extent] The extent that constrains the
+ * @property {import("./extent.js").Extent} [extent] The extent that constrains the
  * center, in other words, center cannot be set outside this extent.
  * @property {number} [maxResolution] The maximum resolution used to determine
  * the resolution constraint. It is used together with `minResolution` (or
@@ -114,7 +114,7 @@ import Units from './proj/Units.js';
  * resolution constraint. It is used together with `maxZoom` (or
  * `minResolution`) and `zoomFactor`.  Note that if `maxResolution` is also
  * provided, it is given precedence over `minZoom`.
- * @property {module:ol/proj~ProjectionLike} [projection='EPSG:3857'] The
+ * @property {import("./proj.js").ProjectionLike} [projection='EPSG:3857'] The
  * projection. The default is Spherical Mercator.
  * @property {number} [resolution] The initial resolution for the view. The
  * units are `projection` units per pixel (e.g. meters per pixel). An
@@ -136,7 +136,7 @@ import Units from './proj/Units.js';
 
 /**
  * @typedef {Object} AnimationOptions
- * @property {module:ol/coordinate~Coordinate|undefined} center The center of the view at the end of
+ * @property {import("./coordinate.js").Coordinate|undefined} center The center of the view at the end of
  * the animation.
  * @property {number|undefined} zoom The zoom level of the view at the end of the
  * animation. This takes precedence over `resolution`.
@@ -144,7 +144,7 @@ import Units from './proj/Units.js';
  * of the animation.  If `zoom` is also provided, this option will be ignored.
  * @property {number|undefined} rotation The rotation of the view at the end of
  * the animation.
- * @property {module:ol/coordinate~Coordinate|undefined} anchor Optional anchor to remained fixed
+ * @property {import("./coordinate.js").Coordinate|undefined} anchor Optional anchor to remained fixed
  * during a rotation or resolution animation.
  * @property {number} [duration=1000] The duration of the animation in milliseconds.
  * @property {function(number):number} [easing] The easing function used
@@ -157,8 +157,8 @@ import Units from './proj/Units.js';
 
 /**
  * @typedef {Object} State
- * @property {module:ol/coordinate~Coordinate} center
- * @property {module:ol/proj/Projection} projection
+ * @property {import("./coordinate.js").Coordinate} center
+ * @property {import("./proj/Projection.js").default} projection
  * @property {number} resolution
  * @property {number} rotation
  * @property {number} zoom
@@ -229,7 +229,7 @@ const DEFAULT_MIN_ZOOM = 0;
 class View extends BaseObject {
 
   /**
-   * @param {module:ol/View~ViewOptions=} opt_options View options.
+   * @param {ViewOptions=} opt_options View options.
    */
   constructor(opt_options) {
     super();
@@ -244,7 +244,7 @@ class View extends BaseObject {
 
     /**
      * @private
-     * @type {Array<Array<module:ol/View~Animation>>}
+     * @type {Array<Array<Animation>>}
      */
     this.animations_ = [];
 
@@ -259,7 +259,7 @@ class View extends BaseObject {
     /**
      * @private
      * @const
-     * @type {module:ol/proj/Projection}
+     * @type {import("./proj/Projection.js").default}
      */
     this.projection_ = createProjection(options.projection, 'EPSG:3857');
 
@@ -268,7 +268,7 @@ class View extends BaseObject {
 
   /**
    * Set up the view with the given options.
-   * @param {module:ol/View~ViewOptions} options View options.
+   * @param {ViewOptions} options View options.
    */
   applyOptions_(options) {
 
@@ -317,7 +317,7 @@ class View extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/View~Constraints}
+     * @type {Constraints}
      */
     this.constraints_ = {
       center: centerConstraint,
@@ -342,7 +342,7 @@ class View extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/View~ViewOptions}
+     * @type {ViewOptions}
      */
     this.options_ = options;
 
@@ -353,8 +353,8 @@ class View extends BaseObject {
    * current resolution (or zoom), center, and rotation are applied to any stored
    * options.  The provided options can be used to apply new min/max zoom or
    * resolution limits.
-   * @param {module:ol/View~ViewOptions} newOptions New options to be applied.
-   * @return {module:ol/View~ViewOptions} New options updated with the current view state.
+   * @param {ViewOptions} newOptions New options to be applied.
+   * @return {ViewOptions} New options updated with the current view state.
    */
   getUpdatedOptions_(newOptions) {
     const options = assign({}, this.options_);
@@ -400,7 +400,7 @@ class View extends BaseObject {
    * calling `view.setCenter()`, `view.setResolution()`, or `view.setRotation()`
    * (or another method that calls one of these).
    *
-   * @param {...(module:ol/View~AnimationOptions|function(boolean))} var_args Animation
+   * @param {...(AnimationOptions|function(boolean))} var_args Animation
    *     options.  Multiple animations can be run in series by passing multiple
    *     options objects.  To run multiple animations in parallel, call the method
    *     multiple times.  An optional callback can be provided as a final
@@ -438,9 +438,9 @@ class View extends BaseObject {
     let rotation = this.getRotation();
     const series = [];
     for (let i = 0; i < animationCount; ++i) {
-      const options = /** @type {module:ol/View~AnimationOptions} */ (arguments[i]);
+      const options = /** @type {AnimationOptions} */ (arguments[i]);
 
-      const animation = /** @type {module:ol/View~Animation} */ ({
+      const animation = /** @type {Animation} */ ({
         start: start,
         complete: false,
         anchor: options.anchor,
@@ -603,8 +603,8 @@ class View extends BaseObject {
 
   /**
    * @param {number} rotation Target rotation.
-   * @param {module:ol/coordinate~Coordinate} anchor Rotation anchor.
-   * @return {module:ol/coordinate~Coordinate|undefined} Center for rotation and anchor.
+   * @param {import("./coordinate.js").Coordinate} anchor Rotation anchor.
+   * @return {import("./coordinate.js").Coordinate|undefined} Center for rotation and anchor.
    */
   calculateCenterRotate(rotation, anchor) {
     let center;
@@ -619,8 +619,8 @@ class View extends BaseObject {
 
   /**
    * @param {number} resolution Target resolution.
-   * @param {module:ol/coordinate~Coordinate} anchor Zoom anchor.
-   * @return {module:ol/coordinate~Coordinate|undefined} Center for resolution and anchor.
+   * @param {import("./coordinate.js").Coordinate} anchor Zoom anchor.
+   * @return {import("./coordinate.js").Coordinate|undefined} Center for resolution and anchor.
    */
   calculateCenterZoom(resolution, anchor) {
     let center;
@@ -636,7 +636,7 @@ class View extends BaseObject {
 
   /**
    * @private
-   * @return {module:ol/size~Size} Viewport size or `[100, 100]` when no viewport is found.
+   * @return {import("./size.js").Size} Viewport size or `[100, 100]` when no viewport is found.
    */
   getSizeFromViewport_() {
     const size = [100, 100];
@@ -652,8 +652,8 @@ class View extends BaseObject {
 
   /**
    * Get the constrained center of this view.
-   * @param {module:ol/coordinate~Coordinate|undefined} center Center.
-   * @return {module:ol/coordinate~Coordinate|undefined} Constrained center.
+   * @param {import("./coordinate.js").Coordinate|undefined} center Center.
+   * @return {import("./coordinate.js").Coordinate|undefined} Constrained center.
    * @api
    */
   constrainCenter(center) {
@@ -688,18 +688,18 @@ class View extends BaseObject {
 
   /**
    * Get the view center.
-   * @return {module:ol/coordinate~Coordinate|undefined} The center of the view.
+   * @return {import("./coordinate.js").Coordinate|undefined} The center of the view.
    * @observable
    * @api
    */
   getCenter() {
     return (
-      /** @type {module:ol/coordinate~Coordinate|undefined} */ (this.get(ViewProperty.CENTER))
+      /** @type {import("./coordinate.js").Coordinate|undefined} */ (this.get(ViewProperty.CENTER))
     );
   }
 
   /**
-   * @return {module:ol/View~Constraints} Constraints.
+   * @return {Constraints} Constraints.
    */
   getConstraints() {
     return this.constraints_;
@@ -724,14 +724,14 @@ class View extends BaseObject {
    * The size is the pixel dimensions of the box into which the calculated extent
    * should fit. In most cases you want to get the extent of the entire map,
    * that is `map.getSize()`.
-   * @param {module:ol/size~Size=} opt_size Box pixel size. If not provided, the size of the
+   * @param {import("./size.js").Size=} opt_size Box pixel size. If not provided, the size of the
    * first map that uses this view will be used.
-   * @return {module:ol/extent~Extent} Extent.
+   * @return {import("./extent.js").Extent} Extent.
    * @api
    */
   calculateExtent(opt_size) {
     const size = opt_size || this.getSizeFromViewport_();
-    const center = /** @type {!module:ol/coordinate~Coordinate} */ (this.getCenter());
+    const center = /** @type {!import("./coordinate.js").Coordinate} */ (this.getCenter());
     assert(center, 1); // The view center is not defined
     const resolution = /** @type {!number} */ (this.getResolution());
     assert(resolution !== undefined, 2); // The view resolution is not defined
@@ -797,7 +797,7 @@ class View extends BaseObject {
 
   /**
    * Get the view projection.
-   * @return {module:ol/proj/Projection} The projection of the view.
+   * @return {import("./proj/Projection.js").default} The projection of the view.
    * @api
    */
   getProjection() {
@@ -826,8 +826,8 @@ class View extends BaseObject {
 
   /**
    * Get the resolution for a provided extent (in map units) and size (in pixels).
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {module:ol/size~Size=} opt_size Box pixel size.
+   * @param {import("./extent.js").Extent} extent Extent.
+   * @param {import("./size.js").Size=} opt_size Box pixel size.
    * @return {number} The resolution at which the provided extent will render at
    *     the given size.
    * @api
@@ -895,16 +895,16 @@ class View extends BaseObject {
 
   /**
    * @param {number} pixelRatio Pixel ratio for center rounding.
-   * @return {module:ol/View~State} View state.
+   * @return {State} View state.
    */
   getState(pixelRatio) {
-    const center = /** @type {module:ol/coordinate~Coordinate} */ (this.getCenter());
+    const center = /** @type {import("./coordinate.js").Coordinate} */ (this.getCenter());
     const projection = this.getProjection();
     const resolution = /** @type {number} */ (this.getResolution());
     const pixelResolution = resolution / pixelRatio;
     const rotation = this.getRotation();
     return (
-      /** @type {module:ol/View~State} */ ({
+      /** @type {State} */ ({
         center: [
           Math.round(center[0] / pixelResolution) * pixelResolution,
           Math.round(center[1] / pixelResolution) * pixelResolution
@@ -974,9 +974,9 @@ class View extends BaseObject {
    * The size is pixel dimensions of the box to fit the extent into.
    * In most cases you will want to use the map size, that is `map.getSize()`.
    * Takes care of the map angle.
-   * @param {module:ol/geom/SimpleGeometry|module:ol/extent~Extent} geometryOrExtent The geometry or
+   * @param {import("./geom/SimpleGeometry.js").default|import("./extent.js").Extent} geometryOrExtent The geometry or
    *     extent to fit the view to.
-   * @param {module:ol/View~FitOptions=} opt_options Options.
+   * @param {FitOptions=} opt_options Options.
    * @api
    */
   fit(geometryOrExtent, opt_options) {
@@ -985,7 +985,7 @@ class View extends BaseObject {
     if (!size) {
       size = this.getSizeFromViewport_();
     }
-    /** @type {module:ol/geom/SimpleGeometry} */
+    /** @type {import("./geom/SimpleGeometry.js").default} */
     let geometry;
     if (!(geometryOrExtent instanceof SimpleGeometry)) {
       assert(Array.isArray(geometryOrExtent),
@@ -1076,9 +1076,9 @@ class View extends BaseObject {
 
   /**
    * Center on coordinate and view position.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {module:ol/size~Size} size Box pixel size.
-   * @param {module:ol/pixel~Pixel} position Position on the view to center on.
+   * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("./size.js").Size} size Box pixel size.
+   * @param {import("./pixel.js").Pixel} position Position on the view to center on.
    * @api
    */
   centerOn(coordinate, size, position) {
@@ -1110,7 +1110,7 @@ class View extends BaseObject {
   /**
    * Rotate the view around a given coordinate.
    * @param {number} rotation New rotation value for the view.
-   * @param {module:ol/coordinate~Coordinate=} opt_anchor The rotation center.
+   * @param {import("./coordinate.js").Coordinate=} opt_anchor The rotation center.
    * @api
    */
   rotate(rotation, opt_anchor) {
@@ -1123,7 +1123,7 @@ class View extends BaseObject {
 
   /**
    * Set the center of the current view.
-   * @param {module:ol/coordinate~Coordinate|undefined} center The center of the view.
+   * @param {import("./coordinate.js").Coordinate|undefined} center The center of the view.
    * @observable
    * @api
    */
@@ -1135,7 +1135,7 @@ class View extends BaseObject {
   }
 
   /**
-   * @param {module:ol/ViewHint} hint Hint.
+   * @param {import("./ViewHint.js").default} hint Hint.
    * @param {number} delta Delta.
    * @return {number} New value.
    */
@@ -1194,8 +1194,8 @@ function animationCallback(callback, returnValue) {
 
 
 /**
- * @param {module:ol/View~ViewOptions} options View options.
- * @return {module:ol/centerconstraint~Type} The constraint.
+ * @param {ViewOptions} options View options.
+ * @return {import("./centerconstraint.js").Type} The constraint.
  */
 export function createCenterConstraint(options) {
   if (options.extent !== undefined) {
@@ -1207,8 +1207,8 @@ export function createCenterConstraint(options) {
 
 
 /**
- * @param {module:ol/View~ViewOptions} options View options.
- * @return {{constraint: module:ol/resolutionconstraint~Type, maxResolution: number,
+ * @param {ViewOptions} options View options.
+ * @return {{constraint: import("./resolutionconstraint.js").Type, maxResolution: number,
  *     minResolution: number, minZoom: number, zoomFactor: number}} The constraint.
  */
 export function createResolutionConstraint(options) {
@@ -1289,8 +1289,8 @@ export function createResolutionConstraint(options) {
 
 
 /**
- * @param {module:ol/View~ViewOptions} options View options.
- * @return {module:ol/rotationconstraint~Type} Rotation constraint.
+ * @param {ViewOptions} options View options.
+ * @return {import("./rotationconstraint.js").Type} Rotation constraint.
  */
 export function createRotationConstraint(options) {
   const enableRotation = options.enableRotation !== undefined ?
@@ -1314,7 +1314,7 @@ export function createRotationConstraint(options) {
 
 /**
  * Determine if an animation involves no view change.
- * @param {module:ol/View~Animation} animation The animation.
+ * @param {Animation} animation The animation.
  * @return {boolean} The animation involves no view change.
  */
 export function isNoopAnimation(animation) {

--- a/src/ol/WebGLMap.js
+++ b/src/ol/WebGLMap.js
@@ -56,8 +56,8 @@ import WebGLVectorLayerRenderer from './renderer/webgl/VectorLayer.js';
  * {@link module:ol/layer/Base}, so layers entered in the options or added
  * with `addLayer` can be groups, which can contain further groups, and so on.
  *
- * @fires module:ol/MapBrowserEvent~MapBrowserEvent
- * @fires module:ol/MapEvent~MapEvent
+ * @fires import("./MapBrowserEvent.js").MapBrowserEvent
+ * @fires import("./MapEvent.js").MapEvent
  * @fires module:ol/render/Event~RenderEvent#postcompose
  * @fires module:ol/render/Event~RenderEvent#precompose
  * @api
@@ -65,7 +65,7 @@ import WebGLVectorLayerRenderer from './renderer/webgl/VectorLayer.js';
 class WebGLMap extends PluggableMap {
 
   /**
-   * @param {module:ol/PluggableMap~MapOptions} options Map options.
+   * @param {import("./PluggableMap.js").MapOptions} options Map options.
    */
   constructor(options) {
     options = assign({}, options);

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -5,19 +5,19 @@ import {clamp} from './math.js';
 
 
 /**
- * @typedef {function((module:ol/coordinate~Coordinate|undefined)): (module:ol/coordinate~Coordinate|undefined)} Type
+ * @typedef {function((import("./coordinate.js").Coordinate|undefined)): (import("./coordinate.js").Coordinate|undefined)} Type
  */
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
- * @return {module:ol/centerconstraint~Type} The constraint.
+ * @param {import("./extent.js").Extent} extent Extent.
+ * @return {Type} The constraint.
  */
 export function createExtent(extent) {
   return (
     /**
-     * @param {module:ol/coordinate~Coordinate=} center Center.
-     * @return {module:ol/coordinate~Coordinate|undefined} Center.
+     * @param {import("./coordinate.js").Coordinate=} center Center.
+     * @return {import("./coordinate.js").Coordinate|undefined} Center.
      */
     function(center) {
       if (center) {
@@ -34,8 +34,8 @@ export function createExtent(extent) {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate=} center Center.
- * @return {module:ol/coordinate~Coordinate|undefined} Center.
+ * @param {import("./coordinate.js").Coordinate=} center Center.
+ * @return {import("./coordinate.js").Coordinate|undefined} Center.
  */
 export function none(center) {
   return center;

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -35,7 +35,7 @@ const NAMED_COLOR_RE_ = /^([a-z]*)$/i;
 
 /**
  * Return the color as an rgba string.
- * @param {module:ol/color~Color|string} color Color.
+ * @param {Color|string} color Color.
  * @return {string} Rgba string.
  * @api
  */
@@ -68,7 +68,7 @@ function fromNamed(color) {
 
 /**
  * @param {string} s String.
- * @return {module:ol/color~Color} Color.
+ * @return {Color} Color.
  */
 export const fromString = (
   function() {
@@ -84,7 +84,7 @@ export const fromString = (
     const MAX_CACHE_SIZE = 1024;
 
     /**
-     * @type {Object<string, module:ol/color~Color>}
+     * @type {Object<string, Color>}
      */
     const cache = {};
 
@@ -96,7 +96,7 @@ export const fromString = (
     return (
       /**
        * @param {string} s String.
-       * @return {module:ol/color~Color} Color.
+       * @return {Color} Color.
        */
       function(s) {
         let color;
@@ -125,8 +125,8 @@ export const fromString = (
 /**
  * Return the color as an array. This function maintains a cache of calculated
  * arrays which means the result should not be modified.
- * @param {module:ol/color~Color|string} color Color.
- * @return {module:ol/color~Color} Color.
+ * @param {Color|string} color Color.
+ * @return {Color} Color.
  * @api
  */
 export function asArray(color) {
@@ -140,7 +140,7 @@ export function asArray(color) {
 /**
  * @param {string} s String.
  * @private
- * @return {module:ol/color~Color} Color.
+ * @return {Color} Color.
  */
 function fromStringInternal_(s) {
   let r, g, b, a, color;
@@ -186,15 +186,15 @@ function fromStringInternal_(s) {
     assert(false, 14); // Invalid color
   }
   return (
-    /** @type {module:ol/color~Color} */ (color)
+    /** @type {Color} */ (color)
   );
 }
 
 
 /**
  * TODO this function is only used in the test, we probably shouldn't export it
- * @param {module:ol/color~Color} color Color.
- * @return {module:ol/color~Color} Clamped color.
+ * @param {Color} color Color.
+ * @return {Color} Clamped color.
  */
 export function normalize(color) {
   color[0] = clamp((color[0] + 0.5) | 0, 0, 255);
@@ -206,7 +206,7 @@ export function normalize(color) {
 
 
 /**
- * @param {module:ol/color~Color} color Color.
+ * @param {Color} color Color.
  * @return {string} String.
  */
 export function toString(color) {

--- a/src/ol/colorlike.js
+++ b/src/ol/colorlike.js
@@ -18,15 +18,15 @@ import {toString} from './color.js';
 
 
 /**
- * @param {module:ol/color~Color|module:ol/colorlike~ColorLike} color Color.
- * @return {module:ol/colorlike~ColorLike} The color as an {@link ol/colorlike~ColorLike}.
+ * @param {import("./color.js").Color|ColorLike} color Color.
+ * @return {ColorLike} The color as an {@link ol/colorlike~ColorLike}.
  * @api
  */
 export function asColorLike(color) {
   if (isColorLike(color)) {
     return /** @type {string|CanvasPattern|CanvasGradient} */ (color);
   } else {
-    return toString(/** @type {module:ol/color~Color} */ (color));
+    return toString(/** @type {import("./color.js").Color} */ (color));
   }
 }
 

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -28,7 +28,7 @@ import {visibleAtResolution} from '../layer/Layer.js';
  * @property {string|HTMLElement} [collapseLabel='»'] Text label to use
  * for the expanded attributions button.
  * Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {function(module:ol/MapEvent)} [render] Function called when
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when
  * the control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  */
@@ -46,7 +46,7 @@ import {visibleAtResolution} from '../layer/Layer.js';
 class Attribution extends Control {
 
   /**
-   * @param {module:ol/control/Attribution~Options=} opt_options Attribution options.
+   * @param {Options=} opt_options Attribution options.
    */
   constructor(opt_options) {
 
@@ -146,7 +146,7 @@ class Attribution extends Control {
 
   /**
    * Get a list of visible attributions.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
    * @return {Array<string>} Attributions.
    * @private
    */
@@ -205,7 +205,7 @@ class Attribution extends Control {
 
   /**
    * @private
-   * @param {?module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {?import("../PluggableMap.js").FrameState} frameState Frame state.
    */
   updateElement_(frameState) {
     if (!frameState) {
@@ -315,8 +315,8 @@ class Attribution extends Control {
 
 /**
  * Update the attribution element.
- * @param {module:ol/MapEvent} mapEvent Map event.
- * @this {module:ol/control/Attribution}
+ * @param {import("../MapEvent.js").default} mapEvent Map event.
+ * @this {import("./Attribution.js").default}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -13,7 +13,7 @@ import {listen, unlistenByKey} from '../events.js';
  * @property {HTMLElement} [element] The element is the control's
  * container element. This only needs to be specified if you're developing
  * a custom control.
- * @property {function(module:ol/MapEvent)} [render] Function called when
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when
  * the control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  * @property {HTMLElement|string} [target] Specify a target if you want
@@ -48,7 +48,7 @@ import {listen, unlistenByKey} from '../events.js';
 class Control extends BaseObject {
 
   /**
-   * @param {module:ol/control/Control~Options} options Control options.
+   * @param {Options} options Control options.
    */
   constructor(options) {
 
@@ -68,18 +68,18 @@ class Control extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/PluggableMap}
+     * @type {import("../PluggableMap.js").default}
      */
     this.map_ = null;
 
     /**
      * @protected
-     * @type {!Array<module:ol/events~EventsKey>}
+     * @type {!Array<import("../events.js").EventsKey>}
      */
     this.listenerKeys = [];
 
     /**
-     * @type {function(module:ol/MapEvent)}
+     * @type {function(import("../MapEvent.js").default)}
      */
     this.render = options.render ? options.render : VOID;
 
@@ -99,7 +99,7 @@ class Control extends BaseObject {
 
   /**
    * Get the map associated with this control.
-   * @return {module:ol/PluggableMap} Map.
+   * @return {import("../PluggableMap.js").default} Map.
    * @api
    */
   getMap() {
@@ -110,7 +110,7 @@ class Control extends BaseObject {
    * Remove the control from its current map and attach it to the new map.
    * Subclasses may set up event handlers to get notified about changes to
    * the map here.
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    * @api
    */
   setMap(map) {

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -65,7 +65,7 @@ const getChangeType = (function() {
 class FullScreen extends Control {
 
   /**
-   * @param {module:ol/control/FullScreen~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -22,9 +22,9 @@ const COORDINATE_FORMAT = 'coordinateFormat';
 /**
  * @typedef {Object} Options
  * @property {string} [className='ol-mouse-position'] CSS class name.
- * @property {module:ol/coordinate~CoordinateFormat} [coordinateFormat] Coordinate format.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {function(module:ol/MapEvent)} [render] Function called when the
+ * @property {import("../coordinate.js").CoordinateFormat} [coordinateFormat] Coordinate format.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when the
  * control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  * @property {Element|string} [target] Specify a target if you want the
@@ -49,7 +49,7 @@ const COORDINATE_FORMAT = 'coordinateFormat';
 class MousePosition extends Control {
 
   /**
-   * @param {module:ol/control/MousePosition~Options=} opt_options Mouse position options.
+   * @param {Options=} opt_options Mouse position options.
    */
   constructor(opt_options) {
 
@@ -95,19 +95,19 @@ class MousePosition extends Control {
 
     /**
      * @private
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      */
     this.mapProjection_ = null;
 
     /**
      * @private
-     * @type {?module:ol/proj~TransformFunction}
+     * @type {?import("../proj.js").TransformFunction}
      */
     this.transform_ = null;
 
     /**
      * @private
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("../pixel.js").Pixel}
      */
     this.lastMouseMovePixel_ = null;
 
@@ -123,27 +123,27 @@ class MousePosition extends Control {
   /**
    * Return the coordinate format type used to render the current position or
    * undefined.
-   * @return {module:ol/coordinate~CoordinateFormat|undefined} The format to render the current
+   * @return {import("../coordinate.js").CoordinateFormat|undefined} The format to render the current
    *     position in.
    * @observable
    * @api
    */
   getCoordinateFormat() {
     return (
-      /** @type {module:ol/coordinate~CoordinateFormat|undefined} */ (this.get(COORDINATE_FORMAT))
+      /** @type {import("../coordinate.js").CoordinateFormat|undefined} */ (this.get(COORDINATE_FORMAT))
     );
   }
 
   /**
    * Return the projection that is used to report the mouse position.
-   * @return {module:ol/proj/Projection|undefined} The projection to report mouse
+   * @return {import("../proj/Projection.js").default|undefined} The projection to report mouse
    *     position in.
    * @observable
    * @api
    */
   getProjection() {
     return (
-      /** @type {module:ol/proj/Projection|undefined} */ (this.get(PROJECTION))
+      /** @type {import("../proj/Projection.js").default|undefined} */ (this.get(PROJECTION))
     );
   }
 
@@ -187,7 +187,7 @@ class MousePosition extends Control {
 
   /**
    * Set the coordinate format type used to render the current position.
-   * @param {module:ol/coordinate~CoordinateFormat} format The format to render the current
+   * @param {import("../coordinate.js").CoordinateFormat} format The format to render the current
    *     position in.
    * @observable
    * @api
@@ -198,7 +198,7 @@ class MousePosition extends Control {
 
   /**
    * Set the projection that is used to report the mouse position.
-   * @param {module:ol/proj~ProjectionLike} projection The projection to report mouse
+   * @param {import("../proj.js").ProjectionLike} projection The projection to report mouse
    *     position in.
    * @observable
    * @api
@@ -208,7 +208,7 @@ class MousePosition extends Control {
   }
 
   /**
-   * @param {?module:ol/pixel~Pixel} pixel Pixel.
+   * @param {?import("../pixel.js").Pixel} pixel Pixel.
    * @private
    */
   updateHTML_(pixel) {
@@ -245,8 +245,8 @@ class MousePosition extends Control {
 
 /**
  * Update the mouseposition element.
- * @param {module:ol/MapEvent} mapEvent Map event.
- * @this {module:ol/control/MousePosition}
+ * @param {import("../MapEvent.js").default} mapEvent Map event.
+ * @this {import("./MousePosition.js").default}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -44,15 +44,15 @@ const MIN_RATIO = 0.1;
  * @property {boolean} [collapsible=true] Whether the control can be collapsed or not.
  * @property {string|HTMLElement} [label='»'] Text label to use for the collapsed
  * overviewmap button. Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {Array<module:ol/layer/Layer>|module:ol/Collection<module:ol/layer/Layer>} [layers]
+ * @property {Array<import("../layer/Layer.js").default>|import("../Collection.js").default<import("../layer/Layer.js").default>} [layers]
  * Layers for the overview map. If not set, then all main map layers are used
  * instead.
- * @property {function(module:ol/MapEvent)} [render] Function called when the control
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {HTMLElement|string} [target] Specify a target if you want the control
  * to be rendered outside of the map's viewport.
  * @property {string} [tipLabel='Overview map'] Text label to use for the button tip.
- * @property {module:ol/View} [view] Custom view for the overview map. If not provided,
+ * @property {import("../View.js").default} [view] Custom view for the overview map. If not provided,
  * a default view with an EPSG:3857 projection will be used.
  */
 
@@ -66,7 +66,7 @@ const MIN_RATIO = 0.1;
 class OverviewMap extends Control {
 
   /**
-   * @param {module:ol/control/OverviewMap~Options=} opt_options OverviewMap options.
+   * @param {Options=} opt_options OverviewMap options.
    */
   constructor(opt_options) {
 
@@ -144,7 +144,7 @@ class OverviewMap extends Control {
     this.ovmapDiv_.className = 'ol-overviewmap-map';
 
     /**
-     * @type {module:ol/Map}
+     * @type {import("../Map.js").default}
      * @private
      */
     this.ovmap_ = new Map({
@@ -157,7 +157,7 @@ class OverviewMap extends Control {
     if (options.layers) {
       options.layers.forEach(
         /**
-         * @param {module:ol/layer/Layer} layer Layer.
+         * @param {import("../layer/Layer.js").default} layer Layer.
          */
         (function(layer) {
           ovmap.addLayer(layer);
@@ -169,7 +169,7 @@ class OverviewMap extends Control {
     box.style.boxSizing = 'border-box';
 
     /**
-     * @type {module:ol/Overlay}
+     * @type {import("../Overlay.js").default}
      * @private
      */
     this.boxOverlay_ = new Overlay({
@@ -268,12 +268,12 @@ class OverviewMap extends Control {
 
   /**
    * Handle map property changes.  This only deals with changes to the map's view.
-   * @param {module:ol/Object~ObjectEvent} event The propertychange event.
+   * @param {import("../Object.js").ObjectEvent} event The propertychange event.
    * @private
    */
   handleMapPropertyChange_(event) {
     if (event.key === MapProperty.VIEW) {
-      const oldView = /** @type {module:ol/View} */ (event.oldValue);
+      const oldView = /** @type {import("../View.js").default} */ (event.oldValue);
       if (oldView) {
         this.unbindView_(oldView);
       }
@@ -284,7 +284,7 @@ class OverviewMap extends Control {
 
   /**
    * Register listeners for view property changes.
-   * @param {module:ol/View} view The view.
+   * @param {import("../View.js").default} view The view.
    * @private
    */
   bindView_(view) {
@@ -295,7 +295,7 @@ class OverviewMap extends Control {
 
   /**
    * Unregister listeners for view property changes.
-   * @param {module:ol/View} view The view.
+   * @param {import("../View.js").default} view The view.
    * @private
    */
   unbindView_(view) {
@@ -333,12 +333,12 @@ class OverviewMap extends Control {
       return;
     }
 
-    const mapSize = /** @type {module:ol/size~Size} */ (map.getSize());
+    const mapSize = /** @type {import("../size.js").Size} */ (map.getSize());
 
     const view = map.getView();
     const extent = view.calculateExtent(mapSize);
 
-    const ovmapSize = /** @type {module:ol/size~Size} */ (ovmap.getSize());
+    const ovmapSize = /** @type {import("../size.js").Size} */ (ovmap.getSize());
 
     const ovview = ovmap.getView();
     const ovextent = ovview.calculateExtent(ovmapSize);
@@ -377,7 +377,7 @@ class OverviewMap extends Control {
     const map = this.getMap();
     const ovmap = this.ovmap_;
 
-    const mapSize = /** @type {module:ol/size~Size} */ (map.getSize());
+    const mapSize = /** @type {import("../size.js").Size} */ (map.getSize());
 
     const view = map.getView();
     const extent = view.calculateExtent(mapSize);
@@ -422,7 +422,7 @@ class OverviewMap extends Control {
       return;
     }
 
-    const mapSize = /** @type {module:ol/size~Size} */ (map.getSize());
+    const mapSize = /** @type {import("../size.js").Size} */ (map.getSize());
 
     const view = map.getView();
 
@@ -450,8 +450,8 @@ class OverviewMap extends Control {
 
   /**
    * @param {number} rotation Target rotation.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @return {module:ol/coordinate~Coordinate|undefined} Coordinate for rotation and center anchor.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+   * @return {import("../coordinate.js").Coordinate|undefined} Coordinate for rotation and center anchor.
    * @private
    */
   calculateCoordinateRotate_(rotation, coordinate) {
@@ -558,7 +558,7 @@ class OverviewMap extends Control {
 
   /**
    * Return the overview map.
-   * @return {module:ol/PluggableMap} Overview map.
+   * @return {import("../PluggableMap.js").default} Overview map.
    * @api
    */
   getOverviewMap() {
@@ -569,8 +569,8 @@ class OverviewMap extends Control {
 
 /**
  * Update the overview map element.
- * @param {module:ol/MapEvent} mapEvent Map event.
- * @this {module:ol/control/OverviewMap}
+ * @param {import("../MapEvent.js").default} mapEvent Map event.
+ * @this {import("./OverviewMap.js").default}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -16,7 +16,7 @@ import EventType from '../events/EventType.js';
  * @property {string} [tipLabel='Reset rotation'] Text label to use for the rotate tip.
  * @property {number} [duration=250] Animation duration in milliseconds.
  * @property {boolean} [autoHide=true] Hide the control when rotation is 0.
- * @property {function(module:ol/MapEvent)} [render] Function called when the control should
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when the control should
  * be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {function()} [resetNorth] Function called when the control is clicked.
  * This will override the default `resetNorth`.
@@ -36,7 +36,7 @@ import EventType from '../events/EventType.js';
 class Rotate extends Control {
 
   /**
-   * @param {module:ol/control/Rotate~Options=} opt_options Rotate options.
+   * @param {Options=} opt_options Rotate options.
    */
   constructor(opt_options) {
 
@@ -149,8 +149,8 @@ class Rotate extends Control {
 
 /**
  * Update the rotate control element.
- * @param {module:ol/MapEvent} mapEvent Map event.
- * @this {module:ol/control/Rotate}
+ * @param {import("../MapEvent.js").default} mapEvent Map event.
+ * @this {import("./Rotate.js").default}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -40,11 +40,11 @@ const LEADING_DIGITS = [1, 2, 5];
  * @typedef {Object} Options
  * @property {string} [className='ol-scale-line'] CSS Class name.
  * @property {number} [minWidth=64] Minimum width in pixels.
- * @property {function(module:ol/MapEvent)} [render] Function called when the control
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {HTMLElement|string} [target] Specify a target if you want the control
  * to be rendered outside of the map's viewport.
- * @property {module:ol/control/ScaleLine~Units|string} [units='metric'] Units.
+ * @property {Units|string} [units='metric'] Units.
  */
 
 
@@ -63,7 +63,7 @@ const LEADING_DIGITS = [1, 2, 5];
 class ScaleLine extends Control {
 
   /**
-   * @param {module:ol/control/ScaleLine~Options=} opt_options Scale line options.
+   * @param {Options=} opt_options Scale line options.
    */
   constructor(opt_options) {
 
@@ -89,7 +89,7 @@ class ScaleLine extends Control {
 
     /**
      * @private
-     * @type {?module:ol/View~State}
+     * @type {?import("../View.js").State}
      */
     this.viewState_ = null;
 
@@ -121,21 +121,21 @@ class ScaleLine extends Control {
       this, getChangeEventType(UNITS_PROP),
       this.handleUnitsChanged_, this);
 
-    this.setUnits(/** @type {module:ol/control/ScaleLine~Units} */ (options.units) ||
+    this.setUnits(/** @type {Units} */ (options.units) ||
         Units.METRIC);
 
   }
 
   /**
    * Return the units to use in the scale line.
-   * @return {module:ol/control/ScaleLine~Units|undefined} The units
+   * @return {Units|undefined} The units
    * to use in the scale line.
    * @observable
    * @api
    */
   getUnits() {
     return (
-      /** @type {module:ol/control/ScaleLine~Units|undefined} */ (this.get(UNITS_PROP))
+      /** @type {Units|undefined} */ (this.get(UNITS_PROP))
     );
   }
 
@@ -148,7 +148,7 @@ class ScaleLine extends Control {
 
   /**
    * Set the units to use in the scale line.
-   * @param {module:ol/control/ScaleLine~Units} units The units to use in the scale line.
+   * @param {Units} units The units to use in the scale line.
    * @observable
    * @api
    */
@@ -282,8 +282,8 @@ class ScaleLine extends Control {
 
 /**
  * Update the scale line element.
- * @param {module:ol/MapEvent} mapEvent Map event.
- * @this {module:ol/control/ScaleLine}
+ * @param {import("../MapEvent.js").default} mapEvent Map event.
+ * @this {import("./ScaleLine.js").default}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -35,7 +35,7 @@ import {easeOut} from '../easing.js';
 class Zoom extends Control {
 
   /**
-   * @param {module:ol/control/Zoom~Options=} opt_options Zoom options.
+   * @param {Options=} opt_options Zoom options.
    */
   constructor(opt_options) {
 

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -28,7 +28,7 @@ const Direction = {
  * @typedef {Object} Options
  * @property {string} [className='ol-zoomslider'] CSS class name.
  * @property {number} [duration=200] Animation duration in milliseconds.
- * @property {function(module:ol/MapEvent)} [render] Function called when the control
+ * @property {function(import("../MapEvent.js").default)} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  */
 
@@ -46,7 +46,7 @@ const Direction = {
 class ZoomSlider extends Control {
 
   /**
-   * @param {module:ol/control/ZoomSlider~Options=} opt_options Zoom slider options.
+   * @param {Options=} opt_options Zoom slider options.
    */
   constructor(opt_options) {
 
@@ -107,7 +107,7 @@ class ZoomSlider extends Control {
     /**
      * The calculated thumb size (border box plus margins).  Set when initSlider_
      * is called.
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      * @private
      */
     this.thumbSize_ = null;
@@ -133,7 +133,7 @@ class ZoomSlider extends Control {
     containerElement.className = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL;
     containerElement.appendChild(thumbElement);
     /**
-     * @type {module:ol/pointer/PointerEventHandler}
+     * @type {import("../pointer/PointerEventHandler.js").default}
      * @private
      */
     this.dragger_ = new PointerEventHandler(containerElement);
@@ -222,7 +222,7 @@ class ZoomSlider extends Control {
 
   /**
    * Handle dragger start events.
-   * @param {module:ol/pointer/PointerEvent} event The drag event.
+   * @param {import("../pointer/PointerEvent.js").default} event The drag event.
    * @private
    */
   handleDraggerStart_(event) {
@@ -237,7 +237,7 @@ class ZoomSlider extends Control {
   /**
    * Handle dragger drag events.
    *
-   * @param {module:ol/pointer/PointerEvent|Event} event The drag event.
+   * @param {import("../pointer/PointerEvent.js").default|Event} event The drag event.
    * @private
    */
   handleDraggerDrag_(event) {
@@ -256,7 +256,7 @@ class ZoomSlider extends Control {
 
   /**
    * Handle dragger end events.
-   * @param {module:ol/pointer/PointerEvent|Event} event The drag event.
+   * @param {import("../pointer/PointerEvent.js").default|Event} event The drag event.
    * @private
    */
   handleDraggerEnd_(event) {
@@ -344,8 +344,8 @@ class ZoomSlider extends Control {
 
 /**
  * Update the zoomslider element.
- * @param {module:ol/MapEvent} mapEvent Map event.
- * @this {module:ol/control/ZoomSlider}
+ * @param {import("../MapEvent.js").default} mapEvent Map event.
+ * @this {import("./ZoomSlider.js").default}
  * @api
  */
 export function render(mapEvent) {

--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -15,7 +15,7 @@ import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
  * @property {string|HTMLElement} [label='E'] Text label to use for the button.
  * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string} [tipLabel='Fit to extent'] Text label to use for the button tip.
- * @property {module:ol/extent~Extent} [extent] The extent to zoom to. If undefined the validity
+ * @property {import("../extent.js").Extent} [extent] The extent to zoom to. If undefined the validity
  * extent of the view projection is used.
  */
 
@@ -30,7 +30,7 @@ import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 class ZoomToExtent extends Control {
 
   /**
-   * @param {module:ol/control/ZoomToExtent~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -41,7 +41,7 @@ class ZoomToExtent extends Control {
     });
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      * @protected
      */
     this.extent = options.extent ? options.extent : null;

--- a/src/ol/control/util.js
+++ b/src/ol/control/util.js
@@ -11,14 +11,14 @@ import Zoom from './Zoom.js';
  * @typedef {Object} DefaultsOptions
  * @property {boolean} [attribution=true] Include
  * {@link module:ol/control/Attribution~Attribution}.
- * @property {module:ol/control/Attribution~Options} [attributionOptions]
+ * @property {import("./Attribution.js").Options} [attributionOptions]
  * Options for {@link module:ol/control/Attribution~Attribution}.
  * @property {boolean} [rotate=true] Include
  * {@link module:ol/control/Rotate~Rotate}.
- * @property {module:ol/control/Rotate~Options} [rotateOptions] Options
+ * @property {import("./Rotate.js").Options} [rotateOptions] Options
  * for {@link module:ol/control/Rotate~Rotate}.
  * @property {boolean} [zoom] Include {@link module:ol/control/Zoom~Zoom}.
- * @property {module:ol/control/Zoom~Options} [zoomOptions] Options for
+ * @property {import("./Zoom.js").Options} [zoomOptions] Options for
  * {@link module:ol/control/Zoom~Zoom}.
  * @api
  */
@@ -32,9 +32,9 @@ import Zoom from './Zoom.js';
  * * {@link module:ol/control/Rotate~Rotate}
  * * {@link module:ol/control/Attribution~Attribution}
  *
- * @param {module:ol/control/util~DefaultsOptions=} opt_options
+ * @param {DefaultsOptions=} opt_options
  * Defaults options.
- * @return {module:ol/Collection<module:ol/control/Control>}
+ * @return {import("../Collection.js").default<import("./Control.js").default>}
  * Controls.
  * @function module:ol/control.defaults
  * @api

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -16,7 +16,7 @@ import {padNumber} from './string.js';
  * A function that takes a {@link module:ol/coordinate~Coordinate} and
  * transforms it into a `{string}`.
  *
- * @typedef {function((module:ol/coordinate~Coordinate|undefined)): string} CoordinateFormat
+ * @typedef {function((Coordinate|undefined)): string} CoordinateFormat
  * @api
  */
 
@@ -33,9 +33,9 @@ import {padNumber} from './string.js';
  *     add(coord, [-2, 4]);
  *     // coord is now [5.85, 51.983333]
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/coordinate~Coordinate} delta Delta.
- * @return {module:ol/coordinate~Coordinate} The input coordinate adjusted by
+ * @param {Coordinate} coordinate Coordinate.
+ * @param {Coordinate} delta Delta.
+ * @return {Coordinate} The input coordinate adjusted by
  * the given delta.
  * @api
  */
@@ -49,9 +49,9 @@ export function add(coordinate, delta) {
 /**
  * Calculates the point closest to the passed coordinate on the passed circle.
  *
- * @param {module:ol/coordinate~Coordinate} coordinate The coordinate.
- * @param {module:ol/geom/Circle} circle The circle.
- * @return {module:ol/coordinate~Coordinate} Closest point on the circumference.
+ * @param {Coordinate} coordinate The coordinate.
+ * @param {import("./geom/Circle.js").default} circle The circle.
+ * @return {Coordinate} Closest point on the circumference.
  */
 export function closestOnCircle(coordinate, circle) {
   const r = circle.getRadius();
@@ -81,10 +81,10 @@ export function closestOnCircle(coordinate, circle) {
  * the foot is on the segment, or the closest segment coordinate when the foot
  * is outside the segment.
  *
- * @param {module:ol/coordinate~Coordinate} coordinate The coordinate.
- * @param {Array<module:ol/coordinate~Coordinate>} segment The two coordinates
+ * @param {Coordinate} coordinate The coordinate.
+ * @param {Array<Coordinate>} segment The two coordinates
  * of the segment.
- * @return {module:ol/coordinate~Coordinate} The foot of the perpendicular of
+ * @return {Coordinate} The foot of the perpendicular of
  * the coordinate to the segment.
  */
 export function closestOnSegment(coordinate, segment) {
@@ -118,7 +118,7 @@ export function closestOnSegment(coordinate, segment) {
 /**
  * Returns a {@link module:ol/coordinate~CoordinateFormat} function that can be
  * used to format
- * a {module:ol/coordinate~Coordinate} to a string.
+ * a {Coordinate} to a string.
  *
  * Example without specifying the fractional digits:
  *
@@ -140,13 +140,13 @@ export function closestOnSegment(coordinate, segment) {
  *
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
- * @return {module:ol/coordinate~CoordinateFormat} Coordinate format.
+ * @return {CoordinateFormat} Coordinate format.
  * @api
  */
 export function createStringXY(opt_fractionDigits) {
   return (
     /**
-     * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+     * @param {Coordinate} coordinate Coordinate.
      * @return {string} String XY.
      */
     function(coordinate) {
@@ -213,7 +213,7 @@ export function degreesToStringHDMS(hemispheres, degrees, opt_fractionDigits) {
  *     var out = format(coord, template, 2);
  *     // out is now 'Coordinate is (7.85|47.98).'
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Coordinate} coordinate Coordinate.
  * @param {string} template A template string with `{x}` and `{y}` placeholders
  *     that will be replaced by first and second coordinate values.
  * @param {number=} opt_fractionDigits The number of digits to include
@@ -233,8 +233,8 @@ export function format(coordinate, template, opt_fractionDigits) {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} coordinate1 First coordinate.
- * @param {module:ol/coordinate~Coordinate} coordinate2 Second coordinate.
+ * @param {Coordinate} coordinate1 First coordinate.
+ * @param {Coordinate} coordinate2 Second coordinate.
  * @return {boolean} The two coordinates are equal.
  */
 export function equals(coordinate1, coordinate2) {
@@ -262,9 +262,9 @@ export function equals(coordinate1, coordinate2) {
  *     rotate(coord, rotateRadians);
  *     // coord is now [-47.983333, 7.85]
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Coordinate} coordinate Coordinate.
  * @param {number} angle Angle in radian.
- * @return {module:ol/coordinate~Coordinate} Coordinate.
+ * @return {Coordinate} Coordinate.
  * @api
  */
 export function rotate(coordinate, angle) {
@@ -291,9 +291,9 @@ export function rotate(coordinate, angle) {
  *     scaleCoordinate(coord, scale);
  *     // coord is now [9.42, 57.5799996]
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Coordinate} coordinate Coordinate.
  * @param {number} scale Scale factor.
- * @return {module:ol/coordinate~Coordinate} Coordinate.
+ * @return {Coordinate} Coordinate.
  */
 export function scale(coordinate, scale) {
   coordinate[0] *= scale;
@@ -303,8 +303,8 @@ export function scale(coordinate, scale) {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} coord1 First coordinate.
- * @param {module:ol/coordinate~Coordinate} coord2 Second coordinate.
+ * @param {Coordinate} coord1 First coordinate.
+ * @param {Coordinate} coord2 Second coordinate.
  * @return {number} Squared distance between coord1 and coord2.
  */
 export function squaredDistance(coord1, coord2) {
@@ -315,8 +315,8 @@ export function squaredDistance(coord1, coord2) {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} coord1 First coordinate.
- * @param {module:ol/coordinate~Coordinate} coord2 Second coordinate.
+ * @param {Coordinate} coord1 First coordinate.
+ * @param {Coordinate} coord2 Second coordinate.
  * @return {number} Distance between coord1 and coord2.
  */
 export function distance(coord1, coord2) {
@@ -327,8 +327,8 @@ export function distance(coord1, coord2) {
 /**
  * Calculate the squared distance from a coordinate to a line segment.
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate of the point.
- * @param {Array<module:ol/coordinate~Coordinate>} segment Line segment (2
+ * @param {Coordinate} coordinate Coordinate of the point.
+ * @param {Array<Coordinate>} segment Line segment (2
  * coordinates).
  * @return {number} Squared distance from the point to the line segment.
  */
@@ -358,7 +358,7 @@ export function squaredDistanceToSegment(coordinate, segment) {
  *     var out = toStringHDMS(coord, 1);
  *     // out is now '47° 58′ 60.0″ N 7° 50′ 60.0″ E'
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Coordinate} coordinate Coordinate.
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} Hemisphere, degrees, minutes and seconds.
@@ -393,7 +393,7 @@ export function toStringHDMS(coordinate, opt_fractionDigits) {
  *     var out = toStringXY(coord, 1);
  *     // out is now '7.8, 48.0'
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Coordinate} coordinate Coordinate.
  * @param {number=} opt_fractionDigits The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} XY.

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -8,11 +8,11 @@ import {clear} from './obj.js';
  * Key to use with {@link module:ol/Observable~Observable#unByKey}.
  * @typedef {Object} EventsKey
  * @property {Object} [bindTo]
- * @property {module:ol/events~ListenerFunction} [boundListener]
+ * @property {ListenerFunction} [boundListener]
  * @property {boolean} callOnce
  * @property {number} [deleteIndex]
- * @property {module:ol/events~ListenerFunction} listener
- * @property {module:ol/events/Target~EventTargetLike} target
+ * @property {ListenerFunction} listener
+ * @property {import("./events/Target.js").EventTargetLike} target
  * @property {string} type
  * @api
  */
@@ -22,14 +22,14 @@ import {clear} from './obj.js';
  * Listener function. This function is called with an event object as argument.
  * When the function returns `false`, event propagation will stop.
  *
- * @typedef {function(module:ol/events/Event)|function(module:ol/events/Event): boolean} ListenerFunction
+ * @typedef {function(import("./events/Event.js").default)|function(import("./events/Event.js").default): boolean} ListenerFunction
  * @api
  */
 
 
 /**
- * @param {module:ol/events~EventsKey} listenerObj Listener object.
- * @return {module:ol/events~ListenerFunction} Bound listener.
+ * @param {EventsKey} listenerObj Listener object.
+ * @return {ListenerFunction} Bound listener.
  */
 export function bindListener(listenerObj) {
   const boundListener = function(evt) {
@@ -49,12 +49,12 @@ export function bindListener(listenerObj) {
  * Finds the matching {@link module:ol/events~EventsKey} in the given listener
  * array.
  *
- * @param {!Array<!module:ol/events~EventsKey>} listeners Array of listeners.
+ * @param {!Array<!EventsKey>} listeners Array of listeners.
  * @param {!Function} listener The listener function.
  * @param {Object=} opt_this The `this` value inside the listener.
  * @param {boolean=} opt_setDeleteIndex Set the deleteIndex on the matching
  *     listener, for {@link module:ol/events~unlistenByKey}.
- * @return {module:ol/events~EventsKey|undefined} The matching listener object.
+ * @return {EventsKey|undefined} The matching listener object.
  */
 export function findListener(listeners, listener, opt_this, opt_setDeleteIndex) {
   let listenerObj;
@@ -73,9 +73,9 @@ export function findListener(listeners, listener, opt_this, opt_setDeleteIndex) 
 
 
 /**
- * @param {module:ol/events/Target~EventTargetLike} target Target.
+ * @param {import("./events/Target.js").EventTargetLike} target Target.
  * @param {string} type Type.
- * @return {Array<module:ol/events~EventsKey>|undefined} Listeners.
+ * @return {Array<EventsKey>|undefined} Listeners.
  */
 export function getListeners(target, type) {
   const listenerMap = target.ol_lm;
@@ -86,8 +86,8 @@ export function getListeners(target, type) {
 /**
  * Get the lookup of listeners.  If one does not exist on the target, it is
  * created.
- * @param {module:ol/events/Target~EventTargetLike} target Target.
- * @return {!Object<string, Array<module:ol/events~EventsKey>>} Map of
+ * @param {import("./events/Target.js").EventTargetLike} target Target.
+ * @return {!Object<string, Array<EventsKey>>} Map of
  *     listeners by event type.
  */
 function getListenerMap(target) {
@@ -103,7 +103,7 @@ function getListenerMap(target) {
  * Clean up all listener objects of the given type.  All properties on the
  * listener objects will be removed, and if no listeners remain in the listener
  * map, it will be removed from the target.
- * @param {module:ol/events/Target~EventTargetLike} target Target.
+ * @param {import("./events/Target.js").EventTargetLike} target Target.
  * @param {string} type Type.
  */
 function removeListeners(target, type) {
@@ -132,13 +132,13 @@ function removeListeners(target, type) {
  * This function efficiently binds a `listener` to a `this` object, and returns
  * a key for use with {@link module:ol/events~unlistenByKey}.
  *
- * @param {module:ol/events/Target~EventTargetLike} target Event target.
+ * @param {import("./events/Target.js").EventTargetLike} target Event target.
  * @param {string} type Event type.
- * @param {module:ol/events~ListenerFunction} listener Listener.
+ * @param {ListenerFunction} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
  * @param {boolean=} opt_once If true, add the listener as one-off listener.
- * @return {module:ol/events~EventsKey} Unique key for the listener.
+ * @return {EventsKey} Unique key for the listener.
  */
 export function listen(target, type, listener, opt_this, opt_once) {
   const listenerMap = getListenerMap(target);
@@ -153,7 +153,7 @@ export function listen(target, type, listener, opt_this, opt_once) {
       listenerObj.callOnce = false;
     }
   } else {
-    listenerObj = /** @type {module:ol/events~EventsKey} */ ({
+    listenerObj = /** @type {EventsKey} */ ({
       bindTo: opt_this,
       callOnce: !!opt_once,
       listener: listener,
@@ -181,12 +181,12 @@ export function listen(target, type, listener, opt_this, opt_once) {
  * function, the self-unregistering listener will be turned into a permanent
  * listener.
  *
- * @param {module:ol/events/Target~EventTargetLike} target Event target.
+ * @param {import("./events/Target.js").EventTargetLike} target Event target.
  * @param {string} type Event type.
- * @param {module:ol/events~ListenerFunction} listener Listener.
+ * @param {ListenerFunction} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
- * @return {module:ol/events~EventsKey} Key for unlistenByKey.
+ * @return {EventsKey} Key for unlistenByKey.
  */
 export function listenOnce(target, type, listener, opt_this) {
   return listen(target, type, listener, opt_this, true);
@@ -200,9 +200,9 @@ export function listenOnce(target, type, listener, opt_this) {
  * To return a listener, this function needs to be called with the exact same
  * arguments that were used for a previous {@link module:ol/events~listen} call.
  *
- * @param {module:ol/events/Target~EventTargetLike} target Event target.
+ * @param {import("./events/Target.js").EventTargetLike} target Event target.
  * @param {string} type Event type.
- * @param {module:ol/events~ListenerFunction} listener Listener.
+ * @param {ListenerFunction} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
  */
@@ -224,7 +224,7 @@ export function unlisten(target, type, listener, opt_this) {
  * The argument passed to this function is the key returned from
  * {@link module:ol/events~listen} or {@link module:ol/events~listenOnce}.
  *
- * @param {module:ol/events~EventsKey} key The key.
+ * @param {EventsKey} key The key.
  */
 export function unlistenByKey(key) {
   if (key && key.target) {
@@ -248,7 +248,7 @@ export function unlistenByKey(key) {
  * Unregisters all event listeners on an event target. Inspired by
  * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
- * @param {module:ol/events/Target~EventTargetLike} target Target.
+ * @param {import("./events/Target.js").EventTargetLike} target Target.
  */
 export function unlistenAll(target) {
   const listenerMap = getListenerMap(target);

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -61,7 +61,7 @@ class Event {
 
 
 /**
- * @param {Event|module:ol/events/Event} evt Event
+ * @param {Event|import("./Event.js").default} evt Event
  */
 export function stopPropagation(evt) {
   evt.stopPropagation();
@@ -69,7 +69,7 @@ export function stopPropagation(evt) {
 
 
 /**
- * @param {Event|module:ol/events/Event} evt Event
+ * @param {Event|import("./Event.js").default} evt Event
  */
 export function preventDefault(evt) {
   evt.preventDefault();

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -8,7 +8,7 @@ import Event from '../events/Event.js';
 
 
 /**
- * @typedef {EventTarget|module:ol/events/Target} EventTargetLike
+ * @typedef {EventTarget|import("./Target.js").default} EventTargetLike
  */
 
 
@@ -46,7 +46,7 @@ class Target extends Disposable {
 
     /**
      * @private
-     * @type {!Object<string, Array<module:ol/events~ListenerFunction>>}
+     * @type {!Object<string, Array<import("../events.js").ListenerFunction>>}
      */
     this.listeners_ = {};
 
@@ -54,7 +54,7 @@ class Target extends Disposable {
 
   /**
    * @param {string} type Type.
-   * @param {module:ol/events~ListenerFunction} listener Listener.
+   * @param {import("../events.js").ListenerFunction} listener Listener.
    */
   addEventListener(type, listener) {
     let listeners = this.listeners_[type];
@@ -72,8 +72,8 @@ class Target extends Disposable {
    * Object with a `type` property.
    *
    * @param {{type: string,
-   *     target: (module:ol/events/Target~EventTargetLike|undefined)}|
-   *     module:ol/events/Event|string} event Event object.
+   *     target: (EventTargetLike|undefined)}|
+   *     import("./Event.js").default|string} event Event object.
    * @return {boolean|undefined} `false` if anyone called preventDefault on the
    *     event object or if any of the listeners returned false.
    * @function
@@ -122,7 +122,7 @@ class Target extends Disposable {
    * order that they will be called in.
    *
    * @param {string} type Type.
-   * @return {Array<module:ol/events~ListenerFunction>} Listeners.
+   * @return {Array<import("../events.js").ListenerFunction>} Listeners.
    */
   getListeners(type) {
     return this.listeners_[type];
@@ -141,7 +141,7 @@ class Target extends Disposable {
 
   /**
    * @param {string} type Type.
-   * @param {module:ol/events~ListenerFunction} listener Listener.
+   * @param {import("../events.js").ListenerFunction} listener Listener.
    */
   removeEventListener(type, listener) {
     const listeners = this.listeners_[type];

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -11,7 +11,7 @@ import {WEBKIT, MAC} from '../has.js';
  * A function that takes an {@link module:ol/MapBrowserEvent} and returns a
  * `{boolean}`. If the condition is met, true should be returned.
  *
- * @typedef {function(this: ?, module:ol/MapBrowserEvent): boolean} Condition
+ * @typedef {function(this: ?, import("../MapBrowserEvent.js").default): boolean} Condition
  */
 
 
@@ -19,7 +19,7 @@ import {WEBKIT, MAC} from '../has.js';
  * Return `true` if only the alt-key is pressed, `false` otherwise (e.g. when
  * additionally the shift-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the alt key is pressed.
  * @api
  */
@@ -36,7 +36,7 @@ export const altKeyOnly = function(mapBrowserEvent) {
  * Return `true` if only the alt-key and shift-key is pressed, `false` otherwise
  * (e.g. when additionally the platform-modifier-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the alt and shift keys are pressed.
  * @api
  */
@@ -53,7 +53,7 @@ export const altShiftKeysOnly = function(mapBrowserEvent) {
  * Return `true` if the map has the focus. This condition requires a map target
  * element with a `tabindex` attribute, e.g. `<div id="map" tabindex="1">`.
  *
- * @param {module:ol/MapBrowserEvent} event Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} event Map browser event.
  * @return {boolean} The map has the focus.
  * @api
  */
@@ -65,7 +65,7 @@ export const focus = function(event) {
 /**
  * Return always true.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True.
  * @function
  * @api
@@ -76,7 +76,7 @@ export const always = TRUE;
 /**
  * Return `true` if the event is a `click` event, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `click` event.
  * @api
  */
@@ -91,7 +91,7 @@ export const click = function(mapBrowserEvent) {
  * By definition, this includes left-click on windows/linux, and left-click
  * without the ctrl key on Macs.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} The result.
  */
 export const mouseActionButton = function(mapBrowserEvent) {
@@ -104,7 +104,7 @@ export const mouseActionButton = function(mapBrowserEvent) {
 /**
  * Return always false.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} False.
  * @function
  * @api
@@ -116,7 +116,7 @@ export const never = FALSE;
  * Return `true` if the browser event is a `pointermove` event, `false`
  * otherwise.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the browser event is a `pointermove` event.
  * @api
  */
@@ -128,7 +128,7 @@ export const pointerMove = function(mapBrowserEvent) {
 /**
  * Return `true` if the event is a map `singleclick` event, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `singleclick` event.
  * @api
  */
@@ -140,7 +140,7 @@ export const singleClick = function(mapBrowserEvent) {
 /**
  * Return `true` if the event is a map `dblclick` event, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event is a map `dblclick` event.
  * @api
  */
@@ -153,7 +153,7 @@ export const doubleClick = function(mapBrowserEvent) {
  * Return `true` if no modifier key (alt-, shift- or platform-modifier-key) is
  * pressed.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True only if there no modifier keys are pressed.
  * @api
  */
@@ -171,7 +171,7 @@ export const noModifierKeys = function(mapBrowserEvent) {
  * ctrl-key otherwise) is pressed, `false` otherwise (e.g. when additionally
  * the shift-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the platform modifier key is pressed.
  * @api
  */
@@ -187,7 +187,7 @@ export const platformModifierKeyOnly = function(mapBrowserEvent) {
  * Return `true` if only the shift-key is pressed, `false` otherwise (e.g. when
  * additionally the alt-key is pressed).
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if only the shift key is pressed.
  * @api
  */
@@ -204,7 +204,7 @@ export const shiftKeyOnly = function(mapBrowserEvent) {
  * Return `true` if the target element is not editable, i.e. not a `<input>`-,
  * `<select>`- or `<textarea>`-element, `false` otherwise.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True only if the target element is not editable.
  * @api
  */
@@ -221,7 +221,7 @@ export const targetNotEditable = function(mapBrowserEvent) {
 /**
  * Return `true` if the event originates from a mouse device.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a mouse device.
  * @api
  */
@@ -229,7 +229,7 @@ export const mouseOnly = function(mapBrowserEvent) {
   assert(mapBrowserEvent.pointerEvent, 56); // mapBrowserEvent must originate from a pointer event
   // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
   return (
-    /** @type {module:ol/MapBrowserEvent} */ (mapBrowserEvent).pointerEvent.pointerType == 'mouse'
+    /** @type {import("../MapBrowserEvent.js").default} */ (mapBrowserEvent).pointerEvent.pointerType == 'mouse'
   );
 };
 
@@ -239,7 +239,7 @@ export const mouseOnly = function(mapBrowserEvent) {
  * contact with the surface or if the left mouse button is pressed.
  * See http://www.w3.org/TR/pointerevents/#button-states.
  *
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a primary pointer.
  * @api
  */

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -15,8 +15,8 @@ import Relationship from './extent/Relationship.js';
 /**
  * Build an extent that includes all given coordinates.
  *
- * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
- * @return {module:ol/extent~Extent} Bounding extent.
+ * @param {Array<import("./coordinate.js").Coordinate>} coordinates Coordinates.
+ * @return {Extent} Bounding extent.
  * @api
  */
 export function boundingExtent(coordinates) {
@@ -31,9 +31,9 @@ export function boundingExtent(coordinates) {
 /**
  * @param {Array<number>} xs Xs.
  * @param {Array<number>} ys Ys.
- * @param {module:ol/extent~Extent=} opt_extent Destination extent.
+ * @param {Extent=} opt_extent Destination extent.
  * @private
- * @return {module:ol/extent~Extent} Extent.
+ * @return {Extent} Extent.
  */
 function _boundingExtentXYs(xs, ys, opt_extent) {
   const minX = Math.min.apply(null, xs);
@@ -46,10 +46,10 @@ function _boundingExtentXYs(xs, ys, opt_extent) {
 
 /**
  * Return extent increased by the provided value.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @param {number} value The amount by which the extent should be buffered.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  * @api
  */
 export function buffer(extent, value, opt_extent) {
@@ -73,9 +73,9 @@ export function buffer(extent, value, opt_extent) {
 /**
  * Creates a clone of an extent.
  *
- * @param {module:ol/extent~Extent} extent Extent to clone.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} The clone.
+ * @param {Extent} extent Extent to clone.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} The clone.
  */
 export function clone(extent, opt_extent) {
   if (opt_extent) {
@@ -91,7 +91,7 @@ export function clone(extent, opt_extent) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @param {number} x X.
  * @param {number} y Y.
  * @return {number} Closest squared distance.
@@ -119,8 +119,8 @@ export function closestSquaredDistanceXY(extent, x, y) {
 /**
  * Check if the passed coordinate is contained or on the edge of the extent.
  *
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Extent} extent Extent.
+ * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
  * @return {boolean} The coordinate is contained in the extent.
  * @api
  */
@@ -135,8 +135,8 @@ export function containsCoordinate(extent, coordinate) {
  * An extent is deemed contained if it lies completely within the other extent,
  * including if they share one or more edges.
  *
- * @param {module:ol/extent~Extent} extent1 Extent 1.
- * @param {module:ol/extent~Extent} extent2 Extent 2.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent 2.
  * @return {boolean} The second extent is contained by or on the edge of the
  *     first.
  * @api
@@ -150,7 +150,7 @@ export function containsExtent(extent1, extent2) {
 /**
  * Check if the passed coordinate is contained or on the edge of the extent.
  *
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @param {number} x X coordinate.
  * @param {number} y Y coordinate.
  * @return {boolean} The x, y values are contained in the extent.
@@ -163,10 +163,10 @@ export function containsXY(extent, x, y) {
 
 /**
  * Get the relationship between a coordinate and extent.
- * @param {module:ol/extent~Extent} extent The extent.
- * @param {module:ol/coordinate~Coordinate} coordinate The coordinate.
- * @return {module:ol/extent/Relationship} The relationship (bitwise compare with
- *     module:ol/extent/Relationship~Relationship).
+ * @param {Extent} extent The extent.
+ * @param {import("./coordinate.js").Coordinate} coordinate The coordinate.
+ * @return {import("./extent/Relationship.js").default} The relationship (bitwise compare with
+ *     import("./extent/Relationship.js").Relationship).
  */
 export function coordinateRelationship(extent, coordinate) {
   const minX = extent[0];
@@ -195,7 +195,7 @@ export function coordinateRelationship(extent, coordinate) {
 
 /**
  * Create an empty extent.
- * @return {module:ol/extent~Extent} Empty extent.
+ * @return {Extent} Empty extent.
  * @api
  */
 export function createEmpty() {
@@ -209,8 +209,8 @@ export function createEmpty() {
  * @param {number} minY Minimum Y.
  * @param {number} maxX Maximum X.
  * @param {number} maxY Maximum Y.
- * @param {module:ol/extent~Extent=} opt_extent Destination extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent=} opt_extent Destination extent.
+ * @return {Extent} Extent.
  */
 export function createOrUpdate(minX, minY, maxX, maxY, opt_extent) {
   if (opt_extent) {
@@ -227,8 +227,8 @@ export function createOrUpdate(minX, minY, maxX, maxY, opt_extent) {
 
 /**
  * Create a new empty extent or make the provided one empty.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  */
 export function createOrUpdateEmpty(opt_extent) {
   return createOrUpdate(
@@ -237,9 +237,9 @@ export function createOrUpdateEmpty(opt_extent) {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  */
 export function createOrUpdateFromCoordinate(coordinate, opt_extent) {
   const x = coordinate[0];
@@ -249,9 +249,9 @@ export function createOrUpdateFromCoordinate(coordinate, opt_extent) {
 
 
 /**
- * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Array<import("./coordinate.js").Coordinate>} coordinates Coordinates.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  */
 export function createOrUpdateFromCoordinates(coordinates, opt_extent) {
   const extent = createOrUpdateEmpty(opt_extent);
@@ -264,8 +264,8 @@ export function createOrUpdateFromCoordinates(coordinates, opt_extent) {
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  */
 export function createOrUpdateFromFlatCoordinates(flatCoordinates, offset, end, stride, opt_extent) {
   const extent = createOrUpdateEmpty(opt_extent);
@@ -273,9 +273,9 @@ export function createOrUpdateFromFlatCoordinates(flatCoordinates, offset, end, 
 }
 
 /**
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} rings Rings.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Array<Array<import("./coordinate.js").Coordinate>>} rings Rings.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  */
 export function createOrUpdateFromRings(rings, opt_extent) {
   const extent = createOrUpdateEmpty(opt_extent);
@@ -285,8 +285,8 @@ export function createOrUpdateFromRings(rings, opt_extent) {
 
 /**
  * Determine if two extents are equivalent.
- * @param {module:ol/extent~Extent} extent1 Extent 1.
- * @param {module:ol/extent~Extent} extent2 Extent 2.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent 2.
  * @return {boolean} The two extents are equivalent.
  * @api
  */
@@ -298,9 +298,9 @@ export function equals(extent1, extent2) {
 
 /**
  * Modify an extent to include another extent.
- * @param {module:ol/extent~Extent} extent1 The extent to be modified.
- * @param {module:ol/extent~Extent} extent2 The extent that will be included in the first.
- * @return {module:ol/extent~Extent} A reference to the first (extended) extent.
+ * @param {Extent} extent1 The extent to be modified.
+ * @param {Extent} extent2 The extent that will be included in the first.
+ * @return {Extent} A reference to the first (extended) extent.
  * @api
  */
 export function extend(extent1, extent2) {
@@ -321,8 +321,8 @@ export function extend(extent1, extent2) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {Extent} extent Extent.
+ * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
  */
 export function extendCoordinate(extent, coordinate) {
   if (coordinate[0] < extent[0]) {
@@ -341,9 +341,9 @@ export function extendCoordinate(extent, coordinate) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent} extent Extent.
+ * @param {Array<import("./coordinate.js").Coordinate>} coordinates Coordinates.
+ * @return {Extent} Extent.
  */
 export function extendCoordinates(extent, coordinates) {
   for (let i = 0, ii = coordinates.length; i < ii; ++i) {
@@ -354,12 +354,12 @@ export function extendCoordinates(extent, coordinates) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @return {module:ol/extent~Extent} Extent.
+ * @return {Extent} Extent.
  */
 export function extendFlatCoordinates(extent, flatCoordinates, offset, end, stride) {
   for (; offset < end; offset += stride) {
@@ -370,9 +370,9 @@ export function extendFlatCoordinates(extent, flatCoordinates, offset, end, stri
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} rings Rings.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent} extent Extent.
+ * @param {Array<Array<import("./coordinate.js").Coordinate>>} rings Rings.
+ * @return {Extent} Extent.
  */
 export function extendRings(extent, rings) {
   for (let i = 0, ii = rings.length; i < ii; ++i) {
@@ -383,7 +383,7 @@ export function extendRings(extent, rings) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @param {number} x X.
  * @param {number} y Y.
  */
@@ -399,8 +399,8 @@ export function extendXY(extent, x, y) {
  * This function calls `callback` for each corner of the extent. If the
  * callback returns a truthy value the function returns that value
  * immediately. Otherwise the function returns `false`.
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {function(this:T, module:ol/coordinate~Coordinate): S} callback Callback.
+ * @param {Extent} extent Extent.
+ * @param {function(this:T, import("./coordinate.js").Coordinate): S} callback Callback.
  * @param {T=} opt_this Value to use as `this` when executing `callback`.
  * @return {S|boolean} Value.
  * @template S, T
@@ -429,7 +429,7 @@ export function forEachCorner(extent, callback, opt_this) {
 
 /**
  * Get the size of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @return {number} Area.
  * @api
  */
@@ -444,8 +444,8 @@ export function getArea(extent) {
 
 /**
  * Get the bottom left coordinate of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @return {module:ol/coordinate~Coordinate} Bottom left coordinate.
+ * @param {Extent} extent Extent.
+ * @return {import("./coordinate.js").Coordinate} Bottom left coordinate.
  * @api
  */
 export function getBottomLeft(extent) {
@@ -455,8 +455,8 @@ export function getBottomLeft(extent) {
 
 /**
  * Get the bottom right coordinate of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @return {module:ol/coordinate~Coordinate} Bottom right coordinate.
+ * @param {Extent} extent Extent.
+ * @return {import("./coordinate.js").Coordinate} Bottom right coordinate.
  * @api
  */
 export function getBottomRight(extent) {
@@ -466,8 +466,8 @@ export function getBottomRight(extent) {
 
 /**
  * Get the center coordinate of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @return {module:ol/coordinate~Coordinate} Center.
+ * @param {Extent} extent Extent.
+ * @return {import("./coordinate.js").Coordinate} Center.
  * @api
  */
 export function getCenter(extent) {
@@ -477,9 +477,9 @@ export function getCenter(extent) {
 
 /**
  * Get a corner coordinate of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {module:ol/extent/Corner} corner Corner.
- * @return {module:ol/coordinate~Coordinate} Corner coordinate.
+ * @param {Extent} extent Extent.
+ * @param {import("./extent/Corner.js").default} corner Corner.
+ * @return {import("./coordinate.js").Coordinate} Corner coordinate.
  */
 export function getCorner(extent, corner) {
   let coordinate;
@@ -495,14 +495,14 @@ export function getCorner(extent, corner) {
     assert(false, 13); // Invalid corner
   }
   return (
-    /** @type {!module:ol/coordinate~Coordinate} */ (coordinate)
+    /** @type {!import("./coordinate.js").Coordinate} */ (coordinate)
   );
 }
 
 
 /**
- * @param {module:ol/extent~Extent} extent1 Extent 1.
- * @param {module:ol/extent~Extent} extent2 Extent 2.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent 2.
  * @return {number} Enlarged area.
  */
 export function getEnlargedArea(extent1, extent2) {
@@ -515,12 +515,12 @@ export function getEnlargedArea(extent1, extent2) {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} center Center.
+ * @param {import("./coordinate.js").Coordinate} center Center.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
- * @param {module:ol/size~Size} size Size.
- * @param {module:ol/extent~Extent=} opt_extent Destination extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {import("./size.js").Size} size Size.
+ * @param {Extent=} opt_extent Destination extent.
+ * @return {Extent} Extent.
  */
 export function getForViewAndSize(center, resolution, rotation, size, opt_extent) {
   const dx = resolution * size[0] / 2;
@@ -550,7 +550,7 @@ export function getForViewAndSize(center, resolution, rotation, size, opt_extent
 
 /**
  * Get the height of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @return {number} Height.
  * @api
  */
@@ -560,8 +560,8 @@ export function getHeight(extent) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent1 Extent 1.
- * @param {module:ol/extent~Extent} extent2 Extent 2.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent 2.
  * @return {number} Intersection area.
  */
 export function getIntersectionArea(extent1, extent2) {
@@ -572,10 +572,10 @@ export function getIntersectionArea(extent1, extent2) {
 
 /**
  * Get the intersection of two extents.
- * @param {module:ol/extent~Extent} extent1 Extent 1.
- * @param {module:ol/extent~Extent} extent2 Extent 2.
- * @param {module:ol/extent~Extent=} opt_extent Optional extent to populate with intersection.
- * @return {module:ol/extent~Extent} Intersecting extent.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent 2.
+ * @param {Extent=} opt_extent Optional extent to populate with intersection.
+ * @return {Extent} Intersecting extent.
  * @api
  */
 export function getIntersection(extent1, extent2, opt_extent) {
@@ -609,7 +609,7 @@ export function getIntersection(extent1, extent2, opt_extent) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @return {number} Margin.
  */
 export function getMargin(extent) {
@@ -619,8 +619,8 @@ export function getMargin(extent) {
 
 /**
  * Get the size (width, height) of an extent.
- * @param {module:ol/extent~Extent} extent The extent.
- * @return {module:ol/size~Size} The extent size.
+ * @param {Extent} extent The extent.
+ * @return {import("./size.js").Size} The extent size.
  * @api
  */
 export function getSize(extent) {
@@ -630,8 +630,8 @@ export function getSize(extent) {
 
 /**
  * Get the top left coordinate of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @return {module:ol/coordinate~Coordinate} Top left coordinate.
+ * @param {Extent} extent Extent.
+ * @return {import("./coordinate.js").Coordinate} Top left coordinate.
  * @api
  */
 export function getTopLeft(extent) {
@@ -641,8 +641,8 @@ export function getTopLeft(extent) {
 
 /**
  * Get the top right coordinate of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @return {module:ol/coordinate~Coordinate} Top right coordinate.
+ * @param {Extent} extent Extent.
+ * @return {import("./coordinate.js").Coordinate} Top right coordinate.
  * @api
  */
 export function getTopRight(extent) {
@@ -652,7 +652,7 @@ export function getTopRight(extent) {
 
 /**
  * Get the width of an extent.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @return {number} Width.
  * @api
  */
@@ -663,8 +663,8 @@ export function getWidth(extent) {
 
 /**
  * Determine if one extent intersects another.
- * @param {module:ol/extent~Extent} extent1 Extent 1.
- * @param {module:ol/extent~Extent} extent2 Extent.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent.
  * @return {boolean} The two extents intersect.
  * @api
  */
@@ -678,7 +678,7 @@ export function intersects(extent1, extent2) {
 
 /**
  * Determine if an extent is empty.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @return {boolean} Is empty.
  * @api
  */
@@ -688,9 +688,9 @@ export function isEmpty(extent) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {module:ol/extent~Extent=} opt_extent Extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent} extent Extent.
+ * @param {Extent=} opt_extent Extent.
+ * @return {Extent} Extent.
  */
 export function returnOrUpdate(extent, opt_extent) {
   if (opt_extent) {
@@ -706,7 +706,7 @@ export function returnOrUpdate(extent, opt_extent) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {Extent} extent Extent.
  * @param {number} value Value.
  */
 export function scaleFromCenter(extent, value) {
@@ -722,9 +722,9 @@ export function scaleFromCenter(extent, value) {
 /**
  * Determine if the segment between two coordinates intersects (crosses,
  * touches, or is contained by) the provided extent.
- * @param {module:ol/extent~Extent} extent The extent.
- * @param {module:ol/coordinate~Coordinate} start Segment start coordinate.
- * @param {module:ol/coordinate~Coordinate} end Segment end coordinate.
+ * @param {Extent} extent The extent.
+ * @param {import("./coordinate.js").Coordinate} start Segment start coordinate.
+ * @param {import("./coordinate.js").Coordinate} end Segment end coordinate.
  * @return {boolean} The segment intersects the extent.
  */
 export function intersectsSegment(extent, start, end) {
@@ -777,11 +777,11 @@ export function intersectsSegment(extent, start, end) {
 
 /**
  * Apply a transform function to the extent.
- * @param {module:ol/extent~Extent} extent Extent.
- * @param {module:ol/proj~TransformFunction} transformFn Transform function.
+ * @param {Extent} extent Extent.
+ * @param {import("./proj.js").TransformFunction} transformFn Transform function.
  * Called with `[minX, minY, maxX, maxY]` extent coordinates.
- * @param {module:ol/extent~Extent=} opt_extent Destination extent.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {Extent=} opt_extent Destination extent.
+ * @return {Extent} Extent.
  * @api
  */
 export function applyTransform(extent, transformFn, opt_extent) {

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -17,8 +17,8 @@ import FormatType from './format/FormatType.js';
  *
  * The function is responsible for loading the features and adding them to the
  * source.
- * @typedef {function(this:module:ol/source/Vector, module:ol/extent~Extent, number,
- *                    module:ol/proj/Projection)} FeatureLoader
+ * @typedef {function(this:import("./source/Vector.js").default, import("./extent.js").Extent, number,
+ *                    import("./proj/Projection.js").default)} FeatureLoader
  * @api
  */
 
@@ -31,29 +31,29 @@ import FormatType from './format/FormatType.js';
  * to be loaded, a `{number}` representing the resolution (map units per pixel)
  * and an {@link module:ol/proj/Projection} for the projection  as
  * arguments and returns a `{string}` representing the URL.
- * @typedef {function(module:ol/extent~Extent, number, module:ol/proj/Projection): string} FeatureUrlFunction
+ * @typedef {function(import("./extent.js").Extent, number, import("./proj/Projection.js").default): string} FeatureUrlFunction
  * @api
  */
 
 
 /**
- * @param {string|module:ol/featureloader~FeatureUrlFunction} url Feature URL service.
- * @param {module:ol/format/Feature} format Feature format.
- * @param {function(this:module:ol/VectorTile, Array<module:ol/Feature>, module:ol/proj/Projection, module:ol/extent~Extent)|function(this:module:ol/source/Vector, Array<module:ol/Feature>)} success
+ * @param {string|FeatureUrlFunction} url Feature URL service.
+ * @param {import("./format/Feature.js").default} format Feature format.
+ * @param {function(this:import("./VectorTile.js").default, Array<import("./Feature.js").default>, import("./proj/Projection.js").default, import("./extent.js").Extent)|function(this:import("./source/Vector.js").default, Array<import("./Feature.js").default>)} success
  *     Function called with the loaded features and optionally with the data
  *     projection. Called with the vector tile or source as `this`.
- * @param {function(this:module:ol/VectorTile)|function(this:module:ol/source/Vector)} failure
+ * @param {function(this:import("./VectorTile.js").default)|function(this:import("./source/Vector.js").default)} failure
  *     Function called when loading failed. Called with the vector tile or
  *     source as `this`.
- * @return {module:ol/featureloader~FeatureLoader} The feature loader.
+ * @return {FeatureLoader} The feature loader.
  */
 export function loadFeaturesXhr(url, format, success, failure) {
   return (
     /**
-     * @param {module:ol/extent~Extent} extent Extent.
+     * @param {import("./extent.js").Extent} extent Extent.
      * @param {number} resolution Resolution.
-     * @param {module:ol/proj/Projection} projection Projection.
-     * @this {module:ol/source/Vector|module:ol/VectorTile}
+     * @param {import("./proj/Projection.js").default} projection Projection.
+     * @this {import("./source/Vector.js").default|import("./VectorTile.js").default}
      */
     function(extent, resolution, projection) {
       const xhr = new XMLHttpRequest();
@@ -110,18 +110,18 @@ export function loadFeaturesXhr(url, format, success, failure) {
  * Create an XHR feature loader for a `url` and `format`. The feature loader
  * loads features (with XHR), parses the features, and adds them to the
  * vector source.
- * @param {string|module:ol/featureloader~FeatureUrlFunction} url Feature URL service.
- * @param {module:ol/format/Feature} format Feature format.
- * @return {module:ol/featureloader~FeatureLoader} The feature loader.
+ * @param {string|FeatureUrlFunction} url Feature URL service.
+ * @param {import("./format/Feature.js").default} format Feature format.
+ * @return {FeatureLoader} The feature loader.
  * @api
  */
 export function xhr(url, format) {
   return loadFeaturesXhr(url, format,
     /**
-     * @param {Array<module:ol/Feature>} features The loaded features.
-     * @param {module:ol/proj/Projection} dataProjection Data
+     * @param {Array<import("./Feature.js").default>} features The loaded features.
+     * @param {import("./proj/Projection.js").default} dataProjection Data
      * projection.
-     * @this {module:ol/source/Vector}
+     * @this {import("./source/Vector.js").default}
      */
     function(features, dataProjection) {
       this.addFeatures(features);

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -23,7 +23,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @const
- * @type {Object<module:ol/geom/GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry>}
+ * @type {Object<import("../geom/GeometryType.js").default, function(EsriJSONGeometry): import("../geom/Geometry.js").default>}
  */
 const GEOMETRY_READERS = {};
 GEOMETRY_READERS[GeometryType.POINT] = readPointGeometry;
@@ -36,7 +36,7 @@ GEOMETRY_READERS[GeometryType.MULTI_POLYGON] = readMultiPolygonGeometry;
 
 /**
  * @const
- * @type {Object<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (EsriJSONGeometry)>}
+ * @type {Object<string, function(import("../geom/Geometry.js").default, import("./Feature.js").WriteOptions=): (EsriJSONGeometry)>}
  */
 const GEOMETRY_WRITERS = {};
 GEOMETRY_WRITERS[GeometryType.POINT] = writePointGeometry;
@@ -62,7 +62,7 @@ GEOMETRY_WRITERS[GeometryType.MULTI_POLYGON] = writeMultiPolygonGeometry;
 class EsriJSON extends JSONFeature {
 
   /**
-   * @param {module:ol/format/EsriJSON~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -108,7 +108,7 @@ class EsriJSON extends JSONFeature {
     const options = opt_options ? opt_options : {};
     if (esriJSONObject.features) {
       const esriJSONFeatureCollection = /** @type {EsriJSONFeatureCollection} */ (object);
-      /** @type {Array<module:ol/Feature>} */
+      /** @type {Array<import("../Feature.js").default>} */
       const features = [];
       const esriJSONFeatures = esriJSONFeatureCollection.features;
       options.idField = object.objectIdFieldName;
@@ -144,8 +144,8 @@ class EsriJSON extends JSONFeature {
   /**
    * Encode a geometry as a EsriJSON object.
    *
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {EsriJSONGeometry} Object.
    * @override
    * @api
@@ -157,8 +157,8 @@ class EsriJSON extends JSONFeature {
   /**
    * Encode a feature as a esriJSON Feature object.
    *
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {Object} Object.
    * @override
    * @api
@@ -188,8 +188,8 @@ class EsriJSON extends JSONFeature {
   /**
    * Encode an array of features as a EsriJSON object.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {Object} EsriJSON Object.
    * @override
    * @api
@@ -209,14 +209,14 @@ class EsriJSON extends JSONFeature {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry} Geometry.
+ * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @return {import("../geom/Geometry.js").default} Geometry.
  */
 function readGeometry(object, opt_options) {
   if (!object) {
     return null;
   }
-  /** @type {module:ol/geom/GeometryType} */
+  /** @type {import("../geom/GeometryType.js").default} */
   let type;
   if (typeof object.x === 'number' && typeof object.y === 'number') {
     type = GeometryType.POINT;
@@ -242,7 +242,7 @@ function readGeometry(object, opt_options) {
   }
   const geometryReader = GEOMETRY_READERS[type];
   return (
-    /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometryReader(object), false, opt_options))
+    /** @type {import("../geom/Geometry.js").default} */ (transformWithOptions(geometryReader(object), false, opt_options))
   );
 }
 
@@ -253,7 +253,7 @@ function readGeometry(object, opt_options) {
  * array. It is used for checking for holes.
  * Logic inspired by: https://github.com/Esri/terraformer-arcgis-parser
  * @param {Array<!Array<!Array<number>>>} rings Rings.
- * @param {module:ol/geom/GeometryLayout} layout Geometry layout.
+ * @param {import("../geom/GeometryLayout.js").default} layout Geometry layout.
  * @return {Array<!Array<!Array<number>>>} Transformed rings.
  */
 function convertRings(rings, layout) {
@@ -302,7 +302,7 @@ function convertRings(rings, layout) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry} Point.
+ * @return {import("../geom/Geometry.js").default} Point.
  */
 function readPointGeometry(object) {
   let point;
@@ -324,7 +324,7 @@ function readPointGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry} LineString.
+ * @return {import("../geom/Geometry.js").default} LineString.
  */
 function readLineStringGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -334,7 +334,7 @@ function readLineStringGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry} MultiLineString.
+ * @return {import("../geom/Geometry.js").default} MultiLineString.
  */
 function readMultiLineStringGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -344,7 +344,7 @@ function readMultiLineStringGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/GeometryLayout} The geometry layout to use.
+ * @return {import("../geom/GeometryLayout.js").default} The geometry layout to use.
  */
 function getGeometryLayout(object) {
   let layout = GeometryLayout.XY;
@@ -361,7 +361,7 @@ function getGeometryLayout(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry} MultiPoint.
+ * @return {import("../geom/Geometry.js").default} MultiPoint.
  */
 function readMultiPointGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -371,7 +371,7 @@ function readMultiPointGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry} MultiPolygon.
+ * @return {import("../geom/Geometry.js").default} MultiPolygon.
  */
 function readMultiPolygonGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -383,7 +383,7 @@ function readMultiPolygonGeometry(object) {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @return {module:ol/geom/Geometry} Polygon.
+ * @return {import("../geom/Geometry.js").default} Polygon.
  */
 function readPolygonGeometry(object) {
   const layout = getGeometryLayout(object);
@@ -392,14 +392,14 @@ function readPolygonGeometry(object) {
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONGeometry} EsriJSON geometry.
  */
 function writePointGeometry(geometry, opt_options) {
-  const coordinates = /** @type {module:ol/geom/Point} */ (geometry).getCoordinates();
+  const coordinates = /** @type {import("../geom/Point.js").default} */ (geometry).getCoordinates();
   let esriJSON;
-  const layout = /** @type {module:ol/geom/Point} */ (geometry).getLayout();
+  const layout = /** @type {import("../geom/Point.js").default} */ (geometry).getLayout();
   if (layout === GeometryLayout.XYZ) {
     esriJSON = /** @type {EsriJSONPoint} */ ({
       x: coordinates[0],
@@ -432,7 +432,7 @@ function writePointGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
+ * @param {import("../geom/SimpleGeometry.js").default} geometry Geometry.
  * @return {Object} Object with boolean hasZ and hasM keys.
  */
 function getHasZM(geometry) {
@@ -447,18 +447,18 @@ function getHasZM(geometry) {
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolyline} EsriJSON geometry.
  */
 function writeLineStringGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/LineString} */(geometry));
+  const hasZM = getHasZM(/** @type {import("../geom/LineString.js").default} */(geometry));
   return (
     /** @type {EsriJSONPolyline} */ {
       hasZ: hasZM.hasZ,
       hasM: hasZM.hasM,
       paths: [
-        /** @type {module:ol/geom/LineString} */ (geometry).getCoordinates()
+        /** @type {import("../geom/LineString.js").default} */ (geometry).getCoordinates()
       ]
     }
   );
@@ -466,65 +466,65 @@ function writeLineStringGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolygon} EsriJSON geometry.
  */
 function writePolygonGeometry(geometry, opt_options) {
   // Esri geometries use the left-hand rule
-  const hasZM = getHasZM(/** @type {module:ol/geom/Polygon} */(geometry));
+  const hasZM = getHasZM(/** @type {import("../geom/Polygon.js").default} */(geometry));
   return (
     /** @type {EsriJSONPolygon} */ {
       hasZ: hasZM.hasZ,
       hasM: hasZM.hasM,
-      rings: /** @type {module:ol/geom/Polygon} */ (geometry).getCoordinates(false)
+      rings: /** @type {import("../geom/Polygon.js").default} */ (geometry).getCoordinates(false)
     }
   );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolyline} EsriJSON geometry.
  */
 function writeMultiLineStringGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/MultiLineString} */(geometry));
+  const hasZM = getHasZM(/** @type {import("../geom/MultiLineString.js").default} */(geometry));
   return (
     /** @type {EsriJSONPolyline} */ {
       hasZ: hasZM.hasZ,
       hasM: hasZM.hasM,
-      paths: /** @type {module:ol/geom/MultiLineString} */ (geometry).getCoordinates()
+      paths: /** @type {import("../geom/MultiLineString.js").default} */ (geometry).getCoordinates()
     }
   );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONMultipoint} EsriJSON geometry.
  */
 function writeMultiPointGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/MultiPoint} */(geometry));
+  const hasZM = getHasZM(/** @type {import("../geom/MultiPoint.js").default} */(geometry));
   return (
     /** @type {EsriJSONMultipoint} */ {
       hasZ: hasZM.hasZ,
       hasM: hasZM.hasM,
-      points: /** @type {module:ol/geom/MultiPoint} */ (geometry).getCoordinates()
+      points: /** @type {import("../geom/MultiPoint.js").default} */ (geometry).getCoordinates()
     }
   );
 }
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONPolygon} EsriJSON geometry.
  */
 function writeMultiPolygonGeometry(geometry, opt_options) {
-  const hasZM = getHasZM(/** @type {module:ol/geom/MultiPolygon} */(geometry));
-  const coordinates = /** @type {module:ol/geom/MultiPolygon} */ (geometry).getCoordinates(false);
+  const hasZM = getHasZM(/** @type {import("../geom/MultiPolygon.js").default} */(geometry));
+  const coordinates = /** @type {import("../geom/MultiPolygon.js").default} */ (geometry).getCoordinates(false);
   const output = [];
   for (let i = 0; i < coordinates.length; i++) {
     for (let x = coordinates[i].length - 1; x >= 0; x--) {
@@ -540,13 +540,13 @@ function writeMultiPolygonGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {EsriJSONGeometry} EsriJSON geometry.
  */
 function writeGeometry(geometry, opt_options) {
   const geometryWriter = GEOMETRY_WRITERS[geometry.getType()];
-  return geometryWriter(/** @type {module:ol/geom/Geometry} */(
+  return geometryWriter(/** @type {import("../geom/Geometry.js").default} */(
     transformWithOptions(geometry, true, opt_options)), opt_options);
 }
 

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -8,14 +8,14 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
 
 /**
  * @typedef {Object} ReadOptions
- * @property {module:ol/proj~ProjectionLike} [dataProjection] Projection of the data we are reading.
+ * @property {import("../proj.js").ProjectionLike} [dataProjection] Projection of the data we are reading.
  * If not provided, the projection will be derived from the data (where possible) or
  * the `dataProjection` of the format is assigned (where set). If the projection
  * can not be derived from the data and if no `dataProjection` is set for a format,
  * the features will not be reprojected.
- * @property {module:ol/extent~Extent} [extent] Tile extent of the tile being read. This is only used and
+ * @property {import("../extent.js").Extent} [extent] Tile extent of the tile being read. This is only used and
  * required for {@link module:ol/format/MVT}.
- * @property {module:ol/proj~ProjectionLike} [featureProjection] Projection of the feature geometries
+ * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection of the feature geometries
  * created by the format reader. If not provided, features will be returned in the
  * `dataProjection`.
  */
@@ -23,11 +23,11 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
 
 /**
  * @typedef {Object} WriteOptions
- * @property {module:ol/proj~ProjectionLike} [dataProjection] Projection of the data we are writing.
+ * @property {import("../proj.js").ProjectionLike} [dataProjection] Projection of the data we are writing.
  * If not provided, the `dataProjection` of the format is assigned (where set).
  * If no `dataProjection` is set for a format, the features will be returned
  * in the `featureProjection`.
- * @property {module:ol/proj~ProjectionLike} [featureProjection] Projection of the feature geometries
+ * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection of the feature geometries
  * that will be serialized by the format writer. If not provided, geometries are assumed
  * to be in the `dataProjection` if that is set; in other words, they are not transformed.
  * @property {boolean} [rightHanded] When writing geometries, follow the right-hand
@@ -52,7 +52,7 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
  * Base class for feature formats.
- * {module:ol/format/Feature~FeatureFormat} subclasses provide the ability to decode and encode
+ * {FeatureFormat} subclasses provide the ability to decode and encode
  * {@link module:ol/Feature~Feature} objects from a variety of commonly used geospatial
  * file formats.  See the documentation for each format for more details.
  *
@@ -64,13 +64,13 @@ class FeatureFormat {
 
     /**
      * @protected
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      */
     this.dataProjection = null;
 
     /**
      * @protected
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      */
     this.defaultFeatureProjection = null;
 
@@ -79,8 +79,8 @@ class FeatureFormat {
   /**
    * Adds the data projection to the read options.
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
-   * @return {module:ol/format/Feature~ReadOptions|undefined} Options.
+   * @param {ReadOptions=} opt_options Options.
+   * @return {ReadOptions|undefined} Options.
    * @protected
    */
   getReadOptions(source, opt_options) {
@@ -98,10 +98,10 @@ class FeatureFormat {
   /**
    * Sets the `dataProjection` on the options, if no `dataProjection`
    * is set.
-   * @param {module:ol/format/Feature~WriteOptions|module:ol/format/Feature~ReadOptions|undefined} options
+   * @param {WriteOptions|ReadOptions|undefined} options
    *     Options.
    * @protected
-   * @return {module:ol/format/Feature~WriteOptions|module:ol/format/Feature~ReadOptions|undefined}
+   * @return {WriteOptions|ReadOptions|undefined}
    *     Updated options.
    */
   adaptOptions(options) {
@@ -113,7 +113,7 @@ class FeatureFormat {
 
   /**
    * Get the extent from the source of the last {@link readFeatures} call.
-   * @return {module:ol/extent~Extent} Tile extent.
+   * @return {import("../extent.js").Extent} Tile extent.
    */
   getLastExtent() {
     return null;
@@ -121,7 +121,7 @@ class FeatureFormat {
 
   /**
    * @abstract
-   * @return {module:ol/format/FormatType} Format.
+   * @return {import("./FormatType.js").default} Format.
    */
   getType() {}
 
@@ -130,8 +130,8 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/Feature} Feature.
+   * @param {ReadOptions=} opt_options Read options.
+   * @return {import("../Feature.js").default} Feature.
    */
   readFeature(source, opt_options) {}
 
@@ -140,8 +140,8 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Node|ArrayBuffer|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {Array<module:ol/Feature>} Features.
+   * @param {ReadOptions=} opt_options Read options.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeatures(source, opt_options) {}
 
@@ -150,8 +150,8 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @param {ReadOptions=} opt_options Read options.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometry(source, opt_options) {}
 
@@ -160,7 +160,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Node|Object|string} source Source.
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    */
   readProjection(source) {}
 
@@ -168,8 +168,8 @@ class FeatureFormat {
    * Encode a feature in this format.
    *
    * @abstract
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {WriteOptions=} opt_options Write options.
    * @return {string} Result.
    */
   writeFeature(feature, opt_options) {}
@@ -178,8 +178,8 @@ class FeatureFormat {
    * Encode an array of features in this format.
    *
    * @abstract
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {WriteOptions=} opt_options Write options.
    * @return {string} Result.
    */
   writeFeatures(features, opt_options) {}
@@ -188,8 +188,8 @@ class FeatureFormat {
    * Write a single geometry in this format.
    *
    * @abstract
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {WriteOptions=} opt_options Write options.
    * @return {string} Result.
    */
   writeGeometry(geometry, opt_options) {}
@@ -198,11 +198,11 @@ class FeatureFormat {
 export default FeatureFormat;
 
 /**
- * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
+ * @param {import("../geom/Geometry.js").default|import("../extent.js").Extent} geometry Geometry.
  * @param {boolean} write Set to true for writing, false for reading.
- * @param {module:ol/format/Feature~WriteOptions|module:ol/format/Feature~ReadOptions|undefined} opt_options
+ * @param {WriteOptions|ReadOptions|undefined} opt_options
  *     Options.
- * @return {module:ol/geom/Geometry|module:ol/extent~Extent} Transformed geometry.
+ * @return {import("../geom/Geometry.js").default|import("../extent.js").Extent} Transformed geometry.
  */
 export function transformWithOptions(geometry, write, opt_options) {
   const featureProjection = opt_options ?
@@ -210,7 +210,7 @@ export function transformWithOptions(geometry, write, opt_options) {
   const dataProjection = opt_options ?
     getProjection(opt_options.dataProjection) : null;
   /**
-   * @type {module:ol/geom/Geometry|module:ol/extent~Extent}
+   * @type {import("../geom/Geometry.js").default|import("../extent.js").Extent}
    */
   let transformed;
   if (featureProjection && dataProjection &&

--- a/src/ol/format/GML.js
+++ b/src/ol/format/GML.js
@@ -9,7 +9,7 @@ import GML3 from '../format/GML3.js';
  * version 3.1.1.
  * Currently only supports GML 3.1.1 Simple Features profile.
  *
- * @param {module:ol/format/GMLBase~Options=} opt_options
+ * @param {import("./GMLBase.js").Options=} opt_options
  *     Optional configuration object.
  * @api
  */
@@ -20,8 +20,8 @@ const GML = GML3;
  * Encode an array of features in GML 3.1.1 Simple Features.
  *
  * @function
- * @param {Array<module:ol/Feature>} features Features.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+ * @param {Array<import("../Feature.js").default>} features Features.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api
  */
@@ -32,8 +32,8 @@ GML.prototype.writeFeatures;
  * Encode an array of features in the GML 3.1.1 format as an XML node.
  *
  * @function
- * @param {Array<module:ol/Feature>} features Features.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+ * @param {Array<import("../Feature.js").default>} features Features.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @api
  */

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -41,10 +41,10 @@ const MULTIGEOMETRY_TO_MEMBER_NODENAME = {
 class GML2 extends GMLBase {
 
   /**
-   * @param {module:ol/format/GMLBase~Options=} opt_options Optional configuration object.
+   * @param {import("./GMLBase.js").Options=} opt_options Optional configuration object.
    */
   constructor(opt_options) {
-    const options = /** @type {module:ol/format/GMLBase~Options} */
+    const options = /** @type {import("./GMLBase.js").Options} */
         (opt_options ? opt_options : {});
 
     super(options);
@@ -69,7 +69,7 @@ class GML2 extends GMLBase {
    */
   readFlatCoordinates_(node, objectStack) {
     const s = getAllTextContent(node, false).replace(/^\s*|\s*$/g, '');
-    const context = /** @type {module:ol/xml~NodeStackItem} */ (objectStack[0]);
+    const context = /** @type {import("../xml.js").NodeStackItem} */ (objectStack[0]);
     const containerSrs = context['srsName'];
     let axisOrientation = 'enu';
     if (containerSrs) {
@@ -98,7 +98,7 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/extent~Extent|undefined} Envelope.
+   * @return {import("../extent.js").Extent|undefined} Envelope.
    */
   readBox_(node, objectStack) {
     /** @type {Array<number>} */
@@ -156,7 +156,7 @@ class GML2 extends GMLBase {
     const multiCurve = context['multiCurve'];
     let nodeName;
     if (!Array.isArray(value)) {
-      nodeName = /** @type {module:ol/geom/Geometry} */ (value).getType();
+      nodeName = /** @type {import("../geom/Geometry.js").default} */ (value).getType();
       if (nodeName === 'MultiPolygon' && multiSurface === true) {
         nodeName = 'MultiSurface';
       } else if (nodeName === 'Polygon' && surface === true) {
@@ -173,7 +173,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @param {Array<*>} objectStack Node stack.
    */
   writeFeatureElement(node, feature, objectStack) {
@@ -210,7 +210,7 @@ class GML2 extends GMLBase {
     }
     const item = assign({}, context);
     item.node = node;
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       (item), context.serializers,
       makeSimpleNodeFactory(undefined, featureNS),
       values,
@@ -219,7 +219,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/LineString} geometry LineString geometry.
+   * @param {import("../geom/LineString.js").default} geometry LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -244,7 +244,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/LineString} line LineString geometry.
+   * @param {import("../geom/LineString.js").default} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -258,7 +258,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
+   * @param {import("../geom/MultiLineString.js").default} geometry MultiLineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -279,11 +279,11 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
+   * @param {import("../geom/Geometry.js").default|import("../extent.js").Extent} geometry Geometry.
    * @param {Array<*>} objectStack Node stack.
    */
   writeGeometryElement(node, geometry, objectStack) {
-    const context = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[objectStack.length - 1]);
+    const context = /** @type {import("./Feature.js").WriteOptions} */ (objectStack[objectStack.length - 1]);
     const item = assign({}, context);
     item.node = node;
     let value;
@@ -295,9 +295,9 @@ class GML2 extends GMLBase {
         value = geometry;
       }
     } else {
-      value = transformWithOptions(/** @type {module:ol/geom/Geometry} */ (geometry), true, context);
+      value = transformWithOptions(/** @type {import("../geom/Geometry.js").default} */ (geometry), true, context);
     }
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       (item), this.GEOMETRY_SERIALIZERS_,
       this.GEOMETRY_NODE_FACTORY_, [value],
       objectStack, undefined, this);
@@ -319,7 +319,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
+   * @param {import("../geom/LineString.js").default|import("../geom/LinearRing.js").default} value Geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -340,7 +340,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/LineString} line LineString geometry.
+   * @param {import("../geom/LineString.js").default} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -352,7 +352,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/Polygon} geometry Polygon geometry.
+   * @param {import("../geom/Polygon.js").default} geometry Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -398,7 +398,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Polygon} polygon Polygon geometry.
+   * @param {import("../geom/Polygon.js").default} polygon Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -410,7 +410,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/LinearRing} ring LinearRing geometry.
+   * @param {import("../geom/LinearRing.js").default} ring LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -446,7 +446,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/Point} geometry Point geometry.
+   * @param {import("../geom/Point.js").default} geometry Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -466,7 +466,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
+   * @param {import("../geom/MultiPoint.js").default} geometry MultiPoint geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -486,7 +486,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Point} point Point geometry.
+   * @param {import("../geom/Point.js").default} point Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -498,7 +498,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
+   * @param {import("../geom/LinearRing.js").default} geometry LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -515,7 +515,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
+   * @param {import("../geom/MultiPolygon.js").default} geometry MultiPolygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -536,7 +536,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Polygon} polygon Polygon geometry.
+   * @param {import("../geom/Polygon.js").default} polygon Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -551,7 +551,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -563,7 +563,7 @@ class GML2 extends GMLBase {
     }
     const keys = ['lowerCorner', 'upperCorner'];
     const values = [extent[0] + ' ' + extent[1], extent[2] + ' ' + extent[3]];
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       ({node: node}), this.ENVELOPE_SERIALIZERS_,
       OBJECT_PROPERTY_NODE_FACTORY,
       values,
@@ -587,7 +587,7 @@ class GML2 extends GMLBase {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML2.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
@@ -598,7 +598,7 @@ GML2.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML2.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
@@ -610,7 +610,7 @@ GML2.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML2.prototype.BOX_PARSERS_ = {
@@ -622,7 +622,7 @@ GML2.prototype.BOX_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML2.prototype.GEOMETRY_PARSERS_ = {
@@ -645,7 +645,7 @@ GML2.prototype.GEOMETRY_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML2.prototype.GEOMETRY_SERIALIZERS_ = {
@@ -677,7 +677,7 @@ GML2.prototype.GEOMETRY_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML2.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
@@ -690,7 +690,7 @@ GML2.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML2.prototype.RING_SERIALIZERS_ = {
@@ -701,7 +701,7 @@ GML2.prototype.RING_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML2.prototype.POINTMEMBER_SERIALIZERS_ = {
@@ -713,7 +713,7 @@ GML2.prototype.POINTMEMBER_SERIALIZERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML2.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
@@ -726,7 +726,7 @@ GML2.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML2.prototype.ENVELOPE_SERIALIZERS_ = {

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -52,10 +52,10 @@ const MULTIGEOMETRY_TO_MEMBER_NODENAME = {
 class GML3 extends GMLBase {
 
   /**
-   * @param {module:ol/format/GMLBase~Options=} opt_options Optional configuration object.
+   * @param {import("./GMLBase.js").Options=} opt_options Optional configuration object.
    */
   constructor(opt_options) {
-    const options = /** @type {module:ol/format/GMLBase~Options} */
+    const options = /** @type {import("./GMLBase.js").Options} */
         (opt_options ? opt_options : {});
 
     super(options);
@@ -105,10 +105,10 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
+   * @return {import("../geom/MultiLineString.js").default|undefined} MultiLineString.
    */
   readMultiCurve_(node, objectStack) {
-    /** @type {Array<module:ol/geom/LineString>} */
+    /** @type {Array<import("../geom/LineString.js").default>} */
     const lineStrings = pushParseAndPop([],
       this.MULTICURVE_PARSERS_, node, objectStack, this);
     if (lineStrings) {
@@ -123,10 +123,10 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
+   * @return {import("../geom/MultiPolygon.js").default|undefined} MultiPolygon.
    */
   readMultiSurface_(node, objectStack) {
-    /** @type {Array<module:ol/geom/Polygon>} */
+    /** @type {Array<import("../geom/Polygon.js").default>} */
     const polygons = pushParseAndPop([],
       this.MULTISURFACE_PARSERS_, node, objectStack, this);
     if (polygons) {
@@ -234,7 +234,7 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/geom/Polygon|undefined} Polygon.
+   * @return {import("../geom/Polygon.js").default|undefined} Polygon.
    */
   readSurface_(node, objectStack) {
     /** @type {Array<Array<number>>} */
@@ -258,7 +258,7 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/geom/LineString|undefined} LineString.
+   * @return {import("../geom/LineString.js").default|undefined} LineString.
    */
   readCurve_(node, objectStack) {
     /** @type {Array<number>} */
@@ -276,7 +276,7 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/extent~Extent|undefined} Envelope.
+   * @return {import("../extent.js").Extent|undefined} Envelope.
    */
   readEnvelope_(node, objectStack) {
     /** @type {Array<number>} */
@@ -380,7 +380,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/Point} value Point geometry.
+   * @param {import("../geom/Point.js").default} value Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -436,7 +436,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
+   * @param {import("../geom/LineString.js").default|import("../geom/LinearRing.js").default} value Geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -460,7 +460,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/Point} geometry Point geometry.
+   * @param {import("../geom/Point.js").default} geometry Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -477,7 +477,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {Array<*>} objectStack Node stack.
    */
   writeEnvelope(node, extent, objectStack) {
@@ -488,7 +488,7 @@ class GML3 extends GMLBase {
     }
     const keys = ['lowerCorner', 'upperCorner'];
     const values = [extent[0] + ' ' + extent[1], extent[2] + ' ' + extent[3]];
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       ({node: node}), this.ENVELOPE_SERIALIZERS_,
       OBJECT_PROPERTY_NODE_FACTORY,
       values,
@@ -497,7 +497,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
+   * @param {import("../geom/LinearRing.js").default} geometry LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -532,7 +532,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/Polygon} geometry Polygon geometry.
+   * @param {import("../geom/Polygon.js").default} geometry Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -560,7 +560,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/LineString} geometry LineString geometry.
+   * @param {import("../geom/LineString.js").default} geometry LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -585,7 +585,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
+   * @param {import("../geom/MultiPolygon.js").default} geometry MultiPolygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -606,7 +606,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
+   * @param {import("../geom/MultiPoint.js").default} geometry MultiPoint geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -626,7 +626,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
+   * @param {import("../geom/MultiLineString.js").default} geometry MultiLineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -647,7 +647,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/LinearRing} ring LinearRing geometry.
+   * @param {import("../geom/LinearRing.js").default} ring LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -659,7 +659,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Polygon} polygon Polygon geometry.
+   * @param {import("../geom/Polygon.js").default} polygon Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -674,7 +674,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Point} point Point geometry.
+   * @param {import("../geom/Point.js").default} point Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -686,7 +686,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/LineString} line LineString geometry.
+   * @param {import("../geom/LineString.js").default} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -700,7 +700,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Polygon} polygon Polygon geometry.
+   * @param {import("../geom/Polygon.js").default} polygon Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -712,7 +712,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/LineString} line LineString geometry.
+   * @param {import("../geom/LineString.js").default} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -725,11 +725,11 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
+   * @param {import("../geom/Geometry.js").default|import("../extent.js").Extent} geometry Geometry.
    * @param {Array<*>} objectStack Node stack.
    */
   writeGeometryElement(node, geometry, objectStack) {
-    const context = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[objectStack.length - 1]);
+    const context = /** @type {import("./Feature.js").WriteOptions} */ (objectStack[objectStack.length - 1]);
     const item = assign({}, context);
     item.node = node;
     let value;
@@ -741,9 +741,9 @@ class GML3 extends GMLBase {
         value = geometry;
       }
     } else {
-      value = transformWithOptions(/** @type {module:ol/geom/Geometry} */ (geometry), true, context);
+      value = transformWithOptions(/** @type {import("../geom/Geometry.js").default} */ (geometry), true, context);
     }
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       (item), this.GEOMETRY_SERIALIZERS_,
       this.GEOMETRY_NODE_FACTORY_, [value],
       objectStack, undefined, this);
@@ -751,7 +751,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Element} node Node.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @param {Array<*>} objectStack Node stack.
    */
   writeFeatureElement(node, feature, objectStack) {
@@ -788,7 +788,7 @@ class GML3 extends GMLBase {
     }
     const item = assign({}, context);
     item.node = node;
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       (item), context.serializers,
       makeSimpleNodeFactory(undefined, featureNS),
       values,
@@ -797,7 +797,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array<module:ol/Feature>} features Features.
+   * @param {Array<import("../Feature.js").default>} features Features.
    * @param {Array<*>} objectStack Node stack.
    * @private
    */
@@ -811,7 +811,7 @@ class GML3 extends GMLBase {
       this.writeFeatureElement, this);
     const item = assign({}, context);
     item.node = node;
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       (item),
       serializers,
       makeSimpleNodeFactory(featureType, featureNS), features,
@@ -848,7 +848,7 @@ class GML3 extends GMLBase {
     const multiCurve = context['multiCurve'];
     let nodeName;
     if (!Array.isArray(value)) {
-      nodeName = /** @type {module:ol/geom/Geometry} */ (value).getType();
+      nodeName = /** @type {import("../geom/Geometry.js").default} */ (value).getType();
       if (nodeName === 'MultiPolygon' && multiSurface === true) {
         nodeName = 'MultiSurface';
       } else if (nodeName === 'Polygon' && surface === true) {
@@ -868,8 +868,8 @@ class GML3 extends GMLBase {
   /**
    * Encode a geometry in GML 3.1.1 Simple Features.
    *
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @return {Node} Node.
    * @override
    * @api
@@ -890,8 +890,8 @@ class GML3 extends GMLBase {
   /**
    * Encode an array of features in the GML 3.1.1 format as an XML node.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @return {Element} Node.
    * @override
    * @api
@@ -920,7 +920,7 @@ class GML3 extends GMLBase {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
@@ -933,7 +933,7 @@ GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
@@ -946,7 +946,7 @@ GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.GEOMETRY_PARSERS_ = {
@@ -976,7 +976,7 @@ GML3.prototype.GEOMETRY_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.MULTICURVE_PARSERS_ = {
@@ -991,7 +991,7 @@ GML3.prototype.MULTICURVE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.MULTISURFACE_PARSERS_ = {
@@ -1006,7 +1006,7 @@ GML3.prototype.MULTISURFACE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.CURVEMEMBER_PARSERS_ = {
@@ -1020,7 +1020,7 @@ GML3.prototype.CURVEMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.SURFACEMEMBER_PARSERS_ = {
@@ -1033,7 +1033,7 @@ GML3.prototype.SURFACEMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.SURFACE_PARSERS_ = {
@@ -1045,7 +1045,7 @@ GML3.prototype.SURFACE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.CURVE_PARSERS_ = {
@@ -1057,7 +1057,7 @@ GML3.prototype.CURVE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.ENVELOPE_PARSERS_ = {
@@ -1072,7 +1072,7 @@ GML3.prototype.ENVELOPE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.PATCHES_PARSERS_ = {
@@ -1085,7 +1085,7 @@ GML3.prototype.PATCHES_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GML3.prototype.SEGMENTS_PARSERS_ = {
@@ -1100,8 +1100,8 @@ GML3.prototype.SEGMENTS_PARSERS_ = {
  * Encode an array of features in GML 3.1.1 Simple Features.
  *
  * @function
- * @param {Array<module:ol/Feature>} features Features.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+ * @param {Array<import("../Feature.js").default>} features Features.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api
  */
@@ -1109,7 +1109,7 @@ GML3.prototype.writeFeatures;
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML3.prototype.RING_SERIALIZERS_ = {
@@ -1121,7 +1121,7 @@ GML3.prototype.RING_SERIALIZERS_ = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML3.prototype.ENVELOPE_SERIALIZERS_ = {
@@ -1133,7 +1133,7 @@ GML3.prototype.ENVELOPE_SERIALIZERS_ = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML3.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
@@ -1147,7 +1147,7 @@ GML3.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML3.prototype.POINTMEMBER_SERIALIZERS_ = {
@@ -1159,7 +1159,7 @@ GML3.prototype.POINTMEMBER_SERIALIZERS_ = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML3.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
@@ -1173,7 +1173,7 @@ GML3.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  * @private
  */
 GML3.prototype.GEOMETRY_SERIALIZERS_ = {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -87,12 +87,12 @@ const ONLY_WHITESPACE_RE = /^[\s\xa0]*$/;
 class GMLBase extends XMLFeature {
 
   /**
-   * @param {module:ol/format/GMLBase~Options=} opt_options Optional configuration object.
+   * @param {Options=} opt_options Optional configuration object.
    */
   constructor(opt_options) {
     super();
 
-    const options = /** @type {module:ol/format/GMLBase~Options} */ (opt_options ? opt_options : {});
+    const options = /** @type {Options} */ (opt_options ? opt_options : {});
 
     /**
      * @protected
@@ -132,7 +132,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {Array<module:ol/Feature> | undefined} Features.
+   * @return {Array<import("../Feature.js").default> | undefined} Features.
    */
   readFeaturesInternal(node, objectStack) {
     const localName = node.localName;
@@ -220,17 +220,17 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/Geometry|undefined} Geometry.
+   * @return {import("../geom/Geometry.js").default|undefined} Geometry.
    */
   readGeometryElement(node, objectStack) {
     const context = /** @type {Object} */ (objectStack[0]);
     context['srsName'] = node.firstElementChild.getAttribute('srsName');
     context['srsDimension'] = node.firstElementChild.getAttribute('srsDimension');
-    /** @type {module:ol/geom/Geometry} */
+    /** @type {import("../geom/Geometry.js").default} */
     const geometry = pushParseAndPop(null, this.GEOMETRY_PARSERS_, node, objectStack, this);
     if (geometry) {
       return (
-        /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometry, false, context))
+        /** @type {import("../geom/Geometry.js").default} */ (transformWithOptions(geometry, false, context))
       );
     } else {
       return undefined;
@@ -240,7 +240,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/Feature} Feature.
+   * @return {import("../Feature.js").default} Feature.
    */
   readFeatureElement(node, objectStack) {
     let n;
@@ -281,7 +281,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/Point|undefined} Point.
+   * @return {import("../geom/Point.js").default|undefined} Point.
    */
   readPoint(node, objectStack) {
     const flatCoordinates = this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -293,7 +293,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/MultiPoint|undefined} MultiPoint.
+   * @return {import("../geom/MultiPoint.js").default|undefined} MultiPoint.
    */
   readMultiPoint(node, objectStack) {
     /** @type {Array<Array<number>>} */
@@ -309,10 +309,10 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
+   * @return {import("../geom/MultiLineString.js").default|undefined} MultiLineString.
    */
   readMultiLineString(node, objectStack) {
-    /** @type {Array<module:ol/geom/LineString>} */
+    /** @type {Array<import("../geom/LineString.js").default>} */
     const lineStrings = pushParseAndPop([],
       this.MULTILINESTRING_PARSERS_, node, objectStack, this);
     if (lineStrings) {
@@ -323,10 +323,10 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
+   * @return {import("../geom/MultiPolygon.js").default|undefined} MultiPolygon.
    */
   readMultiPolygon(node, objectStack) {
-    /** @type {Array<module:ol/geom/Polygon>} */
+    /** @type {Array<import("../geom/Polygon.js").default>} */
     const polygons = pushParseAndPop([], this.MULTIPOLYGON_PARSERS_, node, objectStack, this);
     if (polygons) {
       return new MultiPolygon(polygons);
@@ -363,7 +363,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/LineString|undefined} LineString.
+   * @return {import("../geom/LineString.js").default|undefined} LineString.
    */
   readLineString(node, objectStack) {
     const flatCoordinates = this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -395,7 +395,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/LinearRing|undefined} LinearRing.
+   * @return {import("../geom/LinearRing.js").default|undefined} LinearRing.
    */
   readLinearRing(node, objectStack) {
     const flatCoordinates = this.readFlatCoordinatesFromNode_(node, objectStack);
@@ -407,7 +407,7 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {module:ol/geom/Polygon|undefined} Polygon.
+   * @return {import("../geom/Polygon.js").default|undefined} Polygon.
    */
   readPolygon(node, objectStack) {
     /** @type {Array<Array<number>>} */
@@ -471,7 +471,7 @@ class GMLBase extends XMLFeature {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GMLBase.prototype.MULTIPOINT_PARSERS_ = {
@@ -484,7 +484,7 @@ GMLBase.prototype.MULTIPOINT_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
@@ -497,7 +497,7 @@ GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
@@ -510,7 +510,7 @@ GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GMLBase.prototype.POINTMEMBER_PARSERS_ = {
@@ -522,7 +522,7 @@ GMLBase.prototype.POINTMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
@@ -534,7 +534,7 @@ GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @private
  */
 GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
@@ -546,7 +546,7 @@ GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  * @protected
  */
 GMLBase.prototype.RING_PARSERS = {

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -38,7 +38,7 @@ const SCHEMA_LOCATION = 'http://www.topografix.com/GPX/1/1 ' +
 
 /**
  * @const
- * @type {Object<string, function(Node, Array<*>): (module:ol/Feature|undefined)>}
+ * @type {Object<string, function(Node, Array<*>): (import("../Feature.js").default|undefined)>}
  */
 const FEATURE_READER = {
   'rte': readRte,
@@ -49,7 +49,7 @@ const FEATURE_READER = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const GPX_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -61,7 +61,7 @@ const GPX_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -72,7 +72,7 @@ const LINK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const GPX_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -84,7 +84,7 @@ const GPX_SERIALIZERS = makeStructureNS(
 
 /**
  * @typedef {Object} Options
- * @property {function(module:ol/Feature, Node)} [readExtensions] Callback function
+ * @property {function(import("../Feature.js").default, Node)} [readExtensions] Callback function
  * to process `extensions` nodes. To prevent memory leaks, this callback function must
  * not store any references to the node. Note that the `extensions`
  * node is not allowed in GPX 1.0. Moreover, only `extensions`
@@ -117,7 +117,7 @@ const GPX_SERIALIZERS = makeStructureNS(
 class GPX extends XMLFeature {
 
   /**
-   * @param {module:ol/format/GPX~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();
@@ -131,14 +131,14 @@ class GPX extends XMLFeature {
     this.dataProjection = getProjection('EPSG:4326');
 
     /**
-     * @type {function(module:ol/Feature, Node)|undefined}
+     * @type {function(import("../Feature.js").default, Node)|undefined}
      * @private
      */
     this.readExtensions_ = options.readExtensions;
   }
 
   /**
-   * @param {Array<module:ol/Feature>} features List of features.
+   * @param {Array<import("../Feature.js").default>} features List of features.
    * @private
    */
   handleReadExtensions_(features) {
@@ -182,7 +182,7 @@ class GPX extends XMLFeature {
       return [];
     }
     if (node.localName == 'gpx') {
-      /** @type {Array<module:ol/Feature>} */
+      /** @type {Array<import("../Feature.js").default>} */
       const features = pushParseAndPop([], GPX_PARSERS,
         node, [this.getReadOptions(node, opt_options)]);
       if (features) {
@@ -200,8 +200,8 @@ class GPX extends XMLFeature {
    * LineString geometries are output as routes (`<rte>`), and MultiLineString
    * as tracks (`<trk>`).
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @return {Node} Node.
    * @override
    * @api
@@ -216,7 +216,7 @@ class GPX extends XMLFeature {
     gpx.setAttribute('version', '1.1');
     gpx.setAttribute('creator', 'OpenLayers');
 
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
       ({node: gpx}), GPX_SERIALIZERS, GPX_NODE_FACTORY, features, [opt_options]);
     return gpx;
   }
@@ -225,7 +225,7 @@ class GPX extends XMLFeature {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const RTE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -243,7 +243,7 @@ const RTE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const RTEPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -254,7 +254,7 @@ const RTEPT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TRK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -272,7 +272,7 @@ const TRK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TRKSEG_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -282,7 +282,7 @@ const TRKSEG_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TRKPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -293,7 +293,7 @@ const TRKPT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const WPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -328,7 +328,7 @@ const LINK_SEQUENCE = ['text', 'type'];
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const LINK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -349,7 +349,7 @@ const RTE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const RTE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -386,7 +386,7 @@ const TRK_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const TRK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -410,7 +410,7 @@ const TRKSEG_NODE_FACTORY = makeSimpleNodeFactory('trkpt');
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const TRKSEG_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -432,7 +432,7 @@ const WPT_TYPE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const WPT_TYPE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -475,7 +475,7 @@ const GEOMETRY_TYPE_TO_NODENAME = {
  * @return {Node|undefined} Node.
  */
 function GPX_NODE_FACTORY(value, objectStack, opt_nodeName) {
-  const geometry = /** @type {module:ol/Feature} */ (value).getGeometry();
+  const geometry = /** @type {import("../Feature.js").default} */ (value).getGeometry();
   if (geometry) {
     const nodeName = GEOMETRY_TYPE_TO_NODENAME[geometry.getType()];
     if (nodeName) {
@@ -488,7 +488,7 @@ function GPX_NODE_FACTORY(value, objectStack, opt_nodeName) {
 
 /**
  * @param {Array<number>} flatCoordinates Flat coordinates.
- * @param {module:ol/format/GPX~LayoutOptions} layoutOptions Layout options.
+ * @param {LayoutOptions} layoutOptions Layout options.
  * @param {Element} node Node.
  * @param {!Object} values Values.
  * @return {Array<number>} Flat coordinates.
@@ -519,10 +519,10 @@ function appendCoordinate(flatCoordinates, layoutOptions, node, values) {
  * Choose GeometryLayout based on flags in layoutOptions and adjust flatCoordinates
  * and ends arrays by shrinking them accordingly (removing unused zero entries).
  *
- * @param {module:ol/format/GPX~LayoutOptions} layoutOptions Layout options.
+ * @param {LayoutOptions} layoutOptions Layout options.
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {Array<number>=} ends Ends.
- * @return {module:ol/geom/GeometryLayout} Layout.
+ * @return {import("../geom/GeometryLayout.js").default} Layout.
  */
 function applyLayoutOptions(layoutOptions, flatCoordinates, ends) {
   let layout = GeometryLayout.XY;
@@ -592,7 +592,7 @@ function parseRtePt(node, objectStack) {
   if (values) {
     const rteValues = /** @type {!Object} */ (objectStack[objectStack.length - 1]);
     const flatCoordinates = /** @type {Array<number>} */ (rteValues['flatCoordinates']);
-    const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (rteValues['layoutOptions']);
+    const layoutOptions = /** @type {LayoutOptions} */ (rteValues['layoutOptions']);
     appendCoordinate(flatCoordinates, layoutOptions, node, values);
   }
 }
@@ -607,7 +607,7 @@ function parseTrkPt(node, objectStack) {
   if (values) {
     const trkValues = /** @type {!Object} */ (objectStack[objectStack.length - 1]);
     const flatCoordinates = /** @type {Array<number>} */ (trkValues['flatCoordinates']);
-    const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (trkValues['layoutOptions']);
+    const layoutOptions = /** @type {LayoutOptions} */ (trkValues['layoutOptions']);
     appendCoordinate(flatCoordinates, layoutOptions, node, values);
   }
 }
@@ -630,10 +630,10 @@ function parseTrkSeg(node, objectStack) {
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/Feature|undefined} Track.
+ * @return {import("../Feature.js").default|undefined} Track.
  */
 function readRte(node, objectStack) {
-  const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").ReadOptions} */ (objectStack[0]);
   const values = pushParseAndPop({
     'flatCoordinates': [],
     'layoutOptions': {}
@@ -644,7 +644,7 @@ function readRte(node, objectStack) {
   const flatCoordinates = /** @type {Array<number>} */
       (values['flatCoordinates']);
   delete values['flatCoordinates'];
-  const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (values['layoutOptions']);
+  const layoutOptions = /** @type {LayoutOptions} */ (values['layoutOptions']);
   delete values['layoutOptions'];
   const layout = applyLayoutOptions(layoutOptions, flatCoordinates);
   const geometry = new LineString(flatCoordinates, layout);
@@ -658,10 +658,10 @@ function readRte(node, objectStack) {
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/Feature|undefined} Track.
+ * @return {import("../Feature.js").default|undefined} Track.
  */
 function readTrk(node, objectStack) {
-  const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").ReadOptions} */ (objectStack[0]);
   const values = pushParseAndPop({
     'flatCoordinates': [],
     'ends': [],
@@ -675,7 +675,7 @@ function readTrk(node, objectStack) {
   delete values['flatCoordinates'];
   const ends = /** @type {Array<number>} */ (values['ends']);
   delete values['ends'];
-  const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (values['layoutOptions']);
+  const layoutOptions = /** @type {LayoutOptions} */ (values['layoutOptions']);
   delete values['layoutOptions'];
   const layout = applyLayoutOptions(layoutOptions, flatCoordinates, ends);
   const geometry = new MultiLineString(flatCoordinates, layout, ends);
@@ -689,15 +689,15 @@ function readTrk(node, objectStack) {
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/Feature|undefined} Waypoint.
+ * @return {import("../Feature.js").default|undefined} Waypoint.
  */
 function readWpt(node, objectStack) {
-  const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").ReadOptions} */ (objectStack[0]);
   const values = pushParseAndPop({}, WPT_PARSERS, node, objectStack);
   if (!values) {
     return undefined;
   }
-  const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ ({});
+  const layoutOptions = /** @type {LayoutOptions} */ ({});
   const coordinates = appendCoordinate([], layoutOptions, node, values);
   const layout = applyLayoutOptions(layoutOptions, coordinates);
   const geometry = new Point(coordinates, layout);
@@ -721,7 +721,7 @@ function writeLink(node, value, objectStack) {
     properties['linkText'],
     properties['linkType']
   ];
-  pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */ ({node: node}),
+  pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */ ({node: node}),
     LINK_SERIALIZERS, OBJECT_PROPERTY_NODE_FACTORY,
     link, objectStack, LINK_SEQUENCE);
 }
@@ -729,7 +729,7 @@ function writeLink(node, value, objectStack) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeWptType(node, coordinate, objectStack) {
@@ -764,7 +764,7 @@ function writeWptType(node, coordinate, objectStack) {
     RTEPT_TYPE_SEQUENCE[namespaceURI] :
     WPT_TYPE_SEQUENCE[namespaceURI];
   const values = makeSequence(properties, orderedKeys);
-  pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */
+  pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */
     ({node: node, 'properties': properties}),
     WPT_TYPE_SERIALIZERS, OBJECT_PROPERTY_NODE_FACTORY,
     values, objectStack, orderedKeys);
@@ -773,16 +773,16 @@ function writeWptType(node, coordinate, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeRte(node, feature, objectStack) {
-  const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").WriteOptions} */ (objectStack[0]);
   const properties = feature.getProperties();
   const context = {node: node, 'properties': properties};
   let geometry = feature.getGeometry();
   if (geometry) {
-    geometry = /** @type {module:ol/geom/LineString} */ (transformWithOptions(geometry, true, options));
+    geometry = /** @type {import("../geom/LineString.js").default} */ (transformWithOptions(geometry, true, options));
     context['geometryLayout'] = geometry.getLayout();
     properties['rtept'] = geometry.getCoordinates();
   }
@@ -797,17 +797,17 @@ function writeRte(node, feature, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeTrk(node, feature, objectStack) {
-  const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").WriteOptions} */ (objectStack[0]);
   const properties = feature.getProperties();
-  /** @type {module:ol/xml~NodeStackItem} */
+  /** @type {import("../xml.js").NodeStackItem} */
   const context = {node: node, 'properties': properties};
   let geometry = feature.getGeometry();
   if (geometry) {
-    geometry = /** @type {module:ol/geom/MultiLineString} */
+    geometry = /** @type {import("../geom/MultiLineString.js").default} */
       (transformWithOptions(geometry, true, options));
     properties['trkseg'] = geometry.getLineStrings();
   }
@@ -822,11 +822,11 @@ function writeTrk(node, feature, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LineString} lineString LineString.
+ * @param {import("../geom/LineString.js").default} lineString LineString.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeTrkSeg(node, lineString, objectStack) {
-  /** @type {module:ol/xml~NodeStackItem} */
+  /** @type {import("../xml.js").NodeStackItem} */
   const context = {node: node, 'geometryLayout': lineString.getLayout(),
     'properties': {}};
   pushSerializeAndPop(context,
@@ -837,16 +837,16 @@ function writeTrkSeg(node, lineString, objectStack) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeWpt(node, feature, objectStack) {
-  const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").WriteOptions} */ (objectStack[0]);
   const context = objectStack[objectStack.length - 1];
   context['properties'] = feature.getProperties();
   let geometry = feature.getGeometry();
   if (geometry) {
-    geometry = /** @type {module:ol/geom/Point} */
+    geometry = /** @type {import("../geom/Point.js").default} */
       (transformWithOptions(geometry, true, options));
     context['geometryLayout'] = geometry.getLayout();
     writeWptType(node, geometry.getCoordinates(), objectStack);

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -21,8 +21,8 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/proj~ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
- * @property {module:ol/proj~ProjectionLike} [featureProjection] Projection for features read or
+ * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
+ * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection for features read or
  * written by the format.  Options passed to read or write methods will take precedence.
  * @property {string} [geometryName] Geometry name to use when creating features.
  * @property {boolean} [extractGeometryName=false] Certain GeoJSON providers include
@@ -41,7 +41,7 @@ import {get as getProjection} from '../proj.js';
 class GeoJSON extends JSONFeature {
 
   /**
-   * @param {module:ol/format/GeoJSON~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -115,7 +115,7 @@ class GeoJSON extends JSONFeature {
    */
   readFeaturesFromObject(object, opt_options) {
     const geoJSONObject = /** @type {GeoJSONObject} */ (object);
-    /** @type {Array<module:ol/Feature>} */
+    /** @type {Array<import("../Feature.js").default>} */
     let features = null;
     if (geoJSONObject.type === 'FeatureCollection') {
       const geoJSONFeatureCollection = /** @type {GeoJSONFeatureCollection} */ (object);
@@ -154,15 +154,15 @@ class GeoJSON extends JSONFeature {
       projection = this.dataProjection;
     }
     return (
-      /** @type {module:ol/proj/Projection} */ (projection)
+      /** @type {import("../proj/Projection.js").default} */ (projection)
     );
   }
 
   /**
    * Encode a feature as a GeoJSON Feature object.
    *
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {GeoJSONFeature} Object.
    * @override
    * @api
@@ -196,8 +196,8 @@ class GeoJSON extends JSONFeature {
   /**
    * Encode an array of features as a GeoJSON object.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {GeoJSONFeatureCollection} GeoJSON Object.
    * @override
    * @api
@@ -217,8 +217,8 @@ class GeoJSON extends JSONFeature {
   /**
    * Encode a geometry as a GeoJSON object.
    *
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {GeoJSONGeometry|GeoJSONGeometryCollection} Object.
    * @override
    * @api
@@ -231,7 +231,7 @@ class GeoJSON extends JSONFeature {
 
 /**
  * @const
- * @type {Object<string, function(GeoJSONObject): module:ol/geom/Geometry>}
+ * @type {Object<string, function(GeoJSONObject): import("../geom/Geometry.js").default>}
  */
 const GEOMETRY_READERS = {
   'Point': readPointGeometry,
@@ -246,7 +246,7 @@ const GEOMETRY_READERS = {
 
 /**
  * @const
- * @type {Object<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (GeoJSONGeometry|GeoJSONGeometryCollection)>}
+ * @type {Object<string, function(import("../geom/Geometry.js").default, import("./Feature.js").WriteOptions=): (GeoJSONGeometry|GeoJSONGeometryCollection)>}
  */
 const GEOMETRY_WRITERS = {
   'Point': writePointGeometry,
@@ -262,8 +262,8 @@ const GEOMETRY_WRITERS = {
 
 /**
  * @param {GeoJSONGeometry|GeoJSONGeometryCollection} object Object.
- * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/Geometry} Geometry.
+ * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @return {import("../geom/Geometry.js").default} Geometry.
  */
 function readGeometry(object, opt_options) {
   if (!object) {
@@ -271,21 +271,21 @@ function readGeometry(object, opt_options) {
   }
   const geometryReader = GEOMETRY_READERS[object.type];
   return (
-    /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometryReader(object), false, opt_options))
+    /** @type {import("../geom/Geometry.js").default} */ (transformWithOptions(geometryReader(object), false, opt_options))
   );
 }
 
 
 /**
  * @param {GeoJSONGeometryCollection} object Object.
- * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/geom/GeometryCollection} Geometry collection.
+ * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @return {import("../geom/GeometryCollection.js").default} Geometry collection.
  */
 function readGeometryCollectionGeometry(object, opt_options) {
   const geometries = object.geometries.map(
     /**
      * @param {GeoJSONGeometry} geometry Geometry.
-     * @return {module:ol/geom/Geometry} geometry Geometry.
+     * @return {import("../geom/Geometry.js").default} geometry Geometry.
      */
     function(geometry) {
       return readGeometry(geometry, opt_options);
@@ -296,7 +296,7 @@ function readGeometryCollectionGeometry(object, opt_options) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/Point} Point.
+ * @return {import("../geom/Point.js").default} Point.
  */
 function readPointGeometry(object) {
   return new Point(object.coordinates);
@@ -305,7 +305,7 @@ function readPointGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/LineString} LineString.
+ * @return {import("../geom/LineString.js").default} LineString.
  */
 function readLineStringGeometry(object) {
   return new LineString(object.coordinates);
@@ -314,7 +314,7 @@ function readLineStringGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/MultiLineString} MultiLineString.
+ * @return {import("../geom/MultiLineString.js").default} MultiLineString.
  */
 function readMultiLineStringGeometry(object) {
   return new MultiLineString(object.coordinates);
@@ -323,7 +323,7 @@ function readMultiLineStringGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/MultiPoint} MultiPoint.
+ * @return {import("../geom/MultiPoint.js").default} MultiPoint.
  */
 function readMultiPointGeometry(object) {
   return new MultiPoint(object.coordinates);
@@ -332,7 +332,7 @@ function readMultiPointGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/MultiPolygon} MultiPolygon.
+ * @return {import("../geom/MultiPolygon.js").default} MultiPolygon.
  */
 function readMultiPolygonGeometry(object) {
   return new MultiPolygon(object.coordinates);
@@ -341,7 +341,7 @@ function readMultiPolygonGeometry(object) {
 
 /**
  * @param {GeoJSONGeometry} object Object.
- * @return {module:ol/geom/Polygon} Polygon.
+ * @return {import("../geom/Polygon.js").default} Polygon.
  */
 function readPolygonGeometry(object) {
   return new Polygon(object.coordinates);
@@ -349,19 +349,19 @@ function readPolygonGeometry(object) {
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry|GeoJSONGeometryCollection} GeoJSON geometry.
  */
 function writeGeometry(geometry, opt_options) {
   const geometryWriter = GEOMETRY_WRITERS[geometry.getType()];
-  return geometryWriter(/** @type {module:ol/geom/Geometry} */ (
+  return geometryWriter(/** @type {import("../geom/Geometry.js").default} */ (
     transformWithOptions(geometry, true, opt_options)), opt_options);
 }
 
 
 /**
- * @param {module:ol/geom/Geometry} geometry Geometry.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
  * @return {GeoJSONGeometryCollection} Empty GeoJSON geometry collection.
  */
 function writeEmptyGeometryCollectionGeometry(geometry) {
@@ -373,8 +373,8 @@ function writeEmptyGeometryCollectionGeometry(geometry) {
 
 
 /**
- * @param {module:ol/geom/GeometryCollection} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/GeometryCollection.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometryCollection} GeoJSON geometry collection.
  */
 function writeGeometryCollectionGeometry(geometry, opt_options) {
@@ -391,8 +391,8 @@ function writeGeometryCollectionGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/LineString} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/LineString.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeLineStringGeometry(geometry, opt_options) {
@@ -404,8 +404,8 @@ function writeLineStringGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/MultiLineString} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/MultiLineString.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeMultiLineStringGeometry(geometry, opt_options) {
@@ -417,8 +417,8 @@ function writeMultiLineStringGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/MultiPoint} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/MultiPoint.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeMultiPointGeometry(geometry, opt_options) {
@@ -430,8 +430,8 @@ function writeMultiPointGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/MultiPolygon} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeMultiPolygonGeometry(geometry, opt_options) {
@@ -447,8 +447,8 @@ function writeMultiPolygonGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Point} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Point.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writePointGeometry(geometry, opt_options) {
@@ -460,8 +460,8 @@ function writePointGeometry(geometry, opt_options) {
 
 
 /**
- * @param {module:ol/geom/Polygon} geometry Geometry.
- * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+ * @param {import("../geom/Polygon.js").default} geometry Geometry.
+ * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writePolygonGeometry(geometry, opt_options) {

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -69,7 +69,7 @@ const NEWLINE_RE = /\r\n|\r|\n/;
 class IGC extends TextFeature {
 
   /**
-   * @param {module:ol/format/IGC~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -29,8 +29,8 @@ class JSONFeature extends FeatureFormat {
    * read a feature collection.
    *
    * @param {ArrayBuffer|Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/Feature} Feature.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {import("../Feature.js").default} Feature.
    * @api
    */
   readFeature(source, opt_options) {
@@ -43,8 +43,8 @@ class JSONFeature extends FeatureFormat {
    * collection.
    *
    * @param {ArrayBuffer|Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {Array<module:ol/Feature>} Features.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   readFeatures(source, opt_options) {
@@ -55,18 +55,18 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Object} object Object.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
    * @protected
-   * @return {module:ol/Feature} Feature.
+   * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromObject(object, opt_options) {}
 
   /**
    * @abstract
    * @param {Object} object Object.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
    * @protected
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromObject(object, opt_options) {}
 
@@ -74,8 +74,8 @@ class JSONFeature extends FeatureFormat {
    * Read a geometry.
    *
    * @param {ArrayBuffer|Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    * @api
    */
   readGeometry(source, opt_options) {
@@ -86,9 +86,9 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Object} object Object.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
    * @protected
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometryFromObject(object, opt_options) {}
 
@@ -96,7 +96,7 @@ class JSONFeature extends FeatureFormat {
    * Read the projection.
    *
    * @param {ArrayBuffer|Document|Node|Object|string} source Source.
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    * @api
    */
   readProjection(source) {
@@ -107,15 +107,15 @@ class JSONFeature extends FeatureFormat {
    * @abstract
    * @param {Object} object Object.
    * @protected
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    */
   readProjectionFromObject(object) {}
 
   /**
    * Encode a feature as string.
    *
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Encoded feature.
    * @api
    */
@@ -125,8 +125,8 @@ class JSONFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {Object} Object.
    */
   writeFeatureObject(feature, opt_options) {}
@@ -134,8 +134,8 @@ class JSONFeature extends FeatureFormat {
   /**
    * Encode an array of features as string.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Encoded features.
    * @api
    */
@@ -145,8 +145,8 @@ class JSONFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {Object} Object.
    */
   writeFeaturesObject(features, opt_options) {}
@@ -154,8 +154,8 @@ class JSONFeature extends FeatureFormat {
   /**
    * Encode a geometry as string.
    *
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Encoded geometry.
    * @api
    */
@@ -165,8 +165,8 @@ class JSONFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {Object} Object.
    */
   writeGeometryObject(geometry, opt_options) {}

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -35,10 +35,10 @@ import {createElementNS, getAllTextContent, isDocument, isNode, makeArrayExtende
 /**
  * @typedef {Object} Vec2
  * @property {number} x
- * @property {module:ol/style/IconAnchorUnits} xunits
+ * @property {import("../style/IconAnchorUnits.js").default} xunits
  * @property {number} y
- * @property {module:ol/style/IconAnchorUnits} yunits
- * @property {module:ol/style/IconOrigin} origin
+ * @property {import("../style/IconAnchorUnits.js").default} yunits
+ * @property {import("../style/IconOrigin.js").default} origin
  */
 
 /**
@@ -79,7 +79,7 @@ const SCHEMA_LOCATION = 'http://www.opengis.net/kml/2.2 ' +
 
 
 /**
- * @type {Object<string, module:ol/style/IconAnchorUnits>}
+ * @type {Object<string, import("../style/IconAnchorUnits.js").default>}
  */
 const ICON_ANCHOR_UNITS_MAP = {
   'fraction': IconAnchorUnits.FRACTION,
@@ -89,7 +89,7 @@ const ICON_ANCHOR_UNITS_MAP = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PLACEMARK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -126,7 +126,7 @@ const PLACEMARK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const NETWORK_LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -144,7 +144,7 @@ const NETWORK_LINK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -154,7 +154,7 @@ const LINK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const REGION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -175,7 +175,7 @@ const KML_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const KML_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -185,40 +185,40 @@ const KML_SERIALIZERS = makeStructureNS(
 
 
 /**
- * @type {module:ol/color~Color}
+ * @type {import("../color.js").Color}
  */
 let DEFAULT_COLOR;
 
 /**
- * @type {module:ol/style/Fill}
+ * @type {import("../style/Fill.js").default}
  */
 let DEFAULT_FILL_STYLE = null;
 
 /**
  * Get the default fill style (or null if not yet set).
- * @return {module:ol/style/Fill} The default fill style.
+ * @return {import("../style/Fill.js").default} The default fill style.
  */
 export function getDefaultFillStyle() {
   return DEFAULT_FILL_STYLE;
 }
 
 /**
- * @type {module:ol/size~Size}
+ * @type {import("../size.js").Size}
  */
 let DEFAULT_IMAGE_STYLE_ANCHOR;
 
 /**
- * @type {module:ol/style/IconAnchorUnits}
+ * @type {import("../style/IconAnchorUnits.js").default}
  */
 let DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS;
 
 /**
- * @type {module:ol/style/IconAnchorUnits}
+ * @type {import("../style/IconAnchorUnits.js").default}
  */
 let DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS;
 
 /**
- * @type {module:ol/size~Size}
+ * @type {import("../size.js").Size}
  */
 let DEFAULT_IMAGE_STYLE_SIZE;
 
@@ -233,13 +233,13 @@ let DEFAULT_IMAGE_STYLE_SRC;
 let DEFAULT_IMAGE_SCALE_MULTIPLIER;
 
 /**
- * @type {module:ol/style/Image}
+ * @type {import("../style/Image.js").default}
  */
 let DEFAULT_IMAGE_STYLE = null;
 
 /**
  * Get the default image style (or null if not yet set).
- * @return {module:ol/style/Image} The default image style.
+ * @return {import("../style/Image.js").default} The default image style.
  */
 export function getDefaultImageStyle() {
   return DEFAULT_IMAGE_STYLE;
@@ -251,57 +251,57 @@ export function getDefaultImageStyle() {
 let DEFAULT_NO_IMAGE_STYLE;
 
 /**
- * @type {module:ol/style/Stroke}
+ * @type {import("../style/Stroke.js").default}
  */
 let DEFAULT_STROKE_STYLE = null;
 
 /**
  * Get the default stroke style (or null if not yet set).
- * @return {module:ol/style/Stroke} The default stroke style.
+ * @return {import("../style/Stroke.js").default} The default stroke style.
  */
 export function getDefaultStrokeStyle() {
   return DEFAULT_STROKE_STYLE;
 }
 
 /**
- * @type {module:ol/style/Stroke}
+ * @type {import("../style/Stroke.js").default}
  */
 let DEFAULT_TEXT_STROKE_STYLE;
 
 /**
- * @type {module:ol/style/Text}
+ * @type {import("../style/Text.js").default}
  */
 let DEFAULT_TEXT_STYLE = null;
 
 /**
  * Get the default text style (or null if not yet set).
- * @return {module:ol/style/Text} The default text style.
+ * @return {import("../style/Text.js").default} The default text style.
  */
 export function getDefaultTextStyle() {
   return DEFAULT_TEXT_STYLE;
 }
 
 /**
- * @type {module:ol/style/Style}
+ * @type {import("../style/Style.js").default}
  */
 let DEFAULT_STYLE = null;
 
 /**
  * Get the default style (or null if not yet set).
- * @return {module:ol/style/Style} The default style.
+ * @return {import("../style/Style.js").default} The default style.
  */
 export function getDefaultStyle() {
   return DEFAULT_STYLE;
 }
 
 /**
- * @type {Array<module:ol/style/Style>}
+ * @type {Array<import("../style/Style.js").default>}
  */
 let DEFAULT_STYLE_ARRAY = null;
 
 /**
  * Get the default style array (or null if not yet set).
- * @return {Array<module:ol/style/Style>} The default style.
+ * @return {Array<import("../style/Style.js").default>} The default style.
  */
 export function getDefaultStyleArray() {
   return DEFAULT_STYLE_ARRAY;
@@ -377,7 +377,7 @@ function createStyleDefaults() {
  * @typedef {Object} Options
  * @property {boolean} [extractStyles=true] Extract styles from the KML.
  * @property {boolean} [showPointNames=true] Show names as labels for placemarks which contain points.
- * @property {Array<module:ol/style/Style>} [defaultStyle] Default style. The
+ * @property {Array<import("../style/Style.js").default>} [defaultStyle] Default style. The
  * default default style is the same as Google Earth.
  * @property {boolean} [writeStyles=true] Write styles into KML.
  */
@@ -402,7 +402,7 @@ function createStyleDefaults() {
 class KML extends XMLFeature {
 
   /**
-   * @param {module:ol/format/KML~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();
@@ -420,7 +420,7 @@ class KML extends XMLFeature {
 
     /**
      * @private
-     * @type {Array<module:ol/style/Style>}
+     * @type {Array<import("../style/Style.js").default>}
      */
     this.defaultStyle_ = options.defaultStyle ?
       options.defaultStyle : DEFAULT_STYLE_ARRAY;
@@ -441,7 +441,7 @@ class KML extends XMLFeature {
 
     /**
      * @private
-     * @type {!Object<string, (Array<module:ol/style/Style>|string)>}
+     * @type {!Object<string, (Array<import("../style/Style.js").default>|string)>}
      */
     this.sharedStyles_ = {};
 
@@ -458,7 +458,7 @@ class KML extends XMLFeature {
    * @param {Node} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array<module:ol/Feature>|undefined} Features.
+   * @return {Array<import("../Feature.js").default>|undefined} Features.
    */
   readDocumentOrFolder_(node, objectStack) {
     // FIXME use scope somehow
@@ -470,7 +470,7 @@ class KML extends XMLFeature {
         'Style': this.readSharedStyle_.bind(this),
         'StyleMap': this.readSharedStyleMap_.bind(this)
       });
-    /** @type {Array<module:ol/Feature>} */
+    /** @type {Array<import("../Feature.js").default>} */
     const features = pushParseAndPop([], parsersNS, node, objectStack, this);
     if (features) {
       return features;
@@ -483,7 +483,7 @@ class KML extends XMLFeature {
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {module:ol/Feature|undefined} Feature.
+   * @return {import("../Feature.js").default|undefined} Feature.
    */
   readPlacemark_(node, objectStack) {
     const object = pushParseAndPop({'geometry': null},
@@ -496,7 +496,7 @@ class KML extends XMLFeature {
     if (id !== null) {
       feature.setId(id);
     }
-    const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
+    const options = /** @type {import("./Feature.js").ReadOptions} */ (objectStack[0]);
 
     const geometry = object['geometry'];
     if (geometry) {
@@ -823,8 +823,8 @@ class KML extends XMLFeature {
    * Encode an array of features in the KML format as an XML node. GeometryCollections,
    * MultiPoints, MultiLineStrings, and MultiPolygons are output as MultiGeometries.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @return {Node} Node.
    * @override
    * @api
@@ -837,7 +837,7 @@ class KML extends XMLFeature {
     kml.setAttributeNS(xmlnsUri, 'xmlns:xsi', XML_SCHEMA_INSTANCE_URI);
     kml.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', SCHEMA_LOCATION);
 
-    const /** @type {module:ol/xml~NodeStackItem} */ context = {node: kml};
+    const /** @type {import("../xml.js").NodeStackItem} */ context = {node: kml};
     const properties = {};
     if (features.length > 1) {
       properties['Document'] = features;
@@ -855,9 +855,9 @@ class KML extends XMLFeature {
 
 
 /**
- * @param {module:ol/style/Style|undefined} foundStyle Style.
+ * @param {import("../style/Style.js").default|undefined} foundStyle Style.
  * @param {string} name Name.
- * @return {module:ol/style/Style} style Style.
+ * @return {import("../style/Style.js").default} style Style.
  */
 function createNameStyleFunction(foundStyle, name) {
   let textStyle = null;
@@ -902,24 +902,24 @@ function createNameStyleFunction(foundStyle, name) {
 
 
 /**
- * @param {Array<module:ol/style/Style>|undefined} style Style.
+ * @param {Array<import("../style/Style.js").default>|undefined} style Style.
  * @param {string} styleUrl Style URL.
- * @param {Array<module:ol/style/Style>} defaultStyle Default style.
- * @param {!Object<string, (Array<module:ol/style/Style>|string)>} sharedStyles Shared styles.
+ * @param {Array<import("../style/Style.js").default>} defaultStyle Default style.
+ * @param {!Object<string, (Array<import("../style/Style.js").default>|string)>} sharedStyles Shared styles.
  * @param {boolean|undefined} showPointNames true to show names for point placemarks.
- * @return {module:ol/style/Style~StyleFunction} Feature style function.
+ * @return {import("../style/Style.js").StyleFunction} Feature style function.
  */
 function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles, showPointNames) {
 
   return (
     /**
-     * @param {module:ol/Feature} feature feature.
+     * @param {import("../Feature.js").default} feature feature.
      * @param {number} resolution Resolution.
-     * @return {Array<module:ol/style/Style>} Style.
+     * @return {Array<import("../style/Style.js").default>} Style.
      */
     function(feature, resolution) {
       let drawName = showPointNames;
-      /** @type {module:ol/style/Style|undefined} */
+      /** @type {import("../style/Style.js").default|undefined} */
       let nameStyle;
       let name = '';
       if (drawName) {
@@ -960,11 +960,11 @@ function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles,
 
 
 /**
- * @param {Array<module:ol/style/Style>|string|undefined} styleValue Style value.
- * @param {Array<module:ol/style/Style>} defaultStyle Default style.
- * @param {!Object<string, (Array<module:ol/style/Style>|string)>} sharedStyles
+ * @param {Array<import("../style/Style.js").default>|string|undefined} styleValue Style value.
+ * @param {Array<import("../style/Style.js").default>} defaultStyle Default style.
+ * @param {!Object<string, (Array<import("../style/Style.js").default>|string)>} sharedStyles
  * Shared styles.
- * @return {Array<module:ol/style/Style>} Style.
+ * @return {Array<import("../style/Style.js").default>} Style.
  */
 function findStyle(styleValue, defaultStyle, sharedStyles) {
   if (Array.isArray(styleValue)) {
@@ -985,7 +985,7 @@ function findStyle(styleValue, defaultStyle, sharedStyles) {
 
 /**
  * @param {Node} node Node.
- * @return {module:ol/color~Color|undefined} Color.
+ * @return {import("../color.js").Color|undefined} Color.
  */
 function readColor(node) {
   const s = getAllTextContent(node, false);
@@ -1054,7 +1054,7 @@ function readURI(node) {
 
 /**
  * @param {Element} node Node.
- * @return {module:ol/format/KML~Vec2} Vec2.
+ * @return {Vec2} Vec2.
  */
 function readVec2(node) {
   const xunits = node.getAttribute('xunits');
@@ -1094,7 +1094,7 @@ function readScale(node) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const STYLE_MAP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1105,7 +1105,7 @@ const STYLE_MAP_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {Array<module:ol/style/Style>|string|undefined} StyleMap.
+ * @return {Array<import("../style/Style.js").default>|string|undefined} StyleMap.
  */
 function readStyleMapValue(node, objectStack) {
   return pushParseAndPop(undefined,
@@ -1115,7 +1115,7 @@ function readStyleMapValue(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const ICON_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1155,7 +1155,7 @@ function iconStyleParser(node, objectStack) {
   }
   let anchor, anchorXUnits, anchorYUnits;
   let anchorOrigin = IconOrigin.BOTTOM_LEFT;
-  const hotSpot = /** @type {module:ol/format/KML~Vec2|undefined} */
+  const hotSpot = /** @type {Vec2|undefined} */
       (object['hotSpot']);
   if (hotSpot) {
     anchor = [hotSpot.x, hotSpot.y];
@@ -1231,7 +1231,7 @@ function iconStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LABEL_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1254,7 +1254,7 @@ function labelStyleParser(node, objectStack) {
   const styleObject = objectStack[objectStack.length - 1];
   const textStyle = new Text({
     fill: new Fill({
-      color: /** @type {module:ol/color~Color} */
+      color: /** @type {import("../color.js").Color} */
           ('color' in object ? object['color'] : DEFAULT_COLOR)
     }),
     scale: /** @type {number|undefined} */
@@ -1266,7 +1266,7 @@ function labelStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LINE_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1292,7 +1292,7 @@ function lineStyleParser(node, objectStack) {
   }
   const styleObject = objectStack[objectStack.length - 1];
   const strokeStyle = new Stroke({
-    color: /** @type {module:ol/color~Color} */
+    color: /** @type {import("../color.js").Color} */
         ('color' in object ? object['color'] : DEFAULT_COLOR),
     width: /** @type {number} */ ('width' in object ? object['width'] : 1)
   });
@@ -1302,7 +1302,7 @@ function lineStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const POLY_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1325,7 +1325,7 @@ function polyStyleParser(node, objectStack) {
   }
   const styleObject = objectStack[objectStack.length - 1];
   const fillStyle = new Fill({
-    color: /** @type {module:ol/color~Color} */
+    color: /** @type {import("../color.js").Color} */
         ('color' in object ? object['color'] : DEFAULT_COLOR)
   });
   styleObject['fillStyle'] = fillStyle;
@@ -1342,7 +1342,7 @@ function polyStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const FLAT_LINEAR_RING_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1366,7 +1366,7 @@ function readFlatLinearRing(node, objectStack) {
  * @param {Array<*>} objectStack Object stack.
  */
 function gxCoordParser(node, objectStack) {
-  const gxTrackObject = /** @type {module:ol/format/KML~GxTrackObject} */
+  const gxTrackObject = /** @type {GxTrackObject} */
       (objectStack[objectStack.length - 1]);
   const flatCoordinates = gxTrackObject.flatCoordinates;
   const s = getAllTextContent(node, false);
@@ -1386,7 +1386,7 @@ function gxCoordParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
   GX_NAMESPACE_URIS, {
@@ -1397,7 +1397,7 @@ const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
+ * @return {import("../geom/MultiLineString.js").default|undefined} MultiLineString.
  */
 function readGxMultiTrack(node, objectStack) {
   const lineStrings = pushParseAndPop([],
@@ -1411,7 +1411,7 @@ function readGxMultiTrack(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const GX_TRACK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1425,11 +1425,11 @@ const GX_TRACK_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/LineString|undefined} LineString.
+ * @return {import("../geom/LineString.js").default|undefined} LineString.
  */
 function readGxTrack(node, objectStack) {
   const gxTrackObject = pushParseAndPop(
-    /** @type {module:ol/format/KML~GxTrackObject} */ ({
+    /** @type {GxTrackObject} */ ({
       flatCoordinates: [],
       whens: []
     }), GX_TRACK_PARSERS, node, objectStack);
@@ -1447,7 +1447,7 @@ function readGxTrack(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const ICON_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1479,7 +1479,7 @@ function readIcon(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const GEOMETRY_FLAT_COORDINATES_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1500,7 +1500,7 @@ function readFlatCoordinatesFromNode(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1513,7 +1513,7 @@ const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/LineString|undefined} LineString.
+ * @return {import("../geom/LineString.js").default|undefined} LineString.
  */
 function readLineString(node, objectStack) {
   const properties = pushParseAndPop({},
@@ -1534,7 +1534,7 @@ function readLineString(node, objectStack) {
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/Polygon|undefined} Polygon.
+ * @return {import("../geom/Polygon.js").default|undefined} Polygon.
  */
 function readLinearRing(node, objectStack) {
   const properties = pushParseAndPop({},
@@ -1554,7 +1554,7 @@ function readLinearRing(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const MULTI_GEOMETRY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1569,7 +1569,7 @@ const MULTI_GEOMETRY_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/Geometry} Geometry.
+ * @return {import("../geom/Geometry.js").default} Geometry.
  */
 function readMultiGeometry(node, objectStack) {
   const geometries = pushParseAndPop([],
@@ -1580,7 +1580,7 @@ function readMultiGeometry(node, objectStack) {
   if (geometries.length === 0) {
     return new GeometryCollection(geometries);
   }
-  /** @type {module:ol/geom/Geometry} */
+  /** @type {import("../geom/Geometry.js").default} */
   let multiGeometry;
   let homogeneous = true;
   const type = geometries[0].getType();
@@ -1620,7 +1620,7 @@ function readMultiGeometry(node, objectStack) {
     multiGeometry = new GeometryCollection(geometries);
   }
   return (
-    /** @type {module:ol/geom/Geometry} */ (multiGeometry)
+    /** @type {import("../geom/Geometry.js").default} */ (multiGeometry)
   );
 }
 
@@ -1628,7 +1628,7 @@ function readMultiGeometry(node, objectStack) {
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/Point|undefined} Point.
+ * @return {import("../geom/Point.js").default|undefined} Point.
  */
 function readPoint(node, objectStack) {
   const properties = pushParseAndPop({},
@@ -1648,7 +1648,7 @@ function readPoint(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1660,7 +1660,7 @@ const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/geom/Polygon|undefined} Polygon.
+ * @return {import("../geom/Polygon.js").default|undefined} Polygon.
  */
 function readPolygon(node, objectStack) {
   const properties = pushParseAndPop(/** @type {Object<string,*>} */ ({}),
@@ -1686,7 +1686,7 @@ function readPolygon(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1700,7 +1700,7 @@ const STYLE_PARSERS = makeStructureNS(
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {Array<module:ol/style/Style>} Style.
+ * @return {Array<import("../style/Style.js").default>} Style.
  */
 function readStyle(node, objectStack) {
   const styleObject = pushParseAndPop(
@@ -1708,23 +1708,23 @@ function readStyle(node, objectStack) {
   if (!styleObject) {
     return null;
   }
-  let fillStyle = /** @type {module:ol/style/Fill} */
+  let fillStyle = /** @type {import("../style/Fill.js").default} */
       ('fillStyle' in styleObject ?
         styleObject['fillStyle'] : DEFAULT_FILL_STYLE);
   const fill = /** @type {boolean|undefined} */ (styleObject['fill']);
   if (fill !== undefined && !fill) {
     fillStyle = null;
   }
-  let imageStyle = /** @type {module:ol/style/Image} */
+  let imageStyle = /** @type {import("../style/Image.js").default} */
       ('imageStyle' in styleObject ?
         styleObject['imageStyle'] : DEFAULT_IMAGE_STYLE);
   if (imageStyle == DEFAULT_NO_IMAGE_STYLE) {
     imageStyle = undefined;
   }
-  const textStyle = /** @type {module:ol/style/Text} */
+  const textStyle = /** @type {import("../style/Text.js").default} */
       ('textStyle' in styleObject ?
         styleObject['textStyle'] : DEFAULT_TEXT_STYLE);
-  let strokeStyle = /** @type {module:ol/style/Stroke} */
+  let strokeStyle = /** @type {import("../style/Stroke.js").default} */
       ('strokeStyle' in styleObject ?
         styleObject['strokeStyle'] : DEFAULT_STROKE_STYLE);
   const outline = /** @type {boolean|undefined} */
@@ -1745,8 +1745,8 @@ function readStyle(node, objectStack) {
 /**
  * Reads an array of geometries and creates arrays for common geometry
  * properties. Then sets them to the multi geometry.
- * @param {module:ol/geom/MultiPoint|module:ol/geom/MultiLineString|module:ol/geom/MultiPolygon} multiGeometry A multi-geometry.
- * @param {Array<module:ol/geom/Geometry>} geometries List of geometries.
+ * @param {import("../geom/MultiPoint.js").default|import("../geom/MultiLineString.js").default|import("../geom/MultiPolygon.js").default} multiGeometry A multi-geometry.
+ * @param {Array<import("../geom/Geometry.js").default>} geometries List of geometries.
  */
 function setCommonGeometryProperties(multiGeometry, geometries) {
   const ii = geometries.length;
@@ -1778,7 +1778,7 @@ function setCommonGeometryProperties(multiGeometry, geometries) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1806,7 +1806,7 @@ function dataParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const EXTENDED_DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1833,7 +1833,7 @@ function regionParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PAIR_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1861,7 +1861,7 @@ function pairDataParser(node, objectStack) {
     if (styleUrl) {
       objectStack[objectStack.length - 1] = styleUrl;
     }
-    const Style = /** @type {module:ol/style/Style} */
+    const Style = /** @type {import("../style/Style.js").default} */
         (pairObject['Style']);
     if (Style) {
       objectStack[objectStack.length - 1] = Style;
@@ -1892,7 +1892,7 @@ function placemarkStyleMapParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const SCHEMA_DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1925,7 +1925,7 @@ function simpleDataParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LAT_LON_ALT_BOX_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1964,7 +1964,7 @@ function latLonAltBoxParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LOD_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1994,7 +1994,7 @@ function lodParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2020,7 +2020,7 @@ function innerBoundaryIsParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const OUTER_BOUNDARY_IS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2058,7 +2058,7 @@ function linkParser(node, objectStack) {
  * @param {Array<*>} objectStack Object stack.
  */
 function whenParser(node, objectStack) {
-  const gxTrackObject = /** @type {module:ol/format/KML~GxTrackObject} */
+  const gxTrackObject = /** @type {GxTrackObject} */
       (objectStack[objectStack.length - 1]);
   const whens = gxTrackObject.whens;
   const s = getAllTextContent(node, false);
@@ -2069,7 +2069,7 @@ function whenParser(node, objectStack) {
 
 /**
  * @param {Node} node Node to append a TextNode with the color to.
- * @param {module:ol/color~Color|string} color Color.
+ * @param {import("../color.js").Color|string} color Color.
  */
 function writeColorTextNode(node, color) {
   const rgba = asArray(color);
@@ -2125,7 +2125,7 @@ function writeCoordinatesTextNode(node, coordinates, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const EXTENDEDDATA_NODE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2142,7 +2142,7 @@ const EXTENDEDDATA_NODE_SERIALIZERS = makeStructureNS(
  */
 function writeDataNode(node, pair, objectStack) {
   node.setAttribute('name', pair.name);
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const value = pair.value;
 
   if (typeof value == 'object') {
@@ -2182,7 +2182,7 @@ function writeDataNodeValue(node, value) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const DOCUMENT_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2205,12 +2205,12 @@ const DOCUMENT_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
 
 /**
  * @param {Node} node Node.
- * @param {Array<module:ol/Feature>} features Features.
+ * @param {Array<import("../Feature.js").default>} features Features.
  * @param {Array<*>} objectStack Object stack.
- * @this {module:ol/format/KML}
+ * @this {import("./KML.js").default}
  */
 function writeDocument(node, features, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   pushSerializeAndPop(context, DOCUMENT_SERIALIZERS,
     DOCUMENT_NODE_FACTORY, features, objectStack, undefined,
     this);
@@ -2231,7 +2231,7 @@ const DATA_NODE_FACTORY = makeSimpleNodeFactory('Data');
  * @param {Array<*>} objectStack Object stack.
  */
 function writeExtendedData(node, namesAndValues, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const names = namesAndValues.names;
   const values = namesAndValues.values;
   const length = names.length;
@@ -2258,7 +2258,7 @@ const ICON_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const ICON_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2291,7 +2291,7 @@ const GX_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
  * @param {Array<*>} objectStack Object stack.
  */
 function writeIcon(node, icon, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const parentNode = objectStack[objectStack.length - 1].node;
   let orderedKeys = ICON_SEQUENCE[parentNode.namespaceURI];
   let values = makeSequence(icon, orderedKeys);
@@ -2318,7 +2318,7 @@ const ICON_STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const ICON_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2331,11 +2331,11 @@ const ICON_STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Icon} style Icon style.
+ * @param {import("../style/Icon.js").default} style Icon style.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeIconStyle(node, style, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const properties = {};
   const src = style.getSrc();
   const size = style.getSize();
@@ -2356,7 +2356,7 @@ function writeIconStyle(node, style, objectStack) {
     }
 
     if (anchor && (anchor[0] !== size[0] / 2 || anchor[1] !== size[1] / 2)) {
-      const /** @type {module:ol/format/KML~Vec2} */ hotSpot = {
+      const /** @type {Vec2} */ hotSpot = {
         x: anchor[0],
         xunits: IconAnchorUnits.PIXELS,
         y: size[1] - anchor[1],
@@ -2398,7 +2398,7 @@ const LABEL_STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const LABEL_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2409,11 +2409,11 @@ const LABEL_STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Text} style style.
+ * @param {import("../style/Text.js").default} style style.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeLabelStyle(node, style, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const properties = {};
   const fill = style.getFill();
   if (fill) {
@@ -2444,7 +2444,7 @@ const LINE_STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const LINE_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2455,11 +2455,11 @@ const LINE_STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Stroke} style style.
+ * @param {import("../style/Stroke.js").default} style style.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeLineStyle(node, style, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const properties = {
     'color': style.getColor(),
     'width': style.getWidth()
@@ -2499,7 +2499,7 @@ const GEOMETRY_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
   if (value) {
     const parentNode = objectStack[objectStack.length - 1].node;
     return createElementNS(parentNode.namespaceURI,
-      GEOMETRY_TYPE_TO_NODENAME[/** @type {module:ol/geom/Geometry} */ (value).getType()]);
+      GEOMETRY_TYPE_TO_NODENAME[/** @type {import("../geom/Geometry.js").default} */ (value).getType()]);
   }
 };
 
@@ -2538,7 +2538,7 @@ const POLYGON_NODE_FACTORY = makeSimpleNodeFactory('Polygon');
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const MULTI_GEOMETRY_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2554,30 +2554,30 @@ const MULTI_GEOMETRY_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Geometry} geometry Geometry.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeMultiGeometry(node, geometry, objectStack) {
-  /** @type {module:ol/xml~NodeStackItem} */
+  /** @type {import("../xml.js").NodeStackItem} */
   const context = {node: node};
   const type = geometry.getType();
-  /** @type {Array<module:ol/geom/Geometry>} */
+  /** @type {Array<import("../geom/Geometry.js").default>} */
   let geometries;
   /** @type {function(*, Array<*>, string=): (Node|undefined)} */
   let factory;
   if (type == GeometryType.GEOMETRY_COLLECTION) {
-    geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
+    geometries = /** @type {import("../geom/GeometryCollection.js").default} */ (geometry).getGeometries();
     factory = GEOMETRY_NODE_FACTORY;
   } else if (type == GeometryType.MULTI_POINT) {
-    geometries = /** @type {module:ol/geom/MultiPoint} */ (geometry).getPoints();
+    geometries = /** @type {import("../geom/MultiPoint.js").default} */ (geometry).getPoints();
     factory = POINT_NODE_FACTORY;
   } else if (type == GeometryType.MULTI_LINE_STRING) {
     geometries =
-        (/** @type {module:ol/geom/MultiLineString} */ (geometry)).getLineStrings();
+        (/** @type {import("../geom/MultiLineString.js").default} */ (geometry)).getLineStrings();
     factory = LINE_STRING_NODE_FACTORY;
   } else if (type == GeometryType.MULTI_POLYGON) {
     geometries =
-        (/** @type {module:ol/geom/MultiPolygon} */ (geometry)).getPolygons();
+        (/** @type {import("../geom/MultiPolygon.js").default} */ (geometry)).getPolygons();
     factory = POLYGON_NODE_FACTORY;
   } else {
     assert(false, 39); // Unknown geometry type
@@ -2590,7 +2590,7 @@ function writeMultiGeometry(node, geometry, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const BOUNDARY_IS_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2601,11 +2601,11 @@ const BOUNDARY_IS_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/LinearRing} linearRing Linear ring.
+ * @param {import("../geom/LinearRing.js").default} linearRing Linear ring.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeBoundaryIs(node, linearRing, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   pushSerializeAndPop(context,
     BOUNDARY_IS_SERIALIZERS,
     LINEAR_RING_NODE_FACTORY, [linearRing], objectStack);
@@ -2614,7 +2614,7 @@ function writeBoundaryIs(node, linearRing, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const PLACEMARK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2658,12 +2658,12 @@ const EXTENDEDDATA_NODE_FACTORY = makeSimpleNodeFactory('ExtendedData');
  * FIXME currently we do serialize arbitrary/custom feature properties
  * (ExtendedData).
  * @param {Element} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Object stack.
- * @this {module:ol/format/KML}
+ * @this {import("./KML.js").default}
  */
 function writePlacemark(node, feature, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
 
   // set id
   if (feature.getId()) {
@@ -2711,7 +2711,7 @@ function writePlacemark(node, feature, objectStack) {
     OBJECT_PROPERTY_NODE_FACTORY, values, objectStack, orderedKeys);
 
   // serialize geometry
-  const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").WriteOptions} */ (objectStack[0]);
   let geometry = feature.getGeometry();
   if (geometry) {
     geometry = transformWithOptions(geometry, true, options);
@@ -2733,7 +2733,7 @@ const PRIMITIVE_GEOMETRY_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const PRIMITIVE_GEOMETRY_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2746,12 +2746,12 @@ const PRIMITIVE_GEOMETRY_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
+ * @param {import("../geom/SimpleGeometry.js").default} geometry Geometry.
  * @param {Array<*>} objectStack Object stack.
  */
 function writePrimitiveGeometry(node, geometry, objectStack) {
   const flatCoordinates = geometry.getFlatCoordinates();
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   context['layout'] = geometry.getLayout();
   context['stride'] = geometry.getStride();
 
@@ -2769,7 +2769,7 @@ function writePrimitiveGeometry(node, geometry, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const POLYGON_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2798,13 +2798,13 @@ const OUTER_BOUNDARY_NODE_FACTORY = makeSimpleNodeFactory('outerBoundaryIs');
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/geom/Polygon} polygon Polygon.
+ * @param {import("../geom/Polygon.js").default} polygon Polygon.
  * @param {Array<*>} objectStack Object stack.
  */
 function writePolygon(node, polygon, objectStack) {
   const linearRings = polygon.getLinearRings();
   const outerRing = linearRings.shift();
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   // inner rings
   pushSerializeAndPop(context,
     POLYGON_SERIALIZERS,
@@ -2820,7 +2820,7 @@ function writePolygon(node, polygon, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const POLY_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2838,11 +2838,11 @@ const COLOR_NODE_FACTORY = makeSimpleNodeFactory('color');
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Fill} style Style.
+ * @param {import("../style/Fill.js").default} style Style.
  * @param {Array<*>} objectStack Object stack.
  */
 function writePolyStyle(node, style, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   pushSerializeAndPop(context, POLY_STYLE_SERIALIZERS,
     COLOR_NODE_FACTORY, [style.getColor()], objectStack);
 }
@@ -2871,7 +2871,7 @@ const STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2884,11 +2884,11 @@ const STYLE_SERIALIZERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/style/Style} style Style.
+ * @param {import("../style/Style.js").default} style Style.
  * @param {Array<*>} objectStack Object stack.
  */
 function writeStyle(node, style, objectStack) {
-  const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
+  const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const properties = {};
   const fillStyle = style.getFill();
   const strokeStyle = style.getStroke();
@@ -2916,7 +2916,7 @@ function writeStyle(node, style, objectStack) {
 
 /**
  * @param {Element} node Node to append a TextNode with the Vec2 to.
- * @param {module:ol/format/KML~Vec2} vec2 Vec2.
+ * @param {Vec2} vec2 Vec2.
  */
 function writeVec2(node, vec2) {
   node.setAttribute('x', vec2.x);

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -23,7 +23,7 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {function((module:ol/geom/Geometry|Object<string,*>)=)|function(module:ol/geom/GeometryType,Array<number>,(Array<number>|Array<Array<number>>),Object<string,*>,number)} [featureClass]
+ * @property {function((import("../geom/Geometry.js").default|Object<string,*>)=)|function(import("../geom/GeometryType.js").default,Array<number>,(Array<number>|Array<Array<number>>),Object<string,*>,number)} [featureClass]
  * Class for features returned by {@link module:ol/format/MVT#readFeatures}. Set to
  * {@link module:ol/Feature~Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link module:ol/render/Feature~RenderFeature},
@@ -41,13 +41,13 @@ import RenderFeature from '../render/Feature.js';
  * @classdesc
  * Feature format for reading data in the Mapbox MVT format.
  *
- * @param {module:ol/format/MVT~Options=} opt_options Options.
+ * @param {Options=} opt_options Options.
  * @api
  */
 class MVT extends FeatureFormat {
 
   /**
-   * @param {module:ol/format/MVT~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();
@@ -55,7 +55,7 @@ class MVT extends FeatureFormat {
     const options = opt_options ? opt_options : {};
 
     /**
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      */
     this.dataProjection = new Projection({
       code: '',
@@ -64,8 +64,8 @@ class MVT extends FeatureFormat {
 
     /**
      * @private
-     * @type {function((module:ol/geom/Geometry|Object<string,*>)=)|
-     *     function(module:ol/geom/GeometryType,Array<number>,
+     * @type {function((import("../geom/Geometry.js").default|Object<string,*>)=)|
+     *     function(import("../geom/GeometryType.js").default,Array<number>,
      *         (Array<number>|Array<Array<number>>),Object<string,*>,number)}
      */
     this.featureClass_ = options.featureClass ?
@@ -91,7 +91,7 @@ class MVT extends FeatureFormat {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.extent_ = null;
 
@@ -166,8 +166,8 @@ class MVT extends FeatureFormat {
    * @private
    * @param {Object} pbf PBF
    * @param {Object} rawFeature Raw Mapbox feature.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/Feature|module:ol/render/Feature} Feature.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {import("../Feature.js").default|import("../render/Feature.js").default} Feature.
    */
   createFeature_(pbf, rawFeature, opt_options) {
     const type = rawFeature.type;
@@ -252,7 +252,7 @@ class MVT extends FeatureFormat {
 
     const pbf = new PBF(/** @type {ArrayBuffer} */ (source));
     const pbfLayers = pbf.readFields(layersPBFReader, {});
-    /** @type {Array<module:ol/Feature|module:ol/render/Feature>} */
+    /** @type {Array<import("../Feature.js").default|import("../render/Feature.js").default>} */
     const features = [];
     for (const name in pbfLayers) {
       if (layers && layers.indexOf(name) == -1) {
@@ -397,10 +397,10 @@ function readRawFeature(pbf, layer, i) {
  * @param {number} type The raw feature's geometry type
  * @param {number} numEnds Number of ends of the flat coordinates of the
  * geometry.
- * @return {module:ol/geom/GeometryType} The geometry type.
+ * @return {import("../geom/GeometryType.js").default} The geometry type.
  */
 function getGeometryType(type, numEnds) {
-  /** @type {module:ol/geom/GeometryType} */
+  /** @type {import("../geom/GeometryType.js").default} */
   let geometryType;
   if (type === 1) {
     geometryType = numEnds === 1 ?

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -24,7 +24,7 @@ const NAMESPACE_URIS = [null];
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const WAY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -35,7 +35,7 @@ const WAY_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -106,7 +106,7 @@ class OSMXML extends XMLFeature {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const NODE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -119,10 +119,10 @@ const NODE_PARSERS = makeStructureNS(
  * @param {Array<*>} objectStack Object stack.
  */
 function readNode(node, objectStack) {
-  const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
+  const options = /** @type {import("./Feature.js").ReadOptions} */ (objectStack[0]);
   const state = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const id = node.getAttribute('id');
-  /** @type {module:ol/coordinate~Coordinate} */
+  /** @type {import("../coordinate.js").Coordinate} */
   const coordinates = [
     parseFloat(node.getAttribute('lon')),
     parseFloat(node.getAttribute('lat'))

--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -16,7 +16,7 @@ const NAMESPACE_URIS = [null, 'http://www.opengis.net/ows/1.1'];
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -56,7 +56,7 @@ class OWS extends XML {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const ADDRESS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -71,7 +71,7 @@ const ADDRESS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const ALLOWED_VALUES_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -81,7 +81,7 @@ const ALLOWED_VALUES_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CONSTRAINT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -91,7 +91,7 @@ const CONSTRAINT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CONTACT_INFO_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -102,7 +102,7 @@ const CONTACT_INFO_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const DCP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -112,7 +112,7 @@ const DCP_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const HTTP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -123,7 +123,7 @@ const HTTP_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const OPERATION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -133,7 +133,7 @@ const OPERATION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const OPERATIONS_METADATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -143,7 +143,7 @@ const OPERATIONS_METADATA_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PHONE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -154,7 +154,7 @@ const PHONE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const REQUEST_METHOD_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -164,7 +164,7 @@ const REQUEST_METHOD_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const SERVICE_CONTACT_PARSERS =
     makeStructureNS(
@@ -177,7 +177,7 @@ const SERVICE_CONTACT_PARSERS =
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const SERVICE_IDENTIFICATION_PARSERS =
     makeStructureNS(
@@ -193,7 +193,7 @@ const SERVICE_IDENTIFICATION_PARSERS =
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const SERVICE_PROVIDER_PARSERS =
     makeStructureNS(

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -16,7 +16,7 @@ import {get as getProjection} from '../proj.js';
 /**
  * @typedef {Object} Options
  * @property {number} [factor=1e5] The factor by which the coordinates values will be scaled.
- * @property {module:ol/geom/GeometryLayout} [geometryLayout='XY'] Layout of the
+ * @property {import("../geom/GeometryLayout.js").default} [geometryLayout='XY'] Layout of the
  * feature geometries created by the format reader.
  */
 
@@ -38,7 +38,7 @@ import {get as getProjection} from '../proj.js';
 class Polyline extends TextFeature {
 
   /**
-   * @param {module:ol/format/Polyline~Options=} opt_options Optional configuration object.
+   * @param {Options=} opt_options Optional configuration object.
    */
   constructor(opt_options) {
     super();
@@ -59,7 +59,7 @@ class Polyline extends TextFeature {
 
     /**
      * @private
-     * @type {module:ol/geom/GeometryLayout}
+     * @type {import("../geom/GeometryLayout.js").default}
      */
     this.geometryLayout_ = options.geometryLayout ?
       options.geometryLayout : GeometryLayout.XY;
@@ -91,7 +91,7 @@ class Polyline extends TextFeature {
     const coordinates = inflateCoordinates(flatCoordinates, 0, flatCoordinates.length, stride);
 
     return (
-      /** @type {module:ol/geom/Geometry} */ (transformWithOptions(
+      /** @type {import("../geom/Geometry.js").default} */ (transformWithOptions(
         new LineString(coordinates, this.geometryLayout_),
         false,
         this.adaptOptions(opt_options)
@@ -123,7 +123,7 @@ class Polyline extends TextFeature {
    * @inheritDoc
    */
   writeGeometryText(geometry, opt_options) {
-    geometry = /** @type {module:ol/geom/LineString} */
+    geometry = /** @type {import("../geom/LineString.js").default} */
       (transformWithOptions(geometry, true, this.adaptOptions(opt_options)));
     const flatCoordinates = geometry.getFlatCoordinates();
     const stride = geometry.getStride();

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -28,8 +28,8 @@ class TextFeature extends FeatureFormat {
    * Read the feature from the source.
    *
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/Feature} Feature.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {import("../Feature.js").default} Feature.
    * @api
    */
   readFeature(source, opt_options) {
@@ -39,9 +39,9 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {string} text Text.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
    * @protected
-   * @return {module:ol/Feature} Feature.
+   * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromText(text, opt_options) {}
 
@@ -49,8 +49,8 @@ class TextFeature extends FeatureFormat {
    * Read the features from the source.
    *
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {Array<module:ol/Feature>} Features.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   readFeatures(source, opt_options) {
@@ -60,9 +60,9 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {string} text Text.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
    * @protected
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromText(text, opt_options) {}
 
@@ -70,8 +70,8 @@ class TextFeature extends FeatureFormat {
    * Read the geometry from the source.
    *
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    * @api
    */
   readGeometry(source, opt_options) {
@@ -81,9 +81,9 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {string} text Text.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
    * @protected
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometryFromText(text, opt_options) {}
 
@@ -92,7 +92,7 @@ class TextFeature extends FeatureFormat {
    *
    * @function
    * @param {Document|Node|Object|string} source Source.
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    * @api
    */
   readProjection(source) {
@@ -102,7 +102,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @param {string} text Text.
    * @protected
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    */
   readProjectionFromText(text) {
     return this.dataProjection;
@@ -112,8 +112,8 @@ class TextFeature extends FeatureFormat {
    * Encode a feature as a string.
    *
    * @function
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Encoded feature.
    * @api
    */
@@ -123,8 +123,8 @@ class TextFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {module:ol/Feature} feature Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../Feature.js").default} feature Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @protected
    * @return {string} Text.
    */
@@ -133,8 +133,8 @@ class TextFeature extends FeatureFormat {
   /**
    * Encode an array of features as string.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Encoded features.
    * @api
    */
@@ -144,8 +144,8 @@ class TextFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @protected
    * @return {string} Text.
    */
@@ -155,8 +155,8 @@ class TextFeature extends FeatureFormat {
    * Write a single geometry.
    *
    * @function
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Geometry.
    * @api
    */
@@ -166,8 +166,8 @@ class TextFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @protected
    * @return {string} Text.
    */

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -15,7 +15,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/proj~ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
+ * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
  * @property {string} [layerName] Set the name of the TopoJSON topology
  * `objects`'s children as feature property with the specified name. This means
  * that when set to `'layer'`, a topology like
@@ -47,7 +47,7 @@ import {get as getProjection} from '../proj.js';
 class TopoJSON extends JSONFeature {
 
   /**
-   * @param {module:ol/format/TopoJSON~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();
@@ -91,7 +91,7 @@ class TopoJSON extends JSONFeature {
       if (transform) {
         transformArcs(arcs, scale, translate);
       }
-      /** @type {Array<module:ol/Feature>} */
+      /** @type {Array<import("../Feature.js").default>} */
       const features = [];
       const topoJSONFeatures = topoJSONTopology.objects;
       const property = this.layerName_;
@@ -128,7 +128,7 @@ class TopoJSON extends JSONFeature {
 
 /**
  * @const
- * @type {Object<string, function(TopoJSONGeometry, Array, ...Array): module:ol/geom/Geometry>}
+ * @type {Object<string, function(TopoJSONGeometry, Array, ...Array): import("../geom/Geometry.js").default>}
  */
 const GEOMETRY_READERS = {
   'Point': readPointGeometry,
@@ -144,12 +144,12 @@ const GEOMETRY_READERS = {
  * Concatenate arcs into a coordinate array.
  * @param {Array<number>} indices Indices of arcs to concatenate.  Negative
  *     values indicate arcs need to be reversed.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs (already
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs (already
  *     transformed).
- * @return {Array<module:ol/coordinate~Coordinate>} Coordinates array.
+ * @return {Array<import("../coordinate.js").Coordinate>} Coordinates array.
  */
 function concatenateArcs(indices, arcs) {
-  /** @type {Array<module:ol/coordinate~Coordinate>} */
+  /** @type {Array<import("../coordinate.js").Coordinate>} */
   const coordinates = [];
   let index, arc;
   for (let i = 0, ii = indices.length; i < ii; ++i) {
@@ -181,7 +181,7 @@ function concatenateArcs(indices, arcs) {
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
- * @return {module:ol/geom/Point} Geometry.
+ * @return {import("../geom/Point.js").default} Geometry.
  */
 function readPointGeometry(object, scale, translate) {
   const coordinates = object.coordinates;
@@ -198,7 +198,7 @@ function readPointGeometry(object, scale, translate) {
  * @param {TopoJSONGeometry} object TopoJSON object.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
- * @return {module:ol/geom/MultiPoint} Geometry.
+ * @return {import("../geom/MultiPoint.js").default} Geometry.
  */
 function readMultiPointGeometry(object, scale, translate) {
   const coordinates = object.coordinates;
@@ -215,8 +215,8 @@ function readMultiPointGeometry(object, scale, translate) {
  * Create a linestring from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/LineString} Geometry.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
+ * @return {import("../geom/LineString.js").default} Geometry.
  */
 function readLineStringGeometry(object, arcs) {
   const coordinates = concatenateArcs(object.arcs, arcs);
@@ -228,8 +228,8 @@ function readLineStringGeometry(object, arcs) {
  * Create a multi-linestring from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/MultiLineString} Geometry.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
+ * @return {import("../geom/MultiLineString.js").default} Geometry.
  */
 function readMultiLineStringGeometry(object, arcs) {
   const coordinates = [];
@@ -244,8 +244,8 @@ function readMultiLineStringGeometry(object, arcs) {
  * Create a polygon from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/Polygon} Geometry.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
+ * @return {import("../geom/Polygon.js").default} Geometry.
  */
 function readPolygonGeometry(object, arcs) {
   const coordinates = [];
@@ -260,8 +260,8 @@ function readPolygonGeometry(object, arcs) {
  * Create a multi-polygon from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @return {module:ol/geom/MultiPolygon} Geometry.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
+ * @return {import("../geom/MultiPolygon.js").default} Geometry.
  */
 function readMultiPolygonGeometry(object, arcs) {
   const coordinates = [];
@@ -284,14 +284,14 @@ function readMultiPolygonGeometry(object, arcs) {
  *
  * @param {TopoJSONGeometryCollection} collection TopoJSON Geometry
  *     object.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
  * @param {string|undefined} property Property to set the `GeometryCollection`'s parent
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
- * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array<module:ol/Feature>} Array of features.
+ * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @return {Array<import("../Feature.js").default>} Array of features.
  */
 function readFeaturesFromGeometryCollection(collection, arcs, scale, translate, property, name, opt_options) {
   const geometries = collection.geometries;
@@ -308,14 +308,14 @@ function readFeaturesFromGeometryCollection(collection, arcs, scale, translate, 
  * Create a feature from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON geometry object.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
  * @param {string|undefined} property Property to set the `GeometryCollection`'s parent
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
- * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {module:ol/Feature} Feature.
+ * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @return {import("../Feature.js").default} Feature.
  */
 function readFeatureFromGeometry(object, arcs, scale, translate, property, name, opt_options) {
   let geometry;
@@ -327,7 +327,7 @@ function readFeatureFromGeometry(object, arcs, scale, translate, property, name,
     geometry = geometryReader(object, arcs);
   }
   const feature = new Feature();
-  feature.setGeometry(/** @type {module:ol/geom/Geometry} */ (
+  feature.setGeometry(/** @type {import("../geom/Geometry.js").default} */ (
     transformWithOptions(geometry, false, opt_options)));
   if (object.id !== undefined) {
     feature.setId(object.id);
@@ -350,7 +350,7 @@ function readFeatureFromGeometry(object, arcs, scale, translate, property, name,
  * Apply a linear transform to array of arcs.  The provided array of arcs is
  * modified in place.
  *
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<import("../coordinate.js").Coordinate>>} arcs Array of arcs.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
  */
@@ -364,7 +364,7 @@ function transformArcs(arcs, scale, translate) {
 /**
  * Apply a linear transform to an arc.  The provided arc is modified in place.
  *
- * @param {Array<module:ol/coordinate~Coordinate>} arc Arc.
+ * @param {Array<import("../coordinate.js").Coordinate>} arc Arc.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
  */
@@ -386,7 +386,7 @@ function transformArc(arc, scale, translate) {
  * Apply a linear transform to a vertex.  The provided vertex is modified in
  * place.
  *
- * @param {module:ol/coordinate~Coordinate} vertex Vertex.
+ * @param {import("../coordinate.js").Coordinate} vertex Vertex.
  * @param {Array<number>} scale Scale for each dimension.
  * @param {Array<number>} translate Translation for each dimension.
  */

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -18,7 +18,7 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const FEATURE_COLLECTION_PARSERS = {
   'http://www.opengis.net/gml': {
@@ -30,7 +30,7 @@ const FEATURE_COLLECTION_PARSERS = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TRANSACTION_SUMMARY_PARSERS = {
   'http://www.opengis.net/wfs': {
@@ -43,7 +43,7 @@ const TRANSACTION_SUMMARY_PARSERS = {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TRANSACTION_RESPONSE_PARSERS = {
   'http://www.opengis.net/wfs': {
@@ -56,7 +56,7 @@ const TRANSACTION_RESPONSE_PARSERS = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const QUERY_SERIALIZERS = {
   'http://www.opengis.net/wfs': {
@@ -66,7 +66,7 @@ const QUERY_SERIALIZERS = {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const TRANSACTION_SERIALIZERS = {
   'http://www.opengis.net/wfs': {
@@ -83,7 +83,7 @@ const TRANSACTION_SERIALIZERS = {
  * @typedef {Object} Options
  * @property {Object<string, string>|string} [featureNS] The namespace URI used for features.
  * @property {Array<string>|string} [featureType] The feature type to parse. Only used for read operations.
- * @property {module:ol/format/GMLBase} [gmlFormat] The GML format to use to parse the response. Default is `ol/format/GML3`.
+ * @property {import("./GMLBase.js").default} [gmlFormat] The GML format to use to parse the response. Default is `ol/format/GML3`.
  * @property {string} [schemaLocation] Optional schemaLocation to use for serialization, this will override the default.
  */
 
@@ -105,8 +105,8 @@ const TRANSACTION_SERIALIZERS = {
  * @property {number} [count] Number of features to retrieve when paging. This is a
  * WFS 2.0 feature backported to WFS 1.1.0 by some Web Feature Services. Please note that some
  * Web Feature Services have repurposed `maxfeatures` instead.
- * @property {module:ol/extent~Extent} [bbox] Extent to use for the BBOX filter.
- * @property {module:ol/format/filter/Filter} [filter] Filter condition. See
+ * @property {import("../extent.js").Extent} [bbox] Extent to use for the BBOX filter.
+ * @property {import("./filter/Filter.js").default} [filter] Filter condition. See
  * {@link module:ol/format/Filter} for more information.
  * @property {string} [resultType] Indicates what response should be returned,
  * E.g. `hits` only includes the `numberOfFeatures` attribute in the response and no features.
@@ -124,7 +124,7 @@ const TRANSACTION_SERIALIZERS = {
  * @property {boolean} [hasZ] Must be set to true if the transaction is for
  * a 3D layer. This will allow the Z coordinate to be included in the transaction.
  * @property {Array<Object>} nativeElements Native elements. Currently not supported.
- * @property {module:ol/format/GMLBase~Options} [gmlOptions] GML options for the WFS transaction writer.
+ * @property {import("./GMLBase.js").Options} [gmlOptions] GML options for the WFS transaction writer.
  * @property {string} [version='1.1.0'] WFS version to use for the transaction. Can be either `1.0.0` or `1.1.0`.
  */
 
@@ -133,7 +133,7 @@ const TRANSACTION_SERIALIZERS = {
  * Number of features; bounds/extent.
  * @typedef {Object} FeatureCollectionMetadata
  * @property {number} numberOfFeatures
- * @property {module:ol/extent~Extent} bounds
+ * @property {import("../extent.js").Extent} bounds
  */
 
 
@@ -205,7 +205,7 @@ const DEFAULT_VERSION = '1.1.0';
 class WFS extends XMLFeature {
 
   /**
-   * @param {module:ol/format/WFS~Options=} opt_options Optional configuration object.
+   * @param {Options=} opt_options Optional configuration object.
    */
   constructor(opt_options) {
     super();
@@ -226,7 +226,7 @@ class WFS extends XMLFeature {
 
     /**
      * @private
-     * @type {module:ol/format/GMLBase}
+     * @type {import("./GMLBase.js").default}
      */
     this.gmlFormat_ = options.gmlFormat ?
       options.gmlFormat : new GML3();
@@ -257,7 +257,7 @@ class WFS extends XMLFeature {
    * @inheritDoc
    */
   readFeaturesFromNode(node, opt_options) {
-    const context = /** @type {module:ol/xml~NodeStackItem} */ ({
+    const context = /** @type {import("../xml.js").NodeStackItem} */ ({
       'featureType': this.featureType_,
       'featureNS': this.featureNS_
     });
@@ -279,7 +279,7 @@ class WFS extends XMLFeature {
    * Read transaction response of the source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
+   * @return {TransactionResponse|undefined} Transaction response.
    * @api
    */
   readTransactionResponse(source) {
@@ -300,7 +300,7 @@ class WFS extends XMLFeature {
    * Read feature collection metadata of the source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
+   * @return {FeatureCollectionMetadata|undefined}
    *     FeatureCollection metadata.
    * @api
    */
@@ -321,7 +321,7 @@ class WFS extends XMLFeature {
 
   /**
    * @param {Document} doc Document.
-   * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
+   * @return {FeatureCollectionMetadata|undefined}
    *     FeatureCollection metadata.
    */
   readFeatureCollectionMetadataFromDocument(doc) {
@@ -335,7 +335,7 @@ class WFS extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
+   * @return {FeatureCollectionMetadata|undefined}
    *     FeatureCollection metadata.
    */
   readFeatureCollectionMetadataFromNode(node) {
@@ -344,13 +344,13 @@ class WFS extends XMLFeature {
       node.getAttribute('numberOfFeatures'));
     result['numberOfFeatures'] = value;
     return pushParseAndPop(
-      /** @type {module:ol/format/WFS~FeatureCollectionMetadata} */ (result),
+      /** @type {FeatureCollectionMetadata} */ (result),
       FEATURE_COLLECTION_PARSERS, node, [], this.gmlFormat_);
   }
 
   /**
    * @param {Document} doc Document.
-   * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
+   * @return {TransactionResponse|undefined} Transaction response.
    */
   readTransactionResponseFromDocument(doc) {
     for (let n = doc.firstChild; n; n = n.nextSibling) {
@@ -363,18 +363,18 @@ class WFS extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
+   * @return {TransactionResponse|undefined} Transaction response.
    */
   readTransactionResponseFromNode(node) {
     return pushParseAndPop(
-      /** @type {module:ol/format/WFS~TransactionResponse} */({}),
+      /** @type {TransactionResponse} */({}),
       TRANSACTION_RESPONSE_PARSERS, node, []);
   }
 
   /**
    * Encode format as WFS `GetFeature` and return the Node.
    *
-   * @param {module:ol/format/WFS~WriteGetFeatureOptions} options Options.
+   * @param {WriteGetFeatureOptions} options Options.
    * @return {Node} Result.
    * @api
    */
@@ -417,7 +417,7 @@ class WFS extends XMLFeature {
       }
     }
     node.setAttributeNS(XML_SCHEMA_INSTANCE_URI, 'xsi:schemaLocation', this.schemaLocation_);
-    /** @type {module:ol/xml~NodeStackItem} */
+    /** @type {import("../xml.js").NodeStackItem} */
     const context = {
       node: node,
       'srsName': options.srsName,
@@ -436,10 +436,10 @@ class WFS extends XMLFeature {
   /**
    * Encode format as WFS `Transaction` and return the Node.
    *
-   * @param {Array<module:ol/Feature>} inserts The features to insert.
-   * @param {Array<module:ol/Feature>} updates The features to update.
-   * @param {Array<module:ol/Feature>} deletes The features to delete.
-   * @param {module:ol/format/WFS~WriteTransactionOptions} options Write options.
+   * @param {Array<import("../Feature.js").default>} inserts The features to insert.
+   * @param {Array<import("../Feature.js").default>} updates The features to update.
+   * @param {Array<import("../Feature.js").default>} deletes The features to delete.
+   * @param {WriteTransactionOptions} options Write options.
    * @return {Node} Result.
    * @api
    */
@@ -451,7 +451,7 @@ class WFS extends XMLFeature {
     node.setAttribute('service', 'WFS');
     node.setAttribute('version', version);
     let baseObj;
-    /** @type {module:ol/xml~NodeStackItem} */
+    /** @type {import("../xml.js").NodeStackItem} */
     let obj;
     if (options) {
       baseObj = options.gmlOptions ? options.gmlOptions : {};
@@ -549,7 +549,7 @@ function readTransactionSummary(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const OGC_FID_PARSERS = {
   'http://www.opengis.net/ogc': {
@@ -571,7 +571,7 @@ function fidParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const INSERT_RESULTS_PARSERS = {
   'http://www.opengis.net/wfs': {
@@ -593,7 +593,7 @@ function readInsertResults(node, objectStack) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeFeature(node, feature, objectStack) {
@@ -644,7 +644,7 @@ function getTypeName(featurePrefix, featureType) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeDelete(node, feature, objectStack) {
@@ -665,7 +665,7 @@ function writeDelete(node, feature, objectStack) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../Feature.js").default} feature Feature.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeUpdate(node, feature, objectStack) {
@@ -692,7 +692,7 @@ function writeUpdate(node, feature, objectStack) {
         values.push({name: name, value: value});
       }
     }
-    pushSerializeAndPop(/** @type {module:ol/xml~NodeStackItem} */ (
+    pushSerializeAndPop(/** @type {import("../xml.js").NodeStackItem} */ (
       {'gmlVersion': context['gmlVersion'], node: node,
         'hasZ': context['hasZ'], 'srsName': context['srsName']}),
     TRANSACTION_SERIALIZERS,
@@ -751,7 +751,7 @@ function writeNative(node, nativeElement, objectStack) {
 
 
 /**
- * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
 const GETFEATURE_SERIALIZERS = {
   'http://www.opengis.net/wfs': {
@@ -804,7 +804,7 @@ function writeQuery(node, featureType, objectStack) {
   if (featureNS) {
     node.setAttributeNS(XMLNS, 'xmlns:' + featurePrefix, featureNS);
   }
-  const item = /** @type {module:ol/xml~NodeStackItem} */ (assign({}, context));
+  const item = /** @type {import("../xml.js").NodeStackItem} */ (assign({}, context));
   item.node = node;
   pushSerializeAndPop(item,
     QUERY_SERIALIZERS,
@@ -821,11 +821,11 @@ function writeQuery(node, featureType, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Filter} filter Filter.
+ * @param {import("./filter/Filter.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeFilterCondition(node, filter, objectStack) {
-  /** @type {module:ol/xml~NodeStackItem} */
+  /** @type {import("../xml.js").NodeStackItem} */
   const item = {node: node};
   pushSerializeAndPop(item,
     GETFEATURE_SERIALIZERS,
@@ -836,7 +836,7 @@ function writeFilterCondition(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Bbox} filter Filter.
+ * @param {import("./filter/Bbox.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeBboxFilter(node, filter, objectStack) {
@@ -850,7 +850,7 @@ function writeBboxFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Contains} filter Filter.
+ * @param {import("./filter/Contains.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeContainsFilter(node, filter, objectStack) {
@@ -864,7 +864,7 @@ function writeContainsFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Intersects} filter Filter.
+ * @param {import("./filter/Intersects.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeIntersectsFilter(node, filter, objectStack) {
@@ -878,7 +878,7 @@ function writeIntersectsFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Within} filter Filter.
+ * @param {import("./filter/Within.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeWithinFilter(node, filter, objectStack) {
@@ -892,7 +892,7 @@ function writeWithinFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/During} filter Filter.
+ * @param {import("./filter/During.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeDuringFilter(node, filter, objectStack) {
@@ -917,11 +917,11 @@ function writeDuringFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/LogicalNary} filter Filter.
+ * @param {import("./filter/LogicalNary.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeLogicalFilter(node, filter, objectStack) {
-  /** @type {module:ol/xml~NodeStackItem} */
+  /** @type {import("../xml.js").NodeStackItem} */
   const item = {node: node};
   const conditions = filter.conditions;
   for (let i = 0, ii = conditions.length; i < ii; ++i) {
@@ -936,11 +936,11 @@ function writeLogicalFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/Not} filter Filter.
+ * @param {import("./filter/Not.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeNotFilter(node, filter, objectStack) {
-  /** @type {module:ol/xml~NodeStackItem} */
+  /** @type {import("../xml.js").NodeStackItem} */
   const item = {node: node};
   const condition = filter.condition;
   pushSerializeAndPop(item,
@@ -952,7 +952,7 @@ function writeNotFilter(node, filter, objectStack) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/format/filter/ComparisonBinary} filter Filter.
+ * @param {import("./filter/ComparisonBinary.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeComparisonFilter(node, filter, objectStack) {
@@ -966,7 +966,7 @@ function writeComparisonFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/IsNull} filter Filter.
+ * @param {import("./filter/IsNull.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeIsNullFilter(node, filter, objectStack) {
@@ -976,7 +976,7 @@ function writeIsNullFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {module:ol/format/filter/IsBetween} filter Filter.
+ * @param {import("./filter/IsBetween.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeIsBetweenFilter(node, filter, objectStack) {
@@ -994,7 +994,7 @@ function writeIsBetweenFilter(node, filter, objectStack) {
 
 /**
  * @param {Element} node Node.
- * @param {module:ol/format/filter/IsLike} filter Filter.
+ * @param {import("./filter/IsLike.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
 function writeIsLikeFilter(node, filter, objectStack) {
@@ -1056,7 +1056,7 @@ function writeTimeInstant(node, time) {
 /**
  * Encode filter as WFS `Filter` and return the Node.
  *
- * @param {module:ol/format/filter/Filter} filter Filter.
+ * @param {import("./filter/Filter.js").default} filter Filter.
  * @return {Node} Result.
  * @api
  */
@@ -1074,7 +1074,7 @@ export function writeFilter(filter) {
  */
 function writeGetFeature(node, featureTypes, objectStack) {
   const context = /** @type {Object} */ (objectStack[objectStack.length - 1]);
-  const item = /** @type {module:ol/xml~NodeStackItem} */ (assign({}, context));
+  const item = /** @type {import("../xml.js").NodeStackItem} */ (assign({}, context));
   item.node = node;
   pushSerializeAndPop(item,
     GETFEATURE_SERIALIZERS,

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -17,7 +17,7 @@ import SimpleGeometry from '../geom/SimpleGeometry.js';
 
 
 /**
- * @enum {function (new:module:ol/geom/Geometry, Array, module:ol/geom/GeometryLayout)}
+ * @enum {function (new:import("../geom/Geometry.js").default, Array, import("../geom/GeometryLayout.js").default)}
  */
 const GeometryConstructor = {
   'POINT': Point,
@@ -155,7 +155,7 @@ class Lexer {
 
   /**
    * Fetch and return the next token.
-   * @return {!module:ol/format/WKT~Token} Next string token.
+   * @return {!Token} Next string token.
    */
   nextToken() {
     const c = this.nextChar_();
@@ -232,24 +232,24 @@ class Lexer {
 class Parser {
 
   /**
-   * @param {module:ol/format/WKT~Lexer} lexer The lexer.
+   * @param {Lexer} lexer The lexer.
    */
   constructor(lexer) {
 
     /**
-     * @type {module:ol/format/WKT~Lexer}
+     * @type {Lexer}
      * @private
      */
     this.lexer_ = lexer;
 
     /**
-     * @type {module:ol/format/WKT~Token}
+     * @type {Token}
      * @private
      */
     this.token_;
 
     /**
-     * @type {module:ol/geom/GeometryLayout}
+     * @type {import("../geom/GeometryLayout.js").default}
      * @private
      */
     this.layout_ = GeometryLayout.XY;
@@ -265,7 +265,7 @@ class Parser {
 
   /**
    * Tests if the given type matches the type of the current token.
-   * @param {module:ol/format/WKT~TokenType} type Token type.
+   * @param {TokenType} type Token type.
    * @return {boolean} Whether the token matches the given type.
    */
   isTokenType(type) {
@@ -275,7 +275,7 @@ class Parser {
 
   /**
    * If the given type matches the current token, consume it.
-   * @param {module:ol/format/WKT~TokenType} type Token type.
+   * @param {TokenType} type Token type.
    * @return {boolean} Whether the token matches the given type.
    */
   match(type) {
@@ -288,7 +288,7 @@ class Parser {
 
   /**
    * Try to parse the tokens provided by the lexer.
-   * @return {module:ol/geom/Geometry} The geometry.
+   * @return {import("../geom/Geometry.js").default} The geometry.
    */
   parse() {
     this.consume_();
@@ -298,7 +298,7 @@ class Parser {
 
   /**
    * Try to parse the dimensional info.
-   * @return {module:ol/geom/GeometryLayout} The layout.
+   * @return {import("../geom/GeometryLayout.js").default} The layout.
    * @private
    */
   parseGeometryLayout_() {
@@ -321,7 +321,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array<module:ol/geom/Geometry>} A collection of geometries.
+   * @return {!Array<import("../geom/Geometry.js").default>} A collection of geometries.
    * @private
    */
   parseGeometryCollectionText_() {
@@ -534,7 +534,7 @@ class Parser {
   }
 
   /**
-   * @return {!module:ol/geom/Geometry} The geometry.
+   * @return {!import("../geom/Geometry.js").default} The geometry.
    * @private
    */
   parseGeometry_() {
@@ -607,7 +607,7 @@ class Parser {
 class WKT extends TextFeature {
 
   /**
-   * @param {module:ol/format/WKT~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();
@@ -628,7 +628,7 @@ class WKT extends TextFeature {
   /**
    * Parse a WKT string.
    * @param {string} wkt WKT string.
-   * @return {module:ol/geom/Geometry|undefined}
+   * @return {import("../geom/Geometry.js").default|undefined}
    *     The geometry created.
    * @private
    */
@@ -659,7 +659,7 @@ class WKT extends TextFeature {
     const geometry = this.readGeometryFromText(text, opt_options);
     if (this.splitCollection_ &&
         geometry.getType() == GeometryType.GEOMETRY_COLLECTION) {
-      geometries = (/** @type {module:ol/geom/GeometryCollection} */ (geometry))
+      geometries = (/** @type {import("../geom/GeometryCollection.js").default} */ (geometry))
         .getGeometriesArray();
     } else {
       geometries = [geometry];
@@ -680,7 +680,7 @@ class WKT extends TextFeature {
     const geometry = this.parse_(text);
     if (geometry) {
       return (
-        /** @type {module:ol/geom/Geometry} */ (transformWithOptions(geometry, false, opt_options))
+        /** @type {import("../geom/Geometry.js").default} */ (transformWithOptions(geometry, false, opt_options))
       );
     } else {
       return null;
@@ -717,14 +717,14 @@ class WKT extends TextFeature {
    * @inheritDoc
    */
   writeGeometryText(geometry, opt_options) {
-    return encode(/** @type {module:ol/geom/Geometry} */ (
+    return encode(/** @type {import("../geom/Geometry.js").default} */ (
       transformWithOptions(geometry, true, opt_options)));
   }
 }
 
 
 /**
- * @param {module:ol/geom/Point} geom Point geometry.
+ * @param {import("../geom/Point.js").default} geom Point geometry.
  * @return {string} Coordinates part of Point as WKT.
  */
 function encodePointGeometry(geom) {
@@ -737,7 +737,7 @@ function encodePointGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/MultiPoint} geom MultiPoint geometry.
+ * @param {import("../geom/MultiPoint.js").default} geom MultiPoint geometry.
  * @return {string} Coordinates part of MultiPoint as WKT.
  */
 function encodeMultiPointGeometry(geom) {
@@ -751,7 +751,7 @@ function encodeMultiPointGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/GeometryCollection} geom GeometryCollection geometry.
+ * @param {import("../geom/GeometryCollection.js").default} geom GeometryCollection geometry.
  * @return {string} Coordinates part of GeometryCollection as WKT.
  */
 function encodeGeometryCollectionGeometry(geom) {
@@ -765,7 +765,7 @@ function encodeGeometryCollectionGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} geom LineString geometry.
+ * @param {import("../geom/LineString.js").default|import("../geom/LinearRing.js").default} geom LineString geometry.
  * @return {string} Coordinates part of LineString as WKT.
  */
 function encodeLineStringGeometry(geom) {
@@ -779,7 +779,7 @@ function encodeLineStringGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/MultiLineString} geom MultiLineString geometry.
+ * @param {import("../geom/MultiLineString.js").default} geom MultiLineString geometry.
  * @return {string} Coordinates part of MultiLineString as WKT.
  */
 function encodeMultiLineStringGeometry(geom) {
@@ -793,7 +793,7 @@ function encodeMultiLineStringGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/Polygon} geom Polygon geometry.
+ * @param {import("../geom/Polygon.js").default} geom Polygon geometry.
  * @return {string} Coordinates part of Polygon as WKT.
  */
 function encodePolygonGeometry(geom) {
@@ -807,7 +807,7 @@ function encodePolygonGeometry(geom) {
 
 
 /**
- * @param {module:ol/geom/MultiPolygon} geom MultiPolygon geometry.
+ * @param {import("../geom/MultiPolygon.js").default} geom MultiPolygon geometry.
  * @return {string} Coordinates part of MultiPolygon as WKT.
  */
 function encodeMultiPolygonGeometry(geom) {
@@ -820,7 +820,7 @@ function encodeMultiPolygonGeometry(geom) {
 }
 
 /**
- * @param {module:ol/geom/SimpleGeometry} geom SimpleGeometry geometry.
+ * @param {import("../geom/SimpleGeometry.js").default} geom SimpleGeometry geometry.
  * @return {string} Potential dimensional information for WKT type.
  */
 function encodeGeometryLayout(geom) {
@@ -838,7 +838,7 @@ function encodeGeometryLayout(geom) {
 
 /**
  * @const
- * @type {Object<string, function(module:ol/geom/Geometry): string>}
+ * @type {Object<string, function(import("../geom/Geometry.js").default): string>}
  */
 const GeometryEncoder = {
   'Point': encodePointGeometry,
@@ -853,7 +853,7 @@ const GeometryEncoder = {
 
 /**
  * Encode a geometry as WKT.
- * @param {module:ol/geom/Geometry} geom The geometry to encode.
+ * @param {import("../geom/Geometry.js").default} geom The geometry to encode.
  * @return {string} WKT string for the geometry.
  */
 function encode(geom) {

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -20,7 +20,7 @@ const NAMESPACE_URIS = [
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -31,7 +31,7 @@ const PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CAPABILITY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -84,7 +84,7 @@ class WMSCapabilities extends XML {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const SERVICE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -104,7 +104,7 @@ const SERVICE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CONTACT_INFORMATION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -119,7 +119,7 @@ const CONTACT_INFORMATION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CONTACT_PERSON_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -130,7 +130,7 @@ const CONTACT_PERSON_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CONTACT_ADDRESS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -145,7 +145,7 @@ const CONTACT_ADDRESS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const EXCEPTION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -155,7 +155,7 @@ const EXCEPTION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LAYER_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -182,7 +182,7 @@ const LAYER_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const ATTRIBUTION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -194,7 +194,7 @@ const ATTRIBUTION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS =
     makeStructureNS(NAMESPACE_URIS, {
@@ -207,7 +207,7 @@ const EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS =
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const REQUEST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -219,7 +219,7 @@ const REQUEST_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const OPERATIONTYPE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -230,7 +230,7 @@ const OPERATIONTYPE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const DCPTYPE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -240,7 +240,7 @@ const DCPTYPE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const HTTP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -251,7 +251,7 @@ const HTTP_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -266,7 +266,7 @@ const STYLE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const FORMAT_ONLINERESOURCE_PARSERS =
     makeStructureNS(NAMESPACE_URIS, {
@@ -277,7 +277,7 @@ const FORMAT_ONLINERESOURCE_PARSERS =
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const KEYWORDLIST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -324,7 +324,7 @@ function readBoundingBox(node, objectStack) {
 /**
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @return {module:ol/extent~Extent|undefined} Bounding box object.
+ * @return {import("../extent.js").Extent|undefined} Bounding box object.
  */
 function readEXGeographicBoundingBox(node, objectStack) {
   const geographicBoundingBox = pushParseAndPop(

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -38,7 +38,7 @@ const layerIdentifier = '_layer';
 class WMSGetFeatureInfo extends XMLFeature {
 
   /**
-   * @param {module:ol/format/WMSGetFeatureInfo~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super();
@@ -54,7 +54,7 @@ class WMSGetFeatureInfo extends XMLFeature {
 
     /**
      * @private
-     * @type {module:ol/format/GML2}
+     * @type {import("./GML2.js").default}
      */
     this.gmlFormat_ = new GML2();
 
@@ -83,13 +83,13 @@ class WMSGetFeatureInfo extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @private
    */
   readFeatures_(node, objectStack) {
     node.setAttribute('namespaceURI', this.featureNS_);
     const localName = node.localName;
-    /** @type {Array<module:ol/Feature>} */
+    /** @type {Array<import("../Feature.js").default>} */
     let features = [];
     if (node.childNodes.length === 0) {
       return features;

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -32,7 +32,7 @@ const OWS_NAMESPACE_URIS = [
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -51,7 +51,7 @@ class WMTSCapabilities extends XML {
     super();
 
     /**
-     * @type {module:ol/format/OWS}
+     * @type {import("./OWS.js").default}
      * @private
      */
     this.owsParser_ = new OWS();
@@ -87,7 +87,7 @@ class WMTSCapabilities extends XML {
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const CONTENTS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -98,7 +98,7 @@ const CONTENTS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const LAYER_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -117,7 +117,7 @@ const LAYER_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -130,7 +130,7 @@ const STYLE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TMS_LINKS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -140,7 +140,7 @@ const TMS_LINKS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TMS_LIMITS_LIST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -150,7 +150,7 @@ const TMS_LIMITS_LIST_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TMS_LIMITS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -164,7 +164,7 @@ const TMS_LIMITS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const DIMENSION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -177,7 +177,7 @@ const DIMENSION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const WGS84_BBOX_READERS = makeStructureNS(
   OWS_NAMESPACE_URIS, {
@@ -188,7 +188,7 @@ const WGS84_BBOX_READERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TMS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -202,7 +202,7 @@ const TMS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object<string, Object<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
 const TM_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -36,8 +36,8 @@ class XMLFeature extends FeatureFormat {
    * Read a single feature.
    *
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {module:ol/Feature} Feature.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @return {import("../Feature.js").default} Feature.
    * @api
    */
   readFeature(source, opt_options) {
@@ -55,8 +55,8 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Document} doc Document.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
-   * @return {module:ol/Feature} Feature.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromDocument(doc, opt_options) {
     const features = this.readFeaturesFromDocument(doc, opt_options);
@@ -69,8 +69,8 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
-   * @return {module:ol/Feature} Feature.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromNode(node, opt_options) {
     return null; // not implemented
@@ -81,8 +81,8 @@ class XMLFeature extends FeatureFormat {
    *
    * @function
    * @param {Document|Node|Object|string} source Source.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
-   * @return {Array<module:ol/Feature>} Features.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   readFeatures(source, opt_options) {
@@ -101,12 +101,12 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Document} doc Document.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
    * @protected
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromDocument(doc, opt_options) {
-    /** @type {Array<module:ol/Feature>} */
+    /** @type {Array<import("../Feature.js").default>} */
     const features = [];
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
@@ -119,9 +119,9 @@ class XMLFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Node} node Node.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
    * @protected
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {}
 
@@ -144,9 +144,9 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Document} doc Document.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
    * @protected
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometryFromDocument(doc, opt_options) {
     return null; // not implemented
@@ -154,9 +154,9 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Node} node Node.
-   * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
    * @protected
-   * @return {module:ol/geom/Geometry} Geometry.
+   * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometryFromNode(node, opt_options) {
     return null; // not implemented
@@ -166,7 +166,7 @@ class XMLFeature extends FeatureFormat {
    * Read the projection from the source.
    *
    * @param {Document|Node|Object|string} source Source.
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    * @api
    */
   readProjection(source) {
@@ -185,7 +185,7 @@ class XMLFeature extends FeatureFormat {
   /**
    * @param {Document} doc Document.
    * @protected
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    */
   readProjectionFromDocument(doc) {
     return this.dataProjection;
@@ -194,7 +194,7 @@ class XMLFeature extends FeatureFormat {
   /**
    * @param {Node} node Node.
    * @protected
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    */
   readProjectionFromNode(node) {
     return this.dataProjection;
@@ -209,8 +209,8 @@ class XMLFeature extends FeatureFormat {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @protected
    * @return {Node} Node.
    */
@@ -221,8 +221,8 @@ class XMLFeature extends FeatureFormat {
   /**
    * Encode an array of features as string.
    *
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Result.
    * @api
    */
@@ -232,8 +232,8 @@ class XMLFeature extends FeatureFormat {
   }
 
   /**
-   * @param {Array<module:ol/Feature>} features Features.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {Array<import("../Feature.js").default>} features Features.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @return {Node} Node.
    */
   writeFeaturesNode(features, opt_options) {
@@ -249,8 +249,8 @@ class XMLFeature extends FeatureFormat {
   }
 
   /**
-   * @param {module:ol/geom/Geometry} geometry Geometry.
-   * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
+   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
    * @return {Node} Node.
    */
   writeGeometryNode(geometry, opt_options) {

--- a/src/ol/format/filter.js
+++ b/src/ol/format/filter.js
@@ -23,8 +23,8 @@ import Within from '../format/filter/Within.js';
 /**
  * Create a logical `<And>` operator between two or more filter conditions.
  *
- * @param {...module:ol/format/filter/Filter} conditions Filter conditions.
- * @returns {!module:ol/format/filter/And} `<And>` operator.
+ * @param {...import("./filter/Filter.js").default} conditions Filter conditions.
+ * @returns {!import("./filter/And.js").default} `<And>` operator.
  * @api
  */
 export function and(conditions) {
@@ -36,8 +36,8 @@ export function and(conditions) {
 /**
  * Create a logical `<Or>` operator between two or more filter conditions.
  *
- * @param {...module:ol/format/filter/Filter} conditions Filter conditions.
- * @returns {!module:ol/format/filter/Or} `<Or>` operator.
+ * @param {...import("./filter/Filter.js").default} conditions Filter conditions.
+ * @returns {!import("./filter/Or.js").default} `<Or>` operator.
  * @api
  */
 export function or(conditions) {
@@ -49,8 +49,8 @@ export function or(conditions) {
 /**
  * Represents a logical `<Not>` operator for a filter condition.
  *
- * @param {!module:ol/format/filter/Filter} condition Filter condition.
- * @returns {!module:ol/format/filter/Not} `<Not>` operator.
+ * @param {!import("./filter/Filter.js").default} condition Filter condition.
+ * @returns {!import("./filter/Not.js").default} `<Not>` operator.
  * @api
  */
 export function not(condition) {
@@ -63,10 +63,10 @@ export function not(condition) {
  * intersects a fixed bounding box
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/extent~Extent} extent Extent.
+ * @param {!import("../extent.js").Extent} extent Extent.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Bbox} `<BBOX>` operator.
+ * @returns {!import("./filter/Bbox.js").default} `<BBOX>` operator.
  * @api
  */
 export function bbox(geometryName, extent, opt_srsName) {
@@ -78,10 +78,10 @@ export function bbox(geometryName, extent, opt_srsName) {
  * contains a given geometry.
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry} geometry Geometry.
+ * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Contains} `<Contains>` operator.
+ * @returns {!import("./filter/Contains.js").default} `<Contains>` operator.
  * @api
  */
 export function contains(geometryName, geometry, opt_srsName) {
@@ -93,10 +93,10 @@ export function contains(geometryName, geometry, opt_srsName) {
  * intersects a given geometry.
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry} geometry Geometry.
+ * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Intersects} `<Intersects>` operator.
+ * @returns {!import("./filter/Intersects.js").default} `<Intersects>` operator.
  * @api
  */
 export function intersects(geometryName, geometry, opt_srsName) {
@@ -108,10 +108,10 @@ export function intersects(geometryName, geometry, opt_srsName) {
  * is within a given geometry.
  *
  * @param {!string} geometryName Geometry name to use.
- * @param {!module:ol/geom/Geometry} geometry Geometry.
+ * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!module:ol/format/filter/Within} `<Within>` operator.
+ * @returns {!import("./filter/Within.js").default} `<Within>` operator.
  * @api
  */
 export function within(geometryName, geometry, opt_srsName) {
@@ -125,7 +125,7 @@ export function within(geometryName, geometry, opt_srsName) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!module:ol/format/filter/EqualTo} `<PropertyIsEqualTo>` operator.
+ * @returns {!import("./filter/EqualTo.js").default} `<PropertyIsEqualTo>` operator.
  * @api
  */
 export function equalTo(propertyName, expression, opt_matchCase) {
@@ -139,7 +139,7 @@ export function equalTo(propertyName, expression, opt_matchCase) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!module:ol/format/filter/NotEqualTo} `<PropertyIsNotEqualTo>` operator.
+ * @returns {!import("./filter/NotEqualTo.js").default} `<PropertyIsNotEqualTo>` operator.
  * @api
  */
 export function notEqualTo(propertyName, expression, opt_matchCase) {
@@ -152,7 +152,7 @@ export function notEqualTo(propertyName, expression, opt_matchCase) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/LessThan} `<PropertyIsLessThan>` operator.
+ * @returns {!import("./filter/LessThan.js").default} `<PropertyIsLessThan>` operator.
  * @api
  */
 export function lessThan(propertyName, expression) {
@@ -165,7 +165,7 @@ export function lessThan(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
+ * @returns {!import("./filter/LessThanOrEqualTo.js").default} `<PropertyIsLessThanOrEqualTo>` operator.
  * @api
  */
 export function lessThanOrEqualTo(propertyName, expression) {
@@ -178,7 +178,7 @@ export function lessThanOrEqualTo(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/GreaterThan} `<PropertyIsGreaterThan>` operator.
+ * @returns {!import("./filter/GreaterThan.js").default} `<PropertyIsGreaterThan>` operator.
  * @api
  */
 export function greaterThan(propertyName, expression) {
@@ -191,7 +191,7 @@ export function greaterThan(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!module:ol/format/filter/GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
+ * @returns {!import("./filter/GreaterThanOrEqualTo.js").default} `<PropertyIsGreaterThanOrEqualTo>` operator.
  * @api
  */
 export function greaterThanOrEqualTo(propertyName, expression) {
@@ -204,7 +204,7 @@ export function greaterThanOrEqualTo(propertyName, expression) {
  * is null.
  *
  * @param {!string} propertyName Name of the context property to compare.
- * @returns {!module:ol/format/filter/IsNull} `<PropertyIsNull>` operator.
+ * @returns {!import("./filter/IsNull.js").default} `<PropertyIsNull>` operator.
  * @api
  */
 export function isNull(propertyName) {
@@ -219,7 +219,7 @@ export function isNull(propertyName) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} lowerBoundary The lower bound of the range.
  * @param {!number} upperBoundary The upper bound of the range.
- * @returns {!module:ol/format/filter/IsBetween} `<PropertyIsBetween>` operator.
+ * @returns {!import("./filter/IsBetween.js").default} `<PropertyIsBetween>` operator.
  * @api
  */
 export function between(propertyName, lowerBoundary, upperBoundary) {
@@ -240,7 +240,7 @@ export function between(propertyName, lowerBoundary, upperBoundary) {
  * @param {string=} opt_escapeChar Escape character which can be used to escape
  *    the pattern characters. Default is '!'.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!module:ol/format/filter/IsLike} `<PropertyIsLike>` operator.
+ * @returns {!import("./filter/IsLike.js").default} `<PropertyIsLike>` operator.
  * @api
  */
 export function like(propertyName, pattern,
@@ -256,7 +256,7 @@ export function like(propertyName, pattern,
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!string} begin The begin date in ISO-8601 format.
  * @param {!string} end The end date in ISO-8601 format.
- * @returns {!module:ol/format/filter/During} `<During>` operator.
+ * @returns {!import("./filter/During.js").default} `<During>` operator.
  * @api
  */
 export function during(propertyName, begin, end) {

--- a/src/ol/format/filter/And.js
+++ b/src/ol/format/filter/And.js
@@ -12,7 +12,7 @@ import LogicalNary from '../filter/LogicalNary.js';
 class And extends LogicalNary {
 
   /**
-   * @param {...module:ol/format/filter/Filter} conditions Conditions.
+   * @param {...import("./Filter.js").default} conditions Conditions.
    */
   constructor(conditions) {
     const params = ['And'].concat(Array.prototype.slice.call(arguments));

--- a/src/ol/format/filter/Bbox.js
+++ b/src/ol/format/filter/Bbox.js
@@ -14,7 +14,7 @@ class Bbox extends Filter {
 
   /**
    * @param {!string} geometryName Geometry name to use.
-   * @param {!module:ol/extent~Extent} extent Extent.
+   * @param {!import("../../extent.js").Extent} extent Extent.
    * @param {string=} opt_srsName SRS name. No srsName attribute will be set
    * on geometries when this is not provided.
    */
@@ -28,7 +28,7 @@ class Bbox extends Filter {
     this.geometryName = geometryName;
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.extent = extent;
 

--- a/src/ol/format/filter/Contains.js
+++ b/src/ol/format/filter/Contains.js
@@ -13,7 +13,7 @@ class Contains extends Spatial {
 
   /**
    * @param {!string} geometryName Geometry name to use.
-   * @param {!module:ol/geom/Geometry} geometry Geometry.
+   * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
    * @param {string=} opt_srsName SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */

--- a/src/ol/format/filter/Intersects.js
+++ b/src/ol/format/filter/Intersects.js
@@ -13,7 +13,7 @@ class Intersects extends Spatial {
 
   /**
    * @param {!string} geometryName Geometry name to use.
-   * @param {!module:ol/geom/Geometry} geometry Geometry.
+   * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
    * @param {string=} opt_srsName SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */

--- a/src/ol/format/filter/LogicalNary.js
+++ b/src/ol/format/filter/LogicalNary.js
@@ -15,14 +15,14 @@ class LogicalNary extends Filter {
 
   /**
    * @param {!string} tagName The XML tag name for this filter.
-   * @param {...module:ol/format/filter/Filter} conditions Conditions.
+   * @param {...import("./Filter.js").default} conditions Conditions.
    */
   constructor(tagName, conditions) {
 
     super(tagName);
 
     /**
-     * @type {Array<module:ol/format/filter/Filter>}
+     * @type {Array<import("./Filter.js").default>}
      */
     this.conditions = Array.prototype.slice.call(arguments, 1);
     assert(this.conditions.length >= 2, 57); // At least 2 conditions are required.

--- a/src/ol/format/filter/Not.js
+++ b/src/ol/format/filter/Not.js
@@ -11,14 +11,14 @@ import Filter from '../filter/Filter.js';
 class Not extends Filter {
 
   /**
-   * @param {!module:ol/format/filter/Filter} condition Filter condition.
+   * @param {!import("./Filter.js").default} condition Filter condition.
    */
   constructor(condition) {
 
     super('Not');
 
     /**
-     * @type {!module:ol/format/filter/Filter}
+     * @type {!import("./Filter.js").default}
      */
     this.condition = condition;
 

--- a/src/ol/format/filter/Or.js
+++ b/src/ol/format/filter/Or.js
@@ -11,7 +11,7 @@ import LogicalNary from '../filter/LogicalNary.js';
 class Or extends LogicalNary {
 
   /**
-   * @param {...module:ol/format/filter/Filter} conditions Conditions.
+   * @param {...import("./Filter.js").default} conditions Conditions.
    */
   constructor(conditions) {
     const params = ['Or'].concat(Array.prototype.slice.call(arguments));

--- a/src/ol/format/filter/Spatial.js
+++ b/src/ol/format/filter/Spatial.js
@@ -16,7 +16,7 @@ class Spatial extends Filter {
   /**
    * @param {!string} tagName The XML tag name for this filter.
    * @param {!string} geometryName Geometry name to use.
-   * @param {!module:ol/geom/Geometry} geometry Geometry.
+   * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
    * @param {string=} opt_srsName SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
@@ -30,7 +30,7 @@ class Spatial extends Filter {
     this.geometryName = geometryName || 'the_geom';
 
     /**
-     * @type {module:ol/geom/Geometry}
+     * @type {import("../../geom/Geometry.js").default}
      */
     this.geometry = geometry;
 

--- a/src/ol/format/filter/Within.js
+++ b/src/ol/format/filter/Within.js
@@ -13,7 +13,7 @@ class Within extends Spatial {
 
   /**
    * @param {!string} geometryName Geometry name to use.
-   * @param {!module:ol/geom/Geometry} geometry Geometry.
+   * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
    * @param {string=} opt_srsName SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -15,11 +15,11 @@ import {deflateCoordinate} from '../geom/flat/deflate.js';
 class Circle extends SimpleGeometry {
 
   /**
-   * @param {!module:ol/coordinate~Coordinate} center Center.
+   * @param {!import("../coordinate.js").Coordinate} center Center.
    *     For internal use, flat coordinates in combination with `opt_layout` and no
    *     `opt_radius` are also accepted.
    * @param {number=} opt_radius Radius.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(center, opt_radius, opt_layout) {
     super();
@@ -33,7 +33,7 @@ class Circle extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/Circle} Clone.
+   * @return {!import("./Circle.js").default} Clone.
    * @override
    * @api
    */
@@ -81,7 +81,7 @@ class Circle extends SimpleGeometry {
 
   /**
    * Return the center of the circle as {@link module:ol/coordinate~Coordinate coordinate}.
-   * @return {module:ol/coordinate~Coordinate} Center.
+   * @return {import("../coordinate.js").Coordinate} Center.
    * @api
    */
   getCenter() {
@@ -151,7 +151,7 @@ class Circle extends SimpleGeometry {
 
   /**
    * Set the center of the circle as {@link module:ol/coordinate~Coordinate coordinate}.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../coordinate.js").Coordinate} center Center.
    * @api
    */
   setCenter(center) {
@@ -169,9 +169,9 @@ class Circle extends SimpleGeometry {
   /**
    * Set the center (as {@link module:ol/coordinate~Coordinate coordinate}) and the radius (as
    * number) of the circle.
-   * @param {!module:ol/coordinate~Coordinate} center Center.
+   * @param {!import("../coordinate.js").Coordinate} center Center.
    * @param {number} radius Radius.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @api
    */
   setCenterAndRadius(center, radius, opt_layout) {
@@ -226,11 +226,11 @@ class Circle extends SimpleGeometry {
  * correspond to the shape that would be obtained by transforming every point
  * of the original circle.
  *
- * @param {module:ol/proj~ProjectionLike} source The current projection.  Can be a
+ * @param {import("../proj.js").ProjectionLike} source The current projection.  Can be a
  *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
- * @param {module:ol/proj~ProjectionLike} destination The desired projection.  Can be a
+ * @param {import("../proj.js").ProjectionLike} destination The desired projection.  Can be a
  *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
- * @return {module:ol/geom/Circle} This geometry.  Note that original geometry is
+ * @return {import("./Circle.js").default} This geometry.  Note that original geometry is
  *     modified in place.
  * @function
  * @api

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -11,7 +11,7 @@ import {create as createTransform, compose as composeTransform} from '../transfo
 
 
 /**
- * @type {module:ol/transform~Transform}
+ * @type {import("../transform.js").Transform}
  */
 const tmpTransform = createTransform();
 
@@ -35,7 +35,7 @@ class Geometry extends BaseObject {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.extent_ = createEmpty();
 
@@ -47,7 +47,7 @@ class Geometry extends BaseObject {
 
     /**
      * @protected
-     * @type {Object<string, module:ol/geom/Geometry>}
+     * @type {Object<string, import("./Geometry.js").default>}
      */
     this.simplifiedGeometryCache = {};
 
@@ -68,7 +68,7 @@ class Geometry extends BaseObject {
   /**
    * Make a complete copy of the geometry.
    * @abstract
-   * @return {!module:ol/geom/Geometry} Clone.
+   * @return {!import("./Geometry.js").default} Clone.
    */
   clone() {}
 
@@ -76,7 +76,7 @@ class Geometry extends BaseObject {
    * @abstract
    * @param {number} x X.
    * @param {number} y Y.
-   * @param {module:ol/coordinate~Coordinate} closestPoint Closest point.
+   * @param {import("../coordinate.js").Coordinate} closestPoint Closest point.
    * @param {number} minSquaredDistance Minimum squared distance.
    * @return {number} Minimum squared distance.
    */
@@ -85,9 +85,9 @@ class Geometry extends BaseObject {
   /**
    * Return the closest point of the geometry to the passed point as
    * {@link module:ol/coordinate~Coordinate coordinate}.
-   * @param {module:ol/coordinate~Coordinate} point Point.
-   * @param {module:ol/coordinate~Coordinate=} opt_closestPoint Closest point.
-   * @return {module:ol/coordinate~Coordinate} Closest point.
+   * @param {import("../coordinate.js").Coordinate} point Point.
+   * @param {import("../coordinate.js").Coordinate=} opt_closestPoint Closest point.
+   * @return {import("../coordinate.js").Coordinate} Closest point.
    * @api
    */
   getClosestPoint(point, opt_closestPoint) {
@@ -99,7 +99,7 @@ class Geometry extends BaseObject {
   /**
    * Returns true if this geometry includes the specified coordinate. If the
    * coordinate is on the boundary of the geometry, returns false.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @return {boolean} Contains coordinate.
    * @api
    */
@@ -109,16 +109,16 @@ class Geometry extends BaseObject {
 
   /**
    * @abstract
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @protected
-   * @return {module:ol/extent~Extent} extent Extent.
+   * @return {import("../extent.js").Extent} extent Extent.
    */
   computeExtent(extent) {}
 
   /**
    * Get the extent of the geometry.
-   * @param {module:ol/extent~Extent=} opt_extent Extent.
-   * @return {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent=} opt_extent Extent.
+   * @return {import("../extent.js").Extent} extent Extent.
    * @api
    */
   getExtent(opt_extent) {
@@ -134,7 +134,7 @@ class Geometry extends BaseObject {
    * coordinates in place.
    * @abstract
    * @param {number} angle Rotation angle in radians.
-   * @param {module:ol/coordinate~Coordinate} anchor The rotation center.
+   * @param {import("../coordinate.js").Coordinate} anchor The rotation center.
    * @api
    */
   rotate(angle, anchor) {}
@@ -146,7 +146,7 @@ class Geometry extends BaseObject {
    * @param {number} sx The scaling factor in the x-direction.
    * @param {number=} opt_sy The scaling factor in the y-direction (defaults to
    *     sx).
-   * @param {module:ol/coordinate~Coordinate=} opt_anchor The scale origin (defaults to the center
+   * @param {import("../coordinate.js").Coordinate=} opt_anchor The scale origin (defaults to the center
    *     of the geometry extent).
    * @api
    */
@@ -160,7 +160,7 @@ class Geometry extends BaseObject {
    * simplification is used to preserve topology.
    * @function
    * @param {number} tolerance The tolerance distance for simplification.
-   * @return {module:ol/geom/Geometry} A new, simplified version of the original
+   * @return {import("./Geometry.js").default} A new, simplified version of the original
    *     geometry.
    * @api
    */
@@ -174,14 +174,14 @@ class Geometry extends BaseObject {
    * See https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm.
    * @abstract
    * @param {number} squaredTolerance Squared tolerance.
-   * @return {module:ol/geom/Geometry} Simplified geometry.
+   * @return {import("./Geometry.js").default} Simplified geometry.
    */
   getSimplifiedGeometry(squaredTolerance) {}
 
   /**
    * Get the type of this geometry.
    * @abstract
-   * @return {module:ol/geom/GeometryType} Geometry type.
+   * @return {import("./GeometryType.js").default} Geometry type.
    */
   getType() {}
 
@@ -191,14 +191,14 @@ class Geometry extends BaseObject {
    * If you do not want the geometry modified in place, first `clone()` it and
    * then use this function on the clone.
    * @abstract
-   * @param {module:ol/proj~TransformFunction} transformFn Transform.
+   * @param {import("../proj.js").TransformFunction} transformFn Transform.
    */
   applyTransform(transformFn) {}
 
   /**
    * Test if the geometry and the passed extent intersect.
    * @abstract
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @return {boolean} `true` if the geometry and the extent intersect.
    */
   intersectsExtent(extent) {}
@@ -220,11 +220,11 @@ class Geometry extends BaseObject {
    * If you do not want the geometry modified in place, first `clone()` it and
    * then use this function on the clone.
    *
-   * @param {module:ol/proj~ProjectionLike} source The current projection.  Can be a
+   * @param {import("../proj.js").ProjectionLike} source The current projection.  Can be a
    *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
-   * @param {module:ol/proj~ProjectionLike} destination The desired projection.  Can be a
+   * @param {import("../proj.js").ProjectionLike} destination The desired projection.  Can be a
    *     string identifier or a {@link module:ol/proj/Projection~Projection} object.
-   * @return {module:ol/geom/Geometry} This geometry.  Note that original geometry is
+   * @return {import("./Geometry.js").default} This geometry.  Note that original geometry is
    *     modified in place.
    * @api
    */

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -17,7 +17,7 @@ import {clear} from '../obj.js';
 class GeometryCollection extends Geometry {
 
   /**
-   * @param {Array<module:ol/geom/Geometry>=} opt_geometries Geometries.
+   * @param {Array<import("./Geometry.js").default>=} opt_geometries Geometries.
    */
   constructor(opt_geometries) {
 
@@ -25,7 +25,7 @@ class GeometryCollection extends Geometry {
 
     /**
      * @private
-     * @type {Array<module:ol/geom/Geometry>}
+     * @type {Array<import("./Geometry.js").default>}
      */
     this.geometries_ = opt_geometries ? opt_geometries : null;
 
@@ -62,7 +62,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/GeometryCollection} Clone.
+   * @return {!import("./GeometryCollection.js").default} Clone.
    * @override
    * @api
    */
@@ -114,7 +114,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Return the geometries that make up this geometry collection.
-   * @return {Array<module:ol/geom/Geometry>} Geometries.
+   * @return {Array<import("./Geometry.js").default>} Geometries.
    * @api
    */
   getGeometries() {
@@ -122,7 +122,7 @@ class GeometryCollection extends Geometry {
   }
 
   /**
-   * @return {Array<module:ol/geom/Geometry>} Geometries.
+   * @return {Array<import("./Geometry.js").default>} Geometries.
    */
   getGeometriesArray() {
     return this.geometries_;
@@ -228,7 +228,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Set the geometries that make up this geometry collection.
-   * @param {Array<module:ol/geom/Geometry>} geometries Geometries.
+   * @param {Array<import("./Geometry.js").default>} geometries Geometries.
    * @api
    */
   setGeometries(geometries) {
@@ -236,7 +236,7 @@ class GeometryCollection extends Geometry {
   }
 
   /**
-   * @param {Array<module:ol/geom/Geometry>} geometries Geometries.
+   * @param {Array<import("./Geometry.js").default>} geometries Geometries.
    */
   setGeometriesArray(geometries) {
     this.unlistenGeometriesChange_();
@@ -280,8 +280,8 @@ class GeometryCollection extends Geometry {
 
 
 /**
- * @param {Array<module:ol/geom/Geometry>} geometries Geometries.
- * @return {Array<module:ol/geom/Geometry>} Cloned geometries.
+ * @param {Array<import("./Geometry.js").default>} geometries Geometries.
+ * @return {Array<import("./Geometry.js").default>} Cloned geometries.
  */
 function cloneGeometries(geometries) {
   const clonedGeometries = [];

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -24,9 +24,9 @@ import {douglasPeucker} from '../geom/flat/simplify.js';
 class LineString extends SimpleGeometry {
 
   /**
-   * @param {Array<module:ol/coordinate~Coordinate>|Array<number>} coordinates Coordinates.
+   * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
 
@@ -34,7 +34,7 @@ class LineString extends SimpleGeometry {
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      */
     this.flatMidpoint_ = null;
 
@@ -66,7 +66,7 @@ class LineString extends SimpleGeometry {
 
   /**
    * Append the passed coordinate to the coordinates of the linestring.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @api
    */
   appendCoordinate(coordinate) {
@@ -80,7 +80,7 @@ class LineString extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/LineString} Clone.
+   * @return {!import("./LineString.js").default} Clone.
    * @override
    * @api
    */
@@ -110,7 +110,7 @@ class LineString extends SimpleGeometry {
    * If the callback returns a truthy value the function returns that
    * value immediately. Otherwise the function returns `false`.
    *
-   * @param {function(this: S, module:ol/coordinate~Coordinate, module:ol/coordinate~Coordinate): T} callback Function
+   * @param {function(this: S, import("../coordinate.js").Coordinate, import("../coordinate.js").Coordinate): T} callback Function
    *     called for each segment.
    * @return {T|boolean} Value.
    * @template T,S
@@ -131,7 +131,7 @@ class LineString extends SimpleGeometry {
    *
    * @param {number} m M.
    * @param {boolean=} opt_extrapolate Extrapolate. Default is `false`.
-   * @return {module:ol/coordinate~Coordinate} Coordinate.
+   * @return {import("../coordinate.js").Coordinate} Coordinate.
    * @api
    */
   getCoordinateAtM(m, opt_extrapolate) {
@@ -146,7 +146,7 @@ class LineString extends SimpleGeometry {
 
   /**
    * Return the coordinates of the linestring.
-   * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
+   * @return {Array<import("../coordinate.js").Coordinate>} Coordinates.
    * @override
    * @api
    */
@@ -160,9 +160,9 @@ class LineString extends SimpleGeometry {
    * The `fraction` is a number between 0 and 1, where 0 is the start of the
    * linestring and 1 is the end.
    * @param {number} fraction Fraction.
-   * @param {module:ol/coordinate~Coordinate=} opt_dest Optional coordinate whose values will
+   * @param {import("../coordinate.js").Coordinate=} opt_dest Optional coordinate whose values will
    *     be modified. If not provided, a new coordinate will be returned.
-   * @return {module:ol/coordinate~Coordinate} Coordinate of the interpolated point.
+   * @return {import("../coordinate.js").Coordinate} Coordinate of the interpolated point.
    * @api
    */
   getCoordinateAt(fraction, opt_dest) {
@@ -223,8 +223,8 @@ class LineString extends SimpleGeometry {
 
   /**
    * Set the coordinates of the linestring.
-   * @param {!Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -21,9 +21,9 @@ import {douglasPeucker} from '../geom/flat/simplify.js';
 class LinearRing extends SimpleGeometry {
 
   /**
-   * @param {Array<module:ol/coordinate~Coordinate>|Array<number>} coordinates Coordinates.
+   * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
 
@@ -51,7 +51,7 @@ class LinearRing extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/LinearRing} Clone.
+   * @return {!import("./LinearRing.js").default} Clone.
    * @override
    * @api
    */
@@ -87,7 +87,7 @@ class LinearRing extends SimpleGeometry {
 
   /**
    * Return the coordinates of the linear ring.
-   * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
+   * @return {Array<import("../coordinate.js").Coordinate>} Coordinates.
    * @override
    * @api
    */
@@ -122,8 +122,8 @@ class LinearRing extends SimpleGeometry {
 
   /**
    * Set the coordinates of the linear ring.
-   * @param {!Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -23,10 +23,10 @@ import {douglasPeuckerArray} from '../geom/flat/simplify.js';
 class MultiLineString extends SimpleGeometry {
 
   /**
-   * @param {Array<Array<module:ol/coordinate~Coordinate>|module:ol/geom~MultiLineString>|Array<number>} coordinates
+   * @param {Array<Array<import("../coordinate.js").Coordinate>|import("../geom.js").MultiLineString>|Array<number>} coordinates
    *     Coordinates or LineString geometries. (For internal use, flat coordinates in
    *     combination with `opt_layout` and `opt_ends` are also accepted.)
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @param {Array<number>} opt_ends Flat coordinate ends for internal use.
    */
   constructor(coordinates, opt_layout, opt_ends) {
@@ -76,7 +76,7 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Append the passed linestring to the multilinestring.
-   * @param {module:ol/geom/LineString} lineString LineString.
+   * @param {import("./LineString.js").default} lineString LineString.
    * @api
    */
   appendLineString(lineString) {
@@ -91,7 +91,7 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/MultiLineString} Clone.
+   * @return {!import("./MultiLineString.js").default} Clone.
    * @override
    * @api
    */
@@ -135,7 +135,7 @@ class MultiLineString extends SimpleGeometry {
    * @param {number} m M.
    * @param {boolean=} opt_extrapolate Extrapolate. Default is `false`.
    * @param {boolean=} opt_interpolate Interpolate. Default is `false`.
-   * @return {module:ol/coordinate~Coordinate} Coordinate.
+   * @return {import("../coordinate.js").Coordinate} Coordinate.
    * @api
    */
   getCoordinateAtM(m, opt_extrapolate, opt_interpolate) {
@@ -152,7 +152,7 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Return the coordinates of the multilinestring.
-   * @return {Array<Array<module:ol/coordinate~Coordinate>>} Coordinates.
+   * @return {Array<Array<import("../coordinate.js").Coordinate>>} Coordinates.
    * @override
    * @api
    */
@@ -171,7 +171,7 @@ class MultiLineString extends SimpleGeometry {
   /**
    * Return the linestring at the specified index.
    * @param {number} index Index.
-   * @return {module:ol/geom/LineString} LineString.
+   * @return {import("./LineString.js").default} LineString.
    * @api
    */
   getLineString(index) {
@@ -184,14 +184,14 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Return the linestrings of this multilinestring.
-   * @return {Array<module:ol/geom/LineString>} LineStrings.
+   * @return {Array<import("./LineString.js").default>} LineStrings.
    * @api
    */
   getLineStrings() {
     const flatCoordinates = this.flatCoordinates;
     const ends = this.ends_;
     const layout = this.layout;
-    /** @type {Array<module:ol/geom/LineString>} */
+    /** @type {Array<import("./LineString.js").default>} */
     const lineStrings = [];
     let offset = 0;
     for (let i = 0, ii = ends.length; i < ii; ++i) {
@@ -253,8 +253,8 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Set the coordinates of the multilinestring.
-   * @param {!Array<Array<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -19,9 +19,9 @@ import {squaredDistance as squaredDx} from '../math.js';
 class MultiPoint extends SimpleGeometry {
 
   /**
-   * @param {Array<module:ol/coordinate~Coordinate>|Array<number>} coordinates Coordinates.
+   * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -34,7 +34,7 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Append the passed point to this multipoint.
-   * @param {module:ol/geom/Point} point Point.
+   * @param {import("./Point.js").default} point Point.
    * @api
    */
   appendPoint(point) {
@@ -48,7 +48,7 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/MultiPoint} Clone.
+   * @return {!import("./MultiPoint.js").default} Clone.
    * @override
    * @api
    */
@@ -82,7 +82,7 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Return the coordinates of the multipoint.
-   * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
+   * @return {Array<import("../coordinate.js").Coordinate>} Coordinates.
    * @override
    * @api
    */
@@ -94,7 +94,7 @@ class MultiPoint extends SimpleGeometry {
   /**
    * Return the point at the specified index.
    * @param {number} index Index.
-   * @return {module:ol/geom/Point} Point.
+   * @return {import("./Point.js").default} Point.
    * @api
    */
   getPoint(index) {
@@ -108,14 +108,14 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Return the points of this multipoint.
-   * @return {Array<module:ol/geom/Point>} Points.
+   * @return {Array<import("./Point.js").default>} Points.
    * @api
    */
   getPoints() {
     const flatCoordinates = this.flatCoordinates;
     const layout = this.layout;
     const stride = this.stride;
-    /** @type {Array<module:ol/geom/Point>} */
+    /** @type {Array<import("./Point.js").default>} */
     const points = [];
     for (let i = 0, ii = flatCoordinates.length; i < ii; i += stride) {
       const point = new Point(flatCoordinates.slice(i, i + stride), layout);
@@ -151,8 +151,8 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Set the coordinates of the multipoint.
-   * @param {!Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -28,9 +28,9 @@ import {quantizeMultiArray} from '../geom/flat/simplify.js';
 class MultiPolygon extends SimpleGeometry {
 
   /**
-   * @param {Array<Array<Array<module:ol/coordinate~Coordinate>>>|Array<number>} coordinates Coordinates.
+   * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinats in combination with `opt_layout` and `opt_endss` are also accepted.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @param {Array<number>} opt_endss Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
@@ -111,7 +111,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Append the passed polygon to this multipolygon.
-   * @param {module:ol/geom/Polygon} polygon Polygon.
+   * @param {import("./Polygon.js").default} polygon Polygon.
    * @api
    */
   appendPolygon(polygon) {
@@ -135,7 +135,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/MultiPolygon} Clone.
+   * @return {!import("./MultiPolygon.js").default} Clone.
    * @override
    * @api
    */
@@ -193,7 +193,7 @@ class MultiPolygon extends SimpleGeometry {
    *     (clockwise for exterior and counter-clockwise for interior rings).
    *     By default, coordinate orientation will depend on how the geometry was
    *     constructed.
-   * @return {Array<Array<Array<module:ol/coordinate~Coordinate>>>} Coordinates.
+   * @return {Array<Array<Array<import("../coordinate.js").Coordinate>>>} Coordinates.
    * @override
    * @api
    */
@@ -235,7 +235,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Return the interior points as {@link module:ol/geom/MultiPoint multipoint}.
-   * @return {module:ol/geom/MultiPoint} Interior points as XYM coordinates, where M is
+   * @return {import("./MultiPoint.js").default} Interior points as XYM coordinates, where M is
    * the length of the horizontal intersection that the point belongs to.
    * @api
    */
@@ -279,7 +279,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * Return the polygon at the specified index.
    * @param {number} index Index.
-   * @return {module:ol/geom/Polygon} Polygon.
+   * @return {import("./Polygon.js").default} Polygon.
    * @api
    */
   getPolygon(index) {
@@ -305,7 +305,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Return the polygons of this multipolygon.
-   * @return {Array<module:ol/geom/Polygon>} Polygons.
+   * @return {Array<import("./Polygon.js").default>} Polygons.
    * @api
    */
   getPolygons() {
@@ -348,8 +348,8 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Set the coordinates of the multipolygon.
-   * @param {!Array<Array<Array<module:ol/coordinate~Coordinate>>>} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {!Array<Array<Array<import("../coordinate.js").Coordinate>>>} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -16,8 +16,8 @@ import {squaredDistance as squaredDx} from '../math.js';
 class Point extends SimpleGeometry {
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("../coordinate.js").Coordinate} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -26,7 +26,7 @@ class Point extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/Point} Clone.
+   * @return {!import("./Point.js").default} Clone.
    * @override
    * @api
    */
@@ -55,7 +55,7 @@ class Point extends SimpleGeometry {
 
   /**
    * Return the coordinate of the point.
-   * @return {module:ol/coordinate~Coordinate} Coordinates.
+   * @return {import("../coordinate.js").Coordinate} Coordinates.
    * @override
    * @api
    */

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -29,14 +29,14 @@ import {modulo} from '../math.js';
 class Polygon extends SimpleGeometry {
 
   /**
-   * @param {!Array<Array<module:ol/coordinate~Coordinate>>|!Array<number>} coordinates
+   * @param {!Array<Array<import("../coordinate.js").Coordinate>>|!Array<number>} coordinates
    *     Array of linear rings that define the polygon. The first linear ring of the
    *     array defines the outer-boundary or surface of the polygon. Each subsequent
    *     linear ring defines a hole in the surface of the polygon. A linear ring is
    *     an array of vertices' coordinates where the first coordinate and the last are
    *     equivalent. (For internal use, flat coordinates in combination with
    *     `opt_layout` and `opt_ends` are also accepted.)
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @param {Array<number>=} opt_ends Ends (for internal use with flat coordinates).
    */
   constructor(coordinates, opt_layout, opt_ends) {
@@ -57,7 +57,7 @@ class Polygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      */
     this.flatInteriorPoint_ = null;
 
@@ -96,7 +96,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Append the passed linear ring to this polygon.
-   * @param {module:ol/geom/LinearRing} linearRing Linear ring.
+   * @param {import("./LinearRing.js").default} linearRing Linear ring.
    * @api
    */
   appendLinearRing(linearRing) {
@@ -111,7 +111,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Make a complete copy of the geometry.
-   * @return {!module:ol/geom/Polygon} Clone.
+   * @return {!import("./Polygon.js").default} Clone.
    * @override
    * @api
    */
@@ -162,7 +162,7 @@ class Polygon extends SimpleGeometry {
    *     (clockwise for exterior and counter-clockwise for interior rings).
    *     By default, coordinate orientation will depend on how the geometry was
    *     constructed.
-   * @return {Array<Array<module:ol/coordinate~Coordinate>>} Coordinates.
+   * @return {Array<Array<import("../coordinate.js").Coordinate>>} Coordinates.
    * @override
    * @api
    */
@@ -203,7 +203,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Return an interior point of the polygon.
-   * @return {module:ol/geom/Point} Interior point as XYM coordinate, where M is the
+   * @return {import("./Point.js").default} Interior point as XYM coordinate, where M is the
    * length of the horizontal intersection that the point belongs to.
    * @api
    */
@@ -229,7 +229,7 @@ class Polygon extends SimpleGeometry {
    * at index `1` and beyond.
    *
    * @param {number} index Index.
-   * @return {module:ol/geom/LinearRing} Linear ring.
+   * @return {import("./LinearRing.js").default} Linear ring.
    * @api
    */
   getLinearRing(index) {
@@ -242,7 +242,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Return the linear rings of the polygon.
-   * @return {Array<module:ol/geom/LinearRing>} Linear rings.
+   * @return {Array<import("./LinearRing.js").default>} Linear rings.
    * @api
    */
   getLinearRings() {
@@ -312,8 +312,8 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Set the coordinates of the polygon.
-   * @param {!Array<Array<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @override
    * @api
    */
@@ -335,14 +335,14 @@ export default Polygon;
 
 /**
  * Create an approximation of a circle on the surface of a sphere.
- * @param {module:ol/coordinate~Coordinate} center Center (`[lon, lat]` in degrees).
+ * @param {import("../coordinate.js").Coordinate} center Center (`[lon, lat]` in degrees).
  * @param {number} radius The great-circle distance from the center to
  *     the polygon vertices.
  * @param {number=} opt_n Optional number of vertices for the resulting
  *     polygon. Default is `32`.
  * @param {number=} opt_sphereRadius Optional radius for the sphere (defaults to
  *     the Earth's mean radius using the WGS84 ellipsoid).
- * @return {module:ol/geom/Polygon} The "circular" polygon.
+ * @return {import("./Polygon.js").default} The "circular" polygon.
  * @api
  */
 export function circular(center, radius, opt_n, opt_sphereRadius) {
@@ -359,8 +359,8 @@ export function circular(center, radius, opt_n, opt_sphereRadius) {
 
 /**
  * Create a polygon from an extent. The layout used is `XY`.
- * @param {module:ol/extent~Extent} extent The extent.
- * @return {module:ol/geom/Polygon} The polygon.
+ * @param {import("../extent.js").Extent} extent The extent.
+ * @return {import("./Polygon.js").default} The polygon.
  * @api
  */
 export function fromExtent(extent) {
@@ -376,11 +376,11 @@ export function fromExtent(extent) {
 
 /**
  * Create a regular polygon from a circle.
- * @param {module:ol/geom/Circle} circle Circle geometry.
+ * @param {import("./Circle.js").default} circle Circle geometry.
  * @param {number=} opt_sides Number of sides of the polygon. Default is 32.
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in
  *     radians. Default is 0.
- * @return {module:ol/geom/Polygon} Polygon geometry.
+ * @return {import("./Polygon.js").default} Polygon geometry.
  * @api
  */
 export function fromCircle(circle, opt_sides, opt_angle) {
@@ -406,8 +406,8 @@ export function fromCircle(circle, opt_sides, opt_angle) {
 
 /**
  * Modify the coordinates of a polygon to make it a regular polygon.
- * @param {module:ol/geom/Polygon} polygon Polygon geometry.
- * @param {module:ol/coordinate~Coordinate} center Center of the regular polygon.
+ * @param {import("./Polygon.js").default} polygon Polygon geometry.
+ * @param {import("../coordinate.js").Coordinate} center Center of the regular polygon.
  * @param {number} radius Radius of the regular polygon.
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in
  *     radians. Default is 0.

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -23,7 +23,7 @@ class SimpleGeometry extends Geometry {
 
     /**
      * @protected
-     * @type {module:ol/geom/GeometryLayout}
+     * @type {import("./GeometryLayout.js").default}
      */
     this.layout = GeometryLayout.XY;
 
@@ -57,7 +57,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * Return the first coordinate of the geometry.
-   * @return {module:ol/coordinate~Coordinate} First coordinate.
+   * @return {import("../coordinate.js").Coordinate} First coordinate.
    * @api
    */
   getFirstCoordinate() {
@@ -73,7 +73,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * Return the last coordinate of the geometry.
-   * @return {module:ol/coordinate~Coordinate} Last point.
+   * @return {import("../coordinate.js").Coordinate} Last point.
    * @api
    */
   getLastCoordinate() {
@@ -82,7 +82,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * Return the {@link module:ol/geom/GeometryLayout~GeometryLayout layout} of the geometry.
-   * @return {module:ol/geom/GeometryLayout} Layout.
+   * @return {import("./GeometryLayout.js").default} Layout.
    * @api
    */
   getLayout() {
@@ -130,7 +130,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @param {number} squaredTolerance Squared tolerance.
-   * @return {module:ol/geom/SimpleGeometry} Simplified geometry.
+   * @return {import("./SimpleGeometry.js").default} Simplified geometry.
    * @protected
    */
   getSimplifiedGeometryInternal(squaredTolerance) {
@@ -145,7 +145,7 @@ class SimpleGeometry extends Geometry {
   }
 
   /**
-   * @param {module:ol/geom/GeometryLayout} layout Layout.
+   * @param {import("./GeometryLayout.js").default} layout Layout.
    * @param {Array<number>} flatCoordinates Flat coordinates.
     */
   setFlatCoordinates(layout, flatCoordinates) {
@@ -157,12 +157,12 @@ class SimpleGeometry extends Geometry {
   /**
    * @abstract
    * @param {!Array} coordinates Coordinates.
-   * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   setCoordinates(coordinates, opt_layout) {}
 
   /**
-   * @param {module:ol/geom/GeometryLayout|undefined} layout Layout.
+   * @param {import("./GeometryLayout.js").default|undefined} layout Layout.
    * @param {Array} coordinates Coordinates.
    * @param {number} nesting Nesting.
    * @protected
@@ -257,7 +257,7 @@ class SimpleGeometry extends Geometry {
 
 /**
  * @param {number} stride Stride.
- * @return {module:ol/geom/GeometryLayout} layout Layout.
+ * @return {import("./GeometryLayout.js").default} layout Layout.
  */
 function getLayoutForStride(stride) {
   let layout;
@@ -269,13 +269,13 @@ function getLayoutForStride(stride) {
     layout = GeometryLayout.XYZM;
   }
   return (
-    /** @type {module:ol/geom/GeometryLayout} */ (layout)
+    /** @type {import("./GeometryLayout.js").default} */ (layout)
   );
 }
 
 
 /**
- * @param {module:ol/geom/GeometryLayout} layout Layout.
+ * @param {import("./GeometryLayout.js").default} layout Layout.
  * @return {number} Stride.
  */
 export function getStrideForLayout(layout) {
@@ -298,8 +298,8 @@ SimpleGeometry.prototype.containsXY = FALSE;
 
 
 /**
- * @param {module:ol/geom/SimpleGeometry} simpleGeometry Simple geometry.
- * @param {module:ol/transform~Transform} transform Transform.
+ * @param {import("./SimpleGeometry.js").default} simpleGeometry Simple geometry.
+ * @param {import("../transform.js").Transform} transform Transform.
  * @param {Array<number>=} opt_dest Destination.
  * @return {Array<number>} Transformed flat coordinates.
  */

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -9,13 +9,13 @@ import {forEachCorner} from '../../extent.js';
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent.
  * @return {boolean} Contains extent.
  */
 export function linearRingContainsExtent(flatCoordinates, offset, end, stride, extent) {
   const outside = forEachCorner(extent,
     /**
-     * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+     * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
      * @return {boolean} Contains (x, y).
      */
     function(coordinate) {

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -6,7 +6,7 @@
 /**
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
  * @param {number} stride Stride.
  * @return {number} offset Offset.
  */
@@ -21,7 +21,7 @@ export function deflateCoordinate(flatCoordinates, offset, coordinate, stride) {
 /**
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+ * @param {Array<import("../../coordinate.js").Coordinate>} coordinates Coordinates.
  * @param {number} stride Stride.
  * @return {number} offset Offset.
  */
@@ -39,7 +39,7 @@ export function deflateCoordinates(flatCoordinates, offset, coordinates, stride)
 /**
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>} coordinatess Coordinatess.
+ * @param {Array<Array<import("../../coordinate.js").Coordinate>>} coordinatess Coordinatess.
  * @param {number} stride Stride.
  * @param {Array<number>=} opt_ends Ends.
  * @return {Array<number>} Ends.
@@ -61,7 +61,7 @@ export function deflateCoordinatesArray(flatCoordinates, offset, coordinatess, s
 /**
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array<Array<Array<module:ol/coordinate~Coordinate>>>} coordinatesss Coordinatesss.
+ * @param {Array<Array<Array<import("../../coordinate.js").Coordinate>>>} coordinatesss Coordinatesss.
  * @param {number} stride Stride.
  * @param {Array<Array<number>>=} opt_endss Endss.
  * @return {Array<Array<number>>} Endss.

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -6,8 +6,8 @@ import {get as getProjection, getTransform} from '../../proj.js';
 
 
 /**
- * @param {function(number): module:ol/coordinate~Coordinate} interpolate Interpolate function.
- * @param {module:ol/proj~TransformFunction} transform Transform from longitude/latitude to
+ * @param {function(number): import("../../coordinate.js").Coordinate} interpolate Interpolate function.
+ * @param {import("../../proj.js").TransformFunction} transform Transform from longitude/latitude to
  *     projected coordinates.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array<number>} Flat coordinates.
@@ -25,9 +25,9 @@ function line(interpolate, transform, squaredTolerance) {
   let a = transform(geoA);
   let b = transform(geoB);
 
-  /** @type {Array<module:ol/coordinate~Coordinate>} */
+  /** @type {Array<import("../../coordinate.js").Coordinate>} */
   const geoStack = [geoB, geoA];
-  /** @type {Array<module:ol/coordinate~Coordinate>} */
+  /** @type {Array<import("../../coordinate.js").Coordinate>} */
   const stack = [b, a];
   /** @type {Array<number>} */
   const fractionStack = [1, 0];
@@ -84,7 +84,7 @@ function line(interpolate, transform, squaredTolerance) {
  * @param {number} lat1 Latitude 1 in degrees.
  * @param {number} lon2 Longitude 2 in degrees.
  * @param {number} lat2 Latitude 2 in degrees.
- * @param {module:ol/proj/Projection} projection Projection.
+ * @param {import("../../proj/Projection.js").default} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array<number>} Flat coordinates.
  */
@@ -102,7 +102,7 @@ export function greatCircleArc(lon1, lat1, lon2, lat2, projection, squaredTolera
   return line(
     /**
      * @param {number} frac Fraction.
-     * @return {module:ol/coordinate~Coordinate} Coordinate.
+     * @return {import("../../coordinate.js").Coordinate} Coordinate.
      */
     function(frac) {
       if (1 <= d) {
@@ -128,7 +128,7 @@ export function greatCircleArc(lon1, lat1, lon2, lat2, projection, squaredTolera
  * @param {number} lon Longitude.
  * @param {number} lat1 Latitude 1.
  * @param {number} lat2 Latitude 2.
- * @param {module:ol/proj/Projection} projection Projection.
+ * @param {import("../../proj/Projection.js").default} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array<number>} Flat coordinates.
  */
@@ -137,7 +137,7 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
   return line(
     /**
      * @param {number} frac Fraction.
-     * @return {module:ol/coordinate~Coordinate} Coordinate.
+     * @return {import("../../coordinate.js").Coordinate} Coordinate.
      */
     function(frac) {
       return [lon, lat1 + ((lat2 - lat1) * frac)];
@@ -151,7 +151,7 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
  * @param {number} lat Latitude.
  * @param {number} lon1 Longitude 1.
  * @param {number} lon2 Longitude 2.
- * @param {module:ol/proj/Projection} projection Projection.
+ * @param {import("../../proj/Projection.js").default} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array<number>} Flat coordinates.
  */
@@ -160,7 +160,7 @@ export function parallel(lat, lon1, lon2, projection, squaredTolerance) {
   return line(
     /**
      * @param {number} frac Fraction.
-     * @return {module:ol/coordinate~Coordinate} Coordinate.
+     * @return {import("../../coordinate.js").Coordinate} Coordinate.
      */
     function(frac) {
       return [lon1 + ((lon2 - lon1) * frac), lat];

--- a/src/ol/geom/flat/inflate.js
+++ b/src/ol/geom/flat/inflate.js
@@ -8,8 +8,8 @@
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {Array<module:ol/coordinate~Coordinate>=} opt_coordinates Coordinates.
- * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
+ * @param {Array<import("../../coordinate.js").Coordinate>=} opt_coordinates Coordinates.
+ * @return {Array<import("../../coordinate.js").Coordinate>} Coordinates.
  */
 export function inflateCoordinates(flatCoordinates, offset, end, stride, opt_coordinates) {
   const coordinates = opt_coordinates !== undefined ? opt_coordinates : [];
@@ -27,8 +27,8 @@ export function inflateCoordinates(flatCoordinates, offset, end, stride, opt_coo
  * @param {number} offset Offset.
  * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {Array<Array<module:ol/coordinate~Coordinate>>=} opt_coordinatess Coordinatess.
- * @return {Array<Array<module:ol/coordinate~Coordinate>>} Coordinatess.
+ * @param {Array<Array<import("../../coordinate.js").Coordinate>>=} opt_coordinatess Coordinatess.
+ * @return {Array<Array<import("../../coordinate.js").Coordinate>>} Coordinatess.
  */
 export function inflateCoordinatesArray(flatCoordinates, offset, ends, stride, opt_coordinatess) {
   const coordinatess = opt_coordinatess !== undefined ? opt_coordinatess : [];
@@ -49,9 +49,9 @@ export function inflateCoordinatesArray(flatCoordinates, offset, ends, stride, o
  * @param {number} offset Offset.
  * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
- * @param {Array<Array<Array<module:ol/coordinate~Coordinate>>>=} opt_coordinatesss
+ * @param {Array<Array<Array<import("../../coordinate.js").Coordinate>>>=} opt_coordinatesss
  *     Coordinatesss.
- * @return {Array<Array<Array<module:ol/coordinate~Coordinate>>>} Coordinatesss.
+ * @return {Array<Array<Array<import("../../coordinate.js").Coordinate>>>} Coordinatesss.
  */
 export function inflateMultiCoordinatesArray(flatCoordinates, offset, endss, stride, opt_coordinatesss) {
   const coordinatesss = opt_coordinatesss !== undefined ? opt_coordinatesss : [];

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -71,7 +71,7 @@ export function interpolatePoint(flatCoordinates, offset, end, stride, fraction,
  * @param {number} stride Stride.
  * @param {number} m M.
  * @param {boolean} extrapolate Extrapolate.
- * @return {module:ol/coordinate~Coordinate} Coordinate.
+ * @return {import("../../coordinate.js").Coordinate} Coordinate.
  */
 export function lineStringCoordinateAtM(flatCoordinates, offset, end, stride, m, extrapolate) {
   if (end == offset) {
@@ -133,7 +133,7 @@ export function lineStringCoordinateAtM(flatCoordinates, offset, end, stride, m,
  * @param {number} m M.
  * @param {boolean} extrapolate Extrapolate.
  * @param {boolean} interpolate Interpolate.
- * @return {module:ol/coordinate~Coordinate} Coordinate.
+ * @return {import("../../coordinate.js").Coordinate} Coordinate.
  */
 export function lineStringsCoordinateAtM(
   flatCoordinates, offset, ends, stride, m, extrapolate, interpolate) {

--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -11,7 +11,7 @@ import {forEach as forEachSegment} from '../flat/segments.js';
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
  */
 export function intersectsLineString(flatCoordinates, offset, end, stride, extent) {
@@ -33,8 +33,8 @@ export function intersectsLineString(flatCoordinates, offset, end, stride, exten
   }
   return forEachSegment(flatCoordinates, offset, end, stride,
     /**
-     * @param {module:ol/coordinate~Coordinate} point1 Start point.
-     * @param {module:ol/coordinate~Coordinate} point2 End point.
+     * @param {import("../../coordinate.js").Coordinate} point1 Start point.
+     * @param {import("../../coordinate.js").Coordinate} point2 End point.
      * @return {boolean} `true` if the segment and the extent intersect,
      *     `false` otherwise.
      */
@@ -49,7 +49,7 @@ export function intersectsLineString(flatCoordinates, offset, end, stride, exten
  * @param {number} offset Offset.
  * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
  */
 export function intersectsLineStringArray(flatCoordinates, offset, ends, stride, extent) {
@@ -69,7 +69,7 @@ export function intersectsLineStringArray(flatCoordinates, offset, ends, stride,
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
  */
 export function intersectsLinearRing(flatCoordinates, offset, end, stride, extent) {
@@ -98,7 +98,7 @@ export function intersectsLinearRing(flatCoordinates, offset, end, stride, exten
  * @param {number} offset Offset.
  * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
  */
 export function intersectsLinearRingArray(flatCoordinates, offset, ends, stride, extent) {
@@ -123,7 +123,7 @@ export function intersectsLinearRingArray(flatCoordinates, offset, ends, stride,
  * @param {number} offset Offset.
  * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
  */
 export function intersectsLinearRingMultiArray(flatCoordinates, offset, endss, stride, extent) {

--- a/src/ol/geom/flat/segments.js
+++ b/src/ol/geom/flat/segments.js
@@ -11,7 +11,7 @@
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {function(this: S, module:ol/coordinate~Coordinate, module:ol/coordinate~Coordinate): T} callback Function
+ * @param {function(this: S, import("../../coordinate.js").Coordinate, import("../../coordinate.js").Coordinate): T} callback Function
  *     called for each segment.
  * @param {S=} opt_this The object to be used as the value of 'this'
  *     within callback.

--- a/src/ol/geom/flat/transform.js
+++ b/src/ol/geom/flat/transform.js
@@ -8,7 +8,7 @@
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {module:ol/transform~Transform} transform Transform.
+ * @param {import("../../transform.js").Transform} transform Transform.
  * @param {Array<number>=} opt_dest Destination.
  * @return {Array<number>} Transformed coordinates.
  */

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -80,8 +80,8 @@ export {default as Translate} from './interaction/Translate.js';
  * * {@link module:ol/interaction/MouseWheelZoom~MouseWheelZoom}
  * * {@link module:ol/interaction/DragZoom~DragZoom}
  *
- * @param {module:ol/interaction~DefaultsOptions=} opt_options Defaults options.
- * @return {module:ol/Collection<module:ol/interaction/Interaction>}
+ * @param {DefaultsOptions=} opt_options Defaults options.
+ * @return {import("./Collection.js").default<import("./interaction/Interaction.js").default>}
  * A collection of interactions to be used with the {@link module:ol/Map~Map}
  * constructor's `interactions` option.
  * @api

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -20,7 +20,7 @@ import Interaction, {zoomByDelta} from '../interaction/Interaction.js';
 class DoubleClickZoom extends Interaction {
 
   /**
-   * @param {module:ol/interaction/DoubleClickZoom~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super({
@@ -49,9 +49,9 @@ class DoubleClickZoom extends Interaction {
 /**
  * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
  * doubleclick) and eventually zooms the map.
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/DoubleClickZoom}
+ * @this {import("./DoubleClickZoom.js").default}
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -13,13 +13,13 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @typedef {Object} Options
- * @property {Array<function(new: module:ol/format/Feature)>} [formatConstructors] Format constructors.
- * @property {module:ol/source/Vector} [source] Optional vector source where features will be added.  If a source is provided
+ * @property {Array<function(new: import("../format/Feature.js").default)>} [formatConstructors] Format constructors.
+ * @property {import("../source/Vector.js").default} [source] Optional vector source where features will be added.  If a source is provided
  * all existing features will be removed and new features will be added when
  * they are dropped on the target.  If you want to add features to a vector
  * source without removing the existing features (append only), instead of
  * providing the source option listen for the "addfeatures" event.
- * @property {module:ol/proj~ProjectionLike} [projection] Target projection. By default, the map's view's projection is used.
+ * @property {import("../proj.js").ProjectionLike} [projection] Target projection. By default, the map's view's projection is used.
  * @property {Element} [target] The element that is used as the drop target, default is the viewport element.
  */
 
@@ -30,7 +30,7 @@ import {get as getProjection} from '../proj.js';
 const DragAndDropEventType = {
   /**
    * Triggered when features are added
-   * @event module:ol/interaction/DragAndDrop~DragAndDropEvent#addfeatures
+   * @event DragAndDropEvent#addfeatures
    * @api
    */
   ADD_FEATURES: 'addfeatures'
@@ -45,10 +45,10 @@ const DragAndDropEventType = {
 class DragAndDropEvent extends Event {
 
   /**
-   * @param {module:ol/interaction/DragAndDrop~DragAndDropEventType} type Type.
+   * @param {DragAndDropEventType} type Type.
    * @param {File} file File.
-   * @param {Array<module:ol/Feature>=} opt_features Features.
-   * @param {module:ol/proj/Projection=} opt_projection Projection.
+   * @param {Array<import("../Feature.js").default>=} opt_features Features.
+   * @param {import("../proj/Projection.js").default=} opt_projection Projection.
    */
   constructor(type, file, opt_features, opt_projection) {
 
@@ -56,7 +56,7 @@ class DragAndDropEvent extends Event {
 
     /**
      * The features parsed from dropped data.
-     * @type {Array<module:ol/Feature>|undefined}
+     * @type {Array<import("../Feature.js").default>|undefined}
      * @api
      */
     this.features = opt_features;
@@ -70,7 +70,7 @@ class DragAndDropEvent extends Event {
 
     /**
      * The feature projection.
-     * @type {module:ol/proj/Projection|undefined}
+     * @type {import("../proj/Projection.js").default|undefined}
      * @api
      */
     this.projection = opt_projection;
@@ -85,11 +85,11 @@ class DragAndDropEvent extends Event {
  * Handles input of vector data by drag and drop.
  * @api
  *
- * @fires module:ol/interaction/DragAndDrop~DragAndDropEvent
+ * @fires DragAndDropEvent
  */
 class DragAndDrop extends Interaction {
   /**
-   * @param {module:ol/interaction/DragAndDrop~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -101,27 +101,27 @@ class DragAndDrop extends Interaction {
 
     /**
      * @private
-     * @type {Array<function(new: module:ol/format/Feature)>}
+     * @type {Array<function(new: import("../format/Feature.js").default)>}
      */
     this.formatConstructors_ = options.formatConstructors ?
       options.formatConstructors : [];
 
     /**
      * @private
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      */
     this.projection_ = options.projection ?
       getProjection(options.projection) : null;
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("../events.js").EventsKey>}
      */
     this.dropListenKeys_ = null;
 
     /**
      * @private
-     * @type {module:ol/source/Vector}
+     * @type {import("../source/Vector.js").default}
      */
     this.source_ = options.source || null;
 
@@ -156,7 +156,7 @@ class DragAndDrop extends Interaction {
        */
       const formatConstructor = formatConstructors[i];
       /**
-       * @type {module:ol/format/Feature}
+       * @type {import("../format/Feature.js").default}
        */
       const format = new formatConstructor();
       features = this.tryReadFeatures_(format, result, {
@@ -216,11 +216,11 @@ class DragAndDrop extends Interaction {
   }
 
   /**
-   * @param {module:ol/format/Feature} format Format.
+   * @param {import("../format/Feature.js").default} format Format.
    * @param {string} text Text.
-   * @param {module:ol/format/Feature~ReadOptions} options Read options.
+   * @param {import("../format/Feature.js").ReadOptions} options Read options.
    * @private
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   tryReadFeatures_(format, text, options) {
     try {
@@ -244,7 +244,7 @@ class DragAndDrop extends Interaction {
 
 /**
  * @param {DragEvent} event Event.
- * @this {module:ol/interaction/DragAndDrop}
+ * @this {import("./DragAndDrop.js").default}
  */
 function handleDrop(event) {
   const files = event.dataTransfer.files;

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -13,22 +13,22 @@ import RenderBox from '../render/Box.js';
  * A function that takes a {@link module:ol/MapBrowserEvent} and two
  * {@link module:ol/pixel~Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
- * @typedef {function(this: ?, module:ol/MapBrowserEvent, module:ol/pixel~Pixel, module:ol/pixel~Pixel):boolean} EndCondition
+ * @typedef {function(this: ?, import("../MapBrowserEvent.js").default, import("../pixel.js").Pixel, import("../pixel.js").Pixel):boolean} EndCondition
  */
 
 
 /**
  * @typedef {Object} Options
  * @property {string} [className='ol-dragbox'] CSS class name for styling the box.
- * @property {module:ol/events/condition~Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
+ * @property {import("../events/condition.js").Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link ol/events/condition~always}.
  * @property {number} [minArea=64] The minimum area of the box in pixel, this value is used by the default
  * `boxEndCondition` function.
- * @property {module:ol/interaction/DragBox~EndCondition} [boxEndCondition] A function that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and two
+ * @property {EndCondition} [boxEndCondition] A function that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and two
  * {@link module:ol/pixel~Pixel}s to indicate whether a `boxend` event should be fired.
  * Default is `true` if the area of the box is bigger than the `minArea` option.
- * @property {function(this:module:ol/interaction/DragBox, module:ol/MapBrowserEvent)} onBoxEnd Code to execute just
+ * @property {function(this:import("./DragBox.js").default, import("../MapBrowserEvent.js").default)} onBoxEnd Code to execute just
  * before `boxend` is fired.
  */
 
@@ -39,21 +39,21 @@ import RenderBox from '../render/Box.js';
 const DragBoxEventType = {
   /**
    * Triggered upon drag box start.
-   * @event module:ol/interaction/DragBox~DragBoxEvent#boxstart
+   * @event DragBoxEvent#boxstart
    * @api
    */
   BOXSTART: 'boxstart',
 
   /**
    * Triggered on drag when box is active.
-   * @event module:ol/interaction/DragBox~DragBoxEvent#boxdrag
+   * @event DragBoxEvent#boxdrag
    * @api
    */
   BOXDRAG: 'boxdrag',
 
   /**
    * Triggered upon drag box end.
-   * @event module:ol/interaction/DragBox~DragBoxEvent#boxend
+   * @event DragBoxEvent#boxend
    * @api
    */
   BOXEND: 'boxend'
@@ -69,8 +69,8 @@ class DragBoxEvent extends Event {
 
   /**
    * @param {string} type The event type.
-   * @param {module:ol/coordinate~Coordinate} coordinate The event coordinate.
-   * @param {module:ol/MapBrowserEvent} mapBrowserEvent Originating event.
+   * @param {import("../coordinate.js").Coordinate} coordinate The event coordinate.
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Originating event.
    */
   constructor(type, coordinate, mapBrowserEvent) {
     super(type);
@@ -78,14 +78,14 @@ class DragBoxEvent extends Event {
     /**
      * The coordinate of the drag event.
      * @const
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      * @api
      */
     this.coordinate = coordinate;
 
     /**
      * @const
-     * @type {module:ol/MapBrowserEvent}
+     * @type {import("../MapBrowserEvent.js").default}
      * @api
      */
     this.mapBrowserEvent = mapBrowserEvent;
@@ -106,12 +106,12 @@ class DragBoxEvent extends Event {
  *
  * This interaction is only supported for mouse devices.
  *
- * @fires module:ol/interaction/DragBox~DragBoxEvent
+ * @fires DragBoxEvent
  * @api
  */
 class DragBox extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/DragBox~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -124,7 +124,7 @@ class DragBox extends PointerInteraction {
     const options = opt_options ? opt_options : {};
 
     /**
-    * @type {module:ol/render/Box}
+    * @type {import("../render/Box.js").default}
     * @private
     */
     this.box_ = new RenderBox(options.className || 'ol-dragbox');
@@ -137,26 +137,26 @@ class DragBox extends PointerInteraction {
 
     /**
      * Function to execute just before `onboxend` is fired
-     * @type {function(this:module:ol/interaction/DragBox, module:ol/MapBrowserEvent)}
+     * @type {function(this:import("./DragBox.js").default, import("../MapBrowserEvent.js").default)}
      * @private
      */
     this.onBoxEnd_ = options.onBoxEnd ? options.onBoxEnd : VOID;
 
     /**
-    * @type {module:ol/pixel~Pixel}
+    * @type {import("../pixel.js").Pixel}
     * @private
     */
     this.startPixel_ = null;
 
     /**
     * @private
-    * @type {module:ol/events/condition~Condition}
+    * @type {import("../events/condition.js").Condition}
     */
     this.condition_ = options.condition ? options.condition : always;
 
     /**
     * @private
-    * @type {module:ol/interaction/DragBox~EndCondition}
+    * @type {EndCondition}
     */
     this.boxEndCondition_ = options.boxEndCondition ?
       options.boxEndCondition : defaultBoxEndCondition;
@@ -164,7 +164,7 @@ class DragBox extends PointerInteraction {
 
   /**
   * Returns geometry of last drawn box.
-  * @return {module:ol/geom/Polygon} Geometry.
+  * @return {import("../geom/Polygon.js").default} Geometry.
   * @api
   */
   getGeometry() {
@@ -176,12 +176,12 @@ class DragBox extends PointerInteraction {
 /**
  * The default condition for determining whether the boxend event
  * should fire.
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent The originating MapBrowserEvent
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent The originating MapBrowserEvent
  *     leading to the box end.
- * @param {module:ol/pixel~Pixel} startPixel The starting pixel of the box.
- * @param {module:ol/pixel~Pixel} endPixel The end pixel of the box.
+ * @param {import("../pixel.js").Pixel} startPixel The starting pixel of the box.
+ * @param {import("../pixel.js").Pixel} endPixel The end pixel of the box.
  * @return {boolean} Whether or not the boxend condition should be fired.
- * @this {module:ol/interaction/DragBox}
+ * @this {import("./DragBox.js").default}
  */
 function defaultBoxEndCondition(mapBrowserEvent, startPixel, endPixel) {
   const width = endPixel[0] - startPixel[0];
@@ -191,8 +191,8 @@ function defaultBoxEndCondition(mapBrowserEvent, startPixel, endPixel) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragBox}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./DragBox.js").default}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -207,9 +207,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragBox}
+ * @this {import("./DragBox.js").default}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -228,9 +228,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragBox}
+ * @this {import("./DragBox.js").default}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -11,10 +11,10 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
+ * @property {import("../events/condition.js").Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link module:ol/events/condition~noModifierKeys}.
- * @property {module:ol/Kinetic} [kinetic] Kinetic inertia to apply to the pan.
+ * @property {import("../Kinetic.js").default} [kinetic] Kinetic inertia to apply to the pan.
  */
 
 
@@ -25,7 +25,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  */
 class DragPan extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/DragPan~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -40,12 +40,12 @@ class DragPan extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/Kinetic|undefined}
+     * @type {import("../Kinetic.js").default|undefined}
      */
     this.kinetic_ = options.kinetic;
 
     /**
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("../pixel.js").Pixel}
      */
     this.lastCentroid = null;
 
@@ -61,7 +61,7 @@ class DragPan extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : noModifierKeys;
 
@@ -77,8 +77,8 @@ class DragPan extends PointerInteraction {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragPan}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./DragPan.js").default}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!this.panning_) {
@@ -114,9 +114,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragPan}
+ * @this {import("./DragPan.js").default}
  */
 function handleUpEvent(mapBrowserEvent) {
   const map = mapBrowserEvent.map;
@@ -125,7 +125,7 @@ function handleUpEvent(mapBrowserEvent) {
     if (!this.noKinetic_ && this.kinetic_ && this.kinetic_.end()) {
       const distance = this.kinetic_.getDistance();
       const angle = this.kinetic_.getAngle();
-      const center = /** @type {!module:ol/coordinate~Coordinate} */ (view.getCenter());
+      const center = /** @type {!import("../coordinate.js").Coordinate} */ (view.getCenter());
       const centerpx = map.getPixelFromCoordinate(center);
       const dest = map.getCoordinateFromPixel([
         centerpx[0] - distance * Math.cos(angle),
@@ -155,9 +155,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragPan}
+ * @this {import("./DragPan.js").default}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (this.targetPointers.length > 0 && this.condition_(mapBrowserEvent)) {

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -11,7 +11,7 @@ import PointerInteraction from '../interaction/Pointer.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [condition] A function that takes an
+ * @property {import("../events/condition.js").Condition} [condition] A function that takes an
  * {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link module:ol/events/condition~altShiftKeysOnly}.
@@ -31,7 +31,7 @@ import PointerInteraction from '../interaction/Pointer.js';
 class DragRotate extends PointerInteraction {
 
   /**
-   * @param {module:ol/interaction/DragRotate~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -46,7 +46,7 @@ class DragRotate extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : altShiftKeysOnly;
 
@@ -68,8 +68,8 @@ class DragRotate extends PointerInteraction {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragRotate}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./DragRotate.js").default}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -95,9 +95,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragRotate}
+ * @this {import("./DragRotate.js").default}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -114,9 +114,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragRotate}
+ * @this {import("./DragRotate.js").default}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -10,7 +10,7 @@ import PointerInteraction from '../interaction/Pointer.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
  * Default is {@link module:ol/events/condition~shiftKeyOnly}.
@@ -32,7 +32,7 @@ import PointerInteraction from '../interaction/Pointer.js';
 class DragRotateAndZoom extends PointerInteraction {
 
   /**
-   * @param {module:ol/interaction/DragRotateAndZoom~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -46,7 +46,7 @@ class DragRotateAndZoom extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : shiftKeyOnly;
 
@@ -80,8 +80,8 @@ class DragRotateAndZoom extends PointerInteraction {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/DragRotateAndZoom}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./DragRotateAndZoom.js").default}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -113,9 +113,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/DragRotateAndZoom}
+ * @this {import("./DragRotateAndZoom.js").default}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {
@@ -134,9 +134,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/DragRotateAndZoom}
+ * @this {import("./DragRotateAndZoom.js").default}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (!mouseOnly(mapBrowserEvent)) {

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -11,7 +11,7 @@ import DragBox from '../interaction/DragBox.js';
  * @typedef {Object} Options
  * @property {string} [className='ol-dragzoom'] CSS class name for styling the
  * box.
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
  * Default is {@link module:ol/events/condition~shiftKeyOnly}.
@@ -32,7 +32,7 @@ import DragBox from '../interaction/DragBox.js';
  */
 class DragZoom extends DragBox {
   /**
-   * @param {module:ol/interaction/DragZoom~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -61,12 +61,12 @@ class DragZoom extends DragBox {
 
 
 /**
- * @this {module:ol/interaction/DragZoom}
+ * @this {import("./DragZoom.js").default}
  */
 function onBoxEnd() {
   const map = this.getMap();
-  const view = /** @type {!module:ol/View} */ (map.getView());
-  const size = /** @type {!module:ol/size~Size} */ (map.getSize());
+  const view = /** @type {!import("../View.js").default} */ (map.getView());
+  const size = /** @type {!import("../size.js").Size} */ (map.getSize());
   let extent = this.getGeometry().getExtent();
 
   if (this.out_) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -30,16 +30,16 @@ import {createEditingStyle} from '../style/Style.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/geom/GeometryType} type Geometry type of
+ * @property {import("../geom/GeometryType.js").default} type Geometry type of
  * the geometries being drawn with this instance.
  * @property {number} [clickTolerance=6] The maximum distance in pixels between
  * "down" and "up" for a "up" event to be considered a "click" event and
  * actually add a point/vertex to the geometry being drawn.  The default of `6`
  * was chosen for the draw interaction to behave correctly on mouse as well as
  * on touch devices.
- * @property {module:ol/Collection<module:ol/Feature>} [features]
+ * @property {import("../Collection.js").default<import("../Feature.js").default>} [features]
  * Destination collection for the drawn features.
- * @property {module:ol/source/Vector} [source] Destination source for
+ * @property {import("../source/Vector.js").default} [source] Destination source for
  * the drawn features.
  * @property {number} [dragVertexDelay=500] Delay in milliseconds after pointerdown
  * before the current vertex can be dragged to its exact position.
@@ -53,16 +53,16 @@ import {createEditingStyle} from '../style/Style.js';
  * @property {number} [minPoints] The number of points that must be drawn
  * before a polygon ring or line string can be finished. Default is `3` for
  * polygon rings and `2` for line strings.
- * @property {module:ol/events/condition~Condition} [finishCondition] A function
+ * @property {import("../events/condition.js").Condition} [finishCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether the drawing can be finished.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style]
  * Style for sketch features.
- * @property {module:ol/interaction/Draw~GeometryFunction} [geometryFunction]
+ * @property {GeometryFunction} [geometryFunction]
  * Function that is called when a geometry's coordinates are updated.
  * @property {string} [geometryName] Geometry name to use for features created
  * by the draw interaction.
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
  * By default {@link module:ol/events/condition~noModifierKeys}, i.e. a click,
@@ -70,7 +70,7 @@ import {createEditingStyle} from '../style/Style.js';
  * @property {boolean} [freehand=false] Operate in freehand mode for lines,
  * polygons, and circles.  This makes the interaction always operate in freehand
  * mode and takes precedence over any `freehandCondition` option.
- * @property {module:ol/events/condition~Condition} [freehandCondition]
+ * @property {import("../events/condition.js").Condition} [freehandCondition]
  * Condition that activates freehand drawing for lines and polygons. This
  * function takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and
  * returns a boolean to indicate whether that event should be handled. The
@@ -86,8 +86,8 @@ import {createEditingStyle} from '../style/Style.js';
  * arguments, and returns a geometry. The optional existing geometry is the
  * geometry that is returned when the function is called without a second
  * argument.
- * @typedef {function(!Array<module:ol/coordinate~Coordinate>, module:ol/geom/SimpleGeometry=):
- *     module:ol/geom/SimpleGeometry} GeometryFunction
+ * @typedef {function(!Array<import("../coordinate.js").Coordinate>, import("../geom/SimpleGeometry.js").default=):
+ *     import("../geom/SimpleGeometry.js").default} GeometryFunction
  */
 
 
@@ -110,13 +110,13 @@ const Mode = {
 const DrawEventType = {
   /**
    * Triggered upon feature draw start
-   * @event module:ol/interaction/Draw~DrawEvent#drawstart
+   * @event DrawEvent#drawstart
    * @api
    */
   DRAWSTART: 'drawstart',
   /**
    * Triggered upon feature draw end
-   * @event module:ol/interaction/Draw~DrawEvent#drawend
+   * @event DrawEvent#drawend
    * @api
    */
   DRAWEND: 'drawend'
@@ -130,8 +130,8 @@ const DrawEventType = {
  */
 class DrawEvent extends Event {
   /**
-   * @param {module:ol/interaction/Draw~DrawEventType} type Type.
-   * @param {module:ol/Feature} feature The feature drawn.
+   * @param {DrawEventType} type Type.
+   * @param {import("../Feature.js").default} feature The feature drawn.
    */
   constructor(type, feature) {
 
@@ -139,7 +139,7 @@ class DrawEvent extends Event {
 
     /**
      * The feature being drawn.
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @api
      */
     this.feature = feature;
@@ -153,12 +153,12 @@ class DrawEvent extends Event {
  * @classdesc
  * Interaction for drawing feature geometries.
  *
- * @fires module:ol/interaction/Draw~DrawEvent
+ * @fires DrawEvent
  * @api
  */
 class Draw extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/Draw~Options} options Options.
+   * @param {Options} options Options.
    */
   constructor(options) {
 
@@ -176,7 +176,7 @@ class Draw extends PointerInteraction {
     this.shouldHandle_ = false;
 
     /**
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("../pixel.js").Pixel}
      * @private
      */
     this.downPx_ = null;
@@ -201,14 +201,14 @@ class Draw extends PointerInteraction {
 
     /**
      * Target source for drawn features.
-     * @type {module:ol/source/Vector}
+     * @type {import("../source/Vector.js").default}
      * @private
      */
     this.source_ = options.source ? options.source : null;
 
     /**
      * Target collection for drawn features.
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      * @private
      */
     this.features_ = options.features ? options.features : null;
@@ -222,14 +222,14 @@ class Draw extends PointerInteraction {
 
     /**
      * Geometry type.
-     * @type {module:ol/geom/GeometryType}
+     * @type {import("../geom/GeometryType.js").default}
      * @private
      */
-    this.type_ = /** @type {module:ol/geom/GeometryType} */ (options.type);
+    this.type_ = /** @type {import("../geom/GeometryType.js").default} */ (options.type);
 
     /**
      * Drawing mode (derived from geometry type.
-     * @type {module:ol/interaction/Draw~Mode}
+     * @type {Mode}
      * @private
      */
     this.mode_ = getMode(this.type_);
@@ -264,7 +264,7 @@ class Draw extends PointerInteraction {
     /**
      * A function to decide if a potential finish coordinate is permissible
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.finishCondition_ = options.finishCondition ? options.finishCondition : TRUE;
 
@@ -272,13 +272,13 @@ class Draw extends PointerInteraction {
     if (!geometryFunction) {
       if (this.type_ === GeometryType.CIRCLE) {
         /**
-         * @param {!Array<module:ol/coordinate~Coordinate>} coordinates
+         * @param {!Array<import("../coordinate.js").Coordinate>} coordinates
          *     The coordinates.
-         * @param {module:ol/geom/SimpleGeometry=} opt_geometry Optional geometry.
-         * @return {module:ol/geom/SimpleGeometry} A geometry.
+         * @param {import("../geom/SimpleGeometry.js").default=} opt_geometry Optional geometry.
+         * @return {import("../geom/SimpleGeometry.js").default} A geometry.
          */
         geometryFunction = function(coordinates, opt_geometry) {
-          const circle = opt_geometry ? /** @type {module:ol/geom/Circle} */ (opt_geometry) :
+          const circle = opt_geometry ? /** @type {import("../geom/Circle.js").default} */ (opt_geometry) :
             new Circle([NaN, NaN]);
           const squaredLength = squaredCoordinateDistance(
             coordinates[0], coordinates[1]);
@@ -296,10 +296,10 @@ class Draw extends PointerInteraction {
           Constructor = Polygon;
         }
         /**
-         * @param {!Array<module:ol/coordinate~Coordinate>} coordinates
+         * @param {!Array<import("../coordinate.js").Coordinate>} coordinates
          *     The coordinates.
-         * @param {module:ol/geom/SimpleGeometry=} opt_geometry Optional geometry.
-         * @return {module:ol/geom/SimpleGeometry} A geometry.
+         * @param {import("../geom/SimpleGeometry.js").default=} opt_geometry Optional geometry.
+         * @return {import("../geom/SimpleGeometry.js").default} A geometry.
          */
         geometryFunction = function(coordinates, opt_geometry) {
           let geometry = opt_geometry;
@@ -323,7 +323,7 @@ class Draw extends PointerInteraction {
     }
 
     /**
-     * @type {module:ol/interaction/Draw~GeometryFunction}
+     * @type {GeometryFunction}
      * @private
      */
     this.geometryFunction_ = geometryFunction;
@@ -337,42 +337,42 @@ class Draw extends PointerInteraction {
     /**
      * Finish coordinate for the feature (first point for polygons, last point for
      * linestrings).
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      * @private
      */
     this.finishCoordinate_ = null;
 
     /**
      * Sketch feature.
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.sketchFeature_ = null;
 
     /**
      * Sketch point.
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.sketchPoint_ = null;
 
     /**
      * Sketch coordinates. Used when drawing a line or polygon.
-     * @type {module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>}
+     * @type {import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>}
      * @private
      */
     this.sketchCoords_ = null;
 
     /**
      * Sketch line. Used when drawing polygon.
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.sketchLine_ = null;
 
     /**
      * Sketch line coordinates. Used when drawing a polygon or circle.
-     * @type {Array<module:ol/coordinate~Coordinate>}
+     * @type {Array<import("../coordinate.js").Coordinate>}
      * @private
      */
     this.sketchLineCoords_ = null;
@@ -389,7 +389,7 @@ class Draw extends PointerInteraction {
 
     /**
      * Draw overlay where our sketch features are drawn.
-     * @type {module:ol/layer/Vector}
+     * @type {import("../layer/Vector.js").default}
      * @private
      */
     this.overlay_ = new VectorLayer({
@@ -411,13 +411,13 @@ class Draw extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : noModifierKeys;
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.freehandCondition_;
     if (options.freehand) {
@@ -443,7 +443,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Get the overlay layer that this interaction renders sketch features to.
-   * @return {module:ol/layer/Vector} Overlay layer.
+   * @return {import("../layer/Vector.js").default} Overlay layer.
    * @api
    */
   getOverlay() {
@@ -452,7 +452,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Handle move events.
-   * @param {module:ol/MapBrowserEvent} event A move event.
+   * @param {import("../MapBrowserEvent.js").default} event A move event.
    * @return {boolean} Pass the event to other interactions.
    * @private
    */
@@ -483,7 +483,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Determine if an event is within the snapping tolerance of the start coord.
-   * @param {module:ol/MapBrowserEvent} event Event.
+   * @param {import("../MapBrowserEvent.js").default} event Event.
    * @return {boolean} The event is within the snapping tolerance of the start.
    * @private
    */
@@ -521,7 +521,7 @@ class Draw extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/MapBrowserEvent} event Event.
+   * @param {import("../MapBrowserEvent.js").default} event Event.
    * @private
    */
   createOrUpdateSketchPoint_(event) {
@@ -530,14 +530,14 @@ class Draw extends PointerInteraction {
       this.sketchPoint_ = new Feature(new Point(coordinates));
       this.updateSketchFeatures_();
     } else {
-      const sketchPointGeom = /** @type {module:ol/geom/Point} */ (this.sketchPoint_.getGeometry());
+      const sketchPointGeom = /** @type {import("../geom/Point.js").default} */ (this.sketchPoint_.getGeometry());
       sketchPointGeom.setCoordinates(coordinates);
     }
   }
 
   /**
    * Start the drawing.
-   * @param {module:ol/MapBrowserEvent} event Event.
+   * @param {import("../MapBrowserEvent.js").default} event Event.
    * @private
    */
   startDrawing_(event) {
@@ -567,12 +567,12 @@ class Draw extends PointerInteraction {
 
   /**
    * Modify the drawing.
-   * @param {module:ol/MapBrowserEvent} event Event.
+   * @param {import("../MapBrowserEvent.js").default} event Event.
    * @private
    */
   modifyDrawing_(event) {
     let coordinate = event.coordinate;
-    const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (this.sketchFeature_.getGeometry());
+    const geometry = /** @type {import("../geom/SimpleGeometry.js").default} */ (this.sketchFeature_.getGeometry());
     let coordinates, last;
     if (this.mode_ === Mode.POINT) {
       last = this.sketchCoords_;
@@ -589,9 +589,9 @@ class Draw extends PointerInteraction {
     }
     last[0] = coordinate[0];
     last[1] = coordinate[1];
-    this.geometryFunction_(/** @type {!Array<module:ol/coordinate~Coordinate>} */ (this.sketchCoords_), geometry);
+    this.geometryFunction_(/** @type {!Array<import("../coordinate.js").Coordinate>} */ (this.sketchCoords_), geometry);
     if (this.sketchPoint_) {
-      const sketchPointGeom = /** @type {module:ol/geom/Point} */ (this.sketchPoint_.getGeometry());
+      const sketchPointGeom = /** @type {import("../geom/Point.js").default} */ (this.sketchPoint_.getGeometry());
       sketchPointGeom.setCoordinates(coordinate);
     }
     let sketchLineGeom;
@@ -601,7 +601,7 @@ class Draw extends PointerInteraction {
         this.sketchLine_ = new Feature();
       }
       const ring = geometry.getLinearRing(0);
-      sketchLineGeom = /** @type {module:ol/geom/LineString} */ (this.sketchLine_.getGeometry());
+      sketchLineGeom = /** @type {import("../geom/LineString.js").default} */ (this.sketchLine_.getGeometry());
       if (!sketchLineGeom) {
         sketchLineGeom = new LineString(ring.getFlatCoordinates(), ring.getLayout());
         this.sketchLine_.setGeometry(sketchLineGeom);
@@ -611,7 +611,7 @@ class Draw extends PointerInteraction {
         sketchLineGeom.changed();
       }
     } else if (this.sketchLineCoords_) {
-      sketchLineGeom = /** @type {module:ol/geom/LineString} */ (this.sketchLine_.getGeometry());
+      sketchLineGeom = /** @type {import("../geom/LineString.js").default} */ (this.sketchLine_.getGeometry());
       sketchLineGeom.setCoordinates(this.sketchLineCoords_);
     }
     this.updateSketchFeatures_();
@@ -619,12 +619,12 @@ class Draw extends PointerInteraction {
 
   /**
    * Add a new coordinate to the drawing.
-   * @param {module:ol/MapBrowserEvent} event Event.
+   * @param {import("../MapBrowserEvent.js").default} event Event.
    * @private
    */
   addToDrawing_(event) {
     const coordinate = event.coordinate;
-    const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (this.sketchFeature_.getGeometry());
+    const geometry = /** @type {import("../geom/SimpleGeometry.js").default} */ (this.sketchFeature_.getGeometry());
     let done;
     let coordinates;
     if (this.mode_ === Mode.LINE_STRING) {
@@ -668,7 +668,7 @@ class Draw extends PointerInteraction {
     if (!this.sketchFeature_) {
       return;
     }
-    const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (this.sketchFeature_.getGeometry());
+    const geometry = /** @type {import("../geom/SimpleGeometry.js").default} */ (this.sketchFeature_.getGeometry());
     let coordinates, sketchLineGeom;
     if (this.mode_ === Mode.LINE_STRING) {
       coordinates = this.sketchCoords_;
@@ -680,7 +680,7 @@ class Draw extends PointerInteraction {
     } else if (this.mode_ === Mode.POLYGON) {
       coordinates = this.sketchCoords_[0];
       coordinates.splice(-2, 1);
-      sketchLineGeom = /** @type {module:ol/geom/LineString} */ (this.sketchLine_.getGeometry());
+      sketchLineGeom = /** @type {import("../geom/LineString.js").default} */ (this.sketchLine_.getGeometry());
       sketchLineGeom.setCoordinates(coordinates);
       this.geometryFunction_(this.sketchCoords_, geometry);
     }
@@ -704,7 +704,7 @@ class Draw extends PointerInteraction {
       return;
     }
     let coordinates = this.sketchCoords_;
-    const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (sketchFeature.getGeometry());
+    const geometry = /** @type {import("../geom/SimpleGeometry.js").default} */ (sketchFeature.getGeometry());
     if (this.mode_ === Mode.LINE_STRING) {
       // remove the redundant last point
       coordinates.pop();
@@ -739,7 +739,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Stop drawing without adding the sketch feature to the target layer.
-   * @return {module:ol/Feature} The sketch feature (or null if none).
+   * @return {import("../Feature.js").default} The sketch feature (or null if none).
    * @private
    */
   abortDrawing_() {
@@ -758,12 +758,12 @@ class Draw extends PointerInteraction {
    * Extend an existing geometry by adding additional points. This only works
    * on features with `LineString` geometries, where the interaction will
    * extend lines by adding points to the end of the coordinates array.
-   * @param {!module:ol/Feature} feature Feature to be extended.
+   * @param {!import("../Feature.js").default} feature Feature to be extended.
    * @api
    */
   extend(feature) {
     const geometry = feature.getGeometry();
-    const lineString = /** @type {module:ol/geom/LineString} */ (geometry);
+    const lineString = /** @type {import("../geom/LineString.js").default} */ (geometry);
     this.sketchFeature_ = feature;
     this.sketchCoords_ = lineString.getCoordinates();
     const last = this.sketchCoords_[this.sketchCoords_.length - 1];
@@ -808,7 +808,7 @@ class Draw extends PointerInteraction {
 
 
 /**
- * @return {module:ol/style/Style~StyleFunction} Styles.
+ * @return {import("../style/Style.js").StyleFunction} Styles.
  */
 function getDefaultStyleFunction() {
   const styles = createEditingStyle();
@@ -821,9 +821,9 @@ function getDefaultStyleFunction() {
 /**
  * Handles the {@link module:ol/MapBrowserEvent map browser event} and may actually
  * draw or finish the drawing.
- * @param {module:ol/MapBrowserEvent} event Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} event Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Draw}
+ * @this {import("./Draw.js").default}
  * @api
  */
 export function handleEvent(event) {
@@ -873,9 +873,9 @@ export function handleEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} event Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} event Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/Draw}
+ * @this {import("./Draw.js").default}
  */
 function handleDownEvent(event) {
   this.shouldHandle_ = !this.freehand_;
@@ -901,9 +901,9 @@ function handleDownEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} event Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} event Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Draw}
+ * @this {import("./Draw.js").default}
  */
 function handleUpEvent(event) {
   let pass = true;
@@ -947,13 +947,13 @@ function handleUpEvent(event) {
 /**
  * Create a `geometryFunction` for `type: 'Circle'` that will create a regular
  * polygon with a user specified number of sides and start angle instead of an
- * `module:ol/geom/Circle~Circle` geometry.
+ * `import("../geom/Circle.js").Circle` geometry.
  * @param {number=} opt_sides Number of sides of the regular polygon. Default is
  *     32.
  * @param {number=} opt_angle Angle of the first point in radians. 0 means East.
  *     Default is the angle defined by the heading from the center of the
  *     regular polygon to the current pointer position.
- * @return {module:ol/interaction/Draw~GeometryFunction} Function that draws a
+ * @return {GeometryFunction} Function that draws a
  *     polygon.
  * @api
  */
@@ -963,7 +963,7 @@ export function createRegularPolygon(opt_sides, opt_angle) {
     const end = coordinates[1];
     const radius = Math.sqrt(
       squaredCoordinateDistance(center, end));
-    const geometry = opt_geometry ? /** @type {module:ol/geom/Polygon} */ (opt_geometry) :
+    const geometry = opt_geometry ? /** @type {import("../geom/Polygon.js").default} */ (opt_geometry) :
       fromCircle(new Circle(center), opt_sides);
     let angle = opt_angle;
     if (!opt_angle) {
@@ -981,7 +981,7 @@ export function createRegularPolygon(opt_sides, opt_angle) {
  * Create a `geometryFunction` that will create a box-shaped polygon (aligned
  * with the coordinate system axes).  Use this with the draw interaction and
  * `type: 'Circle'` to return a box instead of a circle geometry.
- * @return {module:ol/interaction/Draw~GeometryFunction} Function that draws a box-shaped polygon.
+ * @return {GeometryFunction} Function that draws a box-shaped polygon.
  * @api
  */
 export function createBox() {
@@ -1010,8 +1010,8 @@ export function createBox() {
 /**
  * Get the drawing mode.  The mode for mult-part geometries is the same as for
  * their single-part cousins.
- * @param {module:ol/geom/GeometryType} type Geometry type.
- * @return {module:ol/interaction/Draw~Mode} Drawing mode.
+ * @param {import("../geom/GeometryType.js").default} type Geometry type.
+ * @return {Mode} Drawing mode.
  */
 function getMode(type) {
   let mode;
@@ -1028,7 +1028,7 @@ function getMode(type) {
     mode = Mode.CIRCLE;
   }
   return (
-    /** @type {!module:ol/interaction/Draw~Mode} */ (mode)
+    /** @type {!Mode} */ (mode)
   );
 }
 

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -18,14 +18,14 @@ import {createEditingStyle} from '../style/Style.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/extent~Extent} [extent] Initial extent. Defaults to no
+ * @property {import("../extent.js").Extent} [extent] Initial extent. Defaults to no
  * initial extent.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [boxStyle]
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [boxStyle]
  * Style for the drawn extent box. Defaults to
  * {@link module:ol/style/Style~createEditing()['Polygon']}
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [pointerStyle]
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [pointerStyle]
  * Style for the cursor used to draw the extent. Defaults to
  * {@link module:ol/style/Style~createEditing()['Point']}
  * @property {boolean} [wrapX=false] Wrap the drawn extent across multiple maps
@@ -39,7 +39,7 @@ import {createEditingStyle} from '../style/Style.js';
 const ExtentEventType = {
   /**
    * Triggered after the extent is changed
-   * @event module:ol/interaction/Extent~ExtentEventType#extentchanged
+   * @event ExtentEventType#extentchanged
    * @api
    */
   EXTENTCHANGED: 'extentchanged'
@@ -54,14 +54,14 @@ const ExtentEventType = {
 class ExtentInteractionEvent extends Event {
 
   /**
-   * @param {module:ol/extent~Extent} extent the new extent
+   * @param {import("../extent.js").Extent} extent the new extent
    */
   constructor(extent) {
     super(ExtentEventType.EXTENTCHANGED);
 
     /**
      * The current extent.
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      * @api
      */
     this.extent = extent;
@@ -76,12 +76,12 @@ class ExtentInteractionEvent extends Event {
  * Once drawn, the vector box can be modified by dragging its vertices or edges.
  * This interaction is only supported for mouse devices.
  *
- * @fires module:ol/interaction/Extent~Event
+ * @fires Event
  * @api
  */
 class ExtentInteraction extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/Extent~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -96,14 +96,14 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Extent of the drawn box
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      * @private
      */
     this.extent_ = null;
 
     /**
      * Handler for pointer move events
-     * @type {function (module:ol/coordinate~Coordinate): module:ol/extent~Extent|null}
+     * @type {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent|null}
      * @private
      */
     this.pointerHandler_ = null;
@@ -125,14 +125,14 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Feature for displaying the visible extent
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.extentFeature_ = null;
 
     /**
      * Feature for displaying the visible pointer
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.vertexFeature_ = null;
@@ -143,7 +143,7 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Layer for the extentFeature
-     * @type {module:ol/layer/Vector}
+     * @type {import("../layer/Vector.js").default}
      * @private
      */
     this.extentOverlay_ = new VectorLayer({
@@ -158,7 +158,7 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Layer for the vertexFeature
-     * @type {module:ol/layer/Vector}
+     * @type {import("../layer/Vector.js").default}
      * @private
      */
     this.vertexOverlay_ = new VectorLayer({
@@ -177,9 +177,9 @@ class ExtentInteraction extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/pixel~Pixel} pixel cursor location
-   * @param {module:ol/PluggableMap} map map
-   * @returns {module:ol/coordinate~Coordinate|null} snapped vertex on extent
+   * @param {import("../pixel.js").Pixel} pixel cursor location
+   * @param {import("../PluggableMap.js").default} map map
+   * @returns {import("../coordinate.js").Coordinate|null} snapped vertex on extent
    * @private
    */
   snapToVertex_(pixel, map) {
@@ -219,7 +219,7 @@ class ExtentInteraction extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/MapBrowserEvent} mapBrowserEvent pointer move event
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent pointer move event
    * @private
    */
   handlePointerMove_(mapBrowserEvent) {
@@ -234,8 +234,8 @@ class ExtentInteraction extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/extent~Extent} extent extent
-   * @returns {module:ol/Feature} extent as featrue
+   * @param {import("../extent.js").Extent} extent extent
+   * @returns {import("../Feature.js").default} extent as featrue
    * @private
    */
   createOrUpdateExtentFeature_(extent) {
@@ -260,8 +260,8 @@ class ExtentInteraction extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} vertex location of feature
-   * @returns {module:ol/Feature} vertex as feature
+   * @param {import("../coordinate.js").Coordinate} vertex location of feature
+   * @returns {import("../Feature.js").default} vertex as feature
    * @private
    */
   createOrUpdatePointerFeature_(vertex) {
@@ -271,7 +271,7 @@ class ExtentInteraction extends PointerInteraction {
       this.vertexFeature_ = vertexFeature;
       this.vertexOverlay_.getSource().addFeature(vertexFeature);
     } else {
-      const geometry = /** @type {module:ol/geom/Point} */ (vertexFeature.getGeometry());
+      const geometry = /** @type {import("../geom/Point.js").default} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(vertex);
     }
     return vertexFeature;
@@ -289,7 +289,7 @@ class ExtentInteraction extends PointerInteraction {
   /**
    * Returns the current drawn extent in the view projection
    *
-   * @return {module:ol/extent~Extent} Drawn extent in the view projection.
+   * @return {import("../extent.js").Extent} Drawn extent in the view projection.
    * @api
    */
   getExtent() {
@@ -299,7 +299,7 @@ class ExtentInteraction extends PointerInteraction {
   /**
    * Manually sets the drawn extent, using the view projection.
    *
-   * @param {module:ol/extent~Extent} extent Extent
+   * @param {import("../extent.js").Extent} extent Extent
    * @api
    */
   setExtent(extent) {
@@ -311,9 +311,9 @@ class ExtentInteraction extends PointerInteraction {
 }
 
 /**
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Propagate event?
- * @this {module:ol/interaction/Extent~ExtentInteraction}
+ * @this {ExtentInteraction}
  */
 function handleEvent(mapBrowserEvent) {
   if (!(mapBrowserEvent instanceof MapBrowserPointerEvent)) {
@@ -330,9 +330,9 @@ function handleEvent(mapBrowserEvent) {
 }
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Event handled?
- * @this {module:ol/interaction/Extent~ExtentInteraction}
+ * @this {ExtentInteraction}
  */
 function handleDownEvent(mapBrowserEvent) {
   const pixel = mapBrowserEvent.pixel;
@@ -389,9 +389,9 @@ function handleDownEvent(mapBrowserEvent) {
 }
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Event handled?
- * @this {module:ol/interaction/Extent~ExtentInteraction}
+ * @this {ExtentInteraction}
  */
 function handleDragEvent(mapBrowserEvent) {
   if (this.pointerHandler_) {
@@ -403,9 +403,9 @@ function handleDragEvent(mapBrowserEvent) {
 }
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Extent~ExtentInteraction}
+ * @this {ExtentInteraction}
  */
 function handleUpEvent(mapBrowserEvent) {
   this.pointerHandler_ = null;
@@ -420,7 +420,7 @@ function handleUpEvent(mapBrowserEvent) {
 /**
  * Returns the default style for the drawn bbox
  *
- * @return {module:ol/style/Style~StyleFunction} Default Extent style
+ * @return {import("../style/Style.js").StyleFunction} Default Extent style
  */
 function getDefaultExtentStyleFunction() {
   const style = createEditingStyle();
@@ -432,7 +432,7 @@ function getDefaultExtentStyleFunction() {
 /**
  * Returns the default style for the pointer
  *
- * @return {module:ol/style/Style~StyleFunction} Default pointer style
+ * @return {import("../style/Style.js").StyleFunction} Default pointer style
  */
 function getDefaultPointerStyleFunction() {
   const style = createEditingStyle();
@@ -442,8 +442,8 @@ function getDefaultPointerStyleFunction() {
 }
 
 /**
- * @param {module:ol/coordinate~Coordinate} fixedPoint corner that will be unchanged in the new extent
- * @returns {function (module:ol/coordinate~Coordinate): module:ol/extent~Extent} event handler
+ * @param {import("../coordinate.js").Coordinate} fixedPoint corner that will be unchanged in the new extent
+ * @returns {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent} event handler
  */
 function getPointHandler(fixedPoint) {
   return function(point) {
@@ -452,9 +452,9 @@ function getPointHandler(fixedPoint) {
 }
 
 /**
- * @param {module:ol/coordinate~Coordinate} fixedP1 first corner that will be unchanged in the new extent
- * @param {module:ol/coordinate~Coordinate} fixedP2 second corner that will be unchanged in the new extent
- * @returns {function (module:ol/coordinate~Coordinate): module:ol/extent~Extent|null} event handler
+ * @param {import("../coordinate.js").Coordinate} fixedP1 first corner that will be unchanged in the new extent
+ * @param {import("../coordinate.js").Coordinate} fixedP2 second corner that will be unchanged in the new extent
+ * @returns {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent|null} event handler
  */
 function getEdgeHandler(fixedP1, fixedP2) {
   if (fixedP1[0] == fixedP2[0]) {
@@ -471,8 +471,8 @@ function getEdgeHandler(fixedP1, fixedP2) {
 }
 
 /**
- * @param {module:ol/extent~Extent} extent extent
- * @returns {Array<Array<module:ol/coordinate~Coordinate>>} extent line segments
+ * @param {import("../extent.js").Extent} extent extent
+ * @returns {Array<Array<import("../coordinate.js").Coordinate>>} extent line segments
  */
 function getSegments(extent) {
   return [

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -10,7 +10,7 @@ import {clamp} from '../math.js';
 /**
  * Object literal with config options for interactions.
  * @typedef {Object} InteractionOptions
- * @property {function(module:ol/MapBrowserEvent):boolean} handleEvent
+ * @property {function(import("../MapBrowserEvent.js").default):boolean} handleEvent
  * Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. If the function returns a falsy value, propagation of
  * the event to other interactions in the map's interactions chain will be
@@ -33,21 +33,21 @@ import {clamp} from '../math.js';
  */
 class Interaction extends BaseObject {
   /**
-   * @param {module:ol/interaction/Interaction~InteractionOptions} options Options.
+   * @param {InteractionOptions} options Options.
    */
   constructor(options) {
     super();
 
     /**
      * @private
-     * @type {module:ol/PluggableMap}
+     * @type {import("../PluggableMap.js").default}
      */
     this.map_ = null;
 
     this.setActive(true);
 
     /**
-     * @type {function(module:ol/MapBrowserEvent):boolean}
+     * @type {function(import("../MapBrowserEvent.js").default):boolean}
      */
     this.handleEvent = options.handleEvent;
 
@@ -65,7 +65,7 @@ class Interaction extends BaseObject {
 
   /**
    * Get the map associated with this interaction.
-   * @return {module:ol/PluggableMap} Map.
+   * @return {import("../PluggableMap.js").default} Map.
    * @api
    */
   getMap() {
@@ -86,7 +86,7 @@ class Interaction extends BaseObject {
    * Remove the interaction from its current map and attach it to the new map.
    * Subclasses may set up event handlers to get notified about changes to
    * the map here.
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    */
   setMap(map) {
     this.map_ = map;
@@ -95,8 +95,8 @@ class Interaction extends BaseObject {
 
 
 /**
- * @param {module:ol/View} view View.
- * @param {module:ol/coordinate~Coordinate} delta Delta.
+ * @param {import("../View.js").default} view View.
+ * @param {import("../coordinate.js").Coordinate} delta Delta.
  * @param {number=} opt_duration Duration.
  */
 export function pan(view, delta, opt_duration) {
@@ -118,9 +118,9 @@ export function pan(view, delta, opt_duration) {
 
 
 /**
- * @param {module:ol/View} view View.
+ * @param {import("../View.js").default} view View.
  * @param {number|undefined} rotation Rotation.
- * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
+ * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
  */
 export function rotate(view, rotation, opt_anchor, opt_duration) {
@@ -130,9 +130,9 @@ export function rotate(view, rotation, opt_anchor, opt_duration) {
 
 
 /**
- * @param {module:ol/View} view View.
+ * @param {import("../View.js").default} view View.
  * @param {number|undefined} rotation Rotation.
- * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
+ * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
  */
 export function rotateWithoutConstraints(view, rotation, opt_anchor, opt_duration) {
@@ -154,9 +154,9 @@ export function rotateWithoutConstraints(view, rotation, opt_anchor, opt_duratio
 
 
 /**
- * @param {module:ol/View} view View.
+ * @param {import("../View.js").default} view View.
  * @param {number|undefined} resolution Resolution to go to.
- * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
+ * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
  * @param {number=} opt_direction Zooming direction; > 0 indicates
  *     zooming out, in which case the constraints system will select
@@ -174,9 +174,9 @@ export function zoom(view, resolution, opt_anchor, opt_duration, opt_direction) 
 
 
 /**
- * @param {module:ol/View} view View.
+ * @param {import("../View.js").default} view View.
  * @param {number} delta Delta from previous zoom level.
- * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
+ * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
  */
 export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
@@ -212,9 +212,9 @@ export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
 
 
 /**
- * @param {module:ol/View} view View.
+ * @param {import("../View.js").default} view View.
  * @param {number|undefined} resolution Resolution to go to.
- * @param {module:ol/coordinate~Coordinate=} opt_anchor Anchor coordinate.
+ * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
  */
 export function zoomWithoutConstraints(view, resolution, opt_anchor, opt_duration) {

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -10,7 +10,7 @@ import Interaction, {pan} from '../interaction/Interaction.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
  * {@link module:ol/events/condition~noModifierKeys} and
@@ -36,7 +36,7 @@ import Interaction, {pan} from '../interaction/Interaction.js';
  */
 class KeyboardPan extends Interaction {
   /**
-   * @param {module:ol/interaction/KeyboardPan~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -48,7 +48,7 @@ class KeyboardPan extends Interaction {
 
     /**
      * @private
-     * @param {module:ol/MapBrowserEvent} mapBrowserEvent Browser event.
+     * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Browser event.
      * @return {boolean} Combined condition result.
      */
     this.defaultCondition_ = function(mapBrowserEvent) {
@@ -58,7 +58,7 @@ class KeyboardPan extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition !== undefined ?
       options.condition : this.defaultCondition_;
@@ -85,9 +85,9 @@ class KeyboardPan extends Interaction {
  * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
  * `KeyEvent`, and decides the direction to pan to (if an arrow key was
  * pressed).
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/KeyboardPan}
+ * @this {import("./KeyboardPan.js").default}
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -9,7 +9,7 @@ import Interaction, {zoomByDelta} from '../interaction/Interaction.js';
 /**
  * @typedef {Object} Options
  * @property {number} [duration=100] Animation duration in milliseconds.
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
  * {@link module:ol/events/condition~targetNotEditable}.
@@ -32,7 +32,7 @@ import Interaction, {zoomByDelta} from '../interaction/Interaction.js';
  */
 class KeyboardZoom extends Interaction {
   /**
-   * @param {module:ol/interaction/KeyboardZoom~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -44,7 +44,7 @@ class KeyboardZoom extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : targetNotEditable;
 
@@ -69,9 +69,9 @@ class KeyboardZoom extends Interaction {
  * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
  * `KeyEvent`, and decides whether to zoom in or out (depending on whether the
  * key pressed was '+' or '-').
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/KeyboardZoom}
+ * @this {import("./KeyboardZoom.js").default}
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -61,39 +61,39 @@ const ModifyEventType = {
 /**
  * @typedef {Object} SegmentData
  * @property {Array<number>} [depth]
- * @property {module:ol/Feature} feature
- * @property {module:ol/geom/SimpleGeometry} geometry
+ * @property {import("../Feature.js").default} feature
+ * @property {import("../geom/SimpleGeometry.js").default} geometry
  * @property {number} index
- * @property {Array<module:ol/extent~Extent>} segment
- * @property {Array<module:ol/interaction/Modify~SegmentData>} [featureSegments]
+ * @property {Array<import("../extent.js").Extent>} segment
+ * @property {Array<SegmentData>} [featureSegments]
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event will be considered to add or move a
  * vertex to the sketch. Default is
  * {@link module:ol/events/condition~primaryAction}.
- * @property {module:ol/events/condition~Condition} [deleteCondition] A function
+ * @property {import("../events/condition.js").Condition} [deleteCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. By default,
  * {@link module:ol/events/condition~singleClick} with
  * {@link module:ol/events/condition~altKeyOnly} results in a vertex deletion.
- * @property {module:ol/events/condition~Condition} [insertVertexCondition] A
+ * @property {import("../events/condition.js").Condition} [insertVertexCondition] A
  * function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and
  * returns a boolean to indicate whether a new vertex can be added to the sketch
  * features. Default is {@link module:ol/events/condition~always}.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style]
  * Style used for the features being modified. By default the default edit
  * style is used (see {@link module:ol/style}).
- * @property {module:ol/source/Vector} [source] The vector source with
+ * @property {import("../source/Vector.js").default} [source] The vector source with
  * features to modify.  If a vector source is not provided, a feature collection
  * must be provided with the features option.
- * @property {module:ol/Collection<module:ol/Feature>} [features]
+ * @property {import("../Collection.js").default<import("../Feature.js").default>} [features]
  * The features the interaction works on.  If a feature collection is not
  * provided, a vector source must be provided with the source option.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
@@ -109,9 +109,9 @@ const ModifyEventType = {
 export class ModifyEvent extends Event {
   /**
    * @param {ModifyEventType} type Type.
-   * @param {module:ol/Collection<module:ol/Feature>} features
+   * @param {import("../Collection.js").default<import("../Feature.js").default>} features
    * The features modified.
-   * @param {module:ol/MapBrowserPointerEvent} mapBrowserPointerEvent
+   * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserPointerEvent
    * Associated {@link module:ol/MapBrowserPointerEvent}.
    */
   constructor(type, features, mapBrowserPointerEvent) {
@@ -119,14 +119,14 @@ export class ModifyEvent extends Event {
 
     /**
      * The features being modified.
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      * @api
      */
     this.features = features;
 
     /**
      * Associated {@link module:ol/MapBrowserEvent}.
-     * @type {module:ol/MapBrowserEvent}
+     * @type {import("../MapBrowserEvent.js").default}
      * @api
      */
     this.mapBrowserEvent = mapBrowserPointerEvent;
@@ -148,12 +148,12 @@ export class ModifyEvent extends Event {
  * By default, the interaction will allow deletion of vertices when the `alt`
  * key is pressed.  To configure the interaction with a different condition
  * for deletion, use the `deleteCondition` option.
- * @fires module:ol/interaction/Modify~ModifyEvent
+ * @fires ModifyEvent
  * @api
  */
 class Modify extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/Modify~Options} options Options.
+   * @param {Options} options Options.
    */
   constructor(options) {
 
@@ -166,14 +166,14 @@ class Modify extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : primaryAction;
 
 
     /**
      * @private
-     * @param {module:ol/MapBrowserEvent} mapBrowserEvent Browser event.
+     * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Browser event.
      * @return {boolean} Combined condition result.
      */
     this.defaultDeleteCondition_ = function(mapBrowserEvent) {
@@ -181,14 +181,14 @@ class Modify extends PointerInteraction {
     };
 
     /**
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      * @private
      */
     this.deleteCondition_ = options.deleteCondition ?
       options.deleteCondition : this.defaultDeleteCondition_;
 
     /**
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      * @private
      */
     this.insertVertexCondition_ = options.insertVertexCondition ?
@@ -196,7 +196,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Editing vertex.
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.vertexFeature_ = null;
@@ -209,7 +209,7 @@ class Modify extends PointerInteraction {
     this.vertexSegments_ = null;
 
     /**
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("../pixel.js").Pixel}
      * @private
      */
     this.lastPixel_ = [0, 0];
@@ -230,7 +230,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Segment RTree for each layer
-     * @type {module:ol/structs/RBush<module:ol/interaction/Modify~SegmentData>}
+     * @type {import("../structs/RBush.js").default<SegmentData>}
      * @private
      */
     this.rBush_ = new RBush();
@@ -264,7 +264,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Draw overlay where sketch features are drawn.
-     * @type {module:ol/layer/Vector}
+     * @type {import("../layer/Vector.js").default}
      * @private
      */
     this.overlay_ = new VectorLayer({
@@ -281,7 +281,7 @@ class Modify extends PointerInteraction {
     /**
      * @const
      * @private
-     * @type {!Object<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
+     * @type {!Object<string, function(import("../Feature.js").default, import("../geom/Geometry.js").default)>}
      */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,
@@ -297,7 +297,7 @@ class Modify extends PointerInteraction {
 
 
     /**
-     * @type {module:ol/source/Vector}
+     * @type {import("../source/Vector.js").default}
      * @private
      */
     this.source_ = null;
@@ -318,7 +318,7 @@ class Modify extends PointerInteraction {
     }
 
     /**
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      * @private
      */
     this.features_ = features;
@@ -330,7 +330,7 @@ class Modify extends PointerInteraction {
       this.handleFeatureRemove_, this);
 
     /**
-     * @type {module:ol/MapBrowserPointerEvent}
+     * @type {import("../MapBrowserPointerEvent.js").default}
      * @private
      */
     this.lastPointerEvent_ = null;
@@ -338,7 +338,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @private
    */
   addFeature_(feature) {
@@ -355,7 +355,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/MapBrowserPointerEvent} evt Map browser event
+   * @param {import("../MapBrowserPointerEvent.js").default} evt Map browser event
    * @private
    */
   willModifyFeatures_(evt) {
@@ -367,7 +367,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @private
    */
   removeFeature_(feature) {
@@ -383,15 +383,15 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @private
    */
   removeFeatureSegmentData_(feature) {
     const rBush = this.rBush_;
-    const /** @type {Array<module:ol/interaction/Modify~SegmentData>} */ nodesToRemove = [];
+    const /** @type {Array<SegmentData>} */ nodesToRemove = [];
     rBush.forEach(
       /**
-       * @param {module:ol/interaction/Modify~SegmentData} node RTree node.
+       * @param {SegmentData} node RTree node.
        */
       function(node) {
         if (feature === node.feature) {
@@ -424,7 +424,7 @@ class Modify extends PointerInteraction {
 
   /**
    * Get the overlay layer that this interaction renders sketch features to.
-   * @return {module:ol/layer/Vector} Overlay layer.
+   * @return {import("../layer/Vector.js").default} Overlay layer.
    * @api
    */
   getOverlay() {
@@ -432,7 +432,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/source/Vector~VectorSourceEvent} event Event.
+   * @param {import("../source/Vector.js").VectorSourceEvent} event Event.
    * @private
    */
   handleSourceAdd_(event) {
@@ -442,7 +442,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/source/Vector~VectorSourceEvent} event Event.
+   * @param {import("../source/Vector.js").VectorSourceEvent} event Event.
    * @private
    */
   handleSourceRemove_(event) {
@@ -452,42 +452,42 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Collection~CollectionEvent} evt Event.
+   * @param {import("../Collection.js").CollectionEvent} evt Event.
    * @private
    */
   handleFeatureAdd_(evt) {
-    this.addFeature_(/** @type {module:ol/Feature} */ (evt.element));
+    this.addFeature_(/** @type {import("../Feature.js").default} */ (evt.element));
   }
 
   /**
-   * @param {module:ol/events/Event} evt Event.
+   * @param {import("../events/Event.js").default} evt Event.
    * @private
    */
   handleFeatureChange_(evt) {
     if (!this.changingFeature_) {
-      const feature = /** @type {module:ol/Feature} */ (evt.target);
+      const feature = /** @type {import("../Feature.js").default} */ (evt.target);
       this.removeFeature_(feature);
       this.addFeature_(feature);
     }
   }
 
   /**
-   * @param {module:ol/Collection~CollectionEvent} evt Event.
+   * @param {import("../Collection.js").CollectionEvent} evt Event.
    * @private
    */
   handleFeatureRemove_(evt) {
-    const feature = /** @type {module:ol/Feature} */ (evt.element);
+    const feature = /** @type {import("../Feature.js").default} */ (evt.element);
     this.removeFeature_(feature);
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/Point} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/Point.js").default} geometry Geometry.
    * @private
    */
   writePointGeometry_(feature, geometry) {
     const coordinates = geometry.getCoordinates();
-    const segmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+    const segmentData = /** @type {SegmentData} */ ({
       feature: feature,
       geometry: geometry,
       segment: [coordinates, coordinates]
@@ -496,15 +496,15 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/MultiPoint} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/MultiPoint.js").default} geometry Geometry.
    * @private
    */
   writeMultiPointGeometry_(feature, geometry) {
     const points = geometry.getCoordinates();
     for (let i = 0, ii = points.length; i < ii; ++i) {
       const coordinates = points[i];
-      const segmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+      const segmentData = /** @type {SegmentData} */ ({
         feature: feature,
         geometry: geometry,
         depth: [i],
@@ -516,15 +516,15 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/LineString} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/LineString.js").default} geometry Geometry.
    * @private
    */
   writeLineStringGeometry_(feature, geometry) {
     const coordinates = geometry.getCoordinates();
     for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       const segment = coordinates.slice(i, i + 2);
-      const segmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+      const segmentData = /** @type {SegmentData} */ ({
         feature: feature,
         geometry: geometry,
         index: i,
@@ -535,8 +535,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/MultiLineString} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/MultiLineString.js").default} geometry Geometry.
    * @private
    */
   writeMultiLineStringGeometry_(feature, geometry) {
@@ -545,7 +545,7 @@ class Modify extends PointerInteraction {
       const coordinates = lines[j];
       for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
         const segment = coordinates.slice(i, i + 2);
-        const segmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+        const segmentData = /** @type {SegmentData} */ ({
           feature: feature,
           geometry: geometry,
           depth: [j],
@@ -558,8 +558,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/Polygon} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/Polygon.js").default} geometry Geometry.
    * @private
    */
   writePolygonGeometry_(feature, geometry) {
@@ -568,7 +568,7 @@ class Modify extends PointerInteraction {
       const coordinates = rings[j];
       for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
         const segment = coordinates.slice(i, i + 2);
-        const segmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+        const segmentData = /** @type {SegmentData} */ ({
           feature: feature,
           geometry: geometry,
           depth: [j],
@@ -581,8 +581,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/MultiPolygon} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
    * @private
    */
   writeMultiPolygonGeometry_(feature, geometry) {
@@ -593,7 +593,7 @@ class Modify extends PointerInteraction {
         const coordinates = rings[j];
         for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
           const segment = coordinates.slice(i, i + 2);
-          const segmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+          const segmentData = /** @type {SegmentData} */ ({
             feature: feature,
             geometry: geometry,
             depth: [j, k],
@@ -613,19 +613,19 @@ class Modify extends PointerInteraction {
    * {@link CIRCLE_CIRCUMFERENCE_INDEX} is
    * the circumference, and is not a line segment.
    *
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/geom/Circle} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("../geom/Circle.js").default} geometry Geometry.
    * @private
    */
   writeCircleGeometry_(feature, geometry) {
     const coordinates = geometry.getCenter();
-    const centerSegmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+    const centerSegmentData = /** @type {SegmentData} */ ({
       feature: feature,
       geometry: geometry,
       index: CIRCLE_CENTER_INDEX,
       segment: [coordinates, coordinates]
     });
-    const circumferenceSegmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+    const circumferenceSegmentData = /** @type {SegmentData} */ ({
       feature: feature,
       geometry: geometry,
       index: CIRCLE_CIRCUMFERENCE_INDEX,
@@ -638,8 +638,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/GeometryCollection} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/GeometryCollection.js").default} geometry Geometry.
    * @private
    */
   writeGeometryCollectionGeometry_(feature, geometry) {
@@ -650,8 +650,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinates Coordinates.
-   * @return {module:ol/Feature} Vertex feature.
+   * @param {import("../coordinate.js").Coordinate} coordinates Coordinates.
+   * @return {import("../Feature.js").default} Vertex feature.
    * @private
    */
   createOrUpdateVertexFeature_(coordinates) {
@@ -661,14 +661,14 @@ class Modify extends PointerInteraction {
       this.vertexFeature_ = vertexFeature;
       this.overlay_.getSource().addFeature(vertexFeature);
     } else {
-      const geometry = /** @type {module:ol/geom/Point} */ (vertexFeature.getGeometry());
+      const geometry = /** @type {import("../geom/Point.js").default} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(coordinates);
     }
     return vertexFeature;
   }
 
   /**
-   * @param {module:ol/MapBrowserEvent} evt Event.
+   * @param {import("../MapBrowserEvent.js").default} evt Event.
    * @private
    */
   handlePointerMove_(evt) {
@@ -677,8 +677,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/pixel~Pixel} pixel Pixel
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../pixel.js").Pixel} pixel Pixel
+   * @param {import("../PluggableMap.js").default} map Map.
    * @private
    */
   handlePointerAtPixel_(pixel, map) {
@@ -744,8 +744,8 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/interaction/Modify~SegmentData} segmentData Segment data.
-   * @param {module:ol/coordinate~Coordinate} vertex Vertex.
+   * @param {SegmentData} segmentData Segment data.
+   * @param {import("../coordinate.js").Coordinate} vertex Vertex.
    * @private
    */
   insertVertex_(segmentData, vertex) {
@@ -785,7 +785,7 @@ class Modify extends PointerInteraction {
     const rTree = this.rBush_;
     rTree.remove(segmentData);
     this.updateSegmentIndices_(geometry, index, depth, 1);
-    const newSegmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+    const newSegmentData = /** @type {SegmentData} */ ({
       segment: [segment[0], vertex],
       feature: feature,
       geometry: geometry,
@@ -796,7 +796,7 @@ class Modify extends PointerInteraction {
       newSegmentData);
     this.dragSegments_.push([newSegmentData, 1]);
 
-    const newSegmentData2 = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+    const newSegmentData2 = /** @type {SegmentData} */ ({
       segment: [vertex, segment[1]],
       feature: feature,
       geometry: geometry,
@@ -921,7 +921,7 @@ class Modify extends PointerInteraction {
           segments.push(right.segment[1]);
         }
         if (left !== undefined && right !== undefined) {
-          const newSegmentData = /** @type {module:ol/interaction/Modify~SegmentData} */ ({
+          const newSegmentData = /** @type {SegmentData} */ ({
             depth: segmentData.depth,
             feature: segmentData.feature,
             geometry: segmentData.geometry,
@@ -944,7 +944,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
+   * @param {import("../geom/SimpleGeometry.js").default} geometry Geometry.
    * @param {Array} coordinates Coordinates.
    * @private
    */
@@ -955,7 +955,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
+   * @param {import("../geom/SimpleGeometry.js").default} geometry Geometry.
    * @param {number} index Index.
    * @param {Array<number>|undefined} depth Depth.
    * @param {number} delta Delta (1 or -1).
@@ -975,8 +975,8 @@ class Modify extends PointerInteraction {
 
 
 /**
- * @param {module:ol/interaction/Modify~SegmentData} a The first segment data.
- * @param {module:ol/interaction/Modify~SegmentData} b The second segment data.
+ * @param {SegmentData} a The first segment data.
+ * @param {SegmentData} b The second segment data.
  * @return {number} The difference in indexes.
  */
 function compareIndexes(a, b) {
@@ -985,9 +985,9 @@ function compareIndexes(a, b) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} evt Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/Modify}
+ * @this {import("./Modify.js").default}
  */
 function handleDownEvent(evt) {
   if (!this.condition_(evt)) {
@@ -1000,7 +1000,7 @@ function handleDownEvent(evt) {
   const vertexFeature = this.vertexFeature_;
   if (vertexFeature) {
     const insertVertices = [];
-    const geometry = /** @type {module:ol/geom/Point} */ (vertexFeature.getGeometry());
+    const geometry = /** @type {import("../geom/Point.js").default} */ (vertexFeature.getGeometry());
     const vertex = geometry.getCoordinates();
     const vertexExtent = boundingExtent([vertex]);
     const segmentDataMatches = this.rBush_.getInExtent(vertexExtent);
@@ -1061,8 +1061,8 @@ function handleDownEvent(evt) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} evt Event.
- * @this {module:ol/interaction/Modify}
+ * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
+ * @this {import("./Modify.js").default}
  */
 function handleDragEvent(evt) {
   this.ignoreNextSingleClick_ = false;
@@ -1137,9 +1137,9 @@ function handleDragEvent(evt) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} evt Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Modify}
+ * @this {import("./Modify.js").default}
  */
 function handleUpEvent(evt) {
   for (let i = this.dragSegments_.length - 1; i >= 0; --i) {
@@ -1169,9 +1169,9 @@ function handleUpEvent(evt) {
 /**
  * Handles the {@link module:ol/MapBrowserEvent map browser event} and may modify the
  * geometry.
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Modify}
+ * @this {import("./Modify.js").default}
  */
 function handleEvent(mapBrowserEvent) {
   if (!(mapBrowserEvent instanceof MapBrowserPointerEvent)) {
@@ -1204,9 +1204,9 @@ function handleEvent(mapBrowserEvent) {
 /**
  * Returns the distance from a point to a line segment.
  *
- * @param {module:ol/coordinate~Coordinate} pointCoordinates The coordinates of the point from
+ * @param {import("../coordinate.js").Coordinate} pointCoordinates The coordinates of the point from
  *        which to calculate the distance.
- * @param {module:ol/interaction/Modify~SegmentData} segmentData The object describing the line
+ * @param {SegmentData} segmentData The object describing the line
  *        segment we are calculating the distance to.
  * @return {number} The square of the distance between a point and a line segment.
  */
@@ -1214,7 +1214,7 @@ function pointDistanceToSegmentDataSquared(pointCoordinates, segmentData) {
   const geometry = segmentData.geometry;
 
   if (geometry.getType() === GeometryType.CIRCLE) {
-    const circleGeometry = /** @type {module:ol/geom/Circle} */ (geometry);
+    const circleGeometry = /** @type {import("../geom/Circle.js").default} */ (geometry);
 
     if (segmentData.index === CIRCLE_CIRCUMFERENCE_INDEX) {
       const distanceToCenterSquared =
@@ -1230,11 +1230,11 @@ function pointDistanceToSegmentDataSquared(pointCoordinates, segmentData) {
 /**
  * Returns the point closest to a given line segment.
  *
- * @param {module:ol/coordinate~Coordinate} pointCoordinates The point to which a closest point
+ * @param {import("../coordinate.js").Coordinate} pointCoordinates The point to which a closest point
  *        should be found.
- * @param {module:ol/interaction/Modify~SegmentData} segmentData The object describing the line
+ * @param {SegmentData} segmentData The object describing the line
  *        segment which should contain the closest point.
- * @return {module:ol/coordinate~Coordinate} The point closest to the specified line segment.
+ * @return {import("../coordinate.js").Coordinate} The point closest to the specified line segment.
  */
 function closestOnSegmentData(pointCoordinates, segmentData) {
   const geometry = segmentData.geometry;
@@ -1248,7 +1248,7 @@ function closestOnSegmentData(pointCoordinates, segmentData) {
 
 
 /**
- * @return {module:ol/style/Style~StyleFunction} Styles.
+ * @return {import("../style/Style.js").StyleFunction} Styles.
  */
 function getDefaultStyleFunction() {
   const style = createEditingStyle();

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -28,7 +28,7 @@ export const Mode = {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
  * {@link module:ol/events/condition~always}.
@@ -50,7 +50,7 @@ export const Mode = {
  */
 class MouseWheelZoom extends Interaction {
   /**
-   * @param {module:ol/interaction/MouseWheelZoom~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -92,13 +92,13 @@ class MouseWheelZoom extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : always;
 
     /**
      * @private
-     * @type {?module:ol/coordinate~Coordinate}
+     * @type {?import("../coordinate.js").Coordinate}
      */
     this.lastAnchor_ = null;
 
@@ -116,7 +116,7 @@ class MouseWheelZoom extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/interaction/MouseWheelZoom~Mode|undefined}
+     * @type {Mode|undefined}
      */
     this.mode_ = undefined;
 
@@ -159,7 +159,7 @@ class MouseWheelZoom extends Interaction {
 
   /**
    * @private
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    */
   handleWheelZoom_(map) {
     const view = map.getView();
@@ -194,9 +194,9 @@ class MouseWheelZoom extends Interaction {
 /**
  * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
  * mousewheel-event) and eventually zooms the map.
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} Allow event propagation.
- * @this {module:ol/interaction/MouseWheelZoom}
+ * @this {import("./MouseWheelZoom.js").default}
  */
 function handleEvent(mapBrowserEvent) {
   if (!this.condition_(mapBrowserEvent)) {

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -24,7 +24,7 @@ import {disable} from '../rotationconstraint.js';
  */
 class PinchRotate extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/PinchRotate~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -39,7 +39,7 @@ class PinchRotate extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      */
     this.anchor_ = null;
 
@@ -79,8 +79,8 @@ class PinchRotate extends PointerInteraction {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/PinchRotate}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./PinchRotate.js").default}
  */
 function handleDragEvent(mapBrowserEvent) {
   let rotationDelta = 0.0;
@@ -129,9 +129,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/PinchRotate}
+ * @this {import("./PinchRotate.js").default}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (this.targetPointers.length < 2) {
@@ -150,9 +150,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/PinchRotate}
+ * @this {import("./PinchRotate.js").default}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (this.targetPointers.length >= 2) {

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -23,7 +23,7 @@ import PointerInteraction, {centroid as centroidFromPointers} from '../interacti
  */
 class PinchZoom extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/PinchZoom~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -44,7 +44,7 @@ class PinchZoom extends PointerInteraction {
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      */
     this.anchor_ = null;
 
@@ -72,8 +72,8 @@ class PinchZoom extends PointerInteraction {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/PinchZoom}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./PinchZoom.js").default}
  */
 function handleDragEvent(mapBrowserEvent) {
   let scaleDelta = 1.0;
@@ -124,9 +124,9 @@ function handleDragEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/PinchZoom}
+ * @this {import("./PinchZoom.js").default}
  */
 function handleUpEvent(mapBrowserEvent) {
   if (this.targetPointers.length < 2) {
@@ -151,9 +151,9 @@ function handleUpEvent(mapBrowserEvent) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/PinchZoom}
+ * @this {import("./PinchZoom.js").default}
  */
 function handleDownEvent(mapBrowserEvent) {
   if (this.targetPointers.length >= 2) {

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -9,53 +9,53 @@ import {getValues} from '../obj.js';
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/Pointer}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./Pointer.js").default}
  */
 const handleDragEvent = VOID;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Capture dragging.
- * @this {module:ol/interaction/Pointer}
+ * @this {import("./Pointer.js").default}
  */
 const handleUpEvent = FALSE;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Capture dragging.
- * @this {module:ol/interaction/Pointer}
+ * @this {import("./Pointer.js").default}
  */
 const handleDownEvent = FALSE;
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {module:ol/interaction/Pointer}
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @this {import("./Pointer.js").default}
  */
 const handleMoveEvent = VOID;
 
 
 /**
  * @typedef {Object} Options
- * @property {function(module:ol/MapBrowserPointerEvent):boolean} [handleDownEvent]
+ * @property {function(import("../MapBrowserPointerEvent.js").default):boolean} [handleDownEvent]
  * Function handling "down" events. If the function returns `true` then a drag
  * sequence is started.
- * @property {function(module:ol/MapBrowserPointerEvent)} [handleDragEvent]
+ * @property {function(import("../MapBrowserPointerEvent.js").default)} [handleDragEvent]
  * Function handling "drag" events. This function is called on "move" events
  * during a drag sequence.
- * @property {function(module:ol/MapBrowserEvent):boolean} [handleEvent]
+ * @property {function(import("../MapBrowserEvent.js").default):boolean} [handleEvent]
  * Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. The function may return `false` to prevent the
  * propagation of the event to other interactions in the map's interactions
  * chain.
- * @property {function(module:ol/MapBrowserPointerEvent)} [handleMoveEvent]
+ * @property {function(import("../MapBrowserPointerEvent.js").default)} [handleMoveEvent]
  * Function handling "move" events. This function is called on "move" events,
  * also during a drag sequence (so during a drag sequence both the
  * `handleDragEvent` function and this function are called).
- * @property {function(module:ol/MapBrowserPointerEvent):boolean} [handleUpEvent]
+ * @property {function(import("../MapBrowserPointerEvent.js").default):boolean} [handleUpEvent]
  *  Function handling "up" events. If the function returns `false` then the
  * current drag sequence is stopped.
  * @property {function(boolean):boolean} stopDown
@@ -77,7 +77,7 @@ const handleMoveEvent = VOID;
  */
 class PointerInteraction extends Interaction {
   /**
-   * @param {module:ol/interaction/Pointer~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -88,28 +88,28 @@ class PointerInteraction extends Interaction {
     });
 
     /**
-     * @type {function(module:ol/MapBrowserPointerEvent):boolean}
+     * @type {function(import("../MapBrowserPointerEvent.js").default):boolean}
      * @private
      */
     this.handleDownEvent_ = options.handleDownEvent ?
       options.handleDownEvent : handleDownEvent;
 
     /**
-     * @type {function(module:ol/MapBrowserPointerEvent)}
+     * @type {function(import("../MapBrowserPointerEvent.js").default)}
      * @private
      */
     this.handleDragEvent_ = options.handleDragEvent ?
       options.handleDragEvent : handleDragEvent;
 
     /**
-     * @type {function(module:ol/MapBrowserPointerEvent)}
+     * @type {function(import("../MapBrowserPointerEvent.js").default)}
      * @private
      */
     this.handleMoveEvent_ = options.handleMoveEvent ?
       options.handleMoveEvent : handleMoveEvent;
 
     /**
-     * @type {function(module:ol/MapBrowserPointerEvent):boolean}
+     * @type {function(import("../MapBrowserPointerEvent.js").default):boolean}
      * @private
      */
     this.handleUpEvent_ = options.handleUpEvent ?
@@ -130,13 +130,13 @@ class PointerInteraction extends Interaction {
     this.stopDown = options.stopDown ? options.stopDown : stopDown;
 
     /**
-     * @type {!Object<string, module:ol/pointer/PointerEvent>}
+     * @type {!Object<string, import("../pointer/PointerEvent.js").default>}
      * @private
      */
     this.trackedPointers_ = {};
 
     /**
-     * @type {Array<module:ol/pointer/PointerEvent>}
+     * @type {Array<import("../pointer/PointerEvent.js").default>}
      * @protected
      */
     this.targetPointers = [];
@@ -144,7 +144,7 @@ class PointerInteraction extends Interaction {
   }
 
   /**
-   * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+   * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
    * @private
    */
   updateTrackedPointers_(mapBrowserEvent) {
@@ -169,8 +169,8 @@ class PointerInteraction extends Interaction {
 
 
 /**
- * @param {Array<module:ol/pointer/PointerEvent>} pointerEvents List of events.
- * @return {module:ol/pixel~Pixel} Centroid pixel.
+ * @param {Array<import("../pointer/PointerEvent.js").default>} pointerEvents List of events.
+ * @return {import("../pixel.js").Pixel} Centroid pixel.
  */
 export function centroid(pointerEvents) {
   const length = pointerEvents.length;
@@ -185,7 +185,7 @@ export function centroid(pointerEvents) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
  * @return {boolean} Whether the event is a pointerdown, pointerdrag
  *     or pointerup event.
  */
@@ -201,9 +201,9 @@ function isPointerDraggingEvent(mapBrowserEvent) {
  * Handles the {@link module:ol/MapBrowserEvent map browser event} and may call into
  * other functions, if event sequences like e.g. 'drag' or 'down-up' etc. are
  * detected.
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Pointer}
+ * @this {import("./Pointer.js").default}
  * @api
  */
 export function handleEvent(mapBrowserEvent) {

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -34,19 +34,19 @@ const SelectEventType = {
  * {@link module:ol/render/Feature} and an
  * {@link module:ol/layer/Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
- * @typedef {function((module:ol/Feature|module:ol/render/Feature), module:ol/layer/Layer):
+ * @typedef {function((import("../Feature.js").default|import("../render/Feature.js").default), import("../layer/Layer.js").default):
  *     boolean} FilterFunction
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/events/condition~Condition} [addCondition] A function
+ * @property {import("../events/condition.js").Condition} [addCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
  * By default, this is {@link module:ol/events/condition~never}. Use this if you
  * want to use different events for add and remove instead of `toggle`.
- * @property {module:ol/events/condition~Condition} [condition] A function that
+ * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. This is the event
  * for the selected features as a whole. By default, this is
@@ -55,21 +55,21 @@ const SelectEventType = {
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- * @property {Array<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers]
+ * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default): boolean} [layers]
  * A list of layers from which features should be selected. Alternatively, a
  * filter function can be provided. The function will be called for each layer
  * in the map and should return `true` for layers that you want to be
  * selectable. If the option is absent, all visible layers will be considered
  * selectable.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style]
  * Style for the selected features. By default the default edit style is used
  * (see {@link module:ol/style}).
- * @property {module:ol/events/condition~Condition} [removeCondition] A function
+ * @property {import("../events/condition.js").Condition} [removeCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
  * By default, this is {@link module:ol/events/condition~never}. Use this if you
  * want to use different events for add and remove instead of `toggle`.
- * @property {module:ol/events/condition~Condition} [toggleCondition] A function
+ * @property {import("../events/condition.js").Condition} [toggleCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. This is in addition
  * to the `condition` event. By default,
@@ -80,12 +80,12 @@ const SelectEventType = {
  * @property {boolean} [multi=false] A boolean that determines if the default
  * behaviour should select only single features or all (overlapping) features at
  * the clicked map position. The default of `false` means single select.
- * @property {module:ol/Collection<module:ol/Feature>} [features]
+ * @property {import("../Collection.js").default<import("../Feature.js").default>} [features]
  * Collection where the interaction will place selected features. Optional. If
  * not set the interaction will create a collection. In any case the collection
  * used by the interaction is returned by
  * {@link module:ol/interaction/Select~Select#getFeatures}.
- * @property {module:ol/interaction/Select~FilterFunction} [filter] A function
+ * @property {FilterFunction} [filter] A function
  * that takes an {@link module:ol/Feature} and an
  * {@link module:ol/layer/Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
@@ -105,9 +105,9 @@ const SelectEventType = {
 class SelectEvent extends Event {
   /**
    * @param {SelectEventType} type The event type.
-   * @param {Array<module:ol/Feature>} selected Selected features.
-   * @param {Array<module:ol/Feature>} deselected Deselected features.
-   * @param {module:ol/MapBrowserEvent} mapBrowserEvent Associated
+   * @param {Array<import("../Feature.js").default>} selected Selected features.
+   * @param {Array<import("../Feature.js").default>} deselected Deselected features.
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Associated
    *     {@link module:ol/MapBrowserEvent}.
    */
   constructor(type, selected, deselected, mapBrowserEvent) {
@@ -115,21 +115,21 @@ class SelectEvent extends Event {
 
     /**
      * Selected features array.
-     * @type {Array<module:ol/Feature>}
+     * @type {Array<import("../Feature.js").default>}
      * @api
      */
     this.selected = selected;
 
     /**
      * Deselected features array.
-     * @type {Array<module:ol/Feature>}
+     * @type {Array<import("../Feature.js").default>}
      * @api
      */
     this.deselected = deselected;
 
     /**
      * Associated {@link module:ol/MapBrowserEvent}.
-     * @type {module:ol/MapBrowserEvent}
+     * @type {import("../MapBrowserEvent.js").default}
      * @api
      */
     this.mapBrowserEvent = mapBrowserEvent;
@@ -156,7 +156,7 @@ class SelectEvent extends Event {
  */
 class Select extends Interaction {
   /**
-   * @param {module:ol/interaction/Select~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -168,25 +168,25 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : singleClick;
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.addCondition_ = options.addCondition ? options.addCondition : never;
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.removeCondition_ = options.removeCondition ? options.removeCondition : never;
 
     /**
      * @private
-     * @type {module:ol/events/condition~Condition}
+     * @type {import("../events/condition.js").Condition}
      */
     this.toggleCondition_ = options.toggleCondition ? options.toggleCondition : shiftKeyOnly;
 
@@ -198,7 +198,7 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/interaction/Select~FilterFunction}
+     * @type {FilterFunction}
      */
     this.filter_ = options.filter ? options.filter : TRUE;
 
@@ -222,11 +222,11 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {module:ol/layer/Vector}
+     * @type {import("../layer/Vector.js").default}
      */
     this.featureOverlay_ = featureOverlay;
 
-    /** @type {function(module:ol/layer/Layer): boolean} */
+    /** @type {function(import("../layer/Layer.js").default): boolean} */
     let layerFilter;
     if (options.layers) {
       if (typeof options.layers === 'function') {
@@ -243,7 +243,7 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {function(module:ol/layer/Layer): boolean}
+     * @type {function(import("../layer/Layer.js").default): boolean}
      */
     this.layerFilter_ = layerFilter;
 
@@ -251,7 +251,7 @@ class Select extends Interaction {
      * An association between selected feature (key)
      * and layer (value)
      * @private
-     * @type {Object<number, module:ol/layer/Layer>}
+     * @type {Object<number, import("../layer/Layer.js").default>}
      */
     this.featureLayerAssociation_ = {};
 
@@ -263,8 +263,8 @@ class Select extends Interaction {
   }
 
   /**
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
+   * @param {import("../layer/Layer.js").default} layer Layer.
    * @private
    */
   addFeatureLayerAssociation_(feature, layer) {
@@ -274,7 +274,7 @@ class Select extends Interaction {
 
   /**
    * Get the selected features.
-   * @return {module:ol/Collection<module:ol/Feature>} Features collection.
+   * @return {import("../Collection.js").default<import("../Feature.js").default>} Features collection.
    * @api
    */
   getFeatures() {
@@ -295,20 +295,20 @@ class Select extends Interaction {
    * the (last) selected feature. Note that this will not work with any
    * programmatic method like pushing features to
    * {@link module:ol/interaction/Select~Select#getFeatures collection}.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature
-   * @return {module:ol/layer/Vector} Layer.
+   * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature
+   * @return {import("../layer/Vector.js").default} Layer.
    * @api
    */
   getLayer(feature) {
     const key = getUid(feature);
     return (
-      /** @type {module:ol/layer/Vector} */ (this.featureLayerAssociation_[key])
+      /** @type {import("../layer/Vector.js").default} */ (this.featureLayerAssociation_[key])
     );
   }
 
   /**
    * Get the overlay layer that this interaction renders selected features to.
-   * @return {module:ol/layer/Vector} Overlay layer.
+   * @return {import("../layer/Vector.js").default} Overlay layer.
    * @api
    */
   getOverlay() {
@@ -329,7 +329,7 @@ class Select extends Interaction {
   /**
    * Remove the interaction from its current map, if any,  and attach it to a new
    * map, if any. Pass `null` to just remove the interaction from the current map.
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    * @override
    * @api
    */
@@ -348,29 +348,29 @@ class Select extends Interaction {
   }
 
   /**
-   * @param {module:ol/Collection~CollectionEvent} evt Event.
+   * @param {import("../Collection.js").CollectionEvent} evt Event.
    * @private
    */
   addFeature_(evt) {
     const map = this.getMap();
     if (map) {
-      map.skipFeature(/** @type {module:ol/Feature} */ (evt.element));
+      map.skipFeature(/** @type {import("../Feature.js").default} */ (evt.element));
     }
   }
 
   /**
-   * @param {module:ol/Collection~CollectionEvent} evt Event.
+   * @param {import("../Collection.js").CollectionEvent} evt Event.
    * @private
    */
   removeFeature_(evt) {
     const map = this.getMap();
     if (map) {
-      map.unskipFeature(/** @type {module:ol/Feature} */ (evt.element));
+      map.unskipFeature(/** @type {import("../Feature.js").default} */ (evt.element));
     }
   }
 
   /**
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
    * @private
    */
   removeFeatureLayerAssociation_(feature) {
@@ -383,9 +383,9 @@ class Select extends Interaction {
 /**
  * Handles the {@link module:ol/MapBrowserEvent map browser event} and may change the
  * selected state of features.
- * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} `false` to stop event propagation.
- * @this {module:ol/interaction/Select}
+ * @this {import("./Select.js").default}
  */
 function handleEvent(mapBrowserEvent) {
   if (!this.condition_(mapBrowserEvent)) {
@@ -407,8 +407,8 @@ function handleEvent(mapBrowserEvent) {
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
       (
         /**
-         * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
-         * @param {module:ol/layer/Layer} layer Layer.
+         * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
+         * @param {import("../layer/Layer.js").default} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
@@ -440,8 +440,8 @@ function handleEvent(mapBrowserEvent) {
     map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
       (
         /**
-         * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
-         * @param {module:ol/layer/Layer} layer Layer.
+         * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
+         * @param {import("../layer/Layer.js").default} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
          */
         function(feature, layer) {
@@ -474,7 +474,7 @@ function handleEvent(mapBrowserEvent) {
 
 
 /**
- * @return {module:ol/style/Style~StyleFunction} Styles.
+ * @return {import("../style/Style.js").StyleFunction} Styles.
  */
 function getDefaultStyleFunction() {
   const styles = createEditingStyle();

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -21,26 +21,26 @@ import RBush from '../structs/RBush.js';
 /**
  * @typedef {Object} Result
  * @property {boolean} snapped
- * @property {module:ol/coordinate~Coordinate|null} vertex
- * @property {module:ol/pixel~Pixel|null} vertexPixel
+ * @property {import("../coordinate.js").Coordinate|null} vertex
+ * @property {import("../pixel.js").Pixel|null} vertexPixel
  */
 
 
 /**
  * @typedef {Object} SegmentData
- * @property {module:ol/Feature} feature
- * @property {Array<module:ol/coordinate~Coordinate>} segment
+ * @property {import("../Feature.js").default} feature
+ * @property {Array<import("../coordinate.js").Coordinate>} segment
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/Collection<module:ol/Feature>} [features] Snap to these features. Either this option or source should be provided.
+ * @property {import("../Collection.js").default<import("../Feature.js").default>} [features] Snap to these features. Either this option or source should be provided.
  * @property {boolean} [edge=true] Snap to edges.
  * @property {boolean} [vertex=true] Snap to vertices.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for snapping.
- * @property {module:ol/source/Vector} [source] Snap to features from this source. Either this option or features should be provided
+ * @property {import("../source/Vector.js").default} [source] Snap to features from this source. Either this option or features should be provided
  */
 
 
@@ -67,7 +67,7 @@ import RBush from '../structs/RBush.js';
  */
 class Snap extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/Snap~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -81,7 +81,7 @@ class Snap extends PointerInteraction {
     const options = opt_options ? opt_options : {};
 
     /**
-     * @type {module:ol/source/Vector}
+     * @type {import("../source/Vector.js").default}
      * @private
      */
     this.source_ = options.source ? options.source : null;
@@ -99,19 +99,19 @@ class Snap extends PointerInteraction {
     this.edge_ = options.edge !== undefined ? options.edge : true;
 
     /**
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      * @private
      */
     this.features_ = options.features ? options.features : null;
 
     /**
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("../events.js").EventsKey>}
      * @private
      */
     this.featuresListenerKeys_ = [];
 
     /**
-     * @type {Object<number, module:ol/events~EventsKey>}
+     * @type {Object<number, import("../events.js").EventsKey>}
      * @private
      */
     this.featureChangeListenerKeys_ = {};
@@ -119,7 +119,7 @@ class Snap extends PointerInteraction {
     /**
      * Extents are preserved so indexed segment can be quickly removed
      * when its feature geometry changes
-     * @type {Object<number, module:ol/extent~Extent>}
+     * @type {Object<number, import("../extent.js").Extent>}
      * @private
      */
     this.indexedFeaturesExtents_ = {};
@@ -128,14 +128,14 @@ class Snap extends PointerInteraction {
      * If a feature geometry changes while a pointer drag|move event occurs, the
      * feature doesn't get updated right away.  It will be at the next 'pointerup'
      * event fired.
-     * @type {!Object<number, module:ol/Feature>}
+     * @type {!Object<number, import("../Feature.js").default>}
      * @private
      */
     this.pendingFeatures_ = {};
 
     /**
      * Used for distance sorting in sortByDistance_
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      * @private
      */
     this.pixelCoordinate_ = null;
@@ -148,7 +148,7 @@ class Snap extends PointerInteraction {
       options.pixelTolerance : 10;
 
     /**
-     * @type {function(module:ol/interaction/Snap~SegmentData, module:ol/interaction/Snap~SegmentData): number}
+     * @type {function(SegmentData, SegmentData): number}
      * @private
      */
     this.sortByDistance_ = sortByDistance.bind(this);
@@ -156,7 +156,7 @@ class Snap extends PointerInteraction {
 
     /**
     * Segment RTree for each layer
-    * @type {module:ol/structs/RBush<module:ol/interaction/Snap~SegmentData>}
+    * @type {import("../structs/RBush.js").default<SegmentData>}
     * @private
     */
     this.rBush_ = new RBush();
@@ -165,7 +165,7 @@ class Snap extends PointerInteraction {
     /**
     * @const
     * @private
-    * @type {Object<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
+    * @type {Object<string, function(import("../Feature.js").default, import("../geom/Geometry.js").default)>}
     */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,
@@ -182,7 +182,7 @@ class Snap extends PointerInteraction {
 
   /**
    * Add a feature to the collection of features that we may snap to.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @param {boolean=} opt_listen Whether to listen to the feature change or not
    *     Defaults to `true`.
    * @api
@@ -208,7 +208,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @private
    */
   forEachFeatureAdd_(feature) {
@@ -216,7 +216,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @private
    */
   forEachFeatureRemove_(feature) {
@@ -224,7 +224,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @return {module:ol/Collection<module:ol/Feature>|Array<module:ol/Feature>} Features.
+   * @return {import("../Collection.js").default<import("../Feature.js").default>|Array<import("../Feature.js").default>} Features.
    * @private
    */
   getFeatures_() {
@@ -235,12 +235,12 @@ class Snap extends PointerInteraction {
       features = this.source_.getFeatures();
     }
     return (
-      /** @type {!Array<module:ol/Feature>|!module:ol/Collection<module:ol/Feature>} */ (features)
+      /** @type {!Array<import("../Feature.js").default>|!import("../Collection.js").default<import("../Feature.js").default>} */ (features)
     );
   }
 
   /**
-   * @param {module:ol/source/Vector|module:ol/Collection~CollectionEvent} evt Event.
+   * @param {import("../source/Vector.js").default|import("../Collection.js").CollectionEvent} evt Event.
    * @private
    */
   handleFeatureAdd_(evt) {
@@ -250,11 +250,11 @@ class Snap extends PointerInteraction {
     } else if (evt instanceof CollectionEvent) {
       feature = evt.element;
     }
-    this.addFeature(/** @type {module:ol/Feature} */ (feature));
+    this.addFeature(/** @type {import("../Feature.js").default} */ (feature));
   }
 
   /**
-   * @param {module:ol/source/Vector|module:ol/Collection~CollectionEvent} evt Event.
+   * @param {import("../source/Vector.js").default|import("../Collection.js").CollectionEvent} evt Event.
    * @private
    */
   handleFeatureRemove_(evt) {
@@ -264,15 +264,15 @@ class Snap extends PointerInteraction {
     } else if (evt instanceof CollectionEvent) {
       feature = evt.element;
     }
-    this.removeFeature(/** @type {module:ol/Feature} */ (feature));
+    this.removeFeature(/** @type {import("../Feature.js").default} */ (feature));
   }
 
   /**
-   * @param {module:ol/events/Event} evt Event.
+   * @param {import("../events/Event.js").default} evt Event.
    * @private
    */
   handleFeatureChange_(evt) {
-    const feature = /** @type {module:ol/Feature} */ (evt.target);
+    const feature = /** @type {import("../Feature.js").default} */ (evt.target);
     if (this.handlingDownUpSequence) {
       const uid = getUid(feature);
       if (!(uid in this.pendingFeatures_)) {
@@ -285,7 +285,7 @@ class Snap extends PointerInteraction {
 
   /**
    * Remove a feature from the collection of features that we may snap to.
-   * @param {module:ol/Feature} feature Feature
+   * @param {import("../Feature.js").default} feature Feature
    * @param {boolean=} opt_unlisten Whether to unlisten to the feature change
    *     or not. Defaults to `true`.
    * @api
@@ -349,10 +349,10 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/pixel~Pixel} pixel Pixel
-   * @param {module:ol/coordinate~Coordinate} pixelCoordinate Coordinate
-   * @param {module:ol/PluggableMap} map Map.
-   * @return {module:ol/interaction/Snap~Result} Snap result
+   * @param {import("../pixel.js").Pixel} pixel Pixel
+   * @param {import("../coordinate.js").Coordinate} pixelCoordinate Coordinate
+   * @param {import("../PluggableMap.js").default} map Map.
+   * @return {Result} Snap result
    */
   snapTo(pixel, pixelCoordinate, map) {
 
@@ -398,7 +398,7 @@ class Snap extends PointerInteraction {
       } else if (this.edge_) {
         if (isCircle) {
           vertex = closestOnCircle(pixelCoordinate,
-            /** @type {module:ol/geom/Circle} */ (segments[0].feature.getGeometry()));
+            /** @type {import("../geom/Circle.js").default} */ (segments[0].feature.getGeometry()));
         } else {
           vertex = closestOnSegment(pixelCoordinate, closestSegment);
         }
@@ -424,7 +424,7 @@ class Snap extends PointerInteraction {
       }
     }
     return (
-      /** @type {module:ol/interaction/Snap~Result} */ ({
+      /** @type {Result} */ ({
         snapped: snapped,
         vertex: vertex,
         vertexPixel: vertexPixel
@@ -433,7 +433,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
+   * @param {import("../Feature.js").default} feature Feature
    * @private
    */
   updateFeature_(feature) {
@@ -442,8 +442,8 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/Circle} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/Circle.js").default} geometry Geometry.
    * @private
    */
   writeCircleGeometry_(feature, geometry) {
@@ -451,7 +451,7 @@ class Snap extends PointerInteraction {
     const coordinates = polygon.getCoordinates()[0];
     for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       const segment = coordinates.slice(i, i + 2);
-      const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+      const segmentData = /** @type {SegmentData} */ ({
         feature: feature,
         segment: segment
       });
@@ -460,8 +460,8 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/GeometryCollection} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/GeometryCollection.js").default} geometry Geometry.
    * @private
    */
   writeGeometryCollectionGeometry_(feature, geometry) {
@@ -475,15 +475,15 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/LineString} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/LineString.js").default} geometry Geometry.
    * @private
    */
   writeLineStringGeometry_(feature, geometry) {
     const coordinates = geometry.getCoordinates();
     for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
       const segment = coordinates.slice(i, i + 2);
-      const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+      const segmentData = /** @type {SegmentData} */ ({
         feature: feature,
         segment: segment
       });
@@ -492,8 +492,8 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/MultiLineString} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/MultiLineString.js").default} geometry Geometry.
    * @private
    */
   writeMultiLineStringGeometry_(feature, geometry) {
@@ -502,7 +502,7 @@ class Snap extends PointerInteraction {
       const coordinates = lines[j];
       for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
         const segment = coordinates.slice(i, i + 2);
-        const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+        const segmentData = /** @type {SegmentData} */ ({
           feature: feature,
           segment: segment
         });
@@ -512,15 +512,15 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/MultiPoint} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/MultiPoint.js").default} geometry Geometry.
    * @private
    */
   writeMultiPointGeometry_(feature, geometry) {
     const points = geometry.getCoordinates();
     for (let i = 0, ii = points.length; i < ii; ++i) {
       const coordinates = points[i];
-      const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+      const segmentData = /** @type {SegmentData} */ ({
         feature: feature,
         segment: [coordinates, coordinates]
       });
@@ -529,8 +529,8 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/MultiPolygon} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
    * @private
    */
   writeMultiPolygonGeometry_(feature, geometry) {
@@ -541,7 +541,7 @@ class Snap extends PointerInteraction {
         const coordinates = rings[j];
         for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
           const segment = coordinates.slice(i, i + 2);
-          const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+          const segmentData = /** @type {SegmentData} */ ({
             feature: feature,
             segment: segment
           });
@@ -552,13 +552,13 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/Point} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/Point.js").default} geometry Geometry.
    * @private
    */
   writePointGeometry_(feature, geometry) {
     const coordinates = geometry.getCoordinates();
-    const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+    const segmentData = /** @type {SegmentData} */ ({
       feature: feature,
       segment: [coordinates, coordinates]
     });
@@ -566,8 +566,8 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature
-   * @param {module:ol/geom/Polygon} geometry Geometry.
+   * @param {import("../Feature.js").default} feature Feature
+   * @param {import("../geom/Polygon.js").default} geometry Geometry.
    * @private
    */
   writePolygonGeometry_(feature, geometry) {
@@ -576,7 +576,7 @@ class Snap extends PointerInteraction {
       const coordinates = rings[j];
       for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
         const segment = coordinates.slice(i, i + 2);
-        const segmentData = /** @type {module:ol/interaction/Snap~SegmentData} */ ({
+        const segmentData = /** @type {SegmentData} */ ({
           feature: feature,
           segment: segment
         });
@@ -589,9 +589,9 @@ class Snap extends PointerInteraction {
 
 /**
  * Handle all pointer events events.
- * @param {module:ol/MapBrowserEvent} evt A move event.
+ * @param {import("../MapBrowserEvent.js").default} evt A move event.
  * @return {boolean} Pass the event to other interactions.
- * @this {module:ol/interaction/Snap}
+ * @this {import("./Snap.js").default}
  */
 export function handleEvent(evt) {
   const result = this.snapTo(evt.pixel, evt.coordinate, evt.map);
@@ -604,9 +604,9 @@ export function handleEvent(evt) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} evt Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Snap}
+ * @this {import("./Snap.js").default}
  */
 function handleUpEvent(evt) {
   const featuresToUpdate = getValues(this.pendingFeatures_);
@@ -620,10 +620,10 @@ function handleUpEvent(evt) {
 
 /**
  * Sort segments by distance, helper function
- * @param {module:ol/interaction/Snap~SegmentData} a The first segment data.
- * @param {module:ol/interaction/Snap~SegmentData} b The second segment data.
+ * @param {SegmentData} a The first segment data.
+ * @param {SegmentData} b The second segment data.
  * @return {number} The difference in distance.
- * @this {module:ol/interaction/Snap}
+ * @this {import("./Snap.js").default}
  */
 function sortByDistance(a, b) {
   const deltaA = squaredDistanceToSegment(this.pixelCoordinate_, a.segment);

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -38,9 +38,9 @@ const TranslateEventType = {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/Collection<module:ol/Feature>} [features] Only features contained in this collection will be able to be translated. If
+ * @property {import("../Collection.js").default<import("../Feature.js").default>} [features] Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
- * @property {Array<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers] A list of layers from which features should be
+ * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default): boolean} [layers] A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be translatable. If the option is
@@ -58,9 +58,9 @@ const TranslateEventType = {
  */
 export class TranslateEvent extends Event {
   /**
-   * @param {module:ol/interaction/Translate~TranslateEventType} type Type.
-   * @param {module:ol/Collection<module:ol/Feature>} features The features translated.
-   * @param {module:ol/coordinate~Coordinate} coordinate The event coordinate.
+   * @param {TranslateEventType} type Type.
+   * @param {import("../Collection.js").default<import("../Feature.js").default>} features The features translated.
+   * @param {import("../coordinate.js").Coordinate} coordinate The event coordinate.
    */
   constructor(type, features, coordinate) {
 
@@ -68,7 +68,7 @@ export class TranslateEvent extends Event {
 
     /**
      * The features being translated.
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      * @api
      */
     this.features = features;
@@ -76,7 +76,7 @@ export class TranslateEvent extends Event {
     /**
      * The coordinate of the drag event.
      * @const
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      * @api
      */
     this.coordinate = coordinate;
@@ -90,12 +90,12 @@ export class TranslateEvent extends Event {
  * @classdesc
  * Interaction for translating (moving) features.
  *
- * @fires module:ol/interaction/Translate~TranslateEvent
+ * @fires TranslateEvent
  * @api
  */
 class Translate extends PointerInteraction {
   /**
-   * @param {module:ol/interaction/Translate~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     super({
@@ -109,19 +109,19 @@ class Translate extends PointerInteraction {
 
     /**
      * The last position we translated to.
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      * @private
      */
     this.lastCoordinate_ = null;
 
 
     /**
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      * @private
      */
     this.features_ = options.features !== undefined ? options.features : null;
 
-    /** @type {function(module:ol/layer/Layer): boolean} */
+    /** @type {function(import("../layer/Layer.js").default): boolean} */
     let layerFilter;
     if (options.layers) {
       if (typeof options.layers === 'function') {
@@ -138,7 +138,7 @@ class Translate extends PointerInteraction {
 
     /**
      * @private
-     * @type {function(module:ol/layer/Layer): boolean}
+     * @type {function(import("../layer/Layer.js").default): boolean}
      */
     this.layerFilter_ = layerFilter;
 
@@ -149,7 +149,7 @@ class Translate extends PointerInteraction {
     this.hitTolerance_ = options.hitTolerance ? options.hitTolerance : 0;
 
     /**
-     * @type {module:ol/Feature}
+     * @type {import("../Feature.js").default}
      * @private
      */
     this.lastFeature_ = null;
@@ -163,9 +163,9 @@ class Translate extends PointerInteraction {
   /**
    * Tests to see if the given coordinates intersects any of our selected
    * features.
-   * @param {module:ol/pixel~Pixel} pixel Pixel coordinate to test for intersection.
-   * @param {module:ol/PluggableMap} map Map to test the intersection on.
-   * @return {module:ol/Feature} Returns the feature found at the specified pixel
+   * @param {import("../pixel.js").Pixel} pixel Pixel coordinate to test for intersection.
+   * @param {import("../PluggableMap.js").default} map Map to test the intersection on.
+   * @return {import("../Feature.js").default} Returns the feature found at the specified pixel
    * coordinates.
    * @private
    */
@@ -218,7 +218,7 @@ class Translate extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol/PluggableMap} oldMap Old map.
+   * @param {import("../PluggableMap.js").default} oldMap Old map.
    * @private
    */
   updateState_(oldMap) {
@@ -236,9 +236,9 @@ class Translate extends PointerInteraction {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} event Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} event Event.
  * @return {boolean} Start drag sequence?
- * @this {module:ol/interaction/Translate}
+ * @this {import("./Translate.js").default}
  */
 function handleDownEvent(event) {
   this.lastFeature_ = this.featuresAtPixel_(event.pixel, event.map);
@@ -259,9 +259,9 @@ function handleDownEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} event Event.
+ * @param {import("../MapBrowserPointerEvent.js").default} event Event.
  * @return {boolean} Stop drag sequence?
- * @this {module:ol/interaction/Translate}
+ * @this {import("./Translate.js").default}
  */
 function handleUpEvent(event) {
   if (this.lastCoordinate_) {
@@ -281,8 +281,8 @@ function handleUpEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserPointerEvent} event Event.
- * @this {module:ol/interaction/Translate}
+ * @param {import("../MapBrowserPointerEvent.js").default} event Event.
+ * @this {import("./Translate.js").default}
  */
 function handleDragEvent(event) {
   if (this.lastCoordinate_) {
@@ -308,8 +308,8 @@ function handleDragEvent(event) {
 
 
 /**
- * @param {module:ol/MapBrowserEvent} event Event.
- * @this {module:ol/interaction/Translate}
+ * @param {import("../MapBrowserEvent.js").default} event Event.
+ * @this {import("./Translate.js").default}
  */
 function handleMoveEvent(event) {
   const elem = event.map.getViewport();

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -11,7 +11,7 @@ import {assign} from '../obj.js';
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -36,7 +36,7 @@ import {assign} from '../obj.js';
  */
 class BaseLayer extends BaseObject {
   /**
-   * @param {module:ol/layer/Base~Options} options Layer options.
+   * @param {Options} options Layer options.
    */
   constructor(options) {
 
@@ -59,17 +59,17 @@ class BaseLayer extends BaseObject {
     this.setProperties(properties);
 
     /**
-    * @type {module:ol/layer/Layer~State}
+    * @type {import("./Layer.js").State}
     * @private
     */
-    this.state_ = /** @type {module:ol/layer/Layer~State} */ ({
-      layer: /** @type {module:ol/layer/Layer} */ (this),
+    this.state_ = /** @type {import("./Layer.js").State} */ ({
+      layer: /** @type {import("./Layer.js").default} */ (this),
       managed: true
     });
 
     /**
     * The layer type.
-    * @type {module:ol/LayerType}
+    * @type {import("../LayerType.js").default}
     * @protected;
     */
     this.type;
@@ -78,14 +78,14 @@ class BaseLayer extends BaseObject {
 
   /**
   * Get the layer type (used when creating a layer renderer).
-  * @return {module:ol/LayerType} The layer type.
+  * @return {import("../LayerType.js").default} The layer type.
   */
   getType() {
     return this.type;
   }
 
   /**
-  * @return {module:ol/layer/Layer~State} Layer state.
+  * @return {import("./Layer.js").State} Layer state.
   */
   getLayerState() {
     this.state_.opacity = clamp(this.getOpacity(), 0, 1);
@@ -101,30 +101,30 @@ class BaseLayer extends BaseObject {
 
   /**
   * @abstract
-  * @param {Array<module:ol/layer/Layer>=} opt_array Array of layers (to be
+  * @param {Array<import("./Layer.js").default>=} opt_array Array of layers (to be
   *     modified in place).
-  * @return {Array<module:ol/layer/Layer>} Array of layers.
+  * @return {Array<import("./Layer.js").default>} Array of layers.
   */
   getLayersArray(opt_array) {}
 
   /**
   * @abstract
-  * @param {Array<module:ol/layer/Layer~State>=} opt_states Optional list of layer
+  * @param {Array<import("./Layer.js").State>=} opt_states Optional list of layer
   *     states (to be modified in place).
-  * @return {Array<module:ol/layer/Layer~State>} List of layer states.
+  * @return {Array<import("./Layer.js").State>} List of layer states.
   */
   getLayerStatesArray(opt_states) {}
 
   /**
   * Return the {@link module:ol/extent~Extent extent} of the layer or `undefined` if it
   * will be visible regardless of extent.
-  * @return {module:ol/extent~Extent|undefined} The layer extent.
+  * @return {import("../extent.js").Extent|undefined} The layer extent.
   * @observable
   * @api
   */
   getExtent() {
     return (
-    /** @type {module:ol/extent~Extent|undefined} */ (this.get(LayerProperty.EXTENT))
+    /** @type {import("../extent.js").Extent|undefined} */ (this.get(LayerProperty.EXTENT))
     );
   }
 
@@ -160,7 +160,7 @@ class BaseLayer extends BaseObject {
 
   /**
   * @abstract
-  * @return {module:ol/source/State} Source state.
+  * @return {import("../source/State.js").default} Source state.
   */
   getSourceState() {}
 
@@ -188,7 +188,7 @@ class BaseLayer extends BaseObject {
   /**
   * Set the extent at which the layer is visible.  If `undefined`, the layer
   * will be visible at all extents.
-  * @param {module:ol/extent~Extent|undefined} extent The extent of the layer.
+  * @param {import("../extent.js").Extent|undefined} extent The extent of the layer.
   * @observable
   * @api
   */

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -19,7 +19,7 @@ import SourceState from '../source/State.js';
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -29,7 +29,7 @@ import SourceState from '../source/State.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {Array<module:ol/layer/Base>|module:ol/Collection<module:ol/layer/Base>} [layers] Child layers.
+ * @property {Array<import("./Base.js").default>|import("../Collection.js").default<import("./Base.js").default>} [layers] Child layers.
  */
 
 
@@ -52,12 +52,12 @@ const Property = {
  */
 class LayerGroup extends BaseLayer {
   /**
-   * @param {module:ol/layer/Group~Options=} opt_options Layer options.
+   * @param {Options=} opt_options Layer options.
    */
   constructor(opt_options) {
 
     const options = opt_options || {};
-    const baseOptions = /** @type {module:ol/layer/Group~Options} */ (assign({}, options));
+    const baseOptions = /** @type {Options} */ (assign({}, options));
     delete baseOptions.layers;
 
     let layers = options.layers;
@@ -66,13 +66,13 @@ class LayerGroup extends BaseLayer {
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("../events.js").EventsKey>}
      */
     this.layersListenerKeys_ = [];
 
     /**
      * @private
-     * @type {Object<string, Array<module:ol/events~EventsKey>>}
+     * @type {Object<string, Array<import("../events.js").EventsKey>>}
      */
     this.listenerKeys_ = {};
 
@@ -104,7 +104,7 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../events/Event.js").default} event Event.
    * @private
    */
   handleLayersChanged_() {
@@ -135,11 +135,11 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * @param {module:ol/Collection~CollectionEvent} collectionEvent CollectionEvent.
+   * @param {import("../Collection.js").CollectionEvent} collectionEvent CollectionEvent.
    * @private
    */
   handleLayersAdd_(collectionEvent) {
-    const layer = /** @type {module:ol/layer/Base} */ (collectionEvent.element);
+    const layer = /** @type {import("./Base.js").default} */ (collectionEvent.element);
     const key = getUid(layer).toString();
     this.listenerKeys_[key] = [
       listen(layer, ObjectEventType.PROPERTYCHANGE, this.handleLayerChange_, this),
@@ -149,11 +149,11 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * @param {module:ol/Collection~CollectionEvent} collectionEvent CollectionEvent.
+   * @param {import("../Collection.js").CollectionEvent} collectionEvent CollectionEvent.
    * @private
    */
   handleLayersRemove_(collectionEvent) {
-    const layer = /** @type {module:ol/layer/Base} */ (collectionEvent.element);
+    const layer = /** @type {import("./Base.js").default} */ (collectionEvent.element);
     const key = getUid(layer).toString();
     this.listenerKeys_[key].forEach(unlistenByKey);
     delete this.listenerKeys_[key];
@@ -163,21 +163,21 @@ class LayerGroup extends BaseLayer {
   /**
    * Returns the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
    * in this group.
-   * @return {!module:ol/Collection<module:ol/layer/Base>} Collection of
+   * @return {!import("../Collection.js").default<import("./Base.js").default>} Collection of
    *   {@link module:ol/layer/Base layers} that are part of this group.
    * @observable
    * @api
    */
   getLayers() {
     return (
-      /** @type {!module:ol/Collection<module:ol/layer/Base>} */ (this.get(Property.LAYERS))
+      /** @type {!import("../Collection.js").default<import("./Base.js").default>} */ (this.get(Property.LAYERS))
     );
   }
 
   /**
    * Set the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
    * in this group.
-   * @param {!module:ol/Collection<module:ol/layer/Base>} layers Collection of
+   * @param {!import("../Collection.js").default<import("./Base.js").default>} layers Collection of
    *   {@link module:ol/layer/Base layers} that are part of this group.
    * @observable
    * @api

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -16,7 +16,7 @@ import Style from '../style/Style.js';
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -31,15 +31,15 @@ import Style from '../style/Style.js';
  * @property {number} [radius=8] Radius size in pixels.
  * @property {number} [blur=15] Blur size in pixels.
  * @property {number} [shadow=250] Shadow size in pixels.
- * @property {string|function(module:ol/Feature):number} [weight='weight'] The feature
+ * @property {string|function(import("../Feature.js").default):number} [weight='weight'] The feature
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
- * @property {module:ol/layer/VectorRenderType|string} [renderMode='vector'] Render mode for vector layers:
+ * @property {import("./VectorRenderType.js").default|string} [renderMode='vector'] Render mode for vector layers:
  *  * `'image'`: Vector layers are rendered as images. Great performance, but point symbols and
  *    texts are always rotated with the view and pixels are scaled during zoom animations.
  *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering even during
  *    animations, but slower performance.
- * @property {module:ol/source/Vector} [source] Source.
+ * @property {import("../source/Vector.js").default} [source] Source.
  */
 
 
@@ -68,12 +68,12 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @fires module:ol/render/Event~RenderEvent
+ * @fires import("../render/Event.js").RenderEvent
  * @api
  */
 class Heatmap extends VectorLayer {
   /**
-   * @param {module:ol/layer/Heatmap~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -107,7 +107,7 @@ class Heatmap extends VectorLayer {
 
     /**
      * @private
-     * @type {Array<Array<module:ol/style/Style>>}
+     * @type {Array<Array<import("../style/Style.js").default>>}
      */
     this.styleCache_ = null;
 
@@ -234,7 +234,7 @@ class Heatmap extends VectorLayer {
   }
 
   /**
-   * @param {module:ol/render/Event} event Post compose event
+   * @param {import("../render/Event.js").default} event Post compose event
    * @private
    */
   handleRender_(event) {

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -9,7 +9,7 @@ import Layer from '../layer/Layer.js';
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -19,11 +19,11 @@ import Layer from '../layer/Layer.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link module:ol/Map#addLayer}.
- * @property {module:ol/source/Image} [source] Source for this layer.
+ * @property {import("../source/Image.js").default} [source] Source for this layer.
  */
 
 
@@ -35,13 +35,13 @@ import Layer from '../layer/Layer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @fires module:ol/render/Event~RenderEvent
+ * @fires import("../render/Event.js").RenderEvent
  * @api
  */
 class ImageLayer extends Layer {
 
   /**
-   * @param {module:ol/layer/Image~Options=} opt_options Layer options.
+   * @param {Options=} opt_options Layer options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -50,7 +50,7 @@ class ImageLayer extends Layer {
     /**
      * The layer type.
      * @protected
-     * @type {module:ol/LayerType}
+     * @type {import("../LayerType.js").default}
      */
     this.type = LayerType.IMAGE;
 
@@ -62,7 +62,7 @@ class ImageLayer extends Layer {
 /**
  * Return the associated {@link module:ol/source/Image source} of the image layer.
  * @function
- * @return {module:ol/source/Image} Source.
+ * @return {import("../source/Image.js").default} Source.
  * @api
  */
 ImageLayer.prototype.getSource;

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -16,7 +16,7 @@ import SourceState from '../source/State.js';
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -26,7 +26,7 @@ import SourceState from '../source/State.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {module:ol/source/Source} [source] Source for this layer.  If not provided to the constructor,
+ * @property {import("../source/Source.js").default} [source] Source for this layer.  If not provided to the constructor,
  * the source can be set by calling {@link module:ol/layer/Layer#setSource layer.setSource(source)} after
  * construction.
  */
@@ -34,12 +34,12 @@ import SourceState from '../source/State.js';
 
 /**
  * @typedef {Object} State
- * @property {module:ol/layer/Layer} layer
+ * @property {import("./Layer.js").default} layer
  * @property {number} opacity
- * @property {module:ol/source/Source~State} sourceState
+ * @property {import("../source/Source.js").State} sourceState
  * @property {boolean} visible
  * @property {boolean} managed
- * @property {module:ol/extent~Extent} [extent]
+ * @property {import("../extent.js").Extent} [extent]
  * @property {number} zIndex
  * @property {number} maxResolution
  * @property {number} minResolution
@@ -60,11 +60,11 @@ import SourceState from '../source/State.js';
  *
  * A generic `change` event is fired when the state of the source changes.
  *
- * @fires module:ol/render/Event~RenderEvent
+ * @fires import("../render/Event.js").RenderEvent
  */
 class Layer extends BaseLayer {
   /**
-   * @param {module:ol/layer/Layer~Options} options Layer options.
+   * @param {Options} options Layer options.
    */
   constructor(options) {
 
@@ -75,19 +75,19 @@ class Layer extends BaseLayer {
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("../events.js").EventsKey}
      */
     this.mapPrecomposeKey_ = null;
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("../events.js").EventsKey}
      */
     this.mapRenderKey_ = null;
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("../events.js").EventsKey}
      */
     this.sourceChangeKey_ = null;
 
@@ -123,14 +123,14 @@ class Layer extends BaseLayer {
 
   /**
    * Get the layer source.
-   * @return {module:ol/source/Source} The layer source (or `null` if not yet set).
+   * @return {import("../source/Source.js").default} The layer source (or `null` if not yet set).
    * @observable
    * @api
    */
   getSource() {
     const source = this.get(LayerProperty.SOURCE);
     return (
-      /** @type {module:ol/source/Source} */ (source) || null
+      /** @type {import("../source/Source.js").default} */ (source) || null
     );
   }
 
@@ -174,7 +174,7 @@ class Layer extends BaseLayer {
    *
    * To add the layer to a map and have it managed by the map, use
    * {@link module:ol/Map#addLayer} instead.
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    * @api
    */
   setMap(map) {
@@ -206,7 +206,7 @@ class Layer extends BaseLayer {
 
   /**
    * Set the layer source.
-   * @param {module:ol/source/Source} source The layer source.
+   * @param {import("../source/Source.js").default} source The layer source.
    * @observable
    * @api
    */
@@ -220,7 +220,7 @@ class Layer extends BaseLayer {
  * Return `true` if the layer is visible, and if the passed resolution is
  * between the layer's minResolution and maxResolution. The comparison is
  * inclusive for `minResolution` and exclusive for `maxResolution`.
- * @param {module:ol/layer/Layer~State} layerState Layer state.
+ * @param {State} layerState Layer state.
  * @param {number} resolution Resolution.
  * @return {boolean} The layer is visible at the given resolution.
  */

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -11,7 +11,7 @@ import {assign} from '../obj.js';
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -23,8 +23,8 @@ import {assign} from '../obj.js';
  * be visible.
  * @property {number} [preload=0] Preload. Load low-resolution tiles up to `preload` levels. `0`
  * means no preloading.
- * @property {module:ol/source/Tile} [source] Source for this layer.
- * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {import("../source/Tile.js").default} [source] Source for this layer.
+ * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link module:ol/Map#addLayer}.
@@ -43,7 +43,7 @@ import {assign} from '../obj.js';
  */
 class TileLayer extends Layer {
   /**
-   * @param {module:ol/layer/Tile~Options=} opt_options Tile layer options.
+   * @param {Options=} opt_options Tile layer options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -61,7 +61,7 @@ class TileLayer extends Layer {
     /**
     * The layer type.
     * @protected
-    * @type {module:ol/LayerType}
+    * @type {import("../LayerType.js").default}
     */
     this.type = LayerType.TILE;
 
@@ -112,7 +112,7 @@ class TileLayer extends Layer {
 /**
  * Return the associated {@link module:ol/source/Tile tilesource} of the layer.
  * @function
- * @return {module:ol/source/Tile} Source.
+ * @return {import("../source/Tile.js").default} Source.
  * @api
  */
 TileLayer.prototype.getSource;

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -12,7 +12,7 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -22,26 +22,26 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {module:ol/render~OrderFunction} [renderOrder] Render order. Function to be used when sorting
+ * @property {import("../render.js").OrderFunction} [renderOrder] Render order. Function to be used when sorting
  * features before rendering. By default features are drawn in the order that they are created. Use
  * `null` to avoid the sort, but get an undefined draw order.
  * @property {number} [renderBuffer=100] The buffer in pixels around the viewport extent used by the
  * renderer when getting features from the vector source for the rendering or hit-detection.
  * Recommended value: the size of the largest symbol, line width or label.
- * @property {module:ol/layer/VectorRenderType|string} [renderMode='vector'] Render mode for vector layers:
+ * @property {import("./VectorRenderType.js").default|string} [renderMode='vector'] Render mode for vector layers:
  *  * `'image'`: Vector layers are rendered as images. Great performance, but point symbols and
  *    texts are always rotated with the view and pixels are scaled during zoom animations.
  *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering even during
  *    animations, but slower performance.
- * @property {module:ol/source/Vector} [source] Source.
- * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {import("../source/Vector.js").default} [source] Source.
+ * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link module:ol/Map#addLayer}.
  * @property {boolean} [declutter=false] Declutter images and text. Decluttering is applied to all
  * image and text styles, and the priority is defined by the z-index of the style. Lower z-index
  * means higher priority.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [updateWhileAnimating=false] When set to `true` and `renderMode`
  * is `vector`, feature batches will be recreated during animations. This means that no
@@ -90,11 +90,11 @@ const Property = {
  */
 class VectorLayer extends Layer {
   /**
-   * @param {module:ol/layer/Vector~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options ?
-      opt_options : /** @type {module:ol/layer/Vector~Options} */ ({});
+      opt_options : /** @type {Options} */ ({});
 
     const baseOptions = assign({}, options);
 
@@ -119,14 +119,14 @@ class VectorLayer extends Layer {
 
     /**
     * User provided style.
-    * @type {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
+    * @type {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction}
     * @private
     */
     this.style_ = null;
 
     /**
     * Style function for use within the library.
-    * @type {module:ol/style/Style~StyleFunction|undefined}
+    * @type {import("../style/Style.js").StyleFunction|undefined}
     * @private
     */
     this.styleFunction_ = undefined;
@@ -149,14 +149,14 @@ class VectorLayer extends Layer {
 
     /**
     * @private
-    * @type {module:ol/layer/VectorTileRenderType|string}
+    * @type {import("./VectorTileRenderType.js").default|string}
     */
     this.renderMode_ = options.renderMode || VectorRenderType.VECTOR;
 
     /**
     * The layer type.
     * @protected
-    * @type {module:ol/LayerType}
+    * @type {import("../LayerType.js").default}
     */
     this.type = LayerType.VECTOR;
 
@@ -184,19 +184,19 @@ class VectorLayer extends Layer {
   }
 
   /**
-  * @return {function(module:ol/Feature, module:ol/Feature): number|null|undefined} Render
+  * @return {function(import("../Feature.js").default, import("../Feature.js").default): number|null|undefined} Render
   *     order.
   */
   getRenderOrder() {
     return (
-    /** @type {module:ol/render~OrderFunction|null|undefined} */ (this.get(Property.RENDER_ORDER))
+    /** @type {import("../render.js").OrderFunction|null|undefined} */ (this.get(Property.RENDER_ORDER))
     );
   }
 
   /**
   * Get the style for features.  This returns whatever was passed to the `style`
   * option at construction or to the `setStyle` method.
-  * @return {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
+  * @return {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction}
   *     Layer style.
   * @api
   */
@@ -206,7 +206,7 @@ class VectorLayer extends Layer {
 
   /**
   * Get the style function.
-  * @return {module:ol/style/Style~StyleFunction|undefined} Layer style function.
+  * @return {import("../style/Style.js").StyleFunction|undefined} Layer style function.
   * @api
   */
   getStyleFunction() {
@@ -230,7 +230,7 @@ class VectorLayer extends Layer {
   }
 
   /**
-  * @param {module:ol/render~OrderFunction|null|undefined} renderOrder
+  * @param {import("../render.js").OrderFunction|null|undefined} renderOrder
   *     Render order.
   */
   setRenderOrder(renderOrder) {
@@ -244,7 +244,7 @@ class VectorLayer extends Layer {
   * it is `null` the layer has no style (a `null` style), so only features
   * that have their own styles will be rendered in the layer. See
   * {@link module:ol/style} for information on the default style.
-  * @param {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction|null|undefined} style Layer style.
+  * @param {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction|null|undefined} style Layer style.
   * @api
   */
   setStyle(style) {
@@ -255,7 +255,7 @@ class VectorLayer extends Layer {
   }
 
   /**
-  * @return {module:ol/layer/VectorRenderType|string} The render mode.
+  * @return {import("./VectorRenderType.js").default|string} The render mode.
   */
   getRenderMode() {
     return this.renderMode_;
@@ -266,7 +266,7 @@ class VectorLayer extends Layer {
 /**
  * Return the associated {@link module:ol/source/Vector vectorsource} of the layer.
  * @function
- * @return {module:ol/source/Vector} Source.
+ * @return {import("../source/Vector.js").default} Source.
  * @api
  */
 VectorLayer.prototype.getSource;

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -33,7 +33,7 @@ export const RenderType = {
  * @typedef {Object} Options
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
- * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
  * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
  * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
@@ -43,7 +43,7 @@ export const RenderType = {
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {module:ol/render~OrderFunction} [renderOrder] Render order. Function to be used when sorting
+ * @property {import("../render.js").OrderFunction} [renderOrder] Render order. Function to be used when sorting
  * features before rendering. By default features are drawn in the order that they are created. Use
  * `null` to avoid the sort, but get an undefined draw order.
  * @property {number} [renderBuffer=100] The buffer in pixels around the tile extent used by the
@@ -51,7 +51,7 @@ export const RenderType = {
  * Recommended value: Vector tiles are usually generated with a buffer, so this value should match
  * the largest possible buffer of the used tiles. It should be at least the size of the largest
  * point symbol or line width.
- * @property {module:ol/layer/VectorTileRenderType|string} [renderMode='hybrid'] Render mode for vector tiles:
+ * @property {import("./VectorTileRenderType.js").default|string} [renderMode='hybrid'] Render mode for vector tiles:
  *  * `'image'`: Vector tiles are rendered as images. Great performance, but point symbols and texts
  *    are always rotated with the view and pixels are scaled during zoom animations.
  *  * `'hybrid'`: Polygon and line elements are rendered as images, so pixels are scaled during zoom
@@ -61,8 +61,8 @@ export const RenderType = {
  *    animations, but slower performance than the other options.
  *
  * When `declutter` is set to `true`, `'hybrid'` will be used instead of `'image'`.
- * @property {module:ol/source/VectorTile} [source] Source.
- * @property {module:ol/PluggableMap} [map] Sets the layer as overlay on a map. The map will not manage
+ * @property {import("../source/VectorTile.js").default} [source] Source.
+ * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link module:ol/Map#addLayer}.
@@ -70,7 +70,7 @@ export const RenderType = {
  * image and text styles, and the priority is defined by the z-index of the style. Lower z-index
  * means higher priority. When set to `true`, a `renderMode` of `'image'` will be overridden with
  * `'hybrid'`.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting
@@ -80,9 +80,9 @@ export const RenderType = {
  * recreated during interactions. See also `updateWhileAnimating`.
  * @property {number} [preload=0] Preload. Load low-resolution tiles up to `preload` levels. `0`
  * means no preloading.
- * @property {module:ol/render~OrderFunction} [renderOrder] Render order. Function to be used when sorting
+ * @property {import("../render.js").OrderFunction} [renderOrder] Render order. Function to be used when sorting
  * features before rendering. By default features are drawn in the order that they are created.
- * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
+ * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [useInterimTilesOnError=true] Use interim tiles on error.
  */
@@ -95,12 +95,12 @@ export const RenderType = {
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @param {module:ol/layer/VectorTile~Options=} opt_options Options.
+ * @param {Options=} opt_options Options.
  * @api
  */
 class VectorTileLayer extends VectorLayer {
   /**
-   * @param {module:ol/layer/VectorTile~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -129,7 +129,7 @@ class VectorTileLayer extends VectorLayer {
     /**
     * The layer type.
     * @protected
-    * @type {module:ol/LayerType}
+    * @type {import("../LayerType.js").default}
     */
     this.type = LayerType.VECTOR_TILE;
 
@@ -180,7 +180,7 @@ class VectorTileLayer extends VectorLayer {
 /**
  * Return the associated {@link module:ol/source/VectorTile vectortilesource} of the layer.
  * @function
- * @return {module:ol/source/VectorTile} Source.
+ * @return {import("../source/VectorTile.js").default} Source.
  * @api
  */
 VectorTileLayer.prototype.getSource;

--- a/src/ol/loadingstrategy.js
+++ b/src/ol/loadingstrategy.js
@@ -5,9 +5,9 @@
 
 /**
  * Strategy function for loading all features with a single request.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("./extent.js").Extent} extent Extent.
  * @param {number} resolution Resolution.
- * @return {Array<module:ol/extent~Extent>} Extents.
+ * @return {Array<import("./extent.js").Extent>} Extents.
  * @api
  */
 export function all(extent, resolution) {
@@ -18,9 +18,9 @@ export function all(extent, resolution) {
 /**
  * Strategy function for loading features based on the view's extent and
  * resolution.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("./extent.js").Extent} extent Extent.
  * @param {number} resolution Resolution.
- * @return {Array<module:ol/extent~Extent>} Extents.
+ * @return {Array<import("./extent.js").Extent>} Extents.
  * @api
  */
 export function bbox(extent, resolution) {
@@ -30,23 +30,23 @@ export function bbox(extent, resolution) {
 
 /**
  * Creates a strategy function for loading features based on a tile grid.
- * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
- * @return {function(module:ol/extent~Extent, number): Array<module:ol/extent~Extent>} Loading strategy.
+ * @param {import("./tilegrid/TileGrid.js").default} tileGrid Tile grid.
+ * @return {function(import("./extent.js").Extent, number): Array<import("./extent.js").Extent>} Loading strategy.
  * @api
  */
 export function tile(tileGrid) {
   return (
     /**
-     * @param {module:ol/extent~Extent} extent Extent.
+     * @param {import("./extent.js").Extent} extent Extent.
      * @param {number} resolution Resolution.
-     * @return {Array<module:ol/extent~Extent>} Extents.
+     * @return {Array<import("./extent.js").Extent>} Extents.
      */
     function(extent, resolution) {
       const z = tileGrid.getZForResolution(resolution);
       const tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
-      /** @type {Array<module:ol/extent~Extent>} */
+      /** @type {Array<import("./extent.js").Extent>} */
       const extents = [];
-      /** @type {module:ol/tilecoord~TileCoord} */
+      /** @type {import("./tilecoord.js").TileCoord} */
       const tileCoord = [z, 0, 0];
       for (tileCoord[1] = tileRange.minX; tileCoord[1] <= tileRange.maxX; ++tileCoord[1]) {
         for (tileCoord[2] = tileRange.minY; tileCoord[2] <= tileRange.maxY; ++tileCoord[2]) {

--- a/src/ol/pointer/EventSource.js
+++ b/src/ol/pointer/EventSource.js
@@ -5,13 +5,13 @@
 class EventSource {
 
   /**
-   * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
+   * @param {import("./PointerEventHandler.js").default} dispatcher Event handler.
    * @param {!Object<string, function(Event)>} mapping Event mapping.
    */
   constructor(dispatcher, mapping) {
 
     /**
-     * @type {module:ol/pointer/PointerEventHandler}
+     * @type {import("./PointerEventHandler.js").default}
      */
     this.dispatcher = dispatcher;
 

--- a/src/ol/pointer/MouseSource.js
+++ b/src/ol/pointer/MouseSource.js
@@ -57,7 +57,7 @@ const DEDUP_DIST = 25;
 /**
  * Handler for `mousedown`.
  *
- * @this {module:ol/pointer/MouseSource}
+ * @this {import("./MouseSource.js").default}
  * @param {MouseEvent} inEvent The in event.
  */
 function mousedown(inEvent) {
@@ -76,7 +76,7 @@ function mousedown(inEvent) {
 /**
  * Handler for `mousemove`.
  *
- * @this {module:ol/pointer/MouseSource}
+ * @this {import("./MouseSource.js").default}
  * @param {MouseEvent} inEvent The in event.
  */
 function mousemove(inEvent) {
@@ -89,7 +89,7 @@ function mousemove(inEvent) {
 /**
  * Handler for `mouseup`.
  *
- * @this {module:ol/pointer/MouseSource}
+ * @this {import("./MouseSource.js").default}
  * @param {MouseEvent} inEvent The in event.
  */
 function mouseup(inEvent) {
@@ -107,7 +107,7 @@ function mouseup(inEvent) {
 /**
  * Handler for `mouseover`.
  *
- * @this {module:ol/pointer/MouseSource}
+ * @this {import("./MouseSource.js").default}
  * @param {MouseEvent} inEvent The in event.
  */
 function mouseover(inEvent) {
@@ -120,7 +120,7 @@ function mouseover(inEvent) {
 /**
  * Handler for `mouseout`.
  *
- * @this {module:ol/pointer/MouseSource}
+ * @this {import("./MouseSource.js").default}
  * @param {MouseEvent} inEvent The in event.
  */
 function mouseout(inEvent) {
@@ -134,7 +134,7 @@ function mouseout(inEvent) {
 class MouseSource extends EventSource {
 
   /**
-   * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
+   * @param {import("./PointerEventHandler.js").default} dispatcher Event handler.
    */
   constructor(dispatcher) {
     const mapping = {
@@ -154,7 +154,7 @@ class MouseSource extends EventSource {
 
     /**
      * @const
-     * @type {Array<module:ol/pixel~Pixel>}
+     * @type {Array<import("../pixel.js").Pixel>}
      */
     this.lastTouches = [];
   }
@@ -223,7 +223,7 @@ class MouseSource extends EventSource {
  * for the fake pointer event.
  *
  * @param {Event} inEvent The in event.
- * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
+ * @param {import("./PointerEventHandler.js").default} dispatcher Event handler.
  * @return {Object} The copied event.
  */
 function prepareEvent(inEvent, dispatcher) {

--- a/src/ol/pointer/MsSource.js
+++ b/src/ol/pointer/MsSource.js
@@ -49,7 +49,7 @@ const POINTER_TYPES = [
 /**
  * Handler for `msPointerDown`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msPointerDown(inEvent) {
@@ -61,7 +61,7 @@ function msPointerDown(inEvent) {
 /**
  * Handler for `msPointerMove`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msPointerMove(inEvent) {
@@ -72,7 +72,7 @@ function msPointerMove(inEvent) {
 /**
  * Handler for `msPointerUp`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msPointerUp(inEvent) {
@@ -84,7 +84,7 @@ function msPointerUp(inEvent) {
 /**
  * Handler for `msPointerOut`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msPointerOut(inEvent) {
@@ -95,7 +95,7 @@ function msPointerOut(inEvent) {
 /**
  * Handler for `msPointerOver`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msPointerOver(inEvent) {
@@ -106,7 +106,7 @@ function msPointerOver(inEvent) {
 /**
  * Handler for `msPointerCancel`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msPointerCancel(inEvent) {
@@ -118,7 +118,7 @@ function msPointerCancel(inEvent) {
 /**
  * Handler for `msLostPointerCapture`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msLostPointerCapture(inEvent) {
@@ -129,7 +129,7 @@ function msLostPointerCapture(inEvent) {
 /**
  * Handler for `msGotPointerCapture`.
  *
- * @this {module:ol/pointer/MsSource}
+ * @this {import("./MsSource.js").default}
  * @param {MSPointerEvent} inEvent The in event.
  */
 function msGotPointerCapture(inEvent) {
@@ -140,7 +140,7 @@ function msGotPointerCapture(inEvent) {
 class MsSource extends EventSource {
 
   /**
-   * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
+   * @param {import("./PointerEventHandler.js").default} dispatcher Event handler.
    */
   constructor(dispatcher) {
     const mapping = {

--- a/src/ol/pointer/NativeSource.js
+++ b/src/ol/pointer/NativeSource.js
@@ -37,7 +37,7 @@ import EventSource from '../pointer/EventSource.js';
 /**
  * Handler for `pointerdown`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function pointerDown(inEvent) {
@@ -47,7 +47,7 @@ function pointerDown(inEvent) {
 /**
  * Handler for `pointermove`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function pointerMove(inEvent) {
@@ -57,7 +57,7 @@ function pointerMove(inEvent) {
 /**
  * Handler for `pointerup`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function pointerUp(inEvent) {
@@ -67,7 +67,7 @@ function pointerUp(inEvent) {
 /**
  * Handler for `pointerout`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function pointerOut(inEvent) {
@@ -77,7 +77,7 @@ function pointerOut(inEvent) {
 /**
  * Handler for `pointerover`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function pointerOver(inEvent) {
@@ -87,7 +87,7 @@ function pointerOver(inEvent) {
 /**
  * Handler for `pointercancel`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function pointerCancel(inEvent) {
@@ -97,7 +97,7 @@ function pointerCancel(inEvent) {
 /**
  * Handler for `lostpointercapture`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function lostPointerCapture(inEvent) {
@@ -107,7 +107,7 @@ function lostPointerCapture(inEvent) {
 /**
  * Handler for `gotpointercapture`.
  *
- * @this {module:ol/pointer/NativeSource}
+ * @this {import("./NativeSource.js").default}
  * @param {Event} inEvent The in event.
  */
 function gotPointerCapture(inEvent) {
@@ -117,7 +117,7 @@ function gotPointerCapture(inEvent) {
 class NativeSource extends EventSource {
 
   /**
-   * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
+   * @param {import("./PointerEventHandler.js").default} dispatcher Event handler.
    */
   constructor(dispatcher) {
     const mapping = {

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -111,7 +111,7 @@ class PointerEventHandler extends EventTarget {
     this.eventMap_ = {};
 
     /**
-     * @type {Array<module:ol/pointer/EventSource>}
+     * @type {Array<import("./EventSource.js").default>}
      * @private
      */
     this.eventSourceList_ = [];
@@ -145,7 +145,7 @@ class PointerEventHandler extends EventTarget {
    * Add a new event source that will generate pointer events.
    *
    * @param {string} name A name for the event source
-   * @param {module:ol/pointer/EventSource} source The source event.
+   * @param {import("./EventSource.js").default} source The source event.
    */
   registerSource(name, source) {
     const s = source;
@@ -366,7 +366,7 @@ class PointerEventHandler extends EventTarget {
    * @param {string} inType A string representing the type of event to create.
    * @param {Object} data Pointer event data.
    * @param {Event} event The event.
-   * @return {module:ol/pointer/PointerEvent} A PointerEvent of type `inType`.
+   * @return {import("./PointerEvent.js").default} A PointerEvent of type `inType`.
    */
   makeEvent(inType, data, event) {
     return new PointerEvent(inType, event, data);
@@ -398,7 +398,7 @@ class PointerEventHandler extends EventTarget {
    * This proxy method is required for the legacy IE support.
    * @param {string} eventType The pointer event type.
    * @param {Event} event The event.
-   * @return {module:ol/pointer/PointerEvent} The wrapped event.
+   * @return {import("./PointerEvent.js").default} The wrapped event.
    */
   wrapMouseEvent(eventType, event) {
     const pointerEvent = this.makeEvent(

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -51,7 +51,7 @@ const POINTER_TYPE = 'touch';
  * Handler for `touchstart`, triggers `pointerover`,
  * `pointerenter` and `pointerdown` events.
  *
- * @this {module:ol/pointer/TouchSource}
+ * @this {import("./TouchSource.js").default}
  * @param {TouchEvent} inEvent The in event.
  */
 function touchstart(inEvent) {
@@ -65,7 +65,7 @@ function touchstart(inEvent) {
 /**
  * Handler for `touchmove`.
  *
- * @this {module:ol/pointer/TouchSource}
+ * @this {import("./TouchSource.js").default}
  * @param {TouchEvent} inEvent The in event.
  */
 function touchmove(inEvent) {
@@ -76,7 +76,7 @@ function touchmove(inEvent) {
  * Handler for `touchend`, triggers `pointerup`,
  * `pointerout` and `pointerleave` events.
  *
- * @this {module:ol/pointer/TouchSource}
+ * @this {import("./TouchSource.js").default}
  * @param {TouchEvent} inEvent The event.
  */
 function touchend(inEvent) {
@@ -88,7 +88,7 @@ function touchend(inEvent) {
  * Handler for `touchcancel`, triggers `pointercancel`,
  * `pointerout` and `pointerleave` events.
  *
- * @this {module:ol/pointer/TouchSource}
+ * @this {import("./TouchSource.js").default}
  * @param {TouchEvent} inEvent The in event.
  */
 function touchcancel(inEvent) {
@@ -99,8 +99,8 @@ function touchcancel(inEvent) {
 class TouchSource extends EventSource {
 
   /**
-   * @param {module:ol/pointer/PointerEventHandler} dispatcher The event handler.
-   * @param {module:ol/pointer/MouseSource} mouseSource Mouse source.
+   * @param {import("./PointerEventHandler.js").default} dispatcher The event handler.
+   * @param {import("./MouseSource.js").default} mouseSource Mouse source.
    */
   constructor(dispatcher, mouseSource) {
     const mapping = {
@@ -119,7 +119,7 @@ class TouchSource extends EventSource {
 
     /**
      * @const
-     * @type {module:ol/pointer/MouseSource}
+     * @type {import("./MouseSource.js").default}
      */
     this.mouseSource = mouseSource;
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -67,7 +67,7 @@ import {add as addTransformFunc, clear as clearTransformFuncs, get as getTransfo
 /**
  * A projection as {@link module:ol/proj/Projection}, SRS identifier
  * string or undefined.
- * @typedef {module:ol/proj/Projection|string|undefined} ProjectionLike
+ * @typedef {import("./proj/Projection.js").default|string|undefined} ProjectionLike
  * @api
  */
 
@@ -129,7 +129,7 @@ export function identityTransform(input, opt_output, opt_dimension) {
  * Add a Projection object to the list of supported projections that can be
  * looked up by their code.
  *
- * @param {module:ol/proj/Projection} projection Projection instance.
+ * @param {import("./proj/Projection.js").default} projection Projection instance.
  * @api
  */
 export function addProjection(projection) {
@@ -139,7 +139,7 @@ export function addProjection(projection) {
 
 
 /**
- * @param {Array<module:ol/proj/Projection>} projections Projections.
+ * @param {Array<import("./proj/Projection.js").default>} projections Projections.
  */
 export function addProjections(projections) {
   projections.forEach(addProjection);
@@ -149,16 +149,16 @@ export function addProjections(projections) {
 /**
  * Fetches a Projection object for the code specified.
  *
- * @param {module:ol/proj~ProjectionLike} projectionLike Either a code string which is
+ * @param {ProjectionLike} projectionLike Either a code string which is
  *     a combination of authority and identifier such as "EPSG:4326", or an
  *     existing projection object, or undefined.
- * @return {module:ol/proj/Projection} Projection object, or null if not in list.
+ * @return {import("./proj/Projection.js").default} Projection object, or null if not in list.
  * @api
  */
 export function get(projectionLike) {
   return typeof projectionLike === 'string' ?
     projections.get(/** @type {string} */ (projectionLike)) :
-    (/** @type {module:ol/proj/Projection} */ (projectionLike) || null);
+    (/** @type {import("./proj/Projection.js").default} */ (projectionLike) || null);
 }
 
 
@@ -174,10 +174,10 @@ export function get(projectionLike) {
  * {@link module:ol/proj/Projection~Projection} constructor or by using
  * {@link module:ol/proj/Projection~Projection#setGetPointResolution} to change an existing
  * projection object.
- * @param {module:ol/proj~ProjectionLike} projection The projection.
+ * @param {ProjectionLike} projection The projection.
  * @param {number} resolution Nominal resolution in projection units.
- * @param {module:ol/coordinate~Coordinate} point Point to find adjusted resolution at.
- * @param {module:ol/proj/Units=} opt_units Units to get the point resolution in.
+ * @param {import("./coordinate.js").Coordinate} point Point to find adjusted resolution at.
+ * @param {import("./proj/Units.js").default=} opt_units Units to get the point resolution in.
  * Default is the projection's units.
  * @return {number} Point resolution.
  * @api
@@ -223,7 +223,7 @@ export function getPointResolution(projection, resolution, point, opt_units) {
  * Registers transformation functions that don't alter coordinates. Those allow
  * to transform between projections with equal meaning.
  *
- * @param {Array<module:ol/proj/Projection>} projections Projections.
+ * @param {Array<import("./proj/Projection.js").default>} projections Projections.
  * @api
  */
 export function addEquivalentProjections(projections) {
@@ -242,13 +242,13 @@ export function addEquivalentProjections(projections) {
  * Registers transformation functions to convert coordinates in any projection
  * in projection1 to any projection in projection2.
  *
- * @param {Array<module:ol/proj/Projection>} projections1 Projections with equal
+ * @param {Array<import("./proj/Projection.js").default>} projections1 Projections with equal
  *     meaning.
- * @param {Array<module:ol/proj/Projection>} projections2 Projections with equal
+ * @param {Array<import("./proj/Projection.js").default>} projections2 Projections with equal
  *     meaning.
- * @param {module:ol/proj~TransformFunction} forwardTransform Transformation from any
+ * @param {TransformFunction} forwardTransform Transformation from any
  *   projection in projection1 to any projection in projection2.
- * @param {module:ol/proj~TransformFunction} inverseTransform Transform from any projection
+ * @param {TransformFunction} inverseTransform Transform from any projection
  *   in projection2 to any projection in projection1..
  */
 export function addEquivalentTransforms(projections1, projections2, forwardTransform, inverseTransform) {
@@ -271,9 +271,9 @@ export function clearAllProjections() {
 
 
 /**
- * @param {module:ol/proj/Projection|string|undefined} projection Projection.
+ * @param {import("./proj/Projection.js").default|string|undefined} projection Projection.
  * @param {string} defaultCode Default code.
- * @return {module:ol/proj/Projection} Projection.
+ * @return {import("./proj/Projection.js").default} Projection.
  */
 export function createProjection(projection, defaultCode) {
   if (!projection) {
@@ -282,7 +282,7 @@ export function createProjection(projection, defaultCode) {
     return get(projection);
   } else {
     return (
-      /** @type {module:ol/proj/Projection} */ (projection)
+      /** @type {import("./proj/Projection.js").default} */ (projection)
     );
   }
 }
@@ -291,9 +291,9 @@ export function createProjection(projection, defaultCode) {
 /**
  * Creates a {@link module:ol/proj~TransformFunction} from a simple 2D coordinate transform
  * function.
- * @param {function(module:ol/coordinate~Coordinate): module:ol/coordinate~Coordinate} coordTransform Coordinate
+ * @param {function(import("./coordinate.js").Coordinate): import("./coordinate.js").Coordinate} coordTransform Coordinate
  *     transform.
- * @return {module:ol/proj~TransformFunction} Transform function.
+ * @return {TransformFunction} Transform function.
  */
 export function createTransformFromCoordinateTransform(coordTransform) {
   return (
@@ -327,13 +327,13 @@ export function createTransformFromCoordinateTransform(coordTransform) {
  * converts these into the functions used internally which also handle
  * extents and coordinate arrays.
  *
- * @param {module:ol/proj~ProjectionLike} source Source projection.
- * @param {module:ol/proj~ProjectionLike} destination Destination projection.
- * @param {function(module:ol/coordinate~Coordinate): module:ol/coordinate~Coordinate} forward The forward transform
+ * @param {ProjectionLike} source Source projection.
+ * @param {ProjectionLike} destination Destination projection.
+ * @param {function(import("./coordinate.js").Coordinate): import("./coordinate.js").Coordinate} forward The forward transform
  *     function (that is, from the source projection to the destination
  *     projection) that takes a {@link module:ol/coordinate~Coordinate} as argument and returns
  *     the transformed {@link module:ol/coordinate~Coordinate}.
- * @param {function(module:ol/coordinate~Coordinate): module:ol/coordinate~Coordinate} inverse The inverse transform
+ * @param {function(import("./coordinate.js").Coordinate): import("./coordinate.js").Coordinate} inverse The inverse transform
  *     function (that is, from the destination projection to the source
  *     projection) that takes a {@link module:ol/coordinate~Coordinate} as argument and returns
  *     the transformed {@link module:ol/coordinate~Coordinate}.
@@ -349,11 +349,11 @@ export function addCoordinateTransforms(source, destination, forward, inverse) {
 
 /**
  * Transforms a coordinate from longitude/latitude to a different projection.
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate as longitude and latitude, i.e.
+ * @param {import("./coordinate.js").Coordinate} coordinate Coordinate as longitude and latitude, i.e.
  *     an array with longitude as 1st and latitude as 2nd element.
- * @param {module:ol/proj~ProjectionLike=} opt_projection Target projection. The
+ * @param {ProjectionLike=} opt_projection Target projection. The
  *     default is Web Mercator, i.e. 'EPSG:3857'.
- * @return {module:ol/coordinate~Coordinate} Coordinate projected to the target projection.
+ * @return {import("./coordinate.js").Coordinate} Coordinate projected to the target projection.
  * @api
  */
 export function fromLonLat(coordinate, opt_projection) {
@@ -364,10 +364,10 @@ export function fromLonLat(coordinate, opt_projection) {
 
 /**
  * Transforms a coordinate to longitude/latitude.
- * @param {module:ol/coordinate~Coordinate} coordinate Projected coordinate.
- * @param {module:ol/proj~ProjectionLike=} opt_projection Projection of the coordinate.
+ * @param {import("./coordinate.js").Coordinate} coordinate Projected coordinate.
+ * @param {ProjectionLike=} opt_projection Projection of the coordinate.
  *     The default is Web Mercator, i.e. 'EPSG:3857'.
- * @return {module:ol/coordinate~Coordinate} Coordinate as longitude and latitude, i.e. an array
+ * @return {import("./coordinate.js").Coordinate} Coordinate as longitude and latitude, i.e. an array
  *     with longitude as 1st and latitude as 2nd element.
  * @api
  */
@@ -387,8 +387,8 @@ export function toLonLat(coordinate, opt_projection) {
  * projection does represent the same geographic point as the same coordinate in
  * the other projection.
  *
- * @param {module:ol/proj/Projection} projection1 Projection 1.
- * @param {module:ol/proj/Projection} projection2 Projection 2.
+ * @param {import("./proj/Projection.js").default} projection1 Projection 1.
+ * @param {import("./proj/Projection.js").default} projection2 Projection 2.
  * @return {boolean} Equivalent.
  * @api
  */
@@ -410,10 +410,10 @@ export function equivalent(projection1, projection2) {
  * Searches in the list of transform functions for the function for converting
  * coordinates from the source projection to the destination projection.
  *
- * @param {module:ol/proj/Projection} sourceProjection Source Projection object.
- * @param {module:ol/proj/Projection} destinationProjection Destination Projection
+ * @param {import("./proj/Projection.js").default} sourceProjection Source Projection object.
+ * @param {import("./proj/Projection.js").default} destinationProjection Destination Projection
  *     object.
- * @return {module:ol/proj~TransformFunction} Transform function.
+ * @return {TransformFunction} Transform function.
  */
 export function getTransformFromProjections(sourceProjection, destinationProjection) {
   const sourceCode = sourceProjection.getCode();
@@ -431,9 +431,9 @@ export function getTransformFromProjections(sourceProjection, destinationProject
  * function to convert a coordinates array from the source projection to the
  * destination projection.
  *
- * @param {module:ol/proj~ProjectionLike} source Source.
- * @param {module:ol/proj~ProjectionLike} destination Destination.
- * @return {module:ol/proj~TransformFunction} Transform function.
+ * @param {ProjectionLike} source Source.
+ * @param {ProjectionLike} destination Destination.
+ * @return {TransformFunction} Transform function.
  * @api
  */
 export function getTransform(source, destination) {
@@ -451,10 +451,10 @@ export function getTransform(source, destination) {
  * See the transform method of {@link module:ol/geom/Geometry~Geometry} and its
  * subclasses for geometry transforms.
  *
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/proj~ProjectionLike} source Source projection-like.
- * @param {module:ol/proj~ProjectionLike} destination Destination projection-like.
- * @return {module:ol/coordinate~Coordinate} Coordinate.
+ * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
+ * @param {ProjectionLike} source Source projection-like.
+ * @param {ProjectionLike} destination Destination projection-like.
+ * @return {import("./coordinate.js").Coordinate} Coordinate.
  * @api
  */
 export function transform(coordinate, source, destination) {
@@ -467,10 +467,10 @@ export function transform(coordinate, source, destination) {
  * Transforms an extent from source projection to destination projection.  This
  * returns a new extent (and does not modify the original).
  *
- * @param {module:ol/extent~Extent} extent The extent to transform.
- * @param {module:ol/proj~ProjectionLike} source Source projection-like.
- * @param {module:ol/proj~ProjectionLike} destination Destination projection-like.
- * @return {module:ol/extent~Extent} The transformed extent.
+ * @param {import("./extent.js").Extent} extent The extent to transform.
+ * @param {ProjectionLike} source Source projection-like.
+ * @param {ProjectionLike} destination Destination projection-like.
+ * @return {import("./extent.js").Extent} The transformed extent.
  * @api
  */
 export function transformExtent(extent, source, destination) {
@@ -482,10 +482,10 @@ export function transformExtent(extent, source, destination) {
 /**
  * Transforms the given point to the destination projection.
  *
- * @param {module:ol/coordinate~Coordinate} point Point.
- * @param {module:ol/proj/Projection} sourceProjection Source projection.
- * @param {module:ol/proj/Projection} destinationProjection Destination projection.
- * @return {module:ol/coordinate~Coordinate} Point.
+ * @param {import("./coordinate.js").Coordinate} point Point.
+ * @param {import("./proj/Projection.js").default} sourceProjection Source projection.
+ * @param {import("./proj/Projection.js").default} destinationProjection Destination projection.
+ * @return {import("./coordinate.js").Coordinate} Point.
  */
 export function transformWithProjections(point, sourceProjection, destinationProjection) {
   const transformFunc = getTransformFromProjections(sourceProjection, destinationProjection);

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -7,18 +7,18 @@ import {METERS_PER_UNIT} from '../proj/Units.js';
 /**
  * @typedef {Object} Options
  * @property {string} code The SRS identifier code, e.g. `EPSG:4326`.
- * @property {module:ol/proj/Units|string} [units] Units. Required unless a
+ * @property {import("./Units.js").default|string} [units] Units. Required unless a
  * proj4 projection is defined for `code`.
- * @property {module:ol/extent~Extent} [extent] The validity extent for the SRS.
+ * @property {import("../extent.js").Extent} [extent] The validity extent for the SRS.
  * @property {string} [axisOrientation='enu'] The axis orientation as specified in Proj4.
  * @property {boolean} [global=false] Whether the projection is valid for the whole globe.
  * @property {number} [metersPerUnit] The meters per unit for the SRS.
  * If not provided, the `units` are used to get the meters per unit from the {@link module:ol/proj/Units~METERS_PER_UNIT}
  * lookup table.
- * @property {module:ol/extent~Extent} [worldExtent] The world extent for the SRS.
- * @property {function(number, module:ol/coordinate~Coordinate):number} [getPointResolution]
+ * @property {import("../extent.js").Extent} [worldExtent] The world extent for the SRS.
+ * @property {function(number, import("../coordinate.js").Coordinate):number} [getPointResolution]
  * Function to determine resolution at a point. The function is called with a
- * `{number}` view resolution and an `{module:ol/coordinate~Coordinate}` as arguments, and returns
+ * `{number}` view resolution and an `{import("../coordinate.js").Coordinate}` as arguments, and returns
  * the `{number}` resolution at the passed coordinate. If this is `undefined`,
  * the default {@link module:ol/proj#getPointResolution} function will be used.
  */
@@ -54,7 +54,7 @@ import {METERS_PER_UNIT} from '../proj/Units.js';
 class Projection {
 
   /**
-   * @param {module:ol/proj/Projection~Options} options Projection options.
+   * @param {Options} options Projection options.
    */
   constructor(options) {
     /**
@@ -68,16 +68,16 @@ class Projection {
      * `this.extent_` and `this.worldExtent_` must be configured properly for each
      * tile.
      * @private
-     * @type {module:ol/proj/Units}
+     * @type {import("./Units.js").default}
      */
-    this.units_ = /** @type {module:ol/proj/Units} */ (options.units);
+    this.units_ = /** @type {import("./Units.js").default} */ (options.units);
 
     /**
      * Validity extent of the projection in projected coordinates. For projections
      * with `TILE_PIXELS` units, this is the extent of the tile in
      * tile pixel space.
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.extent_ = options.extent !== undefined ? options.extent : null;
 
@@ -86,7 +86,7 @@ class Projection {
      * `TILE_PIXELS` units, this is the extent of the tile in
      * projected coordinate space.
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.worldExtent_ = options.worldExtent !== undefined ?
       options.worldExtent : null;
@@ -112,13 +112,13 @@ class Projection {
 
     /**
      * @private
-     * @type {function(number, module:ol/coordinate~Coordinate):number|undefined}
+     * @type {function(number, import("../coordinate.js").Coordinate):number|undefined}
      */
     this.getPointResolutionFunc_ = options.getPointResolution;
 
     /**
      * @private
-     * @type {module:ol/tilegrid/TileGrid}
+     * @type {import("../tilegrid/TileGrid.js").default}
      */
     this.defaultTileGrid_ = null;
 
@@ -147,7 +147,7 @@ class Projection {
 
   /**
    * Get the validity extent for this projection.
-   * @return {module:ol/extent~Extent} Extent.
+   * @return {import("../extent.js").Extent} Extent.
    * @api
    */
   getExtent() {
@@ -156,7 +156,7 @@ class Projection {
 
   /**
    * Get the units of this projection.
-   * @return {module:ol/proj/Units} Units.
+   * @return {import("./Units.js").default} Units.
    * @api
    */
   getUnits() {
@@ -176,7 +176,7 @@ class Projection {
 
   /**
    * Get the world extent for this projection.
-   * @return {module:ol/extent~Extent} Extent.
+   * @return {import("../extent.js").Extent} Extent.
    * @api
    */
   getWorldExtent() {
@@ -218,14 +218,14 @@ class Projection {
   }
 
   /**
-   * @return {module:ol/tilegrid/TileGrid} The default tile grid.
+   * @return {import("../tilegrid/TileGrid.js").default} The default tile grid.
    */
   getDefaultTileGrid() {
     return this.defaultTileGrid_;
   }
 
   /**
-   * @param {module:ol/tilegrid/TileGrid} tileGrid The default tile grid.
+   * @param {import("../tilegrid/TileGrid.js").default} tileGrid The default tile grid.
    */
   setDefaultTileGrid(tileGrid) {
     this.defaultTileGrid_ = tileGrid;
@@ -233,7 +233,7 @@ class Projection {
 
   /**
    * Set the validity extent for this projection.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @api
    */
   setExtent(extent) {
@@ -243,7 +243,7 @@ class Projection {
 
   /**
    * Set the world extent for this projection.
-   * @param {module:ol/extent~Extent} worldExtent World extent
+   * @param {import("../extent.js").Extent} worldExtent World extent
    *     [minlon, minlat, maxlon, maxlat].
    * @api
    */
@@ -254,7 +254,7 @@ class Projection {
   /**
    * Set the getPointResolution function (see {@link module:ol/proj~getPointResolution}
    * for this projection.
-   * @param {function(number, module:ol/coordinate~Coordinate):number} func Function
+   * @param {function(number, import("../coordinate.js").Coordinate):number} func Function
    * @api
    */
   setGetPointResolution(func) {
@@ -263,7 +263,7 @@ class Projection {
 
   /**
    * Get the custom point resolution function for this projection (if set).
-   * @return {function(number, module:ol/coordinate~Coordinate):number|undefined} The custom point
+   * @return {function(number, import("../coordinate.js").Coordinate):number|undefined} The custom point
    * resolution function (if set).
    */
   getPointResolutionFunc() {

--- a/src/ol/proj/Units.js
+++ b/src/ol/proj/Units.js
@@ -20,7 +20,7 @@ const Units = {
 /**
  * Meters per unit lookup table.
  * @const
- * @type {Object<module:ol/proj/Units, number>}
+ * @type {Object<import("./Units.js").default, number>}
  * @api
  */
 export const METERS_PER_UNIT = {};

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -24,7 +24,7 @@ export const HALF_SIZE = Math.PI * RADIUS;
 
 /**
  * @const
- * @type {module:ol/extent~Extent}
+ * @type {import("../extent.js").Extent}
  */
 export const EXTENT = [
   -HALF_SIZE, -HALF_SIZE,
@@ -34,7 +34,7 @@ export const EXTENT = [
 
 /**
  * @const
- * @type {module:ol/extent~Extent}
+ * @type {import("../extent.js").Extent}
  */
 export const WORLD_EXTENT = [-180, -85, 180, 85];
 
@@ -69,7 +69,7 @@ class EPSG3857Projection extends Projection {
  * Projections equal to EPSG:3857.
  *
  * @const
- * @type {Array<module:ol/proj/Projection>}
+ * @type {Array<import("./Projection.js").default>}
  */
 export const PROJECTIONS = [
   new EPSG3857Projection('EPSG:3857'),

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -18,7 +18,7 @@ export const RADIUS = 6378137;
  * Extent of the EPSG:4326 projection which is the whole world.
  *
  * @const
- * @type {module:ol/extent~Extent}
+ * @type {import("../extent.js").Extent}
  */
 export const EXTENT = [-180, -90, 180, 90];
 
@@ -64,7 +64,7 @@ class EPSG4326Projection extends Projection {
  * Projections equal to EPSG:4326.
  *
  * @const
- * @type {Array<module:ol/proj/Projection>}
+ * @type {Array<import("./Projection.js").default>}
  */
 export const PROJECTIONS = [
   new EPSG4326Projection('CRS:84'),

--- a/src/ol/proj/projections.js
+++ b/src/ol/proj/projections.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @type {Object<string, module:ol/proj/Projection>}
+ * @type {Object<string, import("./Projection.js").default>}
  */
 let cache = {};
 
@@ -20,7 +20,7 @@ export function clear() {
 /**
  * Get a cached projection by code.
  * @param {string} code The code for the projection.
- * @return {module:ol/proj/Projection} The projection (if cached).
+ * @return {import("./Projection.js").default} The projection (if cached).
  */
 export function get(code) {
   return cache[code] || null;
@@ -30,7 +30,7 @@ export function get(code) {
 /**
  * Add a projection to the cache.
  * @param {string} code The projection code.
- * @param {module:ol/proj/Projection} projection The projection to cache.
+ * @param {import("./Projection.js").default} projection The projection to cache.
  */
 export function add(code, projection) {
   cache[code] = projection;

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -6,7 +6,7 @@ import {isEmpty} from '../obj.js';
 
 /**
  * @private
- * @type {!Object<string, Object<string, module:ol/proj~TransformFunction>>}
+ * @type {!Object<string, Object<string, import("../proj.js").TransformFunction>>}
  */
 let transforms = {};
 
@@ -23,9 +23,9 @@ export function clear() {
  * Registers a conversion function to convert coordinates from the source
  * projection to the destination projection.
  *
- * @param {module:ol/proj/Projection} source Source.
- * @param {module:ol/proj/Projection} destination Destination.
- * @param {module:ol/proj~TransformFunction} transformFn Transform.
+ * @param {import("./Projection.js").default} source Source.
+ * @param {import("./Projection.js").default} destination Destination.
+ * @param {import("../proj.js").TransformFunction} transformFn Transform.
  */
 export function add(source, destination, transformFn) {
   const sourceCode = source.getCode();
@@ -42,9 +42,9 @@ export function add(source, destination, transformFn) {
  * projection to the destination projection.  This method is used to clean up
  * cached transforms during testing.
  *
- * @param {module:ol/proj/Projection} source Source projection.
- * @param {module:ol/proj/Projection} destination Destination projection.
- * @return {module:ol/proj~TransformFunction} transformFn The unregistered transform.
+ * @param {import("./Projection.js").default} source Source projection.
+ * @param {import("./Projection.js").default} destination Destination projection.
+ * @return {import("../proj.js").TransformFunction} transformFn The unregistered transform.
  */
 export function remove(source, destination) {
   const sourceCode = source.getCode();
@@ -62,7 +62,7 @@ export function remove(source, destination) {
  * Get a transform given a source code and a destination code.
  * @param {string} sourceCode The code for the source projection.
  * @param {string} destinationCode The code for the destination projection.
- * @return {module:ol/proj~TransformFunction|undefined} The transform function (if found).
+ * @return {import("../proj.js").TransformFunction|undefined} The transform function (if found).
  */
 export function get(sourceCode, destinationCode) {
   let transform;

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -9,8 +9,8 @@ import CanvasImmediateRenderer from './render/canvas/Immediate.js';
 /**
  * @typedef {Object} State
  * @property {CanvasRenderingContext2D} context Canvas context that the layer is being rendered to.
- * @property {module:ol/Feature|module:ol/render/Feature} feature
- * @property {module:ol/geom/SimpleGeometry} geometry
+ * @property {import("./Feature.js").default|import("./render/Feature.js").default} feature
+ * @property {import("./geom/SimpleGeometry.js").default} geometry
  * @property {number} pixelRatio Pixel ratio used by the layer renderer.
  * @property {number} resolution Resolution that the render batch was created and optimized for.
  * This is not the view's resolution that is being rendered.
@@ -23,14 +23,14 @@ import CanvasImmediateRenderer from './render/canvas/Immediate.js';
  * It takes two instances of {@link module:ol/Feature} or
  * {@link module:ol/render/Feature} and returns a `{number}`.
  *
- * @typedef {function((module:ol/Feature|module:ol/render/Feature),
- *           (module:ol/Feature|module:ol/render/Feature)):number} OrderFunction
+ * @typedef {function((import("./Feature.js").default|import("./render/Feature.js").default),
+ *           (import("./Feature.js").default|import("./render/Feature.js").default)):number} OrderFunction
  */
 
 
 /**
  * @typedef {Object} ToContextOptions
- * @property {module:ol/size~Size} [size] Desired size of the canvas in css
+ * @property {import("./size.js").Size} [size] Desired size of the canvas in css
  * pixels. When provided, both canvas and css size will be set according to the
  * `pixelRatio`. If not provided, the current canvas and css sizes will not be
  * altered.
@@ -59,8 +59,8 @@ import CanvasImmediateRenderer from './render/canvas/Immediate.js';
  * ```
  *
  * @param {CanvasRenderingContext2D} context Canvas context.
- * @param {module:ol/render~ToContextOptions=} opt_options Options.
- * @return {module:ol/render/canvas/Immediate} Canvas Immediate.
+ * @param {ToContextOptions=} opt_options Options.
+ * @return {import("./render/canvas/Immediate.js").default} Canvas Immediate.
  * @api
  */
 export function toContext(context, opt_options) {

--- a/src/ol/render/Box.js
+++ b/src/ol/render/Box.js
@@ -13,7 +13,7 @@ class RenderBox extends Disposable {
     super();
 
     /**
-     * @type {module:ol/geom/Polygon}
+     * @type {import("../geom/Polygon.js").default}
      * @private
      */
     this.geometry_ = null;
@@ -28,19 +28,19 @@ class RenderBox extends Disposable {
 
     /**
      * @private
-     * @type {module:ol/PluggableMap}
+     * @type {import("../PluggableMap.js").default}
      */
     this.map_ = null;
 
     /**
      * @private
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("../pixel.js").Pixel}
      */
     this.startPixel_ = null;
 
     /**
      * @private
-     * @type {module:ol/pixel~Pixel}
+     * @type {import("../pixel.js").Pixel}
      */
     this.endPixel_ = null;
 
@@ -68,7 +68,7 @@ class RenderBox extends Disposable {
   }
 
   /**
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    */
   setMap(map) {
     if (this.map_) {
@@ -83,8 +83,8 @@ class RenderBox extends Disposable {
   }
 
   /**
-   * @param {module:ol/pixel~Pixel} startPixel Start pixel.
-   * @param {module:ol/pixel~Pixel} endPixel End pixel.
+   * @param {import("../pixel.js").Pixel} startPixel Start pixel.
+   * @param {import("../pixel.js").Pixel} endPixel End pixel.
    */
   setPixels(startPixel, endPixel) {
     this.startPixel_ = startPixel;
@@ -116,7 +116,7 @@ class RenderBox extends Disposable {
   }
 
   /**
-   * @return {module:ol/geom/Polygon} Geometry.
+   * @return {import("../geom/Polygon.js").default} Geometry.
    */
   getGeometry() {
     return this.geometry_;

--- a/src/ol/render/Event.js
+++ b/src/ol/render/Event.js
@@ -7,11 +7,11 @@ import Event from '../events/Event.js';
 class RenderEvent extends Event {
 
   /**
-   * @param {module:ol/render/EventType} type Type.
-   * @param {module:ol/render/VectorContext=} opt_vectorContext Vector context.
-   * @param {module:ol/PluggableMap~FrameState=} opt_frameState Frame state.
+   * @param {import("./EventType.js").default} type Type.
+   * @param {import("./VectorContext.js").default=} opt_vectorContext Vector context.
+   * @param {import("../PluggableMap.js").FrameState=} opt_frameState Frame state.
    * @param {?CanvasRenderingContext2D=} opt_context Context.
-   * @param {?module:ol/webgl/Context=} opt_glContext WebGL Context.
+   * @param {?import("../webgl/Context.js").default=} opt_glContext WebGL Context.
    */
   constructor(type, opt_vectorContext, opt_frameState, opt_context, opt_glContext) {
 
@@ -19,14 +19,14 @@ class RenderEvent extends Event {
 
     /**
      * For canvas, this is an instance of {@link module:ol/render/canvas/Immediate}.
-     * @type {module:ol/render/VectorContext|undefined}
+     * @type {import("./VectorContext.js").default|undefined}
      * @api
      */
     this.vectorContext = opt_vectorContext;
 
     /**
      * An object representing the current render frame state.
-     * @type {module:ol/PluggableMap~FrameState|undefined}
+     * @type {import("../PluggableMap.js").FrameState|undefined}
      * @api
      */
     this.frameState = opt_frameState;
@@ -42,7 +42,7 @@ class RenderEvent extends Event {
     /**
      * WebGL context. Only available when a WebGL renderer is used, null
      * otherwise.
-     * @type {module:ol/webgl/Context|null|undefined}
+     * @type {import("../webgl/Context.js").default|null|undefined}
      * @api
      */
     this.glContext = opt_glContext;

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -14,7 +14,7 @@ import {create as createTransform, compose as composeTransform} from '../transfo
 
 
 /**
- * @type {module:ol/transform~Transform}
+ * @type {import("../transform.js").Transform}
  */
 const tmpTransform = createTransform();
 
@@ -24,7 +24,7 @@ const tmpTransform = createTransform();
  * structure, optimized for vector tile rendering and styling. Geometry access
  * through the API is limited to getting the type and extent of the geometry.
  *
- * @param {module:ol/geom/GeometryType} type Geometry type.
+ * @param {import("../geom/GeometryType.js").default} type Geometry type.
  * @param {Array<number>} flatCoordinates Flat coordinates. These always need
  *     to be right-handed for polygons.
  * @param {Array<number>|Array<Array<number>>} ends Ends or Endss.
@@ -35,7 +35,7 @@ class RenderFeature {
   constructor(type, flatCoordinates, ends, properties, id) {
     /**
     * @private
-    * @type {module:ol/extent~Extent|undefined}
+    * @type {import("../extent.js").Extent|undefined}
     */
     this.extent_;
 
@@ -47,7 +47,7 @@ class RenderFeature {
 
     /**
     * @private
-    * @type {module:ol/geom/GeometryType}
+    * @type {import("../geom/GeometryType.js").default}
     */
     this.type_ = type;
 
@@ -95,7 +95,7 @@ class RenderFeature {
 
   /**
   * Get the extent of this feature's geometry.
-  * @return {module:ol/extent~Extent} Extent.
+  * @return {import("../extent.js").Extent} Extent.
   * @api
   */
   getExtent() {
@@ -185,7 +185,7 @@ class RenderFeature {
   /**
   * For API compatibility with {@link module:ol/Feature~Feature}, this method is useful when
   * determining the geometry type in style function (see {@link #getType}).
-  * @return {module:ol/render/Feature} Feature.
+  * @return {import("./Feature.js").default} Feature.
   * @api
   */
   getGeometry() {
@@ -210,7 +210,7 @@ class RenderFeature {
 
   /**
   * Get the type of this feature's geometry.
-  * @return {module:ol/geom/GeometryType} Geometry type.
+  * @return {import("../geom/GeometryType.js").default} Geometry type.
   * @api
   */
   getType() {
@@ -221,8 +221,8 @@ class RenderFeature {
   * Transform geometry coordinates from tile pixel space to projected.
   * The SRS of the source and destination are expected to be the same.
   *
-  * @param {module:ol/proj~ProjectionLike} source The current projection
-  * @param {module:ol/proj~ProjectionLike} destination The desired projection.
+  * @param {import("../proj.js").ProjectionLike} source The current projection
+  * @param {import("../proj.js").ProjectionLike} destination The desired projection.
   */
   transform(source, destination) {
     source = getProjection(source);
@@ -257,7 +257,7 @@ RenderFeature.prototype.getFlatCoordinates =
 
 /**
  * Get the feature for working with its geometry.
- * @return {module:ol/render/Feature} Feature.
+ * @return {import("./Feature.js").default} Feature.
  */
 RenderFeature.prototype.getSimplifiedGeometry =
     RenderFeature.prototype.getGeometry;

--- a/src/ol/render/ReplayGroup.js
+++ b/src/ol/render/ReplayGroup.js
@@ -8,8 +8,8 @@ class ReplayGroup {
   /**
    * @abstract
    * @param {number|undefined} zIndex Z index.
-   * @param {module:ol/render/ReplayType} replayType Replay type.
-   * @return {module:ol/render/VectorContext} Replay.
+   * @param {import("./ReplayType.js").default} replayType Replay type.
+   * @return {import("./VectorContext.js").default} Replay.
    */
   getReplay(zIndex, replayType) {}
 

--- a/src/ol/render/VectorContext.js
+++ b/src/ol/render/VectorContext.js
@@ -12,8 +12,8 @@ class VectorContext {
   /**
    * Render a geometry with a custom renderer.
    *
-   * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/SimpleGeometry.js").default} geometry Geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    * @param {Function} renderer Renderer.
    */
   drawCustom(geometry, feature, renderer) {}
@@ -21,92 +21,92 @@ class VectorContext {
   /**
    * Render a geometry.
    *
-   * @param {module:ol/geom/Geometry} geometry The geometry to render.
+   * @param {import("../geom/Geometry.js").default} geometry The geometry to render.
    */
   drawGeometry(geometry) {}
 
   /**
    * Set the rendering style.
    *
-   * @param {module:ol/style/Style} style The rendering style.
+   * @param {import("../style/Style.js").default} style The rendering style.
    */
   setStyle(style) {}
 
   /**
-   * @param {module:ol/geom/Circle} circleGeometry Circle geometry.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../geom/Circle.js").default} circleGeometry Circle geometry.
+   * @param {import("../Feature.js").default} feature Feature.
    */
   drawCircle(circleGeometry, feature) {}
 
   /**
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/style/Style} style Style.
+   * @param {import("../Feature.js").default} feature Feature.
+   * @param {import("../style/Style.js").default} style Style.
    */
   drawFeature(feature, style) {}
 
   /**
-   * @param {module:ol/geom/GeometryCollection} geometryCollectionGeometry Geometry collection.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../geom/GeometryCollection.js").default} geometryCollectionGeometry Geometry collection.
+   * @param {import("../Feature.js").default} feature Feature.
    */
   drawGeometryCollection(geometryCollectionGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/LineString|module:ol/render/Feature} lineStringGeometry Line string geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/LineString.js").default|import("./Feature.js").default} lineStringGeometry Line string geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawLineString(lineStringGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/MultiLineString|module:ol/render/Feature} multiLineStringGeometry MultiLineString geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/MultiLineString.js").default|import("./Feature.js").default} multiLineStringGeometry MultiLineString geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawMultiLineString(multiLineStringGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/MultiPoint|module:ol/render/Feature} multiPointGeometry MultiPoint geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/MultiPoint.js").default|import("./Feature.js").default} multiPointGeometry MultiPoint geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawMultiPoint(multiPointGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/MultiPolygon} multiPolygonGeometry MultiPolygon geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/MultiPolygon.js").default} multiPolygonGeometry MultiPolygon geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawMultiPolygon(multiPolygonGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/Point|module:ol/render/Feature} pointGeometry Point geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/Point.js").default|import("./Feature.js").default} pointGeometry Point geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawPoint(pointGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/Polygon|module:ol/render/Feature} polygonGeometry Polygon geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/Polygon.js").default|import("./Feature.js").default} polygonGeometry Polygon geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawPolygon(polygonGeometry, feature) {}
 
   /**
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../geom/Geometry.js").default|import("./Feature.js").default} geometry Geometry.
+   * @param {import("../Feature.js").default|import("./Feature.js").default} feature Feature.
    */
   drawText(geometry, feature) {}
 
   /**
-   * @param {module:ol/style/Fill} fillStyle Fill style.
-   * @param {module:ol/style/Stroke} strokeStyle Stroke style.
+   * @param {import("../style/Fill.js").default} fillStyle Fill style.
+   * @param {import("../style/Stroke.js").default} strokeStyle Stroke style.
    */
   setFillStrokeStyle(fillStyle, strokeStyle) {}
 
   /**
-   * @param {module:ol/style/Image} imageStyle Image style.
-   * @param {module:ol/render/canvas~DeclutterGroup=} opt_declutterGroup Declutter.
+   * @param {import("../style/Image.js").default} imageStyle Image style.
+   * @param {import("./canvas.js").DeclutterGroup=} opt_declutterGroup Declutter.
    */
   setImageStyle(imageStyle, opt_declutterGroup) {}
 
   /**
-   * @param {module:ol/style/Text} textStyle Text style.
-   * @param {module:ol/render/canvas~DeclutterGroup=} opt_declutterGroup Declutter.
+   * @param {import("../style/Text.js").default} textStyle Text style.
+   * @param {import("./canvas.js").DeclutterGroup=} opt_declutterGroup Declutter.
    */
   setTextStyle(textStyle, opt_declutterGroup) {}
 }

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -10,14 +10,14 @@ import {create as createTransform} from '../transform.js';
 
 /**
  * @typedef {Object} FillState
- * @property {module:ol/colorlike~ColorLike} fillStyle
+ * @property {import("../colorlike.js").ColorLike} fillStyle
  */
 
 
 /**
  * @typedef {Object} FillStrokeState
- * @property {module:ol/colorlike~ColorLike} [currentFillStyle]
- * @property {module:ol/colorlike~ColorLike} [currentStrokeStyle]
+ * @property {import("../colorlike.js").ColorLike} [currentFillStyle]
+ * @property {import("../colorlike.js").ColorLike} [currentStrokeStyle]
  * @property {string} [currentLineCap]
  * @property {Array<number>} currentLineDash
  * @property {number} [currentLineDashOffset]
@@ -25,8 +25,8 @@ import {create as createTransform} from '../transform.js';
  * @property {number} [currentLineWidth]
  * @property {number} [currentMiterLimit]
  * @property {number} [lastStroke]
- * @property {module:ol/colorlike~ColorLike} [fillStyle]
- * @property {module:ol/colorlike~ColorLike} [strokeStyle]
+ * @property {import("../colorlike.js").ColorLike} [fillStyle]
+ * @property {import("../colorlike.js").ColorLike} [strokeStyle]
  * @property {string} [lineCap]
  * @property {Array<number>} lineDash
  * @property {number} [lineDashOffset]
@@ -44,7 +44,7 @@ import {create as createTransform} from '../transform.js';
  * @property {string} lineJoin
  * @property {number} lineWidth
  * @property {number} miterLimit
- * @property {module:ol/colorlike~ColorLike} strokeStyle
+ * @property {import("../colorlike.js").ColorLike} strokeStyle
  */
 
 
@@ -78,7 +78,7 @@ export const defaultFont = '10px sans-serif';
 
 /**
  * @const
- * @type {module:ol/color~Color}
+ * @type {import("../color.js").Color}
  */
 export const defaultFillStyle = [0, 0, 0, 1];
 
@@ -120,7 +120,7 @@ export const defaultMiterLimit = 10;
 
 /**
  * @const
- * @type {module:ol/color~Color}
+ * @type {import("../color.js").Color}
  */
 export const defaultStrokeStyle = [0, 0, 0, 1];
 
@@ -156,7 +156,7 @@ export const defaultLineWidth = 1;
 /**
  * The label cache for text rendering. To change the default cache size of 2048
  * entries, use {@link module:ol/structs/LRUCache#setSize}.
- * @type {module:ol/structs/LRUCache<HTMLCanvasElement>}
+ * @type {import("../structs/LRUCache.js").default<HTMLCanvasElement>}
  * @api
  */
 export const labelCache = new LRUCache();
@@ -278,7 +278,7 @@ function getMeasureContext() {
 
 /**
  * @param {string} font Font to use for measuring.
- * @return {module:ol/size~Size} Measurement.
+ * @return {import("../size.js").Size} Measurement.
  */
 export const measureTextHeight = (function() {
   let span;
@@ -337,7 +337,7 @@ export const resetTransform = createTransform();
 
 /**
  * @param {CanvasRenderingContext2D} context Context.
- * @param {module:ol/transform~Transform|null} transform Transform.
+ * @param {import("../transform.js").Transform|null} transform Transform.
  * @param {number} opacity Opacity.
  * @param {HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} image Image.
  * @param {number} originX Origin X.

--- a/src/ol/render/canvas/ImageReplay.js
+++ b/src/ol/render/canvas/ImageReplay.js
@@ -7,7 +7,7 @@ import CanvasReplay from '../canvas/Replay.js';
 class CanvasImageReplay extends CanvasReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Maximum extent.
+   * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay can have overlapping geometries.
@@ -18,7 +18,7 @@ class CanvasImageReplay extends CanvasReplay {
 
     /**
      * @private
-     * @type {module:ol/render/canvas~DeclutterGroup}
+     * @type {import("../canvas.js").DeclutterGroup}
      */
     this.declutterGroup_ = null;
 
@@ -198,7 +198,7 @@ class CanvasImageReplay extends CanvasReplay {
     const origin = imageStyle.getOrigin();
     this.anchorX_ = anchor[0];
     this.anchorY_ = anchor[1];
-    this.declutterGroup_ = /** @type {module:ol/render/canvas~DeclutterGroup} */ (declutterGroup);
+    this.declutterGroup_ = /** @type {import("../canvas.js").DeclutterGroup} */ (declutterGroup);
     this.hitDetectionImage_ = hitDetectionImage;
     this.image_ = image;
     this.height_ = size[1];

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -29,8 +29,8 @@ class CanvasImmediateRenderer extends VectorContext {
   /**
    * @param {CanvasRenderingContext2D} context Context.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../extent.js").Extent} extent Extent.
+   * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    */
   constructor(context, pixelRatio, extent, transform, viewRotation) {
@@ -50,13 +50,13 @@ class CanvasImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.extent_ = extent;
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.transform_ = transform;
 
@@ -68,31 +68,31 @@ class CanvasImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~FillState}
+     * @type {?import("../canvas.js").FillState}
      */
     this.contextFillState_ = null;
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~StrokeState}
+     * @type {?import("../canvas.js").StrokeState}
      */
     this.contextStrokeState_ = null;
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~TextState}
+     * @type {?import("../canvas.js").TextState}
      */
     this.contextTextState_ = null;
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~FillState}
+     * @type {?import("../canvas.js").FillState}
      */
     this.fillState_ = null;
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~StrokeState}
+     * @type {?import("../canvas.js").StrokeState}
      */
     this.strokeState_ = null;
 
@@ -200,19 +200,19 @@ class CanvasImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~FillState}
+     * @type {?import("../canvas.js").FillState}
      */
     this.textFillState_ = null;
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~StrokeState}
+     * @type {?import("../canvas.js").StrokeState}
      */
     this.textStrokeState_ = null;
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~TextState}
+     * @type {?import("../canvas.js").TextState}
      */
     this.textState_ = null;
 
@@ -224,7 +224,7 @@ class CanvasImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.tmpLocalTransform_ = createTransform();
 
@@ -375,7 +375,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a circle geometry into the canvas.  Rendering is immediate and uses
    * the current fill and stroke styles.
    *
-   * @param {module:ol/geom/Circle} geometry Circle geometry.
+   * @param {import("../../geom/Circle.js").default} geometry Circle geometry.
    * @override
    * @api
    */
@@ -415,7 +415,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Set the rendering style.  Note that since this is an immediate rendering API,
    * any `zIndex` on the provided style will be ignored.
    *
-   * @param {module:ol/style/Style} style The rendering style.
+   * @param {import("../../style/Style.js").default} style The rendering style.
    * @override
    * @api
    */
@@ -429,7 +429,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a geometry into the canvas.  Call
    * {@link module:ol/render/canvas/Immediate#setStyle} first to set the rendering style.
    *
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry The geometry to render.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry The geometry to render.
    * @override
    * @api
    */
@@ -437,28 +437,28 @@ class CanvasImmediateRenderer extends VectorContext {
     const type = geometry.getType();
     switch (type) {
       case GeometryType.POINT:
-        this.drawPoint(/** @type {module:ol/geom/Point} */ (geometry));
+        this.drawPoint(/** @type {import("../../geom/Point.js").default} */ (geometry));
         break;
       case GeometryType.LINE_STRING:
-        this.drawLineString(/** @type {module:ol/geom/LineString} */ (geometry));
+        this.drawLineString(/** @type {import("../../geom/LineString.js").default} */ (geometry));
         break;
       case GeometryType.POLYGON:
-        this.drawPolygon(/** @type {module:ol/geom/Polygon} */ (geometry));
+        this.drawPolygon(/** @type {import("../../geom/Polygon.js").default} */ (geometry));
         break;
       case GeometryType.MULTI_POINT:
-        this.drawMultiPoint(/** @type {module:ol/geom/MultiPoint} */ (geometry));
+        this.drawMultiPoint(/** @type {import("../../geom/MultiPoint.js").default} */ (geometry));
         break;
       case GeometryType.MULTI_LINE_STRING:
-        this.drawMultiLineString(/** @type {module:ol/geom/MultiLineString} */ (geometry));
+        this.drawMultiLineString(/** @type {import("../../geom/MultiLineString.js").default} */ (geometry));
         break;
       case GeometryType.MULTI_POLYGON:
-        this.drawMultiPolygon(/** @type {module:ol/geom/MultiPolygon} */ (geometry));
+        this.drawMultiPolygon(/** @type {import("../../geom/MultiPolygon.js").default} */ (geometry));
         break;
       case GeometryType.GEOMETRY_COLLECTION:
-        this.drawGeometryCollection(/** @type {module:ol/geom/GeometryCollection} */ (geometry));
+        this.drawGeometryCollection(/** @type {import("../../geom/GeometryCollection.js").default} */ (geometry));
         break;
       case GeometryType.CIRCLE:
-        this.drawCircle(/** @type {module:ol/geom/Circle} */ (geometry));
+        this.drawCircle(/** @type {import("../../geom/Circle.js").default} */ (geometry));
         break;
       default:
     }
@@ -470,8 +470,8 @@ class CanvasImmediateRenderer extends VectorContext {
    * this method is called.  If you need `zIndex` support, you should be using an
    * {@link module:ol/layer/Vector~VectorLayer} instead.
    *
-   * @param {module:ol/Feature} feature Feature.
-   * @param {module:ol/style/Style} style Style.
+   * @param {import("../../Feature.js").default} feature Feature.
+   * @param {import("../../style/Style.js").default} style Style.
    * @override
    * @api
    */
@@ -488,7 +488,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a GeometryCollection to the canvas.  Rendering is immediate and
    * uses the current styles appropriate for each geometry in the collection.
    *
-   * @param {module:ol/geom/GeometryCollection} geometry Geometry collection.
+   * @param {import("../../geom/GeometryCollection.js").default} geometry Geometry collection.
    * @override
    */
   drawGeometryCollection(geometry) {
@@ -502,7 +502,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a Point geometry into the canvas.  Rendering is immediate and uses
    * the current style.
    *
-   * @param {module:ol/geom/Point|module:ol/render/Feature} geometry Point geometry.
+   * @param {import("../../geom/Point.js").default|import("../Feature.js").default} geometry Point geometry.
    * @override
    */
   drawPoint(geometry) {
@@ -520,7 +520,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a MultiPoint geometry  into the canvas.  Rendering is immediate and
    * uses the current style.
    *
-   * @param {module:ol/geom/MultiPoint|module:ol/render/Feature} geometry MultiPoint geometry.
+   * @param {import("../../geom/MultiPoint.js").default|import("../Feature.js").default} geometry MultiPoint geometry.
    * @override
    */
   drawMultiPoint(geometry) {
@@ -538,7 +538,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a LineString into the canvas.  Rendering is immediate and uses
    * the current style.
    *
-   * @param {module:ol/geom/LineString|module:ol/render/Feature} geometry LineString geometry.
+   * @param {import("../../geom/LineString.js").default|import("../Feature.js").default} geometry LineString geometry.
    * @override
    */
   drawLineString(geometry) {
@@ -564,7 +564,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a MultiLineString geometry into the canvas.  Rendering is immediate
    * and uses the current style.
    *
-   * @param {module:ol/geom/MultiLineString|module:ol/render/Feature} geometry MultiLineString geometry.
+   * @param {import("../../geom/MultiLineString.js").default|import("../Feature.js").default} geometry MultiLineString geometry.
    * @override
    */
   drawMultiLineString(geometry) {
@@ -595,7 +595,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a Polygon geometry into the canvas.  Rendering is immediate and uses
    * the current style.
    *
-   * @param {module:ol/geom/Polygon|module:ol/render/Feature} geometry Polygon geometry.
+   * @param {import("../../geom/Polygon.js").default|import("../Feature.js").default} geometry Polygon geometry.
    * @override
    */
   drawPolygon(geometry) {
@@ -629,7 +629,7 @@ class CanvasImmediateRenderer extends VectorContext {
   /**
    * Render MultiPolygon geometry into the canvas.  Rendering is immediate and
    * uses the current style.
-   * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
+   * @param {import("../../geom/MultiPolygon.js").default} geometry MultiPolygon geometry.
    * @override
    */
   drawMultiPolygon(geometry) {
@@ -667,7 +667,7 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~FillState} fillState Fill state.
+   * @param {import("../canvas.js").FillState} fillState Fill state.
    * @private
    */
   setContextFillState_(fillState) {
@@ -686,7 +686,7 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~StrokeState} strokeState Stroke state.
+   * @param {import("../canvas.js").StrokeState} strokeState Stroke state.
    * @private
    */
   setContextStrokeState_(strokeState) {
@@ -742,7 +742,7 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~TextState} textState Text state.
+   * @param {import("../canvas.js").TextState} textState Text state.
    * @private
    */
   setContextTextState_(textState) {
@@ -777,8 +777,8 @@ class CanvasImmediateRenderer extends VectorContext {
    * Set the fill and stroke style for subsequent draw operations.  To clear
    * either fill or stroke styles, pass null for the appropriate parameter.
    *
-   * @param {module:ol/style/Fill} fillStyle Fill style.
-   * @param {module:ol/style/Stroke} strokeStyle Stroke style.
+   * @param {import("../../style/Fill.js").default} fillStyle Fill style.
+   * @param {import("../../style/Stroke.js").default} strokeStyle Stroke style.
    * @override
    */
   setFillStrokeStyle(fillStyle, strokeStyle) {
@@ -824,7 +824,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Set the image style for subsequent draw operations.  Pass null to remove
    * the image style.
    *
-   * @param {module:ol/style/Image} imageStyle Image style.
+   * @param {import("../../style/Image.js").default} imageStyle Image style.
    * @override
    */
   setImageStyle(imageStyle) {
@@ -854,7 +854,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Set the text style for subsequent draw operations.  Pass null to
    * remove the text style.
    *
-   * @param {module:ol/style/Text} textStyle Text style.
+   * @param {import("../../style/Text.js").default} textStyle Text style.
    * @override
    */
   setTextStyle(textStyle) {

--- a/src/ol/render/canvas/LineStringReplay.js
+++ b/src/ol/render/canvas/LineStringReplay.js
@@ -7,7 +7,7 @@ import CanvasReplay from '../canvas/Replay.js';
 class CanvasLineStringReplay extends CanvasReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Maximum extent.
+   * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay can have overlapping geometries.

--- a/src/ol/render/canvas/PolygonReplay.js
+++ b/src/ol/render/canvas/PolygonReplay.js
@@ -13,7 +13,7 @@ import CanvasReplay from '../canvas/Replay.js';
 class CanvasPolygonReplay extends CanvasReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Maximum extent.
+   * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay can have overlapping geometries.
@@ -196,7 +196,7 @@ class CanvasPolygonReplay extends CanvasReplay {
 
   /**
    * @private
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry Geometry.
    */
   setFillStrokeStyles_(geometry) {
     const state = this.state;

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -30,13 +30,13 @@ import {
 
 
 /**
- * @type {module:ol/extent~Extent}
+ * @type {import("../../extent.js").Extent}
  */
 const tmpExtent = createEmpty();
 
 
 /**
- * @type {!module:ol/transform~Transform}
+ * @type {!import("../../transform.js").Transform}
  */
 const tmpTransform = createTransform();
 
@@ -44,7 +44,7 @@ const tmpTransform = createTransform();
 class CanvasReplay extends VectorContext {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Maximum extent.
+   * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay can have overlapping geometries.
@@ -67,7 +67,7 @@ class CanvasReplay extends VectorContext {
     /**
      * @protected
      * @const
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.maxExtent = maxExtent;
 
@@ -116,7 +116,7 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.bufferedMaxExtent_ = null;
 
@@ -134,13 +134,13 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @private
-     * @type {!Object<number,module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>>}
+     * @type {!Object<number,import("../../coordinate.js").Coordinate|Array<import("../../coordinate.js").Coordinate>|Array<Array<import("../../coordinate.js").Coordinate>>>}
      */
     this.coordinateCache_ = {};
 
     /**
      * @private
-     * @type {!module:ol/transform~Transform}
+     * @type {!import("../../transform.js").Transform}
      */
     this.renderedTransform_ = createTransform();
 
@@ -158,9 +158,9 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @protected
-     * @type {module:ol/render/canvas~FillStrokeState}
+     * @type {import("../canvas.js").FillStrokeState}
      */
-    this.state = /** @type {module:ol/render/canvas~FillStrokeState} */ ({});
+    this.state = /** @type {import("../canvas.js").FillStrokeState} */ ({});
 
     /**
      * @private
@@ -172,10 +172,10 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/coordinate~Coordinate} p1 1st point of the background box.
-   * @param {module:ol/coordinate~Coordinate} p2 2nd point of the background box.
-   * @param {module:ol/coordinate~Coordinate} p3 3rd point of the background box.
-   * @param {module:ol/coordinate~Coordinate} p4 4th point of the background box.
+   * @param {import("../../coordinate.js").Coordinate} p1 1st point of the background box.
+   * @param {import("../../coordinate.js").Coordinate} p2 2nd point of the background box.
+   * @param {import("../../coordinate.js").Coordinate} p3 3rd point of the background box.
+   * @param {import("../../coordinate.js").Coordinate} p4 4th point of the background box.
    * @param {Array<*>} fillInstruction Fill instruction.
    * @param {Array<*>} strokeInstruction Stroke instruction.
    */
@@ -203,7 +203,7 @@ class CanvasReplay extends VectorContext {
    * @param {HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} image Image.
    * @param {number} anchorX Anchor X.
    * @param {number} anchorY Anchor Y.
-   * @param {module:ol/render/canvas~DeclutterGroup} declutterGroup Declutter group.
+   * @param {import("../canvas.js").DeclutterGroup} declutterGroup Declutter group.
    * @param {number} height Height.
    * @param {number} opacity Opacity.
    * @param {number} originX Origin X.
@@ -249,13 +249,13 @@ class CanvasReplay extends VectorContext {
     const boxX = x - padding[3];
     const boxY = y - padding[0];
 
-    /** @type {module:ol/coordinate~Coordinate} */
+    /** @type {import("../../coordinate.js").Coordinate} */
     let p1;
-    /** @type {module:ol/coordinate~Coordinate} */
+    /** @type {import("../../coordinate.js").Coordinate} */
     let p2;
-    /** @type {module:ol/coordinate~Coordinate} */
+    /** @type {import("../../coordinate.js").Coordinate} */
     let p3;
-    /** @type {module:ol/coordinate~Coordinate} */
+    /** @type {import("../../coordinate.js").Coordinate} */
     let p4;
     if (fillStroke || rotation !== 0) {
       p1 = [boxX, boxY];
@@ -406,7 +406,7 @@ class CanvasReplay extends VectorContext {
     let flatCoordinates, replayEnd, replayEnds, replayEndss;
     let offset;
     if (type == GeometryType.MULTI_POLYGON) {
-      geometry = /** @type {module:ol/geom/MultiPolygon} */ (geometry);
+      geometry = /** @type {import("../../geom/MultiPolygon.js").default} */ (geometry);
       flatCoordinates = geometry.getOrientedFlatCoordinates();
       replayEndss = [];
       const endss = geometry.getEndss();
@@ -421,10 +421,10 @@ class CanvasReplay extends VectorContext {
     } else if (type == GeometryType.POLYGON || type == GeometryType.MULTI_LINE_STRING) {
       replayEnds = [];
       flatCoordinates = (type == GeometryType.POLYGON) ?
-        /** @type {module:ol/geom/Polygon} */ (geometry).getOrientedFlatCoordinates() :
+        /** @type {import("../../geom/Polygon.js").default} */ (geometry).getOrientedFlatCoordinates() :
         geometry.getFlatCoordinates();
       offset = this.drawCustomCoordinates_(flatCoordinates, 0,
-        /** @type {module:ol/geom/Polygon|module:ol/geom/MultiLineString} */ (geometry).getEnds(),
+        /** @type {import("../../geom/Polygon.js").default|import("../../geom/MultiLineString.js").default} */ (geometry).getEnds(),
         stride, replayEnds);
       this.instructions.push([CanvasInstruction.CUSTOM,
         replayBegin, replayEnds, geometry, renderer, inflateCoordinatesArray]);
@@ -446,8 +446,8 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @protected
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry Geometry.
+   * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
    */
   beginGeometry(geometry, feature) {
     this.beginGeometryInstruction1_ = [CanvasInstruction.BEGIN_GEOMETRY, feature, 0];
@@ -479,7 +479,7 @@ class CanvasReplay extends VectorContext {
    * @param {Array<*>} instruction Instruction.
    */
   setStrokeStyle_(context, instruction) {
-    context.strokeStyle = /** @type {module:ol/colorlike~ColorLike} */ (instruction[1]);
+    context.strokeStyle = /** @type {import("../../colorlike.js").ColorLike} */ (instruction[1]);
     context.lineWidth = /** @type {number} */ (instruction[2]);
     context.lineCap = /** @type {string} */ (instruction[3]);
     context.lineJoin = /** @type {string} */ (instruction[4]);
@@ -491,14 +491,14 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~DeclutterGroup} declutterGroup Declutter group.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../canvas.js").DeclutterGroup} declutterGroup Declutter group.
+   * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
    */
   renderDeclutter_(declutterGroup, feature) {
     if (declutterGroup && declutterGroup.length > 5) {
       const groupCount = declutterGroup[4];
       if (groupCount == 1 || groupCount == declutterGroup.length - 5) {
-        /** @type {module:ol/structs/RBush~Entry} */
+        /** @type {import("../../structs/RBush.js").Entry} */
         const box = {
           minX: /** @type {number} */ (declutterGroup[0]),
           minY: /** @type {number} */ (declutterGroup[1]),
@@ -529,13 +529,13 @@ class CanvasReplay extends VectorContext {
   /**
    * @private
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../transform.js").Transform} transform Transform.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
    * @param {Array<*>} instructions Instructions array.
    * @param {boolean} snapToPixel Snap point symbols and text to integer pixels.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
-   * @param {module:ol/extent~Extent=} opt_hitExtent Only check features that intersect this
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} featureCallback Feature callback.
+   * @param {import("../../extent.js").Extent=} opt_hitExtent Only check features that intersect this
    *     extent.
    * @return {T|undefined} Callback result.
    * @template T
@@ -575,7 +575,7 @@ class CanvasReplay extends VectorContext {
     const coordinateCache = this.coordinateCache_;
     const viewRotation = this.viewRotation_;
 
-    const state = /** @type {module:ol/render~State} */ ({
+    const state = /** @type {import("../../render.js").State} */ ({
       context: context,
       pixelRatio: this.pixelRatio,
       resolution: this.resolution,
@@ -585,14 +585,14 @@ class CanvasReplay extends VectorContext {
     // When the batch size gets too big, performance decreases. 200 is a good
     // balance between batch size and number of fill/stroke instructions.
     const batchSize = this.instructions != instructions || this.overlaps ? 0 : 200;
-    let /** @type {module:ol/Feature|module:ol/render/Feature} */ feature;
+    let /** @type {import("../../Feature.js").default|import("../Feature.js").default} */ feature;
     let x, y;
     while (i < ii) {
       const instruction = instructions[i];
-      const type = /** @type {module:ol/render/canvas/Instruction} */ (instruction[0]);
+      const type = /** @type {import("./Instruction.js").default} */ (instruction[0]);
       switch (type) {
         case CanvasInstruction.BEGIN_GEOMETRY:
-          feature = /** @type {module:ol/Feature|module:ol/render/Feature} */ (instruction[1]);
+          feature = /** @type {import("../../Feature.js").default|import("../Feature.js").default} */ (instruction[1]);
           if ((skipFeatures &&
               skippedFeaturesHash[getUid(feature).toString()]) ||
               !feature.getGeometry()) {
@@ -639,7 +639,7 @@ class CanvasReplay extends VectorContext {
         case CanvasInstruction.CUSTOM:
           d = /** @type {number} */ (instruction[1]);
           dd = instruction[2];
-          const geometry = /** @type {module:ol/geom/SimpleGeometry} */ (instruction[3]);
+          const geometry = /** @type {import("../../geom/SimpleGeometry.js").default} */ (instruction[3]);
           const renderer = instruction[4];
           const fn = instruction.length == 6 ? instruction[5] : undefined;
           state.geometry = geometry;
@@ -666,7 +666,7 @@ class CanvasReplay extends VectorContext {
           // Remaining arguments in DRAW_IMAGE are in alphabetical order
           anchorX = /** @type {number} */ (instruction[4]);
           anchorY = /** @type {number} */ (instruction[5]);
-          declutterGroup = featureCallback ? null : /** @type {module:ol/render/canvas~DeclutterGroup} */ (instruction[6]);
+          declutterGroup = featureCallback ? null : /** @type {import("../canvas.js").DeclutterGroup} */ (instruction[6]);
           const height = /** @type {number} */ (instruction[7]);
           const opacity = /** @type {number} */ (instruction[8]);
           const originX = /** @type {number} */ (instruction[9]);
@@ -704,7 +704,7 @@ class CanvasReplay extends VectorContext {
           const begin = /** @type {number} */ (instruction[1]);
           const end = /** @type {number} */ (instruction[2]);
           const baseline = /** @type {number} */ (instruction[3]);
-          declutterGroup = featureCallback ? null : /** @type {module:ol/render/canvas~DeclutterGroup} */ (instruction[4]);
+          declutterGroup = featureCallback ? null : /** @type {import("../canvas.js").DeclutterGroup} */ (instruction[4]);
           const overflow = /** @type {number} */ (instruction[5]);
           const fillKey = /** @type {string} */ (instruction[6]);
           const maxAngle = /** @type {number} */ (instruction[7]);
@@ -760,7 +760,7 @@ class CanvasReplay extends VectorContext {
           break;
         case CanvasInstruction.END_GEOMETRY:
           if (featureCallback !== undefined) {
-            feature = /** @type {module:ol/Feature|module:ol/render/Feature} */ (instruction[1]);
+            feature = /** @type {import("../../Feature.js").default|import("../Feature.js").default} */ (instruction[1]);
             const result = featureCallback(feature);
             if (result) {
               return result;
@@ -814,7 +814,7 @@ class CanvasReplay extends VectorContext {
             }
           }
 
-          context.fillStyle = /** @type {module:ol/colorlike~ColorLike} */ (instruction[1]);
+          context.fillStyle = /** @type {import("../../colorlike.js").ColorLike} */ (instruction[1]);
           ++i;
           break;
         case CanvasInstruction.SET_STROKE_STYLE:
@@ -850,7 +850,7 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
@@ -864,13 +864,13 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T=} opt_featureCallback
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T=} opt_featureCallback
    *     Feature callback.
-   * @param {module:ol/extent~Extent=} opt_hitExtent Only check features that intersect this
+   * @param {import("../../extent.js").Extent=} opt_hitExtent Only check features that intersect this
    *     extent.
    * @return {T|undefined} Callback result.
    * @template T
@@ -903,7 +903,7 @@ class CanvasReplay extends VectorContext {
     let begin = -1;
     for (i = 0; i < n; ++i) {
       instruction = hitDetectionInstructions[i];
-      type = /** @type {module:ol/render/canvas/Instruction} */ (instruction[0]);
+      type = /** @type {import("./Instruction.js").default} */ (instruction[0]);
       if (type == CanvasInstruction.END_GEOMETRY) {
         begin = i;
       } else if (type == CanvasInstruction.BEGIN_GEOMETRY) {
@@ -966,8 +966,8 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~FillStrokeState} state State.
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+   * @param {import("../canvas.js").FillStrokeState} state State.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry Geometry.
    * @return {Array<*>} Fill instruction.
    */
   createFill(state, geometry) {
@@ -981,14 +981,14 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~FillStrokeState} state State.
+   * @param {import("../canvas.js").FillStrokeState} state State.
    */
   applyStroke(state) {
     this.instructions.push(this.createStroke(state));
   }
 
   /**
-   * @param {module:ol/render/canvas~FillStrokeState} state State.
+   * @param {import("../canvas.js").FillStrokeState} state State.
    * @return {Array<*>} Stroke instruction.
    */
   createStroke(state) {
@@ -1001,9 +1001,9 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~FillStrokeState} state State.
-   * @param {function(this:module:ol/render/canvas/Replay, module:ol/render/canvas~FillStrokeState, (module:ol/geom/Geometry|module:ol/render/Feature)):Array<*>} createFill Create fill.
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+   * @param {import("../canvas.js").FillStrokeState} state State.
+   * @param {function(this:import("./Replay.js").default, import("../canvas.js").FillStrokeState, (import("../../geom/Geometry.js").default|import("../Feature.js").default)):Array<*>} createFill Create fill.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry Geometry.
    */
   updateFillStyle(state, createFill, geometry) {
     const fillStyle = state.fillStyle;
@@ -1016,8 +1016,8 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/render/canvas~FillStrokeState} state State.
-   * @param {function(this:module:ol/render/canvas/Replay, module:ol/render/canvas~FillStrokeState)} applyStroke Apply stroke.
+   * @param {import("../canvas.js").FillStrokeState} state State.
+   * @param {function(this:import("./Replay.js").default, import("../canvas.js").FillStrokeState)} applyStroke Apply stroke.
    */
   updateStrokeStyle(state, applyStroke) {
     const strokeStyle = state.strokeStyle;
@@ -1048,8 +1048,8 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry Geometry.
+   * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
    */
   endGeometry(geometry, feature) {
     this.beginGeometryInstruction1_[2] = this.instructions.length;
@@ -1065,7 +1065,7 @@ class CanvasReplay extends VectorContext {
    * Get the buffered rendering extent.  Rendering will be clipped to the extent
    * provided to the constructor.  To account for symbolizers that may intersect
    * this extent, we calculate a buffered extent (e.g. based on stroke width).
-   * @return {module:ol/extent~Extent} The buffered rendering extent.
+   * @return {import("../../extent.js").Extent} The buffered rendering extent.
    * @protected
    */
   getBufferedMaxExtent() {

--- a/src/ol/render/canvas/ReplayGroup.js
+++ b/src/ol/render/canvas/ReplayGroup.js
@@ -19,9 +19,9 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 
 
 /**
- * @type {Object<module:ol/render/ReplayType,
- *                function(new: module:ol/render/canvas/Replay, number, module:ol/extent~Extent,
- *                number, number, boolean, Array<module:ol/render/canvas~DeclutterGroup>)>}
+ * @type {Object<import("../ReplayType.js").default,
+ *                function(new: import("./Replay.js").default, number, import("../../extent.js").Extent,
+ *                number, number, boolean, Array<import("../canvas.js").DeclutterGroup>)>}
  */
 const BATCH_CONSTRUCTORS = {
   'Circle': CanvasPolygonReplay,
@@ -36,7 +36,7 @@ const BATCH_CONSTRUCTORS = {
 class CanvasReplayGroup extends ReplayGroup {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay group can have overlapping geometries.
@@ -61,7 +61,7 @@ class CanvasReplayGroup extends ReplayGroup {
     this.declutterTree_ = declutterTree;
 
     /**
-     * @type {module:ol/render/canvas~DeclutterGroup}
+     * @type {import("../canvas.js").DeclutterGroup}
      * @private
      */
     this.declutterGroup_ = null;
@@ -74,7 +74,7 @@ class CanvasReplayGroup extends ReplayGroup {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.maxExtent_ = maxExtent;
 
@@ -104,7 +104,7 @@ class CanvasReplayGroup extends ReplayGroup {
 
     /**
      * @private
-     * @type {!Object<string, !Object<module:ol/render/ReplayType, module:ol/render/canvas/Replay>>}
+     * @type {!Object<string, !Object<import("../ReplayType.js").default, import("./Replay.js").default>>}
      */
     this.replaysByZIndex_ = {};
 
@@ -116,14 +116,14 @@ class CanvasReplayGroup extends ReplayGroup {
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.hitDetectionTransform_ = createTransform();
   }
 
   /**
    * @param {boolean} group Group with previous replay.
-   * @return {module:ol/render/canvas~DeclutterGroup} Declutter instruction group.
+   * @return {import("../canvas.js").DeclutterGroup} Declutter instruction group.
    */
   addDeclutter(group) {
     let declutter = null;
@@ -141,7 +141,7 @@ class CanvasReplayGroup extends ReplayGroup {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../transform.js").Transform} transform Transform.
    */
   clip(context, transform) {
     const flatClipCoords = this.getClipCoords(transform);
@@ -154,7 +154,7 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {Array<module:ol/render/ReplayType>} replays Replays.
+   * @param {Array<import("../ReplayType.js").default>} replays Replays.
    * @return {boolean} Has replays of the provided types.
    */
   hasReplays(replays) {
@@ -182,13 +182,13 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
    * @param {number} hitTolerance Hit tolerance in pixels.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
-   * @param {Object<string, module:ol/render/canvas~DeclutterGroup>} declutterReplays Declutter replays.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T} callback Feature callback.
+   * @param {Object<string, import("../canvas.js").DeclutterGroup>} declutterReplays Declutter replays.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -219,7 +219,7 @@ class CanvasReplayGroup extends ReplayGroup {
     }
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     let hitExtent;
     if (this.renderBuffer_ !== undefined) {
@@ -239,7 +239,7 @@ class CanvasReplayGroup extends ReplayGroup {
     let replayType;
 
     /**
-     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+     * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
      * @return {?} Callback result.
      */
     function featureCallback(feature) {
@@ -299,7 +299,7 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../transform.js").Transform} transform Transform.
    * @return {Array<number>} Clip coordinates.
    */
   getClipCoords(transform) {
@@ -335,7 +335,7 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @return {Object<string, Object<module:ol/render/ReplayType, module:ol/render/canvas/Replay>>} Replays.
+   * @return {Object<string, Object<import("../ReplayType.js").default, import("./Replay.js").default>>} Replays.
    */
   getReplays() {
     return this.replaysByZIndex_;
@@ -350,13 +350,13 @@ class CanvasReplayGroup extends ReplayGroup {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {boolean} snapToPixel Snap point symbols and test to integer pixel.
-   * @param {Array<module:ol/render/ReplayType>=} opt_replayTypes Ordered replay types to replay.
+   * @param {Array<import("../ReplayType.js").default>=} opt_replayTypes Ordered replay types to replay.
    *     Default is {@link module:ol/render/replay~ORDER}
-   * @param {Object<string, module:ol/render/canvas~DeclutterGroup>=} opt_declutterReplays Declutter replays.
+   * @param {Object<string, import("../canvas.js").DeclutterGroup>=} opt_declutterReplays Declutter replays.
    */
   replay(
     context,

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -17,7 +17,7 @@ import TextPlacement from '../../style/TextPlacement.js';
 class CanvasTextReplay extends CanvasReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Maximum extent.
+   * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay can have overlapping geometries.
@@ -28,7 +28,7 @@ class CanvasTextReplay extends CanvasReplay {
 
     /**
      * @private
-     * @type {module:ol/render/canvas~DeclutterGroup}
+     * @type {import("../canvas.js").DeclutterGroup}
      */
     this.declutterGroup_;
 
@@ -70,34 +70,34 @@ class CanvasTextReplay extends CanvasReplay {
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~FillState}
+     * @type {?import("../canvas.js").FillState}
      */
     this.textFillState_ = null;
 
     /**
-     * @type {!Object<string, module:ol/render/canvas~FillState>}
+     * @type {!Object<string, import("../canvas.js").FillState>}
      */
     this.fillStates = {};
 
     /**
      * @private
-     * @type {?module:ol/render/canvas~StrokeState}
+     * @type {?import("../canvas.js").StrokeState}
      */
     this.textStrokeState_ = null;
 
     /**
-     * @type {!Object<string, module:ol/render/canvas~StrokeState>}
+     * @type {!Object<string, import("../canvas.js").StrokeState>}
      */
     this.strokeStates = {};
 
     /**
      * @private
-     * @type {module:ol/render/canvas~TextState}
+     * @type {import("../canvas.js").TextState}
      */
-    this.textState_ = /** @type {module:ol/render/canvas~TextState} */ ({});
+    this.textState_ = /** @type {import("../canvas.js").TextState} */ ({});
 
     /**
-     * @type {!Object<string, module:ol/render/canvas~TextState>}
+     * @type {!Object<string, import("../canvas.js").TextState>}
      */
     this.textStates = {};
 
@@ -200,24 +200,24 @@ class CanvasTextReplay extends CanvasReplay {
           end = flatCoordinates.length;
           break;
         case GeometryType.LINE_STRING:
-          flatCoordinates = /** @type {module:ol/geom/LineString} */ (geometry).getFlatMidpoint();
+          flatCoordinates = /** @type {import("../../geom/LineString.js").default} */ (geometry).getFlatMidpoint();
           break;
         case GeometryType.CIRCLE:
-          flatCoordinates = /** @type {module:ol/geom/Circle} */ (geometry).getCenter();
+          flatCoordinates = /** @type {import("../../geom/Circle.js").default} */ (geometry).getCenter();
           break;
         case GeometryType.MULTI_LINE_STRING:
-          flatCoordinates = /** @type {module:ol/geom/MultiLineString} */ (geometry).getFlatMidpoints();
+          flatCoordinates = /** @type {import("../../geom/MultiLineString.js").default} */ (geometry).getFlatMidpoints();
           end = flatCoordinates.length;
           break;
         case GeometryType.POLYGON:
-          flatCoordinates = /** @type {module:ol/geom/Polygon} */ (geometry).getFlatInteriorPoint();
+          flatCoordinates = /** @type {import("../../geom/Polygon.js").default} */ (geometry).getFlatInteriorPoint();
           if (!textState.overflow && flatCoordinates[2] / this.resolution < width) {
             return;
           }
           stride = 3;
           break;
         case GeometryType.MULTI_POLYGON:
-          const interiorPoints = /** @type {module:ol/geom/MultiPolygon} */ (geometry).getFlatInteriorPoints();
+          const interiorPoints = /** @type {import("../../geom/MultiPolygon.js").default} */ (geometry).getFlatInteriorPoints();
           flatCoordinates = [];
           for (i = 0, ii = interiorPoints.length; i < ii; i += 3) {
             if (textState.overflow || interiorPoints[i + 2] / this.resolution >= width) {
@@ -356,7 +356,7 @@ class CanvasTextReplay extends CanvasReplay {
    * @private
    * @param {number} begin Begin.
    * @param {number} end End.
-   * @param {module:ol/render/canvas~DeclutterGroup} declutterGroup Declutter group.
+   * @param {import("../canvas.js").DeclutterGroup} declutterGroup Declutter group.
    */
   drawChars_(begin, end, declutterGroup) {
     const strokeState = this.textStrokeState_;
@@ -366,7 +366,7 @@ class CanvasTextReplay extends CanvasReplay {
     const strokeKey = this.strokeKey_;
     if (strokeState) {
       if (!(strokeKey in this.strokeStates)) {
-        this.strokeStates[strokeKey] = /** @type {module:ol/render/canvas~StrokeState} */ ({
+        this.strokeStates[strokeKey] = /** @type {import("../canvas.js").StrokeState} */ ({
           strokeStyle: strokeState.strokeStyle,
           lineCap: strokeState.lineCap,
           lineDashOffset: strokeState.lineDashOffset,
@@ -379,7 +379,7 @@ class CanvasTextReplay extends CanvasReplay {
     }
     const textKey = this.textKey_;
     if (!(this.textKey_ in this.textStates)) {
-      this.textStates[this.textKey_] = /** @type {module:ol/render/canvas~TextState} */ ({
+      this.textStates[this.textKey_] = /** @type {import("../canvas.js").TextState} */ ({
         font: textState.font,
         textAlign: textState.textAlign || defaultTextAlign,
         scale: textState.scale
@@ -388,7 +388,7 @@ class CanvasTextReplay extends CanvasReplay {
     const fillKey = this.fillKey_;
     if (fillState) {
       if (!(fillKey in this.fillStates)) {
-        this.fillStates[fillKey] = /** @type {module:ol/render/canvas~FillState} */ ({
+        this.fillStates[fillKey] = /** @type {import("../canvas.js").FillState} */ ({
           fillStyle: fillState.fillStyle
         });
       }
@@ -440,7 +440,7 @@ class CanvasTextReplay extends CanvasReplay {
     if (!textStyle) {
       this.text_ = '';
     } else {
-      this.declutterGroup_ = /** @type {module:ol/render/canvas~DeclutterGroup} */ (declutterGroup);
+      this.declutterGroup_ = /** @type {import("../canvas.js").DeclutterGroup} */ (declutterGroup);
 
       const textFillStyle = textStyle.getFill();
       if (!textFillStyle) {
@@ -448,7 +448,7 @@ class CanvasTextReplay extends CanvasReplay {
       } else {
         fillState = this.textFillState_;
         if (!fillState) {
-          fillState = this.textFillState_ = /** @type {module:ol/render/canvas~FillState} */ ({});
+          fillState = this.textFillState_ = /** @type {import("../canvas.js").FillState} */ ({});
         }
         fillState.fillStyle = asColorLike(
           textFillStyle.getColor() || defaultFillStyle);
@@ -460,7 +460,7 @@ class CanvasTextReplay extends CanvasReplay {
       } else {
         strokeState = this.textStrokeState_;
         if (!strokeState) {
-          strokeState = this.textStrokeState_ = /** @type {module:ol/render/canvas~StrokeState} */ ({});
+          strokeState = this.textStrokeState_ = /** @type {import("../canvas.js").StrokeState} */ ({});
         }
         const lineDash = textStrokeStyle.getLineDash();
         const lineDashOffset = textStrokeStyle.getLineDashOffset();

--- a/src/ol/render/replay.js
+++ b/src/ol/render/replay.js
@@ -6,7 +6,7 @@ import ReplayType from '../render/ReplayType.js';
 
 /**
  * @const
- * @type {Array<module:ol/render/ReplayType>}
+ * @type {Array<import("./ReplayType.js").default>}
  */
 export const ORDER = [
   ReplayType.POLYGON,

--- a/src/ol/render/webgl.js
+++ b/src/ol/render/webgl.js
@@ -12,7 +12,7 @@ export const DEFAULT_FONT = '10px sans-serif';
 
 /**
  * @const
- * @type {module:ol/color~Color}
+ * @type {import("../color.js").Color}
  */
 export const DEFAULT_FILLSTYLE = [0.0, 0.0, 0.0, 1.0];
 
@@ -53,7 +53,7 @@ export const DEFAULT_MITERLIMIT = 10;
 
 /**
  * @const
- * @type {module:ol/color~Color}
+ * @type {import("../color.js").Color}
  */
 export const DEFAULT_STROKESTYLE = [0.0, 0.0, 0.0, 1.0];
 

--- a/src/ol/render/webgl/CircleReplay.js
+++ b/src/ol/render/webgl/CircleReplay.js
@@ -18,14 +18,14 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 class WebGLCircleReplay extends WebGLReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super(tolerance, maxExtent);
 
     /**
      * @private
-     * @type {module:ol/render/webgl/circlereplay/defaultshader/Locations}
+     * @type {import("./circlereplay/defaultshader/Locations.js").default}
      */
     this.defaultLocations_ = null;
 
@@ -172,7 +172,7 @@ class WebGLCircleReplay extends WebGLReplay {
   getDeleteResourcesFunction(context) {
     // We only delete our stuff here. The shaders and the program may
     // be used by other CircleReplay instances (for other layers). And
-    // they will be deleted when disposing of the module:ol/webgl/Context~WebGLContext
+    // they will be deleted when disposing of the import("../../webgl/Context.js").WebGLContext
     // object.
     const verticesBuffer = this.verticesBuffer;
     const indicesBuffer = this.indicesBuffer;
@@ -296,7 +296,7 @@ class WebGLCircleReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object} skippedFeaturesHash Ids of features to skip.
    */
   drawReplaySkipping_(gl, context, skippedFeaturesHash) {

--- a/src/ol/render/webgl/ImageReplay.js
+++ b/src/ol/render/webgl/ImageReplay.js
@@ -8,7 +8,7 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 class WebGLImageReplay extends WebGLTextureReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super(tolerance, maxExtent);

--- a/src/ol/render/webgl/Immediate.js
+++ b/src/ol/render/webgl/Immediate.js
@@ -10,12 +10,12 @@ import WebGLReplayGroup from '../webgl/ReplayGroup.js';
 
 class WebGLImmediateRenderer extends VectorContext {
   /**
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
-   * @param {module:ol/size~Size} size Size.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../../size.js").Size} size Size.
+   * @param {import("../../extent.js").Extent} extent Extent.
    * @param {number} pixelRatio Pixel ratio.
    */
   constructor(context, center, resolution, rotation, size, extent, pixelRatio) {
@@ -58,38 +58,38 @@ class WebGLImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {module:ol/style/Image}
+     * @type {import("../../style/Image.js").default}
      */
     this.imageStyle_ = null;
 
     /**
      * @private
-     * @type {module:ol/style/Fill}
+     * @type {import("../../style/Fill.js").default}
      */
     this.fillStyle_ = null;
 
     /**
      * @private
-     * @type {module:ol/style/Stroke}
+     * @type {import("../../style/Stroke.js").default}
      */
     this.strokeStyle_ = null;
 
     /**
      * @private
-     * @type {module:ol/style/Text}
+     * @type {import("../../style/Text.js").default}
      */
     this.textStyle_ = null;
 
   }
 
   /**
-   * @param {module:ol/render/webgl/ReplayGroup} replayGroup Replay group.
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
+   * @param {import("./ReplayGroup.js").default} replayGroup Replay group.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry Geometry.
    * @private
    */
   drawText_(replayGroup, geometry) {
     const context = this.context_;
-    const replay = /** @type {module:ol/render/webgl/TextReplay} */ (
+    const replay = /** @type {import("./TextReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.TEXT));
     replay.setTextStyle(this.textStyle_);
     replay.drawText(geometry, null);
@@ -109,7 +109,7 @@ class WebGLImmediateRenderer extends VectorContext {
    * Set the rendering style.  Note that since this is an immediate rendering API,
    * any `zIndex` on the provided style will be ignored.
    *
-   * @param {module:ol/style/Style} style The rendering style.
+   * @param {import("../../style/Style.js").default} style The rendering style.
    * @override
    * @api
    */
@@ -123,7 +123,7 @@ class WebGLImmediateRenderer extends VectorContext {
    * Render a geometry into the canvas.  Call
    * {@link ol/render/webgl/Immediate#setStyle} first to set the rendering style.
    *
-   * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry The geometry to render.
+   * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry The geometry to render.
    * @override
    * @api
    */
@@ -131,28 +131,28 @@ class WebGLImmediateRenderer extends VectorContext {
     const type = geometry.getType();
     switch (type) {
       case GeometryType.POINT:
-        this.drawPoint(/** @type {module:ol/geom/Point} */ (geometry), null);
+        this.drawPoint(/** @type {import("../../geom/Point.js").default} */ (geometry), null);
         break;
       case GeometryType.LINE_STRING:
-        this.drawLineString(/** @type {module:ol/geom/LineString} */ (geometry), null);
+        this.drawLineString(/** @type {import("../../geom/LineString.js").default} */ (geometry), null);
         break;
       case GeometryType.POLYGON:
-        this.drawPolygon(/** @type {module:ol/geom/Polygon} */ (geometry), null);
+        this.drawPolygon(/** @type {import("../../geom/Polygon.js").default} */ (geometry), null);
         break;
       case GeometryType.MULTI_POINT:
-        this.drawMultiPoint(/** @type {module:ol/geom/MultiPoint} */ (geometry), null);
+        this.drawMultiPoint(/** @type {import("../../geom/MultiPoint.js").default} */ (geometry), null);
         break;
       case GeometryType.MULTI_LINE_STRING:
-        this.drawMultiLineString(/** @type {module:ol/geom/MultiLineString} */ (geometry), null);
+        this.drawMultiLineString(/** @type {import("../../geom/MultiLineString.js").default} */ (geometry), null);
         break;
       case GeometryType.MULTI_POLYGON:
-        this.drawMultiPolygon(/** @type {module:ol/geom/MultiPolygon} */ (geometry), null);
+        this.drawMultiPolygon(/** @type {import("../../geom/MultiPolygon.js").default} */ (geometry), null);
         break;
       case GeometryType.GEOMETRY_COLLECTION:
-        this.drawGeometryCollection(/** @type {module:ol/geom/GeometryCollection} */ (geometry), null);
+        this.drawGeometryCollection(/** @type {import("../../geom/GeometryCollection.js").default} */ (geometry), null);
         break;
       case GeometryType.CIRCLE:
-        this.drawCircle(/** @type {module:ol/geom/Circle} */ (geometry), null);
+        this.drawCircle(/** @type {import("../../geom/Circle.js").default} */ (geometry), null);
         break;
       default:
         // pass
@@ -189,7 +189,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawPoint(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/ImageReplay} */ (
+    const replay = /** @type {import("./ImageReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.IMAGE));
     replay.setImageStyle(this.imageStyle_);
     replay.drawPoint(geometry, data);
@@ -215,7 +215,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawMultiPoint(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/ImageReplay} */ (
+    const replay = /** @type {import("./ImageReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.IMAGE));
     replay.setImageStyle(this.imageStyle_);
     replay.drawMultiPoint(geometry, data);
@@ -240,7 +240,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawLineString(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/LineStringReplay} */ (
+    const replay = /** @type {import("./LineStringReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.LINE_STRING));
     replay.setFillStrokeStyle(null, this.strokeStyle_);
     replay.drawLineString(geometry, data);
@@ -265,7 +265,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawMultiLineString(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/LineStringReplay} */ (
+    const replay = /** @type {import("./LineStringReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.LINE_STRING));
     replay.setFillStrokeStyle(null, this.strokeStyle_);
     replay.drawMultiLineString(geometry, data);
@@ -290,7 +290,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawPolygon(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/PolygonReplay} */ (
+    const replay = /** @type {import("./PolygonReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.POLYGON));
     replay.setFillStrokeStyle(this.fillStyle_, this.strokeStyle_);
     replay.drawPolygon(geometry, data);
@@ -315,7 +315,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawMultiPolygon(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/PolygonReplay} */ (
+    const replay = /** @type {import("./PolygonReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.POLYGON));
     replay.setFillStrokeStyle(this.fillStyle_, this.strokeStyle_);
     replay.drawMultiPolygon(geometry, data);
@@ -340,7 +340,7 @@ class WebGLImmediateRenderer extends VectorContext {
   drawCircle(geometry, data) {
     const context = this.context_;
     const replayGroup = new WebGLReplayGroup(1, this.extent_);
-    const replay = /** @type {module:ol/render/webgl/CircleReplay} */ (
+    const replay = /** @type {import("./CircleReplay.js").default} */ (
       replayGroup.getReplay(0, ReplayType.CIRCLE));
     replay.setFillStrokeStyle(this.fillStyle_, this.strokeStyle_);
     replay.drawCircle(geometry, data);

--- a/src/ol/render/webgl/LineStringReplay.js
+++ b/src/ol/render/webgl/LineStringReplay.js
@@ -38,14 +38,14 @@ const Instruction = {
 class WebGLLineStringReplay extends WebGLReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super(tolerance, maxExtent);
 
     /**
      * @private
-     * @type {module:ol/render/webgl/linestringreplay/defaultshader/Locations}
+     * @type {import("./linestringreplay/defaultshader/Locations.js").default}
      */
     this.defaultLocations_ = null;
 
@@ -386,7 +386,7 @@ class WebGLLineStringReplay extends WebGLReplay {
   }
 
   /**
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
    * @param {number=} opt_index Index count.
    */
   setPolygonStyle(feature, opt_index) {
@@ -532,7 +532,7 @@ class WebGLLineStringReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object} skippedFeaturesHash Ids of features to skip.
    */
   drawReplaySkipping_(gl, context, skippedFeaturesHash) {

--- a/src/ol/render/webgl/PolygonReplay.js
+++ b/src/ol/render/webgl/PolygonReplay.js
@@ -31,15 +31,15 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 
 /**
  * @typedef {Object} PolygonSegment
- * @property {module:ol/render/webgl/PolygonReplay~PolygonVertex} p0
- * @property {module:ol/render/webgl/PolygonReplay~PolygonVertex} p1
+ * @property {PolygonVertex} p0
+ * @property {PolygonVertex} p1
  */
 
 
 class WebGLPolygonReplay extends WebGLReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super(tolerance, maxExtent);
@@ -49,7 +49,7 @@ class WebGLPolygonReplay extends WebGLReplay {
 
     /**
      * @private
-     * @type {module:ol/render/webgl/polygonreplay/defaultshader/Locations}
+     * @type {import("./polygonreplay/defaultshader/Locations.js").default}
      */
     this.defaultLocations_ = null;
 
@@ -143,8 +143,8 @@ class WebGLPolygonReplay extends WebGLReplay {
    * @private
    * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} stride Stride.
-   * @param {module:ol/structs/LinkedList} list Linked list.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @param {boolean} clockwise Coordinate order should be clockwise.
    */
   processFlatCoordinates_(flatCoordinates, stride, list, rtree, clockwise) {
@@ -152,11 +152,11 @@ class WebGLPolygonReplay extends WebGLReplay {
       0, flatCoordinates.length, stride);
     let i, ii;
     let n = this.vertices.length / 2;
-    /** @type {module:ol/render/webgl/PolygonReplay~PolygonVertex} */
+    /** @type {PolygonVertex} */
     let start;
-    /** @type {module:ol/render/webgl/PolygonReplay~PolygonVertex} */
+    /** @type {PolygonVertex} */
     let p0;
-    /** @type {module:ol/render/webgl/PolygonReplay~PolygonVertex} */
+    /** @type {PolygonVertex} */
     let p1;
     const extents = [];
     const segments = [];
@@ -194,7 +194,7 @@ class WebGLPolygonReplay extends WebGLReplay {
   /**
    * Returns the rightmost coordinates of a polygon on the X axis.
    * @private
-   * @param {module:ol/structs/LinkedList} list Polygons ring.
+   * @param {import("../../structs/LinkedList.js").default} list Polygons ring.
    * @return {Array<number>} Max X coordinates.
    */
   getMaxCoords_(list) {
@@ -215,8 +215,8 @@ class WebGLPolygonReplay extends WebGLReplay {
   /**
    * Classifies the points of a polygon list as convex, reflex. Removes collinear vertices.
    * @private
-   * @param {module:ol/structs/LinkedList} list Polygon ring.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Polygon ring.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @param {boolean} ccw The orientation of the polygon is counter-clockwise.
    * @return {boolean} There were reclassified points.
    */
@@ -250,11 +250,11 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} hole Linked list of the hole.
+   * @param {import("../../structs/LinkedList.js").default} hole Linked list of the hole.
    * @param {number} holeMaxX Maximum X value of the hole.
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
    * @param {number} listMaxX Maximum X value of the polygon.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @return {boolean} Bridging was successful.
    */
   bridgeHole_(hole, holeMaxX, list, listMaxX, rtree) {
@@ -264,11 +264,11 @@ class WebGLPolygonReplay extends WebGLReplay {
     }
 
     const p1 = seg.p1;
-    /** @type {module:ol/render/webgl/PolygonReplay~PolygonVertex} */
+    /** @type {PolygonVertex} */
     const p2 = {x: listMaxX, y: p1.y, i: -1};
     let minDist = Infinity;
     let i, ii, bestPoint;
-    /** @type {module:ol/render/webgl/PolygonReplay~PolygonVertex} */
+    /** @type {PolygonVertex} */
     let p5;
 
     const intersectingSegments = this.getIntersections_({p0: p1, p1: p2}, rtree, true);
@@ -325,8 +325,8 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    */
   triangulate_(list, rtree) {
     let ccw = false;
@@ -374,8 +374,8 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @param {boolean} simple The polygon is simple.
    * @param {boolean} ccw Orientation of the polygon is counter-clockwise.
    * @return {boolean} There were processed ears.
@@ -432,8 +432,8 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @param {boolean=} opt_touch Resolve touching segments.
    * @return {boolean} There were resolved intersections.
   */
@@ -499,8 +499,8 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @return {boolean} The polygon is simple.
    */
   isSimple_(list, rtree) {
@@ -517,7 +517,7 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
    * @return {boolean} Orientation is clockwise.
    */
   isClockwise_(list) {
@@ -536,8 +536,8 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/structs/LinkedList} list Linked list of the polygon.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {import("../../structs/LinkedList.js").default} list Linked list of the polygon.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    */
   splitPolygon_(list, rtree) {
     const start = list.firstItem();
@@ -582,13 +582,13 @@ class WebGLPolygonReplay extends WebGLReplay {
    * @param {number} x X coordinate.
    * @param {number} y Y coordinate.
    * @param {number} i Index.
-   * @return {module:ol/render/webgl/PolygonReplay~PolygonVertex} List item.
+   * @return {PolygonVertex} List item.
    */
   createPoint_(x, y, i) {
     let numVertices = this.vertices.length;
     this.vertices[numVertices++] = x;
     this.vertices[numVertices++] = y;
-    /** @type {module:ol/render/webgl/PolygonReplay~PolygonVertex} */
+    /** @type {PolygonVertex} */
     const p = {
       x: x,
       y: y,
@@ -600,11 +600,11 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p0 First point of segment.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p1 Second point of segment.
-   * @param {module:ol/structs/LinkedList} list Polygon ring.
-   * @param {module:ol/structs/RBush=} opt_rtree Insert the segment into the R-Tree.
-   * @return {module:ol/render/webgl/PolygonReplay~PolygonSegment} segment.
+   * @param {PolygonVertex} p0 First point of segment.
+   * @param {PolygonVertex} p1 Second point of segment.
+   * @param {import("../../structs/LinkedList.js").default} list Polygon ring.
+   * @param {import("../../structs/RBush.js").default=} opt_rtree Insert the segment into the R-Tree.
+   * @return {PolygonSegment} segment.
    */
   insertItem_(p0, p1, list, opt_rtree) {
     const seg = {
@@ -621,10 +621,10 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
     * @private
-    * @param {module:ol/render/webgl/PolygonReplay~PolygonSegment} s0 Segment before the remove candidate.
-    * @param {module:ol/render/webgl/PolygonReplay~PolygonSegment} s1 Remove candidate segment.
-    * @param {module:ol/structs/LinkedList} list Polygon ring.
-    * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+    * @param {PolygonSegment} s0 Segment before the remove candidate.
+    * @param {PolygonSegment} s1 Remove candidate segment.
+    * @param {import("../../structs/LinkedList.js").default} list Polygon ring.
+    * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
     */
   removeItem_(s0, s1, list, rtree) {
     if (list.getCurrItem() === s1) {
@@ -638,12 +638,12 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p0 First point.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p1 Second point.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p2 Third point.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {PolygonVertex} p0 First point.
+   * @param {PolygonVertex} p1 Second point.
+   * @param {PolygonVertex} p2 Third point.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @param {boolean=} opt_reflex Only include reflex points.
-   * @return {Array<module:ol/render/webgl/PolygonReplay~PolygonVertex>} Points in the triangle.
+   * @return {Array<PolygonVertex>} Points in the triangle.
    */
   getPointsInTriangle_(p0, p1, p2, rtree, opt_reflex) {
     const result = [];
@@ -667,10 +667,10 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonSegment} segment Segment.
-   * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
+   * @param {PolygonSegment} segment Segment.
+   * @param {import("../../structs/RBush.js").default} rtree R-Tree of the polygon.
    * @param {boolean=} opt_touch Touching segments should be considered an intersection.
-   * @return {Array<module:ol/render/webgl/PolygonReplay~PolygonSegment>} Intersecting segments.
+   * @return {Array<PolygonSegment>} Intersecting segments.
    */
   getIntersections_(segment, rtree, opt_touch) {
     const p0 = segment.p0;
@@ -693,10 +693,10 @@ class WebGLPolygonReplay extends WebGLReplay {
    * See http://paulbourke.net/geometry/pointlineplane/.
    *
    * @private
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p0 First point.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p1 Second point.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p2 Third point.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p3 Fourth point.
+   * @param {PolygonVertex} p0 First point.
+   * @param {PolygonVertex} p1 Second point.
+   * @param {PolygonVertex} p2 Third point.
+   * @param {PolygonVertex} p3 Fourth point.
    * @param {boolean=} opt_touch Touching segments should be considered an intersection.
    * @return {Array<number>|undefined} Intersection coordinates.
    */
@@ -716,11 +716,11 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p0 Point before the start of the diagonal.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p1 Start point of the diagonal.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p2 Ear candidate.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p3 End point of the diagonal.
-   * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p4 Point after the end of the diagonal.
+   * @param {PolygonVertex} p0 Point before the start of the diagonal.
+   * @param {PolygonVertex} p1 Start point of the diagonal.
+   * @param {PolygonVertex} p2 Ear candidate.
+   * @param {PolygonVertex} p3 End point of the diagonal.
+   * @param {PolygonVertex} p4 Point after the end of the diagonal.
    * @return {boolean} Diagonal is inside the polygon.
    */
   diagonalIsInside_(p0, p1, p2, p3, p4) {
@@ -966,7 +966,7 @@ class WebGLPolygonReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object} skippedFeaturesHash Ids of features to skip.
    */
   drawReplaySkipping_(gl, context, skippedFeaturesHash) {

--- a/src/ol/render/webgl/Replay.js
+++ b/src/ol/render/webgl/Replay.js
@@ -18,7 +18,7 @@ import {ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, TRIANGLES,
 class WebGLReplay extends VectorContext {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super();
@@ -32,7 +32,7 @@ class WebGLReplay extends VectorContext {
     /**
      * @protected
      * @const
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.maxExtent = maxExtent;
 
@@ -42,25 +42,25 @@ class WebGLReplay extends VectorContext {
      * we use the "Rendering Relative to Eye" technique described in the "3D
      * Engine Design for Virtual Globes" book.
      * @protected
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../../coordinate.js").Coordinate}
      */
     this.origin = getCenter(maxExtent);
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.projectionMatrix_ = createTransform();
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.offsetRotateMatrix_ = createTransform();
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.offsetScaleMatrix_ = createTransform();
 
@@ -78,7 +78,7 @@ class WebGLReplay extends VectorContext {
 
     /**
      * @protected
-     * @type {?module:ol/webgl/Buffer}
+     * @type {?import("../../webgl/Buffer.js").default}
      */
     this.indicesBuffer = null;
 
@@ -92,7 +92,7 @@ class WebGLReplay extends VectorContext {
     /**
      * Start index per feature (the feature).
      * @protected
-     * @type {Array<module:ol/Feature|module:ol/render/Feature>}
+     * @type {Array<import("../../Feature.js").default|import("../Feature.js").default>}
      */
     this.startIndicesFeature = [];
 
@@ -104,14 +104,14 @@ class WebGLReplay extends VectorContext {
 
     /**
      * @protected
-     * @type {?module:ol/webgl/Buffer}
+     * @type {?import("../../webgl/Buffer.js").default}
      */
     this.verticesBuffer = null;
 
     /**
      * Optional parameter for PolygonReplay instances.
      * @protected
-     * @type {module:ol/render/webgl/LineStringReplay|undefined}
+     * @type {import("./LineStringReplay.js").default|undefined}
      */
     this.lineStringReplay = undefined;
 
@@ -119,14 +119,14 @@ class WebGLReplay extends VectorContext {
 
   /**
    * @abstract
-   * @param {module:ol/webgl/Context} context WebGL context.
+   * @param {import("../../webgl/Context.js").default} context WebGL context.
    * @return {function()} Delete resources function.
    */
   getDeleteResourcesFunction(context) {}
 
   /**
    * @abstract
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    */
   finish(context) {}
 
@@ -134,13 +134,13 @@ class WebGLReplay extends VectorContext {
    * @abstract
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
-   * @return {module:ol/render/webgl/circlereplay/defaultshader/Locations|
-     module:ol/render/webgl/linestringreplay/defaultshader/Locations|
-     module:ol/render/webgl/polygonreplay/defaultshader/Locations|
-     module:ol/render/webgl/texturereplay/defaultshader/Locations} Locations.
+   * @return {import("./circlereplay/defaultshader/Locations.js").default|
+     import("./linestringreplay/defaultshader/Locations.js").default|
+     import("./polygonreplay/defaultshader/Locations.js").default|
+     import("./texturereplay/defaultshader/Locations.js").default} Locations.
    */
   setUpProgram(gl, context, size, pixelRatio) {}
 
@@ -148,10 +148,10 @@ class WebGLReplay extends VectorContext {
    * @abstract
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/render/webgl/circlereplay/defaultshader/Locations|
-     module:ol/render/webgl/linestringreplay/defaultshader/Locations|
-     module:ol/render/webgl/polygonreplay/defaultshader/Locations|
-     module:ol/render/webgl/texturereplay/defaultshader/Locations} locations Locations.
+   * @param {import("./circlereplay/defaultshader/Locations.js").default|
+     import("./linestringreplay/defaultshader/Locations.js").default|
+     import("./polygonreplay/defaultshader/Locations.js").default|
+     import("./texturereplay/defaultshader/Locations.js").default} locations Locations.
    */
   shutDownProgram(gl, locations) {}
 
@@ -159,7 +159,7 @@ class WebGLReplay extends VectorContext {
    * @abstract
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {boolean} hitDetection Hit detection mode.
    */
@@ -169,10 +169,10 @@ class WebGLReplay extends VectorContext {
    * @abstract
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
-   * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} featureCallback Feature callback.
+   * @param {import("../../extent.js").Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -181,11 +181,11 @@ class WebGLReplay extends VectorContext {
   /**
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} featureCallback Feature callback.
    * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
-   * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
+   * @param {import("../../extent.js").Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -204,9 +204,9 @@ class WebGLReplay extends VectorContext {
   /**
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} featureCallback Feature callback.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -223,17 +223,17 @@ class WebGLReplay extends VectorContext {
   }
 
   /**
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} featureCallback Feature callback.
    * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
-   * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
+   * @param {import("../../extent.js").Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -338,7 +338,7 @@ class WebGLReplay extends VectorContext {
   /**
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {number} start Start index.
    * @param {number} end End index.
    */

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -19,9 +19,9 @@ import WebGLTextReplay from '../webgl/TextReplay.js';
 const HIT_DETECTION_SIZE = [1, 1];
 
 /**
- * @type {Object<module:ol/render/ReplayType,
- *                function(new: module:ol/render/webgl/Replay, number,
- *                module:ol/extent~Extent)>}
+ * @type {Object<import("../ReplayType.js").default,
+ *                function(new: import("./Replay.js").default, number,
+ *                import("../../extent.js").Extent)>}
  */
 const BATCH_CONSTRUCTORS = {
   'Circle': WebGLCircleReplay,
@@ -35,14 +35,14 @@ const BATCH_CONSTRUCTORS = {
 class WebGLReplayGroup extends ReplayGroup {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    * @param {number=} opt_renderBuffer Render buffer.
    */
   constructor(tolerance, maxExtent, opt_renderBuffer) {
     super();
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      * @private
      */
     this.maxExtent_ = maxExtent;
@@ -62,20 +62,20 @@ class WebGLReplayGroup extends ReplayGroup {
     /**
      * @private
      * @type {!Object<string,
-     *        Object<module:ol/render/ReplayType, module:ol/render/webgl/Replay>>}
+     *        Object<import("../ReplayType.js").default, import("./Replay.js").default>>}
      */
     this.replaysByZIndex_ = {};
 
   }
 
   /**
-   * @param {module:ol/style/Style} style Style.
+   * @param {import("../../style/Style.js").default} style Style.
    * @param {boolean} group Group with previous replay.
    */
   addDeclutter(style, group) {}
 
   /**
-   * @param {module:ol/webgl/Context} context WebGL context.
+   * @param {import("../../webgl/Context.js").default} context WebGL context.
    * @return {function()} Delete resources function.
    */
   getDeleteResourcesFunction(context) {
@@ -99,7 +99,7 @@ class WebGLReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    */
   finish(context) {
     let zKey;
@@ -141,11 +141,11 @@ class WebGLReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
@@ -181,17 +181,17 @@ class WebGLReplayGroup extends ReplayGroup {
 
   /**
    * @private
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} featureCallback Feature callback.
    * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
-   * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting
+   * @param {import("../../extent.js").Extent=} opt_hitExtent Hit extent: Only features intersecting
    *  this extent are checked.
    * @return {T|undefined} Callback result.
    * @template T
@@ -234,16 +234,16 @@ class WebGLReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} callback Feature callback.
+   * @param {function((import("../../Feature.js").default|import("../Feature.js").default)): T|undefined} callback Feature callback.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -265,7 +265,7 @@ class WebGLReplayGroup extends ReplayGroup {
 
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     let hitExtent;
     if (this.renderBuffer_ !== undefined) {
@@ -278,7 +278,7 @@ class WebGLReplayGroup extends ReplayGroup {
       coordinate, resolution, rotation, HIT_DETECTION_SIZE,
       pixelRatio, opacity, skippedFeaturesHash,
       /**
-       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+       * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
        * @return {?} Callback result.
        */
       function(feature) {
@@ -295,12 +295,12 @@ class WebGLReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {module:ol/webgl/Context} context Context.
-   * @param {module:ol/coordinate~Coordinate} center Center.
+   * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("../../webgl/Context.js").default} context Context.
+   * @param {import("../../coordinate.js").Coordinate} center Center.
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
@@ -325,7 +325,7 @@ class WebGLReplayGroup extends ReplayGroup {
       coordinate, resolution, rotation, HIT_DETECTION_SIZE,
       pixelRatio, opacity, skippedFeaturesHash,
       /**
-       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+       * @param {import("../../Feature.js").default|import("../Feature.js").default} feature Feature.
        * @return {boolean} Is there a feature?
        */
       function(feature) {

--- a/src/ol/render/webgl/TextReplay.js
+++ b/src/ol/render/webgl/TextReplay.js
@@ -16,7 +16,7 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 
 /**
  * @typedef {Object} GlyphAtlas
- * @property {module:ol/style/AtlasManager} atlas
+ * @property {import("../../style/AtlasManager.js").default} atlas
  * @property {Object<string, number>} width
  * @property {number} height
  */
@@ -25,7 +25,7 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 class WebGLTextReplay extends WebGLTextureReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super(tolerance, maxExtent);
@@ -50,14 +50,14 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
     /**
      * @private
-     * @type {{strokeColor: (module:ol/colorlike~ColorLike|null),
+     * @type {{strokeColor: (import("../../colorlike.js").ColorLike|null),
      *         lineCap: (string|undefined),
      *         lineDash: Array<number>,
      *         lineDashOffset: (number|undefined),
      *         lineJoin: (string|undefined),
      *         lineWidth: number,
      *         miterLimit: (number|undefined),
-     *         fillColor: (module:ol/colorlike~ColorLike|null),
+     *         fillColor: (import("../../colorlike.js").ColorLike|null),
      *         font: (string|undefined),
      *         scale: (number|undefined)}}
      */
@@ -106,13 +106,13 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
     /**
      * @private
-     * @type {Object<string, module:ol/render/webgl/TextReplay~GlyphAtlas>}
+     * @type {Object<string, GlyphAtlas>}
      */
     this.atlases_ = {};
 
     /**
      * @private
-     * @type {module:ol/render/webgl/TextReplay~GlyphAtlas|undefined}
+     * @type {GlyphAtlas|undefined}
      */
     this.currAtlas_ = undefined;
 
@@ -139,20 +139,20 @@ class WebGLTextReplay extends WebGLTextureReplay {
           stride = geometry.getStride();
           break;
         case GeometryType.CIRCLE:
-          flatCoordinates = /** @type {module:ol/geom/Circle} */ (geometry).getCenter();
+          flatCoordinates = /** @type {import("../../geom/Circle.js").default} */ (geometry).getCenter();
           break;
         case GeometryType.LINE_STRING:
-          flatCoordinates = /** @type {module:ol/geom/LineString} */ (geometry).getFlatMidpoint();
+          flatCoordinates = /** @type {import("../../geom/LineString.js").default} */ (geometry).getFlatMidpoint();
           break;
         case GeometryType.MULTI_LINE_STRING:
-          flatCoordinates = /** @type {module:ol/geom/MultiLineString} */ (geometry).getFlatMidpoints();
+          flatCoordinates = /** @type {import("../../geom/MultiLineString.js").default} */ (geometry).getFlatMidpoints();
           end = flatCoordinates.length;
           break;
         case GeometryType.POLYGON:
-          flatCoordinates = /** @type {module:ol/geom/Polygon} */ (geometry).getFlatInteriorPoint();
+          flatCoordinates = /** @type {import("../../geom/Polygon.js").default} */ (geometry).getFlatInteriorPoint();
           break;
         case GeometryType.MULTI_POLYGON:
-          flatCoordinates = /** @type {module:ol/geom/MultiPolygon} */ (geometry).getFlatInteriorPoints();
+          flatCoordinates = /** @type {import("../../geom/MultiPolygon.js").default} */ (geometry).getFlatInteriorPoints();
           end = flatCoordinates.length;
           break;
         default:
@@ -394,7 +394,7 @@ class WebGLTextReplay extends WebGLTextureReplay {
   /**
    * @private
    * @param {Object} state Font attributes.
-   * @return {module:ol/render/webgl/TextReplay~GlyphAtlas} Glyph atlas.
+   * @return {GlyphAtlas} Glyph atlas.
    */
   getAtlas_(state) {
     let params = [];

--- a/src/ol/render/webgl/TextureReplay.js
+++ b/src/ol/render/webgl/TextureReplay.js
@@ -13,7 +13,7 @@ import {createTexture} from '../../webgl/Context.js';
 class WebGLTextureReplay extends WebGLReplay {
   /**
    * @param {number} tolerance Tolerance.
-   * @param {module:ol/extent~Extent} maxExtent Max extent.
+   * @param {import("../../extent.js").Extent} maxExtent Max extent.
    */
   constructor(tolerance, maxExtent) {
     super(tolerance, maxExtent);
@@ -62,7 +62,7 @@ class WebGLTextureReplay extends WebGLReplay {
 
     /**
      * @protected
-     * @type {module:ol/render/webgl/texturereplay/defaultshader/Locations}
+     * @type {import("./texturereplay/defaultshader/Locations.js").default}
      */
     this.defaultLocations = null;
 
@@ -350,7 +350,7 @@ class WebGLTextureReplay extends WebGLReplay {
    *
    * @protected
    * @param {WebGLRenderingContext} gl gl.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *  to skip.
    * @param {Array<WebGLTexture>} textures Textures.

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -13,7 +13,7 @@ import SourceState from '../source/State.js';
 class LayerRenderer extends Observable {
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("../layer/Layer.js").default} layer Layer.
    */
   constructor(layer) {
 
@@ -21,7 +21,7 @@ class LayerRenderer extends Observable {
 
     /**
      * @private
-     * @type {module:ol/layer/Layer}
+     * @type {import("../layer/Layer.js").default}
      */
     this.layer_ = layer;
 
@@ -29,10 +29,10 @@ class LayerRenderer extends Observable {
 
   /**
    * Create a function that adds loaded tiles to the tile lookup.
-   * @param {module:ol/source/Tile} source Tile source.
-   * @param {module:ol/proj/Projection} projection Projection of the tiles.
-   * @param {Object<number, Object<string, module:ol/Tile>>} tiles Lookup of loaded tiles by zoom level.
-   * @return {function(number, module:ol/TileRange):boolean} A function that can be
+   * @param {import("../source/Tile.js").default} source Tile source.
+   * @param {import("../proj/Projection.js").default} projection Projection of the tiles.
+   * @param {Object<number, Object<string, import("../Tile.js").default>>} tiles Lookup of loaded tiles by zoom level.
+   * @return {function(number, import("../TileRange.js").default):boolean} A function that can be
    *     called with a zoom level and a tile range to add loaded tiles to the lookup.
    * @protected
    */
@@ -40,7 +40,7 @@ class LayerRenderer extends Observable {
     return (
       /**
        * @param {number} zoom Zoom level.
-       * @param {module:ol/TileRange} tileRange Tile range.
+       * @param {import("../TileRange.js").default} tileRange Tile range.
        * @return {boolean} The tile range is fully loaded.
        */
       function(zoom, tileRange) {
@@ -56,7 +56,7 @@ class LayerRenderer extends Observable {
   }
 
   /**
-   * @return {module:ol/layer/Layer} Layer.
+   * @return {import("../layer/Layer.js").default} Layer.
    */
   getLayer() {
     return this.layer_;
@@ -64,11 +64,11 @@ class LayerRenderer extends Observable {
 
   /**
    * Handle changes in image state.
-   * @param {module:ol/events/Event} event Image change event.
+   * @param {import("../events/Event.js").default} event Image change event.
    * @private
    */
   handleImageChange_(event) {
-    const image = /** @type {module:ol/Image} */ (event.target);
+    const image = /** @type {import("../Image.js").default} */ (event.target);
     if (image.getState() === ImageState.LOADED) {
       this.renderIfReadyAndVisible();
     }
@@ -77,7 +77,7 @@ class LayerRenderer extends Observable {
   /**
    * Load the image if not already loaded, and register the image change
    * listener if needed.
-   * @param {module:ol/ImageBase} image Image.
+   * @param {import("../ImageBase.js").default} image Image.
    * @return {boolean} `true` if the image is already loaded, `false` otherwise.
    * @protected
    */
@@ -104,16 +104,16 @@ class LayerRenderer extends Observable {
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/source/Tile} tileSource Tile source.
+   * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../source/Tile.js").default} tileSource Tile source.
    * @protected
    */
   scheduleExpireCache(frameState, tileSource) {
     if (tileSource.canExpireCache()) {
       /**
-       * @param {module:ol/source/Tile} tileSource Tile source.
-       * @param {module:ol/PluggableMap} map Map.
-       * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+       * @param {import("../source/Tile.js").default} tileSource Tile source.
+       * @param {import("../PluggableMap.js").default} map Map.
+       * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
        */
       const postRenderFunction = function(tileSource, map, frameState) {
         const tileSourceKey = getUid(tileSource).toString();
@@ -124,16 +124,16 @@ class LayerRenderer extends Observable {
       }.bind(null, tileSource);
 
       frameState.postRenderFunctions.push(
-        /** @type {module:ol/PluggableMap~PostRenderFunction} */ (postRenderFunction)
+        /** @type {import("../PluggableMap.js").PostRenderFunction} */ (postRenderFunction)
       );
     }
   }
 
   /**
-   * @param {!Object<string, !Object<string, module:ol/TileRange>>} usedTiles Used tiles.
-   * @param {module:ol/source/Tile} tileSource Tile source.
+   * @param {!Object<string, !Object<string, import("../TileRange.js").default>>} usedTiles Used tiles.
+   * @param {import("../source/Tile.js").default} tileSource Tile source.
    * @param {number} z Z.
-   * @param {module:ol/TileRange} tileRange Tile range.
+   * @param {import("../TileRange.js").default} tileRange Tile range.
    * @protected
    */
   updateUsedTiles(usedTiles, tileSource, z, tileRange) {
@@ -159,15 +159,15 @@ class LayerRenderer extends Observable {
    * - registers idle tiles in frameState.wantedTiles so that they are not
    *   discarded by the tile queue
    * - enqueues missing tiles
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/source/Tile} tileSource Tile source.
-   * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
+   * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../source/Tile.js").default} tileSource Tile source.
+   * @param {import("../tilegrid/TileGrid.js").default} tileGrid Tile grid.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} currentZ Current Z.
    * @param {number} preload Load low resolution tiles up to 'preload' levels.
-   * @param {function(this: T, module:ol/Tile)=} opt_tileCallback Tile callback.
+   * @param {function(this: T, import("../Tile.js").default)=} opt_tileCallback Tile callback.
    * @param {T=} opt_this Object to use as `this` in `opt_tileCallback`.
    * @protected
    * @template T
@@ -220,10 +220,10 @@ class LayerRenderer extends Observable {
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+ * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+ * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
  * @param {number} hitTolerance Hit tolerance in pixels.
- * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature), module:ol/layer/Layer): T} callback Feature callback.
+ * @param {function(this: S, (import("../Feature.js").default|import("../render/Feature.js").default), import("../layer/Layer.js").default): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|void} Callback result.
  * @template S,T
@@ -232,8 +232,8 @@ LayerRenderer.prototype.forEachFeatureAtCoordinate = VOID;
 
 
 /**
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+ * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+ * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
  * @return {boolean} Is there a feature at the given coordinate?
  */
 LayerRenderer.prototype.hasFeatureAtCoordinate = FALSE;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -15,32 +15,32 @@ import {compose as composeTransform, invert as invertTransform, setFromArray as 
 class MapRenderer extends Disposable {
 
   /**
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../PluggableMap.js").default} map Map.
    */
   constructor(map) {
     super();
 
     /**
      * @private
-     * @type {module:ol/PluggableMap}
+     * @type {import("../PluggableMap.js").default}
      */
     this.map_ = map;
 
     /**
      * @private
-     * @type {!Object<string, module:ol/renderer/Layer>}
+     * @type {!Object<string, import("./Layer.js").default>}
      */
     this.layerRenderers_ = {};
 
     /**
      * @private
-     * @type {Object<string, module:ol/events~EventsKey>}
+     * @type {Object<string, import("../events.js").EventsKey>}
      */
     this.layerRendererListeners_ = {};
 
     /**
      * @private
-     * @type {Array<module:ol/renderer/Layer>}
+     * @type {Array<import("./Layer.js").default>}
      */
     this.layerRendererConstructors_ = [];
 
@@ -48,7 +48,7 @@ class MapRenderer extends Disposable {
 
   /**
    * Register layer renderer constructors.
-   * @param {Array<module:ol/renderer/Layer>} constructors Layer renderers.
+   * @param {Array<import("./Layer.js").default>} constructors Layer renderers.
    */
   registerLayerRenderers(constructors) {
     this.layerRendererConstructors_.push.apply(this.layerRendererConstructors_, constructors);
@@ -56,14 +56,14 @@ class MapRenderer extends Disposable {
 
   /**
    * Get the registered layer renderer constructors.
-   * @return {Array<module:ol/renderer/Layer>} Registered layer renderers.
+   * @return {Array<import("./Layer.js").default>} Registered layer renderers.
    */
   getLayerRendererConstructors() {
     return this.layerRendererConstructors_;
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
+   * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @protected
    */
   calculateMatrices2D(frameState) {
@@ -91,13 +91,13 @@ class MapRenderer extends Disposable {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature),
-   *     module:ol/layer/Layer): T} callback Feature callback.
+   * @param {function(this: S, (import("../Feature.js").default|import("../render/Feature.js").default),
+   *     import("../layer/Layer.js").default): T} callback Feature callback.
    * @param {S} thisArg Value to use as `this` when executing `callback`.
-   * @param {function(this: U, module:ol/layer/Layer): boolean} layerFilter Layer filter
+   * @param {function(this: U, import("../layer/Layer.js").default): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function
    *     returns `true` will be tested for features.  By default, all visible
    *     layers will be tested.
@@ -119,8 +119,8 @@ class MapRenderer extends Disposable {
     const viewResolution = viewState.resolution;
 
     /**
-     * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
-     * @param {module:ol/layer/Layer} layer Layer.
+     * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
+     * @param {import("../layer/Layer.js").default} layer Layer.
      * @return {?} Callback result.
      */
     function forEachFeatureAtCoordinate(feature, layer) {
@@ -167,13 +167,13 @@ class MapRenderer extends Disposable {
 
   /**
    * @abstract
-   * @param {module:ol/pixel~Pixel} pixel Pixel.
-   * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
+   * @param {import("../pixel.js").Pixel} pixel Pixel.
+   * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(this: S, import("../layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.
    * @param {S} thisArg Value to use as `this` when executing `callback`.
-   * @param {function(this: U, module:ol/layer/Layer): boolean} layerFilter Layer filter
+   * @param {function(this: U, import("../layer/Layer.js").default): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function
    *     returns `true` will be tested for features.  By default, all visible
    *     layers will be tested.
@@ -184,10 +184,10 @@ class MapRenderer extends Disposable {
   forEachLayerAtPixel(pixel, frameState, hitTolerance, callback, thisArg, layerFilter, thisArg2) {}
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(this: U, module:ol/layer/Layer): boolean} layerFilter Layer filter
+   * @param {function(this: U, import("../layer/Layer.js").default): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function
    *     returns `true` will be tested for features.  By default, all visible
    *     layers will be tested.
@@ -203,9 +203,9 @@ class MapRenderer extends Disposable {
   }
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("../layer/Layer.js").default} layer Layer.
    * @protected
-   * @return {module:ol/renderer/Layer} Layer renderer.
+   * @return {import("./Layer.js").default} Layer renderer.
    */
   getLayerRenderer(layer) {
     const layerKey = getUid(layer).toString();
@@ -234,7 +234,7 @@ class MapRenderer extends Disposable {
   /**
    * @param {string} layerKey Layer key.
    * @protected
-   * @return {module:ol/renderer/Layer} Layer renderer.
+   * @return {import("./Layer.js").default} Layer renderer.
    */
   getLayerRendererByKey(layerKey) {
     return this.layerRenderers_[layerKey];
@@ -242,14 +242,14 @@ class MapRenderer extends Disposable {
 
   /**
    * @protected
-   * @return {Object<string, module:ol/renderer/Layer>} Layer renderers.
+   * @return {Object<string, import("./Layer.js").default>} Layer renderers.
    */
   getLayerRenderers() {
     return this.layerRenderers_;
   }
 
   /**
-   * @return {module:ol/PluggableMap} Map.
+   * @return {import("../PluggableMap.js").default} Map.
    */
   getMap() {
     return this.map_;
@@ -265,7 +265,7 @@ class MapRenderer extends Disposable {
 
   /**
    * @param {string} layerKey Layer key.
-   * @return {module:ol/renderer/Layer} Layer renderer.
+   * @return {import("./Layer.js").default} Layer renderer.
    * @private
    */
   removeLayerRendererByKey_(layerKey) {
@@ -279,8 +279,8 @@ class MapRenderer extends Disposable {
   }
 
   /**
-   * @param {module:ol/PluggableMap} map Map.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../PluggableMap.js").default} map Map.
+   * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
    * @private
    */
   removeUnusedLayerRenderers_(map, frameState) {
@@ -292,22 +292,22 @@ class MapRenderer extends Disposable {
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
    * @protected
    */
   scheduleExpireIconCache(frameState) {
-    frameState.postRenderFunctions.push(/** @type {module:ol/PluggableMap~PostRenderFunction} */ (expireIconCache));
+    frameState.postRenderFunctions.push(/** @type {import("../PluggableMap.js").PostRenderFunction} */ (expireIconCache));
   }
 
   /**
-   * @param {!module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {!import("../PluggableMap.js").FrameState} frameState Frame state.
    * @protected
    */
   scheduleRemoveUnusedLayerRenderers(frameState) {
     for (const layerKey in this.layerRenderers_) {
       if (!(layerKey in frameState.layerStates)) {
         frameState.postRenderFunctions.push(
-          /** @type {module:ol/PluggableMap~PostRenderFunction} */ (this.removeUnusedLayerRenderers_.bind(this))
+          /** @type {import("../PluggableMap.js").PostRenderFunction} */ (this.removeUnusedLayerRenderers_.bind(this))
         );
         return;
       }
@@ -317,8 +317,8 @@ class MapRenderer extends Disposable {
 
 
 /**
- * @param {module:ol/PluggableMap} map Map.
- * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+ * @param {import("../PluggableMap.js").default} map Map.
+ * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
  */
 function expireIconCache(map, frameState) {
   iconImageCache.expire();
@@ -327,21 +327,21 @@ function expireIconCache(map, frameState) {
 
 /**
  * Render.
- * @param {?module:ol/PluggableMap~FrameState} frameState Frame state.
+ * @param {?import("../PluggableMap.js").FrameState} frameState Frame state.
  */
 MapRenderer.prototype.renderFrame = VOID;
 
 
 /**
- * @param {module:ol/render/EventType} type Event type.
- * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+ * @param {import("../render/EventType.js").default} type Event type.
+ * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
  */
 MapRenderer.prototype.dispatchRenderEvent = VOID;
 
 
 /**
- * @param {module:ol/layer/Layer~State} state1 First layer state.
- * @param {module:ol/layer/Layer~State} state2 Second layer state.
+ * @param {import("../layer/Layer.js").State} state1 First layer state.
+ * @param {import("../layer/Layer.js").State} state2 Second layer state.
  * @return {number} The zIndex difference.
  */
 export function sortByZIndex(state1, state2) {

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -21,7 +21,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
 
   /**
-   * @param {module:ol/layer/Image|module:ol/layer/Vector} imageLayer Image or vector layer.
+   * @param {import("../../layer/Image.js").default|import("../../layer/Vector.js").default} imageLayer Image or vector layer.
    */
   constructor(imageLayer) {
 
@@ -29,13 +29,13 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
 
     /**
      * @private
-     * @type {?module:ol/ImageBase}
+     * @type {?import("../../ImageBase.js").default}
      */
     this.image_ = null;
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.imageTransform_ = createTransform();
 
@@ -46,7 +46,7 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
 
     /**
      * @private
-     * @type {module:ol/renderer/canvas/VectorLayer}
+     * @type {import("./VectorLayer.js").default}
      */
     this.vectorRenderer_ = null;
 
@@ -98,7 +98,7 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
     const viewResolution = viewState.resolution;
 
     let image;
-    const imageLayer = /** @type {module:ol/layer/Image} */ (this.getLayer());
+    const imageLayer = /** @type {import("../../layer/Image.js").default} */ (this.getLayer());
     const imageSource = imageLayer.getSource();
 
     const hints = frameState.viewHints;
@@ -121,12 +121,12 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
       let skippedFeatures = this.skippedFeatures_;
       if (vectorRenderer) {
         const context = vectorRenderer.context;
-        const imageFrameState = /** @type {module:ol/PluggableMap~FrameState} */ (assign({}, frameState, {
+        const imageFrameState = /** @type {import("../../PluggableMap.js").FrameState} */ (assign({}, frameState, {
           size: [
             getWidth(renderedExtent) / viewResolution,
             getHeight(renderedExtent) / viewResolution
           ],
-          viewState: /** @type {module:ol/View~State} */ (assign({}, frameState.viewState, {
+          viewState: /** @type {import("../../View.js").State} */ (assign({}, frameState.viewState, {
             rotation: 0
           }))
         }));
@@ -192,24 +192,24 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasImageLayerRenderer['handles'] = function(layer) {
   return layer.getType() === LayerType.IMAGE ||
     layer.getType() === LayerType.VECTOR &&
-    /** @type {module:ol/layer/Vector} */ (layer).getRenderMode() === VectorRenderType.IMAGE;
+    /** @type {import("../../layer/Vector.js").default} */ (layer).getRenderMode() === VectorRenderType.IMAGE;
 };
 
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/canvas/ImageLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./ImageLayer.js").default} The layer renderer.
  */
 CanvasImageLayerRenderer['create'] = function(mapRenderer, layer) {
-  return new CanvasImageLayerRenderer(/** @type {module:ol/layer/Image} */ (layer));
+  return new CanvasImageLayerRenderer(/** @type {import("../../layer/Image.js").default} */ (layer));
 };
 
 

--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -11,7 +11,7 @@ import {create as createTransform, apply as applyTransform} from '../../transfor
 class IntermediateCanvasRenderer extends CanvasLayerRenderer {
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("../../layer/Layer.js").default} layer Layer.
    */
   constructor(layer) {
 
@@ -19,7 +19,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
 
     /**
      * @protected
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.coordinateToCanvasPixelTransform = createTransform();
 
@@ -47,7 +47,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
           !containsExtent(extent, frameState.extent) &&
           intersects(extent, frameState.extent);
       if (clipped) {
-        this.clip(context, frameState, /** @type {module:ol/extent~Extent} */ (extent));
+        this.clip(context, frameState, /** @type {import("../../extent.js").Extent} */ (extent));
       }
 
       const imageTransform = this.getImageTransform();
@@ -83,7 +83,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
 
   /**
    * @abstract
-   * @return {!module:ol/transform~Transform} Image transform.
+   * @return {!import("../../transform.js").Transform} Image transform.
    */
   getImageTransform() {}
 
@@ -99,7 +99,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
     return source.forEachFeatureAtCoordinate(
       coordinate, resolution, rotation, hitTolerance, skippedFeatureUids,
       /**
-       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+       * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
        * @return {?} Callback result.
        */
       function(feature) {

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -13,7 +13,7 @@ import {create as createTransform, apply as applyTransform, compose as composeTr
 class CanvasLayerRenderer extends LayerRenderer {
 
   /**
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("../../layer/Layer.js").default} layer Layer.
    */
   constructor(layer) {
 
@@ -27,7 +27,7 @@ class CanvasLayerRenderer extends LayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.transform_ = createTransform();
 
@@ -35,8 +35,8 @@ class CanvasLayerRenderer extends LayerRenderer {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/extent~Extent} extent Clip extent.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../extent.js").Extent} extent Clip extent.
    * @protected
    */
   clip(context, frameState, extent) {
@@ -44,10 +44,10 @@ class CanvasLayerRenderer extends LayerRenderer {
     const width = frameState.size[0] * pixelRatio;
     const height = frameState.size[1] * pixelRatio;
     const rotation = frameState.viewState.rotation;
-    const topLeft = getTopLeft(/** @type {module:ol/extent~Extent} */ (extent));
-    const topRight = getTopRight(/** @type {module:ol/extent~Extent} */ (extent));
-    const bottomRight = getBottomRight(/** @type {module:ol/extent~Extent} */ (extent));
-    const bottomLeft = getBottomLeft(/** @type {module:ol/extent~Extent} */ (extent));
+    const topLeft = getTopLeft(/** @type {import("../../extent.js").Extent} */ (extent));
+    const topRight = getTopRight(/** @type {import("../../extent.js").Extent} */ (extent));
+    const bottomRight = getBottomRight(/** @type {import("../../extent.js").Extent} */ (extent));
+    const bottomLeft = getBottomLeft(/** @type {import("../../extent.js").Extent} */ (extent));
 
     applyTransform(frameState.coordinateToPixelTransform, topLeft);
     applyTransform(frameState.coordinateToPixelTransform, topRight);
@@ -66,10 +66,10 @@ class CanvasLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @param {module:ol/render/EventType} type Event type.
+   * @param {import("../../render/EventType.js").default} type Event type.
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/transform~Transform=} opt_transform Transform.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../transform.js").Transform=} opt_transform Transform.
    * @private
    */
   dispatchComposeEvent_(type, context, frameState, opt_transform) {
@@ -92,10 +92,10 @@ class CanvasLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
+   * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("../../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(this: S, import("../../layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.
    * @param {S} thisArg Value to use as `this` when executing `callback`.
    * @return {T|undefined} Callback result.
@@ -113,9 +113,9 @@ class CanvasLayerRenderer extends LayerRenderer {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
-   * @param {module:ol/transform~Transform=} opt_transform Transform.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
+   * @param {import("../../transform.js").Transform=} opt_transform Transform.
    * @protected
    */
   postCompose(context, frameState, layerState, opt_transform) {
@@ -124,8 +124,8 @@ class CanvasLayerRenderer extends LayerRenderer {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/transform~Transform=} opt_transform Transform.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../transform.js").Transform=} opt_transform Transform.
    * @protected
    */
   preCompose(context, frameState, opt_transform) {
@@ -134,8 +134,8 @@ class CanvasLayerRenderer extends LayerRenderer {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/transform~Transform=} opt_transform Transform.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../transform.js").Transform=} opt_transform Transform.
    * @protected
    */
   dispatchRenderEvent(context, frameState, opt_transform) {
@@ -143,10 +143,10 @@ class CanvasLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} offsetX Offset on the x-axis in view coordinates.
    * @protected
-   * @return {!module:ol/transform~Transform} Transform.
+   * @return {!import("../../transform.js").Transform} Transform.
    */
   getTransform(frameState, offsetX) {
     const viewState = frameState.viewState;
@@ -163,16 +163,16 @@ class CanvasLayerRenderer extends LayerRenderer {
 
   /**
    * @abstract
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
    * @param {CanvasRenderingContext2D} context Context.
    */
   composeFrame(frameState, layerState, context) {}
 
   /**
    * @abstract
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
    * @return {boolean} whether composeFrame should be called.
    */
   prepareFrame(frameState, layerState) {}

--- a/src/ol/renderer/canvas/Map.js
+++ b/src/ol/renderer/canvas/Map.js
@@ -15,7 +15,7 @@ import SourceState from '../../source/State.js';
 
 
 /**
- * @type {Array<module:ol/renderer/Layer>}
+ * @type {Array<import("../Layer.js").default>}
  */
 export const layerRendererConstructors = [];
 
@@ -27,7 +27,7 @@ export const layerRendererConstructors = [];
 class CanvasMapRenderer extends MapRenderer {
 
   /**
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../../PluggableMap.js").default} map Map.
    */
   constructor(map) {
     super(map);
@@ -60,15 +60,15 @@ class CanvasMapRenderer extends MapRenderer {
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.transform_ = createTransform();
 
   }
 
   /**
-   * @param {module:ol/render/EventType} type Event type.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../render/EventType.js").default} type Event type.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    */
   dispatchRenderEvent(type, frameState) {
     const map = this.getMap();
@@ -90,9 +90,9 @@ class CanvasMapRenderer extends MapRenderer {
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @protected
-   * @return {!module:ol/transform~Transform} Transform.
+   * @return {!import("../../transform.js").Transform} Transform.
    */
   getTransform(frameState) {
     const viewState = frameState.viewState;
@@ -149,7 +149,7 @@ class CanvasMapRenderer extends MapRenderer {
     for (i = 0, ii = layerStatesArray.length; i < ii; ++i) {
       layerState = layerStatesArray[i];
       layer = layerState.layer;
-      layerRenderer = /** @type {module:ol/renderer/canvas/Layer} */ (this.getLayerRenderer(layer));
+      layerRenderer = /** @type {import("./Layer.js").default} */ (this.getLayerRenderer(layer));
       if (!visibleAtResolution(layerState, viewResolution) ||
           layerState.sourceState != SourceState.READY) {
         continue;
@@ -193,7 +193,7 @@ class CanvasMapRenderer extends MapRenderer {
       const layerState = layerStates[i];
       const layer = layerState.layer;
       if (visibleAtResolution(layerState, viewResolution) && layerFilter.call(thisArg2, layer)) {
-        const layerRenderer = /** @type {module:ol/renderer/canvas/Layer} */ (this.getLayerRenderer(layer));
+        const layerRenderer = /** @type {import("./Layer.js").default} */ (this.getLayerRenderer(layer));
         result = layerRenderer.forEachLayerAtCoordinate(
           coordinate, frameState, hitTolerance, callback, thisArg);
         if (result) {

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -19,7 +19,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
   /**
-   * @param {module:ol/layer/Tile|module:ol/layer/VectorTile} tileLayer Tile layer.
+   * @param {import("../../layer/Tile.js").default|import("../../layer/VectorTile.js").default} tileLayer Tile layer.
    * @param {boolean=} opt_noContext Skip the context creation.
    */
   constructor(tileLayer, opt_noContext) {
@@ -40,7 +40,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.renderedExtent_ = null;
 
@@ -52,7 +52,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
     /**
      * @protected
-     * @type {!Array<module:ol/Tile>}
+     * @type {!Array<import("../../Tile.js").default>}
      */
     this.renderedTiles = [];
 
@@ -64,19 +64,19 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
     /**
      * @protected
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.tmpExtent = createEmpty();
 
     /**
      * @private
-     * @type {module:ol/TileRange}
+     * @type {import("../../TileRange.js").default}
      */
     this.tmpTileRange_ = new TileRange(0, 0, 0, 0);
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.imageTransform_ = createTransform();
 
@@ -90,7 +90,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
   /**
    * @private
-   * @param {module:ol/Tile} tile Tile.
+   * @param {import("../../Tile.js").default} tile Tile.
    * @return {boolean} Tile is drawable.
    */
   isDrawableTile_(tile) {
@@ -106,12 +106,12 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {!module:ol/Tile} Tile.
+   * @param {import("../../proj/Projection.js").default} projection Projection.
+   * @return {!import("../../Tile.js").default} Tile.
    */
   getTile(z, x, y, pixelRatio, projection) {
     const layer = this.getLayer();
-    const source = /** @type {module:ol/source/Tile} */ (layer.getSource());
+    const source = /** @type {import("../../source/Tile.js").default} */ (layer.getSource());
     let tile = source.getTile(z, x, y, pixelRatio, projection);
     if (tile.getState() == TileState.ERROR) {
       if (!layer.getUseInterimTilesOnError()) {
@@ -141,7 +141,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
     const viewCenter = viewState.center;
 
     const tileLayer = this.getLayer();
-    const tileSource = /** @type {module:ol/source/Tile} */ (tileLayer.getSource());
+    const tileSource = /** @type {import("../../source/Tile.js").default} */ (tileLayer.getSource());
     const sourceRevision = tileSource.getRevision();
     const tileGrid = tileSource.getTileGridForProjection(projection);
     const z = tileGrid.getZForResolution(viewResolution, this.zDirection);
@@ -163,7 +163,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
     const tilePixelRatio = tileSource.getTilePixelRatio(pixelRatio);
 
     /**
-     * @type {Object<number, Object<string, module:ol/Tile>>}
+     * @type {Object<number, Object<string, import("../../Tile.js").default>>}
      */
     const tilesToDrawByZ = {};
     tilesToDrawByZ[z] = {};
@@ -301,9 +301,9 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
   }
 
   /**
-   * @param {module:ol/Tile} tile Tile.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
+   * @param {import("../../Tile.js").default} tile Tile.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
    * @param {number} x Left of the tile.
    * @param {number} y Top of the tile.
    * @param {number} w Width of the tile.
@@ -358,7 +358,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasTileLayerRenderer['handles'] = function(layer) {
@@ -368,18 +368,18 @@ CanvasTileLayerRenderer['handles'] = function(layer) {
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/canvas/TileLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./TileLayer.js").default} The layer renderer.
  */
 CanvasTileLayerRenderer['create'] = function(mapRenderer, layer) {
-  return new CanvasTileLayerRenderer(/** @type {module:ol/layer/Tile} */ (layer));
+  return new CanvasTileLayerRenderer(/** @type {import("../../layer/Tile.js").default} */ (layer));
 };
 
 
 /**
  * @function
- * @return {module:ol/layer/Tile|module:ol/layer/VectorTile}
+ * @return {import("../../layer/Tile.js").default|import("../../layer/VectorTile.js").default}
  */
 CanvasTileLayerRenderer.prototype.getLayer;
 

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -23,7 +23,7 @@ import {defaultOrder as defaultRenderOrder, getTolerance as getRenderTolerance, 
 class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
   /**
-   * @param {module:ol/layer/Vector} vectorLayer Vector layer.
+   * @param {import("../../layer/Vector.js").default} vectorLayer Vector layer.
    */
   constructor(vectorLayer) {
 
@@ -55,19 +55,19 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.renderedExtent_ = createEmpty();
 
     /**
      * @private
-     * @type {function(module:ol/Feature, module:ol/Feature): number|null}
+     * @type {function(import("../../Feature.js").default, import("../../Feature.js").default): number|null}
      */
     this.renderedRenderOrder_ = null;
 
     /**
      * @private
-     * @type {module:ol/render/canvas/ReplayGroup}
+     * @type {import("../../render/canvas/ReplayGroup.js").default}
      */
     this.replayGroup_ = null;
 
@@ -96,8 +96,8 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
   /**
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
    */
   compose(context, frameState, layerState) {
     const extent = frameState.extent;
@@ -108,7 +108,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const projection = viewState.projection;
     const rotation = viewState.rotation;
     const projectionExtent = projection.getExtent();
-    const vectorSource = /** @type {module:ol/source/Vector} */ (this.getLayer().getSource());
+    const vectorSource = /** @type {import("../../source/Vector.js").default} */ (this.getLayer().getSource());
 
     let transform = this.getTransform(frameState, 0);
 
@@ -116,14 +116,14 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const clipExtent = layerState.extent;
     const clipped = clipExtent !== undefined;
     if (clipped) {
-      this.clip(context, frameState, /** @type {module:ol/extent~Extent} */ (clipExtent));
+      this.clip(context, frameState, /** @type {import("../../extent.js").Extent} */ (clipExtent));
     }
     const replayGroup = this.replayGroup_;
     if (replayGroup && !replayGroup.isEmpty()) {
       if (this.declutterTree_) {
         this.declutterTree_.clear();
       }
-      const layer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
+      const layer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
       let drawOffsetX = 0;
       let drawOffsetY = 0;
       let replayContext;
@@ -235,12 +235,12 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     } else {
       const resolution = frameState.viewState.resolution;
       const rotation = frameState.viewState.rotation;
-      const layer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
+      const layer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
       /** @type {!Object<string, boolean>} */
       const features = {};
       const result = this.replayGroup_.forEachFeatureAtCoordinate(coordinate, resolution, rotation, hitTolerance, {},
         /**
-         * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+         * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
          * @return {?} Callback result.
          */
         function(feature) {
@@ -255,7 +255,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
   }
 
   /**
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../../events/Event.js").default} event Event.
    */
   handleFontsChanged_(event) {
     const layer = this.getLayer();
@@ -266,7 +266,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
   /**
    * Handle changes in image style state.
-   * @param {module:ol/events/Event} event Image style change event.
+   * @param {import("../../events/Event.js").default} event Image style change event.
    * @private
    */
   handleStyleImageChange_(event) {
@@ -277,7 +277,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @inheritDoc
    */
   prepareFrame(frameState, layerState) {
-    const vectorLayer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
+    const vectorLayer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
     const vectorSource = vectorLayer.getSource();
 
     const animating = frameState.viewHints[ViewHint.ANIMATING];
@@ -338,8 +338,8 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       pixelRatio, vectorSource.getOverlaps(), this.declutterTree_, vectorLayer.getRenderBuffer());
     vectorSource.loadFeatures(extent, resolution, projection);
     /**
-     * @param {module:ol/Feature} feature Feature.
-     * @this {module:ol/renderer/canvas/VectorLayer}
+     * @param {import("../../Feature.js").default} feature Feature.
+     * @this {import("./VectorLayer.js").default}
      */
     const render = function(feature) {
       let styles;
@@ -354,11 +354,11 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       }
     }.bind(this);
     if (vectorLayerRenderOrder) {
-      /** @type {Array<module:ol/Feature>} */
+      /** @type {Array<import("../../Feature.js").default>} */
       const features = [];
       vectorSource.forEachFeatureInExtent(extent,
         /**
-         * @param {module:ol/Feature} feature Feature.
+         * @param {import("../../Feature.js").default} feature Feature.
          */
         function(feature) {
           features.push(feature);
@@ -383,11 +383,11 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../../Feature.js").default} feature Feature.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/style/Style|Array<module:ol/style/Style>} styles The style or array of styles.
-   * @param {module:ol/render/canvas/ReplayGroup} replayGroup Replay group.
+   * @param {import("../../style/Style.js").default|Array<import("../../style/Style.js").default>} styles The style or array of styles.
+   * @param {import("../../render/canvas/ReplayGroup.js").default} replayGroup Replay group.
    * @return {boolean} `true` if an image is loading.
    */
   renderFeature(feature, resolution, pixelRatio, styles, replayGroup) {
@@ -415,7 +415,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasVectorLayerRenderer['handles'] = function(layer) {
@@ -425,12 +425,12 @@ CanvasVectorLayerRenderer['handles'] = function(layer) {
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/canvas/VectorLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./VectorLayer.js").default} The layer renderer.
  */
 CanvasVectorLayerRenderer['create'] = function(mapRenderer, layer) {
-  return new CanvasVectorLayerRenderer(/** @type {module:ol/layer/Vector} */ (layer));
+  return new CanvasVectorLayerRenderer(/** @type {import("../../layer/Vector.js").default} */ (layer));
 };
 
 

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -29,7 +29,7 @@ import {
 
 
 /**
- * @type {!Object<string, Array<module:ol/render/ReplayType>>}
+ * @type {!Object<string, Array<import("../../render/ReplayType.js").default>>}
  */
 const IMAGE_REPLAYS = {
   'image': [ReplayType.POLYGON, ReplayType.CIRCLE,
@@ -39,7 +39,7 @@ const IMAGE_REPLAYS = {
 
 
 /**
- * @type {!Object<string, Array<module:ol/render/ReplayType>>}
+ * @type {!Object<string, Array<import("../../render/ReplayType.js").default>>}
  */
 const VECTOR_REPLAYS = {
   'image': [ReplayType.DEFAULT],
@@ -56,7 +56,7 @@ const VECTOR_REPLAYS = {
 class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
   /**
-   * @param {module:ol/layer/VectorTile} layer VectorTile layer.
+   * @param {import("../../layer/VectorTile.js").default} layer VectorTile layer.
    */
   constructor(layer) {
 
@@ -82,7 +82,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.tmpTransform_ = createTransform();
 
@@ -136,15 +136,15 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {module:ol/VectorImageTile} tile Tile.
+   * @param {import("../../VectorImageTile.js").default} tile Tile.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../../proj/Projection.js").default} projection Projection.
    * @private
    */
   createReplayGroup_(tile, pixelRatio, projection) {
     const layer = this.getLayer();
     const revision = layer.getRevision();
-    const renderOrder = /** @type {module:ol/render~OrderFunction} */ (layer.getRenderOrder()) || null;
+    const renderOrder = /** @type {import("../../render.js").OrderFunction} */ (layer.getRenderOrder()) || null;
 
     const replayState = tile.getReplayState(layer);
     if (!replayState.dirty && replayState.renderedRevision == revision &&
@@ -152,7 +152,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       return;
     }
 
-    const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
+    const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
     const sourceTileGrid = source.getTileGrid();
     const tileGrid = source.getTileGridForProjection(projection);
     const resolution = tileGrid.getResolution(tile.tileCoord[0]);
@@ -182,8 +182,8 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
 
       /**
-       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
-       * @this {module:ol/renderer/canvas/VectorTileLayer}
+       * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
+       * @this {import("./VectorTileLayer.js").default}
        */
       const render = function(feature) {
         let styles;
@@ -238,7 +238,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     /** @type {!Object<string, boolean>} */
     const features = {};
 
-    /** @type {Array<module:ol/VectorImageTile>} */
+    /** @type {Array<import("../../VectorImageTile.js").default>} */
     const renderedTiles = this.renderedTiles;
 
     let bufferedExtent, found;
@@ -257,7 +257,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
         replayGroup = sourceTile.getReplayGroup(layer, tile.tileCoord.toString());
         found = found || replayGroup.forEachFeatureAtCoordinate(coordinate, resolution, rotation, hitTolerance, {},
           /**
-           * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+           * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
            * @return {?} Callback result.
            */
           function(feature) {
@@ -273,14 +273,14 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {module:ol/VectorTile} tile Tile.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @return {module:ol/transform~Transform} transform Transform.
+   * @param {import("../../VectorTile.js").default} tile Tile.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @return {import("../../transform.js").Transform} transform Transform.
    * @private
    */
   getReplayTransform_(tile, frameState) {
     const layer = this.getLayer();
-    const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
+    const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
     const tileGrid = source.getTileGrid();
     const tileCoord = tile.tileCoord;
     const tileResolution = tileGrid.getResolution(tileCoord[0]);
@@ -302,7 +302,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../../events/Event.js").default} event Event.
    */
   handleFontsChanged_(event) {
     const layer = this.getLayer();
@@ -313,7 +313,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
   /**
    * Handle changes in image style state.
-   * @param {module:ol/events/Event} event Image style change event.
+   * @param {import("../../events/Event.js").default} event Image style change event.
    * @private
    */
   handleStyleImageChange_(event) {
@@ -328,7 +328,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const renderMode = layer.getRenderMode();
     if (renderMode != VectorTileRenderType.IMAGE) {
       const declutterReplays = layer.getDeclutter() ? {} : null;
-      const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
+      const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
       const replayTypes = VECTOR_REPLAYS[renderMode];
       const pixelRatio = frameState.pixelRatio;
       const rotation = frameState.viewState.rotation;
@@ -349,7 +349,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       const clips = [];
       const zs = [];
       for (let i = tiles.length - 1; i >= 0; --i) {
-        const tile = /** @type {module:ol/VectorImageTile} */ (tiles[i]);
+        const tile = /** @type {import("../../VectorImageTile.js").default} */ (tiles[i]);
         if (tile.getState() == TileState.ABORT) {
           continue;
         }
@@ -411,10 +411,10 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+   * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
    * @param {number} squaredTolerance Squared tolerance.
-   * @param {module:ol/style/Style|Array<module:ol/style/Style>} styles The style or array of styles.
-   * @param {module:ol/render/canvas/ReplayGroup} replayGroup Replay group.
+   * @param {import("../../style/Style.js").default|Array<import("../../style/Style.js").default>} styles The style or array of styles.
+   * @param {import("../../render/canvas/ReplayGroup.js").default} replayGroup Replay group.
    * @return {boolean} `true` if an image is loading.
    */
   renderFeature(feature, squaredTolerance, styles, replayGroup) {
@@ -437,9 +437,9 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {module:ol/VectorImageTile} tile Tile.
+   * @param {import("../../VectorImageTile.js").default} tile Tile.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../../proj/Projection.js").default} projection Projection.
    * @private
    */
   renderTileImage_(tile, pixelRatio, projection) {
@@ -451,7 +451,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       replayState.renderedTileRevision = revision;
       const tileCoord = tile.wrappedTileCoord;
       const z = tileCoord[0];
-      const source = /** @type {module:ol/source/VectorTile} */ (layer.getSource());
+      const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
       const tileGrid = source.getTileGridForProjection(projection);
       const resolution = tileGrid.getResolution(z);
       const context = tile.getContext(layer);
@@ -478,7 +478,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 CanvasVectorTileLayerRenderer['handles'] = function(layer) {
@@ -488,12 +488,12 @@ CanvasVectorTileLayerRenderer['handles'] = function(layer) {
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/canvas/VectorTileLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./VectorTileLayer.js").default} The layer renderer.
  */
 CanvasVectorTileLayerRenderer['create'] = function(mapRenderer, layer) {
-  return new CanvasVectorTileLayerRenderer(/** @type {module:ol/layer/VectorTile} */ (layer));
+  return new CanvasVectorTileLayerRenderer(/** @type {import("../../layer/VectorTile.js").default} */ (layer));
 };
 
 

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -16,9 +16,9 @@ const SIMPLIFY_TOLERANCE = 0.5;
 
 /**
  * @const
- * @type {Object<module:ol/geom/GeometryType,
- *                function(module:ol/render/ReplayGroup, module:ol/geom/Geometry,
- *                         module:ol/style/Style, Object)>}
+ * @type {Object<import("../geom/GeometryType.js").default,
+ *                function(import("../render/ReplayGroup.js").default, import("../geom/Geometry.js").default,
+ *                         import("../style/Style.js").default, Object)>}
  */
 const GEOMETRY_RENDERERS = {
   'Point': renderPointGeometry,
@@ -33,8 +33,8 @@ const GEOMETRY_RENDERERS = {
 
 
 /**
- * @param {module:ol/Feature|module:ol/render/Feature} feature1 Feature 1.
- * @param {module:ol/Feature|module:ol/render/Feature} feature2 Feature 2.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature1 Feature 1.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature2 Feature 2.
  * @return {number} Order.
  */
 export function defaultOrder(feature1, feature2) {
@@ -64,10 +64,10 @@ export function getTolerance(resolution, pixelRatio) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Circle} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/Circle.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default} feature Feature.
  */
 function renderCircleGeometry(replayGroup, geometry, style, feature) {
   const fillStyle = style.getFill();
@@ -87,11 +87,11 @@ function renderCircleGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
- * @param {module:ol/style/Style} style Style.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
+ * @param {import("../style/Style.js").default} style Style.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {function(this: T, module:ol/events/Event)} listener Listener function.
+ * @param {function(this: T, import("../events/Event.js").default)} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {boolean} `true` if style is loading.
  * @template T
@@ -119,9 +119,9 @@ export function renderFeature(replayGroup, feature, style, squaredTolerance, lis
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
- * @param {module:ol/style/Style} style Style.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
+ * @param {import("../style/Style.js").default} style Style.
  * @param {number} squaredTolerance Squared tolerance.
  */
 function renderFeatureInternal(replayGroup, feature, style, squaredTolerance) {
@@ -141,29 +141,29 @@ function renderFeatureInternal(replayGroup, feature, style, squaredTolerance) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  */
 function renderGeometry(replayGroup, geometry, style, feature) {
   if (geometry.getType() == GeometryType.GEOMETRY_COLLECTION) {
-    const geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
+    const geometries = /** @type {import("../geom/GeometryCollection.js").default} */ (geometry).getGeometries();
     for (let i = 0, ii = geometries.length; i < ii; ++i) {
       renderGeometry(replayGroup, geometries[i], style, feature);
     }
     return;
   }
   const replay = replayGroup.getReplay(style.getZIndex(), ReplayType.DEFAULT);
-  replay.drawCustom(/** @type {module:ol/geom/SimpleGeometry} */ (geometry), feature, style.getRenderer());
+  replay.drawCustom(/** @type {import("../geom/SimpleGeometry.js").default} */ (geometry), feature, style.getRenderer());
 }
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/GeometryCollection} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/GeometryCollection.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default} feature Feature.
  */
 function renderGeometryCollectionGeometry(replayGroup, geometry, style, feature) {
   const geometries = geometry.getGeometriesArray();
@@ -177,10 +177,10 @@ function renderGeometryCollectionGeometry(replayGroup, geometry, style, feature)
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/LineString|module:ol/render/Feature} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/LineString.js").default|import("../render/Feature.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  */
 function renderLineStringGeometry(replayGroup, geometry, style, feature) {
   const strokeStyle = style.getStroke();
@@ -199,10 +199,10 @@ function renderLineStringGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/MultiLineString|module:ol/render/Feature} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/MultiLineString.js").default|import("../render/Feature.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  */
 function renderMultiLineStringGeometry(replayGroup, geometry, style, feature) {
   const strokeStyle = style.getStroke();
@@ -221,10 +221,10 @@ function renderMultiLineStringGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/MultiPolygon} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default} feature Feature.
  */
 function renderMultiPolygonGeometry(replayGroup, geometry, style, feature) {
   const fillStyle = style.getFill();
@@ -244,10 +244,10 @@ function renderMultiPolygonGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Point|module:ol/render/Feature} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/Point.js").default|import("../render/Feature.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  */
 function renderPointGeometry(replayGroup, geometry, style, feature) {
   const imageStyle = style.getImage();
@@ -269,10 +269,10 @@ function renderPointGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/MultiPoint|module:ol/render/Feature} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/MultiPoint.js").default|import("../render/Feature.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  */
 function renderMultiPointGeometry(replayGroup, geometry, style, feature) {
   const imageStyle = style.getImage();
@@ -294,10 +294,10 @@ function renderMultiPointGeometry(replayGroup, geometry, style, feature) {
 
 
 /**
- * @param {module:ol/render/ReplayGroup} replayGroup Replay group.
- * @param {module:ol/geom/Polygon|module:ol/render/Feature} geometry Geometry.
- * @param {module:ol/style/Style} style Style.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
+ * @param {import("../geom/Polygon.js").default|import("../render/Feature.js").default} geometry Geometry.
+ * @param {import("../style/Style.js").default} style Style.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  */
 function renderPolygonGeometry(replayGroup, geometry, style, feature) {
   const fillStyle = style.getFill();

--- a/src/ol/renderer/webgl/ImageLayer.js
+++ b/src/ol/renderer/webgl/ImageLayer.js
@@ -29,8 +29,8 @@ import {createTexture} from '../../webgl/Context.js';
 class WebGLImageLayerRenderer extends WebGLLayerRenderer {
 
   /**
-   * @param {module:ol/renderer/webgl/Map} mapRenderer Map renderer.
-   * @param {module:ol/layer/Image} imageLayer Tile layer.
+   * @param {import("./Map.js").default} mapRenderer Map renderer.
+   * @param {import("../../layer/Image.js").default} imageLayer Tile layer.
    */
   constructor(mapRenderer, imageLayer) {
 
@@ -39,7 +39,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
     /**
      * The last rendered image.
      * @private
-     * @type {?module:ol/ImageBase}
+     * @type {?import("../../ImageBase.js").default}
      */
     this.image_ = null;
 
@@ -51,14 +51,14 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
 
     /**
      * @private
-     * @type {?module:ol/transform~Transform}
+     * @type {?import("../../transform.js").Transform}
      */
     this.hitTransformationMatrix_ = null;
 
   }
 
   /**
-   * @param {module:ol/ImageBase} image Image.
+   * @param {import("../../ImageBase.js").default} image Image.
    * @private
    * @return {WebGLTexture} Texture.
    */
@@ -88,7 +88,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
       coordinate, resolution, rotation, hitTolerance, skippedFeatureUids,
 
       /**
-       * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+       * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
        * @return {?} Callback result.
        */
       function(feature) {
@@ -111,7 +111,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
 
     let image = this.image_;
     let texture = this.texture;
-    const imageLayer = /** @type {module:ol/layer/Image} */ (this.getLayer());
+    const imageLayer = /** @type {import("../../layer/Image.js").default} */ (this.getLayer());
     const imageSource = imageLayer.getSource();
 
     const hints = frameState.viewHints;
@@ -147,7 +147,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
               }
             }.bind(null, gl, this.texture);
             frameState.postRenderFunctions.push(
-              /** @type {module:ol/PluggableMap~PostRenderFunction} */ (postRenderFunction)
+              /** @type {import("../../PluggableMap.js").PostRenderFunction} */ (postRenderFunction)
             );
           }
         }
@@ -179,10 +179,10 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
    * @param {number} canvasWidth Canvas width.
    * @param {number} canvasHeight Canvas height.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/coordinate~Coordinate} viewCenter View center.
+   * @param {import("../../coordinate.js").Coordinate} viewCenter View center.
    * @param {number} viewResolution View resolution.
    * @param {number} viewRotation View rotation.
-   * @param {module:ol/extent~Extent} imageExtent Image extent.
+   * @param {import("../../extent.js").Extent} imageExtent Image extent.
    * @private
    */
   updateProjectionMatrix_(
@@ -280,9 +280,9 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
   /**
    * The transformation matrix to get the pixel on the image for a
    * pixel on the map.
-   * @param {module:ol/size~Size} mapSize The map size.
-   * @param {module:ol/size~Size} imageSize The image size.
-   * @return {module:ol/transform~Transform} The transformation matrix.
+   * @param {import("../../size.js").Size} mapSize The map size.
+   * @param {import("../../size.js").Size} imageSize The image size.
+   * @return {import("../../transform.js").Transform} The transformation matrix.
    * @private
    */
   getHitTransformationMatrix_(mapSize, imageSize) {
@@ -315,7 +315,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 WebGLImageLayerRenderer['handles'] = function(layer) {
@@ -325,14 +325,14 @@ WebGLImageLayerRenderer['handles'] = function(layer) {
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/webgl/ImageLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./ImageLayer.js").default} The layer renderer.
  */
 WebGLImageLayerRenderer['create'] = function(mapRenderer, layer) {
   return new WebGLImageLayerRenderer(
-    /** @type {module:ol/renderer/webgl/Map} */ (mapRenderer),
-    /** @type {module:ol/layer/Image} */ (layer)
+    /** @type {import("./Map.js").default} */ (mapRenderer),
+    /** @type {import("../../layer/Image.js").default} */ (layer)
   );
 };
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -17,8 +17,8 @@ import {createEmptyTexture} from '../../webgl/Context.js';
 class WebGLLayerRenderer extends LayerRenderer {
 
   /**
-   * @param {module:ol/renderer/webgl/Map} mapRenderer Map renderer.
-   * @param {module:ol/layer/Layer} layer Layer.
+   * @param {import("./Map.js").default} mapRenderer Map renderer.
+   * @param {import("../../layer/Layer.js").default} layer Layer.
    */
   constructor(mapRenderer, layer) {
 
@@ -26,13 +26,13 @@ class WebGLLayerRenderer extends LayerRenderer {
 
     /**
      * @protected
-     * @type {module:ol/renderer/webgl/Map}
+     * @type {import("./Map.js").default}
      */
     this.mapRenderer = mapRenderer;
 
     /**
      * @private
-     * @type {module:ol/webgl/Buffer}
+     * @type {import("../../webgl/Buffer.js").default}
      */
     this.arrayBuffer_ = new WebGLBuffer([
       -1, -1, 0, 0,
@@ -61,13 +61,13 @@ class WebGLLayerRenderer extends LayerRenderer {
 
     /**
      * @protected
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.texCoordMatrix = createTransform();
 
     /**
      * @protected
-     * @type {module:ol/transform~Transform}
+     * @type {import("../../transform.js").Transform}
      */
     this.projectionMatrix = createTransform();
 
@@ -79,14 +79,14 @@ class WebGLLayerRenderer extends LayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/renderer/webgl/defaultmapshader/Locations}
+     * @type {import("./defaultmapshader/Locations.js").default}
      */
     this.defaultLocations_ = null;
 
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} framebufferDimension Framebuffer dimension.
    * @protected
    */
@@ -109,7 +109,7 @@ class WebGLLayerRenderer extends LayerRenderer {
       }.bind(null, gl, this.framebuffer, this.texture);
 
       frameState.postRenderFunctions.push(
-        /** @type {module:ol/PluggableMap~PostRenderFunction} */ (postRenderFunction)
+        /** @type {import("../../PluggableMap.js").PostRenderFunction} */ (postRenderFunction)
       );
 
       const texture = createEmptyTexture(
@@ -131,9 +131,9 @@ class WebGLLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
+   * @param {import("../../webgl/Context.js").default} context Context.
    */
   composeFrame(frameState, layerState, context) {
 
@@ -175,9 +175,9 @@ class WebGLLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @param {module:ol/render/EventType} type Event type.
-   * @param {module:ol/webgl/Context} context WebGL context.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../render/EventType.js").default} type Event type.
+   * @param {import("../../webgl/Context.js").default} context WebGL context.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @private
    */
   dispatchComposeEvent_(type, context, frameState) {
@@ -200,7 +200,7 @@ class WebGLLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @return {!module:ol/transform~Transform} Matrix.
+   * @return {!import("../../transform.js").Transform} Matrix.
    */
   getTexCoordMatrix() {
     return this.texCoordMatrix;
@@ -214,7 +214,7 @@ class WebGLLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * @return {!module:ol/transform~Transform} Matrix.
+   * @return {!import("../../transform.js").Transform} Matrix.
    */
   getProjectionMatrix() {
     return this.projectionMatrix;
@@ -231,18 +231,18 @@ class WebGLLayerRenderer extends LayerRenderer {
 
   /**
    * @abstract
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @param {module:ol/layer/Layer~State} layerState Layer state.
-   * @param {module:ol/webgl/Context} context Context.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @param {import("../../layer/Layer.js").State} layerState Layer state.
+   * @param {import("../../webgl/Context.js").default} context Context.
    * @return {boolean} whether composeFrame should be called.
    */
   prepareFrame(frameState, layerState, context) {}
 
   /**
    * @abstract
-   * @param {module:ol/pixel~Pixel} pixel Pixel.
-   * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
-   * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {import("../../pixel.js").Pixel} pixel Pixel.
+   * @param {import("../../PluggableMap.js").FrameState} frameState FrameState.
+   * @param {function(this: S, import("../../layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.
    * @param {S} thisArg Value to use as `this` when executing `callback`.
    * @return {T|undefined} Callback result.

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -45,7 +45,7 @@ const WEBGL_TEXTURE_CACHE_HIGH_WATER_MARK = 1024;
 class WebGLMapRenderer extends MapRenderer {
 
   /**
-   * @param {module:ol/PluggableMap} map Map.
+   * @param {import("../../PluggableMap.js").default} map Map.
    */
   constructor(map) {
     super(map);
@@ -102,7 +102,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     /**
      * @private
-     * @type {module:ol/webgl/Context}
+     * @type {import("../../webgl/Context.js").default}
      */
     this.context_ = new WebGLContext(this.canvas_, this.gl_);
 
@@ -113,28 +113,28 @@ class WebGLMapRenderer extends MapRenderer {
 
     /**
      * @private
-     * @type {module:ol/structs/LRUCache<module:ol/renderer/webgl/Map~TextureCacheEntry|null>}
+     * @type {import("../../structs/LRUCache.js").default<TextureCacheEntry|null>}
      */
     this.textureCache_ = new LRUCache();
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../../coordinate.js").Coordinate}
      */
     this.focus_ = null;
 
     /**
      * @private
-     * @type {module:ol/structs/PriorityQueue<Array>}
+     * @type {import("../../structs/PriorityQueue.js").default<Array>}
      */
     this.tileTextureQueue_ = new PriorityQueue(
       /**
        * @param {Array<*>} element Element.
        * @return {number} Priority.
-       * @this {module:ol/renderer/webgl/Map}
+       * @this {import("./Map.js").default}
        */
       (function(element) {
-        const tileCenter = /** @type {module:ol/coordinate~Coordinate} */ (element[1]);
+        const tileCenter = /** @type {import("../../coordinate.js").Coordinate} */ (element[1]);
         const tileResolution = /** @type {number} */ (element[2]);
         const deltaX = tileCenter[0] - this.focus_[0];
         const deltaY = tileCenter[1] - this.focus_[1];
@@ -147,24 +147,24 @@ class WebGLMapRenderer extends MapRenderer {
        */
       function(element) {
         return (
-          /** @type {module:ol/Tile} */ (element[0]).getKey()
+          /** @type {import("../../Tile.js").default} */ (element[0]).getKey()
         );
       });
 
 
     /**
-     * @param {module:ol/PluggableMap} map Map.
-     * @param {?module:ol/PluggableMap~FrameState} frameState Frame state.
+     * @param {import("../../PluggableMap.js").default} map Map.
+     * @param {?import("../../PluggableMap.js").FrameState} frameState Frame state.
      * @return {boolean} false.
-     * @this {module:ol/renderer/webgl/Map}
+     * @this {import("./Map.js").default}
      */
     this.loadNextTileTexture_ =
         function(map, frameState) {
           if (!this.tileTextureQueue_.isEmpty()) {
             this.tileTextureQueue_.reprioritize();
             const element = this.tileTextureQueue_.dequeue();
-            const tile = /** @type {module:ol/Tile} */ (element[0]);
-            const tileSize = /** @type {module:ol/size~Size} */ (element[3]);
+            const tile = /** @type {import("../../Tile.js").default} */ (element[0]);
+            const tileSize = /** @type {import("../../size.js").Size} */ (element[3]);
             const tileGutter = /** @type {number} */ (element[4]);
             this.bindTileTexture(
               tile, tileSize, tileGutter, LINEAR, LINEAR);
@@ -183,8 +183,8 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @param {module:ol/Tile} tile Tile.
-   * @param {module:ol/size~Size} tileSize Tile size.
+   * @param {import("../../Tile.js").default} tile Tile.
+   * @param {import("../../size.js").Size} tileSize Tile size.
    * @param {number} tileGutter Tile gutter.
    * @param {number} magFilter Mag filter.
    * @param {number} minFilter Min filter.
@@ -247,8 +247,8 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @param {module:ol/render/EventType} type Event type.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../render/EventType.js").default} type Event type.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    */
   dispatchRenderEvent(type, frameState) {
     const map = this.getMap();
@@ -280,7 +280,7 @@ class WebGLMapRenderer extends MapRenderer {
     if (!gl.isContextLost()) {
       this.textureCache_.forEach(
         /**
-         * @param {?module:ol/renderer/webgl/Map~TextureCacheEntry} textureCacheEntry
+         * @param {?TextureCacheEntry} textureCacheEntry
          *     Texture cache entry.
          */
         function(textureCacheEntry) {
@@ -294,8 +294,8 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @param {module:ol/PluggableMap} map Map.
-   * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+   * @param {import("../../PluggableMap.js").default} map Map.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @private
    */
   expireCache_(map, frameState) {
@@ -318,7 +318,7 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @return {module:ol/webgl/Context} The context.
+   * @return {import("../../webgl/Context.js").default} The context.
    */
   getContext() {
     return this.context_;
@@ -332,14 +332,14 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @return {module:ol/structs/PriorityQueue<Array>} Tile texture queue.
+   * @return {import("../../structs/PriorityQueue.js").default<Array>} Tile texture queue.
    */
   getTileTextureQueue() {
     return this.tileTextureQueue_;
   }
 
   /**
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../../events/Event.js").default} event Event.
    * @protected
    */
   handleWebGLContextLost(event) {
@@ -349,7 +349,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     const renderers = this.getLayerRenderers();
     for (const id in renderers) {
-      const renderer = /** @type {module:ol/renderer/webgl/Layer} */ (renderers[id]);
+      const renderer = /** @type {import("./Layer.js").default} */ (renderers[id]);
       renderer.handleWebGLContextLost();
     }
   }
@@ -378,7 +378,7 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @param {module:ol/Tile} tile Tile.
+   * @param {import("../../Tile.js").default} tile Tile.
    * @return {boolean} Is tile texture loaded.
    */
   isTileTextureLoaded(tile) {
@@ -412,7 +412,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     this.dispatchRenderEvent(RenderEventType.PRECOMPOSE, frameState);
 
-    /** @type {Array<module:ol/layer/Layer~State>} */
+    /** @type {Array<import("../../layer/Layer.js").State>} */
     const layerStatesToDraw = [];
     const layerStatesArray = frameState.layerStatesArray;
     stableSort(layerStatesArray, sortByZIndex);
@@ -423,7 +423,7 @@ class WebGLMapRenderer extends MapRenderer {
       layerState = layerStatesArray[i];
       if (visibleAtResolution(layerState, viewResolution) &&
           layerState.sourceState == SourceState.READY) {
-        layerRenderer = /** @type {module:ol/renderer/webgl/Layer} */ (this.getLayerRenderer(layerState.layer));
+        layerRenderer = /** @type {import("./Layer.js").default} */ (this.getLayerRenderer(layerState.layer));
         if (layerRenderer.prepareFrame(frameState, layerState, context)) {
           layerStatesToDraw.push(layerState);
         }
@@ -446,7 +446,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     for (i = 0, ii = layerStatesToDraw.length; i < ii; ++i) {
       layerState = layerStatesToDraw[i];
-      layerRenderer = /** @type {module:ol/renderer/webgl/Layer} */ (this.getLayerRenderer(layerState.layer));
+      layerRenderer = /** @type {import("./Layer.js").default} */ (this.getLayerRenderer(layerState.layer));
       layerRenderer.composeFrame(frameState, layerState, context);
     }
 
@@ -460,7 +460,7 @@ class WebGLMapRenderer extends MapRenderer {
     if (this.textureCache_.getCount() - this.textureCacheFrameMarkerCount_ >
         WEBGL_TEXTURE_CACHE_HIGH_WATER_MARK) {
       frameState.postRenderFunctions.push(
-        /** @type {module:ol/PluggableMap~PostRenderFunction} */ (this.expireCache_.bind(this))
+        /** @type {import("../../PluggableMap.js").PostRenderFunction} */ (this.expireCache_.bind(this))
       );
     }
 
@@ -565,7 +565,7 @@ class WebGLMapRenderer extends MapRenderer {
       const layer = layerState.layer;
       if (visibleAtResolution(layerState, viewState.resolution) &&
           layerFilter.call(thisArg, layer)) {
-        const layerRenderer = /** @type {module:ol/renderer/webgl/Layer} */ (this.getLayerRenderer(layer));
+        const layerRenderer = /** @type {import("./Layer.js").default} */ (this.getLayerRenderer(layer));
         result = layerRenderer.forEachLayerAtPixel(
           pixel, frameState, callback, thisArg);
         if (result) {

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -32,8 +32,8 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
   /**
-   * @param {module:ol/renderer/webgl/Map} mapRenderer Map renderer.
-   * @param {module:ol/layer/Tile} tileLayer Tile layer.
+   * @param {import("./Map.js").default} mapRenderer Map renderer.
+   * @param {import("../../layer/Tile.js").default} tileLayer Tile layer.
    */
   constructor(mapRenderer, tileLayer) {
 
@@ -41,25 +41,25 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/webgl/Fragment}
+     * @type {import("../../webgl/Fragment.js").default}
      */
     this.fragmentShader_ = fragment;
 
     /**
      * @private
-     * @type {module:ol/webgl/Vertex}
+     * @type {import("../../webgl/Vertex.js").default}
      */
     this.vertexShader_ = vertex;
 
     /**
      * @private
-     * @type {module:ol/renderer/webgl/tilelayershader/Locations}
+     * @type {import("./tilelayershader/Locations.js").default}
      */
     this.locations_ = null;
 
     /**
      * @private
-     * @type {module:ol/webgl/Buffer}
+     * @type {import("../../webgl/Buffer.js").default}
      */
     this.renderArrayBuffer_ = new WebGLBuffer([
       0, 0, 0, 1,
@@ -70,13 +70,13 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/TileRange}
+     * @type {import("../../TileRange.js").default}
      */
     this.renderedTileRange_ = null;
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.renderedFramebufferExtent_ = null;
 
@@ -88,7 +88,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../../size.js").Size}
      */
     this.tmpSize_ = [0, 0];
 
@@ -112,7 +112,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     return (
       /**
        * @param {number} zoom Zoom level.
-       * @param {module:ol/TileRange} tileRange Tile range.
+       * @param {import("../../TileRange.js").default} tileRange Tile range.
        * @return {boolean} The tile range is fully loaded.
        */
       function(zoom, tileRange) {
@@ -150,7 +150,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     const viewState = frameState.viewState;
     const projection = viewState.projection;
 
-    const tileLayer = /** @type {module:ol/layer/Tile} */ (this.getLayer());
+    const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
     const tileSource = tileLayer.getSource();
     const tileGrid = tileSource.getTileGridForProjection(projection);
     const z = tileGrid.getZForResolution(viewState.resolution);
@@ -214,7 +214,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
       gl.uniform1i(this.locations_.u_texture, 0);
 
       /**
-       * @type {Object<number, Object<string, module:ol/Tile>>}
+       * @type {Object<number, Object<string, import("../../Tile.js").default>>}
        */
       const tilesToDrawByZ = {};
       tilesToDrawByZ[z] = {};
@@ -316,7 +316,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
       frameState, tileSource, tileGrid, pixelRatio, projection, extent, z,
       tileLayer.getPreload(),
       /**
-       * @param {module:ol/Tile} tile Tile.
+       * @param {import("../../Tile.js").default} tile Tile.
        */
       function(tile) {
         if (tile.getState() == TileState.LOADED &&
@@ -387,7 +387,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 WebGLTileLayerRenderer['handles'] = function(layer) {
@@ -397,14 +397,14 @@ WebGLTileLayerRenderer['handles'] = function(layer) {
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/webgl/TileLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./TileLayer.js").default} The layer renderer.
  */
 WebGLTileLayerRenderer['create'] = function(mapRenderer, layer) {
   return new WebGLTileLayerRenderer(
-    /** @type {module:ol/renderer/webgl/Map} */ (mapRenderer),
-    /** @type {module:ol/layer/Tile} */ (layer)
+    /** @type {import("./Map.js").default} */ (mapRenderer),
+    /** @type {import("../../layer/Tile.js").default} */ (layer)
   );
 };
 

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -19,8 +19,8 @@ import {apply as applyTransform} from '../../transform.js';
 class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
 
   /**
-   * @param {module:ol/renderer/webgl/Map} mapRenderer Map renderer.
-   * @param {module:ol/layer/Vector} vectorLayer Vector layer.
+   * @param {import("./Map.js").default} mapRenderer Map renderer.
+   * @param {import("../../layer/Vector.js").default} vectorLayer Vector layer.
    */
   constructor(mapRenderer, vectorLayer) {
 
@@ -46,26 +46,26 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../../extent.js").Extent}
      */
     this.renderedExtent_ = createEmpty();
 
     /**
      * @private
-     * @type {function(module:ol/Feature, module:ol/Feature): number|null}
+     * @type {function(import("../../Feature.js").default, import("../../Feature.js").default): number|null}
      */
     this.renderedRenderOrder_ = null;
 
     /**
      * @private
-     * @type {module:ol/render/webgl/ReplayGroup}
+     * @type {import("../../render/webgl/ReplayGroup.js").default}
      */
     this.replayGroup_ = null;
 
     /**
      * The last layer state.
      * @private
-     * @type {?module:ol/layer/Layer~State}
+     * @type {?import("../../layer/Layer.js").State}
      */
     this.layerState_ = null;
 
@@ -124,7 +124,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
         frameState.size, frameState.pixelRatio, layerState.opacity,
         {},
         /**
-         * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+         * @param {import("../../Feature.js").default|import("../../render/Feature.js").default} feature Feature.
          * @return {?} Callback result.
          */
         function(feature) {
@@ -171,7 +171,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
 
   /**
    * Handle changes in image style state.
-   * @param {module:ol/events/Event} event Image style change event.
+   * @param {import("../../events/Event.js").default} event Image style change event.
    * @private
    */
   handleStyleImageChange_(event) {
@@ -182,7 +182,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
    * @inheritDoc
    */
   prepareFrame(frameState, layerState, context) {
-    const vectorLayer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
+    const vectorLayer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
     const vectorSource = vectorLayer.getSource();
 
     const animating = frameState.viewHints[ViewHint.ANIMATING];
@@ -231,8 +231,8 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
       extent, vectorLayer.getRenderBuffer());
     vectorSource.loadFeatures(extent, resolution, projection);
     /**
-     * @param {module:ol/Feature} feature Feature.
-     * @this {module:ol/renderer/webgl/VectorLayer}
+     * @param {import("../../Feature.js").default} feature Feature.
+     * @this {import("./VectorLayer.js").default}
      */
     const render = function(feature) {
       let styles;
@@ -247,11 +247,11 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
       }
     };
     if (vectorLayerRenderOrder) {
-      /** @type {Array<module:ol/Feature>} */
+      /** @type {Array<import("../../Feature.js").default>} */
       const features = [];
       vectorSource.forEachFeatureInExtent(extent,
         /**
-         * @param {module:ol/Feature} feature Feature.
+         * @param {import("../../Feature.js").default} feature Feature.
          */
         function(feature) {
           features.push(feature);
@@ -273,12 +273,12 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
   }
 
   /**
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../../Feature.js").default} feature Feature.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/style/Style|Array<module:ol/style/Style>} styles The style or array of
+   * @param {import("../../style/Style.js").default|Array<import("../../style/Style.js").default>} styles The style or array of
    *     styles.
-   * @param {module:ol/render/webgl/ReplayGroup} replayGroup Replay group.
+   * @param {import("../../render/webgl/ReplayGroup.js").default} replayGroup Replay group.
    * @return {boolean} `true` if an image is loading.
    */
   renderFeature(feature, resolution, pixelRatio, styles, replayGroup) {
@@ -306,7 +306,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
 
 /**
  * Determine if this renderer handles the provided layer.
- * @param {module:ol/layer/Layer} layer The candidate layer.
+ * @param {import("../../layer/Layer.js").default} layer The candidate layer.
  * @return {boolean} The renderer can render the layer.
  */
 WebGLVectorLayerRenderer['handles'] = function(layer) {
@@ -316,14 +316,14 @@ WebGLVectorLayerRenderer['handles'] = function(layer) {
 
 /**
  * Create a layer renderer.
- * @param {module:ol/renderer/Map} mapRenderer The map renderer.
- * @param {module:ol/layer/Layer} layer The layer to be rendererd.
- * @return {module:ol/renderer/webgl/VectorLayer} The layer renderer.
+ * @param {import("../Map.js").default} mapRenderer The map renderer.
+ * @param {import("../../layer/Layer.js").default} layer The layer to be rendererd.
+ * @return {import("./VectorLayer.js").default} The layer renderer.
  */
 WebGLVectorLayerRenderer['create'] = function(mapRenderer, layer) {
   return new WebGLVectorLayerRenderer(
-    /** @type {module:ol/renderer/webgl/Map} */ (mapRenderer),
-    /** @type {module:ol/layer/Vector} */ (layer)
+    /** @type {import("./Map.js").default} */ (mapRenderer),
+    /** @type {import("../../layer/Vector.js").default} */ (layer)
   );
 };
 

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -13,9 +13,9 @@ import {getPointResolution, transform} from './proj.js';
  * The resolution is calculated regardless of what resolutions
  * are actually available in the dataset (TileGrid, Image, ...).
  *
- * @param {module:ol/proj/Projection} sourceProj Source projection.
- * @param {module:ol/proj/Projection} targetProj Target projection.
- * @param {module:ol/coordinate~Coordinate} targetCenter Target center.
+ * @param {import("./proj/Projection.js").default} sourceProj Source projection.
+ * @param {import("./proj/Projection.js").default} targetProj Target projection.
+ * @param {import("./coordinate.js").Coordinate} targetCenter Target center.
  * @param {number} targetResolution Target resolution.
  * @return {number} The best resolution to use. Can be +-Infinity, NaN or 0.
  */
@@ -61,7 +61,7 @@ export function calculateSourceResolution(sourceProj, targetProj,
  * @param {number} centroidY Centroid of the triangle (y coordinate in pixels).
  * @param {number} x X coordinate of the point (in pixels).
  * @param {number} y Y coordinate of the point (in pixels).
- * @return {module:ol/coordinate~Coordinate} New point 1 px farther from the centroid.
+ * @return {import("./coordinate.js").Coordinate} New point 1 px farther from the centroid.
  */
 function enlargeClipPoint(centroidX, centroidY, x, y) {
   const dX = x - centroidX;
@@ -78,12 +78,12 @@ function enlargeClipPoint(centroidX, centroidY, x, y) {
  * @param {number} height Height of the canvas.
  * @param {number} pixelRatio Pixel ratio.
  * @param {number} sourceResolution Source resolution.
- * @param {module:ol/extent~Extent} sourceExtent Extent of the data source.
+ * @param {import("./extent.js").Extent} sourceExtent Extent of the data source.
  * @param {number} targetResolution Target resolution.
- * @param {module:ol/extent~Extent} targetExtent Target extent.
- * @param {module:ol/reproj/Triangulation} triangulation
+ * @param {import("./extent.js").Extent} targetExtent Target extent.
+ * @param {import("./reproj/Triangulation.js").default} triangulation
  * Calculated triangulation.
- * @param {Array<{extent: module:ol/extent~Extent,
+ * @param {Array<{extent: import("./extent.js").Extent,
  *                 image: (HTMLCanvasElement|HTMLImageElement|HTMLVideoElement)}>} sources
  * Array of sources.
  * @param {number} gutter Gutter of the sources.

--- a/src/ol/reproj/Image.js
+++ b/src/ol/reproj/Image.js
@@ -13,7 +13,7 @@ import Triangulation from '../reproj/Triangulation.js';
 
 
 /**
- * @typedef {function(module:ol/extent~Extent, number, number) : module:ol/ImageBase} FunctionType
+ * @typedef {function(import("../extent.js").Extent, number, number) : import("../ImageBase.js").default} FunctionType
  */
 
 
@@ -24,12 +24,12 @@ import Triangulation from '../reproj/Triangulation.js';
  */
 class ReprojImage extends ImageBase {
   /**
-   * @param {module:ol/proj/Projection} sourceProj Source projection (of the data).
-   * @param {module:ol/proj/Projection} targetProj Target projection.
-   * @param {module:ol/extent~Extent} targetExtent Target extent.
+   * @param {import("../proj/Projection.js").default} sourceProj Source projection (of the data).
+   * @param {import("../proj/Projection.js").default} targetProj Target projection.
+   * @param {import("../extent.js").Extent} targetExtent Target extent.
    * @param {number} targetResolution Target resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/reproj/Image~FunctionType} getImageFunction
+   * @param {FunctionType} getImageFunction
    *     Function returning source images (extent, resolution, pixelRatio).
    */
   constructor(sourceProj, targetProj, targetExtent, targetResolution, pixelRatio, getImageFunction) {
@@ -61,19 +61,19 @@ class ReprojImage extends ImageBase {
 
     /**
      * @private
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      */
     this.targetProj_ = targetProj;
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.maxSourceExtent_ = maxSourceExtent;
 
     /**
      * @private
-     * @type {!module:ol/reproj/Triangulation}
+     * @type {!import("./Triangulation.js").default}
      */
     this.triangulation_ = triangulation;
 
@@ -85,13 +85,13 @@ class ReprojImage extends ImageBase {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.targetExtent_ = targetExtent;
 
     /**
      * @private
-     * @type {module:ol/ImageBase}
+     * @type {import("../ImageBase.js").default}
      */
     this.sourceImage_ = sourceImage;
 
@@ -109,7 +109,7 @@ class ReprojImage extends ImageBase {
 
     /**
      * @private
-     * @type {?module:ol/events~EventsKey}
+     * @type {?import("../events.js").EventsKey}
      */
     this.sourceListenerKey_ = null;
   }
@@ -132,7 +132,7 @@ class ReprojImage extends ImageBase {
   }
 
   /**
-   * @return {module:ol/proj/Projection} Projection.
+   * @return {import("../proj/Projection.js").default} Projection.
    */
   getProjection() {
     return this.targetProj_;
@@ -187,7 +187,7 @@ class ReprojImage extends ImageBase {
    * @private
    */
   unlistenSource_() {
-    unlistenByKey(/** @type {!module:ol/events~EventsKey} */ (this.sourceListenerKey_));
+    unlistenByKey(/** @type {!import("../events.js").EventsKey} */ (this.sourceListenerKey_));
     this.sourceListenerKey_ = null;
   }
 }

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -14,7 +14,7 @@ import Triangulation from '../reproj/Triangulation.js';
 
 
 /**
- * @typedef {function(number, number, number, number) : module:ol/Tile} FunctionType
+ * @typedef {function(number, number, number, number) : import("../Tile.js").default} FunctionType
  */
 
 
@@ -26,15 +26,15 @@ import Triangulation from '../reproj/Triangulation.js';
  */
 class ReprojTile extends Tile {
   /**
-   * @param {module:ol/proj/Projection} sourceProj Source projection.
-   * @param {module:ol/tilegrid/TileGrid} sourceTileGrid Source tile grid.
-   * @param {module:ol/proj/Projection} targetProj Target projection.
-   * @param {module:ol/tilegrid/TileGrid} targetTileGrid Target tile grid.
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Coordinate of the tile.
-   * @param {module:ol/tilecoord~TileCoord} wrappedTileCoord Coordinate of the tile wrapped in X.
+   * @param {import("../proj/Projection.js").default} sourceProj Source projection.
+   * @param {import("../tilegrid/TileGrid.js").default} sourceTileGrid Source tile grid.
+   * @param {import("../proj/Projection.js").default} targetProj Target projection.
+   * @param {import("../tilegrid/TileGrid.js").default} targetTileGrid Target tile grid.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Coordinate of the tile.
+   * @param {import("../tilecoord.js").TileCoord} wrappedTileCoord Coordinate of the tile wrapped in X.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} gutter Gutter of the source tiles.
-   * @param {module:ol/reproj/Tile~FunctionType} getTileFunction
+   * @param {FunctionType} getTileFunction
    *     Function returning source tiles (z, x, y, pixelRatio).
    * @param {number=} opt_errorThreshold Acceptable reprojection error (in px).
    * @param {boolean=} opt_renderEdges Render reprojection edges.
@@ -80,31 +80,31 @@ class ReprojTile extends Tile {
 
     /**
      * @private
-     * @type {module:ol/tilegrid/TileGrid}
+     * @type {import("../tilegrid/TileGrid.js").default}
      */
     this.sourceTileGrid_ = sourceTileGrid;
 
     /**
      * @private
-     * @type {module:ol/tilegrid/TileGrid}
+     * @type {import("../tilegrid/TileGrid.js").default}
      */
     this.targetTileGrid_ = targetTileGrid;
 
     /**
      * @private
-     * @type {module:ol/tilecoord~TileCoord}
+     * @type {import("../tilecoord.js").TileCoord}
      */
     this.wrappedTileCoord_ = wrappedTileCoord ? wrappedTileCoord : tileCoord;
 
     /**
      * @private
-     * @type {!Array<module:ol/Tile>}
+     * @type {!Array<import("../Tile.js").default>}
      */
     this.sourceTiles_ = [];
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("../events.js").EventsKey>}
      */
     this.sourcesListenerKeys_ = null;
 
@@ -156,7 +156,7 @@ class ReprojTile extends Tile {
 
     /**
      * @private
-     * @type {!module:ol/reproj/Triangulation}
+     * @type {!import("./Triangulation.js").default}
      */
     this.triangulation_ = new Triangulation(
       sourceProj, targetProj, limitedTargetExtent, maxSourceExtent,

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -10,8 +10,8 @@ import {getTransform} from '../proj.js';
 /**
  * Single triangle; consists of 3 source points and 3 target points.
  * @typedef {Object} Triangle
- * @property {Array<module:ol/coordinate~Coordinate>} source
- * @property {Array<module:ol/coordinate~Coordinate>} target
+ * @property {Array<import("../coordinate.js").Coordinate>} source
+ * @property {Array<import("../coordinate.js").Coordinate>} target
  */
 
 
@@ -44,33 +44,33 @@ const MAX_TRIANGLE_WIDTH = 0.25;
 class Triangulation {
 
   /**
-   * @param {module:ol/proj/Projection} sourceProj Source projection.
-   * @param {module:ol/proj/Projection} targetProj Target projection.
-   * @param {module:ol/extent~Extent} targetExtent Target extent to triangulate.
-   * @param {module:ol/extent~Extent} maxSourceExtent Maximal source extent that can be used.
+   * @param {import("../proj/Projection.js").default} sourceProj Source projection.
+   * @param {import("../proj/Projection.js").default} targetProj Target projection.
+   * @param {import("../extent.js").Extent} targetExtent Target extent to triangulate.
+   * @param {import("../extent.js").Extent} maxSourceExtent Maximal source extent that can be used.
    * @param {number} errorThreshold Acceptable error (in source units).
    */
   constructor(sourceProj, targetProj, targetExtent, maxSourceExtent, errorThreshold) {
 
     /**
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      * @private
      */
     this.sourceProj_ = sourceProj;
 
     /**
-     * @type {module:ol/proj/Projection}
+     * @type {import("../proj/Projection.js").default}
      * @private
      */
     this.targetProj_ = targetProj;
 
-    /** @type {!Object<string, module:ol/coordinate~Coordinate>} */
+    /** @type {!Object<string, import("../coordinate.js").Coordinate>} */
     let transformInvCache = {};
     const transformInv = getTransform(this.targetProj_, this.sourceProj_);
 
     /**
-     * @param {module:ol/coordinate~Coordinate} c A coordinate.
-     * @return {module:ol/coordinate~Coordinate} Transformed coordinate.
+     * @param {import("../coordinate.js").Coordinate} c A coordinate.
+     * @return {import("../coordinate.js").Coordinate} Transformed coordinate.
      * @private
      */
     this.transformInv_ = function(c) {
@@ -82,7 +82,7 @@ class Triangulation {
     };
 
     /**
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      * @private
      */
     this.maxSourceExtent_ = maxSourceExtent;
@@ -94,7 +94,7 @@ class Triangulation {
     this.errorThresholdSquared_ = errorThreshold * errorThreshold;
 
     /**
-     * @type {Array<module:ol/reproj/Triangulation~Triangle>}
+     * @type {Array<Triangle>}
      * @private
      */
     this.triangles_ = [];
@@ -188,12 +188,12 @@ class Triangulation {
 
   /**
    * Adds triangle to the triangulation.
-   * @param {module:ol/coordinate~Coordinate} a The target a coordinate.
-   * @param {module:ol/coordinate~Coordinate} b The target b coordinate.
-   * @param {module:ol/coordinate~Coordinate} c The target c coordinate.
-   * @param {module:ol/coordinate~Coordinate} aSrc The source a coordinate.
-   * @param {module:ol/coordinate~Coordinate} bSrc The source b coordinate.
-   * @param {module:ol/coordinate~Coordinate} cSrc The source c coordinate.
+   * @param {import("../coordinate.js").Coordinate} a The target a coordinate.
+   * @param {import("../coordinate.js").Coordinate} b The target b coordinate.
+   * @param {import("../coordinate.js").Coordinate} c The target c coordinate.
+   * @param {import("../coordinate.js").Coordinate} aSrc The source a coordinate.
+   * @param {import("../coordinate.js").Coordinate} bSrc The source b coordinate.
+   * @param {import("../coordinate.js").Coordinate} cSrc The source c coordinate.
    * @private
    */
   addTriangle_(a, b, c, aSrc, bSrc, cSrc) {
@@ -208,14 +208,14 @@ class Triangulation {
    * (and reprojects the vertices) if valid.
    * Performs quad subdivision if needed to increase precision.
    *
-   * @param {module:ol/coordinate~Coordinate} a The target a coordinate.
-   * @param {module:ol/coordinate~Coordinate} b The target b coordinate.
-   * @param {module:ol/coordinate~Coordinate} c The target c coordinate.
-   * @param {module:ol/coordinate~Coordinate} d The target d coordinate.
-   * @param {module:ol/coordinate~Coordinate} aSrc The source a coordinate.
-   * @param {module:ol/coordinate~Coordinate} bSrc The source b coordinate.
-   * @param {module:ol/coordinate~Coordinate} cSrc The source c coordinate.
-   * @param {module:ol/coordinate~Coordinate} dSrc The source d coordinate.
+   * @param {import("../coordinate.js").Coordinate} a The target a coordinate.
+   * @param {import("../coordinate.js").Coordinate} b The target b coordinate.
+   * @param {import("../coordinate.js").Coordinate} c The target c coordinate.
+   * @param {import("../coordinate.js").Coordinate} d The target d coordinate.
+   * @param {import("../coordinate.js").Coordinate} aSrc The source a coordinate.
+   * @param {import("../coordinate.js").Coordinate} bSrc The source b coordinate.
+   * @param {import("../coordinate.js").Coordinate} cSrc The source c coordinate.
+   * @param {import("../coordinate.js").Coordinate} dSrc The source d coordinate.
    * @param {number} maxSubdivision Maximal allowed subdivision of the quad.
    * @private
    */
@@ -327,7 +327,7 @@ class Triangulation {
   /**
    * Calculates extent of the 'source' coordinates from all the triangles.
    *
-   * @return {module:ol/extent~Extent} Calculated extent.
+   * @return {import("../extent.js").Extent} Calculated extent.
    */
   calculateSourceExtent() {
     const extent = createEmpty();
@@ -343,7 +343,7 @@ class Triangulation {
   }
 
   /**
-   * @return {Array<module:ol/reproj/Triangulation~Triangle>} Array of the calculated triangles.
+   * @return {Array<Triangle>} Array of the calculated triangles.
    */
   getTriangles() {
     return this.triangles_;

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -12,7 +12,7 @@ import {clamp} from './math.js';
 
 /**
  * @param {Array<number>} resolutions Resolutions.
- * @return {module:ol/resolutionconstraint~Type} Zoom function.
+ * @return {Type} Zoom function.
  */
 export function createSnapToResolutions(resolutions) {
   return (
@@ -45,7 +45,7 @@ export function createSnapToResolutions(resolutions) {
  * @param {number} power Power.
  * @param {number} maxResolution Maximum resolution.
  * @param {number=} opt_maxLevel Maximum level.
- * @return {module:ol/resolutionconstraint~Type} Zoom function.
+ * @return {Type} Zoom function.
  */
 export function createSnapToPower(power, maxResolution, opt_maxLevel) {
   return (

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -39,7 +39,7 @@ export function none(rotation, delta) {
 
 /**
  * @param {number} n N.
- * @return {module:ol/rotationconstraint~Type} Rotation constraint.
+ * @return {Type} Rotation constraint.
  */
 export function createSnapToN(n) {
   const theta = 2 * Math.PI / n;
@@ -62,7 +62,7 @@ export function createSnapToN(n) {
 
 /**
  * @param {number=} opt_tolerance Tolerance.
- * @return {module:ol/rotationconstraint~Type} Rotation constraint.
+ * @return {Type} Rotation constraint.
  */
 export function createSnapToZero(opt_tolerance) {
   const tolerance = opt_tolerance || toRadians(5);

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -12,10 +12,10 @@
 
 /**
  * Returns a buffered size.
- * @param {module:ol/size~Size} size Size.
+ * @param {Size} size Size.
  * @param {number} num The amount by which to buffer.
- * @param {module:ol/size~Size=} opt_size Optional reusable size array.
- * @return {module:ol/size~Size} The buffered size.
+ * @param {Size=} opt_size Optional reusable size array.
+ * @return {Size} The buffered size.
  */
 export function buffer(size, num, opt_size) {
   if (opt_size === undefined) {
@@ -29,7 +29,7 @@ export function buffer(size, num, opt_size) {
 
 /**
  * Determines if a size has a positive area.
- * @param {module:ol/size~Size} size The size to test.
+ * @param {Size} size The size to test.
  * @return {boolean} The size has a positive area.
  */
 export function hasArea(size) {
@@ -39,10 +39,10 @@ export function hasArea(size) {
 
 /**
  * Returns a size scaled by a ratio. The result will be an array of integers.
- * @param {module:ol/size~Size} size Size.
+ * @param {Size} size Size.
  * @param {number} ratio Ratio.
- * @param {module:ol/size~Size=} opt_size Optional reusable size array.
- * @return {module:ol/size~Size} The scaled size.
+ * @param {Size=} opt_size Optional reusable size array.
+ * @return {Size} The scaled size.
  */
 export function scale(size, ratio, opt_size) {
   if (opt_size === undefined) {
@@ -55,12 +55,12 @@ export function scale(size, ratio, opt_size) {
 
 
 /**
- * Returns an `module:ol/size~Size` array for the passed in number (meaning: square) or
- * `module:ol/size~Size` array.
+ * Returns an `Size` array for the passed in number (meaning: square) or
+ * `Size` array.
  * (meaning: non-square),
- * @param {number|module:ol/size~Size} size Width and height.
- * @param {module:ol/size~Size=} opt_size Optional reusable size array.
- * @return {module:ol/size~Size} Size.
+ * @param {number|Size} size Width and height.
+ * @param {Size=} opt_size Optional reusable size array.
+ * @return {Size} Size.
  * @api
  */
 export function toSize(size, opt_size) {

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -33,7 +33,7 @@ const TOS_ATTRIBUTION = '<a class="ol-attribution-bing-tos" ' +
  * @property {number} [maxZoom=21] Max zoom. Default is what's advertized by the BingMaps service.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -52,7 +52,7 @@ const TOS_ATTRIBUTION = '<a class="ol-attribution-bing-tos" ' +
  */
 class BingMaps extends TileImage {
   /**
-   * @param {module:ol/source/BingMaps~Options=} options Bing Maps options.
+   * @param {Options=} options Bing Maps options.
    */
   constructor(options) {
 
@@ -170,9 +170,9 @@ class BingMaps extends TileImage {
           .replace('{culture}', culture);
         return (
           /**
-           * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
+           * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
            * @param {number} pixelRatio Pixel ratio.
-           * @param {module:ol/proj/Projection} projection Projection.
+           * @param {import("../proj/Projection.js").default} projection Projection.
            * @return {string|undefined} Tile URL.
            */
           function(tileCoord, pixelRatio, projection) {

--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -8,13 +8,13 @@ import XYZ from '../source/XYZ.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
- * @property {module:ol/proj~ProjectionLike} [projection='EPSG:3857'] Projection.
+ * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Projection.
  * @property {number} [maxZoom=18] Max zoom.
  * @property {number} [minZoom] Minimum zoom.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
@@ -38,7 +38,7 @@ import XYZ from '../source/XYZ.js';
  */
 class CartoDB extends XYZ {
   /**
-   * @param {module:ol/source/CartoDB~Options=} options CartoDB options.
+   * @param {Options=} options CartoDB options.
    */
   constructor(options) {
     super({

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -14,10 +14,10 @@ import VectorSource from '../source/Vector.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [distance=20] Minimum distance in pixels between clusters.
- * @property {module:ol/extent~Extent} [extent] Extent.
- * @property {function(module:ol/Feature):module:ol/geom/Point} [geometryFunction]
+ * @property {import("../extent.js").Extent} [extent] Extent.
+ * @property {function(import("../Feature.js").default):import("../geom/Point.js").default} [geometryFunction]
  * Function that takes an {@link module:ol/Feature} as argument and returns an
  * {@link module:ol/geom/Point} as cluster calculation point for the feature. When a
  * feature should not be considered for clustering, the function should return
@@ -30,8 +30,8 @@ import VectorSource from '../source/Vector.js';
  * ```
  * See {@link module:ol/geom/Polygon~Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {module:ol/source/Vector} source Source.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {import("./Vector.js").default} source Source.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  */
 
@@ -45,7 +45,7 @@ import VectorSource from '../source/Vector.js';
  */
 class Cluster extends VectorSource {
   /**
-   * @param {module:ol/source/Cluster~Options=} options Cluster options.
+   * @param {Options=} options Cluster options.
    */
   constructor(options) {
     super({
@@ -68,25 +68,25 @@ class Cluster extends VectorSource {
     this.distance = options.distance !== undefined ? options.distance : 20;
 
     /**
-     * @type {Array<module:ol/Feature>}
+     * @type {Array<import("../Feature.js").default>}
      * @protected
      */
     this.features = [];
 
     /**
-     * @param {module:ol/Feature} feature Feature.
-     * @return {module:ol/geom/Point} Cluster calculation point.
+     * @param {import("../Feature.js").default} feature Feature.
+     * @return {import("../geom/Point.js").default} Cluster calculation point.
      * @protected
      */
     this.geometryFunction = options.geometryFunction || function(feature) {
-      const geometry = /** @type {module:ol/geom/Point} */ (feature.getGeometry());
+      const geometry = /** @type {import("../geom/Point.js").default} */ (feature.getGeometry());
       assert(geometry instanceof Point,
-        10); // The default `geometryFunction` can only handle `module:ol/geom/Point~Point` geometries
+        10); // The default `geometryFunction` can only handle `import("../geom/Point.js").Point` geometries
       return geometry;
     };
 
     /**
-     * @type {module:ol/source/Vector}
+     * @type {import("./Vector.js").default}
      * @protected
      */
     this.source = options.source;
@@ -105,7 +105,7 @@ class Cluster extends VectorSource {
 
   /**
    * Get a reference to the wrapped source.
-   * @return {module:ol/source/Vector} Source.
+   * @return {import("./Vector.js").default} Source.
    * @api
    */
   getSource() {
@@ -189,8 +189,8 @@ class Cluster extends VectorSource {
   }
 
   /**
-   * @param {Array<module:ol/Feature>} features Features
-   * @return {module:ol/Feature} The cluster feature.
+   * @param {Array<import("../Feature.js").default>} features Features
+   * @return {import("../Feature.js").default} The cluster feature.
    * @protected
    */
   createCluster(features) {

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -49,7 +49,7 @@ const ImageSourceEventType = {
 class ImageSourceEvent extends Event {
   /**
    * @param {string} type Type.
-   * @param {module:ol/Image} image The image.
+   * @param {import("../Image.js").default} image The image.
    */
   constructor(type, image) {
 
@@ -57,7 +57,7 @@ class ImageSourceEvent extends Event {
 
     /**
      * The image related to the event.
-     * @type {module:ol/Image}
+     * @type {import("../Image.js").default}
      * @api
      */
     this.image = image;
@@ -69,11 +69,11 @@ class ImageSourceEvent extends Event {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions]
- * @property {module:ol/extent~Extent} [extent]
- * @property {module:ol/proj~ProjectionLike} projection
+ * @property {import("./Source.js").AttributionLike} [attributions]
+ * @property {import("../extent.js").Extent} [extent]
+ * @property {import("../proj.js").ProjectionLike} projection
  * @property {Array<number>} [resolutions]
- * @property {module:ol/source/State} [state]
+ * @property {import("./State.js").default} [state]
  */
 
 
@@ -86,7 +86,7 @@ class ImageSourceEvent extends Event {
  */
 class ImageSource extends Source {
   /**
-   * @param {module:ol/source/Image~Options} options Single image source options.
+   * @param {Options} options Single image source options.
    */
   constructor(options) {
     super({
@@ -106,7 +106,7 @@ class ImageSource extends Source {
 
     /**
      * @private
-     * @type {module:ol/reproj/Image}
+     * @type {import("../reproj/Image.js").default}
      */
     this.reprojectedImage_ = null;
 
@@ -140,11 +140,11 @@ class ImageSource extends Source {
   }
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {module:ol/ImageBase} Single image.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {import("../ImageBase.js").default} Single image.
    */
   getImage(extent, resolution, pixelRatio, projection) {
     const sourceProjection = this.getProjection();
@@ -183,22 +183,22 @@ class ImageSource extends Source {
 
   /**
    * @abstract
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {module:ol/ImageBase} Single image.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {import("../ImageBase.js").default} Single image.
    * @protected
    */
   getImageInternal(extent, resolution, pixelRatio, projection) {}
 
   /**
    * Handle image change events.
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../events/Event.js").default} event Event.
    * @protected
    */
   handleImageChange(event) {
-    const image = /** @type {module:ol/Image} */ (event.target);
+    const image = /** @type {import("../Image.js").default} */ (event.target);
     switch (image.getState()) {
       case ImageState.LOADING:
         this.loading = true;
@@ -226,9 +226,9 @@ class ImageSource extends Source {
 
 
 /**
- * Default image load function for image sources that use module:ol/Image~Image image
+ * Default image load function for image sources that use import("../Image.js").Image image
  * instances.
- * @param {module:ol/Image} image Image.
+ * @param {import("../Image.js").default} image Image.
  * @param {string} src Source.
  */
 export function defaultImageLoadFunction(image, src) {

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -14,14 +14,14 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting the image from
  * the remote server.
- * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given
+ * @property {import("../Image.js").LoadFunction} [imageLoadFunction] Optional function to load an image given
  * a URL.
  * @property {Object<string,*>} params ArcGIS Rest parameters. This field is optional. Service
  * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
@@ -29,7 +29,7 @@ import {appendParams} from '../uri.js';
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
  * http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/
  * for further reference.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,
  * `2` means twice the size of the map viewport, and so on.
  * @property {Array<number>} [resolutions] Resolutions. If specified, requests will be made for
@@ -53,11 +53,11 @@ import {appendParams} from '../uri.js';
  */
 class ImageArcGISRest extends ImageSource {
   /**
-   * @param {module:ol/source/ImageArcGISRest~Options=} opt_options Image ArcGIS Rest Options.
+   * @param {Options=} opt_options Image ArcGIS Rest Options.
    */
   constructor(opt_options) {
 
-    const options = opt_options || /** @type {module:ol/source/ImageArcGISRest~Options} */ ({});
+    const options = opt_options || /** @type {Options} */ ({});
 
     super({
       attributions: options.attributions,
@@ -86,7 +86,7 @@ class ImageArcGISRest extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/Image~LoadFunction}
+     * @type {import("../Image.js").LoadFunction}
      */
     this.imageLoadFunction_ = options.imageLoadFunction !== undefined ?
       options.imageLoadFunction : defaultImageLoadFunction;
@@ -100,13 +100,13 @@ class ImageArcGISRest extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/Image}
+     * @type {import("../Image.js").default}
      */
     this.image_ = null;
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.imageSize_ = [0, 0];
 
@@ -207,7 +207,7 @@ class ImageArcGISRest extends ImageSource {
 
   /**
    * Return the image load function of the source.
-   * @return {module:ol/Image~LoadFunction} The image load function.
+   * @return {import("../Image.js").LoadFunction} The image load function.
    * @api
    */
   getImageLoadFunction() {
@@ -215,10 +215,10 @@ class ImageArcGISRest extends ImageSource {
   }
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../extent.js").Extent} extent Extent.
+   * @param {import("../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {Object} params Params.
    * @return {string} Request URL.
    * @private
@@ -255,7 +255,7 @@ class ImageArcGISRest extends ImageSource {
 
   /**
    * Set the image load function of the source.
-   * @param {module:ol/Image~LoadFunction} imageLoadFunction Image load function.
+   * @param {import("../Image.js").LoadFunction} imageLoadFunction Image load function.
    * @api
    */
   setImageLoadFunction(imageLoadFunction) {

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -16,29 +16,29 @@ import ImageSource from '../source/Image.js';
  * this function is cached by the source. The this keyword inside the function
  * references the {@link module:ol/source/ImageCanvas}.
  *
- * @typedef {function(this:module:ol/ImageCanvas, module:ol/extent~Extent, number,
- *     number, module:ol/size~Size, module:ol/proj/Projection): HTMLCanvasElement} FunctionType
+ * @typedef {function(this:import("../ImageCanvas.js").default, import("../extent.js").Extent, number,
+ *     number, import("../size.js").Size, import("../proj/Projection.js").default): HTMLCanvasElement} FunctionType
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
- * @property {module:ol/source/ImageCanvas~FunctionType} [canvasFunction] Canvas function.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
+ * @property {FunctionType} [canvasFunction] Canvas function.
  * The function returning the canvas element used by the source
- * as an image. The arguments passed to the function are: `{module:ol/extent~Extent}` the
+ * as an image. The arguments passed to the function are: `{import("../extent.js").Extent}` the
  * image extent, `{number}` the image resolution, `{number}` the device pixel
- * ratio, `{module:ol/size~Size}` the image size, and `{module:ol/proj/Projection~Projection}` the image
+ * ratio, `{import("../size.js").Size}` the image size, and `{import("../proj/Projection.js").Projection}` the image
  * projection. The canvas returned by this function is cached by the source. If
  * the value returned by the function is later changed then
  * `changed` should be called on the source for the source to
  * invalidate the current cached image. See @link: {@link module:ol/Observable~Observable#changed}
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
  * width and height of the map viewport, and so on. Must be `1` or higher.
  * @property {Array<number>} [resolutions] Resolutions.
  * If specified, new canvases will be created for these resolutions
- * @property {module:ol/source/State} [state] Source state.
+ * @property {import("./State.js").default} [state] Source state.
  */
 
 
@@ -49,7 +49,7 @@ import ImageSource from '../source/Image.js';
  */
 class ImageCanvasSource extends ImageSource {
   /**
-   * @param {module:ol/source/ImageCanvas~Options=} options ImageCanvas options.
+   * @param {Options=} options ImageCanvas options.
    */
   constructor(options) {
 
@@ -62,13 +62,13 @@ class ImageCanvasSource extends ImageSource {
 
     /**
     * @private
-    * @type {module:ol/source/ImageCanvas~FunctionType}
+    * @type {FunctionType}
     */
     this.canvasFunction_ = options.canvasFunction;
 
     /**
     * @private
-    * @type {module:ol/ImageCanvas}
+    * @type {import("../ImageCanvas.js").default}
     */
     this.canvas_ = null;
 

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -22,12 +22,12 @@ import {appendParams} from '../uri.js';
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
  * the image from the remote server.
  * @property {boolean} [useOverlay] If `true`, will use `GETDYNAMICMAPOVERLAYIMAGE`.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [ratio=1] Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or higher.
  * @property {Array<number>} [resolutions] Resolutions.
  * If specified, requests will be made for these resolutions only.
- * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
+ * @property {import("../Image.js").LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
  * @property {Object} [params] Additional parameters.
  */
 
@@ -41,7 +41,7 @@ import {appendParams} from '../uri.js';
  */
 class ImageMapGuide extends ImageSource {
   /**
-   * @param {module:ol/source/ImageMapGuide~Options=} options ImageMapGuide options.
+   * @param {Options=} options ImageMapGuide options.
    */
   constructor(options) {
 
@@ -78,7 +78,7 @@ class ImageMapGuide extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/Image~LoadFunction}
+     * @type {import("../Image.js").LoadFunction}
      */
     this.imageLoadFunction_ = options.imageLoadFunction !== undefined ?
       options.imageLoadFunction : defaultImageLoadFunction;
@@ -111,7 +111,7 @@ class ImageMapGuide extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/Image}
+     * @type {import("../Image.js").default}
      */
     this.image_ = null;
 
@@ -176,7 +176,7 @@ class ImageMapGuide extends ImageSource {
 
   /**
    * Return the image load function of the source.
-   * @return {module:ol/Image~LoadFunction} The image load function.
+   * @return {import("../Image.js").LoadFunction} The image load function.
    * @api
    */
   getImageLoadFunction() {
@@ -196,9 +196,9 @@ class ImageMapGuide extends ImageSource {
   /**
    * @param {string} baseUrl The mapagent url.
    * @param {Object<string, string|number>} params Request parameters.
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {module:ol/size~Size} size Size.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../extent.js").Extent} extent Extent.
+   * @param {import("../size.js").Size} size Size.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @return {string} The mapagent map image request URL.
    */
   getUrl(baseUrl, params, extent, size, projection) {
@@ -224,7 +224,7 @@ class ImageMapGuide extends ImageSource {
 
   /**
    * Set the image load function of the MapGuide source.
-   * @param {module:ol/Image~LoadFunction} imageLoadFunction Image load function.
+   * @param {import("../Image.js").LoadFunction} imageLoadFunction Image load function.
    * @api
    */
   setImageLoadFunction(imageLoadFunction) {
@@ -236,8 +236,8 @@ class ImageMapGuide extends ImageSource {
 
 
 /**
- * @param {module:ol/extent~Extent} extent The map extents.
- * @param {module:ol/size~Size} size The viewport size.
+ * @param {import("../extent.js").Extent} extent The map extents.
+ * @param {import("../size.js").Size} size The viewport size.
  * @param {number} metersPerUnit The meters-per-unit value.
  * @param {number} dpi The display resolution.
  * @return {number} The computed map scale.

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -13,16 +13,16 @@ import ImageSource, {defaultImageLoadFunction} from '../source/Image.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
- * @property {module:ol/extent~Extent} [imageExtent] Extent of the image in map coordinates.
+ * @property {import("../extent.js").Extent} [imageExtent] Extent of the image in map coordinates.
  * This is the [left, bottom, right, top] map coordinates of your image.
- * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {module:ol/size~Size} [imageSize] Size of the image in pixels. Usually the image size is auto-detected, so this
+ * @property {import("../Image.js").LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {import("../size.js").Size} [imageSize] Size of the image in pixels. Usually the image size is auto-detected, so this
  * only needs to be set if auto-detection fails for some reason.
  * @property {string} url Image URL.
  */
@@ -35,13 +35,13 @@ import ImageSource, {defaultImageLoadFunction} from '../source/Image.js';
  */
 class Static extends ImageSource {
   /**
-   * @param {module:ol/source/ImageStatic~Options=} options ImageStatic options.
+   * @param {Options=} options ImageStatic options.
    */
   constructor(options) {
     const crossOrigin = options.crossOrigin !== undefined ?
       options.crossOrigin : null;
 
-    const /** @type {module:ol/Image~LoadFunction} */ imageLoadFunction =
+    const /** @type {import("../Image.js").LoadFunction} */ imageLoadFunction =
         options.imageLoadFunction !== undefined ?
           options.imageLoadFunction : defaultImageLoadFunction;
 
@@ -58,19 +58,19 @@ class Static extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.imageExtent_ = options.imageExtent;
 
     /**
      * @private
-     * @type {module:ol/Image}
+     * @type {import("../Image.js").default}
      */
     this.image_ = new ImageWrapper(this.imageExtent_, undefined, 1, this.url_, crossOrigin, imageLoadFunction);
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.imageSize_ = options.imageSize ? options.imageSize : null;
 
@@ -81,7 +81,7 @@ class Static extends ImageSource {
 
   /**
    * Returns the image extent
-   * @return {module:ol/extent~Extent} image extent.
+   * @return {import("../extent.js").Extent} image extent.
    * @api
    */
   getImageExtent() {

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -20,28 +20,28 @@ import {appendParams} from '../uri.js';
 
 /**
  * @const
- * @type {module:ol/size~Size}
+ * @type {import("../size.js").Size}
  */
 const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
  * the image from the remote server.
- * @property {module:ol/source/WMSServerType|string} [serverType] The type of
+ * @property {import("./WMSServerType.js").default|string} [serverType] The type of
  * the remote WMS server: `mapserver`, `geoserver` or `qgis`. Only needed if `hidpi` is `true`.
- * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
+ * @property {import("../Image.js").LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
  * @property {Object<string,*>} params WMS request parameters.
  * At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher.
@@ -60,11 +60,11 @@ const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
  */
 class ImageWMS extends ImageSource {
   /**
-   * @param {module:ol/source/ImageWMS~Options=} [opt_options] ImageWMS options.
+   * @param {Options=} [opt_options] ImageWMS options.
    */
   constructor(opt_options) {
 
-    const options = opt_options || /** @type {module:ol/source/ImageWMS~Options} */ ({});
+    const options = opt_options || /** @type {Options} */ ({});
 
     super({
       attributions: options.attributions,
@@ -87,7 +87,7 @@ class ImageWMS extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/Image~LoadFunction}
+     * @type {import("../Image.js").LoadFunction}
      */
     this.imageLoadFunction_ = options.imageLoadFunction !== undefined ?
       options.imageLoadFunction : defaultImageLoadFunction;
@@ -107,9 +107,9 @@ class ImageWMS extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/source/WMSServerType|undefined}
+     * @type {import("./WMSServerType.js").default|undefined}
      */
-    this.serverType_ = /** @type {module:ol/source/WMSServerType|undefined} */ (options.serverType);
+    this.serverType_ = /** @type {import("./WMSServerType.js").default|undefined} */ (options.serverType);
 
     /**
      * @private
@@ -119,13 +119,13 @@ class ImageWMS extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/Image}
+     * @type {import("../Image.js").default}
      */
     this.image_ = null;
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.imageSize_ = [0, 0];
 
@@ -147,9 +147,9 @@ class ImageWMS extends ImageSource {
    * Return the GetFeatureInfo URL for the passed coordinate, resolution, and
    * projection. Return `undefined` if the GetFeatureInfo URL cannot be
    * constructed.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
-   * @param {module:ol/proj~ProjectionLike} projection Projection.
+   * @param {import("../proj.js").ProjectionLike} projection Projection.
    * @param {!Object} params GetFeatureInfo params. `INFO_FORMAT` at least should
    *     be provided. If `QUERY_LAYERS` is not provided then the layers specified
    *     in the `LAYERS` parameter will be used. `VERSION` should not be
@@ -267,7 +267,7 @@ class ImageWMS extends ImageSource {
 
   /**
    * Return the image load function of the source.
-   * @return {module:ol/Image~LoadFunction} The image load function.
+   * @return {import("../Image.js").LoadFunction} The image load function.
    * @api
    */
   getImageLoadFunction() {
@@ -275,10 +275,10 @@ class ImageWMS extends ImageSource {
   }
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../extent.js").Extent} extent Extent.
+   * @param {import("../size.js").Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {Object} params Params.
    * @return {string} Request URL.
    * @private
@@ -342,7 +342,7 @@ class ImageWMS extends ImageSource {
 
   /**
    * Set the image load function of the source.
-   * @param {module:ol/Image~LoadFunction} imageLoadFunction Image load function.
+   * @param {import("../Image.js").LoadFunction} imageLoadFunction Image load function.
    * @api
    */
   setImageLoadFunction(imageLoadFunction) {

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -19,7 +19,7 @@ export const ATTRIBUTION = '&#169; ' +
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
@@ -29,7 +29,7 @@ export const ATTRIBUTION = '&#169; ' +
  * @property {boolean} [opaque=true] Whether the layer is opaque.
  * @property {number} [reprojectionErrorThreshold=1.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -48,7 +48,7 @@ export const ATTRIBUTION = '&#169; ' +
  */
 class OSM extends XYZ {
   /**
-   * @param {module:ol/source/OSM~Options=} [opt_options] Open Street Map options.
+   * @param {Options=} [opt_options] Open Street Map options.
    */
   constructor(opt_options) {
 

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -80,7 +80,7 @@ const RasterOperationType = {
 class RasterSourceEvent extends Event {
   /**
    * @param {string} type Type.
-   * @param {module:ol/PluggableMap~FrameState} frameState The frame state.
+   * @param {import("../PluggableMap.js").FrameState} frameState The frame state.
    * @param {Object} data An object made available to operations.
    */
   constructor(type, frameState, data) {
@@ -88,7 +88,7 @@ class RasterSourceEvent extends Event {
 
     /**
      * The raster extent.
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      * @api
      */
     this.extent = frameState.extent;
@@ -114,9 +114,9 @@ class RasterSourceEvent extends Event {
 
 /**
  * @typedef {Object} Options
- * @property {Array<module:ol/source/Source|module:ol/layer/Layer>} sources Input
+ * @property {Array<import("./Source.js").default|import("../layer/Layer.js").default>} sources Input
  * sources or layers. Vector layers must be configured with `renderMode: 'image'`.
- * @property {module:ol/source/Raster~Operation} [operation] Raster operation.
+ * @property {Operation} [operation] Raster operation.
  * The operation will be called with data from input sources
  * and the output will be assigned to the raster source.
  * @property {Object} [lib] Functions that will be made available to operations run in a worker.
@@ -125,7 +125,7 @@ class RasterSourceEvent extends Event {
  * be run in multiple worker threads.  Note that there is additional overhead in
  * transferring data to multiple workers, and that depending on the user's
  * system, it may not be possible to parallelize the work.
- * @property {module:ol/source/Raster~RasterOperationType} [operationType='pixel'] Operation type.
+ * @property {RasterOperationType} [operationType='pixel'] Operation type.
  * Supported values are `'pixel'` and `'image'`.  By default,
  * `'pixel'` operations are assumed, and operations will be called with an
  * array of pixels from input sources.  If set to `'image'`, operations will
@@ -144,7 +144,7 @@ class RasterSourceEvent extends Event {
  */
 class RasterSource extends ImageSource {
   /**
-   * @param {module:ol/source/Raster~Options=} options Options.
+   * @param {Options=} options Options.
    */
   constructor(options) {
     super({});
@@ -157,7 +157,7 @@ class RasterSource extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/source/Raster~RasterOperationType}
+     * @type {RasterOperationType}
      */
     this.operationType_ = options.operationType !== undefined ?
       options.operationType : RasterOperationType.PIXEL;
@@ -170,7 +170,7 @@ class RasterSource extends ImageSource {
 
     /**
      * @private
-     * @type {Array<module:ol/renderer/canvas/Layer>}
+     * @type {Array<import("../renderer/canvas/Layer.js").default>}
      */
     this.renderers_ = createRenderers(options.sources);
 
@@ -181,7 +181,7 @@ class RasterSource extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/TileQueue}
+     * @type {import("../TileQueue.js").default}
      */
     this.tileQueue_ = new TileQueue(
       function() {
@@ -197,14 +197,14 @@ class RasterSource extends ImageSource {
 
     /**
      * The most recently requested frame state.
-     * @type {module:ol/PluggableMap~FrameState}
+     * @type {import("../PluggableMap.js").FrameState}
      * @private
      */
     this.requestedFrameState_;
 
     /**
      * The most recently rendered image canvas.
-     * @type {module:ol/ImageCanvas}
+     * @type {import("../ImageCanvas.js").default}
      * @private
      */
     this.renderedImageCanvas_ = null;
@@ -217,7 +217,7 @@ class RasterSource extends ImageSource {
 
     /**
      * @private
-     * @type {module:ol/PluggableMap~FrameState}
+     * @type {import("../PluggableMap.js").FrameState}
      */
     this.frameState_ = {
       animate: false,
@@ -235,7 +235,7 @@ class RasterSource extends ImageSource {
       tileQueue: this.tileQueue_,
       time: Date.now(),
       usedTiles: {},
-      viewState: /** @type {module:ol/View~State} */ ({
+      viewState: /** @type {import("../View.js").State} */ ({
         rotation: 0
       }),
       viewHints: [],
@@ -250,7 +250,7 @@ class RasterSource extends ImageSource {
 
   /**
    * Set the operation.
-   * @param {module:ol/source/Raster~Operation} operation New operation.
+   * @param {Operation} operation New operation.
    * @param {Object=} opt_lib Functions that will be available to operations run
    *     in a worker.
    * @api
@@ -268,17 +268,17 @@ class RasterSource extends ImageSource {
 
   /**
    * Update the stored frame state.
-   * @param {module:ol/extent~Extent} extent The view extent (in map units).
+   * @param {import("../extent.js").Extent} extent The view extent (in map units).
    * @param {number} resolution The view resolution.
-   * @param {module:ol/proj/Projection} projection The view projection.
-   * @return {module:ol/PluggableMap~FrameState} The updated frame state.
+   * @param {import("../proj/Projection.js").default} projection The view projection.
+   * @return {import("../PluggableMap.js").FrameState} The updated frame state.
    * @private
    */
   updateFrameState_(extent, resolution, projection) {
 
-    const frameState = /** @type {module:ol/PluggableMap~FrameState} */ (assign({}, this.frameState_));
+    const frameState = /** @type {import("../PluggableMap.js").FrameState} */ (assign({}, this.frameState_));
 
-    frameState.viewState = /** @type {module:ol/View~State} */ (assign({}, frameState.viewState));
+    frameState.viewState = /** @type {import("../View.js").State} */ (assign({}, frameState.viewState));
 
     const center = getCenter(extent);
 
@@ -372,7 +372,7 @@ class RasterSource extends ImageSource {
 
   /**
    * Called when pixel processing is complete.
-   * @param {module:ol/PluggableMap~FrameState} frameState The frame state.
+   * @param {import("../PluggableMap.js").FrameState} frameState The frame state.
    * @param {Error} err Any error during processing.
    * @param {ImageData} output The output image data.
    * @param {Object} data The user data.
@@ -427,9 +427,9 @@ let sharedContext = null;
 
 /**
  * Get image data from a renderer.
- * @param {module:ol/renderer/canvas/Layer} renderer Layer renderer.
- * @param {module:ol/PluggableMap~FrameState} frameState The frame state.
- * @param {module:ol/layer/Layer~State} layerState The layer state.
+ * @param {import("../renderer/canvas/Layer.js").default} renderer Layer renderer.
+ * @param {import("../PluggableMap.js").FrameState} frameState The frame state.
+ * @param {import("../layer/Layer.js").State} layerState The layer state.
  * @return {ImageData} The image data.
  */
 function getImageData(renderer, frameState, layerState) {
@@ -455,8 +455,8 @@ function getImageData(renderer, frameState, layerState) {
 
 /**
  * Get a list of layer states from a list of renderers.
- * @param {Array<module:ol/renderer/canvas/Layer>} renderers Layer renderers.
- * @return {Array<module:ol/layer/Layer~State>} The layer states.
+ * @param {Array<import("../renderer/canvas/Layer.js").default>} renderers Layer renderers.
+ * @return {Array<import("../layer/Layer.js").State>} The layer states.
  */
 function getLayerStatesArray(renderers) {
   return renderers.map(function(renderer) {
@@ -467,8 +467,8 @@ function getLayerStatesArray(renderers) {
 
 /**
  * Create renderers for all sources.
- * @param {Array<module:ol/source/Source>} sources The sources.
- * @return {Array<module:ol/renderer/canvas/Layer>} Array of layer renderers.
+ * @param {Array<import("./Source.js").default>} sources The sources.
+ * @return {Array<import("../renderer/canvas/Layer.js").default>} Array of layer renderers.
  */
 function createRenderers(sources) {
   const len = sources.length;
@@ -482,8 +482,8 @@ function createRenderers(sources) {
 
 /**
  * Create a renderer for the provided source.
- * @param {module:ol/source/Source} source The source.
- * @return {module:ol/renderer/canvas/Layer} The renderer.
+ * @param {import("./Source.js").default} source The source.
+ * @return {import("../renderer/canvas/Layer.js").default} The renderer.
  */
 function createRenderer(source) {
   let renderer = null;
@@ -503,8 +503,8 @@ function createRenderer(source) {
 
 /**
  * Create an image renderer for the provided source.
- * @param {module:ol/source/Image} source The source.
- * @return {module:ol/renderer/canvas/Layer} The renderer.
+ * @param {import("./Image.js").default} source The source.
+ * @return {import("../renderer/canvas/Layer.js").default} The renderer.
  */
 function createImageRenderer(source) {
   const layer = new ImageLayer({source: source});
@@ -514,8 +514,8 @@ function createImageRenderer(source) {
 
 /**
  * Create a tile renderer for the provided source.
- * @param {module:ol/source/Tile} source The source.
- * @return {module:ol/renderer/canvas/Layer} The renderer.
+ * @param {import("./Tile.js").default} source The source.
+ * @return {import("../renderer/canvas/Layer.js").default} The renderer.
  */
 function createTileRenderer(source) {
   const layer = new TileLayer({source: source});

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -12,7 +12,7 @@ import SourceState from '../source/State.js';
  * A function that returns a string or an array of strings representing source
  * attributions.
  *
- * @typedef {function(module:ol/PluggableMap~FrameState): (string|Array<string>)} Attribution
+ * @typedef {function(import("../PluggableMap.js").FrameState): (string|Array<string>)} Attribution
  */
 
 
@@ -24,15 +24,15 @@ import SourceState from '../source/State.js';
  * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
  * * a function that returns a string or array of strings (`{@link module:ol/source/Source~Attribution}`)
  *
- * @typedef {string|Array<string>|module:ol/source/Source~Attribution} AttributionLike
+ * @typedef {string|Array<string>|Attribution} AttributionLike
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions]
- * @property {module:ol/proj~ProjectionLike} projection
- * @property {module:ol/source/State} [state]
+ * @property {AttributionLike} [attributions]
+ * @property {import("../proj.js").ProjectionLike} projection
+ * @property {import("./State.js").default} [state]
  * @property {boolean} [wrapX]
  */
 
@@ -48,7 +48,7 @@ import SourceState from '../source/State.js';
  */
 class Source extends BaseObject {
   /**
-   * @param {module:ol/source/Source~Options} options Source options.
+   * @param {Options} options Source options.
    */
   constructor(options) {
 
@@ -56,13 +56,13 @@ class Source extends BaseObject {
 
     /**
     * @private
-    * @type {module:ol/proj/Projection}
+    * @type {import("../proj/Projection.js").default}
     */
     this.projection_ = getProjection(options.projection);
 
     /**
     * @private
-    * @type {?module:ol/source/Source~Attribution}
+    * @type {?Attribution}
     */
     this.attributions_ = this.adaptAttributions_(options.attributions);
 
@@ -75,7 +75,7 @@ class Source extends BaseObject {
 
     /**
     * @private
-    * @type {module:ol/source/State}
+    * @type {import("./State.js").default}
     */
     this.state_ = options.state !== undefined ?
       options.state : SourceState.READY;
@@ -90,8 +90,8 @@ class Source extends BaseObject {
 
   /**
   * Turns the attributions option into an attributions function.
-  * @param {module:ol/source/Source~AttributionLike|undefined} attributionLike The attribution option.
-  * @return {?module:ol/source/Source~Attribution} An attribution function (or null).
+  * @param {AttributionLike|undefined} attributionLike The attribution option.
+  * @return {?Attribution} An attribution function (or null).
   */
   adaptAttributions_(attributionLike) {
     if (!attributionLike) {
@@ -114,7 +114,7 @@ class Source extends BaseObject {
 
   /**
   * Get the attribution function for the source.
-  * @return {?module:ol/source/Source~Attribution} Attribution function.
+  * @return {?Attribution} Attribution function.
   */
   getAttributions() {
     return this.attributions_;
@@ -122,7 +122,7 @@ class Source extends BaseObject {
 
   /**
   * Get the projection of the source.
-  * @return {module:ol/proj/Projection} Projection.
+  * @return {import("../proj/Projection.js").default} Projection.
   * @api
   */
   getProjection() {
@@ -137,7 +137,7 @@ class Source extends BaseObject {
 
   /**
   * Get the state of the source, see {@link module:ol/source/State~State} for possible states.
-  * @return {module:ol/source/State} State.
+  * @return {import("./State.js").default} State.
   * @api
   */
   getState() {
@@ -161,7 +161,7 @@ class Source extends BaseObject {
 
   /**
   * Set the attributions of the source.
-  * @param {module:ol/source/Source~AttributionLike|undefined} attributions Attributions.
+  * @param {AttributionLike|undefined} attributions Attributions.
   *     Can be passed as `string`, `Array<string>`, `{@link module:ol/source/Source~Attribution}`,
   *     or `undefined`.
   * @api
@@ -173,7 +173,7 @@ class Source extends BaseObject {
 
   /**
   * Set the state of the source.
-  * @param {module:ol/source/State} state State.
+  * @param {import("./State.js").default} state State.
   * @protected
   */
   setState(state) {
@@ -183,12 +183,12 @@ class Source extends BaseObject {
 }
 
 /**
- * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+ * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
  * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {Object<string, boolean>} skippedFeatureUids Skipped feature uids.
- * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
+ * @param {function((import("../Feature.js").default|import("../render/Feature.js").default)): T} callback Feature callback.
  * @return {T|void} Callback result.
  * @template T
  */

--- a/src/ol/source/Stamen.js
+++ b/src/ol/source/Stamen.js
@@ -97,7 +97,7 @@ const ProviderConfig = {
  * @property {boolean} [opaque] Whether the layer is opaque.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction]
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction]
  * Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
@@ -116,7 +116,7 @@ const ProviderConfig = {
  */
 class Stamen extends XYZ {
   /**
-   * @param {module:ol/source/Stamen~Options=} options Stamen options.
+   * @param {Options=} options Stamen options.
    */
   constructor(options) {
     const i = options.layer.indexOf('-');

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -14,14 +14,14 @@ import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.j
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions]
+ * @property {import("./Source.js").AttributionLike} [attributions]
  * @property {number} [cacheSize]
- * @property {module:ol/extent~Extent} [extent]
+ * @property {import("../extent.js").Extent} [extent]
  * @property {boolean} [opaque]
  * @property {number} [tilePixelRatio]
- * @property {module:ol/proj~ProjectionLike} [projection]
- * @property {module:ol/source/State} [state]
- * @property {module:ol/tilegrid/TileGrid} [tileGrid]
+ * @property {import("../proj.js").ProjectionLike} [projection]
+ * @property {import("./State.js").default} [state]
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid]
  * @property {boolean} [wrapX=true]
  * @property {number} [transition]
  */
@@ -36,7 +36,7 @@ import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.j
  */
 class TileSource extends Source {
   /**
-   * @param {module:ol/source/Tile~Options=} options SourceTile source options.
+   * @param {Options=} options SourceTile source options.
    */
   constructor(options) {
 
@@ -63,19 +63,19 @@ class TileSource extends Source {
 
     /**
      * @protected
-     * @type {module:ol/tilegrid/TileGrid}
+     * @type {import("../tilegrid/TileGrid.js").default}
      */
     this.tileGrid = options.tileGrid !== undefined ? options.tileGrid : null;
 
     /**
      * @protected
-     * @type {module:ol/TileCache}
+     * @type {import("../TileCache.js").default}
      */
     this.tileCache = new TileCache(options.cacheSize);
 
     /**
      * @protected
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.tmpSize = [0, 0];
 
@@ -87,7 +87,7 @@ class TileSource extends Source {
 
     /**
      * @protected
-     * @type {module:ol/Tile~Options}
+     * @type {import("../Tile.js").Options}
      */
     this.tileOptions = {transition: options.transition};
 
@@ -101,8 +101,8 @@ class TileSource extends Source {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @param {!Object<string, module:ol/TileRange>} usedTiles Used tiles.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {!Object<string, import("../TileRange.js").default>} usedTiles Used tiles.
    */
   expireCache(projection, usedTiles) {
     const tileCache = this.getTileCacheForProjection(projection);
@@ -112,10 +112,10 @@ class TileSource extends Source {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {number} z Zoom level.
-   * @param {module:ol/TileRange} tileRange Tile range.
-   * @param {function(module:ol/Tile):(boolean|undefined)} callback Called with each
+   * @param {import("../TileRange.js").default} tileRange Tile range.
+   * @param {function(import("../Tile.js").default):(boolean|undefined)} callback Called with each
    *     loaded tile.  If the callback returns `false`, the tile will not be
    *     considered loaded.
    * @return {boolean} The tile range is fully covered with loaded tiles.
@@ -133,7 +133,7 @@ class TileSource extends Source {
         tileCoordKey = getKeyZXY(z, x, y);
         loaded = false;
         if (tileCache.containsKey(tileCoordKey)) {
-          tile = /** @type {!module:ol/Tile} */ (tileCache.get(tileCoordKey));
+          tile = /** @type {!import("../Tile.js").default} */ (tileCache.get(tileCoordKey));
           loaded = tile.getState() === TileState.LOADED;
           if (loaded) {
             loaded = (callback(tile) !== false);
@@ -148,7 +148,7 @@ class TileSource extends Source {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @return {number} Gutter.
    */
   getGutterForProjection(projection) {
@@ -177,7 +177,7 @@ class TileSource extends Source {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @return {boolean} Opaque.
    */
   getOpaque(projection) {
@@ -197,14 +197,14 @@ class TileSource extends Source {
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {!module:ol/Tile} Tile.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {!import("../Tile.js").default} Tile.
    */
   getTile(z, x, y, pixelRatio, projection) {}
 
   /**
    * Return the tile grid of the tile source.
-   * @return {module:ol/tilegrid/TileGrid} Tile grid.
+   * @return {import("../tilegrid/TileGrid.js").default} Tile grid.
    * @api
    */
   getTileGrid() {
@@ -212,8 +212,8 @@ class TileSource extends Source {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {!module:ol/tilegrid/TileGrid} Tile grid.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {!import("../tilegrid/TileGrid.js").default} Tile grid.
    */
   getTileGridForProjection(projection) {
     if (!this.tileGrid) {
@@ -224,8 +224,8 @@ class TileSource extends Source {
   }
 
   /**
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {module:ol/TileCache} Tile cache.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {import("../TileCache.js").default} Tile cache.
    * @protected
    */
   getTileCacheForProjection(projection) {
@@ -251,8 +251,8 @@ class TileSource extends Source {
   /**
    * @param {number} z Z.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
-   * @return {module:ol/size~Size} Tile size.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {import("../size.js").Size} Tile size.
    */
   getTilePixelSize(z, pixelRatio, projection) {
     const tileGrid = this.getTileGridForProjection(projection);
@@ -269,9 +269,9 @@ class TileSource extends Source {
    * Returns a tile coordinate wrapped around the x-axis. When the tile coordinate
    * is outside the resolution and extent range of the tile grid, `null` will be
    * returned.
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/proj/Projection=} opt_projection Projection.
-   * @return {module:ol/tilecoord~TileCoord} Tile coordinate to be passed to the tileUrlFunction or
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../proj/Projection.js").default=} opt_projection Projection.
+   * @return {import("../tilecoord.js").TileCoord} Tile coordinate to be passed to the tileUrlFunction or
    *     null if no tile URL should be created for the passed `tileCoord`.
    */
   getTileCoordForTileUrlFunction(tileCoord, opt_projection) {
@@ -299,7 +299,7 @@ class TileSource extends Source {
  * @param {number} z Tile coordinate z.
  * @param {number} x Tile coordinate x.
  * @param {number} y Tile coordinate y.
- * @param {module:ol/proj/Projection} projection Projection.
+ * @param {import("../proj/Projection.js").default} projection Projection.
  */
 TileSource.prototype.useTile = VOID;
 
@@ -312,7 +312,7 @@ TileSource.prototype.useTile = VOID;
 export class TileSourceEvent extends Event {
   /**
    * @param {string} type Type.
-   * @param {module:ol/Tile} tile The tile.
+   * @param {import("../Tile.js").default} tile The tile.
    */
   constructor(type, tile) {
 
@@ -320,7 +320,7 @@ export class TileSourceEvent extends Event {
 
     /**
      * The tile related to the event.
-     * @type {module:ol/Tile}
+     * @type {import("../Tile.js").default}
      * @api
      */
     this.tile = tile;

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -12,7 +12,7 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.
  * Note that you must provide a `crossOrigin` value if you are using the WebGL renderer
@@ -26,15 +26,15 @@ import {appendParams} from '../uri.js';
  * override the default service layer visibility. See
  * http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/
  * for further reference.
- * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid. Base this on the resolutions,
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid. Base this on the resolutions,
  * tilesize and extent supported by the server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL.
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL.
  * The default is
  * ```js
  * function(imageTile, src) {
@@ -62,7 +62,7 @@ import {appendParams} from '../uri.js';
  */
 class TileArcGISRest extends TileImage {
   /**
-   * @param {module:ol/source/TileArcGISRest~Options=} opt_options Tile ArcGIS Rest options.
+   * @param {Options=} opt_options Tile ArcGIS Rest options.
    */
   constructor(opt_options) {
 
@@ -90,7 +90,7 @@ class TileArcGISRest extends TileImage {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.tmpExtent_ = createEmpty();
 
@@ -121,11 +121,11 @@ class TileArcGISRest extends TileImage {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/size~Size} tileSize Tile size.
-   * @param {module:ol/extent~Extent} tileExtent Tile extent.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../size.js").Size} tileSize Tile size.
+   * @param {import("../extent.js").Extent} tileExtent Tile extent.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {Object} params Params.
    * @return {string|undefined} Request URL.
    * @private

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -12,8 +12,8 @@ import {getKeyZXY} from '../tilecoord.js';
 
 class LabeledTile extends Tile {
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/size~Size} tileSize Tile size.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../size.js").Size} tileSize Tile size.
    * @param {string} text Text.
    */
   constructor(tileCoord, tileSize, text) {
@@ -22,7 +22,7 @@ class LabeledTile extends Tile {
 
     /**
     * @private
-    * @type {module:ol/size~Size}
+    * @type {import("../size.js").Size}
     */
     this.tileSize_ = tileSize;
 
@@ -74,8 +74,8 @@ class LabeledTile extends Tile {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  */
 
@@ -91,7 +91,7 @@ class LabeledTile extends Tile {
  */
 class TileDebug extends TileSource {
   /**
-   * @param {module:ol/source/TileDebug~Options=} options Debug tile options.
+   * @param {Options=} options Debug tile options.
    */
   constructor(options) {
 
@@ -110,7 +110,7 @@ class TileDebug extends TileSource {
   getTile(z, x, y) {
     const tileCoordKey = getKeyZXY(z, x, y);
     if (this.tileCache.containsKey(tileCoordKey)) {
-      return /** @type {!module:ol/source/TileDebug~LabeledTile} */ (this.tileCache.get(tileCoordKey));
+      return /** @type {!LabeledTile} */ (this.tileCache.get(tileCoordKey));
     } else {
       const tileSize = toSize(this.tileGrid.getTileSize(z));
       const tileCoord = [z, x, y];

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -16,22 +16,22 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
- * @property {module:ol/extent~Extent} [extent]
+ * @property {import("../extent.js").Extent} [extent]
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [opaque=true] Whether the layer is opaque.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/source/State} [state] Source state.
- * @property {module:ol/ImageTile~TileClass} [tileClass] Class used to instantiate image tiles.
+ * @property {import("./State.js").default} [state] Source state.
+ * @property {import("../ImageTile.js").TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/ImageTile~ImageTile}.
- * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -41,7 +41,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`.
- * @property {module:ol/Tile~UrlFunction} [tileUrlFunction] Optional function to get tile URL given a tile coordinate and the projection.
+ * @property {import("../Tile.js").UrlFunction} [tileUrlFunction] Optional function to get tile URL given a tile coordinate and the projection.
  * @property {string} [url] URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
@@ -59,12 +59,12 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * @classdesc
  * Base class for sources providing images divided into a tile grid.
  *
- * @fires module:ol/source/Tile~TileSourceEvent
+ * @fires import("./Tile.js").TileSourceEvent
  * @api
  */
 class TileImage extends UrlTile {
   /**
-   * @param {!module:ol/source/TileImage~Options} options Image tile options.
+   * @param {!Options} options Image tile options.
    */
   constructor(options) {
 
@@ -95,21 +95,21 @@ class TileImage extends UrlTile {
 
     /**
      * @protected
-     * @type {function(new: module:ol/ImageTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
-     *        ?string, module:ol/Tile~LoadFunction, module:ol/Tile~Options=)}
+     * @type {function(new: import("../ImageTile.js").default, import("../tilecoord.js").TileCoord, import("../TileState.js").default, string,
+     *        ?string, import("../Tile.js").LoadFunction, import("../Tile.js").Options=)}
      */
     this.tileClass = options.tileClass !== undefined ?
       options.tileClass : ImageTile;
 
     /**
      * @protected
-     * @type {!Object<string, module:ol/TileCache>}
+     * @type {!Object<string, import("../TileCache.js").default>}
      */
     this.tileCacheForProjection = {};
 
     /**
      * @protected
-     * @type {!Object<string, module:ol/tilegrid/TileGrid>}
+     * @type {!Object<string, import("../tilegrid/TileGrid.js").default>}
      */
     this.tileGridForProjection = {};
 
@@ -209,7 +209,7 @@ class TileImage extends UrlTile {
         this.tileGridForProjection[projKey] = getTileGridForProjection(projection);
       }
       return (
-        /** @type {!module:ol/tilegrid/TileGrid} */ (this.tileGridForProjection[projKey])
+        /** @type {!import("../tilegrid/TileGrid.js").default} */ (this.tileGridForProjection[projKey])
       );
     }
   }
@@ -237,9 +237,9 @@ class TileImage extends UrlTile {
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {string} key The key set on the tile.
-   * @return {!module:ol/Tile} Tile.
+   * @return {!import("../Tile.js").default} Tile.
    * @private
    */
   createTile_(z, x, y, pixelRatio, projection, key) {
@@ -265,7 +265,7 @@ class TileImage extends UrlTile {
    * @inheritDoc
    */
   getTile(z, x, y, pixelRatio, projection) {
-    const sourceProjection = /** @type {!module:ol/proj/Projection} */ (this.getProjection());
+    const sourceProjection = /** @type {!import("../proj/Projection.js").default} */ (this.getProjection());
     if (!ENABLE_RASTER_REPROJECTION ||
         !sourceProjection || !projection || equivalent(sourceProjection, projection)) {
       return this.getTileInternal(z, x, y, pixelRatio, sourceProjection || projection);
@@ -275,7 +275,7 @@ class TileImage extends UrlTile {
       let tile;
       const tileCoordKey = getKey(tileCoord);
       if (cache.containsKey(tileCoordKey)) {
-        tile = /** @type {!module:ol/Tile} */ (cache.get(tileCoordKey));
+        tile = /** @type {!import("../Tile.js").default} */ (cache.get(tileCoordKey));
       }
       const key = this.getKey();
       if (tile && tile.key == key) {
@@ -313,8 +313,8 @@ class TileImage extends UrlTile {
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {!module:ol/proj/Projection} projection Projection.
-   * @return {!module:ol/Tile} Tile.
+   * @param {!import("../proj/Projection.js").default} projection Projection.
+   * @return {!import("../Tile.js").default} Tile.
    * @protected
    */
   getTileInternal(z, x, y, pixelRatio, projection) {
@@ -372,8 +372,8 @@ class TileImage extends UrlTile {
    * (e.g. projection has no extent defined) or
    * for optimization reasons (custom tile size, resolutions, ...).
    *
-   * @param {module:ol/proj~ProjectionLike} projection Projection.
-   * @param {module:ol/tilegrid/TileGrid} tilegrid Tile grid to use for the projection.
+   * @param {import("../proj.js").ProjectionLike} projection Projection.
+   * @param {import("../tilegrid/TileGrid.js").default} tilegrid Tile grid to use for the projection.
    * @api
    */
   setTileGridForProjection(projection, tilegrid) {
@@ -391,7 +391,7 @@ class TileImage extends UrlTile {
 
 
 /**
- * @param {module:ol/ImageTile} imageTile Image tile.
+ * @param {import("../ImageTile.js").default} imageTile Image tile.
  * @param {string} src Source.
  */
 function defaultTileLoadFunction(imageTile, src) {

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -19,7 +19,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
@@ -31,7 +31,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {tileJSON} [tileJSON] TileJSON configuration for this source.
  * If not provided, `url` must be configured.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -51,7 +51,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  */
 class TileJSON extends TileImage {
   /**
-   * @param {module:ol/source/TileJSON~Options=} options TileJSON options.
+   * @param {Options=} options TileJSON options.
    */
   constructor(options) {
     super({

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -19,7 +19,7 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
@@ -40,20 +40,20 @@ import {appendParams} from '../uri.js';
  * this. See http://mapserver.org/output/tile_mode.html.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
  * the image from the remote server.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/ImageTile~TileClass} [tileClass] Class used to instantiate image tiles.
+ * @property {import("../ImageTile.js").TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/ImageTile~TileClass}.
- * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid. Base this on the resolutions,
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid. Base this on the resolutions,
  * tilesize and extent supported by the server.
  * If this is not defined, a default grid will be used: if there is a projection
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used..
- * @property {module:ol/source/WMSServerType|string} [serverType]
+ * @property {import("./WMSServerType.js").default|string} [serverType]
  * The type of the remote WMS server. Currently only used when `hidpi` is
  * `true`.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -78,11 +78,11 @@ import {appendParams} from '../uri.js';
  */
 class TileWMS extends TileImage {
   /**
-   * @param {module:ol/source/TileWMS~Options=} [opt_options] Tile WMS options.
+   * @param {Options=} [opt_options] Tile WMS options.
    */
   constructor(opt_options) {
 
-    const options = opt_options || /** @type {module:ol/source/TileWMS~Options} */ ({});
+    const options = opt_options || /** @type {Options} */ ({});
 
     const params = options.params || {};
 
@@ -124,9 +124,9 @@ class TileWMS extends TileImage {
 
     /**
      * @private
-     * @type {module:ol/source/WMSServerType|undefined}
+     * @type {import("./WMSServerType.js").default|undefined}
      */
-    this.serverType_ = /** @type {module:ol/source/WMSServerType|undefined} */ (options.serverType);
+    this.serverType_ = /** @type {import("./WMSServerType.js").default|undefined} */ (options.serverType);
 
     /**
      * @private
@@ -136,7 +136,7 @@ class TileWMS extends TileImage {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.tmpExtent_ = createEmpty();
 
@@ -149,9 +149,9 @@ class TileWMS extends TileImage {
    * Return the GetFeatureInfo URL for the passed coordinate, resolution, and
    * projection. Return `undefined` if the GetFeatureInfo URL cannot be
    * constructed.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
-   * @param {module:ol/proj~ProjectionLike} projection Projection.
+   * @param {import("../proj.js").ProjectionLike} projection Projection.
    * @param {!Object} params GetFeatureInfo params. `INFO_FORMAT` at least should
    *     be provided. If `QUERY_LAYERS` is not provided then the layers specified
    *     in the `LAYERS` parameter will be used. `VERSION` should not be
@@ -229,11 +229,11 @@ class TileWMS extends TileImage {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/size~Size} tileSize Tile size.
-   * @param {module:ol/extent~Extent} tileExtent Tile extent.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../size.js").Size} tileSize Tile size.
+   * @param {import("../extent.js").Extent} tileExtent Tile extent.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {Object} params Params.
    * @return {string|undefined} Request URL.
    * @private

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -20,10 +20,10 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
 export class CustomTile extends Tile {
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileState} state State.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../TileState.js").default} state State.
    * @param {string} src Image source URI.
-   * @param {module:ol/extent~Extent} extent Extent of the tile.
+   * @param {import("../extent.js").Extent} extent Extent of the tile.
    * @param {boolean} preemptive Load the tile when visible (before it's needed).
    * @param {boolean} jsonp Load the tile as a script.
    */
@@ -39,7 +39,7 @@ export class CustomTile extends Tile {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.extent_ = extent;
 
@@ -87,7 +87,7 @@ export class CustomTile extends Tile {
 
   /**
    * Synchronously returns data at given coordinate (if available).
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @return {*} The data.
    */
   getData(coordinate) {
@@ -130,7 +130,7 @@ export class CustomTile extends Tile {
   /**
    * Calls the callback (synchronously by default) with the available data
    * for given coordinate (or `null` if not yet loaded).
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {function(this: T, *)} callback Callback.
    * @param {T=} opt_this The object to use as `this` in the callback.
    * @param {boolean=} opt_request If `true` the callback is always async.
@@ -272,7 +272,7 @@ export class CustomTile extends Tile {
  */
 class UTFGrid extends TileSource {
   /**
-   * @param {module:ol/source/UTFGrid~Options=} options Source options.
+   * @param {Options=} options Source options.
    */
   constructor(options) {
     super({
@@ -289,7 +289,7 @@ class UTFGrid extends TileSource {
 
     /**
      * @private
-     * @type {!module:ol/Tile~UrlFunction}
+     * @type {!import("../Tile.js").UrlFunction}
      */
     this.tileUrlFunction_ = nullTileUrlFunction;
 
@@ -370,7 +370,7 @@ class UTFGrid extends TileSource {
    * Calls the callback (synchronously by default) with the available data
    * for given coordinate and resolution (or `null` if not yet loaded or
    * in case of an error).
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
    * @param {function(*)} callback Callback.
    * @param {boolean=} opt_request If `true` the callback is always async.
@@ -382,7 +382,7 @@ class UTFGrid extends TileSource {
     if (this.tileGrid) {
       const tileCoord = this.tileGrid.getTileCoordForCoordAndResolution(
         coordinate, resolution);
-      const tile = /** @type {!module:ol/source/UTFGrid~CustomTile} */(this.getTile(
+      const tile = /** @type {!CustomTile} */(this.getTile(
         tileCoord[0], tileCoord[1], tileCoord[2], 1, this.getProjection()));
       tile.forDataAtCoordinate(coordinate, callback, null, opt_request);
     } else {
@@ -465,7 +465,7 @@ class UTFGrid extends TileSource {
     const tileCoordKey = getKeyZXY(z, x, y);
     if (this.tileCache.containsKey(tileCoordKey)) {
       return (
-        /** @type {!module:ol/Tile} */ (this.tileCache.get(tileCoordKey))
+        /** @type {!import("../Tile.js").default} */ (this.tileCache.get(tileCoordKey))
       );
     } else {
       const tileCoord = [z, x, y];

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -10,16 +10,16 @@ import {getKeyZXY} from '../tilecoord.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions]
+ * @property {import("./Source.js").AttributionLike} [attributions]
  * @property {number} [cacheSize]
- * @property {module:ol/extent~Extent} [extent]
+ * @property {import("../extent.js").Extent} [extent]
  * @property {boolean} [opaque]
- * @property {module:ol/proj~ProjectionLike} [projection]
- * @property {module:ol/source/State} [state]
- * @property {module:ol/tilegrid/TileGrid} [tileGrid]
- * @property {module:ol/Tile~LoadFunction} tileLoadFunction
+ * @property {import("../proj.js").ProjectionLike} [projection]
+ * @property {import("./State.js").default} [state]
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid]
+ * @property {import("../Tile.js").LoadFunction} tileLoadFunction
  * @property {number} [tilePixelRatio]
- * @property {module:ol/Tile~UrlFunction} [tileUrlFunction]
+ * @property {import("../Tile.js").UrlFunction} [tileUrlFunction]
  * @property {string} [url]
  * @property {Array<string>} [urls]
  * @property {boolean} [wrapX=true]
@@ -31,11 +31,11 @@ import {getKeyZXY} from '../tilecoord.js';
  * @classdesc
  * Base class for sources providing tiles divided into a tile grid over http.
  *
- * @fires module:ol/source/TileEvent
+ * @fires import("./TileEvent.js").default
  */
 class UrlTile extends TileSource {
   /**
-   * @param {module:ol/source/UrlTile~Options=} options Image tile options.
+   * @param {Options=} options Image tile options.
    */
   constructor(options) {
 
@@ -54,13 +54,13 @@ class UrlTile extends TileSource {
 
     /**
      * @protected
-     * @type {module:ol/Tile~LoadFunction}
+     * @type {import("../Tile.js").LoadFunction}
      */
     this.tileLoadFunction = options.tileLoadFunction;
 
     /**
      * @protected
-     * @type {module:ol/Tile~UrlFunction}
+     * @type {import("../Tile.js").UrlFunction}
      */
     this.tileUrlFunction = this.fixedTileUrlFunction ?
       this.fixedTileUrlFunction.bind(this) : nullTileUrlFunction;
@@ -90,7 +90,7 @@ class UrlTile extends TileSource {
 
   /**
    * Return the tile load function of the source.
-   * @return {module:ol/Tile~LoadFunction} TileLoadFunction
+   * @return {import("../Tile.js").LoadFunction} TileLoadFunction
    * @api
    */
   getTileLoadFunction() {
@@ -99,7 +99,7 @@ class UrlTile extends TileSource {
 
   /**
    * Return the tile URL function of the source.
-   * @return {module:ol/Tile~UrlFunction} TileUrlFunction
+   * @return {import("../Tile.js").UrlFunction} TileUrlFunction
    * @api
    */
   getTileUrlFunction() {
@@ -119,11 +119,11 @@ class UrlTile extends TileSource {
 
   /**
    * Handle tile change events.
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../events/Event.js").default} event Event.
    * @protected
    */
   handleTileChange(event) {
-    const tile = /** @type {module:ol/Tile} */ (event.target);
+    const tile = /** @type {import("../Tile.js").default} */ (event.target);
     const uid = getUid(tile);
     const tileState = tile.getState();
     let type;
@@ -143,7 +143,7 @@ class UrlTile extends TileSource {
 
   /**
    * Set the tile load function of the source.
-   * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
+   * @param {import("../Tile.js").LoadFunction} tileLoadFunction Tile load function.
    * @api
    */
   setTileLoadFunction(tileLoadFunction) {
@@ -154,7 +154,7 @@ class UrlTile extends TileSource {
 
   /**
    * Set the tile URL function of the source.
-   * @param {module:ol/Tile~UrlFunction} tileUrlFunction Tile URL function.
+   * @param {import("../Tile.js").UrlFunction} tileUrlFunction Tile URL function.
    * @param {string=} opt_key Optional new tile key for the source.
    * @api
    */
@@ -206,7 +206,7 @@ class UrlTile extends TileSource {
 
 
 /**
- * @type {module:ol/Tile~UrlFunction|undefined}
+ * @type {import("../Tile.js").UrlFunction|undefined}
  * @protected
  */
 UrlTile.prototype.fixedTileUrlFunction;

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -26,7 +26,7 @@ import RBush from '../structs/RBush.js';
  * returns an array of {@link module:ol/extent~Extent} with the extents to load. Usually this
  * is one of the standard {@link module:ol/loadingstrategy} strategies.
  *
- * @typedef {function(module:ol/extent~Extent, number): Array<module:ol/extent~Extent>} LoadingStrategy
+ * @typedef {function(import("../extent.js").Extent, number): Array<import("../extent.js").Extent>} LoadingStrategy
  * @api
  */
 
@@ -40,7 +40,7 @@ export class VectorSourceEvent extends Event {
 
   /**
    * @param {string} type Type.
-   * @param {module:ol/Feature=} opt_feature Feature.
+   * @param {import("../Feature.js").default=} opt_feature Feature.
    */
   constructor(type, opt_feature) {
 
@@ -48,7 +48,7 @@ export class VectorSourceEvent extends Event {
 
     /**
      * The feature being added or removed.
-     * @type {module:ol/Feature|undefined}
+     * @type {import("../Feature.js").default|undefined}
      * @api
      */
     this.feature = opt_feature;
@@ -60,13 +60,13 @@ export class VectorSourceEvent extends Event {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
- * @property {Array<module:ol/Feature>|module:ol/Collection<module:ol/Feature>} [features]
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
+ * @property {Array<import("../Feature.js").default>|import("../Collection.js").default<import("../Feature.js").default>} [features]
  * Features. If provided as {@link module:ol/Collection}, the features in the source
  * and the collection will stay in sync.
- * @property {module:ol/format/Feature} [format] The feature format used by the XHR
+ * @property {import("../format/Feature.js").default} [format] The feature format used by the XHR
  * feature loader when `url` is set. Required if `url` is set, otherwise ignored.
- * @property {module:ol/featureloader~FeatureLoader} [loader]
+ * @property {import("../featureloader.js").FeatureLoader} [loader]
  * The loader function used to load features, from a remote source for example.
  * If this is not set and `url` is set, the source will create and use an XHR
  * feature loader.
@@ -109,10 +109,10 @@ export class VectorSourceEvent extends Event {
  * Setting this to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
- * @property {module:ol/source/Vector~LoadingStrategy} [strategy] The loading strategy to use.
+ * @property {LoadingStrategy} [strategy] The loading strategy to use.
  * By default an {@link module:ol/loadingstrategy~all}
  * strategy is used, a one-off strategy which loads all features at once.
- * @property {string|module:ol/featureloader~FeatureUrlFunction} [url]
+ * @property {string|import("../featureloader.js").FeatureUrlFunction} [url]
  * Setting this option instructs the source to load features using an XHR loader
  * (see {@link module:ol/featureloader~xhr}). Use a `string` and an
  * {@link module:ol/loadingstrategy~all} for a one-off download of all features from
@@ -159,7 +159,7 @@ export class VectorSourceEvent extends Event {
  */
 class VectorSource extends Source {
   /**
-   * @param {module:ol/source/Vector~Options=} opt_options Vector source options.
+   * @param {Options=} opt_options Vector source options.
    */
   constructor(opt_options) {
 
@@ -174,13 +174,13 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {module:ol/featureloader~FeatureLoader}
+     * @type {import("../featureloader.js").FeatureLoader}
      */
     this.loader_ = VOID;
 
     /**
      * @private
-     * @type {module:ol/format/Feature|undefined}
+     * @type {import("../format/Feature.js").default|undefined}
      */
     this.format_ = options.format;
 
@@ -192,7 +192,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {string|module:ol/featureloader~FeatureUrlFunction|undefined}
+     * @type {string|import("../featureloader.js").FeatureUrlFunction|undefined}
      */
     this.url_ = options.url;
 
@@ -201,12 +201,12 @@ class VectorSource extends Source {
     } else if (this.url_ !== undefined) {
       assert(this.format_, 7); // `format` must be set when `url` is set
       // create a XHR feature loader for "url" and "format"
-      this.loader_ = xhr(this.url_, /** @type {module:ol/format/Feature} */ (this.format_));
+      this.loader_ = xhr(this.url_, /** @type {import("../format/Feature.js").default} */ (this.format_));
     }
 
     /**
      * @private
-     * @type {module:ol/source/Vector~LoadingStrategy}
+     * @type {LoadingStrategy}
      */
     this.strategy_ = options.strategy !== undefined ? options.strategy : allStrategy;
 
@@ -215,45 +215,45 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {module:ol/structs/RBush<module:ol/Feature>}
+     * @type {import("../structs/RBush.js").default<import("../Feature.js").default>}
      */
     this.featuresRtree_ = useSpatialIndex ? new RBush() : null;
 
     /**
      * @private
-     * @type {module:ol/structs/RBush<{extent: module:ol/extent~Extent}>}
+     * @type {import("../structs/RBush.js").default<{extent: import("../extent.js").Extent}>}
      */
     this.loadedExtentsRtree_ = new RBush();
 
     /**
      * @private
-     * @type {!Object<string, module:ol/Feature>}
+     * @type {!Object<string, import("../Feature.js").default>}
      */
     this.nullGeometryFeatures_ = {};
 
     /**
      * A lookup of features by id (the return from feature.getId()).
      * @private
-     * @type {!Object<string, module:ol/Feature>}
+     * @type {!Object<string, import("../Feature.js").default>}
      */
     this.idIndex_ = {};
 
     /**
      * A lookup of features without id (keyed by getUid(feature)).
      * @private
-     * @type {!Object<string, module:ol/Feature>}
+     * @type {!Object<string, import("../Feature.js").default>}
      */
     this.undefIdIndex_ = {};
 
     /**
      * @private
-     * @type {Object<string, Array<module:ol/events~EventsKey>>}
+     * @type {Object<string, Array<import("../events.js").EventsKey>>}
      */
     this.featureChangeKeys_ = {};
 
     /**
      * @private
-     * @type {module:ol/Collection<module:ol/Feature>}
+     * @type {import("../Collection.js").default<import("../Feature.js").default>}
      */
     this.featuresCollection_ = null;
 
@@ -282,7 +282,7 @@ class VectorSource extends Source {
    * instead. A feature will not be added to the source if feature with
    * the same id is already there. The reason for this behavior is to avoid
    * feature duplication when using bbox or tile loading strategies.
-   * @param {module:ol/Feature} feature Feature to add.
+   * @param {import("../Feature.js").default} feature Feature to add.
    * @api
    */
   addFeature(feature) {
@@ -293,7 +293,7 @@ class VectorSource extends Source {
 
   /**
    * Add a feature without firing a `change` event.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @protected
    */
   addFeatureInternal(feature) {
@@ -322,7 +322,7 @@ class VectorSource extends Source {
 
   /**
    * @param {string} featureKey Unique identifier for the feature.
-   * @param {module:ol/Feature} feature The feature.
+   * @param {import("../Feature.js").default} feature The feature.
    * @private
    */
   setupChangeEvents_(featureKey, feature) {
@@ -337,7 +337,7 @@ class VectorSource extends Source {
 
   /**
    * @param {string} featureKey Unique identifier for the feature.
-   * @param {module:ol/Feature} feature The feature.
+   * @param {import("../Feature.js").default} feature The feature.
    * @return {boolean} The feature is "valid", in the sense that it is also a
    *     candidate for insertion into the Rtree.
    * @private
@@ -362,7 +362,7 @@ class VectorSource extends Source {
 
   /**
    * Add a batch of features to the source.
-   * @param {Array<module:ol/Feature>} features Features to add.
+   * @param {Array<import("../Feature.js").default>} features Features to add.
    * @api
    */
   addFeatures(features) {
@@ -373,7 +373,7 @@ class VectorSource extends Source {
 
   /**
    * Add features without firing a `change` event.
-   * @param {Array<module:ol/Feature>} features Features.
+   * @param {Array<import("../Feature.js").default>} features Features.
    * @protected
    */
   addFeaturesInternal(features) {
@@ -414,7 +414,7 @@ class VectorSource extends Source {
 
 
   /**
-   * @param {!module:ol/Collection<module:ol/Feature>} collection Collection.
+   * @param {!import("../Collection.js").default<import("../Feature.js").default>} collection Collection.
    * @private
    */
   bindFeaturesCollection_(collection) {
@@ -439,7 +439,7 @@ class VectorSource extends Source {
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
-          this.addFeature(/** @type {module:ol/Feature} */ (evt.element));
+          this.addFeature(/** @type {import("../Feature.js").default} */ (evt.element));
           modifyingCollection = false;
         }
       }, this);
@@ -447,7 +447,7 @@ class VectorSource extends Source {
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
-          this.removeFeature(/** @type {module:ol/Feature} */ (evt.element));
+          this.removeFeature(/** @type {import("../Feature.js").default} */ (evt.element));
           modifyingCollection = false;
         }
       }, this);
@@ -501,7 +501,7 @@ class VectorSource extends Source {
    * stop and the function will return the same value.
    * Note: this function only iterate through the feature that have a defined geometry.
    *
-   * @param {function(module:ol/Feature): T} callback Called with each feature
+   * @param {function(import("../Feature.js").default): T} callback Called with each feature
    *     on the source.  Return a truthy value to stop iteration.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -522,8 +522,8 @@ class VectorSource extends Source {
    * a "truthy" value, iteration will stop and the function will return the same
    * value.
    *
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {function(module:ol/Feature): T} callback Called with each feature
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {function(import("../Feature.js").default): T} callback Called with each feature
    *     whose goemetry contains the provided coordinate.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -553,8 +553,8 @@ class VectorSource extends Source {
    * When `useSpatialIndex` is set to false, this method will loop through all
    * features, equivalent to {@link module:ol/source/Vector~VectorSource#forEachFeature #forEachFeature()}.
    *
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {function(module:ol/Feature): T} callback Called with each feature
+   * @param {import("../extent.js").Extent} extent Extent.
+   * @param {function(import("../Feature.js").default): T} callback Called with each feature
    *     whose bounding box intersects the provided extent.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -577,8 +577,8 @@ class VectorSource extends Source {
    * If you only want to test for bounding box intersection, call the
    * {@link module:ol/source/Vector~VectorSource#forEachFeatureInExtent #forEachFeatureInExtent()} method instead.
    *
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @param {function(module:ol/Feature): T} callback Called with each feature
+   * @param {import("../extent.js").Extent} extent Extent.
+   * @param {function(import("../Feature.js").default): T} callback Called with each feature
    *     whose geometry intersects the provided extent.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -587,7 +587,7 @@ class VectorSource extends Source {
   forEachFeatureIntersectingExtent(extent, callback) {
     return this.forEachFeatureInExtent(extent,
       /**
-       * @param {module:ol/Feature} feature Feature.
+       * @param {import("../Feature.js").default} feature Feature.
        * @return {T|undefined} The return value from the last call to the callback.
        * @template T
        */
@@ -607,7 +607,7 @@ class VectorSource extends Source {
    * Get the features collection associated with this source. Will be `null`
    * unless the source was configured with `useSpatialIndex` set to `false`, or
    * with an {@link module:ol/Collection} as `features`.
-   * @return {module:ol/Collection<module:ol/Feature>} The collection of features.
+   * @return {import("../Collection.js").default<import("../Feature.js").default>} The collection of features.
    * @api
    */
   getFeaturesCollection() {
@@ -617,7 +617,7 @@ class VectorSource extends Source {
 
   /**
    * Get all features on the source in random order.
-   * @return {Array<module:ol/Feature>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   getFeatures() {
@@ -631,15 +631,15 @@ class VectorSource extends Source {
       }
     }
     return (
-      /** @type {Array<module:ol/Feature>} */ (features)
+      /** @type {Array<import("../Feature.js").default>} */ (features)
     );
   }
 
 
   /**
    * Get all features whose geometry intersects the provided coordinate.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @return {Array<module:ol/Feature>} Features.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   getFeaturesAtCoordinate(coordinate) {
@@ -658,8 +658,8 @@ class VectorSource extends Source {
    *
    * This method is not available when the source is configured with
    * `useSpatialIndex` set to `false`.
-   * @param {module:ol/extent~Extent} extent Extent.
-   * @return {Array<module:ol/Feature>} Features.
+   * @param {import("../extent.js").Extent} extent Extent.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   getFeaturesInExtent(extent) {
@@ -672,11 +672,11 @@ class VectorSource extends Source {
    *
    * This method is not available when the source is configured with
    * `useSpatialIndex` set to `false`.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
-   * @param {function(module:ol/Feature):boolean=} opt_filter Feature filter function.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {function(import("../Feature.js").default):boolean=} opt_filter Feature filter function.
    *     The filter function will receive one argument, the {@link module:ol/Feature feature}
    *     and it should return a boolean value. By default, no filtering is made.
-   * @return {module:ol/Feature} Closest feature.
+   * @return {import("../Feature.js").default} Closest feature.
    * @api
    */
   getClosestFeatureToCoordinate(coordinate, opt_filter) {
@@ -696,7 +696,7 @@ class VectorSource extends Source {
     const filter = opt_filter ? opt_filter : TRUE;
     this.featuresRtree_.forEachInExtent(extent,
       /**
-       * @param {module:ol/Feature} feature Feature.
+       * @param {import("../Feature.js").default} feature Feature.
        */
       function(feature) {
         if (filter(feature)) {
@@ -727,9 +727,9 @@ class VectorSource extends Source {
    *
    * This method is not available when the source is configured with
    * `useSpatialIndex` set to `false`.
-   * @param {module:ol/extent~Extent=} opt_extent Destination extent. If provided, no new extent
+   * @param {import("../extent.js").Extent=} opt_extent Destination extent. If provided, no new extent
    *     will be created. Instead, that extent's coordinates will be overwritten.
-   * @return {module:ol/extent~Extent} Extent.
+   * @return {import("../extent.js").Extent} Extent.
    * @api
    */
   getExtent(opt_extent) {
@@ -743,7 +743,7 @@ class VectorSource extends Source {
    * `source.getFeatureById(2)` will return a feature with id `'2'` or `2`.
    *
    * @param {string|number} id Feature identifier.
-   * @return {module:ol/Feature} The feature (or `null` if not found).
+   * @return {import("../Feature.js").default} The feature (or `null` if not found).
    * @api
    */
   getFeatureById(id) {
@@ -755,7 +755,7 @@ class VectorSource extends Source {
   /**
    * Get the format associated with this source.
    *
-   * @return {module:ol/format/Feature|undefined} The feature format.
+   * @return {import("../format/Feature.js").default|undefined} The feature format.
    * @api
    */
   getFormat() {
@@ -780,7 +780,7 @@ class VectorSource extends Source {
   /**
    * Get the url associated with this source.
    *
-   * @return {string|module:ol/featureloader~FeatureUrlFunction|undefined} The url.
+   * @return {string|import("../featureloader.js").FeatureUrlFunction|undefined} The url.
    * @api
    */
   getUrl() {
@@ -789,11 +789,11 @@ class VectorSource extends Source {
 
 
   /**
-   * @param {module:ol/events/Event} event Event.
+   * @param {import("../events/Event.js").default} event Event.
    * @private
    */
   handleFeatureChange_(event) {
-    const feature = /** @type {module:ol/Feature} */ (event.target);
+    const feature = /** @type {import("../Feature.js").default} */ (event.target);
     const featureKey = getUid(feature).toString();
     const geometry = feature.getGeometry();
     if (!geometry) {
@@ -841,7 +841,7 @@ class VectorSource extends Source {
 
   /**
    * Returns true if the feature is contained within the source.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @return {boolean} Has feature.
    * @api
    */
@@ -864,9 +864,9 @@ class VectorSource extends Source {
 
 
   /**
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} resolution Resolution.
-   * @param {module:ol/proj/Projection} projection Projection.
+   * @param {import("../proj/Projection.js").default} projection Projection.
    */
   loadFeatures(extent, resolution, projection) {
     const loadedExtentsRtree = this.loadedExtentsRtree_;
@@ -876,7 +876,7 @@ class VectorSource extends Source {
       const extentToLoad = extentsToLoad[i];
       const alreadyLoaded = loadedExtentsRtree.forEachInExtent(extentToLoad,
         /**
-         * @param {{extent: module:ol/extent~Extent}} object Object.
+         * @param {{extent: import("../extent.js").Extent}} object Object.
          * @return {boolean} Contains.
          */
         function(object) {
@@ -893,7 +893,7 @@ class VectorSource extends Source {
 
   /**
    * Remove an extent from the list of loaded extents.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @api
    */
   removeLoadedExtent(extent) {
@@ -915,7 +915,7 @@ class VectorSource extends Source {
    * Remove a single feature from the source.  If you want to remove all features
    * at once, use the {@link module:ol/source/Vector~VectorSource#clear #clear()} method
    * instead.
-   * @param {module:ol/Feature} feature Feature to remove.
+   * @param {import("../Feature.js").default} feature Feature to remove.
    * @api
    */
   removeFeature(feature) {
@@ -934,7 +934,7 @@ class VectorSource extends Source {
 
   /**
    * Remove feature without firing a `change` event.
-   * @param {module:ol/Feature} feature Feature.
+   * @param {import("../Feature.js").default} feature Feature.
    * @protected
    */
   removeFeatureInternal(feature) {
@@ -955,7 +955,7 @@ class VectorSource extends Source {
   /**
    * Remove a feature from the id index.  Called internally when the feature id
    * may have changed.
-   * @param {module:ol/Feature} feature The feature.
+   * @param {import("../Feature.js").default} feature The feature.
    * @return {boolean} Removed the feature from the index.
    * @private
    */
@@ -975,7 +975,7 @@ class VectorSource extends Source {
   /**
    * Set the new loader of the source. The next loadFeatures call will use the
    * new loader.
-   * @param {module:ol/featureloader~FeatureLoader} loader The loader to set.
+   * @param {import("../featureloader.js").FeatureLoader} loader The loader to set.
    * @api
    */
   setLoader(loader) {

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -12,23 +12,23 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=128] Cache size.
- * @property {module:ol/extent~Extent} [extent]
- * @property {module:ol/format/Feature} [format] Feature format for tiles. Used and required by the default.
+ * @property {import("../extent.js").Extent} [extent]
+ * @property {import("../format/Feature.js").default} [format] Feature format for tiles. Used and required by the default.
  * @property {boolean} [overlaps=true] This source may have overlapping geometries. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
- * @property {module:ol/source/State} [state] Source state.
- * @property {module:ol/VectorTile~TileClass} [tileClass] Class used to instantiate image tiles.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {import("./State.js").default} [state] Source state.
+ * @property {import("../VectorTile.js").TileClass} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/VectorTile}.
  * @property {number} [maxZoom=22] Optional max zoom level.
  * @property {number} [minZoom] Optional min zoom level.
- * @property {number|module:ol/size~Size} [tileSize=512] Optional tile size.
- * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction]
+ * @property {number|import("../size.js").Size} [tileSize=512] Optional tile size.
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction]
  * Optional function to load a tile given a URL. Could look like this:
  * ```js
  * function(tile, url) {
@@ -45,7 +45,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  *   }
  * });
  * ```
- * @property {module:ol/Tile~UrlFunction} [tileUrlFunction] Optional function to get tile URL given a tile coordinate and the projection.
+ * @property {import("../Tile.js").UrlFunction} [tileUrlFunction] Optional function to get tile URL given a tile coordinate and the projection.
  * @property {string} [url] URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
@@ -69,12 +69,12 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * {@link module:ol/source/Vector} for vector sources that are suitable for feature
  * editing.
  *
- * @fires module:ol/source/Tile~TileSourceEvent
+ * @fires import("./Tile.js").TileSourceEvent
  * @api
  */
 class VectorTile extends UrlTile {
   /**
-   * @param {!module:ol/source/VectorTile~Options} options Vector tile options.
+   * @param {!Options} options Vector tile options.
    */
   constructor(options) {
     const projection = options.projection || 'EPSG:3857';
@@ -106,13 +106,13 @@ class VectorTile extends UrlTile {
 
     /**
      * @private
-     * @type {module:ol/format/Feature}
+     * @type {import("../format/Feature.js").default}
      */
     this.format_ = options.format ? options.format : null;
 
     /**
        * @private
-       * @type {Object<string, module:ol/VectorTile>}
+       * @type {Object<string, import("../VectorTile.js").default>}
        */
     this.sourceTiles_ = {};
 
@@ -124,14 +124,14 @@ class VectorTile extends UrlTile {
 
     /**
        * @protected
-       * @type {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
-       *        module:ol/format/Feature, module:ol/Tile~LoadFunction)}
+       * @type {function(new: import("../VectorTile.js").default, import("../tilecoord.js").TileCoord, import("../TileState.js").default, string,
+       *        import("../format/Feature.js").default, import("../Tile.js").LoadFunction)}
        */
     this.tileClass = options.tileClass ? options.tileClass : Tile;
 
     /**
      * @private
-     * @type {Object<string, module:ol/tilegrid/TileGrid>}
+     * @type {Object<string, import("../tilegrid/TileGrid.js").default>}
      */
     this.tileGrids_ = {};
 
@@ -160,7 +160,7 @@ class VectorTile extends UrlTile {
     const tileCoordKey = getKeyZXY(z, x, y);
     if (this.tileCache.containsKey(tileCoordKey)) {
       return (
-        /** @type {!module:ol/Tile} */ (this.tileCache.get(tileCoordKey))
+        /** @type {!import("../Tile.js").default} */ (this.tileCache.get(tileCoordKey))
       );
     } else {
       const tileCoord = [z, x, y];

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -14,20 +14,20 @@ import {appendParams} from '../uri.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
- * @property {module:ol/tilegrid/WMTS} tileGrid Tile grid.
- * @property {module:ol/proj~ProjectionLike} projection Projection.
+ * @property {import("../tilegrid/WMTS.js").default} tileGrid Tile grid.
+ * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {module:ol/source/WMTSRequestEncoding|string} [requestEncoding='KVP'] Request encoding.
+ * @property {import("./WMTSRequestEncoding.js").default|string} [requestEncoding='KVP'] Request encoding.
  * @property {string} layer Layer name as advertised in the WMTS capabilities.
  * @property {string} style Style name as advertised in the WMTS capabilities.
- * @property {module:ol/ImageTile~TileClass} [tileClass]  Class used to instantiate image tiles. Default is {@link module:ol/ImageTile~ImageTile}.
+ * @property {import("../ImageTile.js").TileClass} [tileClass]  Class used to instantiate image tiles. Default is {@link module:ol/ImageTile~ImageTile}.
  * @property {number} [tilePixelRatio=1] The pixel ratio used by the tile service.
  * For example, if the tile service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
@@ -42,7 +42,7 @@ import {appendParams} from '../uri.js';
  * template.  For KVP encoding, it is normal URL. A `{?-?}` template pattern,
  * for example `subdomain{a-f}.domain.com`, may be used instead of defining
  * each one separately in the `urls` option.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -63,14 +63,14 @@ import {appendParams} from '../uri.js';
  */
 class WMTS extends TileImage {
   /**
-   * @param {module:ol/source/WMTS~Options=} options WMTS options.
+   * @param {Options=} options WMTS options.
    */
   constructor(options) {
 
     // TODO: add support for TileMatrixLimits
 
     const requestEncoding = options.requestEncoding !== undefined ?
-      /** @type {module:ol/source/WMTSRequestEncoding} */ (options.requestEncoding) :
+      /** @type {import("./WMTSRequestEncoding.js").default} */ (options.requestEncoding) :
       WMTSRequestEncoding.KVP;
 
     // FIXME: should we create a default tileGrid?
@@ -139,7 +139,7 @@ class WMTS extends TileImage {
 
     /**
      * @private
-     * @type {module:ol/source/WMTSRequestEncoding}
+     * @type {import("./WMTSRequestEncoding.js").default}
      */
     this.requestEncoding_ = requestEncoding;
 
@@ -208,7 +208,7 @@ class WMTS extends TileImage {
 
   /**
    * Return the request encoding, either "KVP" or "REST".
-   * @return {module:ol/source/WMTSRequestEncoding} Request encoding.
+   * @return {import("./WMTSRequestEncoding.js").default} Request encoding.
    * @api
    */
   getRequestEncoding() {
@@ -285,7 +285,7 @@ export default WMTS;
  *  - format - {string} Image format for the layer. Default is the first
  *       format returned in the GetCapabilities response.
  *  - crossOrigin - {string|null|undefined} Cross origin. Default is `undefined`.
- * @return {?module:ol/source/WMTS~Options} WMTS source options object or `null` if the layer was not found.
+ * @return {?Options} WMTS source options object or `null` if the layer was not found.
  * @api
  */
 export function optionsFromCapabilities(wmtsCap, config) {
@@ -459,8 +459,8 @@ export function optionsFromCapabilities(wmtsCap, config) {
 
 /**
  * @param {string} template Template.
- * @return {module:ol/Tile~UrlFunction} Tile URL function.
- * @this {module:ol/source/WMTS}
+ * @return {import("../Tile.js").UrlFunction} Tile URL function.
+ * @this {import("./WMTS.js").default}
  */
 function createFromWMTSTemplate(template) {
   const requestEncoding = this.requestEncoding_;
@@ -497,9 +497,9 @@ function createFromWMTSTemplate(template) {
 
   return (
     /**
-     * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
+     * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
      * @param {number} pixelRatio Pixel ratio.
-     * @param {module:ol/proj/Projection} projection Projection.
+     * @param {import("../proj/Projection.js").default} projection Projection.
      * @return {string|undefined} Tile URL.
      */
     function(tileCoord, pixelRatio, projection) {

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -7,20 +7,20 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [opaque=true] Whether the layer is opaque.
- * @property {module:ol/proj~ProjectionLike} [projection='EPSG:3857'] Projection.
+ * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {number} [maxZoom=18] Optional max zoom level.
  * @property {number} [minZoom=0] Optional min zoom level.
- * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid.
- * @property {module:ol/Tile~LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
+ * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is
  * ```js
  * function(imageTile, src) {
  *   imageTile.getImage().src = src;
@@ -30,8 +30,8 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * For example, if the tile service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`
  * should be set to `2`.
- * @property {number|module:ol/size~Size} [tileSize=[256, 256]] The tile size used by the tile service.
- * @property {module:ol/Tile~UrlFunction} [tileUrlFunction] Optional function to get
+ * @property {number|import("../size.js").Size} [tileSize=[256, 256]] The tile size used by the tile service.
+ * @property {import("../Tile.js").UrlFunction} [tileUrlFunction] Optional function to get
  * tile URL given a tile coordinate and the projection.
  * Required if url or urls are not provided.
  * @property {string} [url] URL template. Must include `{x}`, `{y}` or `{-y}`,
@@ -64,7 +64,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  */
 class XYZ extends TileImage {
   /**
-   * @param {module:ol/source/XYZ~Options=} opt_options XYZ options.
+   * @param {Options=} opt_options XYZ options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -26,13 +26,13 @@ const TierSizeCalculation = {
 export class CustomTile extends ImageTile {
 
   /**
-   * @param {module:ol/tilegrid/TileGrid} tileGrid TileGrid that the tile belongs to.
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileState} state State.
+   * @param {import("../tilegrid/TileGrid.js").default} tileGrid TileGrid that the tile belongs to.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../TileState.js").default} state State.
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
-   * @param {module:ol/Tile~LoadFunction} tileLoadFunction Tile load function.
-   * @param {module:ol/Tile~Options=} opt_options Tile options.
+   * @param {import("../Tile.js").LoadFunction} tileLoadFunction Tile load function.
+   * @param {import("../Tile.js").Options=} opt_options Tile options.
    */
   constructor(tileGrid, tileCoord, state, src, crossOrigin, tileLoadFunction, opt_options) {
 
@@ -46,7 +46,7 @@ export class CustomTile extends ImageTile {
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.tileSize_ = toSize(tileGrid.getTileSize(tileCoord[0]));
 
@@ -81,13 +81,13 @@ export class CustomTile extends ImageTile {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize=2048] Cache size.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
- * @property {module:ol/proj~ProjectionLike} [projection] Projection.
+ * @property {import("../proj.js").ProjectionLike} [projection] Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {string} [url] URL template or base URL of the Zoomify service.
@@ -102,8 +102,8 @@ export class CustomTile extends ImageTile {
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
  * @property {string} [tierSizeCalculation] Tier size calculation method: `default` or `truncated`.
- * @property {module:ol/size~Size} [size] Size of the image.
- * @property {module:ol/extent~Extent} [extent] Extent for the TileGrid that is created.
+ * @property {import("../size.js").Size} [size] Size of the image.
+ * @property {import("../extent.js").Extent} [extent] Extent for the TileGrid that is created.
  * Default sets the TileGrid in the
  * fourth quadrant, meaning extent is `[0, -height, width, 0]`. To change the
  * extent to the first quadrant (the default for OpenLayers 2) set the extent
@@ -123,7 +123,7 @@ export class CustomTile extends ImageTile {
 class Zoomify extends TileImage {
 
   /**
-   * @param {module:ol/source/Zoomify~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -197,15 +197,15 @@ class Zoomify extends TileImage {
 
     /**
      * @param {string} template Template.
-     * @return {module:ol/Tile~UrlFunction} Tile URL function.
+     * @return {import("../Tile.js").UrlFunction} Tile URL function.
      */
     function createFromTemplate(template) {
 
       return (
         /**
-         * @param {module:ol/tilecoord~TileCoord} tileCoord Tile Coordinate.
+         * @param {import("../tilecoord.js").TileCoord} tileCoord Tile Coordinate.
          * @param {number} pixelRatio Pixel ratio.
-         * @param {module:ol/proj/Projection} projection Projection.
+         * @param {import("../proj/Projection.js").default} projection Projection.
          * @return {string|undefined} Tile URL.
          */
         function(tileCoord, pixelRatio, projection) {

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -16,7 +16,7 @@ import GeometryType from './geom/GeometryType.js';
  * Object literal with options for the {@link getLength} or {@link getArea}
  * functions.
  * @typedef {Object} SphereMetricOptions
- * @property {module:ol/proj~ProjectionLike} [projection='EPSG:3857']
+ * @property {import("./proj.js").ProjectionLike} [projection='EPSG:3857']
  * Projection of the  geometry.  By default, the geometry is assumed to be in
  * Web Mercator.
  * @property {number} [radius=6371008.8] Sphere radius.  By default, the radius of the
@@ -74,8 +74,8 @@ function getLengthInternal(coordinates, radius) {
  * great circle distances between coordinates.  For polygons, the length is
  * the sum of all rings.  For points, the length is zero.  For multi-part
  * geometries, the length is the sum of the length of each part.
- * @param {module:ol/geom/Geometry} geometry A geometry.
- * @param {module:ol/sphere~SphereMetricOptions=} opt_options Options for the
+ * @param {import("./geom/Geometry.js").default} geometry A geometry.
+ * @param {SphereMetricOptions=} opt_options Options for the
  * length calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  * You can change this by providing a `projection` option.
  * @return {number} The spherical length (in meters).
@@ -98,20 +98,20 @@ export function getLength(geometry, opt_options) {
     }
     case GeometryType.LINE_STRING:
     case GeometryType.LINEAR_RING: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {import("./geom/SimpleGeometry.js").default} */ (geometry).getCoordinates();
       length = getLengthInternal(coordinates, radius);
       break;
     }
     case GeometryType.MULTI_LINE_STRING:
     case GeometryType.POLYGON: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {import("./geom/SimpleGeometry.js").default} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         length += getLengthInternal(coordinates[i], radius);
       }
       break;
     }
     case GeometryType.MULTI_POLYGON: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {import("./geom/SimpleGeometry.js").default} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         coords = coordinates[i];
         for (j = 0, jj = coords.length; j < jj; ++j) {
@@ -121,7 +121,7 @@ export function getLength(geometry, opt_options) {
       break;
     }
     case GeometryType.GEOMETRY_COLLECTION: {
-      const geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
+      const geometries = /** @type {import("./geom/GeometryCollection.js").default} */ (geometry).getGeometries();
       for (i = 0, ii = geometries.length; i < ii; ++i) {
         length += getLength(geometries[i], opt_options);
       }
@@ -143,7 +143,7 @@ export function getLength(geometry, opt_options) {
  * Polygons on a Sphere", JPL Publication 07-03, Jet Propulsion
  * Laboratory, Pasadena, CA, June 2007
  *
- * @param {Array<module:ol/coordinate~Coordinate>} coordinates List of coordinates of a linear
+ * @param {Array<import("./coordinate.js").Coordinate>} coordinates List of coordinates of a linear
  * ring. If the ring is oriented clockwise, the area will be positive,
  * otherwise it will be negative.
  * @param {number} radius The sphere radius.
@@ -170,8 +170,8 @@ function getAreaInternal(coordinates, radius) {
 /**
  * Get the spherical area of a geometry.  This is the area (in meters) assuming
  * that polygon edges are segments of great circles on a sphere.
- * @param {module:ol/geom/Geometry} geometry A geometry.
- * @param {module:ol/sphere~SphereMetricOptions=} opt_options Options for the area
+ * @param {import("./geom/Geometry.js").default} geometry A geometry.
+ * @param {SphereMetricOptions=} opt_options Options for the area
  *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  *     You can change this by providing a `projection` option.
  * @return {number} The spherical area (in square meters).
@@ -196,7 +196,7 @@ export function getArea(geometry, opt_options) {
       break;
     }
     case GeometryType.POLYGON: {
-      coordinates = /** @type {module:ol/geom/Polygon} */ (geometry).getCoordinates();
+      coordinates = /** @type {import("./geom/Polygon.js").default} */ (geometry).getCoordinates();
       area = Math.abs(getAreaInternal(coordinates[0], radius));
       for (i = 1, ii = coordinates.length; i < ii; ++i) {
         area -= Math.abs(getAreaInternal(coordinates[i], radius));
@@ -204,7 +204,7 @@ export function getArea(geometry, opt_options) {
       break;
     }
     case GeometryType.MULTI_POLYGON: {
-      coordinates = /** @type {module:ol/geom/SimpleGeometry} */ (geometry).getCoordinates();
+      coordinates = /** @type {import("./geom/SimpleGeometry.js").default} */ (geometry).getCoordinates();
       for (i = 0, ii = coordinates.length; i < ii; ++i) {
         coords = coordinates[i];
         area += Math.abs(getAreaInternal(coords[0], radius));
@@ -215,7 +215,7 @@ export function getArea(geometry, opt_options) {
       break;
     }
     case GeometryType.GEOMETRY_COLLECTION: {
-      const geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
+      const geometries = /** @type {import("./geom/GeometryCollection.js").default} */ (geometry).getGeometries();
       for (i = 0, ii = geometries.length; i < ii; ++i) {
         area += getArea(geometries[i], opt_options);
       }
@@ -232,13 +232,13 @@ export function getArea(geometry, opt_options) {
 /**
  * Returns the coordinate at the given distance and bearing from `c1`.
  *
- * @param {module:ol/coordinate~Coordinate} c1 The origin point (`[lon, lat]` in degrees).
+ * @param {import("./coordinate.js").Coordinate} c1 The origin point (`[lon, lat]` in degrees).
  * @param {number} distance The great-circle distance between the origin
  *     point and the target point.
  * @param {number} bearing The bearing (in radians).
  * @param {number=} opt_radius The sphere radius to use.  Defaults to the Earth's
  *     mean radius using the WGS84 ellipsoid.
- * @return {module:ol/coordinate~Coordinate} The target point.
+ * @return {import("./coordinate.js").Coordinate} The target point.
  */
 export function offset(c1, distance, bearing, opt_radius) {
   const radius = opt_radius || DEFAULT_RADIUS;

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -22,7 +22,7 @@ import EventType from '../events/EventType.js';
  * Object's properties (e.g. 'hasOwnProperty' is not allowed as a key). Expiring
  * items from the cache is the responsibility of the user.
  *
- * @fires module:ol/events/Event~Event
+ * @fires import("../events/Event.js").Event
  * @template T
  */
 class LRUCache extends EventTarget {
@@ -47,19 +47,19 @@ class LRUCache extends EventTarget {
 
     /**
      * @private
-     * @type {!Object<string, module:ol/structs/LRUCache~Entry>}
+     * @type {!Object<string, Entry>}
      */
     this.entries_ = {};
 
     /**
      * @private
-     * @type {?module:ol/structs/LRUCache~Entry}
+     * @type {?Entry}
      */
     this.oldest_ = null;
 
     /**
      * @private
-     * @type {?module:ol/structs/LRUCache~Entry}
+     * @type {?Entry}
      */
     this.newest_ = null;
 
@@ -96,7 +96,7 @@ class LRUCache extends EventTarget {
 
 
   /**
-   * @param {function(this: S, T, string, module:ol/structs/LRUCache): ?} f The function
+   * @param {function(this: S, T, string, import("./LRUCache.js").default): ?} f The function
    *     to call for every entry from the oldest to the newer. This function takes
    *     3 arguments (the entry value, the entry key and the LRUCache object).
    *     The return value is ignored.
@@ -123,7 +123,7 @@ class LRUCache extends EventTarget {
     if (entry === this.newest_) {
       return entry.value_;
     } else if (entry === this.oldest_) {
-      this.oldest_ = /** @type {module:ol/structs/LRUCache~Entry} */ (this.oldest_.newer);
+      this.oldest_ = /** @type {Entry} */ (this.oldest_.newer);
       this.oldest_.older = null;
     } else {
       entry.newer.older = entry.older;
@@ -146,12 +146,12 @@ class LRUCache extends EventTarget {
     const entry = this.entries_[key];
     assert(entry !== undefined, 15); // Tried to get a value for a key that does not exist in the cache
     if (entry === this.newest_) {
-      this.newest_ = /** @type {module:ol/structs/LRUCache~Entry} */ (entry.older);
+      this.newest_ = /** @type {Entry} */ (entry.older);
       if (this.newest_) {
         this.newest_.newer = null;
       }
     } else if (entry === this.oldest_) {
-      this.oldest_ = /** @type {module:ol/structs/LRUCache~Entry} */ (entry.newer);
+      this.oldest_ = /** @type {Entry} */ (entry.newer);
       if (this.oldest_) {
         this.oldest_.older = null;
       }
@@ -235,7 +235,7 @@ class LRUCache extends EventTarget {
     if (entry.newer) {
       entry.newer.older = null;
     }
-    this.oldest_ = /** @type {module:ol/structs/LRUCache~Entry} */ (entry.newer);
+    this.oldest_ = /** @type {Entry} */ (entry.newer);
     if (!this.oldest_) {
       this.newest_ = null;
     }
@@ -261,7 +261,7 @@ class LRUCache extends EventTarget {
   set(key, value) {
     assert(!(key in this.entries_),
       16); // Tried to set a value for a key that is used already
-    const entry = /** @type {module:ol/structs/LRUCache~Entry} */ ({
+    const entry = /** @type {Entry} */ ({
       key_: key,
       newer: null,
       older: this.newest_,

--- a/src/ol/structs/LinkedList.js
+++ b/src/ol/structs/LinkedList.js
@@ -5,8 +5,8 @@
 
 /**
  * @typedef {Object} Item
- * @property {module:ol/structs/LinkedList~Item} [prev]
- * @property {module:ol/structs/LinkedList~Item} [next]
+ * @property {Item} [prev]
+ * @property {Item} [next]
  * @property {?} data
  */
 
@@ -24,19 +24,19 @@ class LinkedList {
 
     /**
      * @private
-     * @type {module:ol/structs/LinkedList~Item|undefined}
+     * @type {Item|undefined}
      */
     this.first_;
 
     /**
      * @private
-     * @type {module:ol/structs/LinkedList~Item|undefined}
+     * @type {Item|undefined}
      */
     this.last_;
 
     /**
      * @private
-     * @type {module:ol/structs/LinkedList~Item|undefined}
+     * @type {Item|undefined}
      */
     this.head_;
 
@@ -61,7 +61,7 @@ class LinkedList {
    */
   insertItem(data) {
 
-    /** @type {module:ol/structs/LinkedList~Item} */
+    /** @type {Item} */
     const item = {
       prev: undefined,
       next: undefined,
@@ -227,7 +227,7 @@ class LinkedList {
 
   /**
    * Concatenates two lists.
-   * @param {module:ol/structs/LinkedList} list List to merge into the current list.
+   * @param {import("./LinkedList.js").default} list List to merge into the current list.
    */
   concat(list) {
     if (list.head_) {

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -37,7 +37,7 @@ class RBush {
      * A mapping between the objects added to this rbush wrapper
      * and the objects that are actually added to the internal rbush.
      * @private
-     * @type {Object<number, module:ol/structs/RBush~Entry>}
+     * @type {Object<number, Entry>}
      */
     this.items_ = {};
 
@@ -45,11 +45,11 @@ class RBush {
 
   /**
    * Insert a value into the RBush.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {T} value Value.
    */
   insert(extent, value) {
-    /** @type {module:ol/structs/RBush~Entry} */
+    /** @type {Entry} */
     const item = {
       minX: extent[0],
       minY: extent[1],
@@ -65,7 +65,7 @@ class RBush {
 
   /**
    * Bulk-insert values into the RBush.
-   * @param {Array<module:ol/extent~Extent>} extents Extents.
+   * @param {Array<import("../extent.js").Extent>} extents Extents.
    * @param {Array<T>} values Values.
    */
   load(extents, values) {
@@ -74,7 +74,7 @@ class RBush {
       const extent = extents[i];
       const value = values[i];
 
-      /** @type {module:ol/structs/RBush~Entry} */
+      /** @type {Entry} */
       const item = {
         minX: extent[0],
         minY: extent[1],
@@ -107,7 +107,7 @@ class RBush {
 
   /**
    * Update the extent of a value in the RBush.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {T} value Value.
    */
   update(extent, value) {
@@ -134,11 +134,11 @@ class RBush {
 
   /**
    * Return all values in the given extent.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @return {Array<T>} All in extent.
    */
   getInExtent(extent) {
-    /** @type {module:ol/structs/RBush~Entry} */
+    /** @type {Entry} */
     const bbox = {
       minX: extent[0],
       minY: extent[1],
@@ -168,7 +168,7 @@ class RBush {
 
   /**
    * Calls a callback function with each value in the provided extent.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {function(this: S, T): *} callback Callback.
    * @param {S=} opt_this The object to use as `this` in `callback`.
    * @return {*} Callback return value.
@@ -217,8 +217,8 @@ class RBush {
 
 
   /**
-   * @param {module:ol/extent~Extent=} opt_extent Extent.
-   * @return {module:ol/extent~Extent} Extent.
+   * @param {import("../extent.js").Extent=} opt_extent Extent.
+   * @return {import("../extent.js").Extent} Extent.
    */
   getExtent(opt_extent) {
     // FIXME add getExtent() to rbush
@@ -228,7 +228,7 @@ class RBush {
 
 
   /**
-   * @param {module:ol/structs/RBush} rbush R-Tree.
+   * @param {import("./RBush.js").default} rbush R-Tree.
    */
   concat(rbush) {
     this.rbush_.load(rbush.rbush_.all());

--- a/src/ol/style/Atlas.js
+++ b/src/ol/style/Atlas.js
@@ -58,13 +58,13 @@ class Atlas {
 
     /**
      * @private
-     * @type {Array<module:ol/style/Atlas~AtlasBlock>}
+     * @type {Array<AtlasBlock>}
      */
     this.emptyBlocks_ = [{x: 0, y: 0, width: size, height: size}];
 
     /**
      * @private
-     * @type {Object<string, module:ol/style/Atlas~AtlasInfo>}
+     * @type {Object<string, AtlasInfo>}
      */
     this.entries_ = {};
 
@@ -83,7 +83,7 @@ class Atlas {
 
   /**
    * @param {string} id The identifier of the entry to check.
-   * @return {?module:ol/style/Atlas~AtlasInfo} The atlas info.
+   * @return {?AtlasInfo} The atlas info.
    */
   get(id) {
     return this.entries_[id] || null;
@@ -97,7 +97,7 @@ class Atlas {
    *    Called to render the new image onto an atlas image.
    * @param {Object=} opt_this Value to use as `this` when executing
    *    `renderCallback`.
-   * @return {?module:ol/style/Atlas~AtlasInfo} The position and atlas image for the entry.
+   * @return {?AtlasInfo} The position and atlas image for the entry.
    */
   add(id, width, height, renderCallback, opt_this) {
     for (let i = 0, ii = this.emptyBlocks_.length; i < ii; ++i) {
@@ -130,7 +130,7 @@ class Atlas {
   /**
    * @private
    * @param {number} index The index of the block.
-   * @param {module:ol/style/Atlas~AtlasBlock} block The block to split.
+   * @param {AtlasBlock} block The block to split.
    * @param {number} width The width of the entry to insert.
    * @param {number} height The height of the entry to insert.
    */
@@ -138,9 +138,9 @@ class Atlas {
     const deltaWidth = block.width - width;
     const deltaHeight = block.height - height;
 
-    /** @type {module:ol/style/Atlas~AtlasBlock} */
+    /** @type {AtlasBlock} */
     let newBlock1;
-    /** @type {module:ol/style/Atlas~AtlasBlock} */
+    /** @type {AtlasBlock} */
     let newBlock2;
 
     if (deltaWidth > deltaHeight) {
@@ -188,8 +188,8 @@ class Atlas {
    * blocks (that are potentially smaller) are filled first.
    * @private
    * @param {number} index The index of the block to remove.
-   * @param {module:ol/style/Atlas~AtlasBlock} newBlock1 The 1st block to add.
-   * @param {module:ol/style/Atlas~AtlasBlock} newBlock2 The 2nd block to add.
+   * @param {AtlasBlock} newBlock1 The 1st block to add.
+   * @param {AtlasBlock} newBlock2 The 2nd block to add.
    */
   updateBlocks_(index, newBlock1, newBlock2) {
     const args = [index, 1];

--- a/src/ol/style/AtlasManager.js
+++ b/src/ol/style/AtlasManager.js
@@ -57,7 +57,7 @@ const MAX_ATLAS_SIZE = -1;
  */
 class AtlasManager {
   /**
-   * @param {module:ol/style/AtlasManager~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -90,7 +90,7 @@ class AtlasManager {
 
     /**
      * @private
-     * @type {Array<module:ol/style/Atlas>}
+     * @type {Array<import("./Atlas.js").default>}
      */
     this.atlases_ = [new Atlas(this.currentSize_, this.space_)];
 
@@ -103,33 +103,33 @@ class AtlasManager {
 
     /**
      * @private
-     * @type {Array<module:ol/style/Atlas>}
+     * @type {Array<import("./Atlas.js").default>}
      */
     this.hitAtlases_ = [new Atlas(this.currentHitSize_, this.space_)];
   }
 
   /**
    * @param {string} id The identifier of the entry to check.
-   * @return {?module:ol/style/AtlasManager~AtlasManagerInfo} The position and atlas image for the
+   * @return {?AtlasManagerInfo} The position and atlas image for the
    *    entry, or `null` if the entry is not part of the atlas manager.
    */
   getInfo(id) {
-    /** @type {?module:ol/style/Atlas~AtlasInfo} */
+    /** @type {?import("./Atlas.js").AtlasInfo} */
     const info = this.getInfo_(this.atlases_, id);
 
     if (!info) {
       return null;
     }
-    const hitInfo = /** @type {module:ol/style/Atlas~AtlasInfo} */ (this.getInfo_(this.hitAtlases_, id));
+    const hitInfo = /** @type {import("./Atlas.js").AtlasInfo} */ (this.getInfo_(this.hitAtlases_, id));
 
     return this.mergeInfos_(info, hitInfo);
   }
 
   /**
    * @private
-   * @param {Array<module:ol/style/Atlas>} atlases The atlases to search.
+   * @param {Array<import("./Atlas.js").default>} atlases The atlases to search.
    * @param {string} id The identifier of the entry to check.
-   * @return {?module:ol/style/Atlas~AtlasInfo} The position and atlas image for the entry,
+   * @return {?import("./Atlas.js").AtlasInfo} The position and atlas image for the entry,
    *    or `null` if the entry is not part of the atlases.
    */
   getInfo_(atlases, id) {
@@ -145,15 +145,15 @@ class AtlasManager {
 
   /**
    * @private
-   * @param {module:ol/style/Atlas~AtlasInfo} info The info for the real image.
-   * @param {module:ol/style/Atlas~AtlasInfo} hitInfo The info for the hit-detection
+   * @param {import("./Atlas.js").AtlasInfo} info The info for the real image.
+   * @param {import("./Atlas.js").AtlasInfo} hitInfo The info for the hit-detection
    *    image.
-   * @return {?module:ol/style/AtlasManager~AtlasManagerInfo} The position and atlas image for the
+   * @return {?AtlasManagerInfo} The position and atlas image for the
    *    entry, or `null` if the entry is not part of the atlases.
    */
   mergeInfos_(info, hitInfo) {
     return (
-      /** @type {module:ol/style/AtlasManager~AtlasManagerInfo} */ ({
+      /** @type {AtlasManagerInfo} */ ({
         offsetX: info.offsetX,
         offsetY: info.offsetY,
         image: info.image,
@@ -180,7 +180,7 @@ class AtlasManager {
    *    detection atlas image.
    * @param {Object=} opt_this Value to use as `this` when executing
    *    `renderCallback` and `renderHitCallback`.
-   * @return {?module:ol/style/AtlasManager~AtlasManagerInfo}  The position and atlas image for the
+   * @return {?AtlasManagerInfo}  The position and atlas image for the
    *    entry, or `null` if the image is too big.
    */
   add(id, width, height, renderCallback, opt_renderHitCallback, opt_this) {
@@ -189,7 +189,7 @@ class AtlasManager {
       return null;
     }
 
-    /** @type {?module:ol/style/Atlas~AtlasInfo} */
+    /** @type {?import("./Atlas.js").AtlasInfo} */
     const info = this.add_(false, id, width, height, renderCallback, opt_this);
     if (!info) {
       return null;
@@ -201,7 +201,7 @@ class AtlasManager {
     const renderHitCallback = opt_renderHitCallback !== undefined ?
       opt_renderHitCallback : VOID;
 
-    const hitInfo = /** @type {module:ol/style/Atlas~AtlasInfo} */ (this.add_(true,
+    const hitInfo = /** @type {import("./Atlas.js").AtlasInfo} */ (this.add_(true,
       id, width, height, renderHitCallback, opt_this));
 
     return this.mergeInfos_(info, hitInfo);
@@ -217,7 +217,7 @@ class AtlasManager {
    *    Called to render the new image onto an atlas image.
    * @param {Object=} opt_this Value to use as `this` when executing
    *    `renderCallback` and `renderHitCallback`.
-   * @return {?module:ol/style/Atlas~AtlasInfo}  The position and atlas image for the entry,
+   * @return {?import("./Atlas.js").AtlasInfo}  The position and atlas image for the entry,
    *    or `null` if the image is too big.
    */
   add_(isHitAtlas, id, width, height, renderCallback, opt_this) {

--- a/src/ol/style/Circle.js
+++ b/src/ol/style/Circle.js
@@ -7,10 +7,10 @@ import RegularShape from '../style/RegularShape.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/style/Fill} [fill] Fill style.
+ * @property {import("./Fill.js").default} [fill] Fill style.
  * @property {number} radius Circle radius.
- * @property {module:ol/style/Stroke} [stroke] Stroke style.
- * @property {module:ol/style/AtlasManager} [atlasManager] The atlas manager to use for this circle.
+ * @property {import("./Stroke.js").default} [stroke] Stroke style.
+ * @property {import("./AtlasManager.js").default} [atlasManager] The atlas manager to use for this circle.
  * When using WebGL it is recommended to use an atlas manager to avoid texture switching. If an atlas manager is given,
  * the circle is added to an atlas. By default no atlas manager is used.
  */
@@ -23,11 +23,11 @@ import RegularShape from '../style/RegularShape.js';
  */
 class CircleStyle extends RegularShape {
   /**
-   * @param {module:ol/style/Circle~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
-    const options = opt_options || /** @type {module:ol/style/Circle~Options} */ ({});
+    const options = opt_options || /** @type {Options} */ ({});
 
     super({
       points: Infinity,
@@ -41,7 +41,7 @@ class CircleStyle extends RegularShape {
 
   /**
   * Clones the style.  If an atlasmanager was provided to the original style it will be used in the cloned style, too.
-  * @return {module:ol/style/Circle} The cloned style.
+  * @return {import("./Circle.js").default} The cloned style.
   * @override
   * @api
   */

--- a/src/ol/style/Fill.js
+++ b/src/ol/style/Fill.js
@@ -7,7 +7,7 @@ import {asString} from '../color.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/color~Color|module:ol/colorlike~ColorLike} [color] A color, gradient or pattern.
+ * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [color] A color, gradient or pattern.
  * See {@link module:ol/color~Color} and {@link module:ol/colorlike~ColorLike} for possible formats.
  * Default null; if null, the Canvas/renderer default black will be used.
  */
@@ -20,7 +20,7 @@ import {asString} from '../color.js';
  */
 class Fill {
   /**
-   * @param {module:ol/style/Fill~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -28,7 +28,7 @@ class Fill {
 
     /**
      * @private
-     * @type {module:ol/color~Color|module:ol/colorlike~ColorLike}
+     * @type {import("../color.js").Color|import("../colorlike.js").ColorLike}
      */
     this.color_ = options.color !== undefined ? options.color : null;
 
@@ -41,7 +41,7 @@ class Fill {
 
   /**
    * Clones the style. The color is not cloned if it is an {@link module:ol/colorlike~ColorLike}.
-   * @return {module:ol/style/Fill} The cloned style.
+   * @return {import("./Fill.js").default} The cloned style.
    * @api
    */
   clone() {
@@ -53,7 +53,7 @@ class Fill {
 
   /**
    * Get the fill color.
-   * @return {module:ol/color~Color|module:ol/colorlike~ColorLike} Color.
+   * @return {import("../color.js").Color|import("../colorlike.js").ColorLike} Color.
    * @api
    */
   getColor() {
@@ -63,7 +63,7 @@ class Fill {
   /**
    * Set the color.
    *
-   * @param {module:ol/color~Color|module:ol/colorlike~ColorLike} color Color.
+   * @param {import("../color.js").Color|import("../colorlike.js").ColorLike} color Color.
    * @api
    */
   setColor(color) {

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -16,15 +16,15 @@ import ImageStyle from '../style/Image.js';
 /**
  * @typedef {Object} Options
  * @property {Array<number>} [anchor=[0.5, 0.5]] Anchor. Default value is the icon center.
- * @property {module:ol/style/IconOrigin} [anchorOrigin] Origin of the anchor: `bottom-left`, `bottom-right`,
+ * @property {import("./IconOrigin.js").default} [anchorOrigin] Origin of the anchor: `bottom-left`, `bottom-right`,
  * `top-left` or `top-right`. Default is `top-left`.
- * @property {module:ol/style/IconAnchorUnits} [anchorXUnits] Units in which the anchor x value is
+ * @property {import("./IconAnchorUnits.js").default} [anchorXUnits] Units in which the anchor x value is
  * specified. A value of `'fraction'` indicates the x value is a fraction of the icon. A value of `'pixels'` indicates
  * the x value in pixels. Default is `'fraction'`.
- * @property {module:ol/style/IconAnchorUnits} [anchorYUnits] Units in which the anchor y value is
+ * @property {import("./IconAnchorUnits.js").default} [anchorYUnits] Units in which the anchor y value is
  * specified. A value of `'fraction'` indicates the y value is a fraction of the icon. A value of `'pixels'` indicates
  * the y value in pixels. Default is `'fraction'`.
- * @property {module:ol/color~Color|string} [color] Color to tint the icon. If not specified,
+ * @property {import("../color.js").Color|string} [color] Color to tint the icon. If not specified,
  * the icon will be left as is.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images. Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to access pixel data with the Canvas renderer.
@@ -34,15 +34,15 @@ import ImageStyle from '../style/Image.js';
  * to provide the size of the image, with the `imgSize` option.
  * @property {Array<number>} [offset=[0, 0]] Offset, which, together with the size and the offset origin, define the
  * sub-rectangle to use from the original icon image.
- * @property {module:ol/style/IconOrigin} [offsetOrigin] Origin of the offset: `bottom-left`, `bottom-right`,
+ * @property {import("./IconOrigin.js").default} [offsetOrigin] Origin of the offset: `bottom-left`, `bottom-right`,
  * `top-left` or `top-right`. Default is `top-left`.
  * @property {number} [opacity=1] Opacity of the icon.
  * @property {number} [scale=1] Scale.
  * @property {boolean} [rotateWithView=false] Whether to rotate the icon with the view.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
- * @property {module:ol/size~Size} [size] Icon size in pixel. Can be used together with `offset` to define the
+ * @property {import("../size.js").Size} [size] Icon size in pixel. Can be used together with `offset` to define the
  * sub-rectangle to use from the origin (sprite) icon image.
- * @property {module:ol/size~Size} [imgSize] Image size in pixels. Only required if `img` is set and `src` is not, and
+ * @property {import("../size.js").Size} [imgSize] Image size in pixels. Only required if `img` is set and `src` is not, and
  * for SVG images in Internet Explorer 11. The provided `imgSize` needs to match the actual size of the image.
  * @property {string} [src] Image source URI.
  */
@@ -55,7 +55,7 @@ import ImageStyle from '../style/Image.js';
  */
 class Icon extends ImageStyle {
   /**
-   * @param {module:ol/style/Icon~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};
@@ -102,21 +102,21 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {module:ol/style/IconOrigin}
+     * @type {import("./IconOrigin.js").default}
      */
     this.anchorOrigin_ = options.anchorOrigin !== undefined ?
       options.anchorOrigin : IconOrigin.TOP_LEFT;
 
     /**
      * @private
-     * @type {module:ol/style/IconAnchorUnits}
+     * @type {import("./IconAnchorUnits.js").default}
      */
     this.anchorXUnits_ = options.anchorXUnits !== undefined ?
       options.anchorXUnits : IconAnchorUnits.FRACTION;
 
     /**
      * @private
-     * @type {module:ol/style/IconAnchorUnits}
+     * @type {import("./IconAnchorUnits.js").default}
      */
     this.anchorYUnits_ = options.anchorYUnits !== undefined ?
       options.anchorYUnits : IconAnchorUnits.FRACTION;
@@ -134,7 +134,7 @@ class Icon extends ImageStyle {
     const image = options.img !== undefined ? options.img : null;
 
     /**
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     const imgSize = options.imgSize !== undefined ? options.imgSize : null;
 
@@ -155,20 +155,20 @@ class Icon extends ImageStyle {
       6); // A defined and non-empty `src` or `image` must be provided
 
     /**
-     * @type {module:ol/ImageState}
+     * @type {import("../ImageState.js").default}
      */
     const imageState = options.src !== undefined ?
       ImageState.IDLE : ImageState.LOADED;
 
     /**
      * @private
-     * @type {module:ol/color~Color}
+     * @type {import("../color.js").Color}
      */
     this.color_ = options.color !== undefined ? asArray(options.color) : null;
 
     /**
      * @private
-     * @type {module:ol/style/IconImage}
+     * @type {import("./IconImage.js").default}
      */
     this.iconImage_ = getIconImage(
       image, /** @type {string} */ (src), imgSize, this.crossOrigin_, imageState, this.color_);
@@ -181,7 +181,7 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {module:ol/style/IconOrigin}
+     * @type {import("./IconOrigin.js").default}
      */
     this.offsetOrigin_ = options.offsetOrigin !== undefined ?
       options.offsetOrigin : IconOrigin.TOP_LEFT;
@@ -194,7 +194,7 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.size_ = options.size !== undefined ? options.size : null;
 
@@ -202,7 +202,7 @@ class Icon extends ImageStyle {
 
   /**
    * Clones the style. The underlying Image/HTMLCanvasElement is not cloned.
-   * @return {module:ol/style/Icon} The cloned style.
+   * @return {import("./Icon.js").default} The cloned style.
    * @api
    */
   clone() {
@@ -282,7 +282,7 @@ class Icon extends ImageStyle {
 
   /**
    * Get the icon color.
-   * @return {module:ol/color~Color} Color.
+   * @return {import("../color.js").Color} Color.
    * @api
    */
   getColor() {

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -13,10 +13,10 @@ class IconImage extends EventTarget {
   /**
    * @param {HTMLImageElement|HTMLCanvasElement} image Image.
    * @param {string|undefined} src Src.
-   * @param {module:ol/size~Size} size Size.
+   * @param {import("../size.js").Size} size Size.
    * @param {?string} crossOrigin Cross origin.
-   * @param {module:ol/ImageState} imageState Image state.
-   * @param {module:ol/color~Color} color Color.
+   * @param {import("../ImageState.js").default} imageState Image state.
+   * @param {import("../color.js").Color} color Color.
    */
   constructor(image, src, size, crossOrigin, imageState, color) {
 
@@ -48,25 +48,25 @@ class IconImage extends EventTarget {
 
     /**
      * @private
-     * @type {module:ol/color~Color}
+     * @type {import("../color.js").Color}
      */
     this.color_ = color;
 
     /**
      * @private
-     * @type {Array<module:ol/events~EventsKey>}
+     * @type {Array<import("../events.js").EventsKey>}
      */
     this.imageListenerKeys_ = null;
 
     /**
      * @private
-     * @type {module:ol/ImageState}
+     * @type {import("../ImageState.js").default}
      */
     this.imageState_ = imageState;
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.size_ = size;
 
@@ -141,7 +141,7 @@ class IconImage extends EventTarget {
   }
 
   /**
-   * @return {module:ol/ImageState} Image state.
+   * @return {import("../ImageState.js").default} Image state.
    */
   getImageState() {
     return this.imageState_;
@@ -167,7 +167,7 @@ class IconImage extends EventTarget {
   }
 
   /**
-   * @return {module:ol/size~Size} Image size.
+   * @return {import("../size.js").Size} Image size.
    */
   getSize() {
     return this.size_;
@@ -243,11 +243,11 @@ class IconImage extends EventTarget {
 /**
  * @param {HTMLImageElement|HTMLCanvasElement} image Image.
  * @param {string} src Src.
- * @param {module:ol/size~Size} size Size.
+ * @param {import("../size.js").Size} size Size.
  * @param {?string} crossOrigin Cross origin.
- * @param {module:ol/ImageState} imageState Image state.
- * @param {module:ol/color~Color} color Color.
- * @return {module:ol/style/IconImage} Icon image.
+ * @param {import("../ImageState.js").default} imageState Image state.
+ * @param {import("../color.js").Color} color Color.
+ * @return {import("./IconImage.js").default} Icon image.
  */
 export function get(image, src, size, crossOrigin, imageState, color) {
   let iconImage = iconImageCache.get(src, crossOrigin, color);

--- a/src/ol/style/IconImageCache.js
+++ b/src/ol/style/IconImageCache.js
@@ -11,7 +11,7 @@ class IconImageCache {
   constructor() {
 
     /**
-    * @type {!Object<string, module:ol/style/IconImage>}
+    * @type {!Object<string, import("./IconImage.js").default>}
     * @private
     */
     this.cache_ = {};
@@ -56,8 +56,8 @@ class IconImageCache {
   /**
   * @param {string} src Src.
   * @param {?string} crossOrigin Cross origin.
-  * @param {module:ol/color~Color} color Color.
-  * @return {module:ol/style/IconImage} Icon image.
+  * @param {import("../color.js").Color} color Color.
+  * @return {import("./IconImage.js").default} Icon image.
   */
   get(src, crossOrigin, color) {
     const key = getKey(src, crossOrigin, color);
@@ -67,8 +67,8 @@ class IconImageCache {
   /**
   * @param {string} src Src.
   * @param {?string} crossOrigin Cross origin.
-  * @param {module:ol/color~Color} color Color.
-  * @param {module:ol/style/IconImage} iconImage Icon image.
+  * @param {import("../color.js").Color} color Color.
+  * @param {import("./IconImage.js").default} iconImage Icon image.
   */
   set(src, crossOrigin, color, iconImage) {
     const key = getKey(src, crossOrigin, color);
@@ -93,7 +93,7 @@ class IconImageCache {
 /**
  * @param {string} src Src.
  * @param {?string} crossOrigin Cross origin.
- * @param {module:ol/color~Color} color Color.
+ * @param {import("../color.js").Color} color Color.
  * @return {string} Cache key.
  */
 function getKey(src, crossOrigin, color) {

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -21,7 +21,7 @@
  */
 class ImageStyle {
   /**
-   * @param {module:ol/style/Image~Options} options Options.
+   * @param {Options} options Options.
    */
   constructor(options) {
 
@@ -122,19 +122,19 @@ class ImageStyle {
 
   /**
    * @abstract
-   * @return {module:ol/ImageState} Image state.
+   * @return {import("../ImageState.js").default} Image state.
    */
   getImageState() {}
 
   /**
    * @abstract
-   * @return {module:ol/size~Size} Image size.
+   * @return {import("../size.js").Size} Image size.
    */
   getImageSize() {}
 
   /**
    * @abstract
-   * @return {module:ol/size~Size} Size of the hit-detection image.
+   * @return {import("../size.js").Size} Size of the hit-detection image.
    */
   getHitDetectionImageSize() {}
 
@@ -148,7 +148,7 @@ class ImageStyle {
   /**
    * Get the size of the symbolizer (in pixels).
    * @abstract
-   * @return {module:ol/size~Size} Size.
+   * @return {import("../size.js").Size} Size.
    */
   getSize() {}
 
@@ -201,9 +201,9 @@ class ImageStyle {
 
   /**
    * @abstract
-   * @param {function(this: T, module:ol/events/Event)} listener Listener function.
+   * @param {function(this: T, import("../events/Event.js").default)} listener Listener function.
    * @param {T} thisArg Value to use as `this` when executing `listener`.
-   * @return {module:ol/events~EventsKey|undefined} Listener key.
+   * @return {import("../events.js").EventsKey|undefined} Listener key.
    * @template T
    */
   listenImageChange(listener, thisArg) {}
@@ -216,7 +216,7 @@ class ImageStyle {
 
   /**
    * @abstract
-   * @param {function(this: T, module:ol/events/Event)} listener Listener function.
+   * @param {function(this: T, import("../events/Event.js").default)} listener Listener function.
    * @param {T} thisArg Value to use as `this` when executing `listener`.
    * @template T
    */

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -13,17 +13,17 @@ import ImageStyle from '../style/Image.js';
 /**
  * Specify radius for regular polygons, or radius1 and radius2 for stars.
  * @typedef {Object} Options
- * @property {module:ol/style/Fill} [fill] Fill style.
+ * @property {import("./Fill.js").default} [fill] Fill style.
  * @property {number} points Number of points for stars and regular polygons. In case of a polygon, the number of points
  * is the number of sides.
  * @property {number} [radius] Radius of a regular polygon.
  * @property {number} [radius1] Outer radius of a star.
  * @property {number} [radius2] Inner radius of a star.
  * @property {number} [angle=0] Shape's angle in radians. A value of 0 will have one of the shape's point facing up.
- * @property {module:ol/style/Stroke} [stroke] Stroke style.
+ * @property {import("./Stroke.js").default} [stroke] Stroke style.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {boolean} [rotateWithView=false] Whether to rotate the shape with the view.
- * @property {module:ol/style/AtlasManager} [atlasManager] The atlas manager to use for this symbol. When
+ * @property {import("./AtlasManager.js").default} [atlasManager] The atlas manager to use for this symbol. When
  * using WebGL it is recommended to use an atlas manager to avoid texture switching. If an atlas manager is given, the
  * symbol is added to an atlas. By default no atlas manager is used.
  */
@@ -31,7 +31,7 @@ import ImageStyle from '../style/Image.js';
 
 /**
  * @typedef {Object} RenderOptions
- * @property {module:ol/colorlike~ColorLike} [strokeStyle]
+ * @property {import("../colorlike.js").ColorLike} [strokeStyle]
  * @property {number} strokeWidth
  * @property {number} size
  * @property {string} lineCap
@@ -51,7 +51,7 @@ import ImageStyle from '../style/Image.js';
  */
 class RegularShape extends ImageStyle {
   /**
-   * @param {module:ol/style/RegularShape~Options} options Options.
+   * @param {Options} options Options.
    */
   constructor(options) {
     /**
@@ -87,7 +87,7 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {module:ol/style/Fill}
+     * @type {import("./Fill.js").default}
      */
     this.fill_ = options.fill !== undefined ? options.fill : null;
 
@@ -124,7 +124,7 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {module:ol/style/Stroke}
+     * @type {import("./Stroke.js").default}
      */
     this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
@@ -136,25 +136,25 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.size_ = null;
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.imageSize_ = null;
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.hitDetectionImageSize_ = null;
 
     /**
      * @protected
-     * @type {module:ol/style/AtlasManager|undefined}
+     * @type {import("./AtlasManager.js").default|undefined}
      */
     this.atlasManager_ = options.atlasManager;
 
@@ -164,7 +164,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * Clones the style. If an atlasmanager was provided to the original style it will be used in the cloned style, too.
-   * @return {module:ol/style/RegularShape} The cloned style.
+   * @return {import("./RegularShape.js").default} The cloned style.
    * @api
    */
   clone() {
@@ -203,7 +203,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * Get the fill style for the shape.
-   * @return {module:ol/style/Fill} Fill style.
+   * @return {import("./Fill.js").default} Fill style.
    * @api
    */
   getFill() {
@@ -291,7 +291,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * Get the stroke style for the shape.
-   * @return {module:ol/style/Stroke} Stroke style.
+   * @return {import("./Stroke.js").default} Stroke style.
    * @api
    */
   getStroke() {
@@ -315,7 +315,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * @protected
-   * @param {module:ol/style/AtlasManager|undefined} atlasManager An atlas manager.
+   * @param {import("./AtlasManager.js").default|undefined} atlasManager An atlas manager.
    */
   render_(atlasManager) {
     let imageSize;
@@ -359,7 +359,7 @@ class RegularShape extends ImageStyle {
 
     let size = 2 * (this.radius_ + strokeWidth) + 1;
 
-    /** @type {module:ol/style/RegularShape~RenderOptions} */
+    /** @type {RenderOptions} */
     const renderOptions = {
       strokeStyle: strokeStyle,
       strokeWidth: strokeWidth,
@@ -421,7 +421,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * @private
-   * @param {module:ol/style/RegularShape~RenderOptions} renderOptions Render options.
+   * @param {RenderOptions} renderOptions Render options.
    * @param {CanvasRenderingContext2D} context The rendering context.
    * @param {number} x The origin for the symbol (x).
    * @param {number} y The origin for the symbol (y).
@@ -481,7 +481,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * @private
-   * @param {module:ol/style/RegularShape~RenderOptions} renderOptions Render options.
+   * @param {RenderOptions} renderOptions Render options.
    */
   createHitDetectionCanvas_(renderOptions) {
     this.hitDetectionImageSize_ = [renderOptions.size, renderOptions.size];
@@ -500,7 +500,7 @@ class RegularShape extends ImageStyle {
 
   /**
    * @private
-   * @param {module:ol/style/RegularShape~RenderOptions} renderOptions Render options.
+   * @param {RenderOptions} renderOptions Render options.
    * @param {CanvasRenderingContext2D} context The context.
    * @param {number} x The origin for the symbol (x).
    * @param {number} y The origin for the symbol (y).

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -6,7 +6,7 @@ import {getUid} from '../util.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/color~Color|module:ol/colorlike~ColorLike} [color] A color, gradient or pattern.
+ * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [color] A color, gradient or pattern.
  * See {@link module:ol/color~Color} and {@link module:ol/colorlike~ColorLike} for possible formats.
  * Default null; if null, the Canvas/renderer default black will be used.
  * @property {string} [lineCap='round'] Line cap style: `butt`, `round`, or `square`.
@@ -30,7 +30,7 @@ import {getUid} from '../util.js';
  */
 class Stroke {
   /**
-   * @param {module:ol/style/Stroke~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -38,7 +38,7 @@ class Stroke {
 
     /**
      * @private
-     * @type {module:ol/color~Color|module:ol/colorlike~ColorLike}
+     * @type {import("../color.js").Color|import("../colorlike.js").ColorLike}
      */
     this.color_ = options.color !== undefined ? options.color : null;
 
@@ -87,7 +87,7 @@ class Stroke {
 
   /**
    * Clones the style.
-   * @return {module:ol/style/Stroke} The cloned style.
+   * @return {import("./Stroke.js").default} The cloned style.
    * @api
    */
   clone() {
@@ -105,7 +105,7 @@ class Stroke {
 
   /**
    * Get the stroke color.
-   * @return {module:ol/color~Color|module:ol/colorlike~ColorLike} Color.
+   * @return {import("../color.js").Color|import("../colorlike.js").ColorLike} Color.
    * @api
    */
   getColor() {
@@ -169,7 +169,7 @@ class Stroke {
   /**
    * Set the color.
    *
-   * @param {module:ol/color~Color|module:ol/colorlike~ColorLike} color Color.
+   * @param {import("../color.js").Color|import("../colorlike.js").ColorLike} color Color.
    * @api
    */
   setColor(color) {

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -99,8 +99,8 @@ import Stroke from '../style/Stroke.js';
  * {@link module:ol/style/Style} or an array of them. This way e.g. a
  * vector layer can be styled.
  *
- * @typedef {function((module:ol/Feature|module:ol/render/Feature), number):
- *     (module:ol/style/Style|Array<module:ol/style/Style>)} StyleFunction
+ * @typedef {function((import("../Feature.js").default|import("../render/Feature.js").default), number):
+ *     (import("./Style.js").default|Array<import("./Style.js").default>)} StyleFunction
  */
 
 
@@ -108,8 +108,8 @@ import Stroke from '../style/Stroke.js';
  * A function that takes an {@link module:ol/Feature} as argument and returns an
  * {@link module:ol/geom/Geometry} that will be rendered and styled for the feature.
  *
- * @typedef {function((module:ol/Feature|module:ol/render/Feature)):
- *     (module:ol/geom/Geometry|module:ol/render/Feature|undefined)} GeometryFunction
+ * @typedef {function((import("../Feature.js").default|import("../render/Feature.js").default)):
+ *     (import("../geom/Geometry.js").default|import("../render/Feature.js").default|undefined)} GeometryFunction
  */
 
 
@@ -119,21 +119,21 @@ import Stroke from '../style/Stroke.js';
  * 1. The pixel coordinates of the geometry in GeoJSON notation.
  * 2. The {@link module:ol/render~State} of the layer renderer.
  *
- * @typedef {function((module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>),module:ol/render~State)}
+ * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>),import("../render.js").State)}
  * RenderFunction
  */
 
 
 /**
  * @typedef {Object} Options
- * @property {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction} [geometry] Feature property or geometry
+ * @property {string|import("../geom/Geometry.js").default|GeometryFunction} [geometry] Feature property or geometry
  * or function returning a geometry to render for this style.
- * @property {module:ol/style/Fill} [fill] Fill style.
- * @property {module:ol/style/Image} [image] Image style.
- * @property {module:ol/style/Style~RenderFunction} [renderer] Custom renderer. When configured, `fill`, `stroke` and `image` will be
+ * @property {import("./Fill.js").default} [fill] Fill style.
+ * @property {import("./Image.js").default} [image] Image style.
+ * @property {RenderFunction} [renderer] Custom renderer. When configured, `fill`, `stroke` and `image` will be
  * ignored, and the provided function will be called with each render frame for each geometry.
- * @property {module:ol/style/Stroke} [stroke] Stroke style.
- * @property {module:ol/style/Text} [text] Text style.
+ * @property {import("./Stroke.js").default} [stroke] Stroke style.
+ * @property {import("./Text.js").default} [text] Text style.
  * @property {number} [zIndex] Z index.
  */
 
@@ -147,7 +147,7 @@ import Stroke from '../style/Stroke.js';
  */
 class Style {
   /**
-   * @param {module:ol/style/Style~Options=} opt_options Style options.
+   * @param {Options=} opt_options Style options.
    */
   constructor(opt_options) {
 
@@ -155,13 +155,13 @@ class Style {
 
     /**
      * @private
-     * @type {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction}
+     * @type {string|import("../geom/Geometry.js").default|GeometryFunction}
      */
     this.geometry_ = null;
 
     /**
      * @private
-     * @type {!module:ol/style/Style~GeometryFunction}
+     * @type {!GeometryFunction}
      */
     this.geometryFunction_ = defaultGeometryFunction;
 
@@ -171,31 +171,31 @@ class Style {
 
     /**
      * @private
-     * @type {module:ol/style/Fill}
+     * @type {import("./Fill.js").default}
      */
     this.fill_ = options.fill !== undefined ? options.fill : null;
 
     /**
        * @private
-       * @type {module:ol/style/Image}
+       * @type {import("./Image.js").default}
        */
     this.image_ = options.image !== undefined ? options.image : null;
 
     /**
      * @private
-     * @type {module:ol/style/Style~RenderFunction|null}
+     * @type {RenderFunction|null}
      */
     this.renderer_ = options.renderer !== undefined ? options.renderer : null;
 
     /**
      * @private
-     * @type {module:ol/style/Stroke}
+     * @type {import("./Stroke.js").default}
      */
     this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
     /**
      * @private
-     * @type {module:ol/style/Text}
+     * @type {import("./Text.js").default}
      */
     this.text_ = options.text !== undefined ? options.text : null;
 
@@ -209,7 +209,7 @@ class Style {
 
   /**
    * Clones the style.
-   * @return {module:ol/style/Style} The cloned style.
+   * @return {import("./Style.js").default} The cloned style.
    * @api
    */
   clone() {
@@ -230,7 +230,7 @@ class Style {
   /**
    * Get the custom renderer function that was configured with
    * {@link #setRenderer} or the `renderer` constructor option.
-   * @return {module:ol/style/Style~RenderFunction|null} Custom renderer function.
+   * @return {RenderFunction|null} Custom renderer function.
    * @api
    */
   getRenderer() {
@@ -240,7 +240,7 @@ class Style {
   /**
    * Sets a custom renderer function for this style. When set, `fill`, `stroke`
    * and `image` options of the style will be ignored.
-   * @param {module:ol/style/Style~RenderFunction|null} renderer Custom renderer function.
+   * @param {RenderFunction|null} renderer Custom renderer function.
    * @api
    */
   setRenderer(renderer) {
@@ -249,7 +249,7 @@ class Style {
 
   /**
    * Get the geometry to be rendered.
-   * @return {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction}
+   * @return {string|import("../geom/Geometry.js").default|GeometryFunction}
    * Feature property or geometry or function that returns the geometry that will
    * be rendered with this style.
    * @api
@@ -260,7 +260,7 @@ class Style {
 
   /**
    * Get the function used to generate a geometry for rendering.
-   * @return {!module:ol/style/Style~GeometryFunction} Function that is called with a feature
+   * @return {!GeometryFunction} Function that is called with a feature
    * and returns the geometry to render instead of the feature's geometry.
    * @api
    */
@@ -270,7 +270,7 @@ class Style {
 
   /**
    * Get the fill style.
-   * @return {module:ol/style/Fill} Fill style.
+   * @return {import("./Fill.js").default} Fill style.
    * @api
    */
   getFill() {
@@ -279,7 +279,7 @@ class Style {
 
   /**
    * Set the fill style.
-   * @param {module:ol/style/Fill} fill Fill style.
+   * @param {import("./Fill.js").default} fill Fill style.
    * @api
    */
   setFill(fill) {
@@ -288,7 +288,7 @@ class Style {
 
   /**
    * Get the image style.
-   * @return {module:ol/style/Image} Image style.
+   * @return {import("./Image.js").default} Image style.
    * @api
    */
   getImage() {
@@ -297,7 +297,7 @@ class Style {
 
   /**
    * Set the image style.
-   * @param {module:ol/style/Image} image Image style.
+   * @param {import("./Image.js").default} image Image style.
    * @api
    */
   setImage(image) {
@@ -306,7 +306,7 @@ class Style {
 
   /**
    * Get the stroke style.
-   * @return {module:ol/style/Stroke} Stroke style.
+   * @return {import("./Stroke.js").default} Stroke style.
    * @api
    */
   getStroke() {
@@ -315,7 +315,7 @@ class Style {
 
   /**
    * Set the stroke style.
-   * @param {module:ol/style/Stroke} stroke Stroke style.
+   * @param {import("./Stroke.js").default} stroke Stroke style.
    * @api
    */
   setStroke(stroke) {
@@ -324,7 +324,7 @@ class Style {
 
   /**
    * Get the text style.
-   * @return {module:ol/style/Text} Text style.
+   * @return {import("./Text.js").default} Text style.
    * @api
    */
   getText() {
@@ -333,7 +333,7 @@ class Style {
 
   /**
    * Set the text style.
-   * @param {module:ol/style/Text} text Text style.
+   * @param {import("./Text.js").default} text Text style.
    * @api
    */
   setText(text) {
@@ -352,7 +352,7 @@ class Style {
   /**
    * Set a geometry that is rendered instead of the feature's geometry.
    *
-   * @param {string|module:ol/geom/Geometry|module:ol/style/Style~GeometryFunction} geometry
+   * @param {string|import("../geom/Geometry.js").default|GeometryFunction} geometry
    *     Feature property or geometry or function returning a geometry to render
    *     for this style.
    * @api
@@ -363,7 +363,7 @@ class Style {
     } else if (typeof geometry === 'string') {
       this.geometryFunction_ = function(feature) {
         return (
-          /** @type {module:ol/geom/Geometry} */ (feature.get(geometry))
+          /** @type {import("../geom/Geometry.js").default} */ (feature.get(geometry))
         );
       };
     } else if (!geometry) {
@@ -371,7 +371,7 @@ class Style {
     } else if (geometry !== undefined) {
       this.geometryFunction_ = function() {
         return (
-          /** @type {module:ol/geom/Geometry} */ (geometry)
+          /** @type {import("../geom/Geometry.js").default} */ (geometry)
         );
       };
     }
@@ -392,11 +392,11 @@ class Style {
 
 /**
  * Convert the provided object into a style function.  Functions passed through
- * unchanged.  Arrays of module:ol/style/Style or single style objects wrapped in a
+ * unchanged.  Arrays of import("./Style.js").default or single style objects wrapped in a
  * new style function.
- * @param {module:ol/style/Style~StyleFunction|Array<module:ol/style/Style>|module:ol/style/Style} obj
+ * @param {StyleFunction|Array<import("./Style.js").default>|import("./Style.js").default} obj
  *     A style function, a single style, or an array of styles.
- * @return {module:ol/style/Style~StyleFunction} A style function.
+ * @return {StyleFunction} A style function.
  */
 export function toFunction(obj) {
   let styleFunction;
@@ -405,14 +405,14 @@ export function toFunction(obj) {
     styleFunction = obj;
   } else {
     /**
-     * @type {Array<module:ol/style/Style>}
+     * @type {Array<import("./Style.js").default>}
      */
     let styles;
     if (Array.isArray(obj)) {
       styles = obj;
     } else {
       assert(obj instanceof Style,
-        41); // Expected an `module:ol/style/Style~Style` or an array of `module:ol/style/Style~Style`
+        41); // Expected an `Style` or an array of `Style`
       styles = [obj];
     }
     styleFunction = function() {
@@ -424,20 +424,20 @@ export function toFunction(obj) {
 
 
 /**
- * @type {Array<module:ol/style/Style>}
+ * @type {Array<import("./Style.js").default>}
  */
 let defaultStyles = null;
 
 
 /**
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature.
  * @param {number} resolution Resolution.
- * @return {Array<module:ol/style/Style>} Style.
+ * @return {Array<import("./Style.js").default>} Style.
  */
 export function createDefaultStyle(feature, resolution) {
   // We don't use an immediately-invoked function
   // and a closure so we don't get an error at script evaluation time in
-  // browsers that do not support Canvas. (module:ol/style/Circle~CircleStyle does
+  // browsers that do not support Canvas. (import("./Circle.js").CircleStyle does
   // canvas.getContext('2d') at construction time, which will cause an.error
   // in such browsers.)
   if (!defaultStyles) {
@@ -466,10 +466,10 @@ export function createDefaultStyle(feature, resolution) {
 
 /**
  * Default styles for editing features.
- * @return {Object<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} Styles
+ * @return {Object<import("../geom/GeometryType.js").default, Array<import("./Style.js").default>>} Styles
  */
 export function createEditingStyle() {
-  /** @type {Object<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} */
+  /** @type {Object<import("../geom/GeometryType.js").default, Array<import("./Style.js").default>>} */
   const styles = {};
   const white = [255, 255, 255, 1];
   const blue = [0, 153, 255, 1];
@@ -537,8 +537,8 @@ export function createEditingStyle() {
 
 /**
  * Function that is called with a feature and returns its default geometry.
- * @param {module:ol/Feature|module:ol/render/Feature} feature Feature to get the geometry for.
- * @return {module:ol/geom/Geometry|module:ol/render/Feature|undefined} Geometry to render.
+ * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature to get the geometry for.
+ * @return {import("../geom/Geometry.js").default|import("../render/Feature.js").default|undefined} Geometry to render.
  */
 function defaultGeometryFunction(feature) {
   return feature.getGeometry();

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -24,7 +24,7 @@ const DEFAULT_FILL_COLOR = '#333';
  * @property {number} [offsetY=0] Vertical text offset in pixels. A positive will shift the text down.
  * @property {boolean} [overflow=false] For polygon labels or when `placement` is set to `'line'`, allow text to exceed
  * the width of the polygon at the label position or the length of the path that it follows.
- * @property {module:ol/style/TextPlacement|string} [placement] Text placement.
+ * @property {import("./TextPlacement.js").default|string} [placement] Text placement.
  * @property {number} [scale] Scale.
  * @property {boolean} [rotateWithView=false] Whether to rotate the text with the view.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
@@ -34,11 +34,11 @@ const DEFAULT_FILL_COLOR = '#333';
  * placement where `maxAngle` is not exceeded.
  * @property {string} [textBaseline='middle'] Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
  * 'hanging', 'ideographic'.
- * @property {module:ol/style/Fill} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
- * @property {module:ol/style/Stroke} [stroke] Stroke style.
- * @property {module:ol/style/Fill} [backgroundFill] Fill style for the text background when `placement` is
+ * @property {import("./Fill.js").default} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
+ * @property {import("./Stroke.js").default} [stroke] Stroke style.
+ * @property {import("./Fill.js").default} [backgroundFill] Fill style for the text background when `placement` is
  * `'point'`. Default is no fill.
- * @property {module:ol/style/Stroke} [backgroundStroke] Stroke style for the text background  when `placement`
+ * @property {import("./Stroke.js").default} [backgroundStroke] Stroke style for the text background  when `placement`
  * is `'point'`. Default is no stroke.
  * @property {Array<number>} [padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
  * values in the array is `[top, right, bottom, left]`.
@@ -52,7 +52,7 @@ const DEFAULT_FILL_COLOR = '#333';
  */
 class Text {
   /**
-   * @param {module:ol/style/Text~Options=} opt_options Options.
+   * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
 
@@ -102,7 +102,7 @@ class Text {
 
     /**
     * @private
-    * @type {module:ol/style/Fill}
+    * @type {import("./Fill.js").default}
     */
     this.fill_ = options.fill !== undefined ? options.fill :
       new Fill({color: DEFAULT_FILL_COLOR});
@@ -115,7 +115,7 @@ class Text {
 
     /**
     * @private
-    * @type {module:ol/style/TextPlacement|string}
+    * @type {import("./TextPlacement.js").default|string}
     */
     this.placement_ = options.placement !== undefined ? options.placement : TextPlacement.POINT;
 
@@ -127,7 +127,7 @@ class Text {
 
     /**
     * @private
-    * @type {module:ol/style/Stroke}
+    * @type {import("./Stroke.js").default}
     */
     this.stroke_ = options.stroke !== undefined ? options.stroke : null;
 
@@ -145,13 +145,13 @@ class Text {
 
     /**
     * @private
-    * @type {module:ol/style/Fill}
+    * @type {import("./Fill.js").default}
     */
     this.backgroundFill_ = options.backgroundFill ? options.backgroundFill : null;
 
     /**
     * @private
-    * @type {module:ol/style/Stroke}
+    * @type {import("./Stroke.js").default}
     */
     this.backgroundStroke_ = options.backgroundStroke ? options.backgroundStroke : null;
 
@@ -164,7 +164,7 @@ class Text {
 
   /**
   * Clones the style.
-  * @return {module:ol/style/Text} The cloned style.
+  * @return {import("./Text.js").default} The cloned style.
   * @api
   */
   clone() {
@@ -217,7 +217,7 @@ class Text {
 
   /**
   * Get the label placement.
-  * @return {module:ol/style/TextPlacement|string} Text placement.
+  * @return {import("./TextPlacement.js").default|string} Text placement.
   * @api
   */
   getPlacement() {
@@ -244,7 +244,7 @@ class Text {
 
   /**
   * Get the fill style for the text.
-  * @return {module:ol/style/Fill} Fill style.
+  * @return {import("./Fill.js").default} Fill style.
   * @api
   */
   getFill() {
@@ -280,7 +280,7 @@ class Text {
 
   /**
   * Get the stroke style for the text.
-  * @return {module:ol/style/Stroke} Stroke style.
+  * @return {import("./Stroke.js").default} Stroke style.
   * @api
   */
   getStroke() {
@@ -316,7 +316,7 @@ class Text {
 
   /**
   * Get the background fill style for the text.
-  * @return {module:ol/style/Fill} Fill style.
+  * @return {import("./Fill.js").default} Fill style.
   * @api
   */
   getBackgroundFill() {
@@ -325,7 +325,7 @@ class Text {
 
   /**
   * Get the background stroke style for the text.
-  * @return {module:ol/style/Stroke} Stroke style.
+  * @return {import("./Stroke.js").default} Stroke style.
   * @api
   */
   getBackgroundStroke() {
@@ -394,7 +394,7 @@ class Text {
   /**
   * Set the text placement.
   *
-  * @param {module:ol/style/TextPlacement|string} placement Placement.
+  * @param {import("./TextPlacement.js").default|string} placement Placement.
   * @api
   */
   setPlacement(placement) {
@@ -404,7 +404,7 @@ class Text {
   /**
   * Set the fill.
   *
-  * @param {module:ol/style/Fill} fill Fill style.
+  * @param {import("./Fill.js").default} fill Fill style.
   * @api
   */
   setFill(fill) {
@@ -434,7 +434,7 @@ class Text {
   /**
   * Set the stroke.
   *
-  * @param {module:ol/style/Stroke} stroke Stroke style.
+  * @param {import("./Stroke.js").default} stroke Stroke style.
   * @api
   */
   setStroke(stroke) {
@@ -474,7 +474,7 @@ class Text {
   /**
   * Set the background fill.
   *
-  * @param {module:ol/style/Fill} fill Fill style.
+  * @param {import("./Fill.js").default} fill Fill style.
   * @api
   */
   setBackgroundFill(fill) {
@@ -484,7 +484,7 @@ class Text {
   /**
   * Set the background stroke.
   *
-  * @param {module:ol/style/Stroke} stroke Stroke style.
+  * @param {import("./Stroke.js").default} stroke Stroke style.
   * @api
   */
   setBackgroundStroke(stroke) {

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -15,8 +15,8 @@
  * @param {number} z Z.
  * @param {number} x X.
  * @param {number} y Y.
- * @param {module:ol/tilecoord~TileCoord=} opt_tileCoord Tile coordinate.
- * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
+ * @param {TileCoord=} opt_tileCoord Tile coordinate.
+ * @return {TileCoord} Tile coordinate.
  */
 export function createOrUpdate(z, x, y, opt_tileCoord) {
   if (opt_tileCoord !== undefined) {
@@ -43,7 +43,7 @@ export function getKeyZXY(z, x, y) {
 
 /**
  * Get the key for a tile coord.
- * @param {module:ol/tilecoord~TileCoord} tileCoord The tile coord.
+ * @param {TileCoord} tileCoord The tile coord.
  * @return {string} Key.
  */
 export function getKey(tileCoord) {
@@ -54,7 +54,7 @@ export function getKey(tileCoord) {
 /**
  * Get a tile coord given a key.
  * @param {string} key The tile coord key.
- * @return {module:ol/tilecoord~TileCoord} The tile coord.
+ * @return {TileCoord} The tile coord.
  */
 export function fromKey(key) {
   return key.split('/').map(Number);
@@ -62,7 +62,7 @@ export function fromKey(key) {
 
 
 /**
- * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coord.
+ * @param {TileCoord} tileCoord Tile coord.
  * @return {number} Hash.
  */
 export function hash(tileCoord) {
@@ -71,7 +71,7 @@ export function hash(tileCoord) {
 
 
 /**
- * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coord.
+ * @param {TileCoord} tileCoord Tile coord.
  * @return {string} Quad key.
  */
 export function quadKey(tileCoord) {
@@ -96,8 +96,8 @@ export function quadKey(tileCoord) {
 
 
 /**
- * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {!module:ol/tilegrid/TileGrid} tileGrid Tile grid.
+ * @param {TileCoord} tileCoord Tile coordinate.
+ * @param {!import("./tilegrid/TileGrid.js").default} tileGrid Tile grid.
  * @return {boolean} Tile coordinate is within extent and zoom level range.
  */
 export function withinExtentAndZ(tileCoord, tileGrid) {

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -12,8 +12,8 @@ import TileGrid from './tilegrid/TileGrid.js';
 
 
 /**
- * @param {module:ol/proj/Projection} projection Projection.
- * @return {!module:ol/tilegrid/TileGrid} Default tile grid for the
+ * @param {import("./proj/Projection.js").default} projection Projection.
+ * @return {!import("./tilegrid/TileGrid.js").default} Default tile grid for the
  * passed projection.
  */
 export function getForProjection(projection) {
@@ -27,10 +27,10 @@ export function getForProjection(projection) {
 
 
 /**
- * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
- * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
- * @param {module:ol/proj/Projection} projection Projection.
- * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
+ * @param {import("./tilegrid/TileGrid.js").default} tileGrid Tile grid.
+ * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
+ * @param {import("./proj/Projection.js").default} projection Projection.
+ * @return {import("./tilecoord.js").TileCoord} Tile coordinate.
  */
 export function wrapX(tileGrid, tileCoord, projection) {
   const z = tileCoord[0];
@@ -48,13 +48,13 @@ export function wrapX(tileGrid, tileCoord, projection) {
 
 
 /**
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("./extent.js").Extent} extent Extent.
  * @param {number=} opt_maxZoom Maximum zoom level (default is
  *     DEFAULT_MAX_ZOOM).
- * @param {number|module:ol/size~Size=} opt_tileSize Tile size (default uses
+ * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {module:ol/extent/Corner=} opt_corner Extent corner (default is `'top-left'`).
- * @return {!module:ol/tilegrid/TileGrid} TileGrid instance.
+ * @param {import("./extent/Corner.js").default=} opt_corner Extent corner (default is `'top-left'`).
+ * @return {!import("./tilegrid/TileGrid.js").default} TileGrid instance.
  */
 export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
   const corner = opt_corner !== undefined ? opt_corner : Corner.TOP_LEFT;
@@ -72,26 +72,26 @@ export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
 
 /**
  * @typedef {Object} XYZOptions
- * @property {module:ol/extent~Extent} [extent] Extent for the tile grid. The origin for an XYZ tile grid is the
+ * @property {import("./extent.js").Extent} [extent] Extent for the tile grid. The origin for an XYZ tile grid is the
  * top-left corner of the extent. The zero level of the grid is defined by the resolution at which one tile fits in the
  * provided extent. If not provided, the extent of the EPSG:3857 projection is used.
  * @property {number} [maxZoom] Maximum zoom. The default is `42`. This determines the number of levels
  * in the grid set. For example, a `maxZoom` of 21 means there are 22 levels in the grid set.
  * @property {number} [minZoom=0] Minimum zoom.
- * @property {number|module:ol/size~Size} [tileSize=[256, 256]] Tile size in pixels.
+ * @property {number|import("./size.js").Size} [tileSize=[256, 256]] Tile size in pixels.
  */
 
 
 /**
  * Creates a tile grid with a standard XYZ tiling scheme.
- * @param {module:ol/tilegrid~XYZOptions=} opt_options Tile grid options.
- * @return {!module:ol/tilegrid/TileGrid} Tile grid instance.
+ * @param {XYZOptions=} opt_options Tile grid options.
+ * @return {!import("./tilegrid/TileGrid.js").default} Tile grid instance.
  * @api
  */
 export function createXYZ(opt_options) {
-  const options = /** @type {module:ol/tilegrid/TileGrid~Options} */ ({});
+  const options = /** @type {import("./tilegrid/TileGrid.js").Options} */ ({});
   assign(options, opt_options !== undefined ?
-    opt_options : /** @type {module:ol/tilegrid~XYZOptions} */ ({}));
+    opt_options : /** @type {XYZOptions} */ ({}));
   if (options.extent === undefined) {
     options.extent = getProjection('EPSG:3857').getExtent();
   }
@@ -105,10 +105,10 @@ export function createXYZ(opt_options) {
 
 /**
  * Create a resolutions array from an extent.  A zoom factor of 2 is assumed.
- * @param {module:ol/extent~Extent} extent Extent.
+ * @param {import("./extent.js").Extent} extent Extent.
  * @param {number=} opt_maxZoom Maximum zoom level (default is
  *     DEFAULT_MAX_ZOOM).
- * @param {number|module:ol/size~Size=} opt_tileSize Tile size (default uses
+ * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
  * @return {!Array<number>} Resolutions array.
  */
@@ -134,13 +134,13 @@ function resolutionsFromExtent(extent, opt_maxZoom, opt_tileSize) {
 
 
 /**
- * @param {module:ol/proj~ProjectionLike} projection Projection.
+ * @param {import("./proj.js").ProjectionLike} projection Projection.
  * @param {number=} opt_maxZoom Maximum zoom level (default is
  *     DEFAULT_MAX_ZOOM).
- * @param {number|module:ol/size~Size=} opt_tileSize Tile size (default uses
+ * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {module:ol/extent/Corner=} opt_corner Extent corner (default is `'top-left'`).
- * @return {!module:ol/tilegrid/TileGrid} TileGrid instance.
+ * @param {import("./extent/Corner.js").default=} opt_corner Extent corner (default is `'top-left'`).
+ * @return {!import("./tilegrid/TileGrid.js").default} TileGrid instance.
  */
 export function createForProjection(projection, opt_maxZoom, opt_tileSize, opt_corner) {
   const extent = extentFromProjection(projection);
@@ -151,8 +151,8 @@ export function createForProjection(projection, opt_maxZoom, opt_tileSize, opt_c
 /**
  * Generate a tile grid extent from a projection.  If the projection has an
  * extent, it is used.  If not, a global extent is assumed.
- * @param {module:ol/proj~ProjectionLike} projection Projection.
- * @return {module:ol/extent~Extent} Extent.
+ * @param {import("./proj.js").ProjectionLike} projection Projection.
+ * @return {import("./extent.js").Extent} Extent.
  */
 export function extentFromProjection(projection) {
   projection = getProjection(projection);

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -13,21 +13,21 @@ import {createOrUpdate as createOrUpdateTileCoord} from '../tilecoord.js';
 
 /**
  * @private
- * @type {module:ol/tilecoord~TileCoord}
+ * @type {import("../tilecoord.js").TileCoord}
  */
 const tmpTileCoord = [0, 0, 0];
 
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/extent~Extent} [extent] Extent for the tile grid. No tiles outside this
+ * @property {import("../extent.js").Extent} [extent] Extent for the tile grid. No tiles outside this
  * extent will be requested by {@link module:ol/source/Tile} sources. When no `origin` or
  * `origins` are configured, the `origin` will be set to the top-left corner of the extent.
  * @property {number} [minZoom=0] Minimum zoom.
- * @property {module:ol/coordinate~Coordinate} [origin] The tile grid origin, i.e. where the `x`
+ * @property {import("../coordinate.js").Coordinate} [origin] The tile grid origin, i.e. where the `x`
  * and `y` axes meet (`[z, 0, 0]`). Tile coordinates increase left to right and upwards. If not
  * specified, `extent` or `origins` must be provided.
- * @property {Array<module:ol/coordinate~Coordinate>} [origins] Tile grid origins, i.e. where
+ * @property {Array<import("../coordinate.js").Coordinate>} [origins] Tile grid origins, i.e. where
  * the `x` and `y` axes meet (`[z, 0, 0]`), for each zoom level. If given, the array length
  * should match the length of the `resolutions` array, i.e. each resolution can have a different
  * origin. Tile coordinates increase left to right and upwards. If not specified, `extent` or
@@ -35,10 +35,10 @@ const tmpTileCoord = [0, 0, 0];
  * @property {!Array<number>} resolutions Resolutions. The array index of each resolution needs
  * to match the zoom level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`.
- * @property {Array<module:ol/size~Size>} [sizes] Sizes.
- * @property {number|module:ol/size~Size} [tileSize] Tile size.
+ * @property {Array<import("../size.js").Size>} [sizes] Sizes.
+ * @property {number|import("../size.js").Size} [tileSize] Tile size.
  * Default is `[256, 256]`.
- * @property {Array<module:ol/size~Size>} [tileSizes] Tile sizes. If given, the array length
+ * @property {Array<import("../size.js").Size>} [tileSizes] Tile sizes. If given, the array length
  * should match the length of the `resolutions` array, i.e. each resolution can have a different
  * tile size.
  */
@@ -52,7 +52,7 @@ const tmpTileCoord = [0, 0, 0];
  */
 class TileGrid {
   /**
-   * @param {module:ol/tilegrid/TileGrid~Options} options Tile grid options.
+   * @param {Options} options Tile grid options.
    */
   constructor(options) {
 
@@ -103,13 +103,13 @@ class TileGrid {
 
     /**
      * @private
-     * @type {module:ol/coordinate~Coordinate}
+     * @type {import("../coordinate.js").Coordinate}
      */
     this.origin_ = options.origin !== undefined ? options.origin : null;
 
     /**
      * @private
-     * @type {Array<module:ol/coordinate~Coordinate>}
+     * @type {Array<import("../coordinate.js").Coordinate>}
      */
     this.origins_ = null;
     if (options.origins !== undefined) {
@@ -131,7 +131,7 @@ class TileGrid {
 
     /**
      * @private
-     * @type {Array<number|module:ol/size~Size>}
+     * @type {Array<number|import("../size.js").Size>}
      */
     this.tileSizes_ = null;
     if (options.tileSizes !== undefined) {
@@ -142,7 +142,7 @@ class TileGrid {
 
     /**
      * @private
-     * @type {number|module:ol/size~Size}
+     * @type {number|import("../size.js").Size}
      */
     this.tileSize_ = options.tileSize !== undefined ?
       options.tileSize :
@@ -154,20 +154,20 @@ class TileGrid {
 
     /**
      * @private
-     * @type {module:ol/extent~Extent}
+     * @type {import("../extent.js").Extent}
      */
     this.extent_ = extent !== undefined ? extent : null;
 
 
     /**
      * @private
-     * @type {Array<module:ol/TileRange>}
+     * @type {Array<import("../TileRange.js").default>}
      */
     this.fullTileRanges_ = null;
 
     /**
      * @private
-     * @type {module:ol/size~Size}
+     * @type {import("../size.js").Size}
      */
     this.tmpSize_ = [0, 0];
 
@@ -187,9 +187,9 @@ class TileGrid {
   /**
    * Call a function with each tile coordinate for a given extent and zoom level.
    *
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} zoom Integer zoom level.
-   * @param {function(module:ol/tilecoord~TileCoord)} callback Function called with each tile coordinate.
+   * @param {function(import("../tilecoord.js").TileCoord)} callback Function called with each tile coordinate.
    * @api
    */
   forEachTileCoord(extent, zoom, callback) {
@@ -202,11 +202,11 @@ class TileGrid {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {function(this: T, number, module:ol/TileRange): boolean} callback Callback.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {function(this: T, number, import("../TileRange.js").default): boolean} callback Callback.
    * @param {T=} opt_this The object to use as `this` in `callback`.
-   * @param {module:ol/TileRange=} opt_tileRange Temporary module:ol/TileRange object.
-   * @param {module:ol/extent~Extent=} opt_extent Temporary module:ol/extent~Extent object.
+   * @param {import("../TileRange.js").default=} opt_tileRange Temporary import("../TileRange.js").default object.
+   * @param {import("../extent.js").Extent=} opt_extent Temporary import("../extent.js").Extent object.
    * @return {boolean} Callback succeeded.
    * @template T
    */
@@ -238,7 +238,7 @@ class TileGrid {
 
   /**
    * Get the extent for this tile grid, if it was configured.
-   * @return {module:ol/extent~Extent} Extent.
+   * @return {import("../extent.js").Extent} Extent.
    */
   getExtent() {
     return this.extent_;
@@ -265,7 +265,7 @@ class TileGrid {
   /**
    * Get the origin for the grid at the given zoom level.
    * @param {number} z Integer zoom level.
-   * @return {module:ol/coordinate~Coordinate} Origin.
+   * @return {import("../coordinate.js").Coordinate} Origin.
    * @api
    */
   getOrigin(z) {
@@ -296,10 +296,10 @@ class TileGrid {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/TileRange=} opt_tileRange Temporary module:ol/TileRange object.
-   * @param {module:ol/extent~Extent=} opt_extent Temporary module:ol/extent~Extent object.
-   * @return {module:ol/TileRange} Tile range.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../TileRange.js").default=} opt_tileRange Temporary import("../TileRange.js").default object.
+   * @param {import("../extent.js").Extent=} opt_extent Temporary import("../extent.js").Extent object.
+   * @return {import("../TileRange.js").default} Tile range.
    */
   getTileCoordChildTileRange(tileCoord, opt_tileRange, opt_extent) {
     if (tileCoord[0] < this.maxZoom) {
@@ -318,9 +318,9 @@ class TileGrid {
   /**
    * Get the extent for a tile range.
    * @param {number} z Integer zoom level.
-   * @param {module:ol/TileRange} tileRange Tile range.
-   * @param {module:ol/extent~Extent=} opt_extent Temporary module:ol/extent~Extent object.
-   * @return {module:ol/extent~Extent} Extent.
+   * @param {import("../TileRange.js").default} tileRange Tile range.
+   * @param {import("../extent.js").Extent=} opt_extent Temporary import("../extent.js").Extent object.
+   * @return {import("../extent.js").Extent} Extent.
    */
   getTileRangeExtent(z, tileRange, opt_extent) {
     const origin = this.getOrigin(z);
@@ -335,10 +335,10 @@ class TileGrid {
 
   /**
    * Get a tile range for the given extent and integer zoom level.
-   * @param {module:ol/extent~Extent} extent Extent.
+   * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} z Integer zoom level.
-   * @param {module:ol/TileRange=} opt_tileRange Temporary tile range object.
-   * @return {module:ol/TileRange} Tile range.
+   * @param {import("../TileRange.js").default=} opt_tileRange Temporary tile range object.
+   * @return {import("../TileRange.js").default} Tile range.
    */
   getTileRangeForExtentAndZ(extent, z, opt_tileRange) {
     const tileCoord = tmpTileCoord;
@@ -350,8 +350,8 @@ class TileGrid {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @return {module:ol/coordinate~Coordinate} Tile center.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @return {import("../coordinate.js").Coordinate} Tile center.
    */
   getTileCoordCenter(tileCoord) {
     const origin = this.getOrigin(tileCoord[0]);
@@ -366,9 +366,9 @@ class TileGrid {
   /**
    * Get the extent of a tile coordinate.
    *
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
-   * @param {module:ol/extent~Extent=} opt_extent Temporary extent object.
-   * @return {module:ol/extent~Extent} Extent.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {import("../extent.js").Extent=} opt_extent Temporary extent object.
+   * @return {import("../extent.js").Extent} Extent.
    * @api
    */
   getTileCoordExtent(tileCoord, opt_extent) {
@@ -387,10 +387,10 @@ class TileGrid {
    * method considers that coordinates that intersect tile boundaries should be
    * assigned the higher tile coordinate.
    *
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
-   * @param {module:ol/tilecoord~TileCoord=} opt_tileCoord Destination module:ol/tilecoord~TileCoord object.
-   * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
+   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Destination import("../tilecoord.js").TileCoord object.
+   * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @api
    */
   getTileCoordForCoordAndResolution(coordinate, resolution, opt_tileCoord) {
@@ -407,8 +407,8 @@ class TileGrid {
    * @param {boolean} reverseIntersectionPolicy Instead of letting edge
    *     intersections go to the higher tile coordinate, let edge intersections
    *     go to the lower tile coordinate.
-   * @param {module:ol/tilecoord~TileCoord=} opt_tileCoord Temporary module:ol/tilecoord~TileCoord object.
-   * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
+   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Temporary import("../tilecoord.js").TileCoord object.
+   * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @private
    */
   getTileCoordForXYAndResolution_(x, y, resolution, reverseIntersectionPolicy, opt_tileCoord) {
@@ -446,8 +446,8 @@ class TileGrid {
    * @param {boolean} reverseIntersectionPolicy Instead of letting edge
    *     intersections go to the higher tile coordinate, let edge intersections
    *     go to the lower tile coordinate.
-   * @param {module:ol/tilecoord~TileCoord=} opt_tileCoord Temporary module:ol/tilecoord~TileCoord object.
-   * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
+   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Temporary import("../tilecoord.js").TileCoord object.
+   * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @private
    */
   getTileCoordForXYAndZ_(x, y, z, reverseIntersectionPolicy, opt_tileCoord) {
@@ -475,10 +475,10 @@ class TileGrid {
 
   /**
    * Get a tile coordinate given a map coordinate and zoom level.
-   * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
+   * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} z Zoom level.
-   * @param {module:ol/tilecoord~TileCoord=} opt_tileCoord Destination module:ol/tilecoord~TileCoord object.
-   * @return {module:ol/tilecoord~TileCoord} Tile coordinate.
+   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Destination import("../tilecoord.js").TileCoord object.
+   * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @api
    */
   getTileCoordForCoordAndZ(coordinate, z, opt_tileCoord) {
@@ -487,7 +487,7 @@ class TileGrid {
   }
 
   /**
-   * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @return {number} Tile resolution.
    */
   getTileCoordResolution(tileCoord) {
@@ -497,9 +497,9 @@ class TileGrid {
   /**
    * Get the tile size for a zoom level. The type of the return value matches the
    * `tileSize` or `tileSizes` that the tile grid was configured with. To always
-   * get an `module:ol/size~Size`, run the result through `module:ol/size~Size.toSize()`.
+   * get an `import("../size.js").Size`, run the result through `import("../size.js").Size.toSize()`.
    * @param {number} z Z.
-   * @return {number|module:ol/size~Size} Tile size.
+   * @return {number|import("../size.js").Size} Tile size.
    * @api
    */
   getTileSize(z) {
@@ -512,7 +512,7 @@ class TileGrid {
 
   /**
    * @param {number} z Zoom level.
-   * @return {module:ol/TileRange} Extent tile range for the specified zoom level.
+   * @return {import("../TileRange.js").default} Extent tile range for the specified zoom level.
    */
   getFullTileRange(z) {
     if (!this.fullTileRanges_) {
@@ -536,7 +536,7 @@ class TileGrid {
   }
 
   /**
-   * @param {!module:ol/extent~Extent} extent Extent for this tile grid.
+   * @param {!import("../extent.js").Extent} extent Extent for this tile grid.
    * @private
    */
   calculateTileRanges_(extent) {

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -9,14 +9,14 @@ import TileGrid from '../tilegrid/TileGrid.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/extent~Extent} [extent] Extent for the tile grid. No tiles
+ * @property {import("../extent.js").Extent} [extent] Extent for the tile grid. No tiles
  * outside this extent will be requested by {@link module:ol/source/Tile} sources.
  * When no `origin` or `origins` are configured, the `origin` will be set to the
  * top-left corner of the extent.
- * @property {module:ol/coordinate~Coordinate} [origin] The tile grid origin, i.e.
+ * @property {import("../coordinate.js").Coordinate} [origin] The tile grid origin, i.e.
  * where the `x` and `y` axes meet (`[z, 0, 0]`). Tile coordinates increase left
  * to right and upwards. If not specified, `extent` or `origins` must be provided.
- * @property {Array<module:ol/coordinate~Coordinate>} [origins] Tile grid origins,
+ * @property {Array<import("../coordinate.js").Coordinate>} [origins] Tile grid origins,
  * i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for each zoom level. If
  * given, the array length should match the length of the `resolutions` array, i.e.
  * each resolution can have a different origin. Tile coordinates increase left to
@@ -26,7 +26,7 @@ import TileGrid from '../tilegrid/TileGrid.js';
  * is configured, the resolutions array will have a length of `maxZoom + 1`
  * @property {!Array<string>} matrixIds matrix IDs. The length of this array needs
  * to match the length of the `resolutions` array.
- * @property {Array<module:ol/size~Size>} [sizes] Number of tile rows and columns
+ * @property {Array<import("../size.js").Size>} [sizes] Number of tile rows and columns
  * of the grid for each zoom level. The values here are the `TileMatrixWidth` and
  * `TileMatrixHeight` advertised in the GetCapabilities response of the WMTS, and
  * define the grid's extent together with the `origin`.
@@ -34,8 +34,8 @@ import TileGrid from '../tilegrid/TileGrid.js';
  * which tile requests are made by sources. Note that when the top-left corner of
  * the `extent` is used as `origin` or `origins`, then the `y` value must be
  * negative because OpenLayers tile coordinates increase upwards.
- * @property {number|module:ol/size~Size} [tileSize] Tile size.
- * @property {Array<module:ol/size~Size>} [tileSizes] Tile sizes. The length of
+ * @property {number|import("../size.js").Size} [tileSize] Tile size.
+ * @property {Array<import("../size.js").Size>} [tileSizes] Tile sizes. The length of
  * this array needs to match the length of the `resolutions` array.
  * @property {Array<number>} [widths] Number of tile columns that cover the grid's
  * extent for each zoom level. Only required when used with a source that has `wrapX`
@@ -52,7 +52,7 @@ import TileGrid from '../tilegrid/TileGrid.js';
  */
 class WMTSTileGrid extends TileGrid {
   /**
-   * @param {module:ol/tilegrid/WMTS~Options} options WMTS options.
+   * @param {Options} options WMTS options.
    */
   constructor(options) {
     super({
@@ -98,11 +98,11 @@ export default WMTSTileGrid;
  * optional TileMatrixSetLimits.
  * @param {Object} matrixSet An object representing a matrixSet in the
  *     capabilities document.
- * @param {module:ol/extent~Extent=} opt_extent An optional extent to restrict the tile
+ * @param {import("../extent.js").Extent=} opt_extent An optional extent to restrict the tile
  *     ranges the server provides.
  * @param {Array<Object>=} opt_matrixLimits An optional object representing
  *     the available matrices for tileGrid.
- * @return {module:ol/tilegrid/WMTS} WMTS tileGrid instance.
+ * @return {import("./WMTS.js").default} WMTS tileGrid instance.
  * @api
  */
 export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matrixLimits) {
@@ -111,11 +111,11 @@ export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matri
   const resolutions = [];
   /** @type {!Array<string>} */
   const matrixIds = [];
-  /** @type {!Array<module:ol/coordinate~Coordinate>} */
+  /** @type {!Array<import("../coordinate.js").Coordinate>} */
   const origins = [];
-  /** @type {!Array<module:ol/size~Size>} */
+  /** @type {!Array<import("../size.js").Size>} */
   const tileSizes = [];
-  /** @type {!Array<module:ol/size~Size>} */
+  /** @type {!Array<import("../size.js").Size>} */
   const sizes = [];
 
   const matrixLimits = opt_matrixLimits !== undefined ? opt_matrixLimits : [];

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -8,8 +8,8 @@ import {hash as tileCoordHash} from './tilecoord.js';
 
 /**
  * @param {string} template Template.
- * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
- * @return {module:ol/Tile~UrlFunction} Tile URL function.
+ * @param {import("./tilegrid/TileGrid.js").default} tileGrid Tile grid.
+ * @return {import("./Tile.js").UrlFunction} Tile URL function.
  */
 export function createFromTemplate(template, tileGrid) {
   const zRegEx = /\{z\}/g;
@@ -18,9 +18,9 @@ export function createFromTemplate(template, tileGrid) {
   const dashYRegEx = /\{-y\}/g;
   return (
     /**
-     * @param {module:ol/tilecoord~TileCoord} tileCoord Tile Coordinate.
+     * @param {import("./tilecoord.js").TileCoord} tileCoord Tile Coordinate.
      * @param {number} pixelRatio Pixel ratio.
-     * @param {module:ol/proj/Projection} projection Projection.
+     * @param {import("./proj/Projection.js").default} projection Projection.
      * @return {string|undefined} Tile URL.
      */
     function(tileCoord, pixelRatio, projection) {
@@ -48,8 +48,8 @@ export function createFromTemplate(template, tileGrid) {
 
 /**
  * @param {Array<string>} templates Templates.
- * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
- * @return {module:ol/Tile~UrlFunction} Tile URL function.
+ * @param {import("./tilegrid/TileGrid.js").default} tileGrid Tile grid.
+ * @return {import("./Tile.js").UrlFunction} Tile URL function.
  */
 export function createFromTemplates(templates, tileGrid) {
   const len = templates.length;
@@ -62,8 +62,8 @@ export function createFromTemplates(templates, tileGrid) {
 
 
 /**
- * @param {Array<module:ol/Tile~UrlFunction>} tileUrlFunctions Tile URL Functions.
- * @return {module:ol/Tile~UrlFunction} Tile URL function.
+ * @param {Array<import("./Tile.js").UrlFunction>} tileUrlFunctions Tile URL Functions.
+ * @return {import("./Tile.js").UrlFunction} Tile URL function.
  */
 export function createFromTileUrlFunctions(tileUrlFunctions) {
   if (tileUrlFunctions.length === 1) {
@@ -71,9 +71,9 @@ export function createFromTileUrlFunctions(tileUrlFunctions) {
   }
   return (
     /**
-     * @param {module:ol/tilecoord~TileCoord} tileCoord Tile Coordinate.
+     * @param {import("./tilecoord.js").TileCoord} tileCoord Tile Coordinate.
      * @param {number} pixelRatio Pixel ratio.
-     * @param {module:ol/proj/Projection} projection Projection.
+     * @param {import("./proj/Projection.js").default} projection Projection.
      * @return {string|undefined} Tile URL.
      */
     function(tileCoord, pixelRatio, projection) {
@@ -90,9 +90,9 @@ export function createFromTileUrlFunctions(tileUrlFunctions) {
 
 
 /**
- * @param {module:ol/tilecoord~TileCoord} tileCoord Tile coordinate.
+ * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
  * @param {number} pixelRatio Pixel ratio.
- * @param {module:ol/proj/Projection} projection Projection.
+ * @param {import("./proj/Projection.js").default} projection Projection.
  * @return {string|undefined} Tile URL.
  */
 export function nullTileUrlFunction(tileCoord, pixelRatio, projection) {

--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -26,14 +26,14 @@ import {assert} from './asserts.js';
 
 /**
  * @private
- * @type {module:ol/transform~Transform}
+ * @type {Transform}
  */
 const tmp_ = new Array(6);
 
 
 /**
  * Create an identity transform.
- * @return {!module:ol/transform~Transform} Identity transform.
+ * @return {!Transform} Identity transform.
  */
 export function create() {
   return [1, 0, 0, 1, 0, 0];
@@ -42,8 +42,8 @@ export function create() {
 
 /**
  * Resets the given transform to an identity transform.
- * @param {!module:ol/transform~Transform} transform Transform.
- * @return {!module:ol/transform~Transform} Transform.
+ * @param {!Transform} transform Transform.
+ * @return {!Transform} Transform.
  */
 export function reset(transform) {
   return set(transform, 1, 0, 0, 1, 0, 0);
@@ -53,9 +53,9 @@ export function reset(transform) {
 /**
  * Multiply the underlying matrices of two transforms and return the result in
  * the first transform.
- * @param {!module:ol/transform~Transform} transform1 Transform parameters of matrix 1.
- * @param {!module:ol/transform~Transform} transform2 Transform parameters of matrix 2.
- * @return {!module:ol/transform~Transform} transform1 multiplied with transform2.
+ * @param {!Transform} transform1 Transform parameters of matrix 1.
+ * @param {!Transform} transform2 Transform parameters of matrix 2.
+ * @return {!Transform} transform1 multiplied with transform2.
  */
 export function multiply(transform1, transform2) {
   const a1 = transform1[0];
@@ -83,14 +83,14 @@ export function multiply(transform1, transform2) {
 
 /**
  * Set the transform components a-f on a given transform.
- * @param {!module:ol/transform~Transform} transform Transform.
+ * @param {!Transform} transform Transform.
  * @param {number} a The a component of the transform.
  * @param {number} b The b component of the transform.
  * @param {number} c The c component of the transform.
  * @param {number} d The d component of the transform.
  * @param {number} e The e component of the transform.
  * @param {number} f The f component of the transform.
- * @return {!module:ol/transform~Transform} Matrix with transform applied.
+ * @return {!Transform} Matrix with transform applied.
  */
 export function set(transform, a, b, c, d, e, f) {
   transform[0] = a;
@@ -105,9 +105,9 @@ export function set(transform, a, b, c, d, e, f) {
 
 /**
  * Set transform on one matrix from another matrix.
- * @param {!module:ol/transform~Transform} transform1 Matrix to set transform to.
- * @param {!module:ol/transform~Transform} transform2 Matrix to set transform from.
- * @return {!module:ol/transform~Transform} transform1 with transform from transform2 applied.
+ * @param {!Transform} transform1 Matrix to set transform to.
+ * @param {!Transform} transform2 Matrix to set transform from.
+ * @return {!Transform} transform1 with transform from transform2 applied.
  */
 export function setFromArray(transform1, transform2) {
   transform1[0] = transform2[0];
@@ -124,9 +124,9 @@ export function setFromArray(transform1, transform2) {
  * Transforms the given coordinate with the given transform returning the
  * resulting, transformed coordinate. The coordinate will be modified in-place.
  *
- * @param {module:ol/transform~Transform} transform The transformation.
- * @param {module:ol/coordinate~Coordinate|module:ol/pixel~Pixel} coordinate The coordinate to transform.
- * @return {module:ol/coordinate~Coordinate|module:ol/pixel~Pixel} return coordinate so that operations can be
+ * @param {Transform} transform The transformation.
+ * @param {import("./coordinate.js").Coordinate|import("./pixel.js").Pixel} coordinate The coordinate to transform.
+ * @return {import("./coordinate.js").Coordinate|import("./pixel.js").Pixel} return coordinate so that operations can be
  *     chained together.
  */
 export function apply(transform, coordinate) {
@@ -140,9 +140,9 @@ export function apply(transform, coordinate) {
 
 /**
  * Applies rotation to the given transform.
- * @param {!module:ol/transform~Transform} transform Transform.
+ * @param {!Transform} transform Transform.
  * @param {number} angle Angle in radians.
- * @return {!module:ol/transform~Transform} The rotated transform.
+ * @return {!Transform} The rotated transform.
  */
 export function rotate(transform, angle) {
   const cos = Math.cos(angle);
@@ -153,10 +153,10 @@ export function rotate(transform, angle) {
 
 /**
  * Applies scale to a given transform.
- * @param {!module:ol/transform~Transform} transform Transform.
+ * @param {!Transform} transform Transform.
  * @param {number} x Scale factor x.
  * @param {number} y Scale factor y.
- * @return {!module:ol/transform~Transform} The scaled transform.
+ * @return {!Transform} The scaled transform.
  */
 export function scale(transform, x, y) {
   return multiply(transform, set(tmp_, x, 0, 0, y, 0, 0));
@@ -165,10 +165,10 @@ export function scale(transform, x, y) {
 
 /**
  * Applies translation to the given transform.
- * @param {!module:ol/transform~Transform} transform Transform.
+ * @param {!Transform} transform Transform.
  * @param {number} dx Translation x.
  * @param {number} dy Translation y.
- * @return {!module:ol/transform~Transform} The translated transform.
+ * @return {!Transform} The translated transform.
  */
 export function translate(transform, dx, dy) {
   return multiply(transform, set(tmp_, 1, 0, 0, 1, dx, dy));
@@ -178,7 +178,7 @@ export function translate(transform, dx, dy) {
 /**
  * Creates a composite transform given an initial translation, scale, rotation, and
  * final translation (in that order only, not commutative).
- * @param {!module:ol/transform~Transform} transform The transform (will be modified in place).
+ * @param {!Transform} transform The transform (will be modified in place).
  * @param {number} dx1 Initial translation x.
  * @param {number} dy1 Initial translation y.
  * @param {number} sx Scale factor x.
@@ -186,7 +186,7 @@ export function translate(transform, dx, dy) {
  * @param {number} angle Rotation (in counter-clockwise radians).
  * @param {number} dx2 Final translation x.
  * @param {number} dy2 Final translation y.
- * @return {!module:ol/transform~Transform} The composite transform.
+ * @return {!Transform} The composite transform.
  */
 export function compose(transform, dx1, dy1, sx, sy, angle, dx2, dy2) {
   const sin = Math.sin(angle);
@@ -203,8 +203,8 @@ export function compose(transform, dx1, dy1, sx, sy, angle, dx2, dy2) {
 
 /**
  * Invert the given transform.
- * @param {!module:ol/transform~Transform} transform Transform.
- * @return {!module:ol/transform~Transform} Inverse of the transform.
+ * @param {!Transform} transform Transform.
+ * @return {!Transform} Inverse of the transform.
  */
 export function invert(transform) {
   const det = determinant(transform);
@@ -230,7 +230,7 @@ export function invert(transform) {
 
 /**
  * Returns the determinant of the given matrix.
- * @param {!module:ol/transform~Transform} mat Matrix.
+ * @param {!Transform} mat Matrix.
  * @return {number} Determinant.
  */
 export function determinant(mat) {

--- a/src/ol/vec/mat4.js
+++ b/src/ol/vec/mat4.js
@@ -13,7 +13,7 @@ export function create() {
 
 /**
  * @param {Array<number>} mat4 Flattened 4x4 matrix receiving the result.
- * @param {module:ol/transform~Transform} transform Transformation matrix.
+ * @param {import("../transform.js").Transform} transform Transformation matrix.
  * @return {Array<number>} 2D transformation matrix as flattened 4x4 matrix.
  */
 export function fromTransform(mat4, transform) {

--- a/src/ol/webgl/Context.js
+++ b/src/ol/webgl/Context.js
@@ -13,7 +13,7 @@ import ContextEventType from '../webgl/ContextEventType.js';
 
 /**
  * @typedef {Object} BufferCacheEntry
- * @property {module:ol/webgl/Buffer} buf
+ * @property {import("./Buffer.js").default} buf
  * @property {WebGLBuffer} buffer
  */
 
@@ -45,7 +45,7 @@ class WebGLContext extends Disposable {
 
     /**
      * @private
-     * @type {!Object<string, module:ol/webgl/Context~BufferCacheEntry>}
+     * @type {!Object<string, BufferCacheEntry>}
      */
     this.bufferCache_ = {};
 
@@ -107,7 +107,7 @@ class WebGLContext extends Disposable {
    * the WebGL buffer, bind it, populate it, and add an entry to
    * the cache.
    * @param {number} target Target.
-   * @param {module:ol/webgl/Buffer} buf Buffer.
+   * @param {import("./Buffer.js").default} buf Buffer.
    */
   bindBuffer(target, buf) {
     const gl = this.getGL();
@@ -135,7 +135,7 @@ class WebGLContext extends Disposable {
   }
 
   /**
-   * @param {module:ol/webgl/Buffer} buf Buffer.
+   * @param {import("./Buffer.js").default} buf Buffer.
    */
   deleteBuffer(buf) {
     const gl = this.getGL();
@@ -200,7 +200,7 @@ class WebGLContext extends Disposable {
   /**
    * Get shader from the cache if it's in the cache. Otherwise, create
    * the WebGL shader, compile it, and add entry to cache.
-   * @param {module:ol/webgl/Shader} shaderObject Shader object.
+   * @param {import("./Shader.js").default} shaderObject Shader object.
    * @return {WebGLShader} Shader.
    */
   getShader(shaderObject) {
@@ -221,8 +221,8 @@ class WebGLContext extends Disposable {
    * Get the program from the cache if it's in the cache. Otherwise create
    * the WebGL program, attach the shaders to it, and add an entry to the
    * cache.
-   * @param {module:ol/webgl/Fragment} fragmentShaderObject Fragment shader.
-   * @param {module:ol/webgl/Vertex} vertexShaderObject Vertex shader.
+   * @param {import("./Fragment.js").default} fragmentShaderObject Fragment shader.
+   * @param {import("./Vertex.js").default} vertexShaderObject Vertex shader.
    * @return {WebGLProgram} Program.
    */
   getProgram(fragmentShaderObject, vertexShaderObject) {

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -133,7 +133,7 @@ export function parse(xml) {
  * object stack.
  * @param {function(this: T, Node, Array<*>): (Array<*>|undefined)} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
- * @return {module:ol/xml~Parser} Parser.
+ * @return {Parser} Parser.
  * @template T
  */
 export function makeArrayExtender(valueReader, opt_this) {
@@ -158,7 +158,7 @@ export function makeArrayExtender(valueReader, opt_this) {
  * object stack.
  * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
- * @return {module:ol/xml~Parser} Parser.
+ * @return {Parser} Parser.
  * @template T
  */
 export function makeArrayPusher(valueReader, opt_this) {
@@ -182,7 +182,7 @@ export function makeArrayPusher(valueReader, opt_this) {
  * top of the stack.
  * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
- * @return {module:ol/xml~Parser} Parser.
+ * @return {Parser} Parser.
  * @template T
  */
 export function makeReplacer(valueReader, opt_this) {
@@ -206,7 +206,7 @@ export function makeReplacer(valueReader, opt_this) {
  * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
  * @param {string=} opt_property Property.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
- * @return {module:ol/xml~Parser} Parser.
+ * @return {Parser} Parser.
  * @template T
  */
 export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
@@ -237,7 +237,7 @@ export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
  * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
  * @param {string=} opt_property Property.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
- * @return {module:ol/xml~Parser} Parser.
+ * @return {Parser} Parser.
  * @template T
  */
 export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
@@ -263,13 +263,13 @@ export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
  * {@link module:ol/xml~NodeStackItem} at the top of the `objectStack`.
  * @param {function(this: T, Node, V, Array<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
- * @return {module:ol/xml~Serializer} Serializer.
+ * @return {Serializer} Serializer.
  * @template T, V
  */
 export function makeChildAppender(nodeWriter, opt_this) {
   return function(node, value, objectStack) {
     nodeWriter.call(opt_this !== undefined ? opt_this : this, node, value, objectStack);
-    const parent = /** @type {module:ol/xml~NodeStackItem} */ (objectStack[objectStack.length - 1]);
+    const parent = /** @type {NodeStackItem} */ (objectStack[objectStack.length - 1]);
     const parentNode = parent.node;
     parentNode.appendChild(node);
   };
@@ -285,7 +285,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
  * geometries.
  * @param {function(this: T, Element, V, Array<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
- * @return {module:ol/xml~Serializer} Serializer.
+ * @return {Serializer} Serializer.
  * @template T, V
  */
 export function makeArraySerializer(nodeWriter, opt_this) {
@@ -326,7 +326,7 @@ export function makeSimpleNodeFactory(opt_nodeName, opt_namespaceURI) {
      * @return {Node} Node.
      */
     function(value, objectStack, opt_nodeName) {
-      const context = /** @type {module:ol/xml~NodeStackItem} */ (objectStack[objectStack.length - 1]);
+      const context = /** @type {NodeStackItem} */ (objectStack[objectStack.length - 1]);
       const node = context.node;
       let nodeName = fixedNodeName;
       if (nodeName === undefined) {
@@ -397,7 +397,7 @@ export function makeStructureNS(namespaceURIs, structure, opt_structureNS) {
 
 /**
  * Parse a node using the parsers and object stack.
- * @param {Object<string, Object<string, module:ol/xml~Parser>>} parsersNS
+ * @param {Object<string, Object<string, Parser>>} parsersNS
  *     Parsers by namespace.
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
@@ -420,7 +420,7 @@ export function parseNode(parsersNS, node, objectStack, opt_this) {
 /**
  * Push an object on top of the stack, parse and return the popped object.
  * @param {T} object Object.
- * @param {Object<string, Object<string, module:ol/xml~Parser>>} parsersNS
+ * @param {Object<string, Object<string, Parser>>} parsersNS
  *     Parsers by namespace.
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
@@ -437,7 +437,7 @@ export function pushParseAndPop(object, parsersNS, node, objectStack, opt_this) 
 
 /**
  * Walk through an array of `values` and call a serializer for each value.
- * @param {Object<string, Object<string, module:ol/xml~Serializer>>} serializersNS
+ * @param {Object<string, Object<string, Serializer>>} serializersNS
  *     Namespaced serializers.
  * @param {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)} nodeFactory
  *     Node factory. The `nodeFactory` creates the node whose namespace and name
@@ -477,7 +477,7 @@ export function serialize(
 
 /**
  * @param {O} object Object.
- * @param {Object<string, Object<string, module:ol/xml~Serializer>>} serializersNS
+ * @param {Object<string, Object<string, Serializer>>} serializersNS
  *     Namespaced serializers.
  * @param {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)} nodeFactory
  *     Node factory. The `nodeFactory` creates the node whose namespace and name

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,60 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": ["es2017", "dom"],                        /* Specify library files to be included in the compilation. */
+    "allowJs": true,                          /* Allow javascript files to be compiled. */
+    "checkJs": true,                          /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true,                           /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": false,                          /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": ["node"],                        /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": [
+    "src/ol/**/*.js"
+  ]
+}


### PR DESCRIPTION
This is an initial, work-in-progress branch that replaces Closure Compiler type checking with TypeScript type checking.  The first phase of this work will be to replace our custom type annotations with those understood by `tsc`.

This branch will transform the `module:ol/foo/Bar~Options` types in an automated way.  For example, say we currently have a typedef in `ol/foo/Bar.js`:

```js
// in ol/foo/Bar.js

/**
 * @typedef {Object} Options.
 * @property {string} bam A string.
 */
```

Currently, we use that typedef in another module like this:

```js
// before in ol/foo/Baz.js

/**
 * @param {module:ol/foo/Bar~Options} options Some options.
 */
// ...
```

After this change, we will "import" the type and use it like this:
```js
// after in ol/foo/Baz.js

/** @typedef {import("./Bar.js").Options} _ol_foo_Bar_Options_ */

/**
 * @param {_ol_foo_Bar_Options_} options Some options.
 */
// ...
```

We can follow up this change with hand edited type names (e.g. `BarOptions` instead of `_ol_foo_Bar_Options_`).