### PR TITLE
Set `sideEffects` to `false` instead of `"false"`

### DIFF
--- a/src/ol/package.json
+++ b/src/ol/package.json
@@ -10,5 +10,5 @@
     "pixelworks": "1.1.0",
     "rbush": "2.0.2"
   },
-  "sideEffects": "false"
+  "sideEffects": false
 }


### PR DESCRIPTION
It looks like setting this to `"false"` doesn't have any negative effects, but the value is supposed to be a boolean.

See https://github.com/webpack/webpack/blob/271fb7b543e017cde14186f3c7eb741bd9892c0c/lib/optimize/SideEffectsFlagPlugin.js#L43-L49 for a couple checks - still haven't found exactly where it is parsed from `package.json`.

It is definitely set as a boolean in their test cases.  See https://github.com/webpack/webpack/blob/271fb7b543e017cde14186f3c7eb741bd9892c0c/test/statsCases/side-effects-issue-7428/components/package.json.

I don't think we need to do another patch release because of this.  In testing the ol-webpack project, the bundle size wasn't any bigger with `"sideEffects": "false"`.