### PR TITLE
Avoid error when calling getExtent on null geometry

### DIFF
--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -3,7 +3,7 @@
  */
 import {inherits} from '../util.js';
 import {FALSE} from '../functions.js';
-import {createOrUpdateFromFlatCoordinates, getCenter} from '../extent.js';
+import {createOrUpdateFromFlatCoordinates, getCenter, createOrUpdateEmpty} from '../extent.js';
 import Geometry from '../geom/Geometry.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import {rotate, scale, translate, transform2D} from '../geom/flat/transform.js';
@@ -92,6 +92,9 @@ SimpleGeometry.prototype.containsXY = FALSE;
  * @inheritDoc
  */
 SimpleGeometry.prototype.computeExtent = function(extent) {
+  if (!this.flatCoordinates) {
+    return createOrUpdateEmpty();
+  }
   return createOrUpdateFromFlatCoordinates(this.flatCoordinates,
     0, this.flatCoordinates.length, this.stride, extent);
 };

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -12,6 +12,13 @@ describe('ol/geom/Polygon', function() {
     }).not.to.throwException();
   });
 
+  it('can call getExtent with a null geometry', function() {
+    expect(function() {
+      const p = new Polygon(null);
+      p.getExtent();
+    }).not.to.throwException();
+  });
+
   describe('construct empty', function() {
 
     let polygon;


### PR DESCRIPTION
If `flatCoordinates` were null, an error was thrown.