### PR TITLE
Make examples work in IE11

### DIFF
--- a/examples/webpack/config.js
+++ b/examples/webpack/config.js
@@ -18,6 +18,18 @@ module.exports = {
   context: src,
   target: 'web',
   entry: entry,
+  module: {
+    rules: [{
+      use: {
+        loader: 'buble-loader'
+      },
+      test: /\.js$/,
+      include: [
+        path.join(__dirname, '..', '..', 'src'),
+        path.join(__dirname, '..')
+      ]
+    }]
+  },
   optimization: {
     runtimeChunk: {
       name: 'common'

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -64,20 +64,20 @@ function createWordIndex(exampleData) {
 /**
  * Gets the source for the chunk that matches the jsPath
  * @param {Object} chunk Chunk.
- * @param {string} jsPath Path of the file.
+ * @param {string} jsName Name of the file.
  * @return {string} The source.
  */
-function getJsSource(chunk, jsPath) {
+function getJsSource(chunk, jsName) {
   let jsSource;
   for (let i = 0, ii = chunk.modules.length; i < ii; ++i) {
     const module = chunk.modules[i];
     if (module.modules) {
-      jsSource = getJsSource(module, jsPath);
+      jsSource = getJsSource(module, jsName);
       if (jsSource) {
         return jsSource;
       }
     }
-    if (module.identifier == jsPath) {
+    if (module.identifier.endsWith(jsName)) {
       return module.source;
     }
   }
@@ -151,8 +151,7 @@ ExampleBuilder.prototype.render = async function(dir, chunk) {
 
   // add in script tag
   const jsName = `${name}.js`;
-  const jsPath = path.join(dir, jsName);
-  let jsSource = getJsSource(chunk, jsPath);
+  let jsSource = getJsSource(chunk, path.join('.', jsName));
   jsSource = jsSource.replace(/'\.\.\/src\//g, '\'');
   if (data.cloak) {
     for (const entry of data.cloak) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-plugin-jsdoc-closure": "1.5.1",
+    "buble-loader": "^0.5.1",
     "chaikin-smooth": "^1.0.4",
     "clean-css-cli": "4.1.11",
     "copy-webpack-plugin": "^4.4.1",
@@ -87,7 +88,7 @@
     "url-polyfill": "^1.0.13",
     "walk": "^2.3.9",
     "webpack": "4.15.1",
-    "webpack-cli": "^3.0.3",
+    "webpack-cli": "^3.0.8",
     "webpack-dev-server": "^3.1.4"
   },
   "eslintConfig": {


### PR DESCRIPTION
The full build works already in IE 11 (thanks to [buble](https://github.com/openlayers/openlayers/blob/04e825e49aae22ad8c71f73b33f82c54b790c6a2/config/rollup.js#L17)), so we only need to add babel transpilation to the examples.

Fixes #8356.