### PR TITLE
Skip rendering when there is no replay group

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -392,7 +392,9 @@ CanvasVectorTileLayerRenderer.prototype.postCompose = function(context, frameSta
           continue;
         }
         const replayGroup = sourceTile.getReplayGroup(layer, tileCoord.toString());
-        if (renderMode != VectorTileRenderType.VECTOR && !replayGroup.hasReplays(replayTypes)) {
+        if (!replayGroup || !replayGroup.hasReplays(replayTypes)) {
+          // sourceTile was not yet loaded when this.createReplayGroup_() was
+          // called, or it has no replays of the types we want to render
           continue;
         }
         if (!transform) {


### PR DESCRIPTION
Since 710cefc, we render lower resolution vector tiles when the optimal resolution tiles have not been loaded yet. In an interaction sequence where the user zooms out far and then zooms back in a bit, it can now happen that loading of the lowest resolution tile has been triggered, but it has not been loaded yet before moving back to a higher resolution. In such a scenario, the `hasReplays` check fails because it is called on an undefined replay group.

This pull request fixes that.