### PR TITLE
copy ZM values to polygon in makeRegular

### DIFF
--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -434,6 +434,9 @@ export function makeRegular(polygon, center, radius, opt_angle) {
     const angle = startAngle + (modulo(i, sides) * 2 * Math.PI / sides);
     flatCoordinates[offset] = center[0] + (radius * Math.cos(angle));
     flatCoordinates[offset + 1] = center[1] + (radius * Math.sin(angle));
+    for (let j = 2; j < stride; j++) {
+      flatCoordinates[offset + j] = center[j];
+    }
   }
   polygon.changed();
 }

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -404,14 +404,19 @@ export function fromCircle(circle, opt_sides, opt_angle) {
   const sides = opt_sides ? opt_sides : 32;
   const stride = circle.getStride();
   const layout = circle.getLayout();
+  const center = circle.getCenter();
   const arrayLength = stride * (sides + 1);
   const flatCoordinates = new Array(arrayLength);
-  for (let i = 0; i < arrayLength; i++) {
+  for (let i = 0; i < arrayLength; i += stride) {
     flatCoordinates[i] = 0;
+    flatCoordinates[i + 1] = 0;
+    for (let j = 2; j < stride; j++) {
+      flatCoordinates[i + j] = center[j];
+    }
   }
   const ends = [flatCoordinates.length];
   const polygon = new Polygon(flatCoordinates, layout, ends);
-  makeRegular(polygon, circle.getCenter(), circle.getRadius(), opt_angle);
+  makeRegular(polygon, center, circle.getRadius(), opt_angle);
   return polygon;
 }
 
@@ -434,9 +439,6 @@ export function makeRegular(polygon, center, radius, opt_angle) {
     const angle = startAngle + (modulo(i, sides) * 2 * Math.PI / sides);
     flatCoordinates[offset] = center[0] + (radius * Math.cos(angle));
     flatCoordinates[offset + 1] = center[1] + (radius * Math.sin(angle));
-    for (let j = 2; j < stride; j++) {
-      flatCoordinates[offset + j] = center[j];
-    }
   }
   polygon.changed();
 }

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -605,6 +605,14 @@ describe('ol/geom/Polygon', function() {
       expect(coordinates[0][0]).to.roughlyEqual(0, 1e-9);
       expect(coordinates[0][1]).to.roughlyEqual(1, 1e-9);
     });
+
+    it('creates a regular polygon, maintaining ZM values', () => {
+      const circle = new Circle([0, 0, 1, 1], 1, 'XYZM');
+      const polygon = fromCircle(circle);
+      const coordinates = polygon.getLinearRing(0).getCoordinates();
+      expect(coordinates[0][2]).to.eql(1);
+      expect(coordinates[0][3]).to.eql(1);
+    });
   });
 
 });


### PR DESCRIPTION
When creating a polygon using `Polygon.fromCircle` the `Z` or `ZM` values in `XYZ` or `XYZM` geometry layouts are copied to the new geometries coordinates, instead of assuming `0`.
