### PR TITLE
style/Icon: Add `setAnchor()` method

### DIFF
--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -285,6 +285,18 @@ Icon.prototype.getAnchor = function() {
   return this.normalizedAnchor_;
 };
 
+/**
+ * Set the anchor point. The anchor determines the center point for the
+ * symbolizer.
+ *
+ * @param {Array.<number>} anchor Anchor.
+ * @api
+ */
+Icon.prototype.setAnchor = function(anchor) {
+  this.anchor_ = anchor;
+  this.normalizedAnchor_ = null;
+};
+
 
 /**
  * Get the icon color.

--- a/test/spec/ol/style/icon.test.js
+++ b/test/spec/ol/style/icon.test.js
@@ -172,6 +172,20 @@ describe('ol.style.Icon', function() {
     });
   });
 
+  describe('#setAnchor', function() {
+    it('resets the cached anchor', function() {
+      const iconStyle = new Icon({
+        src: 'test.png',
+        size: size,
+        anchor: [0.25, 0.25]
+      });
+      expect(iconStyle.getAnchor()).to.eql([9, 12]);
+
+      iconStyle.setAnchor([0.5, 0.5]);
+      expect(iconStyle.getAnchor()).to.eql([18, 24]);
+    });
+  });
+
   describe('#getOrigin', function() {
     const offset = [16, 20];
     const imageSize = [144, 192];


### PR DESCRIPTION
This allows users to adjust the anchor after the `Icon` is defined. This can be useful if the anchor should depend on the rotation of the icon.
