### PR TITLE
ESLint config update

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -313,7 +313,7 @@ exports.publish = function(taffyData, opts, tutorials) {
 
         if (example.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
           caption = RegExp.$1;
-          code    = RegExp.$3;
+          code = RegExp.$3;
         }
 
         return {

--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -136,7 +136,7 @@ const map = new Map({
   layers: [raster, vector],
   interactions: defaultInteractions().extend([new Select({
     condition: function(evt) {
-      return  evt.type == 'pointermove' ||
+      return evt.type == 'pointermove' ||
           evt.type == 'singleclick';
     },
     style: selectStyleFunction

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -27,7 +27,7 @@ const map = new Map({
   })
 });
 
-let select = null;  // ref to currently selected interaction
+let select = null; // ref to currently selected interaction
 
 // select interaction working on "singleclick"
 const selectSingleClick = new Select();

--- a/examples/zoomify.js
+++ b/examples/zoomify.js
@@ -8,7 +8,7 @@ const imgHeight = 6100;
 
 const zoomifyUrl = 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?zoomify=' +
     '/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF/';
-const iipUrl = 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?FIF=' + '/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF' +  '&JTL={z},{tileIndex}';
+const iipUrl = 'http://vips.vtech.fr/cgi-bin/iipsrv.fcgi?FIF=' + '/mnt/MD1/AD00/plan_CHU-4HD-01/FOND.TIF' + '&JTL={z},{tileIndex}';
 
 const layer = new TileLayer({
   source: new Zoomify({

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "copy-webpack-plugin": "^4.4.1",
     "coveralls": "3.0.1",
     "eslint": "5.0.1",
-    "eslint-config-openlayers": "^10.0.0",
+    "eslint-config-openlayers": "^11.0.0",
     "expect.js": "0.3.1",
     "front-matter": "^2.1.2",
     "fs-extra": "^6.0.0",

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -26,7 +26,7 @@ export function binarySearch(haystack, needle, opt_comparator) {
     cmp = +comparator(haystack[mid], needle);
 
     if (cmp < 0.0) { /* Too low. */
-      low  = mid + 1;
+      low = mid + 1;
 
     } else { /* Key found or too high */
       high = mid;

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -25,7 +25,7 @@ export function clamp(value, min, max) {
  * @param {number} x X.
  * @return {number} Hyperbolic cosine of x.
  */
-export const cosh  = (function() {
+export const cosh = (function() {
   // Wrapped in a iife, to save the overhead of checking for the native
   // implementation on every invocation.
   let cosh;

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -660,7 +660,7 @@ class CanvasReplay extends VectorContext {
         case CanvasInstruction.DRAW_IMAGE:
           d = /** @type {number} */ (instruction[1]);
           dd = /** @type {number} */ (instruction[2]);
-          image =  /** @type {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement} */
+          image = /** @type {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement} */
               (instruction[3]);
           // Remaining arguments in DRAW_IMAGE are in alphabetical order
           anchorX = /** @type {number} */ (instruction[4]);
@@ -711,7 +711,7 @@ class CanvasReplay extends VectorContext {
           const measure = /** @type {function(string):number} */ (instruction[8]);
           const offsetY = /** @type {number} */ (instruction[9]);
           const strokeKey = /** @type {string} */ (instruction[10]);
-          const strokeWidth =  /** @type {number} */ (instruction[11]);
+          const strokeWidth = /** @type {number} */ (instruction[11]);
           const text = /** @type {string} */ (instruction[12]);
           const textKey = /** @type {string} */ (instruction[13]);
           const textScale = /** @type {number} */ (instruction[14]);

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -266,7 +266,7 @@ class CanvasTextReplay extends CanvasReplay {
       const textState = this.textStates[textKey] || this.textState_;
       const pixelRatio = this.pixelRatio;
       const scale = textState.scale * pixelRatio;
-      const align =  TEXT_ALIGN[textState.textAlign || defaultTextAlign];
+      const align = TEXT_ALIGN[textState.textAlign || defaultTextAlign];
       const strokeWidth = strokeKey && strokeState.lineWidth ? strokeState.lineWidth : 0;
 
       const lines = text.split('\n');

--- a/src/ol/render/webgl/CircleReplay.js
+++ b/src/ol/render/webgl/CircleReplay.js
@@ -136,7 +136,7 @@ class WebGLCircleReplay extends WebGLReplay {
         this.styles_.pop();
         if (this.styles_.length) {
           const lastState = this.styles_[this.styles_.length - 1];
-          this.state_.fillColor =  /** @type {Array.<number>} */ (lastState[0]);
+          this.state_.fillColor = /** @type {Array.<number>} */ (lastState[0]);
           this.state_.strokeColor = /** @type {Array.<number>} */ (lastState[1]);
           this.state_.lineWidth = /** @type {number} */ (lastState[2]);
           this.state_.changed = false;

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -10,7 +10,7 @@ import EventType from '../events/EventType.js';
 import {FALSE, UNDEFINED} from '../functions.js';
 import SourceState from '../source/State.js';
 
-class LayerRenderer  extends Observable {
+class LayerRenderer extends Observable {
 
   /**
    * @param {module:ol/layer/Layer} layer Layer.

--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -132,7 +132,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
 
       const imageData = this.hitCanvasContext_.getImageData(0, 0, 1, 1).data;
       if (imageData[3] > 0) {
-        return callback.call(thisArg, this.getLayer(),  imageData);
+        return callback.call(thisArg, this.getLayer(), imageData);
       } else {
         return undefined;
       }

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -112,7 +112,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const clipExtent = layerState.extent;
     const clipped = clipExtent !== undefined;
     if (clipped) {
-      this.clip(context, frameState,  /** @type {module:ol/extent~Extent} */ (clipExtent));
+      this.clip(context, frameState, /** @type {module:ol/extent~Extent} */ (clipExtent));
     }
     const replayGroup = this.replayGroup_;
     if (replayGroup && !replayGroup.isEmpty()) {

--- a/src/ol/renderer/webgl/ImageLayer.js
+++ b/src/ol/renderer/webgl/ImageLayer.js
@@ -266,7 +266,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
 
       const imageData = this.hitCanvasContext_.getImageData(0, 0, 1, 1).data;
       if (imageData[3] > 0) {
-        return callback.call(thisArg, this.getLayer(),  imageData);
+        return callback.call(thisArg, this.getLayer(), imageData);
       } else {
         return undefined;
       }

--- a/src/ol/source/WMTSRequestEncoding.js
+++ b/src/ol/source/WMTSRequestEncoding.js
@@ -7,6 +7,6 @@
  * @enum {string}
  */
 export default {
-  KVP: 'KVP',  // see spec §8
+  KVP: 'KVP', // see spec §8
   REST: 'REST' // see spec §10
 };

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -246,7 +246,7 @@ class LRUCache extends EventTarget {
    * @param {T} value Value.
    */
   replace(key, value) {
-    this.get(key);  // update `newest_`
+    this.get(key); // update `newest_`
     this.entries_[key].value_ = value;
   }
 

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -185,7 +185,7 @@ class RegularShape extends ImageStyle {
       radius2: this.getRadius2(),
       angle: this.getAngle(),
       snapToPixel: this.getSnapToPixel(),
-      stroke: this.getStroke() ?  this.getStroke().clone() : undefined,
+      stroke: this.getStroke() ? this.getStroke().clone() : undefined,
       rotation: this.getRotation(),
       rotateWithView: this.getRotateWithView(),
       atlasManager: this.atlasManager_

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -82,7 +82,7 @@ describe('ol.interaction.Snap', function() {
       snapInteraction.setMap(map);
 
       const event = {
-        pixel: [7 + width / 2,  height / 2 - 4],
+        pixel: [7 + width / 2, height / 2 - 4],
         coordinate: [7, 4],
         map: map
       };
@@ -100,7 +100,7 @@ describe('ol.interaction.Snap', function() {
       snapInteraction.setMap(map);
 
       const event = {
-        pixel: [7 + width / 2,  height / 2 - 4],
+        pixel: [7 + width / 2, height / 2 - 4],
         coordinate: [7, 4],
         map: map
       };
@@ -117,7 +117,7 @@ describe('ol.interaction.Snap', function() {
       snapInteraction.setMap(map);
 
       const event = {
-        pixel: [5 + width / 2,  height / 2 - 5],
+        pixel: [5 + width / 2, height / 2 - 5],
         coordinate: [5, 5],
         map: map
       };

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -251,7 +251,7 @@ describe('ol.Map', function() {
 
   });
 
-  describe('#forEachLayerAtPixel()', function()  {
+  describe('#forEachLayerAtPixel()', function() {
 
     let target, map, original, log;
 

--- a/test/spec/ol/render/box.test.js
+++ b/test/spec/ol/render/box.test.js
@@ -50,7 +50,7 @@ describe('ol.render.Box', function() {
   });
 
   describe('#setPixels()', function() {
-    it('applies correct styles for a box', function()  {
+    it('applies correct styles for a box', function() {
       box.setPixels([1, 2], [4, 8]);
       expect(box.element_.style.left).to.be('1px');
       expect(box.element_.style.top).to.be('2px');

--- a/test/spec/ol/tile.test.js
+++ b/test/spec/ol/tile.test.js
@@ -5,7 +5,7 @@ import TileState from '../../../src/ol/TileState.js';
 
 
 describe('ol.Tile', function() {
-  describe('constructor', function()  {
+  describe('constructor', function() {
     it('sets a default transition', function() {
       const coord = [0, 0, 0];
       const tile = new Tile(coord, TileState.IDLE);
@@ -72,7 +72,7 @@ describe('ol.Tile', function() {
       tail = addToChain(tail, TileState.IDLE); //discard, deprecated by head
       tail = addToChain(tail, TileState.LOADED); //keep, use for rendering
       renderTile = tail; //store this tile for later tests
-      tail = addToChain(tail, TileState.IDLE);  //rest of list outdated by tile above
+      tail = addToChain(tail, TileState.IDLE); //rest of list outdated by tile above
       tail = addToChain(tail, TileState.LOADED);
       tail = addToChain(tail, TileState.LOADING);
       tail = addToChain(tail, TileState.LOADED);


### PR DESCRIPTION
This brings in the latest `eslint-config-openlayers`.   The latest version enforces [`no-multi-spaces`](https://eslint.org/docs/rules/no-multi-spaces) (see openlayers/eslint-config-openlayers#11), so the second commit fixes violations of that rule.  We also now have import checking via [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import).  We only do some basic import validation but there are other rules that can be enabled (see openlayers/eslint-config-openlayers#13).
