### PR TITLE
Markdown links

### DIFF
--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -6,7 +6,7 @@ import {VERSION} from './util.js';
 /**
  * Error object thrown when an assertion failed. This is an ECMA-262 Error,
  * extended with a `code` property.
- * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error.
  */
 class AssertionError extends Error {
 

--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -6,7 +6,7 @@ import {VERSION} from './util.js';
 /**
  * Error object thrown when an assertion failed. This is an ECMA-262 Error,
  * extended with a `code` property.
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error}
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
  */
 class AssertionError extends Error {
 
@@ -22,7 +22,7 @@ class AssertionError extends Error {
 
     /**
      * Error code. The meaning of the code can be found on
-     * {@link https://openlayers.org/en/latest/doc/errors/} (replace `latest` with
+     * https://openlayers.org/en/latest/doc/errors/ (replace `latest` with
      * the version found in the OpenLayers script's header comment if a version
      * other than the latest is used).
      * @type {number}

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -16,7 +16,7 @@ import {get as getProjection, getTransformFromProjections, identityTransform} fr
  * @property {boolean} [tracking=false] Start Tracking right after
  * instantiation.
  * @property {PositionOptions} [trackingOptions] Tracking options.
- * See {@link http://www.w3.org/TR/geolocation-API/#position_options_interface}.
+ * See http://www.w3.org/TR/geolocation-API/#position_options_interface.
  * @property {module:ol/proj~ProjectionLike} [projection] The projection the position
  * is reported in.
  */

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -285,7 +285,7 @@ class Geolocation extends BaseObject {
 
   /**
    * Get the tracking options.
-   * @see http://www.w3.org/TR/geolocation-API/#position-options
+   * See http://www.w3.org/TR/geolocation-API/#position-options.
    * @return {PositionOptions|undefined} PositionOptions as defined by
    *     the [HTML5 Geolocation spec
    *     ](http://www.w3.org/TR/geolocation-API/#position_options_interface).
@@ -319,7 +319,7 @@ class Geolocation extends BaseObject {
 
   /**
    * Set the tracking options.
-   * @see http://www.w3.org/TR/geolocation-API/#position-options
+   * See http://www.w3.org/TR/geolocation-API/#position-options.
    * @param {PositionOptions} options PositionOptions as defined by the
    *     [HTML5 Geolocation spec
    *     ](http://www.w3.org/TR/geolocation-API/#position_options_interface).

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -56,7 +56,7 @@ class MapBrowserEvent extends MapEvent {
 
   /**
    * Prevents the default browser action.
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/event.preventDefault
+   * See https://developer.mozilla.org/en-US/docs/Web/API/event.preventDefault.
    * @override
    * @api
    */
@@ -67,7 +67,7 @@ class MapBrowserEvent extends MapEvent {
 
   /**
    * Prevents further propagation of the current event.
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/event.stopPropagation
+   * See https://developer.mozilla.org/en-US/docs/Web/API/event.stopPropagation.
    * @override
    * @api
    */

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -127,7 +127,7 @@ function removeListeners(target, type) {
 
 /**
  * Registers an event listener on an event target. Inspired by
- * {@link https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html}
+ * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * This function efficiently binds a `listener` to a `this` object, and returns
  * a key for use with {@link module:ol/events~unlistenByKey}.
@@ -170,7 +170,7 @@ export function listen(target, type, listener, opt_this, opt_once) {
 
 /**
  * Registers a one-off event listener on an event target. Inspired by
- * {@link https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html}
+ * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * This function efficiently binds a `listener` as self-unregistering listener
  * to a `this` object, and returns a key for use with
@@ -195,7 +195,7 @@ export function listenOnce(target, type, listener, opt_this) {
 
 /**
  * Unregisters an event listener on an event target. Inspired by
- * {@link https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html}
+ * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * To return a listener, this function needs to be called with the exact same
  * arguments that were used for a previous {@link module:ol/events~listen} call.
@@ -219,7 +219,7 @@ export function unlisten(target, type, listener, opt_this) {
 
 /**
  * Unregisters event listeners on an event target. Inspired by
- * {@link https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html}
+ * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * The argument passed to this function is the key returned from
  * {@link module:ol/events~listen} or {@link module:ol/events~listenOnce}.
@@ -246,7 +246,7 @@ export function unlistenByKey(key) {
 
 /**
  * Unregisters all event listeners on an event target. Inspired by
- * {@link https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html}
+ * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
  */

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -5,7 +5,7 @@
 /**
  * @classdesc
  * Stripped down implementation of the W3C DOM Level 2 Event interface.
- * @see https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-interface
+ * See https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-interface.
  *
  * This implementation only provides `type` and `target` properties, and
  * `stopPropagation` and `preventDefault` methods. It is meant as base class

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -5,7 +5,7 @@
 /**
  * @classdesc
  * Stripped down implementation of the W3C DOM Level 2 Event interface.
- * @see {@link https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-interface}
+ * @see https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-interface
  *
  * This implementation only provides `type` and `target` properties, and
  * `stopPropagation` and `preventDefault` methods. It is meant as base class

--- a/src/ol/events/EventTarget.js
+++ b/src/ol/events/EventTarget.js
@@ -15,7 +15,7 @@ import Event from '../events/Event.js';
 /**
  * @classdesc
  * A simplified implementation of the W3C DOM Level 2 EventTarget interface.
- * @see https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget
+ * See https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget.
  *
  * There are two important simplifications compared to the specification:
  *

--- a/src/ol/events/EventTarget.js
+++ b/src/ol/events/EventTarget.js
@@ -15,7 +15,7 @@ import Event from '../events/Event.js';
 /**
  * @classdesc
  * A simplified implementation of the W3C DOM Level 2 EventTarget interface.
- * @see {@link https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget}
+ * @see https://www.w3.org/TR/2000/REC-DOM-Level-2-Events-20001113/events.html#Events-EventTarget
  *
  * There are two important simplifications compared to the specification:
  *

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -237,7 +237,7 @@ export const mouseOnly = function(mapBrowserEvent) {
 /**
  * Return `true` if the event originates from a primary pointer in
  * contact with the surface or if the left mouse button is pressed.
- * @see http://www.w3.org/TR/pointerevents/#button-states
+ * See http://www.w3.org/TR/pointerevents/#button-states.
  *
  * @param {module:ol/MapBrowserEvent} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a primary pointer.

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -171,7 +171,7 @@ class Geometry extends BaseObject {
   /**
    * Create a simplified version of this geometry using the Douglas Peucker
    * algorithm.
-   * @see https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
+   * See https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm.
    * @abstract
    * @param {number} squaredTolerance Squared tolerance.
    * @return {module:ol/geom/Geometry} Simplified geometry.

--- a/src/ol/obj.js
+++ b/src/ol/obj.js
@@ -6,8 +6,8 @@
 /**
  * Polyfill for Object.assign().  Assigns enumerable and own properties from
  * one or more source objects to a target object.
+ * See https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign.
  *
- * @see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @param {!Object} target The target object.
  * @param {...Object} var_sources The source object(s).
  * @return {!Object} The modified target object.

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -18,12 +18,12 @@
  * for example by Bing Maps or OpenStreetMap), together with the relevant
  * transform functions.
  *
- * Additional transforms may be added by using the {@link http://proj4js.org/}
+ * Additional transforms may be added by using the http://proj4js.org/
  * library (version 2.2 or later). You can use the full build supplied by
  * Proj4js, or create a custom build to support those projections you need; see
  * the Proj4js website for how to do this. You also need the Proj4js definitions
  * for the required projections. These definitions can be obtained from
- * {@link https://epsg.io/}, and are a JS function, so can be loaded in a script
+ * https://epsg.io/, and are a JS function, so can be loaded in a script
  * tag (as in the examples) or pasted into your application.
  *
  * After all required projection definitions are added to proj4's registry (by

--- a/src/ol/render/webgl/PolygonReplay.js
+++ b/src/ol/render/webgl/PolygonReplay.js
@@ -690,7 +690,7 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * Line intersection algorithm by Paul Bourke.
-   * @see http://paulbourke.net/geometry/pointlineplane/
+   * See http://paulbourke.net/geometry/pointlineplane/.
    *
    * @private
    * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p0 First point.

--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -13,19 +13,19 @@ import XYZ from '../source/XYZ.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {module:ol/proj~ProjectionLike} [projection='EPSG:3857'] Projection.
  * @property {number} [maxZoom=18] Max zoom.
  * @property {number} [minZoom] Minimum zoom.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {Object} [config] If using anonymous maps, the CartoDB config to use. See
- * {@link http://docs.cartodb.com/cartodb-platform/maps-api/anonymous-maps/}
+ * http://docs.cartodb.com/cartodb-platform/maps-api/anonymous-maps/
  * for more detail.
  * If using named maps, a key-value lookup with the template parameters.
- * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
+ * See http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/
  * for more detail.
  * @property {string} [map] If using named maps, this will be the name of the template to load.
- * See {@link http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/}
+ * See http://docs.cartodb.com/cartodb-platform/maps-api/named-maps/
  * for more detail.
  * @property {string} account If using named maps, this will be the name of the template to load.
  */

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -18,7 +18,7 @@ import {appendParams} from '../uri.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting the image from
  * the remote server.
  * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given
@@ -27,7 +27,7 @@ import {appendParams} from '../uri.js';
  * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
  * `IMAGE` by default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`, and `IMAGESR`
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
- * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
+ * http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/
  * for further reference.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -16,7 +16,7 @@ import {appendParams} from '../uri.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {number} [displayDpi=96] The display resolution.
  * @property {number} [metersPerUnit=1] The meters-per-unit value.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -17,7 +17,7 @@ import ImageSource, {defaultImageLoadFunction} from '../source/Image.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {module:ol/extent~Extent} [imageExtent] Extent of the image in map coordinates.
  * This is the [left, bottom, right, top] map coordinates of your image.
  * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -31,7 +31,7 @@ const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
  * the image from the remote server.
  * @property {module:ol/source/WMSServerType|string} [serverType] The type of

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -24,7 +24,7 @@ export const ATTRIBUTION = '&copy; ' +
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {number} [maxZoom=19] Max zoom.
  * @property {boolean} [opaque=true] Whether the layer is opaque.
  * @property {number} [reprojectionErrorThreshold=1.5] Maximum allowed reprojection error (in pixels).

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -17,14 +17,14 @@ import {appendParams} from '../uri.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.
  * Note that you must provide a `crossOrigin` value if you are using the WebGL renderer
  * or if you want to access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image}
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
  * for more detail.
  * @property {Object.<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
  * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
  * and `IMAGESR` will be set dynamically. Set `LAYERS` to
  * override the default service layer visibility. See
- * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
+ * http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/
  * for further reference.
  * @property {module:ol/tilegrid/TileGrid} [tileGrid] Tile grid. Base this on the resolutions,
  * tilesize and extent supported by the server.

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -21,7 +21,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [opaque=true] Whether the layer is opaque.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -4,7 +4,7 @@
 // FIXME check order of async callbacks
 
 /**
- * @see http://mapbox.com/developers/api/
+ * See http://mapbox.com/developers/api/.
  */
 
 

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -24,7 +24,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [jsonp=false] Use JSONP with callback to load the TileJSON.
  * Useful when the server does not support CORS..
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -24,7 +24,7 @@ import {appendParams} from '../uri.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {Object.<string,*>} params WMS request parameters.
  * At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -19,7 +19,7 @@ import {appendParams} from '../uri.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {module:ol/tilegrid/WMTS} tileGrid Tile grid.
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -12,7 +12,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [opaque=true] Whether the layer is opaque.
  * @property {module:ol/proj~ProjectionLike} [projection='EPSG:3857'] Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -87,7 +87,7 @@ CustomTile.prototype.getImage = function() {
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
- * {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {module:ol/proj~ProjectionLike} [projection] Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.

--- a/src/ol/structs/PriorityQueue.js
+++ b/src/ol/structs/PriorityQueue.js
@@ -17,8 +17,8 @@ export const DROP = Infinity;
  * The implementation is inspired from the Closure Library's Heap class and
  * Python's heapq module.
  *
- * @see http://closure-library.googlecode.com/svn/docs/closure_goog_structs_heap.js.source.html
- * @see http://hg.python.org/cpython/file/2.7/Lib/heapq.py
+ * See http://closure-library.googlecode.com/svn/docs/closure_goog_structs_heap.js.source.html
+ * and http://hg.python.org/cpython/file/2.7/Lib/heapq.py.
  *
  * @template T
  */

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -17,8 +17,8 @@ import {isEmpty} from '../obj.js';
 
 /**
  * Wrapper around the RBush by Vladimir Agafonkin.
+ * See https://github.com/mourner/rbush.
  *
- * @see https://github.com/mourner/rbush
  * @template T
  */
 class RBush {

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -28,7 +28,7 @@ import ImageStyle from '../style/Image.js';
  * the icon will be left as is.
  * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images. Note that you must provide a
  * `crossOrigin` value if you are using the WebGL renderer or if you want to access pixel data with the Canvas renderer.
- * See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image} for more detail.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {HTMLImageElement|HTMLCanvasElement} [img] Image object for the icon. If the `src` option is not provided then the
  * provided image must already be loaded. And in that case, it is required
  * to provide the size of the image, with the `imgSize` option.

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -17,7 +17,7 @@ const DEFAULT_FILL_COLOR = '#333';
 /**
  * @typedef {Object} Options
  * @property {string} [font] Font style as CSS 'font' value, see:
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font}. Default is '10px sans-serif'
+ * https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font. Default is '10px sans-serif'
  * @property {number} [maxAngle] When `placement` is set to `'line'`, allow a maximum angle between adjacent characters.
  * The expected value is in radians, and the default is 45° (`Math.PI / 4`).
  * @property {number} [offsetX=0] Horizontal text offset in pixels. A positive will shift the text right.


### PR DESCRIPTION
This replaces the JSDoc-specific `{@link https://www.example.com/}` comments with plain URLs to be parsed by Markdown (e.g. `https://www.example.com`).  In addition, it removes the unnecessary `@see` tags.

We still have a lot of `@link` tags to symbols within the API docs.  When we rework how the API docs are generated, we can replace these with Markdown link syntax.