### PR TITLE
Minor type fixes

### DIFF
--- a/doc/tutorials/background.md
+++ b/doc/tutorials/background.md
@@ -37,13 +37,13 @@ Class hierarchies grouped by their parent are provided in a subfolder of the pac
 For convenience, these are also available as named exports, e.g.
 
 ```js
-import {Map, View} from `ol`;
-import {Tile, Vector} from `ol/layer`;
+import {Map, View} from 'ol';
+import {Tile, Vector} from 'ol/layer';
 ```
 
 In addition to these re-exported classes, modules with lowercase names also provide constants or functions as named exports:
 
 ```js
-import {inherits} from `ol`;
-import {fromLonLat} from `ol/proj`;
+import {inherits} from 'ol';
+import {fromLonLat} from 'ol/proj';
 ```

--- a/examples/custom-controls.js
+++ b/examples/custom-controls.js
@@ -1,4 +1,4 @@
-import {inherits} from '../src/ol/index.js';
+import {inherits} from '../src/ol/util.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import {defaults as defaultControls, Control} from '../src/ol/control.js';

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -1,4 +1,4 @@
-import {inherits} from '../src/ol/index.js';
+import {inherits} from '../src/ol/util.js';
 import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -29,7 +29,7 @@ app.Drag = function() {
   });
 
   /**
-   * @type {module:ol~Pixel}
+   * @type {module:ol/pixel~Pixel}
    * @private
    */
   this.coordinate_ = null;

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -31,7 +31,7 @@ class MapBrowserEvent extends MapEvent {
 
     /**
      * The map pixel relative to the viewport corresponding to the original browser event.
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      * @api
      */
     this.pixel = map.getEventPixel(browserEvent);

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -93,7 +93,7 @@ class BaseObject extends Observable {
   constructor(opt_values) {
     super();
 
-    // Call {@link module:ol~getUid} to ensure that the order of objects' ids is
+    // Call {@link module:ol/util~getUid} to ensure that the order of objects' ids is
     // the same as the order in which they were created.  This also helps to
     // ensure that object properties are always added in the same order, which
     // helps many JavaScript engines generate faster code.

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -508,7 +508,7 @@ class Overlay extends BaseObject {
   }
 
   /**
-   * @param {module:ol~Pixel} pixel The pixel location.
+   * @param {module:ol/pixel~Pixel} pixel The pixel location.
    * @param {module:ol/size~Size|undefined} mapSize The map size.
    * @protected
    */

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -543,7 +543,7 @@ class PluggableMap extends BaseObject {
    * Detect features that intersect a pixel on the viewport, and execute a
    * callback with each intersecting feature. Layers included in the detection can
    * be configured through the `layerFilter` option in `opt_options`.
-   * @param {module:ol~Pixel} pixel Pixel.
+   * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature),
    *     module:ol/layer/Layer): T} callback Feature callback. The callback will be
    *     called with two arguments. The first argument is one
@@ -575,7 +575,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get all features that intersect a pixel on the viewport.
-   * @param {module:ol~Pixel} pixel Pixel.
+   * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
    * @return {Array.<module:ol/Feature|module:ol/render/Feature>} The detected features or
    * `null` if none were found.
@@ -596,7 +596,7 @@ class PluggableMap extends BaseObject {
    * Detect layers that have a color value at a pixel on the viewport, and
    * execute a callback with each matching layer. Layers included in the
    * detection can be configured through `opt_layerFilter`.
-   * @param {module:ol~Pixel} pixel Pixel.
+   * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback
    *     Layer callback. This callback will receive two arguments: first is the
    *     {@link module:ol/layer/Layer layer}, second argument is an array representing
@@ -624,7 +624,7 @@ class PluggableMap extends BaseObject {
   /**
    * Detect if features intersect a pixel on the viewport. Layers included in the
    * detection can be configured through `opt_layerFilter`.
-   * @param {module:ol~Pixel} pixel Pixel.
+   * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
    * @return {boolean} Is there a feature at the given pixel?
    * @template U
@@ -656,7 +656,7 @@ class PluggableMap extends BaseObject {
   /**
    * Returns the map pixel position for a browser event relative to the viewport.
    * @param {Event} event Event.
-   * @return {module:ol~Pixel} Pixel.
+   * @return {module:ol/pixel~Pixel} Pixel.
    * @api
    */
   getEventPixel(event) {
@@ -700,7 +700,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the coordinate for a given pixel.  This returns a coordinate in the
    * map view projection.
-   * @param {module:ol~Pixel} pixel Pixel position in the map viewport.
+   * @param {module:ol/pixel~Pixel} pixel Pixel position in the map viewport.
    * @return {module:ol/coordinate~Coordinate} The coordinate for the pixel position.
    * @api
    */
@@ -784,7 +784,7 @@ class PluggableMap extends BaseObject {
    * Get the pixel for a coordinate.  This takes a coordinate in the map view
    * projection and returns the corresponding pixel.
    * @param {module:ol/coordinate~Coordinate} coordinate A map coordinate.
-   * @return {module:ol~Pixel} A pixel position in the map viewport.
+   * @return {module:ol/pixel~Pixel} A pixel position in the map viewport.
    * @api
    */
   getPixelFromCoordinate(coordinate) {

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1077,7 +1077,7 @@ class View extends BaseObject {
    * Center on coordinate and view position.
    * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
    * @param {module:ol/size~Size} size Box pixel size.
-   * @param {module:ol~Pixel} position Position on the view to center on.
+   * @param {module:ol/pixel~Pixel} position Position on the view to center on.
    * @api
    */
   centerOn(coordinate, size, position) {

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -107,7 +107,7 @@ class MousePosition extends Control {
 
     /**
      * @private
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      */
     this.lastMouseMovePixel_ = null;
 
@@ -208,7 +208,7 @@ class MousePosition extends Control {
   }
 
   /**
-   * @param {?module:ol~Pixel} pixel Pixel.
+   * @param {?module:ol/pixel~Pixel} pixel Pixel.
    * @private
    */
   updateHTML_(pixel) {

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -33,9 +33,3 @@ export {default as WebGLMap} from './WebGLMap.js';
 
 export {getUid, inherits, VERSION} from './util.js';
 
-/**
- * An array with two elements, representing a pixel. The first element is the
- * x-coordinate, the second the y-coordinate of the pixel.
- * @typedef {Array.<number>} Pixel
- * @api
- */

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -11,9 +11,9 @@ import RenderBox from '../render/Box.js';
 
 /**
  * A function that takes a {@link module:ol/MapBrowserEvent} and two
- * {@link module:ol~Pixel}s and returns a `{boolean}`. If the condition is met,
+ * {@link module:ol/pixel~Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
- * @typedef {function(this: ?, module:ol/MapBrowserEvent, module:ol~Pixel, module:ol~Pixel):boolean} EndCondition
+ * @typedef {function(this: ?, module:ol/MapBrowserEvent, module:ol/pixel~Pixel, module:ol/pixel~Pixel):boolean} EndCondition
  */
 
 
@@ -26,7 +26,7 @@ import RenderBox from '../render/Box.js';
  * @property {number} [minArea=64] The minimum area of the box in pixel, this value is used by the default
  * `boxEndCondition` function.
  * @property {module:ol/interaction/DragBox~EndCondition} [boxEndCondition] A function that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and two
- * {@link module:ol~Pixel}s to indicate whether a `boxend` event should be fired.
+ * {@link module:ol/pixel~Pixel}s to indicate whether a `boxend` event should be fired.
  * Default is `true` if the area of the box is bigger than the `minArea` option.
  * @property {function(this:module:ol/interaction/DragBox, module:ol/MapBrowserEvent)} onBoxEnd Code to execute just
  * before `boxend` is fired.
@@ -143,7 +143,7 @@ class DragBox extends PointerInteraction {
     this.onBoxEnd_ = options.onBoxEnd ? options.onBoxEnd : UNDEFINED;
 
     /**
-    * @type {module:ol~Pixel}
+    * @type {module:ol/pixel~Pixel}
     * @private
     */
     this.startPixel_ = null;
@@ -178,8 +178,8 @@ class DragBox extends PointerInteraction {
  * should fire.
  * @param {module:ol/MapBrowserEvent} mapBrowserEvent The originating MapBrowserEvent
  *     leading to the box end.
- * @param {module:ol~Pixel} startPixel The starting pixel of the box.
- * @param {module:ol~Pixel} endPixel The end pixel of the box.
+ * @param {module:ol/pixel~Pixel} startPixel The starting pixel of the box.
+ * @param {module:ol/pixel~Pixel} endPixel The end pixel of the box.
  * @return {boolean} Whether or not the boxend condition should be fired.
  * @this {module:ol/interaction/DragBox}
  */

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -45,7 +45,7 @@ class DragPan extends PointerInteraction {
     this.kinetic_ = options.kinetic;
 
     /**
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      */
     this.lastCentroid = null;
 

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -176,7 +176,7 @@ class Draw extends PointerInteraction {
     this.shouldHandle_ = false;
 
     /**
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      * @private
      */
     this.downPx_ = null;

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -177,7 +177,7 @@ class ExtentInteraction extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol~Pixel} pixel cursor location
+   * @param {module:ol/pixel~Pixel} pixel cursor location
    * @param {module:ol/PluggableMap} map map
    * @returns {module:ol/coordinate~Coordinate|null} snapped vertex on extent
    * @private

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -209,7 +209,7 @@ class Modify extends PointerInteraction {
     this.vertexSegments_ = null;
 
     /**
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      * @private
      */
     this.lastPixel_ = [0, 0];
@@ -668,7 +668,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol~Pixel} pixel Pixel
+   * @param {module:ol/pixel~Pixel} pixel Pixel
    * @param {module:ol/PluggableMap} map Map.
    * @private
    */

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -170,7 +170,7 @@ class PointerInteraction extends Interaction {
 
 /**
  * @param {Array.<module:ol/pointer/PointerEvent>} pointerEvents List of events.
- * @return {module:ol~Pixel} Centroid pixel.
+ * @return {module:ol/pixel~Pixel} Centroid pixel.
  */
 export function centroid(pointerEvents) {
   const length = pointerEvents.length;

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -22,7 +22,7 @@ import RBush from '../structs/RBush.js';
  * @typedef {Object} Result
  * @property {boolean} snapped
  * @property {module:ol/coordinate~Coordinate|null} vertex
- * @property {module:ol~Pixel|null} vertexPixel
+ * @property {module:ol/pixel~Pixel|null} vertexPixel
  */
 
 
@@ -348,7 +348,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {module:ol~Pixel} pixel Pixel
+   * @param {module:ol/pixel~Pixel} pixel Pixel
    * @param {module:ol/coordinate~Coordinate} pixelCoordinate Coordinate
    * @param {module:ol/PluggableMap} map Map.
    * @return {module:ol/interaction/Snap~Result} Snap result

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -163,7 +163,7 @@ class Translate extends PointerInteraction {
   /**
    * Tests to see if the given coordinates intersects any of our selected
    * features.
-   * @param {module:ol~Pixel} pixel Pixel coordinate to test for intersection.
+   * @param {module:ol/pixel~Pixel} pixel Pixel coordinate to test for intersection.
    * @param {module:ol/PluggableMap} map Map to test the intersection on.
    * @return {module:ol/Feature} Returns the feature found at the specified pixel
    * coordinates.

--- a/src/ol/pixel.js
+++ b/src/ol/pixel.js
@@ -1,0 +1,6 @@
+/**
+ * An array with two elements, representing a pixel. The first element is the
+ * x-coordinate, the second the y-coordinate of the pixel.
+ * @typedef {Array.<number>} Pixel
+ * @api
+ */

--- a/src/ol/pointer/MouseSource.js
+++ b/src/ol/pointer/MouseSource.js
@@ -154,7 +154,7 @@ class MouseSource extends EventSource {
 
     /**
      * @const
-     * @type {Array.<module:ol~Pixel>}
+     * @type {Array.<module:ol/pixel~Pixel>}
      */
     this.lastTouches = [];
   }

--- a/src/ol/render/Box.js
+++ b/src/ol/render/Box.js
@@ -34,13 +34,13 @@ class RenderBox extends Disposable {
 
     /**
      * @private
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      */
     this.startPixel_ = null;
 
     /**
      * @private
-     * @type {module:ol~Pixel}
+     * @type {module:ol/pixel~Pixel}
      */
     this.endPixel_ = null;
 
@@ -83,8 +83,8 @@ class RenderBox extends Disposable {
   }
 
   /**
-   * @param {module:ol~Pixel} startPixel Start pixel.
-   * @param {module:ol~Pixel} endPixel End pixel.
+   * @param {module:ol/pixel~Pixel} startPixel Start pixel.
+   * @param {module:ol/pixel~Pixel} endPixel End pixel.
    */
   setPixels(startPixel, endPixel) {
     this.startPixel_ = startPixel;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -167,7 +167,7 @@ class MapRenderer extends Disposable {
 
   /**
    * @abstract
-   * @param {module:ol~Pixel} pixel Pixel.
+   * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
    * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -240,7 +240,7 @@ class WebGLLayerRenderer extends LayerRenderer {
 
   /**
    * @abstract
-   * @param {module:ol~Pixel} pixel Pixel.
+   * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {module:ol/PluggableMap~FrameState} frameState FrameState.
    * @param {function(this: S, module:ol/layer/Layer, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.

--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -125,8 +125,8 @@ export function setFromArray(transform1, transform2) {
  * resulting, transformed coordinate. The coordinate will be modified in-place.
  *
  * @param {module:ol/transform~Transform} transform The transformation.
- * @param {module:ol/coordinate~Coordinate|module:ol~Pixel} coordinate The coordinate to transform.
- * @return {module:ol/coordinate~Coordinate|module:ol~Pixel} return coordinate so that operations can be
+ * @param {module:ol/coordinate~Coordinate|module:ol/pixel~Pixel} coordinate The coordinate to transform.
+ * @return {module:ol/coordinate~Coordinate|module:ol/pixel~Pixel} return coordinate so that operations can be
  *     chained together.
  */
 export function apply(transform, coordinate) {

--- a/test/spec/ol/assertionerror.test.js
+++ b/test/spec/ol/assertionerror.test.js
@@ -1,4 +1,4 @@
-import {VERSION} from '../../../src/ol/index.js';
+import {VERSION} from '../../../src/ol/util.js';
 import AssertionError from '../../../src/ol/AssertionError.js';
 
 describe('ol.AssertionError', function() {

--- a/test/spec/ol/index.test.js
+++ b/test/spec/ol/index.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../src/ol/index.js';
+import {getUid} from '../../../src/ol/util.js';
 
 describe('getUid()', function() {
   it('is constant once generated', function() {

--- a/test/spec/ol/layer/group.test.js
+++ b/test/spec/ol/layer/group.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../src/ol/index.js';
+import {getUid} from '../../../../src/ol/util.js';
 import {stableSort} from '../../../../src/ol/array.js';
 import Collection from '../../../../src/ol/Collection.js';
 import {getIntersection} from '../../../../src/ol/extent.js';

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../src/ol/index.js';
+import {getUid} from '../../../../src/ol/util.js';
 import Map from '../../../../src/ol/Map.js';
 import Layer, {visibleAtResolution} from '../../../../src/ol/layer/Layer.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';

--- a/test/spec/ol/net.test.js
+++ b/test/spec/ol/net.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../src/ol/index.js';
+import {getUid} from '../../../src/ol/util.js';
 import {jsonp as requestJSONP} from '../../../src/ol/net.js';
 
 describe('ol.net', function() {

--- a/test/spec/ol/render/webgl/circlereplay.test.js
+++ b/test/spec/ol/render/webgl/circlereplay.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Circle from '../../../../../src/ol/geom/Circle.js';
 import WebGLCircleReplay from '../../../../../src/ol/render/webgl/CircleReplay.js';

--- a/test/spec/ol/render/webgl/linestringreplay.test.js
+++ b/test/spec/ol/render/webgl/linestringreplay.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';

--- a/test/spec/ol/render/webgl/polygonreplay.test.js
+++ b/test/spec/ol/render/webgl/polygonreplay.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';

--- a/test/spec/ol/renderer/canvas/map.test.js
+++ b/test/spec/ol/renderer/canvas/map.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';

--- a/test/spec/ol/renderer/canvas/replay.test.js
+++ b/test/spec/ol/renderer/canvas/replay.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import GeometryCollection from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../../src/ol/index.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import {clear} from '../../../../../src/ol/obj.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';

--- a/test/spec/ol/style/icon.test.js
+++ b/test/spec/ol/style/icon.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../../src/ol/index.js';
+import {getUid} from '../../../../src/ol/util.js';
 import {shared as iconImageCache} from '../../../../src/ol/style/IconImageCache.js';
 import Icon from '../../../../src/ol/style/Icon.js';
 import IconImage, {get as getIconImage} from '../../../../src/ol/style/IconImage.js';

--- a/test/spec/ol/tile.test.js
+++ b/test/spec/ol/tile.test.js
@@ -1,4 +1,4 @@
-import {getUid} from '../../../src/ol/index.js';
+import {getUid} from '../../../src/ol/util.js';
 import ImageTile from '../../../src/ol/ImageTile.js';
 import Tile from '../../../src/ol/Tile.js';
 import TileState from '../../../src/ol/TileState.js';


### PR DESCRIPTION
Related to the TypeScript effort (see #8345).

The only required change here is related to the `module:ol~Pixel` type.  This uses node's module resolution, implicitly finding the type in the `ol/index.js` module.  To be explicit, we could change this to `module:ol/index~Pixel`, but there is a bit more consistency in these:

 * `module:ol/pixel~Pixel`
 * `module:ol/size~Size`
 * `module:ol/coordinate~Coordinate`

The other changes related to imports from `ol/util` make it so internally we never import from the `ol/index` module - this module is only used to re-export things for convenience.
