### PR TITLE
Add abstract translate to ol/geom/Geometry

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -153,6 +153,15 @@ class Geometry extends BaseObject {
   scale(sx, opt_sy, opt_anchor) {}
 
   /**
+   * Translate the geometry. This modifies the geometry coordinates in place.
+   * @abstract
+   * @param {number} deltaX Delta X.
+   * @param {number} deltaY Delta Y.
+   * @api
+   */
+  translate(deltaX, deltaY) {}
+
+  /**
    * Create a simplified version of this geometry.  For linestrings, this uses
    * the the {@link
    * https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm


### PR DESCRIPTION
This seems to be missing even though both subclasses (SimpleGeometry and GeometryCollection) implement it and SimpleGeometry even tries to @inheritDoc.