### PR TITLE
Keep function names when building examples

### DIFF
--- a/examples/webpack/config.js
+++ b/examples/webpack/config.js
@@ -1,3 +1,4 @@
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const ExampleBuilder = require('./example-builder');
 const fs = require('fs');
@@ -31,6 +32,16 @@ module.exports = {
     }]
   },
   optimization: {
+    minimizer: [
+      new UglifyJsPlugin({
+        sourceMap: true,
+        uglifyOptions: {
+          mangle: {
+            keep_fnames: true
+          }
+        }
+      })
+    ],
     runtimeChunk: {
       name: 'common'
     },


### PR DESCRIPTION
Currently all live examples that use `ol/source/Raster`'s `lib` config option with named functions are broken (e.g. https://openlayers.org/en/v5.1.3/examples/color-manipulation.html). This is because Webpack mangles the function names, but the Raster source's worker tries to access them with the key of the `lib` object.

This would not happen with anonymous functions, but then eslint would complain about using functions that were not defined.

This pull request turns off name mangling for function names, which works around the issue.