### PR TITLE
Type name on same line as type

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -1745,8 +1745,7 @@ function readStyle(node, objectStack) {
 /**
  * Reads an array of geometries and creates arrays for common geometry
  * properties. Then sets them to the multi geometry.
- * @param {module:ol/geom/MultiPoint|module:ol/geom/MultiLineString|module:ol/geom/MultiPolygon}
- *     multiGeometry A multi-geometry.
+ * @param {module:ol/geom/MultiPoint|module:ol/geom/MultiLineString|module:ol/geom/MultiPolygon} multiGeometry A multi-geometry.
  * @param {Array.<module:ol/geom/Geometry>} geometries List of geometries.
  */
 function setCommonGeometryProperties(multiGeometry, geometries) {

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -734,8 +734,7 @@ function writeProperty(node, pair, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {{vendorId: string, safeToIgnore: boolean, value: string}}
- *     nativeElement The native element.
+ * @param {{vendorId: string, safeToIgnore: boolean, value: string}} nativeElement The native element.
  * @param {Array.<*>} objectStack Node stack.
  */
 function writeNative(node, nativeElement, objectStack) {

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -242,8 +242,7 @@ class VectorLayer extends Layer {
   * it is `null` the layer has no style (a `null` style), so only features
   * that have their own styles will be rendered in the layer. See
   * {@link module:ol/style} for information on the default style.
-  * @param {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction|null|undefined}
-  *     style Layer style.
+  * @param {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction|null|undefined} style Layer style.
   * @api
   */
   setStyle(style) {

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -533,8 +533,7 @@ class CanvasReplay extends VectorContext {
    * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
    * @param {Array.<*>} instructions Instructions array.
-   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined}
-   *     featureCallback Feature callback.
+   * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @param {module:ol/extent~Extent=} opt_hitExtent Only check features that intersect this
    *     extent.
    * @return {T|undefined} Callback result.

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -223,8 +223,7 @@ class LayerRenderer extends Observable {
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
  * @param {number} hitTolerance Hit tolerance in pixels.
- * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature), module:ol/layer/Layer): T}
- *     callback Feature callback.
+ * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature), module:ol/layer/Layer): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
  * @return {T|undefined} Callback result.
  * @template S,T

--- a/src/ol/style/AtlasManager.js
+++ b/src/ol/style/AtlasManager.js
@@ -176,8 +176,7 @@ class AtlasManager {
    * @param {number} height The height.
    * @param {function(CanvasRenderingContext2D, number, number)} renderCallback
    *    Called to render the new image onto an atlas image.
-   * @param {function(CanvasRenderingContext2D, number, number)=}
-   *    opt_renderHitCallback Called to render a hit-detection image onto a hit
+   * @param {function(CanvasRenderingContext2D, number, number)=} opt_renderHitCallback Called to render a hit-detection image onto a hit
    *    detection atlas image.
    * @param {Object=} opt_this Value to use as `this` when executing
    *    `renderCallback` and `renderHitCallback`.

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -131,8 +131,7 @@ export function parse(xml) {
 /**
  * Make an array extender function for extending the array at the top of the
  * object stack.
- * @param {function(this: T, Node, Array.<*>): (Array.<*>|undefined)}
- *     valueReader Value reader.
+ * @param {function(this: T, Node, Array.<*>): (Array.<*>|undefined)} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
  * @template T
@@ -262,8 +261,7 @@ export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
  * Create a serializer that appends nodes written by its `nodeWriter` to its
  * designated parent. The parent is the `node` of the
  * {@link module:ol/xml~NodeStackItem} at the top of the `objectStack`.
- * @param {function(this: T, Node, V, Array.<*>)}
- *     nodeWriter Node writer.
+ * @param {function(this: T, Node, V, Array.<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {module:ol/xml~Serializer} Serializer.
  * @template T, V
@@ -285,8 +283,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
  * designed to serialize a single item. An example would be a LineString
  * geometry writer, which could be reused for writing MultiLineString
  * geometries.
- * @param {function(this: T, Node, V, Array.<*>)}
- *     nodeWriter Node writer.
+ * @param {function(this: T, Node, V, Array.<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {module:ol/xml~Serializer} Serializer.
  * @template T, V


### PR DESCRIPTION
It looks like the TypeScript parser requires that a `@param` name be on the same line as the type.  I'll ticket this upstream, but there is no harm in getting this change in ahead of an upstream fix.

See #8345.