### PR TITLE
Cancel old image source requests

### DIFF
--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -235,10 +235,14 @@ class ImageSource extends Source {
  * @param {string} src Source.
  */
 export function defaultImageLoadFunction(image, src) {
-  this.previousImageElement.onload = () => {
-    image.getImage().src = this.previousImageElement.src;
-  };
-  this.previousImageElement.src = src;
+  if(this.previousImageElement){
+    this.previousImageElement.onload = () => {
+      image.getImage().src = this.previousImageElement.src;
+    };
+    this.previousImageElement.src = src;
+  } else {
+    image.getImage().src = src;
+  }
 }
 
 

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -116,6 +116,12 @@ class ImageSource extends Source {
      * @type {number}
      */
     this.reprojectedRevision_ = 0;
+
+    /**
+     * @private
+     * @type {HTMLImageElement}
+     */
+    this.previousImageElement = new Image();
   }
 
   /**
@@ -229,7 +235,10 @@ class ImageSource extends Source {
  * @param {string} src Source.
  */
 export function defaultImageLoadFunction(image, src) {
-  image.getImage().src = src;
+  this.previousImageElement.onload = () => {
+    image.getImage().src = this.previousImageElement.src;
+  };
+  this.previousImageElement.src = src;
 }
 
 

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -235,7 +235,7 @@ class ImageSource extends Source {
  * @param {string} src Source.
  */
 export function defaultImageLoadFunction(image, src) {
-  if(this.previousImageElement){
+  if (this.previousImageElement) {
     this.previousImageElement.onload = () => {
       image.getImage().src = this.previousImageElement.src;
     };

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -194,7 +194,7 @@ class ImageArcGISRest extends ImageSource {
       projection, params);
 
     this.image_ = new ImageWrapper(extent, resolution, pixelRatio,
-      url, this.crossOrigin_, this.imageLoadFunction_);
+      url, this.crossOrigin_, this.getImageLoadFunction());
 
     this.renderedRevision_ = this.getRevision();
 
@@ -211,7 +211,7 @@ class ImageArcGISRest extends ImageSource {
    * @api
    */
   getImageLoadFunction() {
-    return this.imageLoadFunction_;
+    return this.imageLoadFunction_.bind(this);
   }
 
   /**

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -162,7 +162,7 @@ class ImageMapGuide extends ImageSource {
         projection);
       image = new ImageWrapper(extent, resolution, pixelRatio,
         imageUrl, this.crossOrigin_,
-        this.imageLoadFunction_);
+        this.getImageLoadFunction());
       listen(image, EventType.CHANGE,
         this.handleImageChange, this);
     } else {
@@ -180,7 +180,7 @@ class ImageMapGuide extends ImageSource {
    * @api
    */
   getImageLoadFunction() {
-    return this.imageLoadFunction_;
+    return this.imageLoadFunction_.bind(this);
   }
 
   /**

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -56,7 +56,7 @@ class Static extends ImageSource {
      * @private
      * @type {module:ol/Image}
      */
-    this.image_ = new ImageWrapper(imageExtent, undefined, 1, options.url, crossOrigin, imageLoadFunction);
+    this.image_ = new ImageWrapper(imageExtent, undefined, 1, options.url, crossOrigin, imageLoadFunction.bind(this));
 
     /**
      * @private

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -254,7 +254,7 @@ class ImageWMS extends ImageSource {
       projection, params);
 
     this.image_ = new ImageWrapper(requestExtent, resolution, pixelRatio,
-      url, this.crossOrigin_, this.imageLoadFunction_);
+      url, this.crossOrigin_, this.getImageLoadFunction());
 
     this.renderedRevision_ = this.getRevision();
 
@@ -271,7 +271,7 @@ class ImageWMS extends ImageSource {
    * @api
    */
   getImageLoadFunction() {
-    return this.imageLoadFunction_;
+    return this.imageLoadFunction_.bind(this);
   }
 
   /**


### PR DESCRIPTION
Header line:  Cancel old image source requests

When we navigate using images, instead of tiles, every request that we make is processed, even when we already made a new request. Old requests are not being aborted. With this changes, old requests are canceled.