### PR TITLE
Avoid shadowing EventTarget

### DIFF
--- a/src/ol/ImageBase.js
+++ b/src/ol/ImageBase.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/ImageBase
  */
-import EventTarget from './events/EventTarget.js';
+import EventTarget from './events/Target.js';
 import EventType from './events/EventType.js';
 
 /**

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -5,7 +5,7 @@ import {DEVICE_PIXEL_RATIO} from './has.js';
 import MapBrowserEventType from './MapBrowserEventType.js';
 import MapBrowserPointerEvent from './MapBrowserPointerEvent.js';
 import {listen, unlistenByKey} from './events.js';
-import EventTarget from './events/EventTarget.js';
+import EventTarget from './events/Target.js';
 import PointerEventType from './pointer/EventType.js';
 import PointerEventHandler from './pointer/PointerEventHandler.js';
 

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -2,7 +2,7 @@
  * @module ol/Observable
  */
 import {listen, unlistenByKey, unlisten, listenOnce} from './events.js';
-import EventTarget from './events/EventTarget.js';
+import EventTarget from './events/Target.js';
 import EventType from './events/EventType.js';
 
 /**

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -3,7 +3,7 @@
  */
 import TileState from './TileState.js';
 import {easeIn} from './easing.js';
-import EventTarget from './events/EventTarget.js';
+import EventTarget from './events/Target.js';
 import EventType from './events/EventType.js';
 
 

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -12,7 +12,7 @@ import {clear} from './obj.js';
  * @property {boolean} callOnce
  * @property {number} [deleteIndex]
  * @property {module:ol/events~ListenerFunction} listener
- * @property {EventTarget|module:ol/events/EventTarget} target
+ * @property {module:ol/events/Target~EventTargetLike} target
  * @property {string} type
  * @api
  */
@@ -73,7 +73,7 @@ export function findListener(listeners, listener, opt_this, opt_setDeleteIndex) 
 
 
 /**
- * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
+ * @param {module:ol/events/Target~EventTargetLike} target Target.
  * @param {string} type Type.
  * @return {Array<module:ol/events~EventsKey>|undefined} Listeners.
  */
@@ -86,7 +86,7 @@ export function getListeners(target, type) {
 /**
  * Get the lookup of listeners.  If one does not exist on the target, it is
  * created.
- * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
+ * @param {module:ol/events/Target~EventTargetLike} target Target.
  * @return {!Object<string, Array<module:ol/events~EventsKey>>} Map of
  *     listeners by event type.
  */
@@ -103,7 +103,7 @@ function getListenerMap(target) {
  * Clean up all listener objects of the given type.  All properties on the
  * listener objects will be removed, and if no listeners remain in the listener
  * map, it will be removed from the target.
- * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
+ * @param {module:ol/events/Target~EventTargetLike} target Target.
  * @param {string} type Type.
  */
 function removeListeners(target, type) {
@@ -132,7 +132,7 @@ function removeListeners(target, type) {
  * This function efficiently binds a `listener` to a `this` object, and returns
  * a key for use with {@link module:ol/events~unlistenByKey}.
  *
- * @param {module:ol/events/EventTarget~EventTargetLike} target Event target.
+ * @param {module:ol/events/Target~EventTargetLike} target Event target.
  * @param {string} type Event type.
  * @param {module:ol/events~ListenerFunction} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
@@ -181,7 +181,7 @@ export function listen(target, type, listener, opt_this, opt_once) {
  * function, the self-unregistering listener will be turned into a permanent
  * listener.
  *
- * @param {module:ol/events/EventTarget~EventTargetLike} target Event target.
+ * @param {module:ol/events/Target~EventTargetLike} target Event target.
  * @param {string} type Event type.
  * @param {module:ol/events~ListenerFunction} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
@@ -200,7 +200,7 @@ export function listenOnce(target, type, listener, opt_this) {
  * To return a listener, this function needs to be called with the exact same
  * arguments that were used for a previous {@link module:ol/events~listen} call.
  *
- * @param {module:ol/events/EventTarget~EventTargetLike} target Event target.
+ * @param {module:ol/events/Target~EventTargetLike} target Event target.
  * @param {string} type Event type.
  * @param {module:ol/events~ListenerFunction} listener Listener.
  * @param {Object=} opt_this Object referenced by the `this` keyword in the
@@ -248,7 +248,7 @@ export function unlistenByKey(key) {
  * Unregisters all event listeners on an event target. Inspired by
  * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
- * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
+ * @param {module:ol/events/Target~EventTargetLike} target Target.
  */
 export function unlistenAll(target) {
   const listenerMap = getListenerMap(target);

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -10,7 +10,7 @@
  * This implementation only provides `type` and `target` properties, and
  * `stopPropagation` and `preventDefault` methods. It is meant as base class
  * for higher level events defined in the library, and works with
- * {@link module:ol/events/EventTarget~EventTarget}.
+ * {@link module:ol/events/Target~Target}.
  */
 class Event {
 

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -1,5 +1,5 @@
 /**
- * @module ol/events/EventTarget
+ * @module ol/events/Target
  */
 import Disposable from '../Disposable.js';
 import {unlistenAll} from '../events.js';
@@ -8,7 +8,7 @@ import Event from '../events/Event.js';
 
 
 /**
- * @typedef {EventTarget|module:ol/events/EventTarget} EventTargetLike
+ * @typedef {EventTarget|module:ol/events/Target} EventTargetLike
  */
 
 
@@ -27,7 +27,7 @@ import Event from '../events/Event.js';
  *    more listeners after this one will be called. Same as when the listener
  *    returns false.
  */
-class EventTarget extends Disposable {
+class Target extends Disposable {
   constructor() {
 
     super();
@@ -72,7 +72,7 @@ class EventTarget extends Disposable {
    * Object with a `type` property.
    *
    * @param {{type: string,
-   *     target: (EventTarget|module:ol/events/EventTarget|undefined)}|
+   *     target: (module:ol/events/Target~EventTargetLike|undefined)}|
    *     module:ol/events/Event|string} event Event object.
    * @return {boolean|undefined} `false` if anyone called preventDefault on the
    *     event object or if any of the listeners returned false.
@@ -130,7 +130,7 @@ class EventTarget extends Disposable {
 
   /**
    * @param {string=} opt_type Type. If not provided,
-   *     `true` will be returned if this EventTarget has any listeners.
+   *     `true` will be returned if this event target has any listeners.
    * @return {boolean} Has listeners.
    */
   hasListener(opt_type) {
@@ -162,4 +162,4 @@ class EventTarget extends Disposable {
 }
 
 
-export default EventTarget;
+export default Target;

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -33,7 +33,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import {listen, unlisten} from '../events.js';
-import EventTarget from '../events/EventTarget.js';
+import EventTarget from '../events/Target.js';
 import {POINTER, MSPOINTER, TOUCH} from '../has.js';
 import PointerEventType from '../pointer/EventType.js';
 import MouseSource from '../pointer/MouseSource.js';

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -3,7 +3,7 @@
  */
 
 import {assert} from '../asserts.js';
-import EventTarget from '../events/EventTarget.js';
+import EventTarget from '../events/Target.js';
 import EventType from '../events/EventType.js';
 
 

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -4,7 +4,7 @@
 
 import {createCanvasContext2D} from '../dom.js';
 import {listenOnce, unlistenByKey} from '../events.js';
-import EventTarget from '../events/EventTarget.js';
+import EventTarget from '../events/Target.js';
 import EventType from '../events/EventType.js';
 import ImageState from '../ImageState.js';
 import {shared as iconImageCache} from '../style/IconImageCache.js';

--- a/test/spec/ol/events.test.js
+++ b/test/spec/ol/events.test.js
@@ -1,5 +1,5 @@
 import {listen, listenOnce, bindListener, unlisten, unlistenAll, unlistenByKey, findListener, getListeners} from '../../../src/ol/events.js';
-import EventTarget from '../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../src/ol/events/Target.js';
 
 describe('ol.events', function() {
   let add, remove, target;

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -1,7 +1,7 @@
 import Disposable from '../../../../src/ol/Disposable.js';
 import {listen} from '../../../../src/ol/events.js';
 import Event from '../../../../src/ol/events/Event.js';
-import EventTarget from '../../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../../src/ol/events/Target.js';
 
 
 describe('ol.events.EventTarget', function() {

--- a/test/spec/ol/interaction/draganddrop.test.js
+++ b/test/spec/ol/interaction/draganddrop.test.js
@@ -1,6 +1,6 @@
 import View from '../../../../src/ol/View.js';
 import Event from '../../../../src/ol/events/Event.js';
-import EventTarget from '../../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../../src/ol/events/Target.js';
 import GeoJSON from '../../../../src/ol/format/GeoJSON.js';
 import DragAndDrop from '../../../../src/ol/interaction/DragAndDrop.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';

--- a/test/spec/ol/interaction/interaction.test.js
+++ b/test/spec/ol/interaction/interaction.test.js
@@ -1,6 +1,6 @@
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
-import EventTarget from '../../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../../src/ol/events/Target.js';
 import Interaction, {zoomByDelta} from '../../../../src/ol/interaction/Interaction.js';
 
 describe('ol.interaction.Interaction', function() {

--- a/test/spec/ol/observable.test.js
+++ b/test/spec/ol/observable.test.js
@@ -1,4 +1,4 @@
-import EventTarget from '../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../src/ol/events/Target.js';
 import Observable, {unByKey} from '../../../src/ol/Observable.js';
 
 

--- a/test/spec/ol/pointer/mousesource.test.js
+++ b/test/spec/ol/pointer/mousesource.test.js
@@ -1,5 +1,5 @@
 import {listen} from '../../../../src/ol/events.js';
-import EventTarget from '../../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../../src/ol/events/Target.js';
 import PointerEventHandler from '../../../../src/ol/pointer/PointerEventHandler.js';
 import TouchSource from '../../../../src/ol/pointer/TouchSource.js';
 import MouseSource from '../../../../src/ol/pointer/MouseSource.js';

--- a/test/spec/ol/pointer/pointereventhandler.test.js
+++ b/test/spec/ol/pointer/pointereventhandler.test.js
@@ -1,5 +1,5 @@
 import {listen} from '../../../../src/ol/events.js';
-import EventTarget from '../../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../../src/ol/events/Target.js';
 import MouseSource from '../../../../src/ol/pointer/MouseSource.js';
 import PointerEvent from '../../../../src/ol/pointer/PointerEvent.js';
 import PointerEventHandler from '../../../../src/ol/pointer/PointerEventHandler.js';

--- a/test/spec/ol/pointer/touchsource.test.js
+++ b/test/spec/ol/pointer/touchsource.test.js
@@ -1,6 +1,6 @@
 import {listen} from '../../../../src/ol/events.js';
 import Event from '../../../../src/ol/events/Event.js';
-import EventTarget from '../../../../src/ol/events/EventTarget.js';
+import EventTarget from '../../../../src/ol/events/Target.js';
 import {assign} from '../../../../src/ol/obj.js';
 import PointerEventHandler from '../../../../src/ol/pointer/PointerEventHandler.js';
 import TouchSource from '../../../../src/ol/pointer/TouchSource.js';


### PR DESCRIPTION
The `npm run typecheck` script in #8345 revealed that our `EventTarget` class shadows the DOM `EventTarget` type.  This branch changes our class to `Target` to differentiate.