### PR TITLE
Fewer dots in types

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -168,9 +168,9 @@ function generateSourceFiles(sourceFiles) {
  * for display purposes. This function mutates the original arrays.
  *
  * @private
- * @param {Array.<module:jsdoc/doclet.Doclet>} doclets - The array of classes and functions to
+ * @param {Array<module:jsdoc/doclet.Doclet>} doclets - The array of classes and functions to
  * check.
- * @param {Array.<module:jsdoc/doclet.Doclet>} modules - The array of module doclets to search.
+ * @param {Array<module:jsdoc/doclet.Doclet>} modules - The array of module doclets to search.
  */
 function attachModuleSymbols(doclets, modules) {
   const symbols = {};

--- a/examples/color-manipulation.js
+++ b/examples/color-manipulation.js
@@ -20,8 +20,8 @@ const twoPi = 2 * Math.PI;
 
 /**
  * Convert an RGB pixel into an HCL pixel.
- * @param {Array.<number>} pixel A pixel in RGB space.
- * @return {Array.<number>} A pixel in HCL space.
+ * @param {Array<number>} pixel A pixel in RGB space.
+ * @return {Array<number>} A pixel in HCL space.
  */
 function rgb2hcl(pixel) {
   const red = rgb2xyz(pixel[0]);
@@ -55,8 +55,8 @@ function rgb2hcl(pixel) {
 
 /**
  * Convert an HCL pixel into an RGB pixel.
- * @param {Array.<number>} pixel A pixel in HCL space.
- * @return {Array.<number>} A pixel in RGB space.
+ * @param {Array<number>} pixel A pixel in HCL space.
+ * @return {Array<number>} A pixel in RGB space.
  */
 function hcl2rgb(pixel) {
   const h = pixel[0];

--- a/examples/image-filter.js
+++ b/examples/image-filter.js
@@ -101,7 +101,7 @@ imagery.on('postcompose', function(event) {
  * Apply a convolution kernel to canvas.  This works for any size kernel, but
  * performance starts degrading above 3 x 3.
  * @param {CanvasRenderingContext2D} context Canvas 2d context.
- * @param {Array.<number>} kernel Kernel.
+ * @param {Array<number>} kernel Kernel.
  */
 function convolve(context, kernel) {
   const canvas = context.canvas;

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -12,7 +12,7 @@ const bins = 10;
 /**
  * Calculate the Vegetation Greenness Index (VGI) from an input pixel.  This
  * is a rough estimate assuming that pixel values correspond to reflectance.
- * @param {Array.<number>} pixel An array of [R, G, B, A] values.
+ * @param {Array<number>} pixel An array of [R, G, B, A] values.
  * @return {number} The VGI value for the given pixel.
  */
 function vgi(pixel) {

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -7,7 +7,7 @@ import {OSM, Raster, XYZ} from '../src/ol/source.js';
 /**
  * Generates a shaded relief image given elevation data.  Uses a 3x3
  * neighborhood for determining slope and aspect.
- * @param {Array.<ImageData>} inputs Array of input images.
+ * @param {Array<ImageData>} inputs Array of input images.
  * @param {Object} data Data added in the "beforeoperations" event.
  * @return {ImageData} Output image.
  */

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -26,7 +26,7 @@ handlebars.registerHelper('indent', (text, options) => {
  * Create an inverted index of keywords from examples.  Property names are
  * lowercased words.  Property values are objects mapping example index to word
  * count.
- * @param {Array.<Object>} exampleData Array of example data objects.
+ * @param {Array<Object>} exampleData Array of example data objects.
  * @return {Object} Word index.
  */
 function createWordIndex(exampleData) {

--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -107,7 +107,7 @@ class Collection extends BaseObject {
    * Add elements to the collection.  This pushes each item in the provided array
    * to the end of the collection.
    * @param {!Array<T>} arr Array.
-   * @return {module:ol/Collection.<T>} This collection.
+   * @return {module:ol/Collection<T>} This collection.
    * @api
    */
   extend(arr) {

--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -62,7 +62,7 @@ export class CollectionEvent extends Event {
 class Collection extends BaseObject {
 
   /**
-   * @param {Array.<T>=} opt_array Array.
+   * @param {Array<T>=} opt_array Array.
    * @param {module:ol/Collection~Options=} opt_options Collection options.
    */
   constructor(opt_array, opt_options) {
@@ -79,7 +79,7 @@ class Collection extends BaseObject {
 
     /**
      * @private
-     * @type {!Array.<T>}
+     * @type {!Array<T>}
      */
     this.array_ = opt_array ? opt_array : [];
 
@@ -106,7 +106,7 @@ class Collection extends BaseObject {
   /**
    * Add elements to the collection.  This pushes each item in the provided array
    * to the end of the collection.
-   * @param {!Array.<T>} arr Array.
+   * @param {!Array<T>} arr Array.
    * @return {module:ol/Collection.<T>} This collection.
    * @api
    */
@@ -119,7 +119,7 @@ class Collection extends BaseObject {
 
   /**
    * Iterate over each element, calling the provided callback.
-   * @param {function(T, number, Array.<T>): *} f The function to call
+   * @param {function(T, number, Array<T>): *} f The function to call
    *     for every element. This function takes 3 arguments (the element, the
    *     index and the array). The return value is ignored.
    * @api
@@ -136,7 +136,7 @@ class Collection extends BaseObject {
    * is mutated, no events will be dispatched by the collection, and the
    * collection's "length" property won't be in sync with the actual length
    * of the array.
-   * @return {!Array.<T>} Array.
+   * @return {!Array<T>} Array.
    * @api
    */
   getArray() {

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -54,7 +54,7 @@ import Style from './style/Style.js';
  */
 class Feature extends BaseObject {
   /**
-   * @param {module:ol/geom/Geometry|Object.<string, *>=} opt_geometryOrProperties
+   * @param {module:ol/geom/Geometry|Object<string, *>=} opt_geometryOrProperties
    *     You may pass a Geometry object directly, or an object literal containing
    *     properties. If you pass an object literal, you may include a Geometry
    *     associated with a `geometry` key.
@@ -104,7 +104,7 @@ class Feature extends BaseObject {
         const geometry = opt_geometryOrProperties;
         this.setGeometry(geometry);
       } else {
-        /** @type {Object.<string, *>} */
+        /** @type {Object<string, *>} */
         const properties = opt_geometryOrProperties;
         this.setProperties(properties);
       }

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -78,7 +78,7 @@ class Feature extends BaseObject {
     /**
      * User provided style.
      * @private
-     * @type {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
+     * @type {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
      */
     this.style_ = null;
 
@@ -170,7 +170,7 @@ class Feature extends BaseObject {
   /**
    * Get the feature's style. Will return what was provided to the
    * {@link module:ol/Feature~Feature#setStyle} method.
-   * @return {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} The feature style.
+   * @return {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} The feature style.
    * @api
    */
   getStyle() {
@@ -225,7 +225,7 @@ class Feature extends BaseObject {
    * Set the style for the feature.  This can be a single style object, an array
    * of styles, or a function that takes a resolution and returns an array of
    * styles. If it is `null` the feature has no style (a `null` style).
-   * @param {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} style Style for this feature.
+   * @param {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} style Style for this feature.
    * @api
    * @fires module:ol/events/Event~Event#event:change
    */
@@ -273,7 +273,7 @@ class Feature extends BaseObject {
  * Convert the provided object into a feature style function.  Functions passed
  * through unchanged.  Arrays of module:ol/style/Style or single style objects wrapped
  * in a new feature style function.
- * @param {module:ol/style/Style~StyleFunction|!Array.<module:ol/style/Style>|!module:ol/style/Style} obj
+ * @param {module:ol/style/Style~StyleFunction|!Array<module:ol/style/Style>|!module:ol/style/Style} obj
  *     A feature style function, a single style, or an array of styles.
  * @return {module:ol/style/Style~StyleFunction} A style function.
  */
@@ -282,7 +282,7 @@ export function createStyleFunction(obj) {
     return obj;
   } else {
     /**
-     * @type {Array.<module:ol/style/Style>}
+     * @type {Array<module:ol/style/Style>}
      */
     let styles;
     if (Array.isArray(obj)) {

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -27,7 +27,7 @@ const DEFAULT_STROKE_STYLE = new Stroke({
 
 /**
  * TODO can be configurable
- * @type {Array.<number>}
+ * @type {Array<number>}
  * @private
  */
 const INTERVALS = [
@@ -200,13 +200,13 @@ class Graticule {
     this.maxLines_ = options.maxLines !== undefined ? options.maxLines : 100;
 
     /**
-     * @type {Array.<module:ol/geom/LineString>}
+     * @type {Array<module:ol/geom/LineString>}
      * @private
      */
     this.meridians_ = [];
 
     /**
-     * @type {Array.<module:ol/geom/LineString>}
+     * @type {Array<module:ol/geom/LineString>}
      * @private
      */
     this.parallels_ = [];
@@ -236,13 +236,13 @@ class Graticule {
     this.projectionCenterLonLat_ = null;
 
     /**
-     * @type {Array.<module:ol/Graticule~GraticuleLabelDataType>}
+     * @type {Array<module:ol/Graticule~GraticuleLabelDataType>}
      * @private
      */
     this.meridiansLabels_ = null;
 
     /**
-     * @type {Array.<module:ol/Graticule~GraticuleLabelDataType>}
+     * @type {Array<module:ol/Graticule~GraticuleLabelDataType>}
      * @private
      */
     this.parallelsLabels_ = null;
@@ -526,9 +526,9 @@ class Graticule {
     const centerLat = this.projectionCenterLonLat_[1];
     let interval = -1;
     const target = Math.pow(this.targetSize_ * resolution, 2);
-    /** @type {Array.<number>} **/
+    /** @type {Array<number>} **/
     const p1 = [];
-    /** @type {Array.<number>} **/
+    /** @type {Array<number>} **/
     const p2 = [];
     for (let i = 0, ii = INTERVALS.length; i < ii; ++i) {
       const delta = INTERVALS[i] / 2;
@@ -579,7 +579,7 @@ class Graticule {
 
   /**
    * Get the list of meridians.  Meridians are lines of equal longitude.
-   * @return {Array.<module:ol/geom/LineString>} The meridians.
+   * @return {Array<module:ol/geom/LineString>} The meridians.
    * @api
    */
   getMeridians() {
@@ -609,7 +609,7 @@ class Graticule {
 
   /**
    * Get the list of parallels.  Parallels are lines of equal latitude.
-   * @return {Array.<module:ol/geom/LineString>} The parallels.
+   * @return {Array<module:ol/geom/LineString>} The parallels.
    * @api
    */
   getParallels() {

--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -58,7 +58,7 @@ class ImageWrapper extends ImageBase {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.imageListenerKeys_ = null;
 

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -52,7 +52,7 @@ class ImageTile extends Tile {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.imageListenerKeys_ = null;
 

--- a/src/ol/Kinetic.js
+++ b/src/ol/Kinetic.js
@@ -38,7 +38,7 @@ class Kinetic {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.points_ = [];
 

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -68,7 +68,7 @@ class MapBrowserEventHandler extends EventTarget {
     this.activePointers_ = 0;
 
     /**
-     * @type {!Object.<number, boolean>}
+     * @type {!Object<number, boolean>}
      * @private
      */
     this.trackedTouches_ = {};

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -39,7 +39,7 @@ class MapBrowserEventHandler extends EventTarget {
     this.dragging_ = false;
 
     /**
-     * @type {!Array.<module:ol/events~EventsKey>}
+     * @type {!Array<module:ol/events~EventsKey>}
      * @private
      */
     this.dragListenerKeys_ = [];

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -126,7 +126,7 @@ class BaseObject extends Observable {
 
   /**
    * Get a list of object property names.
-   * @return {Array.<string>} List of property names.
+   * @return {Array<string>} List of property names.
    * @api
    */
   getKeys() {

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -88,7 +88,7 @@ class ObjectEvent extends Event {
 class BaseObject extends Observable {
 
   /**
-   * @param {Object.<string, *>=} opt_values An object with key-value pairs.
+   * @param {Object<string, *>=} opt_values An object with key-value pairs.
    */
   constructor(opt_values) {
     super();
@@ -101,7 +101,7 @@ class BaseObject extends Observable {
 
     /**
      * @private
-     * @type {!Object.<string, *>}
+     * @type {!Object<string, *>}
      */
     this.values_ = {};
 
@@ -135,7 +135,7 @@ class BaseObject extends Observable {
 
   /**
    * Get an object of all property names and values.
-   * @return {Object.<string, *>} Object.
+   * @return {Object<string, *>} Object.
    * @api
    */
   getProperties() {
@@ -176,7 +176,7 @@ class BaseObject extends Observable {
   /**
    * Sets a collection of key-value pairs.  Note that this changes any existing
    * properties and adds new ones (it does not remove any existing properties).
-   * @param {Object.<string, *>} values Values.
+   * @param {Object<string, *>} values Values.
    * @param {boolean=} opt_silent Update without triggering an event.
    * @api
    */
@@ -205,7 +205,7 @@ class BaseObject extends Observable {
 
 
 /**
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const changeEventTypeCache = {};
 

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -50,9 +50,9 @@ class Observable extends EventTarget {
 
   /**
    * Listen for a certain type of event.
-   * @param {string|Array.<string>} type The event type or array of event types.
+   * @param {string|Array<string>} type The event type or array of event types.
    * @param {function(?): ?} listener The listener function.
-   * @return {module:ol/events~EventsKey|Array.<module:ol/events~EventsKey>} Unique key for the listener. If
+   * @return {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} Unique key for the listener. If
    *     called with an array of event types as the first argument, the return
    *     will be an array of keys.
    * @api
@@ -72,9 +72,9 @@ class Observable extends EventTarget {
 
   /**
    * Listen once for a certain type of event.
-   * @param {string|Array.<string>} type The event type or array of event types.
+   * @param {string|Array<string>} type The event type or array of event types.
    * @param {function(?): ?} listener The listener function.
-   * @return {module:ol/events~EventsKey|Array.<module:ol/events~EventsKey>} Unique key for the listener. If
+   * @return {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} Unique key for the listener. If
    *     called with an array of event types as the first argument, the return
    *     will be an array of keys.
    * @api
@@ -94,7 +94,7 @@ class Observable extends EventTarget {
 
   /**
    * Unlisten for a certain type of event.
-   * @param {string|Array.<string>} type The event type or array of event types.
+   * @param {string|Array<string>} type The event type or array of event types.
    * @param {function(?): ?} listener The listener function.
    * @api
    */
@@ -113,7 +113,7 @@ class Observable extends EventTarget {
 
 /**
  * Removes an event listener using the key returned by `on()` or `once()`.
- * @param {module:ol/events~EventsKey|Array.<module:ol/events~EventsKey>} key The key returned by `on()`
+ * @param {module:ol/events~EventsKey|Array<module:ol/events~EventsKey>} key The key returned by `on()`
  *     or `once()` (or an array of keys).
  * @api
  */

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -15,7 +15,7 @@ import {containsExtent} from './extent.js';
  * @property {number|string} [id] Set the overlay id. The overlay id can be used
  * with the {@link module:ol/Map~Map#getOverlayById} method.
  * @property {HTMLElement} [element] The overlay element.
- * @property {Array.<number>} [offset=[0, 0]] Offsets in pixels used when positioning
+ * @property {Array<number>} [offset=[0, 0]] Offsets in pixels used when positioning
  * the overlay. The first element in the
  * array is the horizontal offset. A positive value shifts the overlay right.
  * The second element in the array is the vertical offset. A positive value
@@ -248,12 +248,12 @@ class Overlay extends BaseObject {
 
   /**
    * Get the offset of this overlay.
-   * @return {Array.<number>} The offset.
+   * @return {Array<number>} The offset.
    * @observable
    * @api
    */
   getOffset() {
-    return /** @type {Array.<number>} */ (this.get(Property.OFFSET));
+    return /** @type {Array<number>} */ (this.get(Property.OFFSET));
   }
 
   /**
@@ -371,7 +371,7 @@ class Overlay extends BaseObject {
 
   /**
    * Set the offset for this overlay.
-   * @param {Array.<number>} offset Offset.
+   * @param {Array<number>} offset Offset.
    * @observable
    * @api
    */

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -42,14 +42,14 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {module:ol/coordinate~Coordinate} focus
  * @property {number} index
  * @property {Object.<number, module:ol/layer/Layer~State>} layerStates
- * @property {Array.<module:ol/layer/Layer~State>} layerStatesArray
+ * @property {Array<module:ol/layer/Layer~State>} layerStatesArray
  * @property {module:ol/transform~Transform} pixelToCoordinateTransform
- * @property {Array.<module:ol/PluggableMap~PostRenderFunction>} postRenderFunctions
+ * @property {Array<module:ol/PluggableMap~PostRenderFunction>} postRenderFunctions
  * @property {module:ol/size~Size} size
  * @property {!Object.<string, boolean>} skippedFeatureUids
  * @property {module:ol/TileQueue} tileQueue
  * @property {Object.<string, Object.<string, module:ol/TileRange>>} usedTiles
- * @property {Array.<number>} viewHints
+ * @property {Array<number>} viewHints
  * @property {!Object.<string, Object.<string, boolean>>} wantedTiles
  */
 
@@ -85,12 +85,12 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 /**
  * Object literal with config options for the map.
  * @typedef {Object} MapOptions
- * @property {module:ol/Collection.<module:ol/control/Control>|Array.<module:ol/control/Control>} [controls]
+ * @property {module:ol/Collection.<module:ol/control/Control>|Array<module:ol/control/Control>} [controls]
  * Controls initially added to the map. If not specified,
  * {@link module:ol/control/util~defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
- * @property {module:ol/Collection.<module:ol/interaction/Interaction>|Array.<module:ol/interaction/Interaction>} [interactions]
+ * @property {module:ol/Collection.<module:ol/interaction/Interaction>|Array<module:ol/interaction/Interaction>} [interactions]
  * Interactions that are initially added to the map. If not specified,
  * {@link module:ol/interaction~defaults} is used.
  * @property {HTMLElement|Document|string} [keyboardEventTarget] The element to
@@ -101,7 +101,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * map target (i.e. the user-provided div for the map). If this is not
  * `document`, the target element needs to be focused for key events to be
  * emitted, requiring that the target element has a `tabindex` attribute.
- * @property {Array.<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>} [layers]
+ * @property {Array<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>} [layers]
  * Layers. If this is not defined, a map with no layers will be rendered. Note
  * that layers are rendered in the order supplied, so if you want, for example,
  * a vector layer to appear on top of a tile layer, it must come after the tile
@@ -118,7 +118,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {number} [moveTolerance=1] The minimum distance in pixels the
  * cursor must move to be detected as a map move event instead of a click.
  * Increasing this value can make it easier to click on the map.
- * @property {module:ol/Collection.<module:ol/Overlay>|Array.<module:ol/Overlay>} [overlays]
+ * @property {module:ol/Collection.<module:ol/Overlay>|Array<module:ol/Overlay>} [overlays]
  * Overlays initially added to the map. By default, no overlays are added.
  * @property {HTMLElement|string} [target] The container for the map, either the
  * element itself or the `id` of the element. If not specified at construction
@@ -236,7 +236,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.layerGroupPropertyListenerKeys_ = null;
 
@@ -301,7 +301,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.keyHandlerKeys_ = null;
 
@@ -354,7 +354,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {!Array.<module:ol/PluggableMap~PostRenderFunction>}
+     * @type {!Array<module:ol/PluggableMap~PostRenderFunction>}
      */
     this.postRenderFunctions_ = [];
 
@@ -577,7 +577,7 @@ class PluggableMap extends BaseObject {
    * Get all features that intersect a pixel on the viewport.
    * @param {module:ol/pixel~Pixel} pixel Pixel.
    * @param {module:ol/PluggableMap~AtPixelOptions=} opt_options Optional options.
-   * @return {Array.<module:ol/Feature|module:ol/render/Feature>} The detected features or
+   * @return {Array<module:ol/Feature|module:ol/render/Feature>} The detected features or
    * `null` if none were found.
    * @api
    */

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -74,10 +74,10 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @typedef {Object} MapOptionsInternal
- * @property {module:ol/Collection.<module:ol/control/Control>} [controls]
- * @property {module:ol/Collection.<module:ol/interaction/Interaction>} [interactions]
+ * @property {module:ol/Collection<module:ol/control/Control>} [controls]
+ * @property {module:ol/Collection<module:ol/interaction/Interaction>} [interactions]
  * @property {HTMLElement|Document} keyboardEventTarget
- * @property {module:ol/Collection.<module:ol/Overlay>} overlays
+ * @property {module:ol/Collection<module:ol/Overlay>} overlays
  * @property {Object<string, *>} values
  */
 
@@ -85,12 +85,12 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 /**
  * Object literal with config options for the map.
  * @typedef {Object} MapOptions
- * @property {module:ol/Collection.<module:ol/control/Control>|Array<module:ol/control/Control>} [controls]
+ * @property {module:ol/Collection<module:ol/control/Control>|Array<module:ol/control/Control>} [controls]
  * Controls initially added to the map. If not specified,
  * {@link module:ol/control/util~defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
- * @property {module:ol/Collection.<module:ol/interaction/Interaction>|Array<module:ol/interaction/Interaction>} [interactions]
+ * @property {module:ol/Collection<module:ol/interaction/Interaction>|Array<module:ol/interaction/Interaction>} [interactions]
  * Interactions that are initially added to the map. If not specified,
  * {@link module:ol/interaction~defaults} is used.
  * @property {HTMLElement|Document|string} [keyboardEventTarget] The element to
@@ -101,7 +101,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * map target (i.e. the user-provided div for the map). If this is not
  * `document`, the target element needs to be focused for key events to be
  * emitted, requiring that the target element has a `tabindex` attribute.
- * @property {Array<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>} [layers]
+ * @property {Array<module:ol/layer/Base>|module:ol/Collection<module:ol/layer/Base>} [layers]
  * Layers. If this is not defined, a map with no layers will be rendered. Note
  * that layers are rendered in the order supplied, so if you want, for example,
  * a vector layer to appear on top of a tile layer, it must come after the tile
@@ -118,7 +118,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {number} [moveTolerance=1] The minimum distance in pixels the
  * cursor must move to be detected as a map move event instead of a click.
  * Increasing this value can make it easier to click on the map.
- * @property {module:ol/Collection.<module:ol/Overlay>|Array<module:ol/Overlay>} [overlays]
+ * @property {module:ol/Collection<module:ol/Overlay>|Array<module:ol/Overlay>} [overlays]
  * Overlays initially added to the map. By default, no overlays are added.
  * @property {HTMLElement|string} [target] The container for the map, either the
  * element itself or the `id` of the element. If not specified at construction
@@ -310,19 +310,19 @@ class PluggableMap extends BaseObject {
     listen(this.viewport_, EventType.MOUSEWHEEL, this.handleBrowserEvent, this);
 
     /**
-     * @type {module:ol/Collection.<module:ol/control/Control>}
+     * @type {module:ol/Collection<module:ol/control/Control>}
      * @protected
      */
     this.controls = optionsInternal.controls || new Collection();
 
     /**
-     * @type {module:ol/Collection.<module:ol/interaction/Interaction>}
+     * @type {module:ol/Collection<module:ol/interaction/Interaction>}
      * @protected
      */
     this.interactions = optionsInternal.interactions || new Collection();
 
     /**
-     * @type {module:ol/Collection.<module:ol/Overlay>}
+     * @type {module:ol/Collection<module:ol/Overlay>}
      * @private
      */
     this.overlays_ = optionsInternal.overlays;
@@ -716,7 +716,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the map controls. Modifying this collection changes the controls
    * associated with the map.
-   * @return {module:ol/Collection.<module:ol/control/Control>} Controls.
+   * @return {module:ol/Collection<module:ol/control/Control>} Controls.
    * @api
    */
   getControls() {
@@ -726,7 +726,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the map overlays. Modifying this collection changes the overlays
    * associated with the map.
-   * @return {module:ol/Collection.<module:ol/Overlay>} Overlays.
+   * @return {module:ol/Collection<module:ol/Overlay>} Overlays.
    * @api
    */
   getOverlays() {
@@ -751,7 +751,7 @@ class PluggableMap extends BaseObject {
    * associated with the map.
    *
    * Interactions are used for e.g. pan, zoom and rotate.
-   * @return {module:ol/Collection.<module:ol/interaction/Interaction>} Interactions.
+   * @return {module:ol/Collection<module:ol/interaction/Interaction>} Interactions.
    * @api
    */
   getInteractions() {
@@ -772,7 +772,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get the collection of layers associated with this map.
-   * @return {!module:ol/Collection.<module:ol/layer/Base>} Layers.
+   * @return {!module:ol/Collection<module:ol/layer/Base>} Layers.
    * @api
    */
   getLayers() {

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -41,16 +41,16 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {null|module:ol/extent~Extent} extent
  * @property {module:ol/coordinate~Coordinate} focus
  * @property {number} index
- * @property {Object.<number, module:ol/layer/Layer~State>} layerStates
+ * @property {Object<number, module:ol/layer/Layer~State>} layerStates
  * @property {Array<module:ol/layer/Layer~State>} layerStatesArray
  * @property {module:ol/transform~Transform} pixelToCoordinateTransform
  * @property {Array<module:ol/PluggableMap~PostRenderFunction>} postRenderFunctions
  * @property {module:ol/size~Size} size
- * @property {!Object.<string, boolean>} skippedFeatureUids
+ * @property {!Object<string, boolean>} skippedFeatureUids
  * @property {module:ol/TileQueue} tileQueue
- * @property {Object.<string, Object.<string, module:ol/TileRange>>} usedTiles
+ * @property {Object<string, Object<string, module:ol/TileRange>>} usedTiles
  * @property {Array<number>} viewHints
- * @property {!Object.<string, Object.<string, boolean>>} wantedTiles
+ * @property {!Object<string, Object<string, boolean>>} wantedTiles
  */
 
 
@@ -78,7 +78,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {module:ol/Collection.<module:ol/interaction/Interaction>} [interactions]
  * @property {HTMLElement|Document} keyboardEventTarget
  * @property {module:ol/Collection.<module:ol/Overlay>} overlays
- * @property {Object.<string, *>} values
+ * @property {Object<string, *>} values
  */
 
 
@@ -330,7 +330,7 @@ class PluggableMap extends BaseObject {
     /**
      * A lookup of overlays by id.
      * @private
-     * @type {Object.<string, module:ol/Overlay>}
+     * @type {Object<string, module:ol/Overlay>}
      */
     this.overlayIdIndex_ = {};
 
@@ -368,7 +368,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * Uids of features to skip at rendering time.
-     * @type {Object.<string, boolean>}
+     * @type {Object<string, boolean>}
      * @private
      */
     this.skippedFeatureUids_ = {};
@@ -1356,7 +1356,7 @@ function createOptionsInternal(options) {
   }
 
   /**
-   * @type {Object.<string, *>}
+   * @type {Object<string, *>}
    */
   const values = {};
 

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -93,7 +93,7 @@ class Tile extends EventTarget {
     /**
      * Lookup of start times for rendering transitions.  If the start time is
      * equal to -1, the transition is complete.
-     * @type {Object.<number, number>}
+     * @type {Object<number, number>}
      */
     this.transitionStarts_ = {};
 

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -16,7 +16,7 @@ class TileCache extends LRUCache {
   }
 
   /**
-   * @param {!Object.<string, module:ol/TileRange>} usedTiles Used tiles.
+   * @param {!Object<string, module:ol/TileRange>} usedTiles Used tiles.
    */
   expireCache(usedTiles) {
     while (this.canExpireCache()) {

--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -50,7 +50,7 @@ class TileQueue extends PriorityQueue {
 
     /**
      * @private
-     * @type {!Object.<string,boolean>}
+     * @type {!Object<string,boolean>}
      */
     this.tilesLoadingKeys_ = {};
 

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -33,7 +33,7 @@ class VectorImageTile extends Tile {
    * @param {module:ol/Tile~UrlFunction} tileUrlFunction Tile url function.
    * @param {module:ol/tilegrid/TileGrid} sourceTileGrid Tile grid of the source.
    * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid of the renderer.
-   * @param {Object.<string, module:ol/VectorTile>} sourceTiles Source tiles.
+   * @param {Object<string, module:ol/VectorTile>} sourceTiles Source tiles.
    * @param {number} pixelRatio Pixel ratio.
    * @param {module:ol/proj/Projection} projection Projection.
    * @param {function(new: module:ol/VectorTile, module:ol/tilecoord~TileCoord, module:ol/TileState, string,
@@ -51,7 +51,7 @@ class VectorImageTile extends Tile {
 
     /**
      * @private
-     * @type {!Object.<string, CanvasRenderingContext2D>}
+     * @type {!Object<string, CanvasRenderingContext2D>}
      */
     this.context_ = {};
 
@@ -63,13 +63,13 @@ class VectorImageTile extends Tile {
 
     /**
      * @private
-     * @type {!Object.<string, module:ol/VectorImageTile~ReplayState>}
+     * @type {!Object<string, module:ol/VectorImageTile~ReplayState>}
      */
     this.replayState_ = {};
 
     /**
      * @private
-     * @type {Object.<string, module:ol/VectorTile>}
+     * @type {Object<string, module:ol/VectorTile>}
      */
     this.sourceTiles_ = sourceTiles;
 

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -75,7 +75,7 @@ class VectorImageTile extends Tile {
 
     /**
      * Keys of source tiles used by this tile. Use with {@link #getTile}.
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.tileKeys = [];
 
@@ -95,12 +95,12 @@ class VectorImageTile extends Tile {
     this.wrappedTileCoord = urlTileCoord;
 
     /**
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.loadListenerKeys_ = [];
 
     /**
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.sourceTileListenerKeys_ = [];
 

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -51,7 +51,7 @@ class VectorTile extends Tile {
 
     /**
      * @private
-     * @type {Array.<module:ol/Feature>}
+     * @type {Array<module:ol/Feature>}
      */
     this.features_ = null;
 
@@ -120,7 +120,7 @@ class VectorTile extends Tile {
   /**
    * Get the features for this tile. Geometries will be in the projection returned
    * by {@link module:ol/VectorTile~VectorTile#getProjection}.
-   * @return {Array.<module:ol/Feature|module:ol/render/Feature>} Features.
+   * @return {Array<module:ol/Feature|module:ol/render/Feature>} Features.
    * @api
    */
   getFeatures() {
@@ -166,7 +166,7 @@ class VectorTile extends Tile {
 
   /**
    * Handler for successful tile load.
-   * @param {Array.<module:ol/Feature>} features The loaded features.
+   * @param {Array<module:ol/Feature>} features The loaded features.
    * @param {module:ol/proj/Projection} dataProjection Data projection.
    * @param {module:ol/extent~Extent} extent Extent.
    */
@@ -202,7 +202,7 @@ class VectorTile extends Tile {
   /**
    * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
    * Sets the features for the tile.
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @api
    */
   setFeatures(features) {

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -70,7 +70,7 @@ class VectorTile extends Tile {
 
     /**
      * @private
-     * @type {Object.<string, module:ol/render/ReplayGroup>}
+     * @type {Object<string, module:ol/render/ReplayGroup>}
      */
     this.replayGroups_ = {};
 

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -273,7 +273,7 @@ class View extends BaseObject {
   applyOptions_(options) {
 
     /**
-     * @type {Object.<string, *>}
+     * @type {Object<string, *>}
      */
     const properties = {};
     properties[ViewProperty.CENTER] = options.center !== undefined ?

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -56,7 +56,7 @@ import Units from './proj/Units.js';
  * @property {module:ol/size~Size} [size] The size in pixels of the box to fit
  * the extent into. Default is the current size of the first map in the DOM that
  * uses this view, or `[100, 100]` if no such map is found.
- * @property {!Array.<number>} [padding=[0, 0, 0, 0]] Padding (in pixels) to be
+ * @property {!Array<number>} [padding=[0, 0, 0, 0]] Padding (in pixels) to be
  * cleared inside the view. Values in the array are top, right, bottom and left
  * padding.
  * @property {boolean} [constrainResolution=true] Constrain the resolution.
@@ -121,7 +121,7 @@ import Units from './proj/Units.js';
  * alternative to setting this is to set `zoom`. Layer sources will not be
  * fetched if neither this nor `zoom` are defined, but they can be set later
  * with {@link #setZoom} or {@link #setResolution}.
- * @property {Array.<number>} [resolutions] Resolutions to determine the
+ * @property {Array<number>} [resolutions] Resolutions to determine the
  * resolution constraint. If set the `maxResolution`, `minResolution`,
  * `minZoom`, `maxZoom`, and `zoomFactor` options are ignored.
  * @property {number} [rotation=0] The initial rotation for the view in radians
@@ -238,13 +238,13 @@ class View extends BaseObject {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.hints_ = [0, 0];
 
     /**
      * @private
-     * @type {Array.<Array.<module:ol/View~Animation>>}
+     * @type {Array<Array<module:ol/View~Animation>>}
      */
     this.animations_ = [];
 
@@ -301,7 +301,7 @@ class View extends BaseObject {
 
     /**
      * @private
-     * @type {Array.<number>|undefined}
+     * @type {Array<number>|undefined}
      */
     this.resolutions_ = options.resolutions;
 
@@ -710,8 +710,8 @@ class View extends BaseObject {
   }
 
   /**
-   * @param {Array.<number>=} opt_hints Destination array.
-   * @return {Array.<number>} Hint.
+   * @param {Array<number>=} opt_hints Destination array.
+   * @return {Array<number>} Hint.
    */
   getHints(opt_hints) {
     if (opt_hints !== undefined) {
@@ -821,7 +821,7 @@ class View extends BaseObject {
   /**
    * Get the resolutions for the view. This returns the array of resolutions
    * passed to the constructor of the View, or undefined if none were given.
-   * @return {Array.<number>|undefined} The resolutions of the view.
+   * @return {Array<number>|undefined} The resolutions of the view.
    * @api
    */
   getResolutions() {

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -7,7 +7,7 @@
  * Performs a binary search on the provided sorted list and returns the index of the item if found. If it can't be found it'll return -1.
  * https://github.com/darkskyapp/binary-search
  *
- * @param {Array.<*>} haystack Items to search through.
+ * @param {Array<*>} haystack Items to search through.
  * @param {*} needle The item to look for.
  * @param {Function=} opt_comparator Comparator function.
  * @return {number} The index of the item if found, -1 if not.
@@ -53,7 +53,7 @@ export function numberSafeCompareFunction(a, b) {
 
 /**
  * Whether the array contains the given object.
- * @param {Array.<*>} arr The array to test for the presence of the element.
+ * @param {Array<*>} arr The array to test for the presence of the element.
  * @param {*} obj The object for which to test.
  * @return {boolean} The object is in the array.
  */
@@ -63,7 +63,7 @@ export function includes(arr, obj) {
 
 
 /**
- * @param {Array.<number>} arr Array.
+ * @param {Array<number>} arr Array.
  * @param {number} target Target.
  * @param {number} direction 0 means return the nearest, > 0
  *    means return the largest nearest, < 0 means return the
@@ -109,7 +109,7 @@ export function linearFindNearest(arr, target, direction) {
 
 
 /**
- * @param {Array.<*>} arr Array.
+ * @param {Array<*>} arr Array.
  * @param {number} begin Begin index.
  * @param {number} end End index.
  */
@@ -125,8 +125,8 @@ export function reverseSubArray(arr, begin, end) {
 
 
 /**
- * @param {Array.<VALUE>} arr The array to modify.
- * @param {!Array.<VALUE>|VALUE} data The elements or arrays of elements to add to arr.
+ * @param {Array<VALUE>} arr The array to modify.
+ * @param {!Array<VALUE>|VALUE} data The elements or arrays of elements to add to arr.
  * @template VALUE
  */
 export function extend(arr, data) {
@@ -139,7 +139,7 @@ export function extend(arr, data) {
 
 
 /**
- * @param {Array.<VALUE>} arr The array to modify.
+ * @param {Array<VALUE>} arr The array to modify.
  * @param {VALUE} obj The element to remove.
  * @template VALUE
  * @return {boolean} If the element was removed.
@@ -155,7 +155,7 @@ export function remove(arr, obj) {
 
 
 /**
- * @param {Array.<VALUE>} arr The array to search in.
+ * @param {Array<VALUE>} arr The array to search in.
  * @param {function(VALUE, number, ?) : boolean} func The function to compare.
  * @template VALUE
  * @return {VALUE|null} The element found or null.
@@ -194,7 +194,7 @@ export function equals(arr1, arr2) {
 
 
 /**
- * @param {Array.<*>} arr The array to sort (modifies original).
+ * @param {Array<*>} arr The array to sort (modifies original).
  * @param {Function} compareFnc Comparison function.
  */
 export function stableSort(arr, compareFnc) {
@@ -214,7 +214,7 @@ export function stableSort(arr, compareFnc) {
 
 
 /**
- * @param {Array.<*>} arr The array to search in.
+ * @param {Array<*>} arr The array to search in.
  * @param {Function} func Comparison function.
  * @return {number} Return index.
  */
@@ -229,7 +229,7 @@ export function findIndex(arr, func) {
 
 
 /**
- * @param {Array.<*>} arr The array to test.
+ * @param {Array<*>} arr The array to test.
  * @param {Function=} opt_func Comparison function.
  * @param {boolean=} opt_strict Strictly sorted (default false).
  * @return {boolean} Return index.

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -84,7 +84,7 @@ export const fromString = (
     const MAX_CACHE_SIZE = 1024;
 
     /**
-     * @type {Object.<string, module:ol/color~Color>}
+     * @type {Object<string, module:ol/color~Color>}
      */
     const cache = {};
 

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -10,7 +10,7 @@ import {clamp} from './math.js';
  * red, green, and blue should be integers in the range 0..255 inclusive.
  * alpha should be a float in the range 0..1 inclusive. If no alpha value is
  * given then `1` will be used.
- * @typedef {Array.<number>} Color
+ * @typedef {Array<number>} Color
  * @api
  */
 

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -153,7 +153,7 @@ class Attribution extends Control {
   getSourceAttributions_(frameState) {
     /**
      * Used to determine if an attribution already exists.
-     * @type {!Object.<string, boolean>}
+     * @type {!Object<string, boolean>}
      */
     const lookup = {};
 

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -131,7 +131,7 @@ class Attribution extends Control {
 
     /**
      * A list of currently rendered resolutions.
-     * @type {Array.<string>}
+     * @type {Array<string>}
      * @private
      */
     this.renderedAttributions_ = [];
@@ -147,7 +147,7 @@ class Attribution extends Control {
   /**
    * Get a list of visible attributions.
    * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @return {Array.<string>} Attributions.
+   * @return {Array<string>} Attributions.
    * @private
    */
   getSourceAttributions_(frameState) {
@@ -159,7 +159,7 @@ class Attribution extends Control {
 
     /**
      * A list of visible attributions.
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     const visibleAttributions = [];
 

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -74,7 +74,7 @@ class Control extends BaseObject {
 
     /**
      * @protected
-     * @type {!Array.<module:ol/events~EventsKey>}
+     * @type {!Array<module:ol/events~EventsKey>}
      */
     this.listenerKeys = [];
 

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -44,7 +44,7 @@ const MIN_RATIO = 0.1;
  * @property {boolean} [collapsible=true] Whether the control can be collapsed or not.
  * @property {string|HTMLElement} [label='»'] Text label to use for the collapsed
  * overviewmap button. Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {Array<module:ol/layer/Layer>|module:ol/Collection.<module:ol/layer/Layer>} [layers]
+ * @property {Array<module:ol/layer/Layer>|module:ol/Collection<module:ol/layer/Layer>} [layers]
  * Layers for the overview map. If not set, then all main map layers are used
  * instead.
  * @property {function(module:ol/MapEvent)} [render] Function called when the control

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -44,7 +44,7 @@ const MIN_RATIO = 0.1;
  * @property {boolean} [collapsible=true] Whether the control can be collapsed or not.
  * @property {string|HTMLElement} [label='»'] Text label to use for the collapsed
  * overviewmap button. Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {Array.<module:ol/layer/Layer>|module:ol/Collection.<module:ol/layer/Layer>} [layers]
+ * @property {Array<module:ol/layer/Layer>|module:ol/Collection.<module:ol/layer/Layer>} [layers]
  * Layers for the overview map. If not set, then all main map layers are used
  * instead.
  * @property {function(module:ol/MapEvent)} [render] Function called when the control

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -31,7 +31,7 @@ export const Units = {
 
 /**
  * @const
- * @type {Array.<number>}
+ * @type {Array<number>}
  */
 const LEADING_DIGITS = [1, 2, 5];
 

--- a/src/ol/control/util.js
+++ b/src/ol/control/util.js
@@ -34,7 +34,7 @@ import Zoom from './Zoom.js';
  *
  * @param {module:ol/control/util~DefaultsOptions=} opt_options
  * Defaults options.
- * @return {module:ol/Collection.<module:ol/control/Control>}
+ * @return {module:ol/Collection<module:ol/control/Control>}
  * Controls.
  * @function module:ol/control.defaults
  * @api

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -7,7 +7,7 @@ import {padNumber} from './string.js';
 
 /**
  * An array of numbers representing an xy coordinate. Example: `[16, 48]`.
- * @typedef {Array.<number>} Coordinate
+ * @typedef {Array<number>} Coordinate
  * @api
  */
 
@@ -82,7 +82,7 @@ export function closestOnCircle(coordinate, circle) {
  * is outside the segment.
  *
  * @param {module:ol/coordinate~Coordinate} coordinate The coordinate.
- * @param {Array.<module:ol/coordinate~Coordinate>} segment The two coordinates
+ * @param {Array<module:ol/coordinate~Coordinate>} segment The two coordinates
  * of the segment.
  * @return {module:ol/coordinate~Coordinate} The foot of the perpendicular of
  * the coordinate to the segment.
@@ -328,7 +328,7 @@ export function distance(coord1, coord2) {
  * Calculate the squared distance from a coordinate to a line segment.
  *
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate of the point.
- * @param {Array.<module:ol/coordinate~Coordinate>} segment Line segment (2
+ * @param {Array<module:ol/coordinate~Coordinate>} segment Line segment (2
  * coordinates).
  * @return {number} Squared distance from the point to the line segment.
  */

--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -62,7 +62,7 @@ export const CLASS_COLLAPSED = 'ol-collapsed';
  * Get the list of font families from a font spec.  Note that this doesn't work
  * for font families that have commas in them.
  * @param {string} The CSS font property.
- * @return {Object.<string>} The font families (or null if the input spec is invalid).
+ * @return {Object<string>} The font families (or null if the input spec is invalid).
  */
 export const getFontFamilies = (function() {
   let style;

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -87,7 +87,7 @@ export function getListeners(target, type) {
  * Get the lookup of listeners.  If one does not exist on the target, it is
  * created.
  * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
- * @return {!Object.<string, Array<module:ol/events~EventsKey>>} Map of
+ * @return {!Object<string, Array<module:ol/events~EventsKey>>} Map of
  *     listeners by event type.
  */
 function getListenerMap(target) {

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -75,7 +75,7 @@ export function findListener(listeners, listener, opt_this, opt_setDeleteIndex) 
 /**
  * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
  * @param {string} type Type.
- * @return {Array.<module:ol/events~EventsKey>|undefined} Listeners.
+ * @return {Array<module:ol/events~EventsKey>|undefined} Listeners.
  */
 export function getListeners(target, type) {
   const listenerMap = target.ol_lm;
@@ -87,7 +87,7 @@ export function getListeners(target, type) {
  * Get the lookup of listeners.  If one does not exist on the target, it is
  * created.
  * @param {module:ol/events/EventTarget~EventTargetLike} target Target.
- * @return {!Object.<string, Array.<module:ol/events~EventsKey>>} Map of
+ * @return {!Object.<string, Array<module:ol/events~EventsKey>>} Map of
  *     listeners by event type.
  */
 function getListenerMap(target) {

--- a/src/ol/events/EventTarget.js
+++ b/src/ol/events/EventTarget.js
@@ -46,7 +46,7 @@ class EventTarget extends Disposable {
 
     /**
      * @private
-     * @type {!Object.<string, Array.<module:ol/events~ListenerFunction>>}
+     * @type {!Object.<string, Array<module:ol/events~ListenerFunction>>}
      */
     this.listeners_ = {};
 
@@ -122,7 +122,7 @@ class EventTarget extends Disposable {
    * order that they will be called in.
    *
    * @param {string} type Type.
-   * @return {Array.<module:ol/events~ListenerFunction>} Listeners.
+   * @return {Array<module:ol/events~ListenerFunction>} Listeners.
    */
   getListeners(type) {
     return this.listeners_[type];

--- a/src/ol/events/EventTarget.js
+++ b/src/ol/events/EventTarget.js
@@ -34,19 +34,19 @@ class EventTarget extends Disposable {
 
     /**
      * @private
-     * @type {!Object.<string, number>}
+     * @type {!Object<string, number>}
      */
     this.pendingRemovals_ = {};
 
     /**
      * @private
-     * @type {!Object.<string, number>}
+     * @type {!Object<string, number>}
      */
     this.dispatching_ = {};
 
     /**
      * @private
-     * @type {!Object.<string, Array<module:ol/events~ListenerFunction>>}
+     * @type {!Object<string, Array<module:ol/events~ListenerFunction>>}
      */
     this.listeners_ = {};
 

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -8,14 +8,14 @@ import Relationship from './extent/Relationship.js';
 
 /**
  * An array of numbers representing an extent: `[minx, miny, maxx, maxy]`.
- * @typedef {Array.<number>} Extent
+ * @typedef {Array<number>} Extent
  * @api
  */
 
 /**
  * Build an extent that includes all given coordinates.
  *
- * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+ * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @return {module:ol/extent~Extent} Bounding extent.
  * @api
  */
@@ -29,8 +29,8 @@ export function boundingExtent(coordinates) {
 
 
 /**
- * @param {Array.<number>} xs Xs.
- * @param {Array.<number>} ys Ys.
+ * @param {Array<number>} xs Xs.
+ * @param {Array<number>} ys Ys.
  * @param {module:ol/extent~Extent=} opt_extent Destination extent.
  * @private
  * @return {module:ol/extent~Extent} Extent.
@@ -249,7 +249,7 @@ export function createOrUpdateFromCoordinate(coordinate, opt_extent) {
 
 
 /**
- * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+ * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @param {module:ol/extent~Extent=} opt_extent Extent.
  * @return {module:ol/extent~Extent} Extent.
  */
@@ -260,7 +260,7 @@ export function createOrUpdateFromCoordinates(coordinates, opt_extent) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -273,7 +273,7 @@ export function createOrUpdateFromFlatCoordinates(flatCoordinates, offset, end, 
 }
 
 /**
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} rings Rings.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} rings Rings.
  * @param {module:ol/extent~Extent=} opt_extent Extent.
  * @return {module:ol/extent~Extent} Extent.
  */
@@ -342,7 +342,7 @@ export function extendCoordinate(extent, coordinate) {
 
 /**
  * @param {module:ol/extent~Extent} extent Extent.
- * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+ * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @return {module:ol/extent~Extent} Extent.
  */
 export function extendCoordinates(extent, coordinates) {
@@ -355,7 +355,7 @@ export function extendCoordinates(extent, coordinates) {
 
 /**
  * @param {module:ol/extent~Extent} extent Extent.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -371,7 +371,7 @@ export function extendFlatCoordinates(extent, flatCoordinates, offset, end, stri
 
 /**
  * @param {module:ol/extent~Extent} extent Extent.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} rings Rings.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} rings Rings.
  * @return {module:ol/extent~Extent} Extent.
  */
 export function extendRings(extent, rings) {

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -39,7 +39,7 @@ import FormatType from './format/FormatType.js';
 /**
  * @param {string|module:ol/featureloader~FeatureUrlFunction} url Feature URL service.
  * @param {module:ol/format/Feature} format Feature format.
- * @param {function(this:module:ol/VectorTile, Array.<module:ol/Feature>, module:ol/proj/Projection, module:ol/extent~Extent)|function(this:module:ol/source/Vector, Array.<module:ol/Feature>)} success
+ * @param {function(this:module:ol/VectorTile, Array<module:ol/Feature>, module:ol/proj/Projection, module:ol/extent~Extent)|function(this:module:ol/source/Vector, Array<module:ol/Feature>)} success
  *     Function called with the loaded features and optionally with the data
  *     projection. Called with the vector tile or source as `this`.
  * @param {function(this:module:ol/VectorTile)|function(this:module:ol/source/Vector)} failure
@@ -118,7 +118,7 @@ export function loadFeaturesXhr(url, format, success, failure) {
 export function xhr(url, format) {
   return loadFeaturesXhr(url, format,
     /**
-     * @param {Array.<module:ol/Feature>} features The loaded features.
+     * @param {Array<module:ol/Feature>} features The loaded features.
      * @param {module:ol/proj/Projection} dataProjection Data
      * projection.
      * @this {module:ol/source/Vector}

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -108,7 +108,7 @@ class EsriJSON extends JSONFeature {
     const options = opt_options ? opt_options : {};
     if (esriJSONObject.features) {
       const esriJSONFeatureCollection = /** @type {EsriJSONFeatureCollection} */ (object);
-      /** @type {Array.<module:ol/Feature>} */
+      /** @type {Array<module:ol/Feature>} */
       const features = [];
       const esriJSONFeatures = esriJSONFeatureCollection.features;
       options.idField = object.objectIdFieldName;
@@ -188,7 +188,7 @@ class EsriJSON extends JSONFeature {
   /**
    * Encode an array of features as a EsriJSON object.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {Object} EsriJSON Object.
    * @override
@@ -252,9 +252,9 @@ function readGeometry(object, opt_options) {
  * Checks if any polygons in this array contain any other polygons in this
  * array. It is used for checking for holes.
  * Logic inspired by: https://github.com/Esri/terraformer-arcgis-parser
- * @param {Array.<!Array.<!Array.<number>>>} rings Rings.
+ * @param {Array<!Array<!Array<number>>>} rings Rings.
  * @param {module:ol/geom/GeometryLayout} layout Geometry layout.
- * @return {Array.<!Array.<!Array.<number>>>} Transformed rings.
+ * @return {Array<!Array<!Array<number>>>} Transformed rings.
  */
 function convertRings(rings, layout) {
   const flatRing = [];
@@ -376,7 +376,7 @@ function readMultiPointGeometry(object) {
 function readMultiPolygonGeometry(object) {
   const layout = getGeometryLayout(object);
   return new MultiPolygon(
-    /** @type {Array.<Array.<Array.<Array.<number>>>>} */(object.rings),
+    /** @type {Array<Array<Array<Array<number>>>>} */(object.rings),
     layout);
 }
 

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -23,7 +23,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @const
- * @type {Object.<module:ol/geom/GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry>}
+ * @type {Object<module:ol/geom/GeometryType, function(EsriJSONGeometry): module:ol/geom/Geometry>}
  */
 const GEOMETRY_READERS = {};
 GEOMETRY_READERS[GeometryType.POINT] = readPointGeometry;
@@ -36,7 +36,7 @@ GEOMETRY_READERS[GeometryType.MULTI_POLYGON] = readMultiPolygonGeometry;
 
 /**
  * @const
- * @type {Object.<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (EsriJSONGeometry)>}
+ * @type {Object<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (EsriJSONGeometry)>}
  */
 const GEOMETRY_WRITERS = {};
 GEOMETRY_WRITERS[GeometryType.POINT] = writePointGeometry;

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -141,7 +141,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Node|ArrayBuffer|Object|string} source Source.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    */
   readFeatures(source, opt_options) {}
 
@@ -178,7 +178,7 @@ class FeatureFormat {
    * Encode an array of features in this format.
    *
    * @abstract
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {string} Result.
    */
@@ -234,8 +234,8 @@ export function transformWithOptions(geometry, write, opt_options) {
     const power = Math.pow(10, opt_options.decimals);
     // if decimals option on write, round each coordinate appropriately
     /**
-     * @param {Array.<number>} coordinates Coordinates.
-     * @return {Array.<number>} Transformed coordinates.
+     * @param {Array<number>} coordinates Coordinates.
+     * @return {Array<number>} Transformed coordinates.
      */
     const transform = function(coordinates) {
       for (let i = 0, ii = coordinates.length; i < ii; ++i) {

--- a/src/ol/format/GML.js
+++ b/src/ol/format/GML.js
@@ -20,7 +20,7 @@ const GML = GML3;
  * Encode an array of features in GML 3.1.1 Simple Features.
  *
  * @function
- * @param {Array.<module:ol/Feature>} features Features.
+ * @param {Array<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api
@@ -32,7 +32,7 @@ GML.prototype.writeFeatures;
  * Encode an array of features in the GML 3.1.1 format as an XML node.
  *
  * @function
- * @param {Array.<module:ol/Feature>} features Features.
+ * @param {Array<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {Node} Node.
  * @api

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -21,7 +21,7 @@ const schemaLocation = GMLNS + ' http://schemas.opengis.net/gml/2.1.2/feature.xs
 
 /**
  * @const
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const MULTIGEOMETRY_TO_MEMBER_NODENAME = {
   'MultiLineString': 'lineStringMember',
@@ -587,7 +587,7 @@ class GML2 extends GMLBase {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML2.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
@@ -598,7 +598,7 @@ GML2.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML2.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
@@ -610,7 +610,7 @@ GML2.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML2.prototype.BOX_PARSERS_ = {
@@ -622,7 +622,7 @@ GML2.prototype.BOX_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML2.prototype.GEOMETRY_PARSERS_ = {
@@ -645,7 +645,7 @@ GML2.prototype.GEOMETRY_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML2.prototype.GEOMETRY_SERIALIZERS_ = {
@@ -677,7 +677,7 @@ GML2.prototype.GEOMETRY_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML2.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
@@ -690,7 +690,7 @@ GML2.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML2.prototype.RING_SERIALIZERS_ = {
@@ -701,7 +701,7 @@ GML2.prototype.RING_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML2.prototype.POINTMEMBER_SERIALIZERS_ = {
@@ -713,7 +713,7 @@ GML2.prototype.POINTMEMBER_SERIALIZERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML2.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
@@ -726,7 +726,7 @@ GML2.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
 };
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML2.prototype.ENVELOPE_SERIALIZERS_ = {

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -63,9 +63,9 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>|undefined} Flat coordinates.
+   * @return {Array<number>|undefined} Flat coordinates.
    */
   readFlatCoordinates_(node, objectStack) {
     const s = getAllTextContent(node, false).replace(/^\s*|\s*$/g, '');
@@ -96,12 +96,12 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/extent~Extent|undefined} Envelope.
    */
   readBox_(node, objectStack) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const flatCoordinates = pushParseAndPop([null],
       this.BOX_PARSERS_, node, objectStack, this);
     return createOrUpdate(flatCoordinates[1][0],
@@ -111,15 +111,15 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   innerBoundaryIsParser_(node, objectStack) {
-    /** @type {Array.<number>|undefined} */
+    /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
     if (flatLinearRing) {
-      const flatLinearRings = /** @type {Array.<Array.<number>>} */
+      const flatLinearRings = /** @type {Array<Array<number>>} */
           (objectStack[objectStack.length - 1]);
       flatLinearRings.push(flatLinearRing);
     }
@@ -127,15 +127,15 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   outerBoundaryIsParser_(node, objectStack) {
-    /** @type {Array.<number>|undefined} */
+    /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
     if (flatLinearRing) {
-      const flatLinearRings = /** @type {Array.<Array.<number>>} */
+      const flatLinearRings = /** @type {Array<Array<number>>} */
           (objectStack[objectStack.length - 1]);
       flatLinearRings[0] = flatLinearRing;
     }
@@ -144,7 +144,7 @@ class GML2 extends GMLBase {
   /**
    * @const
    * @param {*} value Value.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
    * @return {Node|undefined} Node.
    * @private
@@ -174,7 +174,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/Feature} feature Feature.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    */
   writeFeatureElement(node, feature, objectStack) {
     const fid = feature.getId();
@@ -220,7 +220,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString} geometry LineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeCurveOrLineString_(node, geometry, objectStack) {
@@ -245,7 +245,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString} line LineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeLineStringOrCurveMember_(node, line, objectStack) {
@@ -259,7 +259,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeMultiCurveOrLineString_(node, geometry, objectStack) {
@@ -280,7 +280,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    */
   writeGeometryElement(node, geometry, objectStack) {
     const context = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[objectStack.length - 1]);
@@ -320,7 +320,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeCoordinates_(node, value, objectStack) {
@@ -341,7 +341,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString} line LineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeCurveSegments_(node, line, objectStack) {
@@ -353,7 +353,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Polygon} geometry Polygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeSurfaceOrPolygon_(node, geometry, objectStack) {
@@ -380,7 +380,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {*} value Value.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
    * @return {Node} Node.
    * @private
@@ -399,7 +399,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Polygon} polygon Polygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeSurfacePatches_(node, polygon, objectStack) {
@@ -411,7 +411,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LinearRing} ring LinearRing geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeRing_(node, ring, objectStack) {
@@ -421,7 +421,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Array.<number>} point Point geometry.
+   * @param {Array<number>} point Point geometry.
    * @param {string=} opt_srsName Optional srsName
    * @param {boolean=} opt_hasZ whether the geometry has a Z coordinate (is 3D) or not.
    * @return {string} The coords string.
@@ -447,7 +447,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Point} geometry Point geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writePoint_(node, geometry, objectStack) {
@@ -467,7 +467,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeMultiPoint_(node, geometry, objectStack) {
@@ -487,7 +487,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Point} point Point geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writePointMember_(node, point, objectStack) {
@@ -499,7 +499,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeLinearRing_(node, geometry, objectStack) {
@@ -516,7 +516,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeMultiSurfaceOrPolygon_(node, geometry, objectStack) {
@@ -537,7 +537,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Polygon} polygon Polygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeSurfaceOrPolygonMember_(node, polygon, objectStack) {
@@ -552,7 +552,7 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/extent~Extent} extent Extent.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeEnvelope(node, extent, objectStack) {
@@ -573,7 +573,7 @@ class GML2 extends GMLBase {
   /**
    * @const
    * @param {*} value Value.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
    * @return {Node|undefined} Node.
    * @private

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -103,12 +103,12 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
    */
   readMultiCurve_(node, objectStack) {
-    /** @type {Array.<module:ol/geom/LineString>} */
+    /** @type {Array<module:ol/geom/LineString>} */
     const lineStrings = pushParseAndPop([],
       this.MULTICURVE_PARSERS_, node, objectStack, this);
     if (lineStrings) {
@@ -121,12 +121,12 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
    */
   readMultiSurface_(node, objectStack) {
-    /** @type {Array.<module:ol/geom/Polygon>} */
+    /** @type {Array<module:ol/geom/Polygon>} */
     const polygons = pushParseAndPop([],
       this.MULTISURFACE_PARSERS_, node, objectStack, this);
     if (polygons) {
@@ -136,7 +136,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   curveMemberParser_(node, objectStack) {
@@ -145,7 +145,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   surfaceMemberParser_(node, objectStack) {
@@ -155,9 +155,9 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<(Array.<number>)>|undefined} flat coordinates.
+   * @return {Array<(Array<number>)>|undefined} flat coordinates.
    */
   readPatch_(node, objectStack) {
     return pushParseAndPop([null],
@@ -166,9 +166,9 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>|undefined} flat coordinates.
+   * @return {Array<number>|undefined} flat coordinates.
    */
   readSegment_(node, objectStack) {
     return pushParseAndPop([null],
@@ -177,9 +177,9 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<(Array.<number>)>|undefined} flat coordinates.
+   * @return {Array<(Array<number>)>|undefined} flat coordinates.
    */
   readPolygonPatch_(node, objectStack) {
     return pushParseAndPop([null],
@@ -188,9 +188,9 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>|undefined} flat coordinates.
+   * @return {Array<number>|undefined} flat coordinates.
    */
   readLineStringSegment_(node, objectStack) {
     return pushParseAndPop([null],
@@ -200,15 +200,15 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   interiorParser_(node, objectStack) {
-    /** @type {Array.<number>|undefined} */
+    /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
     if (flatLinearRing) {
-      const flatLinearRings = /** @type {Array.<Array.<number>>} */
+      const flatLinearRings = /** @type {Array<Array<number>>} */
           (objectStack[objectStack.length - 1]);
       flatLinearRings.push(flatLinearRing);
     }
@@ -216,15 +216,15 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   exteriorParser_(node, objectStack) {
-    /** @type {Array.<number>|undefined} */
+    /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(undefined,
       this.RING_PARSERS, node, objectStack, this);
     if (flatLinearRing) {
-      const flatLinearRings = /** @type {Array.<Array.<number>>} */
+      const flatLinearRings = /** @type {Array<Array<number>>} */
           (objectStack[objectStack.length - 1]);
       flatLinearRings[0] = flatLinearRing;
     }
@@ -232,12 +232,12 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/Polygon|undefined} Polygon.
    */
   readSurface_(node, objectStack) {
-    /** @type {Array.<Array.<number>>} */
+    /** @type {Array<Array<number>>} */
     const flatLinearRings = pushParseAndPop([null],
       this.SURFACE_PARSERS_, node, objectStack, this);
     if (flatLinearRings && flatLinearRings[0]) {
@@ -256,12 +256,12 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/LineString|undefined} LineString.
    */
   readCurve_(node, objectStack) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const flatCoordinates = pushParseAndPop([null],
       this.CURVE_PARSERS_, node, objectStack, this);
     if (flatCoordinates) {
@@ -274,12 +274,12 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/extent~Extent|undefined} Envelope.
    */
   readEnvelope_(node, objectStack) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const flatCoordinates = pushParseAndPop([null],
       this.ENVELOPE_PARSERS_, node, objectStack, this);
     return createOrUpdate(flatCoordinates[1][0],
@@ -289,14 +289,14 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>|undefined} Flat coordinates.
+   * @return {Array<number>|undefined} Flat coordinates.
    */
   readFlatPos_(node, objectStack) {
     let s = getAllTextContent(node, false);
     const re = /^\s*([+\-]?\d*\.?\d+(?:[eE][+\-]?\d+)?)\s*/;
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const flatCoordinates = [];
     let m;
     while ((m = re.exec(s))) {
@@ -334,9 +334,9 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>|undefined} Flat coordinates.
+   * @return {Array<number>|undefined} Flat coordinates.
    */
   readFlatPosList_(node, objectStack) {
     const s = getAllTextContent(node, false).replace(/^\s*|\s*$/g, '');
@@ -381,7 +381,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Point} value Point geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writePos_(node, value, objectStack) {
@@ -411,7 +411,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Array.<number>} point Point geometry.
+   * @param {Array<number>} point Point geometry.
    * @param {string=} opt_srsName Optional srsName
    * @param {boolean=} opt_hasZ whether the geometry has a Z coordinate (is 3D) or not.
    * @return {string} The coords string.
@@ -437,7 +437,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writePosList_(node, value, objectStack) {
@@ -461,7 +461,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Point} geometry Point geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writePoint_(node, geometry, objectStack) {
@@ -478,7 +478,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/extent~Extent} extent Extent.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    */
   writeEnvelope(node, extent, objectStack) {
     const context = objectStack[objectStack.length - 1];
@@ -498,7 +498,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeLinearRing_(node, geometry, objectStack) {
@@ -514,7 +514,7 @@ class GML3 extends GMLBase {
 
   /**
    * @param {*} value Value.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
    * @return {Node} Node.
    * @private
@@ -533,7 +533,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Polygon} geometry Polygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeSurfaceOrPolygon_(node, geometry, objectStack) {
@@ -561,7 +561,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString} geometry LineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeCurveOrLineString_(node, geometry, objectStack) {
@@ -586,7 +586,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeMultiSurfaceOrPolygon_(node, geometry, objectStack) {
@@ -607,7 +607,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeMultiPoint_(node, geometry, objectStack) {
@@ -627,7 +627,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeMultiCurveOrLineString_(node, geometry, objectStack) {
@@ -648,7 +648,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LinearRing} ring LinearRing geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeRing_(node, ring, objectStack) {
@@ -660,7 +660,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Polygon} polygon Polygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeSurfaceOrPolygonMember_(node, polygon, objectStack) {
@@ -675,7 +675,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Point} point Point geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writePointMember_(node, point, objectStack) {
@@ -687,7 +687,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString} line LineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeLineStringOrCurveMember_(node, line, objectStack) {
@@ -701,7 +701,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Polygon} polygon Polygon geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeSurfacePatches_(node, polygon, objectStack) {
@@ -713,7 +713,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/LineString} line LineString geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeCurveSegments_(node, line, objectStack) {
@@ -726,7 +726,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/geom/Geometry|module:ol/extent~Extent} geometry Geometry.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    */
   writeGeometryElement(node, geometry, objectStack) {
     const context = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[objectStack.length - 1]);
@@ -752,7 +752,7 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {module:ol/Feature} feature Feature.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<*>} objectStack Node stack.
    */
   writeFeatureElement(node, feature, objectStack) {
     const fid = feature.getId();
@@ -797,8 +797,8 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<module:ol/Feature>} features Features.
-   * @param {Array.<*>} objectStack Node stack.
+   * @param {Array<module:ol/Feature>} features Features.
+   * @param {Array<*>} objectStack Node stack.
    * @private
    */
   writeFeatureMembers_(node, features, objectStack) {
@@ -821,7 +821,7 @@ class GML3 extends GMLBase {
   /**
    * @const
    * @param {*} value Value.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
    * @return {Node|undefined} Node.
    * @private
@@ -835,7 +835,7 @@ class GML3 extends GMLBase {
   /**
    * @const
    * @param {*} value Value.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
    * @return {Node|undefined} Node.
    * @private
@@ -890,7 +890,7 @@ class GML3 extends GMLBase {
   /**
    * Encode an array of features in the GML 3.1.1 format as an XML node.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
    * @return {Node} Node.
    * @override
@@ -1100,7 +1100,7 @@ GML3.prototype.SEGMENTS_PARSERS_ = {
  * Encode an array of features in GML 3.1.1 Simple Features.
  *
  * @function
- * @param {Array.<module:ol/Feature>} features Features.
+ * @param {Array<module:ol/Feature>} features Features.
  * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
  * @return {string} Result.
  * @api

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -31,7 +31,7 @@ const schemaLocation = GMLNS +
 
 /**
  * @const
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const MULTIGEOMETRY_TO_MEMBER_NODENAME = {
   'MultiLineString': 'lineStringMember',
@@ -920,7 +920,7 @@ class GML3 extends GMLBase {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
@@ -933,7 +933,7 @@ GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
@@ -946,7 +946,7 @@ GML3.prototype.FLAT_LINEAR_RINGS_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.GEOMETRY_PARSERS_ = {
@@ -976,7 +976,7 @@ GML3.prototype.GEOMETRY_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.MULTICURVE_PARSERS_ = {
@@ -991,7 +991,7 @@ GML3.prototype.MULTICURVE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.MULTISURFACE_PARSERS_ = {
@@ -1006,7 +1006,7 @@ GML3.prototype.MULTISURFACE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.CURVEMEMBER_PARSERS_ = {
@@ -1020,7 +1020,7 @@ GML3.prototype.CURVEMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.SURFACEMEMBER_PARSERS_ = {
@@ -1033,7 +1033,7 @@ GML3.prototype.SURFACEMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.SURFACE_PARSERS_ = {
@@ -1045,7 +1045,7 @@ GML3.prototype.SURFACE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.CURVE_PARSERS_ = {
@@ -1057,7 +1057,7 @@ GML3.prototype.CURVE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.ENVELOPE_PARSERS_ = {
@@ -1072,7 +1072,7 @@ GML3.prototype.ENVELOPE_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.PATCHES_PARSERS_ = {
@@ -1085,7 +1085,7 @@ GML3.prototype.PATCHES_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GML3.prototype.SEGMENTS_PARSERS_ = {
@@ -1109,7 +1109,7 @@ GML3.prototype.writeFeatures;
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML3.prototype.RING_SERIALIZERS_ = {
@@ -1121,7 +1121,7 @@ GML3.prototype.RING_SERIALIZERS_ = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML3.prototype.ENVELOPE_SERIALIZERS_ = {
@@ -1133,7 +1133,7 @@ GML3.prototype.ENVELOPE_SERIALIZERS_ = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML3.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
@@ -1147,7 +1147,7 @@ GML3.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML3.prototype.POINTMEMBER_SERIALIZERS_ = {
@@ -1159,7 +1159,7 @@ GML3.prototype.POINTMEMBER_SERIALIZERS_ = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML3.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
@@ -1173,7 +1173,7 @@ GML3.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  * @private
  */
 GML3.prototype.GEOMETRY_SERIALIZERS_ = {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -52,7 +52,7 @@ const ONLY_WHITESPACE_RE = /^[\s\xa0]*$/;
  * feature namespaces themselves. So for instance there might be a featureType
  * item `topp:states` in the `featureType` array and then there will be a key
  * `topp` in the featureNS object with value `http://www.openplans.org/topp`.
- * @property {Array.<string>|string} [featureType] Feature type(s) to parse.
+ * @property {Array<string>|string} [featureType] Feature type(s) to parse.
  * If multiple feature types need to be configured
  * which come from different feature namespaces, `featureNS` will be an object
  * with the keys being the prefixes used in the entries of featureType array.
@@ -96,7 +96,7 @@ class GMLBase extends XMLFeature {
 
     /**
      * @protected
-     * @type {Array.<string>|string|undefined}
+     * @type {Array<string>|string|undefined}
      */
     this.featureType = options.featureType;
 
@@ -131,8 +131,8 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
-   * @return {Array.<module:ol/Feature> | undefined} Features.
+   * @param {Array<*>} objectStack Object stack.
+   * @return {Array<module:ol/Feature> | undefined} Features.
    */
   readFeaturesInternal(node, objectStack) {
     const localName = node.localName;
@@ -219,7 +219,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/Geometry|undefined} Geometry.
    */
   readGeometryElement(node, objectStack) {
@@ -239,7 +239,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/Feature} Feature.
    */
   readFeatureElement(node, objectStack) {
@@ -280,7 +280,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/Point|undefined} Point.
    */
   readPoint(node, objectStack) {
@@ -292,11 +292,11 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/MultiPoint|undefined} MultiPoint.
    */
   readMultiPoint(node, objectStack) {
-    /** @type {Array.<Array.<number>>} */
+    /** @type {Array<Array<number>>} */
     const coordinates = pushParseAndPop([],
       this.MULTIPOINT_PARSERS_, node, objectStack, this);
     if (coordinates) {
@@ -308,11 +308,11 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
    */
   readMultiLineString(node, objectStack) {
-    /** @type {Array.<module:ol/geom/LineString>} */
+    /** @type {Array<module:ol/geom/LineString>} */
     const lineStrings = pushParseAndPop([],
       this.MULTILINESTRING_PARSERS_, node, objectStack, this);
     if (lineStrings) {
@@ -322,11 +322,11 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
    */
   readMultiPolygon(node, objectStack) {
-    /** @type {Array.<module:ol/geom/Polygon>} */
+    /** @type {Array<module:ol/geom/Polygon>} */
     const polygons = pushParseAndPop([], this.MULTIPOLYGON_PARSERS_, node, objectStack, this);
     if (polygons) {
       return new MultiPolygon(polygons);
@@ -335,7 +335,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   pointMemberParser_(node, objectStack) {
@@ -344,7 +344,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   lineStringMemberParser_(node, objectStack) {
@@ -353,7 +353,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   polygonMemberParser_(node, objectStack) {
@@ -362,7 +362,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/LineString|undefined} LineString.
    */
   readLineString(node, objectStack) {
@@ -377,9 +377,9 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>|undefined} LinearRing flat coordinates.
+   * @return {Array<number>|undefined} LinearRing flat coordinates.
    */
   readFlatLinearRing_(node, objectStack) {
     const ring = pushParseAndPop(null,
@@ -394,7 +394,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/LinearRing|undefined} LinearRing.
    */
   readLinearRing(node, objectStack) {
@@ -406,11 +406,11 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/Polygon|undefined} Polygon.
    */
   readPolygon(node, objectStack) {
-    /** @type {Array.<Array.<number>>} */
+    /** @type {Array<Array<number>>} */
     const flatLinearRings = pushParseAndPop([null],
       this.FLAT_LINEAR_RINGS_PARSERS_, node, objectStack, this);
     if (flatLinearRings && flatLinearRings[0]) {
@@ -429,9 +429,9 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<number>} Flat coordinates.
+   * @return {Array<number>} Flat coordinates.
    */
   readFlatCoordinatesFromNode_(node, objectStack) {
     return pushParseAndPop(null, this.GEOMETRY_FLAT_COORDINATES_PARSERS_, node, objectStack, this);

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -44,7 +44,7 @@ const ONLY_WHITESPACE_RE = /^[\s\xa0]*$/;
 
 /**
  * @typedef {Object} Options
- * @property {Object.<string, string>|string} [featureNS] Feature
+ * @property {Object<string, string>|string} [featureNS] Feature
  * namespace. If not defined will be derived from GML. If multiple
  * feature types have been configured which come from different feature
  * namespaces, this will be an object with the keys being the prefixes used
@@ -102,7 +102,7 @@ class GMLBase extends XMLFeature {
 
     /**
      * @protected
-     * @type {Object.<string, string>|string|undefined}
+     * @type {Object<string, string>|string|undefined}
      */
     this.featureNS = options.featureNS;
 
@@ -119,7 +119,7 @@ class GMLBase extends XMLFeature {
     this.schemaLocation = '';
 
     /**
-     * @type {Object.<string, Object.<string, Object>>}
+     * @type {Object<string, Object<string, Object>>}
      */
     this.FEATURE_COLLECTION_PARSERS = {};
     this.FEATURE_COLLECTION_PARSERS[GMLNS] = {
@@ -471,7 +471,7 @@ class GMLBase extends XMLFeature {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GMLBase.prototype.MULTIPOINT_PARSERS_ = {
@@ -484,7 +484,7 @@ GMLBase.prototype.MULTIPOINT_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
@@ -497,7 +497,7 @@ GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
@@ -510,7 +510,7 @@ GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GMLBase.prototype.POINTMEMBER_PARSERS_ = {
@@ -522,7 +522,7 @@ GMLBase.prototype.POINTMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
@@ -534,7 +534,7 @@ GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @private
  */
 GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
@@ -546,7 +546,7 @@ GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  * @protected
  */
 GMLBase.prototype.RING_PARSERS = {

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -19,7 +19,7 @@ import {createElementNS, makeArrayPusher, makeArraySerializer, makeChildAppender
 
 /**
  * @const
- * @type {Array.<null|string>}
+ * @type {Array<null|string>}
  */
 const NAMESPACE_URIS = [
   null,
@@ -38,7 +38,7 @@ const SCHEMA_LOCATION = 'http://www.topografix.com/GPX/1/1 ' +
 
 /**
  * @const
- * @type {Object.<string, function(Node, Array.<*>): (module:ol/Feature|undefined)>}
+ * @type {Object.<string, function(Node, Array<*>): (module:ol/Feature|undefined)>}
  */
 const FEATURE_READER = {
   'rte': readRte,
@@ -138,7 +138,7 @@ class GPX extends XMLFeature {
   }
 
   /**
-   * @param {Array.<module:ol/Feature>} features List of features.
+   * @param {Array<module:ol/Feature>} features List of features.
    * @private
    */
   handleReadExtensions_(features) {
@@ -182,7 +182,7 @@ class GPX extends XMLFeature {
       return [];
     }
     if (node.localName == 'gpx') {
-      /** @type {Array.<module:ol/Feature>} */
+      /** @type {Array<module:ol/Feature>} */
       const features = pushParseAndPop([], GPX_PARSERS,
         node, [this.getReadOptions(node, opt_options)]);
       if (features) {
@@ -200,7 +200,7 @@ class GPX extends XMLFeature {
    * LineString geometries are output as routes (`<rte>`), and MultiLineString
    * as tracks (`<trk>`).
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
    * @return {Node} Node.
    * @override
@@ -321,7 +321,7 @@ const WPT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 const LINK_SEQUENCE = ['text', 'type'];
 
@@ -339,7 +339,7 @@ const LINK_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const RTE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -366,7 +366,7 @@ const RTE_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const RTEPT_TYPE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -376,7 +376,7 @@ const RTEPT_TYPE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const TRK_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -403,7 +403,7 @@ const TRK_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const TRKSEG_NODE_FACTORY = makeSimpleNodeFactory('trkpt');
 
@@ -420,7 +420,7 @@ const TRKSEG_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const WPT_TYPE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -470,7 +470,7 @@ const GEOMETRY_TYPE_TO_NODENAME = {
 
 /**
  * @param {*} value Value.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @param {string=} opt_nodeName Node name.
  * @return {Node|undefined} Node.
  */
@@ -487,11 +487,11 @@ function GPX_NODE_FACTORY(value, objectStack, opt_nodeName) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {module:ol/format/GPX~LayoutOptions} layoutOptions Layout options.
  * @param {Node} node Node.
  * @param {!Object} values Values.
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 function appendCoordinate(flatCoordinates, layoutOptions, node, values) {
   flatCoordinates.push(
@@ -520,8 +520,8 @@ function appendCoordinate(flatCoordinates, layoutOptions, node, values) {
  * and ends arrays by shrinking them accordingly (removing unused zero entries).
  *
  * @param {module:ol/format/GPX~LayoutOptions} layoutOptions Layout options.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
- * @param {Array.<number>=} ends Ends.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>=} ends Ends.
  * @return {module:ol/geom/GeometryLayout} Layout.
  */
 function applyLayoutOptions(layoutOptions, flatCoordinates, ends) {
@@ -561,7 +561,7 @@ function applyLayoutOptions(layoutOptions, flatCoordinates, ends) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function parseLink(node, objectStack) {
   const values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -575,7 +575,7 @@ function parseLink(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function parseExtensions(node, objectStack) {
   const values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -585,13 +585,13 @@ function parseExtensions(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function parseRtePt(node, objectStack) {
   const values = pushParseAndPop({}, RTEPT_PARSERS, node, objectStack);
   if (values) {
     const rteValues = /** @type {!Object} */ (objectStack[objectStack.length - 1]);
-    const flatCoordinates = /** @type {Array.<number>} */ (rteValues['flatCoordinates']);
+    const flatCoordinates = /** @type {Array<number>} */ (rteValues['flatCoordinates']);
     const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (rteValues['layoutOptions']);
     appendCoordinate(flatCoordinates, layoutOptions, node, values);
   }
@@ -600,13 +600,13 @@ function parseRtePt(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function parseTrkPt(node, objectStack) {
   const values = pushParseAndPop({}, TRKPT_PARSERS, node, objectStack);
   if (values) {
     const trkValues = /** @type {!Object} */ (objectStack[objectStack.length - 1]);
-    const flatCoordinates = /** @type {Array.<number>} */ (trkValues['flatCoordinates']);
+    const flatCoordinates = /** @type {Array<number>} */ (trkValues['flatCoordinates']);
     const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (trkValues['layoutOptions']);
     appendCoordinate(flatCoordinates, layoutOptions, node, values);
   }
@@ -615,21 +615,21 @@ function parseTrkPt(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function parseTrkSeg(node, objectStack) {
   const values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   parseNode(TRKSEG_PARSERS, node, objectStack);
-  const flatCoordinates = /** @type {Array.<number>} */
+  const flatCoordinates = /** @type {Array<number>} */
       (values['flatCoordinates']);
-  const ends = /** @type {Array.<number>} */ (values['ends']);
+  const ends = /** @type {Array<number>} */ (values['ends']);
   ends.push(flatCoordinates.length);
 }
 
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/Feature|undefined} Track.
  */
 function readRte(node, objectStack) {
@@ -641,7 +641,7 @@ function readRte(node, objectStack) {
   if (!values) {
     return undefined;
   }
-  const flatCoordinates = /** @type {Array.<number>} */
+  const flatCoordinates = /** @type {Array<number>} */
       (values['flatCoordinates']);
   delete values['flatCoordinates'];
   const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (values['layoutOptions']);
@@ -657,7 +657,7 @@ function readRte(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/Feature|undefined} Track.
  */
 function readTrk(node, objectStack) {
@@ -670,10 +670,10 @@ function readTrk(node, objectStack) {
   if (!values) {
     return undefined;
   }
-  const flatCoordinates = /** @type {Array.<number>} */
+  const flatCoordinates = /** @type {Array<number>} */
       (values['flatCoordinates']);
   delete values['flatCoordinates'];
-  const ends = /** @type {Array.<number>} */ (values['ends']);
+  const ends = /** @type {Array<number>} */ (values['ends']);
   delete values['ends'];
   const layoutOptions = /** @type {module:ol/format/GPX~LayoutOptions} */ (values['layoutOptions']);
   delete values['layoutOptions'];
@@ -688,7 +688,7 @@ function readTrk(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/Feature|undefined} Waypoint.
  */
 function readWpt(node, objectStack) {
@@ -711,7 +711,7 @@ function readWpt(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {string} value Value for the link's `href` attribute.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeLink(node, value, objectStack) {
   node.setAttribute('href', value);
@@ -730,7 +730,7 @@ function writeLink(node, value, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeWptType(node, coordinate, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -774,7 +774,7 @@ function writeWptType(node, coordinate, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeRte(node, feature, objectStack) {
   const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);
@@ -798,7 +798,7 @@ function writeRte(node, feature, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeTrk(node, feature, objectStack) {
   const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);
@@ -823,7 +823,7 @@ function writeTrk(node, feature, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/geom/LineString} lineString LineString.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeTrkSeg(node, lineString, objectStack) {
   /** @type {module:ol/xml~NodeStackItem} */
@@ -838,7 +838,7 @@ function writeTrkSeg(node, lineString, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeWpt(node, feature, objectStack) {
   const options = /** @type {module:ol/format/Feature~WriteOptions} */ (objectStack[0]);

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -38,7 +38,7 @@ const SCHEMA_LOCATION = 'http://www.topografix.com/GPX/1/1 ' +
 
 /**
  * @const
- * @type {Object.<string, function(Node, Array<*>): (module:ol/Feature|undefined)>}
+ * @type {Object<string, function(Node, Array<*>): (module:ol/Feature|undefined)>}
  */
 const FEATURE_READER = {
   'rte': readRte,
@@ -49,7 +49,7 @@ const FEATURE_READER = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const GPX_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -61,7 +61,7 @@ const GPX_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -72,7 +72,7 @@ const LINK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const GPX_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -225,7 +225,7 @@ class GPX extends XMLFeature {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const RTE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -243,7 +243,7 @@ const RTE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const RTEPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -254,7 +254,7 @@ const RTEPT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TRK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -272,7 +272,7 @@ const TRK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TRKSEG_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -282,7 +282,7 @@ const TRKSEG_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TRKPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -293,7 +293,7 @@ const TRKPT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const WPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -328,7 +328,7 @@ const LINK_SEQUENCE = ['text', 'type'];
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const LINK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -339,7 +339,7 @@ const LINK_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const RTE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -349,7 +349,7 @@ const RTE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const RTE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -366,7 +366,7 @@ const RTE_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const RTEPT_TYPE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -376,7 +376,7 @@ const RTEPT_TYPE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const TRK_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -386,7 +386,7 @@ const TRK_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const TRK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -410,7 +410,7 @@ const TRKSEG_NODE_FACTORY = makeSimpleNodeFactory('trkpt');
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const TRKSEG_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -420,7 +420,7 @@ const TRKSEG_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const WPT_TYPE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -432,7 +432,7 @@ const WPT_TYPE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const WPT_TYPE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -459,7 +459,7 @@ const WPT_TYPE_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const GEOMETRY_TYPE_TO_NODENAME = {
   'Point': 'wpt',

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -231,7 +231,7 @@ class GeoJSON extends JSONFeature {
 
 /**
  * @const
- * @type {Object.<string, function(GeoJSONObject): module:ol/geom/Geometry>}
+ * @type {Object<string, function(GeoJSONObject): module:ol/geom/Geometry>}
  */
 const GEOMETRY_READERS = {
   'Point': readPointGeometry,
@@ -246,7 +246,7 @@ const GEOMETRY_READERS = {
 
 /**
  * @const
- * @type {Object.<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (GeoJSONGeometry|GeoJSONGeometryCollection)>}
+ * @type {Object<string, function(module:ol/geom/Geometry, module:ol/format/Feature~WriteOptions=): (GeoJSONGeometry|GeoJSONGeometryCollection)>}
  */
 const GEOMETRY_WRITERS = {
   'Point': writePointGeometry,

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -115,7 +115,7 @@ class GeoJSON extends JSONFeature {
    */
   readFeaturesFromObject(object, opt_options) {
     const geoJSONObject = /** @type {GeoJSONObject} */ (object);
-    /** @type {Array.<module:ol/Feature>} */
+    /** @type {Array<module:ol/Feature>} */
     let features = null;
     if (geoJSONObject.type === 'FeatureCollection') {
       const geoJSONFeatureCollection = /** @type {GeoJSONFeatureCollection} */ (object);
@@ -196,7 +196,7 @@ class GeoJSON extends JSONFeature {
   /**
    * Encode an array of features as a GeoJSON object.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {GeoJSONFeatureCollection} GeoJSON Object.
    * @override

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -94,7 +94,7 @@ class IGC extends TextFeature {
   readFeatureFromText(text, opt_options) {
     const altitudeMode = this.altitudeMode_;
     const lines = text.split(NEWLINE_RE);
-    /** @type {Object.<string, string>} */
+    /** @type {Object<string, string>} */
     const properties = {};
     const flatCoordinates = [];
     let year = 2000;

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -44,7 +44,7 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Node|Object|string} source Source.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    * @api
    */
   readFeatures(source, opt_options) {
@@ -66,7 +66,7 @@ class JSONFeature extends FeatureFormat {
    * @param {Object} object Object.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
    * @protected
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    */
   readFeaturesFromObject(object, opt_options) {}
 
@@ -134,7 +134,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * Encode an array of features as string.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {string} Encoded features.
    * @api
@@ -145,7 +145,7 @@ class JSONFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {Object} Object.
    */

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -79,7 +79,7 @@ const SCHEMA_LOCATION = 'http://www.opengis.net/kml/2.2 ' +
 
 
 /**
- * @type {Object.<string, module:ol/style/IconAnchorUnits>}
+ * @type {Object<string, module:ol/style/IconAnchorUnits>}
  */
 const ICON_ANCHOR_UNITS_MAP = {
   'fraction': IconAnchorUnits.FRACTION,
@@ -89,7 +89,7 @@ const ICON_ANCHOR_UNITS_MAP = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PLACEMARK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -126,7 +126,7 @@ const PLACEMARK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const NETWORK_LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -144,7 +144,7 @@ const NETWORK_LINK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -154,7 +154,7 @@ const LINK_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const REGION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -165,7 +165,7 @@ const REGION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const KML_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -175,7 +175,7 @@ const KML_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const KML_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -441,7 +441,7 @@ class KML extends XMLFeature {
 
     /**
      * @private
-     * @type {!Object.<string, (Array<module:ol/style/Style>|string)>}
+     * @type {!Object<string, (Array<module:ol/style/Style>|string)>}
      */
     this.sharedStyles_ = {};
 
@@ -905,7 +905,7 @@ function createNameStyleFunction(foundStyle, name) {
  * @param {Array<module:ol/style/Style>|undefined} style Style.
  * @param {string} styleUrl Style URL.
  * @param {Array<module:ol/style/Style>} defaultStyle Default style.
- * @param {!Object.<string, (Array<module:ol/style/Style>|string)>} sharedStyles Shared styles.
+ * @param {!Object<string, (Array<module:ol/style/Style>|string)>} sharedStyles Shared styles.
  * @param {boolean|undefined} showPointNames true to show names for point placemarks.
  * @return {module:ol/style/Style~StyleFunction} Feature style function.
  */
@@ -962,7 +962,7 @@ function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles,
 /**
  * @param {Array<module:ol/style/Style>|string|undefined} styleValue Style value.
  * @param {Array<module:ol/style/Style>} defaultStyle Default style.
- * @param {!Object.<string, (Array<module:ol/style/Style>|string)>} sharedStyles
+ * @param {!Object<string, (Array<module:ol/style/Style>|string)>} sharedStyles
  * Shared styles.
  * @return {Array<module:ol/style/Style>} Style.
  */
@@ -1094,7 +1094,7 @@ function readScale(node) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const STYLE_MAP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1115,7 +1115,7 @@ function readStyleMapValue(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const ICON_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1231,7 +1231,7 @@ function iconStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LABEL_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1266,7 +1266,7 @@ function labelStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LINE_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1302,7 +1302,7 @@ function lineStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const POLY_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1342,7 +1342,7 @@ function polyStyleParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const FLAT_LINEAR_RING_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1386,7 +1386,7 @@ function gxCoordParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
   GX_NAMESPACE_URIS, {
@@ -1411,7 +1411,7 @@ function readGxMultiTrack(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const GX_TRACK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1447,7 +1447,7 @@ function readGxTrack(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const ICON_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1479,7 +1479,7 @@ function readIcon(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const GEOMETRY_FLAT_COORDINATES_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1500,7 +1500,7 @@ function readFlatCoordinatesFromNode(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1554,7 +1554,7 @@ function readLinearRing(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const MULTI_GEOMETRY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1648,7 +1648,7 @@ function readPoint(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1686,7 +1686,7 @@ function readPolygon(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1778,7 +1778,7 @@ function setCommonGeometryProperties(multiGeometry, geometries) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1806,7 +1806,7 @@ function dataParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const EXTENDED_DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1833,7 +1833,7 @@ function regionParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PAIR_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1892,7 +1892,7 @@ function placemarkStyleMapParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const SCHEMA_DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1925,7 +1925,7 @@ function simpleDataParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LAT_LON_ALT_BOX_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1964,7 +1964,7 @@ function latLonAltBoxParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LOD_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -1994,7 +1994,7 @@ function lodParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2020,7 +2020,7 @@ function innerBoundaryIsParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const OUTER_BOUNDARY_IS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2125,7 +2125,7 @@ function writeCoordinatesTextNode(node, coordinates, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const EXTENDEDDATA_NODE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2182,7 +2182,7 @@ function writeDataNodeValue(node, value) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const DOCUMENT_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2245,7 +2245,7 @@ function writeExtendedData(node, namesAndValues, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const ICON_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2258,7 +2258,7 @@ const ICON_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const ICON_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2308,7 +2308,7 @@ function writeIcon(node, icon, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const ICON_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2318,7 +2318,7 @@ const ICON_STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const ICON_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2388,7 +2388,7 @@ function writeIconStyle(node, style, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const LABEL_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2398,7 +2398,7 @@ const LABEL_STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const LABEL_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2434,7 +2434,7 @@ function writeLabelStyle(node, style, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const LINE_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2444,7 +2444,7 @@ const LINE_STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const LINE_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2474,7 +2474,7 @@ function writeLineStyle(node, style, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const GEOMETRY_TYPE_TO_NODENAME = {
   'Point': 'Point',
@@ -2538,7 +2538,7 @@ const POLYGON_NODE_FACTORY = makeSimpleNodeFactory('Polygon');
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const MULTI_GEOMETRY_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2590,7 +2590,7 @@ function writeMultiGeometry(node, geometry, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const BOUNDARY_IS_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2614,7 +2614,7 @@ function writeBoundaryIs(node, linearRing, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const PLACEMARK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2637,7 +2637,7 @@ const PLACEMARK_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const PLACEMARK_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2723,7 +2723,7 @@ function writePlacemark(node, feature, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const PRIMITIVE_GEOMETRY_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2733,7 +2733,7 @@ const PRIMITIVE_GEOMETRY_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const PRIMITIVE_GEOMETRY_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2769,7 +2769,7 @@ function writePrimitiveGeometry(node, geometry, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const POLYGON_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2820,7 +2820,7 @@ function writePolygon(node, polygon, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const POLY_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -2861,7 +2861,7 @@ function writeScaleTextNode(node, scale) {
 
 /**
  * @const
- * @type {Object.<string, Array<string>>}
+ * @type {Object<string, Array<string>>}
  */
 const STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2871,7 +2871,7 @@ const STYLE_SEQUENCE = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -43,14 +43,14 @@ import {createElementNS, getAllTextContent, isDocument, isNode, makeArrayExtende
 
 /**
  * @typedef {Object} GxTrackObject
- * @property {Array.<number>} flatCoordinates
- * @property {Array.<number>} whens
+ * @property {Array<number>} flatCoordinates
+ * @property {Array<number>} whens
  */
 
 
 /**
  * @const
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 const GX_NAMESPACE_URIS = [
   'http://www.google.com/kml/ext/2.2'
@@ -59,7 +59,7 @@ const GX_NAMESPACE_URIS = [
 
 /**
  * @const
- * @type {Array.<null|string>}
+ * @type {Array<null|string>}
  */
 const NAMESPACE_URIS = [
   null,
@@ -165,7 +165,7 @@ const REGION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const KML_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -295,13 +295,13 @@ export function getDefaultStyle() {
 }
 
 /**
- * @type {Array.<module:ol/style/Style>}
+ * @type {Array<module:ol/style/Style>}
  */
 let DEFAULT_STYLE_ARRAY = null;
 
 /**
  * Get the default style array (or null if not yet set).
- * @return {Array.<module:ol/style/Style>} The default style.
+ * @return {Array<module:ol/style/Style>} The default style.
  */
 export function getDefaultStyleArray() {
   return DEFAULT_STYLE_ARRAY;
@@ -377,7 +377,7 @@ function createStyleDefaults() {
  * @typedef {Object} Options
  * @property {boolean} [extractStyles=true] Extract styles from the KML.
  * @property {boolean} [showPointNames=true] Show names as labels for placemarks which contain points.
- * @property {Array.<module:ol/style/Style>} [defaultStyle] Default style. The
+ * @property {Array<module:ol/style/Style>} [defaultStyle] Default style. The
  * default default style is the same as Google Earth.
  * @property {boolean} [writeStyles=true] Write styles into KML.
  */
@@ -420,7 +420,7 @@ class KML extends XMLFeature {
 
     /**
      * @private
-     * @type {Array.<module:ol/style/Style>}
+     * @type {Array<module:ol/style/Style>}
      */
     this.defaultStyle_ = options.defaultStyle ?
       options.defaultStyle : DEFAULT_STYLE_ARRAY;
@@ -441,7 +441,7 @@ class KML extends XMLFeature {
 
     /**
      * @private
-     * @type {!Object.<string, (Array.<module:ol/style/Style>|string)>}
+     * @type {!Object.<string, (Array<module:ol/style/Style>|string)>}
      */
     this.sharedStyles_ = {};
 
@@ -456,9 +456,9 @@ class KML extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
-   * @return {Array.<module:ol/Feature>|undefined} Features.
+   * @return {Array<module:ol/Feature>|undefined} Features.
    */
   readDocumentOrFolder_(node, objectStack) {
     // FIXME use scope somehow
@@ -470,7 +470,7 @@ class KML extends XMLFeature {
         'Style': this.readSharedStyle_.bind(this),
         'StyleMap': this.readSharedStyleMap_.bind(this)
       });
-    /** @type {Array.<module:ol/Feature>} */
+    /** @type {Array<module:ol/Feature>} */
     const features = pushParseAndPop([], parsersNS, node, objectStack, this);
     if (features) {
       return features;
@@ -481,7 +481,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/Feature|undefined} Feature.
    */
@@ -524,7 +524,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   readSharedStyle_(node, objectStack) {
@@ -550,7 +550,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
+   * @param {Array<*>} objectStack Object stack.
    * @private
    */
   readSharedStyleMap_(node, objectStack) {
@@ -698,7 +698,7 @@ class KML extends XMLFeature {
    * Read the network links of the KML.
    *
    * @param {Document|Node|string} source Source.
-   * @return {Array.<Object>} Network links.
+   * @return {Array<Object>} Network links.
    * @api
    */
   readNetworkLinks(source) {
@@ -718,7 +718,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Document} doc Document.
-   * @return {Array.<Object>} Network links.
+   * @return {Array<Object>} Network links.
    */
   readNetworkLinksFromDocument(doc) {
     const networkLinks = [];
@@ -732,7 +732,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @return {Array.<Object>} Network links.
+   * @return {Array<Object>} Network links.
    */
   readNetworkLinksFromNode(node) {
     const networkLinks = [];
@@ -760,7 +760,7 @@ class KML extends XMLFeature {
    * Read the regions of the KML.
    *
    * @param {Document|Node|string} source Source.
-   * @return {Array.<Object>} Regions.
+   * @return {Array<Object>} Regions.
    * @api
    */
   readRegion(source) {
@@ -780,7 +780,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Document} doc Document.
-   * @return {Array.<Object>} Region.
+   * @return {Array<Object>} Region.
    */
   readRegionFromDocument(doc) {
     const regions = [];
@@ -794,7 +794,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @return {Array.<Object>} Region.
+   * @return {Array<Object>} Region.
    * @api
    */
   readRegionFromNode(node) {
@@ -823,7 +823,7 @@ class KML extends XMLFeature {
    * Encode an array of features in the KML format as an XML node. GeometryCollections,
    * MultiPoints, MultiLineStrings, and MultiPolygons are output as MultiGeometries.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
    * @return {Node} Node.
    * @override
@@ -902,10 +902,10 @@ function createNameStyleFunction(foundStyle, name) {
 
 
 /**
- * @param {Array.<module:ol/style/Style>|undefined} style Style.
+ * @param {Array<module:ol/style/Style>|undefined} style Style.
  * @param {string} styleUrl Style URL.
- * @param {Array.<module:ol/style/Style>} defaultStyle Default style.
- * @param {!Object.<string, (Array.<module:ol/style/Style>|string)>} sharedStyles Shared styles.
+ * @param {Array<module:ol/style/Style>} defaultStyle Default style.
+ * @param {!Object.<string, (Array<module:ol/style/Style>|string)>} sharedStyles Shared styles.
  * @param {boolean|undefined} showPointNames true to show names for point placemarks.
  * @return {module:ol/style/Style~StyleFunction} Feature style function.
  */
@@ -915,7 +915,7 @@ function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles,
     /**
      * @param {module:ol/Feature} feature feature.
      * @param {number} resolution Resolution.
-     * @return {Array.<module:ol/style/Style>} Style.
+     * @return {Array<module:ol/style/Style>} Style.
      */
     function(feature, resolution) {
       let drawName = showPointNames;
@@ -960,11 +960,11 @@ function createFeatureStyleFunction(style, styleUrl, defaultStyle, sharedStyles,
 
 
 /**
- * @param {Array.<module:ol/style/Style>|string|undefined} styleValue Style value.
- * @param {Array.<module:ol/style/Style>} defaultStyle Default style.
- * @param {!Object.<string, (Array.<module:ol/style/Style>|string)>} sharedStyles
+ * @param {Array<module:ol/style/Style>|string|undefined} styleValue Style value.
+ * @param {Array<module:ol/style/Style>} defaultStyle Default style.
+ * @param {!Object.<string, (Array<module:ol/style/Style>|string)>} sharedStyles
  * Shared styles.
- * @return {Array.<module:ol/style/Style>} Style.
+ * @return {Array<module:ol/style/Style>} Style.
  */
 function findStyle(styleValue, defaultStyle, sharedStyles) {
   if (Array.isArray(styleValue)) {
@@ -1009,7 +1009,7 @@ function readColor(node) {
 
 /**
  * @param {Node} node Node.
- * @return {Array.<number>|undefined} Flat coordinates.
+ * @return {Array<number>|undefined} Flat coordinates.
  */
 export function readFlatCoordinates(node) {
   let s = getAllTextContent(node, false);
@@ -1104,8 +1104,8 @@ const STYLE_MAP_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<module:ol/style/Style>|string|undefined} StyleMap.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<module:ol/style/Style>|string|undefined} StyleMap.
  */
 function readStyleMapValue(node, objectStack) {
   return pushParseAndPop(undefined,
@@ -1128,7 +1128,7 @@ const ICON_STYLE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function iconStyleParser(node, objectStack) {
   // FIXME refreshMode
@@ -1242,7 +1242,7 @@ const LABEL_STYLE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function labelStyleParser(node, objectStack) {
   // FIXME colorMode
@@ -1277,7 +1277,7 @@ const LINE_STYLE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function lineStyleParser(node, objectStack) {
   // FIXME colorMode
@@ -1314,7 +1314,7 @@ const POLY_STYLE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function polyStyleParser(node, objectStack) {
   // FIXME colorMode
@@ -1352,8 +1352,8 @@ const FLAT_LINEAR_RING_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<number>} LinearRing flat coordinates.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<number>} LinearRing flat coordinates.
  */
 function readFlatLinearRing(node, objectStack) {
   return pushParseAndPop(null,
@@ -1363,7 +1363,7 @@ function readFlatLinearRing(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function gxCoordParser(node, objectStack) {
   const gxTrackObject = /** @type {module:ol/format/KML~GxTrackObject} */
@@ -1396,7 +1396,7 @@ const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
  */
 function readGxMultiTrack(node, objectStack) {
@@ -1424,7 +1424,7 @@ const GX_TRACK_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/LineString|undefined} LineString.
  */
 function readGxTrack(node, objectStack) {
@@ -1463,7 +1463,7 @@ const ICON_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object} Icon object.
  */
 function readIcon(node, objectStack) {
@@ -1489,8 +1489,8 @@ const GEOMETRY_FLAT_COORDINATES_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<number>} Flat coordinates.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<number>} Flat coordinates.
  */
 function readFlatCoordinatesFromNode(node, objectStack) {
   return pushParseAndPop(null,
@@ -1512,7 +1512,7 @@ const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/LineString|undefined} LineString.
  */
 function readLineString(node, objectStack) {
@@ -1533,7 +1533,7 @@ function readLineString(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
 function readLinearRing(node, objectStack) {
@@ -1568,7 +1568,7 @@ const MULTI_GEOMETRY_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Geometry} Geometry.
  */
 function readMultiGeometry(node, objectStack) {
@@ -1627,7 +1627,7 @@ function readMultiGeometry(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Point|undefined} Point.
  */
 function readPoint(node, objectStack) {
@@ -1659,7 +1659,7 @@ const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
 function readPolygon(node, objectStack) {
@@ -1699,8 +1699,8 @@ const STYLE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<module:ol/style/Style>} Style.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<module:ol/style/Style>} Style.
  */
 function readStyle(node, objectStack) {
   const styleObject = pushParseAndPop(
@@ -1746,7 +1746,7 @@ function readStyle(node, objectStack) {
  * Reads an array of geometries and creates arrays for common geometry
  * properties. Then sets them to the multi geometry.
  * @param {module:ol/geom/MultiPoint|module:ol/geom/MultiLineString|module:ol/geom/MultiPolygon} multiGeometry A multi-geometry.
- * @param {Array.<module:ol/geom/Geometry>} geometries List of geometries.
+ * @param {Array<module:ol/geom/Geometry>} geometries List of geometries.
  */
 function setCommonGeometryProperties(multiGeometry, geometries) {
   const ii = geometries.length;
@@ -1789,7 +1789,7 @@ const DATA_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function dataParser(node, objectStack) {
   const name = node.getAttribute('name');
@@ -1817,7 +1817,7 @@ const EXTENDED_DATA_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function extendedDataParser(node, objectStack) {
   parseNode(EXTENDED_DATA_PARSERS, node, objectStack);
@@ -1825,7 +1825,7 @@ function extendedDataParser(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function regionParser(node, objectStack) {
   parseNode(REGION_PARSERS, node, objectStack);
@@ -1845,7 +1845,7 @@ const PAIR_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function pairDataParser(node, objectStack) {
   const pairObject = pushParseAndPop(
@@ -1872,7 +1872,7 @@ function pairDataParser(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function placemarkStyleMapParser(node, objectStack) {
   const styleMapValue = readStyleMapValue(node, objectStack);
@@ -1902,7 +1902,7 @@ const SCHEMA_DATA_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function schemaDataParser(node, objectStack) {
   parseNode(SCHEMA_DATA_PARSERS, node, objectStack);
@@ -1911,7 +1911,7 @@ function schemaDataParser(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function simpleDataParser(node, objectStack) {
   const name = node.getAttribute('name');
@@ -1941,7 +1941,7 @@ const LAT_LON_ALT_BOX_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function latLonAltBoxParser(node, objectStack) {
   const object = pushParseAndPop({}, LAT_LON_ALT_BOX_PARSERS, node, objectStack);
@@ -1977,7 +1977,7 @@ const LOD_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function lodParser(node, objectStack) {
   const object = pushParseAndPop({}, LOD_PARSERS, node, objectStack);
@@ -2004,14 +2004,14 @@ const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function innerBoundaryIsParser(node, objectStack) {
-  /** @type {Array.<number>|undefined} */
+  /** @type {Array<number>|undefined} */
   const flatLinearRing = pushParseAndPop(undefined,
     INNER_BOUNDARY_IS_PARSERS, node, objectStack);
   if (flatLinearRing) {
-    const flatLinearRings = /** @type {Array.<Array.<number>>} */
+    const flatLinearRings = /** @type {Array<Array<number>>} */
         (objectStack[objectStack.length - 1]);
     flatLinearRings.push(flatLinearRing);
   }
@@ -2030,14 +2030,14 @@ const OUTER_BOUNDARY_IS_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function outerBoundaryIsParser(node, objectStack) {
-  /** @type {Array.<number>|undefined} */
+  /** @type {Array<number>|undefined} */
   const flatLinearRing = pushParseAndPop(undefined,
     OUTER_BOUNDARY_IS_PARSERS, node, objectStack);
   if (flatLinearRing) {
-    const flatLinearRings = /** @type {Array.<Array.<number>>} */
+    const flatLinearRings = /** @type {Array<Array<number>>} */
         (objectStack[objectStack.length - 1]);
     flatLinearRings[0] = flatLinearRing;
   }
@@ -2046,7 +2046,7 @@ function outerBoundaryIsParser(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function linkParser(node, objectStack) {
   parseNode(LINK_PARSERS, node, objectStack);
@@ -2055,7 +2055,7 @@ function linkParser(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function whenParser(node, objectStack) {
   const gxTrackObject = /** @type {module:ol/format/KML~GxTrackObject} */
@@ -2085,8 +2085,8 @@ function writeColorTextNode(node, color) {
 
 /**
  * @param {Node} node Node to append a TextNode with the coordinates to.
- * @param {Array.<number>} coordinates Coordinates.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<number>} coordinates Coordinates.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeCoordinatesTextNode(node, coordinates, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -2138,7 +2138,7 @@ const EXTENDEDDATA_NODE_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {{name: *, value: *}} pair Name value pair.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeDataNode(node, pair, objectStack) {
   node.setAttribute('name', pair.name);
@@ -2193,7 +2193,7 @@ const DOCUMENT_SERIALIZERS = makeStructureNS(
 /**
  * @const
  * @param {*} value Value.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @param {string=} opt_nodeName Node name.
  * @return {Node|undefined} Node.
  */
@@ -2205,8 +2205,8 @@ const DOCUMENT_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<module:ol/Feature>} features Features.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<module:ol/Feature>} features Features.
+ * @param {Array<*>} objectStack Object stack.
  * @this {module:ol/format/KML}
  */
 function writeDocument(node, features, objectStack) {
@@ -2220,7 +2220,7 @@ function writeDocument(node, features, objectStack) {
 /**
  * A factory for creating Data nodes.
  * @const
- * @type {function(*, Array.<*>): (Node|undefined)}
+ * @type {function(*, Array<*>): (Node|undefined)}
  */
 const DATA_NODE_FACTORY = makeSimpleNodeFactory('Data');
 
@@ -2228,7 +2228,7 @@ const DATA_NODE_FACTORY = makeSimpleNodeFactory('Data');
 /**
  * @param {Node} node Node.
  * @param {{names: Array<string>, values: (Array<*>)}} namesAndValues Names and values.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeExtendedData(node, namesAndValues, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2245,7 +2245,7 @@ function writeExtendedData(node, namesAndValues, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const ICON_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2275,7 +2275,7 @@ const ICON_SERIALIZERS = makeStructureNS(
 /**
  * @const
  * @param {*} value Value.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @param {string=} opt_nodeName Node name.
  * @return {Node|undefined} Node.
  */
@@ -2288,7 +2288,7 @@ const GX_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
 /**
  * @param {Node} node Node.
  * @param {Object} icon Icon object.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeIcon(node, icon, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2308,7 +2308,7 @@ function writeIcon(node, icon, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const ICON_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2332,7 +2332,7 @@ const ICON_STYLE_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/style/Icon} style Icon style.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeIconStyle(node, style, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2388,7 +2388,7 @@ function writeIconStyle(node, style, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const LABEL_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2410,7 +2410,7 @@ const LABEL_STYLE_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/style/Text} style style.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeLabelStyle(node, style, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2434,7 +2434,7 @@ function writeLabelStyle(node, style, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const LINE_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2456,7 +2456,7 @@ const LINE_STYLE_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/style/Stroke} style style.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeLineStyle(node, style, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2491,7 +2491,7 @@ const GEOMETRY_TYPE_TO_NODENAME = {
 /**
  * @const
  * @param {*} value Value.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @param {string=} opt_nodeName Node name.
  * @return {Node|undefined} Node.
  */
@@ -2507,7 +2507,7 @@ const GEOMETRY_NODE_FACTORY = function(value, objectStack, opt_nodeName) {
 /**
  * A factory for creating Point nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const POINT_NODE_FACTORY = makeSimpleNodeFactory('Point');
 
@@ -2515,7 +2515,7 @@ const POINT_NODE_FACTORY = makeSimpleNodeFactory('Point');
 /**
  * A factory for creating LineString nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const LINE_STRING_NODE_FACTORY = makeSimpleNodeFactory('LineString');
 
@@ -2523,7 +2523,7 @@ const LINE_STRING_NODE_FACTORY = makeSimpleNodeFactory('LineString');
 /**
  * A factory for creating LinearRing nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const LINEAR_RING_NODE_FACTORY = makeSimpleNodeFactory('LinearRing');
 
@@ -2531,7 +2531,7 @@ const LINEAR_RING_NODE_FACTORY = makeSimpleNodeFactory('LinearRing');
 /**
  * A factory for creating Polygon nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const POLYGON_NODE_FACTORY = makeSimpleNodeFactory('Polygon');
 
@@ -2555,15 +2555,15 @@ const MULTI_GEOMETRY_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/geom/Geometry} geometry Geometry.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeMultiGeometry(node, geometry, objectStack) {
   /** @type {module:ol/xml~NodeStackItem} */
   const context = {node: node};
   const type = geometry.getType();
-  /** @type {Array.<module:ol/geom/Geometry>} */
+  /** @type {Array<module:ol/geom/Geometry>} */
   let geometries;
-  /** @type {function(*, Array.<*>, string=): (Node|undefined)} */
+  /** @type {function(*, Array<*>, string=): (Node|undefined)} */
   let factory;
   if (type == GeometryType.GEOMETRY_COLLECTION) {
     geometries = /** @type {module:ol/geom/GeometryCollection} */ (geometry).getGeometries();
@@ -2602,7 +2602,7 @@ const BOUNDARY_IS_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/geom/LinearRing} linearRing Linear ring.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeBoundaryIs(node, linearRing, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2637,7 +2637,7 @@ const PLACEMARK_SERIALIZERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const PLACEMARK_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2649,7 +2649,7 @@ const PLACEMARK_SEQUENCE = makeStructureNS(
 /**
  * A factory for creating ExtendedData nodes.
  * @const
- * @type {function(*, Array.<*>): (Node|undefined)}
+ * @type {function(*, Array<*>): (Node|undefined)}
  */
 const EXTENDEDDATA_NODE_FACTORY = makeSimpleNodeFactory('ExtendedData');
 
@@ -2659,7 +2659,7 @@ const EXTENDEDDATA_NODE_FACTORY = makeSimpleNodeFactory('ExtendedData');
  * (ExtendedData).
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @this {module:ol/format/KML}
  */
 function writePlacemark(node, feature, objectStack) {
@@ -2723,7 +2723,7 @@ function writePlacemark(node, feature, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const PRIMITIVE_GEOMETRY_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2747,7 +2747,7 @@ const PRIMITIVE_GEOMETRY_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writePrimitiveGeometry(node, geometry, objectStack) {
   const flatCoordinates = geometry.getFlatCoordinates();
@@ -2783,7 +2783,7 @@ const POLYGON_SERIALIZERS = makeStructureNS(
 /**
  * A factory for creating innerBoundaryIs nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const INNER_BOUNDARY_NODE_FACTORY = makeSimpleNodeFactory('innerBoundaryIs');
 
@@ -2791,7 +2791,7 @@ const INNER_BOUNDARY_NODE_FACTORY = makeSimpleNodeFactory('innerBoundaryIs');
 /**
  * A factory for creating outerBoundaryIs nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const OUTER_BOUNDARY_NODE_FACTORY = makeSimpleNodeFactory('outerBoundaryIs');
 
@@ -2799,7 +2799,7 @@ const OUTER_BOUNDARY_NODE_FACTORY = makeSimpleNodeFactory('outerBoundaryIs');
 /**
  * @param {Node} node Node.
  * @param {module:ol/geom/Polygon} polygon Polygon.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writePolygon(node, polygon, objectStack) {
   const linearRings = polygon.getLinearRings();
@@ -2831,7 +2831,7 @@ const POLY_STYLE_SERIALIZERS = makeStructureNS(
 /**
  * A factory for creating coordinates nodes.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 const COLOR_NODE_FACTORY = makeSimpleNodeFactory('color');
 
@@ -2839,7 +2839,7 @@ const COLOR_NODE_FACTORY = makeSimpleNodeFactory('color');
 /**
  * @param {Node} node Node.
  * @param {module:ol/style/Fill} style Style.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writePolyStyle(node, style, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};
@@ -2861,7 +2861,7 @@ function writeScaleTextNode(node, scale) {
 
 /**
  * @const
- * @type {Object.<string, Array.<string>>}
+ * @type {Object.<string, Array<string>>}
  */
 const STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
@@ -2885,7 +2885,7 @@ const STYLE_SERIALIZERS = makeStructureNS(
 /**
  * @param {Node} node Node.
  * @param {module:ol/style/Style} style Style.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function writeStyle(node, style, objectStack) {
   const /** @type {module:ol/xml~NodeStackItem} */ context = {node: node};

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -23,7 +23,7 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {function((module:ol/geom/Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType,Array<number>,(Array<number>|Array<Array<number>>),Object.<string,*>,number)} [featureClass]
+ * @property {function((module:ol/geom/Geometry|Object<string,*>)=)|function(module:ol/geom/GeometryType,Array<number>,(Array<number>|Array<Array<number>>),Object<string,*>,number)} [featureClass]
  * Class for features returned by {@link module:ol/format/MVT#readFeatures}. Set to
  * {@link module:ol/Feature~Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link module:ol/render/Feature~RenderFeature},
@@ -64,9 +64,9 @@ class MVT extends FeatureFormat {
 
     /**
      * @private
-     * @type {function((module:ol/geom/Geometry|Object.<string,*>)=)|
+     * @type {function((module:ol/geom/Geometry|Object<string,*>)=)|
      *     function(module:ol/geom/GeometryType,Array<number>,
-     *         (Array<number>|Array<Array<number>>),Object.<string,*>,number)}
+     *         (Array<number>|Array<Array<number>>),Object<string,*>,number)}
      */
     this.featureClass_ = options.featureClass ?
       options.featureClass : RenderFeature;

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -23,7 +23,7 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {function((module:ol/geom/Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType,Array.<number>,(Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)} [featureClass]
+ * @property {function((module:ol/geom/Geometry|Object.<string,*>)=)|function(module:ol/geom/GeometryType,Array<number>,(Array<number>|Array<Array<number>>),Object.<string,*>,number)} [featureClass]
  * Class for features returned by {@link module:ol/format/MVT#readFeatures}. Set to
  * {@link module:ol/Feature~Feature} to get full editing and geometry support at the cost of
  * decreased rendering performance. The default is {@link module:ol/render/Feature~RenderFeature},
@@ -32,7 +32,7 @@ import RenderFeature from '../render/Feature.js';
  * features.
  * @property {string} [layerName='layer'] Name of the feature attribute that
  * holds the layer name.
- * @property {Array.<string>} [layers] Layers to read features from. If not
+ * @property {Array<string>} [layers] Layers to read features from. If not
  * provided, features will be read from all layers.
  */
 
@@ -65,8 +65,8 @@ class MVT extends FeatureFormat {
     /**
      * @private
      * @type {function((module:ol/geom/Geometry|Object.<string,*>)=)|
-     *     function(module:ol/geom/GeometryType,Array.<number>,
-     *         (Array.<number>|Array.<Array.<number>>),Object.<string,*>,number)}
+     *     function(module:ol/geom/GeometryType,Array<number>,
+     *         (Array<number>|Array<Array<number>>),Object.<string,*>,number)}
      */
     this.featureClass_ = options.featureClass ?
       options.featureClass : RenderFeature;
@@ -85,7 +85,7 @@ class MVT extends FeatureFormat {
 
     /**
      * @private
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.layers_ = options.layers ? options.layers : null;
 
@@ -103,8 +103,8 @@ class MVT extends FeatureFormat {
    * @suppress {missingProperties}
    * @param {Object} pbf PBF.
    * @param {Object} feature Raw feature.
-   * @param {Array.<number>} flatCoordinates Array to store flat coordinates in.
-   * @param {Array.<number>} ends Array to store ends in.
+   * @param {Array<number>} flatCoordinates Array to store flat coordinates in.
+   * @param {Array<number>} ends Array to store ends in.
    * @private
    */
   readRawGeometry_(pbf, feature, flatCoordinates, ends) {
@@ -252,7 +252,7 @@ class MVT extends FeatureFormat {
 
     const pbf = new PBF(/** @type {ArrayBuffer} */ (source));
     const pbfLayers = pbf.readFields(layersPBFReader, {});
-    /** @type {Array.<module:ol/Feature|module:ol/render/Feature>} */
+    /** @type {Array<module:ol/Feature|module:ol/render/Feature>} */
     const features = [];
     for (const name in pbfLayers) {
       if (layers && layers.indexOf(name) == -1) {
@@ -280,7 +280,7 @@ class MVT extends FeatureFormat {
 
   /**
    * Sets the layers that features will be read from.
-   * @param {Array.<string>} layers Layers.
+   * @param {Array<string>} layers Layers.
    * @api
    */
   setLayers(layers) {

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -17,7 +17,7 @@ import {pushParseAndPop, makeStructureNS} from '../xml.js';
 
 /**
  * @const
- * @type {Array.<null>}
+ * @type {Array<null>}
  */
 const NAMESPACE_URIS = [null];
 
@@ -75,7 +75,7 @@ class OSMXML extends XMLFeature {
       // parse nodes in ways
       for (let j = 0; j < state.ways.length; j++) {
         const values = /** @type {Object} */ (state.ways[j]);
-        /** @type {Array.<number>} */
+        /** @type {Array<number>} */
         const flatCoordinates = [];
         for (let i = 0, ii = values.ndrefs.length; i < ii; i++) {
           const point = state.nodes[values.ndrefs[i]];
@@ -133,7 +133,7 @@ const NODE_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function readNode(node, objectStack) {
   const options = /** @type {module:ol/format/Feature~ReadOptions} */ (objectStack[0]);
@@ -162,7 +162,7 @@ function readNode(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function readWay(node, objectStack) {
   const id = node.getAttribute('id');
@@ -178,7 +178,7 @@ function readWay(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function readNd(node, objectStack) {
   const values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -188,7 +188,7 @@ function readNd(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function readTag(node, objectStack) {
   const values = /** @type {Object} */ (objectStack[objectStack.length - 1]);

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -24,7 +24,7 @@ const NAMESPACE_URIS = [null];
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const WAY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -35,7 +35,7 @@ const WAY_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -123,7 +123,7 @@ class OSMXML extends XMLFeature {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const NODE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {

--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -9,7 +9,7 @@ import {makeObjectPropertyPusher, makeObjectPropertySetter, makeStructureNS, pus
 
 /**
  * @const
- * @type {Array.<null|string>}
+ * @type {Array<null|string>}
  */
 const NAMESPACE_URIS = [null, 'http://www.opengis.net/ows/1.1'];
 
@@ -206,7 +206,7 @@ const SERVICE_PROVIDER_PARSERS =
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The address.
  */
 function readAddress(node, objectStack) {
@@ -217,7 +217,7 @@ function readAddress(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The values.
  */
 function readAllowedValues(node, objectStack) {
@@ -228,7 +228,7 @@ function readAllowedValues(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The constraint.
  */
 function readConstraint(node, objectStack) {
@@ -244,7 +244,7 @@ function readConstraint(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The contact info.
  */
 function readContactInfo(node, objectStack) {
@@ -255,7 +255,7 @@ function readContactInfo(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The DCP.
  */
 function readDcp(node, objectStack) {
@@ -266,7 +266,7 @@ function readDcp(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The GET object.
  */
 function readGet(node, objectStack) {
@@ -281,7 +281,7 @@ function readGet(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The HTTP object.
  */
 function readHttp(node, objectStack) {
@@ -291,7 +291,7 @@ function readHttp(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The operation.
  */
 function readOperation(node, objectStack) {
@@ -309,7 +309,7 @@ function readOperation(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The operations metadata.
  */
 function readOperationsMetadata(node, objectStack) {
@@ -321,7 +321,7 @@ function readOperationsMetadata(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The phone.
  */
 function readPhone(node, objectStack) {
@@ -332,7 +332,7 @@ function readPhone(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The service identification.
  */
 function readServiceIdentification(node, objectStack) {
@@ -344,7 +344,7 @@ function readServiceIdentification(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The service contact.
  */
 function readServiceContact(node, objectStack) {
@@ -356,7 +356,7 @@ function readServiceContact(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The service provider.
  */
 function readServiceProvider(node, objectStack) {
@@ -368,7 +368,7 @@ function readServiceProvider(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {string|undefined} The value.
  */
 function readValue(node, objectStack) {

--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -16,7 +16,7 @@ const NAMESPACE_URIS = [null, 'http://www.opengis.net/ows/1.1'];
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -56,7 +56,7 @@ class OWS extends XML {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const ADDRESS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -71,7 +71,7 @@ const ADDRESS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const ALLOWED_VALUES_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -81,7 +81,7 @@ const ALLOWED_VALUES_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CONSTRAINT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -91,7 +91,7 @@ const CONSTRAINT_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CONTACT_INFO_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -102,7 +102,7 @@ const CONTACT_INFO_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const DCP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -112,7 +112,7 @@ const DCP_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const HTTP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -123,7 +123,7 @@ const HTTP_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const OPERATION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -133,7 +133,7 @@ const OPERATION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const OPERATIONS_METADATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -143,7 +143,7 @@ const OPERATIONS_METADATA_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PHONE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -154,7 +154,7 @@ const PHONE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const REQUEST_METHOD_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -164,7 +164,7 @@ const REQUEST_METHOD_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const SERVICE_CONTACT_PARSERS =
     makeStructureNS(
@@ -177,7 +177,7 @@ const SERVICE_CONTACT_PARSERS =
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const SERVICE_IDENTIFICATION_PARSERS =
     makeStructureNS(
@@ -193,7 +193,7 @@ const SERVICE_IDENTIFICATION_PARSERS =
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const SERVICE_PROVIDER_PARSERS =
     makeStructureNS(

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -138,7 +138,7 @@ class Polyline extends TextFeature {
  *
  * Attention: This function will modify the passed array!
  *
- * @param {Array.<number>} numbers A list of n-dimensional points.
+ * @param {Array<number>} numbers A list of n-dimensional points.
  * @param {number} stride The number of dimension of the points in the list.
  * @param {number=} opt_factor The factor by which the numbers will be
  *     multiplied. The remaining decimal places will get rounded away.
@@ -177,14 +177,14 @@ export function encodeDeltas(numbers, stride, opt_factor) {
  *     encoded string.
  * @param {number=} opt_factor The factor by which the resulting numbers will
  *     be divided. Default is `1e5`.
- * @return {Array.<number>} A list of n-dimensional points.
+ * @return {Array<number>} A list of n-dimensional points.
  * @api
  */
 export function decodeDeltas(encoded, stride, opt_factor) {
   const factor = opt_factor ? opt_factor : 1e5;
   let d;
 
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const lastNumbers = new Array(stride);
   for (d = 0; d < stride; ++d) {
     lastNumbers[d] = 0;
@@ -209,7 +209,7 @@ export function decodeDeltas(encoded, stride, opt_factor) {
  *
  * Attention: This function will modify the passed array!
  *
- * @param {Array.<number>} numbers A list of floating point numbers.
+ * @param {Array<number>} numbers A list of floating point numbers.
  * @param {number=} opt_factor The factor by which the numbers will be
  *     multiplied. The remaining decimal places will get rounded away.
  *     Default is `1e5`.
@@ -232,7 +232,7 @@ export function encodeFloats(numbers, opt_factor) {
  * @param {string} encoded An encoded string.
  * @param {number=} opt_factor The factor by which the result will be divided.
  *     Default is `1e5`.
- * @return {Array.<number>} A list of floating point numbers.
+ * @return {Array<number>} A list of floating point numbers.
  * @api
  */
 export function decodeFloats(encoded, opt_factor) {
@@ -250,7 +250,7 @@ export function decodeFloats(encoded, opt_factor) {
  *
  * Attention: This function will modify the passed array!
  *
- * @param {Array.<number>} numbers A list of signed integers.
+ * @param {Array<number>} numbers A list of signed integers.
  * @return {string} The encoded string.
  */
 export function encodeSignedIntegers(numbers) {
@@ -266,7 +266,7 @@ export function encodeSignedIntegers(numbers) {
  * Decode a list of signed integers from an encoded string
  *
  * @param {string} encoded An encoded string.
- * @return {Array.<number>} A list of signed integers.
+ * @return {Array<number>} A list of signed integers.
  */
 export function decodeSignedIntegers(encoded) {
   const numbers = decodeUnsignedIntegers(encoded);
@@ -281,7 +281,7 @@ export function decodeSignedIntegers(encoded) {
 /**
  * Encode a list of unsigned integers and return an encoded string
  *
- * @param {Array.<number>} numbers A list of unsigned integers.
+ * @param {Array<number>} numbers A list of unsigned integers.
  * @return {string} The encoded string.
  */
 export function encodeUnsignedIntegers(numbers) {
@@ -297,7 +297,7 @@ export function encodeUnsignedIntegers(numbers) {
  * Decode a list of unsigned integers from an encoded string
  *
  * @param {string} encoded An encoded string.
- * @return {Array.<number>} A list of unsigned integers.
+ * @return {Array<number>} A list of unsigned integers.
  */
 export function decodeUnsignedIntegers(encoded) {
   const numbers = [];

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -50,7 +50,7 @@ class TextFeature extends FeatureFormat {
    *
    * @param {Document|Node|Object|string} source Source.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    * @api
    */
   readFeatures(source, opt_options) {
@@ -62,7 +62,7 @@ class TextFeature extends FeatureFormat {
    * @param {string} text Text.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
    * @protected
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    */
   readFeaturesFromText(text, opt_options) {}
 
@@ -133,7 +133,7 @@ class TextFeature extends FeatureFormat {
   /**
    * Encode an array of features as string.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {string} Encoded features.
    * @api
@@ -144,7 +144,7 @@ class TextFeature extends FeatureFormat {
 
   /**
    * @abstract
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @protected
    * @return {string} Text.

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -32,7 +32,7 @@ import {get as getProjection} from '../proj.js';
  * ```
  * will result in features that have a property `'layer'` set to `'example'`.
  * When not set, no property will be added to features.
- * @property {Array.<string>} [layers] Names of the TopoJSON topology's
+ * @property {Array<string>} [layers] Names of the TopoJSON topology's
  * `objects`'s children to read features from.  If not provided, features will
  * be read from all children.
  */
@@ -62,7 +62,7 @@ class TopoJSON extends JSONFeature {
 
     /**
      * @private
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.layers_ = options.layers ? options.layers : null;
 
@@ -91,7 +91,7 @@ class TopoJSON extends JSONFeature {
       if (transform) {
         transformArcs(arcs, scale, translate);
       }
-      /** @type {Array.<module:ol/Feature>} */
+      /** @type {Array<module:ol/Feature>} */
       const features = [];
       const topoJSONFeatures = topoJSONTopology.objects;
       const property = this.layerName_;
@@ -171,14 +171,14 @@ const GEOMETRY_READERS = {
 
 /**
  * Concatenate arcs into a coordinate array.
- * @param {Array.<number>} indices Indices of arcs to concatenate.  Negative
+ * @param {Array<number>} indices Indices of arcs to concatenate.  Negative
  *     values indicate arcs need to be reversed.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs (already
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs (already
  *     transformed).
- * @return {Array.<module:ol/coordinate~Coordinate>} Coordinates array.
+ * @return {Array<module:ol/coordinate~Coordinate>} Coordinates array.
  */
 function concatenateArcs(indices, arcs) {
-  /** @type {Array.<module:ol/coordinate~Coordinate>} */
+  /** @type {Array<module:ol/coordinate~Coordinate>} */
   const coordinates = [];
   let index, arc;
   for (let i = 0, ii = indices.length; i < ii; ++i) {
@@ -208,8 +208,8 @@ function concatenateArcs(indices, arcs) {
  * Create a point from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  * @return {module:ol/geom/Point} Geometry.
  */
 function readPointGeometry(object, scale, translate) {
@@ -225,8 +225,8 @@ function readPointGeometry(object, scale, translate) {
  * Create a multi-point from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  * @return {module:ol/geom/MultiPoint} Geometry.
  */
 function readMultiPointGeometry(object, scale, translate) {
@@ -244,7 +244,7 @@ function readMultiPointGeometry(object, scale, translate) {
  * Create a linestring from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
  * @return {module:ol/geom/LineString} Geometry.
  */
 function readLineStringGeometry(object, arcs) {
@@ -257,7 +257,7 @@ function readLineStringGeometry(object, arcs) {
  * Create a multi-linestring from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
  * @return {module:ol/geom/MultiLineString} Geometry.
  */
 function readMultiLineStringGeometry(object, arcs) {
@@ -273,7 +273,7 @@ function readMultiLineStringGeometry(object, arcs) {
  * Create a polygon from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
  * @return {module:ol/geom/Polygon} Geometry.
  */
 function readPolygonGeometry(object, arcs) {
@@ -289,7 +289,7 @@ function readPolygonGeometry(object, arcs) {
  * Create a multi-polygon from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON object.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
  * @return {module:ol/geom/MultiPolygon} Geometry.
  */
 function readMultiPolygonGeometry(object, arcs) {
@@ -313,14 +313,14 @@ function readMultiPolygonGeometry(object, arcs) {
  *
  * @param {TopoJSONGeometryCollection} collection TopoJSON Geometry
  *     object.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  * @param {string|undefined} property Property to set the `GeometryCollection`'s parent
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
  * @param {module:ol/format/Feature~ReadOptions=} opt_options Read options.
- * @return {Array.<module:ol/Feature>} Array of features.
+ * @return {Array<module:ol/Feature>} Array of features.
  */
 function readFeaturesFromGeometryCollection(collection, arcs, scale, translate, property, name, opt_options) {
   const geometries = collection.geometries;
@@ -337,9 +337,9 @@ function readFeaturesFromGeometryCollection(collection, arcs, scale, translate, 
  * Create a feature from a TopoJSON geometry object.
  *
  * @param {TopoJSONGeometry} object TopoJSON geometry object.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  * @param {string|undefined} property Property to set the `GeometryCollection`'s parent
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
@@ -379,9 +379,9 @@ function readFeatureFromGeometry(object, arcs, scale, translate, property, name,
  * Apply a linear transform to array of arcs.  The provided array of arcs is
  * modified in place.
  *
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} arcs Array of arcs.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  */
 function transformArcs(arcs, scale, translate) {
   for (let i = 0, ii = arcs.length; i < ii; ++i) {
@@ -393,9 +393,9 @@ function transformArcs(arcs, scale, translate) {
 /**
  * Apply a linear transform to an arc.  The provided arc is modified in place.
  *
- * @param {Array.<module:ol/coordinate~Coordinate>} arc Arc.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<module:ol/coordinate~Coordinate>} arc Arc.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  */
 function transformArc(arc, scale, translate) {
   let x = 0;
@@ -416,8 +416,8 @@ function transformArc(arc, scale, translate) {
  * place.
  *
  * @param {module:ol/coordinate~Coordinate} vertex Vertex.
- * @param {Array.<number>} scale Scale for each dimension.
- * @param {Array.<number>} translate Translation for each dimension.
+ * @param {Array<number>} scale Scale for each dimension.
+ * @param {Array<number>} translate Translation for each dimension.
  */
 function transformVertex(vertex, scale, translate) {
   vertex[0] = vertex[0] * scale[0] + translate[0];

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -157,7 +157,7 @@ class TopoJSON extends JSONFeature {
 
 /**
  * @const
- * @type {Object.<string, function(TopoJSONGeometry, Array, ...Array): module:ol/geom/Geometry>}
+ * @type {Object<string, function(TopoJSONGeometry, Array, ...Array): module:ol/geom/Geometry>}
  */
 const GEOMETRY_READERS = {
   'Point': readPointGeometry,

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -82,7 +82,7 @@ const TRANSACTION_SERIALIZERS = {
 /**
  * @typedef {Object} Options
  * @property {Object.<string, string>|string} [featureNS] The namespace URI used for features.
- * @property {Array.<string>|string} [featureType] The feature type to parse. Only used for read operations.
+ * @property {Array<string>|string} [featureType] The feature type to parse. Only used for read operations.
  * @property {module:ol/format/GMLBase} [gmlFormat] The GML format to use to parse the response. Default is `ol/format/GML3`.
  * @property {string} [schemaLocation] Optional schemaLocation to use for serialization, this will override the default.
  */
@@ -92,14 +92,14 @@ const TRANSACTION_SERIALIZERS = {
  * @typedef {Object} WriteGetFeatureOptions
  * @property {string} featureNS The namespace URI used for features.
  * @property {string} featurePrefix The prefix for the feature namespace.
- * @property {Array.<string>} featureTypes The feature type names.
+ * @property {Array<string>} featureTypes The feature type names.
  * @property {string} [srsName] SRS name. No srsName attribute will be set on
  * geometries when this is not provided.
  * @property {string} [handle] Handle.
  * @property {string} [outputFormat] Output format.
  * @property {number} [maxFeatures] Maximum number of features to fetch.
  * @property {string} [geometryName] Geometry name to use in a BBOX filter.
- * @property {Array.<string>} [propertyNames] Optional list of property names to serialize.
+ * @property {Array<string>} [propertyNames] Optional list of property names to serialize.
  * @property {number} [startIndex] Start index to use for WFS paging. This is a
  * WFS 2.0 feature backported to WFS 1.1.0 by some Web Feature Services.
  * @property {number} [count] Number of features to retrieve when paging. This is a
@@ -123,7 +123,7 @@ const TRANSACTION_SERIALIZERS = {
  * @property {string} [handle] Handle.
  * @property {boolean} [hasZ] Must be set to true if the transaction is for
  * a 3D layer. This will allow the Z coordinate to be included in the transaction.
- * @property {Array.<Object>} nativeElements Native elements. Currently not supported.
+ * @property {Array<Object>} nativeElements Native elements. Currently not supported.
  * @property {module:ol/format/GMLBase~Options} [gmlOptions] GML options for the WFS transaction writer.
  * @property {string} [version='1.1.0'] WFS version to use for the transaction. Can be either `1.0.0` or `1.1.0`.
  */
@@ -143,7 +143,7 @@ const TRANSACTION_SERIALIZERS = {
  * @property {number} totalDeleted
  * @property {number} totalInserted
  * @property {number} totalUpdated
- * @property {Array.<string>} insertIds
+ * @property {Array<string>} insertIds
  */
 
 
@@ -214,7 +214,7 @@ class WFS extends XMLFeature {
 
     /**
      * @private
-     * @type {Array.<string>|string|undefined}
+     * @type {Array<string>|string|undefined}
      */
     this.featureType_ = options.featureType;
 
@@ -240,14 +240,14 @@ class WFS extends XMLFeature {
   }
 
   /**
-   * @return {Array.<string>|string|undefined} featureType
+   * @return {Array<string>|string|undefined} featureType
    */
   getFeatureType() {
     return this.featureType_;
   }
 
   /**
-   * @param {Array.<string>|string|undefined} featureType Feature type(s) to parse.
+   * @param {Array<string>|string|undefined} featureType Feature type(s) to parse.
    */
   setFeatureType(featureType) {
     this.featureType_ = featureType;
@@ -429,16 +429,16 @@ class WFS extends XMLFeature {
     };
     assert(Array.isArray(options.featureTypes),
       11); // `options.featureTypes` should be an Array
-    writeGetFeature(node, /** @type {!Array.<string>} */ (options.featureTypes), [context]);
+    writeGetFeature(node, /** @type {!Array<string>} */ (options.featureTypes), [context]);
     return node;
   }
 
   /**
    * Encode format as WFS `Transaction` and return the Node.
    *
-   * @param {Array.<module:ol/Feature>} inserts The features to insert.
-   * @param {Array.<module:ol/Feature>} updates The features to update.
-   * @param {Array.<module:ol/Feature>} deletes The features to delete.
+   * @param {Array<module:ol/Feature>} inserts The features to insert.
+   * @param {Array<module:ol/Feature>} updates The features to update.
+   * @param {Array<module:ol/Feature>} deletes The features to delete.
    * @param {module:ol/format/WFS~WriteTransactionOptions} options Write options.
    * @return {Node} Result.
    * @api
@@ -538,7 +538,7 @@ class WFS extends XMLFeature {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Transaction Summary.
  */
 function readTransactionSummary(node, objectStack) {
@@ -562,7 +562,7 @@ const OGC_FID_PARSERS = {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  */
 function fidParser(node, objectStack) {
   parseNode(OGC_FID_PARSERS, node, objectStack);
@@ -582,8 +582,8 @@ const INSERT_RESULTS_PARSERS = {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<string>|undefined} Insert results.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<string>|undefined} Insert results.
  */
 function readInsertResults(node, objectStack) {
   return pushParseAndPop(
@@ -594,7 +594,7 @@ function readInsertResults(node, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeFeature(node, feature, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -614,7 +614,7 @@ function writeFeature(node, feature, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {number|string} fid Feature identifier.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeOgcFidFilter(node, fid, objectStack) {
   const filter = createElementNS(OGCNS, 'Filter');
@@ -645,7 +645,7 @@ function getTypeName(featurePrefix, featureType) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeDelete(node, feature, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -666,7 +666,7 @@ function writeDelete(node, feature, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/Feature} feature Feature.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeUpdate(node, feature, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -706,7 +706,7 @@ function writeUpdate(node, feature, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {Object} pair Property name and value.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeProperty(node, pair, objectStack) {
   const name = createElementNS(WFSNS, 'Name');
@@ -735,7 +735,7 @@ function writeProperty(node, pair, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {{vendorId: string, safeToIgnore: boolean, value: string}} nativeElement The native element.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeNative(node, nativeElement, objectStack) {
   if (nativeElement.vendorId) {
@@ -782,7 +782,7 @@ const GETFEATURE_SERIALIZERS = {
 /**
  * @param {Node} node Node.
  * @param {string} featureType Feature type.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeQuery(node, featureType, objectStack) {
   const context = /** @type {Object} */ (objectStack[objectStack.length - 1]);
@@ -822,7 +822,7 @@ function writeQuery(node, featureType, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/Filter} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeFilterCondition(node, filter, objectStack) {
   /** @type {module:ol/xml~NodeStackItem} */
@@ -837,7 +837,7 @@ function writeFilterCondition(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/Bbox} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeBboxFilter(node, filter, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -851,7 +851,7 @@ function writeBboxFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/Contains} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeContainsFilter(node, filter, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -865,7 +865,7 @@ function writeContainsFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/Intersects} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeIntersectsFilter(node, filter, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -879,7 +879,7 @@ function writeIntersectsFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/Within} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeWithinFilter(node, filter, objectStack) {
   const context = objectStack[objectStack.length - 1];
@@ -893,7 +893,7 @@ function writeWithinFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/During} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeDuringFilter(node, filter, objectStack) {
 
@@ -918,7 +918,7 @@ function writeDuringFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/LogicalNary} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeLogicalFilter(node, filter, objectStack) {
   /** @type {module:ol/xml~NodeStackItem} */
@@ -937,7 +937,7 @@ function writeLogicalFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/Not} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeNotFilter(node, filter, objectStack) {
   /** @type {module:ol/xml~NodeStackItem} */
@@ -953,7 +953,7 @@ function writeNotFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/ComparisonBinary} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeComparisonFilter(node, filter, objectStack) {
   if (filter.matchCase !== undefined) {
@@ -967,7 +967,7 @@ function writeComparisonFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/IsNull} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeIsNullFilter(node, filter, objectStack) {
   writeOgcPropertyName(node, filter.propertyName);
@@ -977,7 +977,7 @@ function writeIsNullFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/IsBetween} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeIsBetweenFilter(node, filter, objectStack) {
   writeOgcPropertyName(node, filter.propertyName);
@@ -995,7 +995,7 @@ function writeIsBetweenFilter(node, filter, objectStack) {
 /**
  * @param {Node} node Node.
  * @param {module:ol/format/filter/IsLike} filter Filter.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeIsLikeFilter(node, filter, objectStack) {
   node.setAttribute('wildCard', filter.wildCard);
@@ -1069,8 +1069,8 @@ export function writeFilter(filter) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<string>} featureTypes Feature types.
- * @param {Array.<*>} objectStack Node stack.
+ * @param {Array<string>} featureTypes Feature types.
+ * @param {Array<*>} objectStack Node stack.
  */
 function writeGetFeature(node, featureTypes, objectStack) {
   const context = /** @type {Object} */ (objectStack[objectStack.length - 1]);

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -18,7 +18,7 @@ import {createElementNS, isDocument, isNode, makeArrayPusher, makeChildAppender,
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const FEATURE_COLLECTION_PARSERS = {
   'http://www.opengis.net/gml': {
@@ -30,7 +30,7 @@ const FEATURE_COLLECTION_PARSERS = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TRANSACTION_SUMMARY_PARSERS = {
   'http://www.opengis.net/wfs': {
@@ -43,7 +43,7 @@ const TRANSACTION_SUMMARY_PARSERS = {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TRANSACTION_RESPONSE_PARSERS = {
   'http://www.opengis.net/wfs': {
@@ -56,7 +56,7 @@ const TRANSACTION_RESPONSE_PARSERS = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const QUERY_SERIALIZERS = {
   'http://www.opengis.net/wfs': {
@@ -66,7 +66,7 @@ const QUERY_SERIALIZERS = {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const TRANSACTION_SERIALIZERS = {
   'http://www.opengis.net/wfs': {
@@ -81,7 +81,7 @@ const TRANSACTION_SERIALIZERS = {
 
 /**
  * @typedef {Object} Options
- * @property {Object.<string, string>|string} [featureNS] The namespace URI used for features.
+ * @property {Object<string, string>|string} [featureNS] The namespace URI used for features.
  * @property {Array<string>|string} [featureType] The feature type to parse. Only used for read operations.
  * @property {module:ol/format/GMLBase} [gmlFormat] The GML format to use to parse the response. Default is `ol/format/GML3`.
  * @property {string} [schemaLocation] Optional schemaLocation to use for serialization, this will override the default.
@@ -178,7 +178,7 @@ const FESNS = 'http://www.opengis.net/fes';
 
 
 /**
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const SCHEMA_LOCATIONS = {
   '1.1.0': 'http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd',
@@ -220,7 +220,7 @@ class WFS extends XMLFeature {
 
     /**
      * @private
-     * @type {Object.<string, string>|string|undefined}
+     * @type {Object<string, string>|string|undefined}
      */
     this.featureNS_ = options.featureNS;
 
@@ -549,7 +549,7 @@ function readTransactionSummary(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const OGC_FID_PARSERS = {
   'http://www.opengis.net/ogc': {
@@ -571,7 +571,7 @@ function fidParser(node, objectStack) {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const INSERT_RESULTS_PARSERS = {
   'http://www.opengis.net/wfs': {
@@ -751,7 +751,7 @@ function writeNative(node, nativeElement, objectStack) {
 
 
 /**
- * @type {Object.<string, Object.<string, module:ol/xml~Serializer>>}
+ * @type {Object<string, Object<string, module:ol/xml~Serializer>>}
  */
 const GETFEATURE_SERIALIZERS = {
   'http://www.opengis.net/wfs': {

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -85,7 +85,7 @@ const TokenType = {
 
 /**
  * @const
- * @type {Object.<string, string>}
+ * @type {Object<string, string>}
  */
 const WKTGeometryType = {};
 for (const type in GeometryType) {
@@ -838,7 +838,7 @@ function encodeGeometryLayout(geom) {
 
 /**
  * @const
- * @type {Object.<string, function(module:ol/geom/Geometry): string>}
+ * @type {Object<string, function(module:ol/geom/Geometry): string>}
  */
 const GeometryEncoder = {
   'Point': encodePointGeometry,

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -321,7 +321,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<module:ol/geom/Geometry>} A collection of geometries.
+   * @return {!Array<module:ol/geom/Geometry>} A collection of geometries.
    * @private
    */
   parseGeometryCollectionText_() {
@@ -340,7 +340,7 @@ class Parser {
   }
 
   /**
-   * @return {Array.<number>} All values in a point.
+   * @return {Array<number>} All values in a point.
    * @private
    */
   parsePointText_() {
@@ -356,7 +356,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} All points in a linestring.
+   * @return {!Array<!Array<number>>} All points in a linestring.
    * @private
    */
   parseLineStringText_() {
@@ -372,7 +372,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} All points in a polygon.
+   * @return {!Array<!Array<number>>} All points in a polygon.
    * @private
    */
   parsePolygonText_() {
@@ -388,7 +388,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} All points in a multipoint.
+   * @return {!Array<!Array<number>>} All points in a multipoint.
    * @private
    */
   parseMultiPointText_() {
@@ -409,7 +409,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} All linestring points
+   * @return {!Array<!Array<number>>} All linestring points
    *                                        in a multilinestring.
    * @private
    */
@@ -426,7 +426,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} All polygon points in a multipolygon.
+   * @return {!Array<!Array<number>>} All polygon points in a multipolygon.
    * @private
    */
   parseMultiPolygonText_() {
@@ -442,7 +442,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<number>} A point.
+   * @return {!Array<number>} A point.
    * @private
    */
   parsePoint_() {
@@ -463,7 +463,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} An array of points.
+   * @return {!Array<!Array<number>>} An array of points.
    * @private
    */
   parsePointList_() {
@@ -475,7 +475,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} An array of points.
+   * @return {!Array<!Array<number>>} An array of points.
    * @private
    */
   parsePointTextList_() {
@@ -487,7 +487,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} An array of points.
+   * @return {!Array<!Array<number>>} An array of points.
    * @private
    */
   parseLineStringTextList_() {
@@ -499,7 +499,7 @@ class Parser {
   }
 
   /**
-   * @return {!Array.<!Array.<number>>} An array of points.
+   * @return {!Array<!Array<number>>} An array of points.
    * @private
    */
   parsePolygonTextList_() {

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -10,7 +10,7 @@ import {makeArrayPusher, makeObjectPropertyPusher, makeObjectPropertySetter,
 
 /**
  * @const
- * @type {Array.<null|string>}
+ * @type {Array<null|string>}
  */
 const NAMESPACE_URIS = [
   null,
@@ -287,7 +287,7 @@ const KEYWORDLIST_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Attribution object.
  */
 function readAttribution(node, objectStack) {
@@ -297,7 +297,7 @@ function readAttribution(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object} Bounding box object.
  */
 function readBoundingBox(node, objectStack) {
@@ -323,7 +323,7 @@ function readBoundingBox(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/extent~Extent|undefined} Bounding box object.
  */
 function readEXGeographicBoundingBox(node, objectStack) {
@@ -355,7 +355,7 @@ function readEXGeographicBoundingBox(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Capability object.
  */
 function readCapability(node, objectStack) {
@@ -365,7 +365,7 @@ function readCapability(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Service object.
  */
 function readService(node, objectStack) {
@@ -375,7 +375,7 @@ function readService(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Contact information object.
  */
 function readContactInformation(node, objectStack) {
@@ -385,7 +385,7 @@ function readContactInformation(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Contact person object.
  */
 function readContactPersonPrimary(node, objectStack) {
@@ -395,7 +395,7 @@ function readContactPersonPrimary(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Contact address object.
  */
 function readContactAddress(node, objectStack) {
@@ -405,8 +405,8 @@ function readContactAddress(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<string>|undefined} Format array.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<string>|undefined} Format array.
  */
 function readException(node, objectStack) {
   return pushParseAndPop([], EXCEPTION_PARSERS, node, objectStack);
@@ -415,7 +415,7 @@ function readException(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Layer object.
  */
 function readCapabilityLayer(node, objectStack) {
@@ -425,7 +425,7 @@ function readCapabilityLayer(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Layer object.
  */
 function readLayer(node, objectStack) {
@@ -497,7 +497,7 @@ function readLayer(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object} Dimension object.
  */
 function readDimension(node, objectStack) {
@@ -517,7 +517,7 @@ function readDimension(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Online resource object.
  */
 function readFormatOnlineresource(node, objectStack) {
@@ -527,7 +527,7 @@ function readFormatOnlineresource(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Request object.
  */
 function readRequest(node, objectStack) {
@@ -537,7 +537,7 @@ function readRequest(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} DCP type object.
  */
 function readDCPType(node, objectStack) {
@@ -547,7 +547,7 @@ function readDCPType(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} HTTP object.
  */
 function readHTTP(node, objectStack) {
@@ -557,7 +557,7 @@ function readHTTP(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Operation type object.
  */
 function readOperationType(node, objectStack) {
@@ -567,7 +567,7 @@ function readOperationType(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Online resource object.
  */
 function readSizedFormatOnlineresource(node, objectStack) {
@@ -586,7 +586,7 @@ function readSizedFormatOnlineresource(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Authority URL object.
  */
 function readAuthorityURL(node, objectStack) {
@@ -601,7 +601,7 @@ function readAuthorityURL(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Metadata URL object.
  */
 function readMetadataURL(node, objectStack) {
@@ -616,7 +616,7 @@ function readMetadataURL(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Style object.
  */
 function readStyle(node, objectStack) {
@@ -626,8 +626,8 @@ function readStyle(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
- * @return {Array.<string>|undefined} Keyword list.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Array<string>|undefined} Keyword list.
  */
 function readKeywordList(node, objectStack) {
   return pushParseAndPop([], KEYWORDLIST_PARSERS, node, objectStack);

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -20,7 +20,7 @@ const NAMESPACE_URIS = [
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -31,7 +31,7 @@ const PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CAPABILITY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -84,7 +84,7 @@ class WMSCapabilities extends XML {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const SERVICE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -104,7 +104,7 @@ const SERVICE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CONTACT_INFORMATION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -119,7 +119,7 @@ const CONTACT_INFORMATION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CONTACT_PERSON_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -130,7 +130,7 @@ const CONTACT_PERSON_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CONTACT_ADDRESS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -145,7 +145,7 @@ const CONTACT_ADDRESS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const EXCEPTION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -155,7 +155,7 @@ const EXCEPTION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LAYER_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -182,7 +182,7 @@ const LAYER_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const ATTRIBUTION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -194,7 +194,7 @@ const ATTRIBUTION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS =
     makeStructureNS(NAMESPACE_URIS, {
@@ -207,7 +207,7 @@ const EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS =
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const REQUEST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -219,7 +219,7 @@ const REQUEST_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const OPERATIONTYPE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -230,7 +230,7 @@ const OPERATIONTYPE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const DCPTYPE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -240,7 +240,7 @@ const DCPTYPE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const HTTP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -251,7 +251,7 @@ const HTTP_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -266,7 +266,7 @@ const STYLE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const FORMAT_ONLINERESOURCE_PARSERS =
     makeStructureNS(NAMESPACE_URIS, {
@@ -277,7 +277,7 @@ const FORMAT_ONLINERESOURCE_PARSERS =
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const KEYWORDLIST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -429,7 +429,7 @@ function readCapabilityLayer(node, objectStack) {
  * @return {Object|undefined} Layer object.
  */
 function readLayer(node, objectStack) {
-  const parentLayerObject = /**  @type {!Object.<string,*>} */ (objectStack[objectStack.length - 1]);
+  const parentLayerObject = /**  @type {!Object<string,*>} */ (objectStack[objectStack.length - 1]);
 
   const layerObject = pushParseAndPop({}, LAYER_PARSERS, node, objectStack);
 

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -10,7 +10,7 @@ import {makeArrayPusher, makeStructureNS, pushParseAndPop} from '../xml.js';
 
 /**
  * @typedef {Object} Options
- * @property {Array.<string>} [layers] If set, only features of the given layers will be returned by the format when read.
+ * @property {Array<string>} [layers] If set, only features of the given layers will be returned by the format when read.
  */
 
 
@@ -61,20 +61,20 @@ class WMSGetFeatureInfo extends XMLFeature {
 
     /**
      * @private
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.layers_ = options.layers ? options.layers : null;
   }
 
   /**
-   * @return {Array.<string>} layers
+   * @return {Array<string>} layers
    */
   getLayers() {
     return this.layers_;
   }
 
   /**
-   * @param {Array.<string>} layers Layers to parse.
+   * @param {Array<string>} layers Layers to parse.
    */
   setLayers(layers) {
     this.layers_ = layers;
@@ -82,14 +82,14 @@ class WMSGetFeatureInfo extends XMLFeature {
 
   /**
    * @param {Node} node Node.
-   * @param {Array.<*>} objectStack Object stack.
-   * @return {Array.<module:ol/Feature>} Features.
+   * @param {Array<*>} objectStack Object stack.
+   * @return {Array<module:ol/Feature>} Features.
    * @private
    */
   readFeatures_(node, objectStack) {
     node.setAttribute('namespaceURI', this.featureNS_);
     const localName = node.localName;
-    /** @type {Array.<module:ol/Feature>} */
+    /** @type {Array<module:ol/Feature>} */
     let features = [];
     if (node.childNodes.length === 0) {
       return features;

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -12,7 +12,7 @@ import {pushParseAndPop, makeStructureNS,
 
 /**
  * @const
- * @type {Array.<null|string>}
+ * @type {Array<null|string>}
  */
 const NAMESPACE_URIS = [
   null,
@@ -22,7 +22,7 @@ const NAMESPACE_URIS = [
 
 /**
  * @const
- * @type {Array.<null|string>}
+ * @type {Array<null|string>}
  */
 const OWS_NAMESPACE_URIS = [
   null,
@@ -219,7 +219,7 @@ const TM_PARSERS = makeStructureNS(
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Attribution object.
  */
 function readContents(node, objectStack) {
@@ -229,7 +229,7 @@ function readContents(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Layers object.
  */
 function readLayer(node, objectStack) {
@@ -239,7 +239,7 @@ function readLayer(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Tile Matrix Set object.
  */
 function readTileMatrixSet(node, objectStack) {
@@ -249,7 +249,7 @@ function readTileMatrixSet(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Style object.
  */
 function readStyle(node, objectStack) {
@@ -266,7 +266,7 @@ function readStyle(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Tile Matrix Set Link object.
  */
 function readTileMatrixSetLink(node, objectStack) {
@@ -276,7 +276,7 @@ function readTileMatrixSetLink(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Dimension object.
  */
 function readDimensions(node, objectStack) {
@@ -286,7 +286,7 @@ function readDimensions(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Resource URL object.
  */
 function readResourceUrl(node, objectStack) {
@@ -309,7 +309,7 @@ function readResourceUrl(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} WGS84 BBox object.
  */
 function readWgs84BoundingBox(node, objectStack) {
@@ -323,7 +323,7 @@ function readWgs84BoundingBox(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Legend object.
  */
 function readLegendUrl(node, objectStack) {
@@ -336,7 +336,7 @@ function readLegendUrl(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Coordinates object.
  */
 function readCoordinates(node, objectStack) {
@@ -355,7 +355,7 @@ function readCoordinates(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} TileMatrix object.
  */
 function readTileMatrix(node, objectStack) {
@@ -365,7 +365,7 @@ function readTileMatrix(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} TileMatrixSetLimits Object.
  */
 function readTileMatrixLimitsList(node, objectStack) {
@@ -375,7 +375,7 @@ function readTileMatrixLimitsList(node, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} TileMatrixLimits Array.
  */
 function readTileMatrixLimits(node, objectStack) {

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -32,7 +32,7 @@ const OWS_NAMESPACE_URIS = [
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -87,7 +87,7 @@ class WMTSCapabilities extends XML {
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const CONTENTS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -98,7 +98,7 @@ const CONTENTS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const LAYER_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -117,7 +117,7 @@ const LAYER_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -130,7 +130,7 @@ const STYLE_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TMS_LINKS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -140,7 +140,7 @@ const TMS_LINKS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TMS_LIMITS_LIST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -150,7 +150,7 @@ const TMS_LIMITS_LIST_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TMS_LIMITS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -164,7 +164,7 @@ const TMS_LIMITS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const DIMENSION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -177,7 +177,7 @@ const DIMENSION_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const WGS84_BBOX_READERS = makeStructureNS(
   OWS_NAMESPACE_URIS, {
@@ -188,7 +188,7 @@ const WGS84_BBOX_READERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TMS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
@@ -202,7 +202,7 @@ const TMS_PARSERS = makeStructureNS(
 
 /**
  * @const
- * @type {Object.<string, Object.<string, module:ol/xml~Parser>>}
+ * @type {Object<string, Object<string, module:ol/xml~Parser>>}
  */
 const TM_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -82,7 +82,7 @@ class XMLFeature extends FeatureFormat {
    * @function
    * @param {Document|Node|Object|string} source Source.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    * @api
    */
   readFeatures(source, opt_options) {
@@ -103,10 +103,10 @@ class XMLFeature extends FeatureFormat {
    * @param {Document} doc Document.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
    * @protected
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    */
   readFeaturesFromDocument(doc, opt_options) {
-    /** @type {Array.<module:ol/Feature>} */
+    /** @type {Array<module:ol/Feature>} */
     const features = [];
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
@@ -121,7 +121,7 @@ class XMLFeature extends FeatureFormat {
    * @param {Node} node Node.
    * @param {module:ol/format/Feature~ReadOptions=} opt_options Options.
    * @protected
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    */
   readFeaturesFromNode(node, opt_options) {}
 
@@ -221,7 +221,7 @@ class XMLFeature extends FeatureFormat {
   /**
    * Encode an array of features as string.
    *
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Write options.
    * @return {string} Result.
    * @api
@@ -232,7 +232,7 @@ class XMLFeature extends FeatureFormat {
   }
 
   /**
-   * @param {Array.<module:ol/Feature>} features Features.
+   * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
    * @return {Node} Node.
    */

--- a/src/ol/format/filter/LogicalNary.js
+++ b/src/ol/format/filter/LogicalNary.js
@@ -22,7 +22,7 @@ class LogicalNary extends Filter {
     super(tagName);
 
     /**
-     * @type {Array.<module:ol/format/filter/Filter>}
+     * @type {Array<module:ol/format/filter/Filter>}
      */
     this.conditions = Array.prototype.slice.call(arguments, 1);
     assert(this.conditions.length >= 2, 57); // At least 2 conditions are required.

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -179,7 +179,7 @@ class Circle extends SimpleGeometry {
     if (!this.flatCoordinates) {
       this.flatCoordinates = [];
     }
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const flatCoordinates = this.flatCoordinates;
     let offset = deflateCoordinate(
       flatCoordinates, 0, center, this.stride);

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -47,7 +47,7 @@ class Geometry extends BaseObject {
 
     /**
      * @protected
-     * @type {Object.<string, module:ol/geom/Geometry>}
+     * @type {Object<string, module:ol/geom/Geometry>}
      */
     this.simplifiedGeometryCache = {};
 

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -17,7 +17,7 @@ import {clear} from '../obj.js';
 class GeometryCollection extends Geometry {
 
   /**
-   * @param {Array.<module:ol/geom/Geometry>=} opt_geometries Geometries.
+   * @param {Array<module:ol/geom/Geometry>=} opt_geometries Geometries.
    */
   constructor(opt_geometries) {
 
@@ -25,7 +25,7 @@ class GeometryCollection extends Geometry {
 
     /**
      * @private
-     * @type {Array.<module:ol/geom/Geometry>}
+     * @type {Array<module:ol/geom/Geometry>}
      */
     this.geometries_ = opt_geometries ? opt_geometries : null;
 
@@ -114,7 +114,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Return the geometries that make up this geometry collection.
-   * @return {Array.<module:ol/geom/Geometry>} Geometries.
+   * @return {Array<module:ol/geom/Geometry>} Geometries.
    * @api
    */
   getGeometries() {
@@ -122,7 +122,7 @@ class GeometryCollection extends Geometry {
   }
 
   /**
-   * @return {Array.<module:ol/geom/Geometry>} Geometries.
+   * @return {Array<module:ol/geom/Geometry>} Geometries.
    */
   getGeometriesArray() {
     return this.geometries_;
@@ -228,7 +228,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Set the geometries that make up this geometry collection.
-   * @param {Array.<module:ol/geom/Geometry>} geometries Geometries.
+   * @param {Array<module:ol/geom/Geometry>} geometries Geometries.
    * @api
    */
   setGeometries(geometries) {
@@ -236,7 +236,7 @@ class GeometryCollection extends Geometry {
   }
 
   /**
-   * @param {Array.<module:ol/geom/Geometry>} geometries Geometries.
+   * @param {Array<module:ol/geom/Geometry>} geometries Geometries.
    */
   setGeometriesArray(geometries) {
     this.unlistenGeometriesChange_();
@@ -283,8 +283,8 @@ class GeometryCollection extends Geometry {
 
 
 /**
- * @param {Array.<module:ol/geom/Geometry>} geometries Geometries.
- * @return {Array.<module:ol/geom/Geometry>} Cloned geometries.
+ * @param {Array<module:ol/geom/Geometry>} geometries Geometries.
+ * @return {Array<module:ol/geom/Geometry>} Cloned geometries.
  */
 function cloneGeometries(geometries) {
   const clonedGeometries = [];

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -24,7 +24,7 @@ import {douglasPeucker} from '../geom/flat/simplify.js';
 class LineString extends SimpleGeometry {
 
   /**
-   * @param {Array.<module:ol/coordinate~Coordinate>|Array.<number>} coordinates Coordinates.
+   * @param {Array<module:ol/coordinate~Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    */
@@ -146,7 +146,7 @@ class LineString extends SimpleGeometry {
 
   /**
    * Return the coordinates of the linestring.
-   * @return {Array.<module:ol/coordinate~Coordinate>} Coordinates.
+   * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
    * @override
    * @api
    */
@@ -182,7 +182,7 @@ class LineString extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<number>} Flat midpoint.
+   * @return {Array<number>} Flat midpoint.
    */
   getFlatMidpoint() {
     if (this.flatMidpointRevision_ != this.getRevision()) {
@@ -223,7 +223,7 @@ class LineString extends SimpleGeometry {
 
   /**
    * Set the coordinates of the linestring.
-   * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+   * @param {!Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    * @override
    * @api

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -21,7 +21,7 @@ import {douglasPeucker} from '../geom/flat/simplify.js';
 class LinearRing extends SimpleGeometry {
 
   /**
-   * @param {Array.<module:ol/coordinate~Coordinate>|Array.<number>} coordinates Coordinates.
+   * @param {Array<module:ol/coordinate~Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    */
@@ -87,7 +87,7 @@ class LinearRing extends SimpleGeometry {
 
   /**
    * Return the coordinates of the linear ring.
-   * @return {Array.<module:ol/coordinate~Coordinate>} Coordinates.
+   * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
    * @override
    * @api
    */
@@ -122,7 +122,7 @@ class LinearRing extends SimpleGeometry {
 
   /**
    * Set the coordinates of the linear ring.
-   * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+   * @param {!Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    * @override
    * @api

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -23,18 +23,18 @@ import {douglasPeuckerArray} from '../geom/flat/simplify.js';
 class MultiLineString extends SimpleGeometry {
 
   /**
-   * @param {Array.<Array.<module:ol/coordinate~Coordinate>|module:ol/geom~MultiLineString>|Array.<number>} coordinates
+   * @param {Array<Array<module:ol/coordinate~Coordinate>|module:ol/geom~MultiLineString>|Array<number>} coordinates
    *     Coordinates or LineString geometries. (For internal use, flat coordinates in
    *     combination with `opt_layout` and `opt_ends` are also accepted.)
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
-   * @param {Array.<number>} opt_ends Flat coordinate ends for internal use.
+   * @param {Array<number>} opt_ends Flat coordinate ends for internal use.
    */
   constructor(coordinates, opt_layout, opt_ends) {
 
     super();
 
     /**
-     * @type {Array.<number>}
+     * @type {Array<number>}
      * @private
      */
     this.ends_ = [];
@@ -152,7 +152,7 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Return the coordinates of the multilinestring.
-   * @return {Array.<Array.<module:ol/coordinate~Coordinate>>} Coordinates.
+   * @return {Array<Array<module:ol/coordinate~Coordinate>>} Coordinates.
    * @override
    * @api
    */
@@ -162,7 +162,7 @@ class MultiLineString extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<number>} Ends.
+   * @return {Array<number>} Ends.
    */
   getEnds() {
     return this.ends_;
@@ -184,14 +184,14 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Return the linestrings of this multilinestring.
-   * @return {Array.<module:ol/geom/LineString>} LineStrings.
+   * @return {Array<module:ol/geom/LineString>} LineStrings.
    * @api
    */
   getLineStrings() {
     const flatCoordinates = this.flatCoordinates;
     const ends = this.ends_;
     const layout = this.layout;
-    /** @type {Array.<module:ol/geom/LineString>} */
+    /** @type {Array<module:ol/geom/LineString>} */
     const lineStrings = [];
     let offset = 0;
     for (let i = 0, ii = ends.length; i < ii; ++i) {
@@ -204,7 +204,7 @@ class MultiLineString extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<number>} Flat midpoints.
+   * @return {Array<number>} Flat midpoints.
    */
   getFlatMidpoints() {
     const midpoints = [];
@@ -253,7 +253,7 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Set the coordinates of the multilinestring.
-   * @param {!Array.<Array.<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
+   * @param {!Array<Array<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    * @override
    * @api

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -19,7 +19,7 @@ import {squaredDistance as squaredDx} from '../math.js';
 class MultiPoint extends SimpleGeometry {
 
   /**
-   * @param {Array.<module:ol/coordinate~Coordinate>|Array.<number>} coordinates Coordinates.
+   * @param {Array<module:ol/coordinate~Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    */
@@ -82,7 +82,7 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Return the coordinates of the multipoint.
-   * @return {Array.<module:ol/coordinate~Coordinate>} Coordinates.
+   * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
    * @override
    * @api
    */
@@ -108,14 +108,14 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Return the points of this multipoint.
-   * @return {Array.<module:ol/geom/Point>} Points.
+   * @return {Array<module:ol/geom/Point>} Points.
    * @api
    */
   getPoints() {
     const flatCoordinates = this.flatCoordinates;
     const layout = this.layout;
     const stride = this.stride;
-    /** @type {Array.<module:ol/geom/Point>} */
+    /** @type {Array<module:ol/geom/Point>} */
     const points = [];
     for (let i = 0, ii = flatCoordinates.length; i < ii; i += stride) {
       const point = new Point(flatCoordinates.slice(i, i + stride), layout);
@@ -151,7 +151,7 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Set the coordinates of the multipoint.
-   * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+   * @param {!Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    * @override
    * @api

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -28,17 +28,17 @@ import {quantizeMultiArray} from '../geom/flat/simplify.js';
 class MultiPolygon extends SimpleGeometry {
 
   /**
-   * @param {Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>|Array.<number>} coordinates Coordinates.
+   * @param {Array<Array<Array<module:ol/coordinate~Coordinate>>>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinats in combination with `opt_layout` and `opt_endss` are also accepted.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
-   * @param {Array.<number>} opt_endss Array of ends for internal use with flat coordinates.
+   * @param {Array<number>} opt_endss Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
 
     super();
 
     /**
-     * @type {Array.<Array.<number>>}
+     * @type {Array<Array<number>>}
      * @private
      */
     this.endss_ = [];
@@ -51,7 +51,7 @@ class MultiPolygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.flatInteriorPoints_ = null;
 
@@ -75,7 +75,7 @@ class MultiPolygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.orientedFlatCoordinates_ = null;
 
@@ -115,7 +115,7 @@ class MultiPolygon extends SimpleGeometry {
    * @api
    */
   appendPolygon(polygon) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     let ends;
     if (!this.flatCoordinates) {
       this.flatCoordinates = polygon.getFlatCoordinates().slice();
@@ -193,7 +193,7 @@ class MultiPolygon extends SimpleGeometry {
    *     (clockwise for exterior and counter-clockwise for interior rings).
    *     By default, coordinate orientation will depend on how the geometry was
    *     constructed.
-   * @return {Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>} Coordinates.
+   * @return {Array<Array<Array<module:ol/coordinate~Coordinate>>>} Coordinates.
    * @override
    * @api
    */
@@ -212,14 +212,14 @@ class MultiPolygon extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<Array.<number>>} Endss.
+   * @return {Array<Array<number>>} Endss.
    */
   getEndss() {
     return this.endss_;
   }
 
   /**
-   * @return {Array.<number>} Flat interior points.
+   * @return {Array<number>} Flat interior points.
    */
   getFlatInteriorPoints() {
     if (this.flatInteriorPointsRevision_ != this.getRevision()) {
@@ -244,7 +244,7 @@ class MultiPolygon extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<number>} Oriented flat coordinates.
+   * @return {Array<number>} Oriented flat coordinates.
    */
   getOrientedFlatCoordinates() {
     if (this.orientedRevision_ != this.getRevision()) {
@@ -305,7 +305,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Return the polygons of this multipolygon.
-   * @return {Array.<module:ol/geom/Polygon>} Polygons.
+   * @return {Array<module:ol/geom/Polygon>} Polygons.
    * @api
    */
   getPolygons() {
@@ -348,7 +348,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Set the coordinates of the multipolygon.
-   * @param {!Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>} coordinates Coordinates.
+   * @param {!Array<Array<Array<module:ol/coordinate~Coordinate>>>} coordinates Coordinates.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    * @override
    * @api

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -29,7 +29,7 @@ import {modulo} from '../math.js';
 class Polygon extends SimpleGeometry {
 
   /**
-   * @param {!Array.<Array.<module:ol/coordinate~Coordinate>>|!Array.<number>} coordinates
+   * @param {!Array<Array<module:ol/coordinate~Coordinate>>|!Array<number>} coordinates
    *     Array of linear rings that define the polygon. The first linear ring of the
    *     array defines the outer-boundary or surface of the polygon. Each subsequent
    *     linear ring defines a hole in the surface of the polygon. A linear ring is
@@ -37,14 +37,14 @@ class Polygon extends SimpleGeometry {
    *     equivalent. (For internal use, flat coordinates in combination with
    *     `opt_layout` and `opt_ends` are also accepted.)
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
-   * @param {Array.<number>=} opt_ends Ends (for internal use with flat coordinates).
+   * @param {Array<number>=} opt_ends Ends (for internal use with flat coordinates).
    */
   constructor(coordinates, opt_layout, opt_ends) {
 
     super();
 
     /**
-     * @type {Array.<number>}
+     * @type {Array<number>}
      * @private
      */
     this.ends_ = [];
@@ -81,7 +81,7 @@ class Polygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.orientedFlatCoordinates_ = null;
 
@@ -162,7 +162,7 @@ class Polygon extends SimpleGeometry {
    *     (clockwise for exterior and counter-clockwise for interior rings).
    *     By default, coordinate orientation will depend on how the geometry was
    *     constructed.
-   * @return {Array.<Array.<module:ol/coordinate~Coordinate>>} Coordinates.
+   * @return {Array<Array<module:ol/coordinate~Coordinate>>} Coordinates.
    * @override
    * @api
    */
@@ -181,14 +181,14 @@ class Polygon extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<number>} Ends.
+   * @return {Array<number>} Ends.
    */
   getEnds() {
     return this.ends_;
   }
 
   /**
-   * @return {Array.<number>} Interior point.
+   * @return {Array<number>} Interior point.
    */
   getFlatInteriorPoint() {
     if (this.flatInteriorPointRevision_ != this.getRevision()) {
@@ -242,7 +242,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Return the linear rings of the polygon.
-   * @return {Array.<module:ol/geom/LinearRing>} Linear rings.
+   * @return {Array<module:ol/geom/LinearRing>} Linear rings.
    * @api
    */
   getLinearRings() {
@@ -261,7 +261,7 @@ class Polygon extends SimpleGeometry {
   }
 
   /**
-   * @return {Array.<number>} Oriented flat coordinates.
+   * @return {Array<number>} Oriented flat coordinates.
    */
   getOrientedFlatCoordinates() {
     if (this.orientedRevision_ != this.getRevision()) {
@@ -312,7 +312,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Set the coordinates of the polygon.
-   * @param {!Array.<Array.<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
+   * @param {!Array<Array<module:ol/coordinate~Coordinate>>} coordinates Coordinates.
    * @param {module:ol/geom/GeometryLayout=} opt_layout Layout.
    * @override
    * @api
@@ -347,7 +347,7 @@ export default Polygon;
  */
 export function circular(center, radius, opt_n, opt_sphereRadius) {
   const n = opt_n ? opt_n : 32;
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const flatCoordinates = [];
   for (let i = 0; i < n; ++i) {
     extend(flatCoordinates, sphereOffset(center, radius, 2 * Math.PI * i / n, opt_sphereRadius));

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -35,7 +35,7 @@ class SimpleGeometry extends Geometry {
 
     /**
      * @protected
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.flatCoordinates = null;
 
@@ -65,7 +65,7 @@ class SimpleGeometry extends Geometry {
   }
 
   /**
-   * @return {Array.<number>} Flat coordinates.
+   * @return {Array<number>} Flat coordinates.
    */
   getFlatCoordinates() {
     return this.flatCoordinates;
@@ -146,7 +146,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @param {module:ol/geom/GeometryLayout} layout Layout.
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
     */
   setFlatCoordinates(layout, flatCoordinates) {
     this.stride = getStrideForLayout(layout);
@@ -300,8 +300,8 @@ SimpleGeometry.prototype.containsXY = FALSE;
 /**
  * @param {module:ol/geom/SimpleGeometry} simpleGeometry Simple geometry.
  * @param {module:ol/transform~Transform} transform Transform.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Transformed flat coordinates.
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Transformed flat coordinates.
  */
 export function transformGeom2D(simpleGeometry, transform, opt_dest) {
   const flatCoordinates = simpleGeometry.getFlatCoordinates();

--- a/src/ol/geom/flat/area.js
+++ b/src/ol/geom/flat/area.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -26,9 +26,9 @@ export function linearRing(flatCoordinates, offset, end, stride) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @return {number} Area.
  */
@@ -44,9 +44,9 @@ export function linearRings(flatCoordinates, offset, ends, stride) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @return {number} Area.
  */

--- a/src/ol/geom/flat/center.js
+++ b/src/ol/geom/flat/center.js
@@ -5,11 +5,11 @@ import {createEmpty, createOrUpdateFromFlatCoordinates} from '../../extent.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
- * @return {Array.<number>} Flat centers.
+ * @return {Array<number>} Flat centers.
  */
 export function linearRingss(flatCoordinates, offset, endss, stride) {
   const flatCenters = [];

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -8,13 +8,13 @@ import {lerp, squaredDistance as squaredDx} from '../../math.js';
  * Returns the point on the 2D line segment flatCoordinates[offset1] to
  * flatCoordinates[offset2] that is closest to the point (x, y).  Extra
  * dimensions are linearly interpolated.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset1 Offset 1.
  * @param {number} offset2 Offset 2.
  * @param {number} stride Stride.
  * @param {number} x X.
  * @param {number} y Y.
- * @param {Array.<number>} closestPoint Closest point.
+ * @param {Array<number>} closestPoint Closest point.
  */
 function assignClosest(flatCoordinates, offset1, offset2, stride, x, y, closestPoint) {
   const x1 = flatCoordinates[offset1];
@@ -49,7 +49,7 @@ function assignClosest(flatCoordinates, offset1, offset2, stride, x, y, closestP
 /**
  * Return the squared of the largest distance between any pair of consecutive
  * coordinates.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -74,9 +74,9 @@ export function maxSquaredDelta(flatCoordinates, offset, end, stride, max) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {number} max Max squared delta.
  * @return {number} Max squared delta.
@@ -93,9 +93,9 @@ export function arrayMaxSquaredDelta(flatCoordinates, offset, ends, stride, max)
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @param {number} max Max squared delta.
  * @return {number} Max squared delta.
@@ -112,7 +112,7 @@ export function multiArrayMaxSquaredDelta(flatCoordinates, offset, endss, stride
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -120,9 +120,9 @@ export function multiArrayMaxSquaredDelta(flatCoordinates, offset, endss, stride
  * @param {boolean} isRing Is ring.
  * @param {number} x X.
  * @param {number} y Y.
- * @param {Array.<number>} closestPoint Closest point.
+ * @param {Array<number>} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
- * @param {Array.<number>=} opt_tmpPoint Temporary point object.
+ * @param {Array<number>=} opt_tmpPoint Temporary point object.
  * @return {number} Minimum squared distance.
  */
 export function assignClosestPoint(flatCoordinates, offset, end,
@@ -193,17 +193,17 @@ export function assignClosestPoint(flatCoordinates, offset, end,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {number} maxDelta Max delta.
  * @param {boolean} isRing Is ring.
  * @param {number} x X.
  * @param {number} y Y.
- * @param {Array.<number>} closestPoint Closest point.
+ * @param {Array<number>} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
- * @param {Array.<number>=} opt_tmpPoint Temporary point object.
+ * @param {Array<number>=} opt_tmpPoint Temporary point object.
  * @return {number} Minimum squared distance.
  */
 export function assignClosestArrayPoint(flatCoordinates, offset, ends,
@@ -222,17 +222,17 @@ export function assignClosestArrayPoint(flatCoordinates, offset, ends,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @param {number} maxDelta Max delta.
  * @param {boolean} isRing Is ring.
  * @param {number} x X.
  * @param {number} y Y.
- * @param {Array.<number>} closestPoint Closest point.
+ * @param {Array<number>} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
- * @param {Array.<number>=} opt_tmpPoint Temporary point object.
+ * @param {Array<number>=} opt_tmpPoint Temporary point object.
  * @return {number} Minimum squared distance.
  */
 export function assignClosestMultiArrayPoint(flatCoordinates, offset,

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -5,7 +5,7 @@ import {forEachCorner} from '../../extent.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -26,7 +26,7 @@ export function linearRingContainsExtent(flatCoordinates, offset, end, stride, e
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -63,9 +63,9 @@ export function linearRingContainsXY(flatCoordinates, offset, end, stride, x, y)
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {number} x X.
  * @param {number} y Y.
@@ -88,9 +88,9 @@ export function linearRingsContainsXY(flatCoordinates, offset, ends, stride, x, 
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @param {number} x X.
  * @param {number} y Y.

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {number} stride Stride.
@@ -19,9 +19,9 @@ export function deflateCoordinate(flatCoordinates, offset, coordinate, stride) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<module:ol/coordinate~Coordinate>} coordinates Coordinates.
+ * @param {Array<module:ol/coordinate~Coordinate>} coordinates Coordinates.
  * @param {number} stride Stride.
  * @return {number} offset Offset.
  */
@@ -37,12 +37,12 @@ export function deflateCoordinates(flatCoordinates, offset, coordinates, stride)
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>} coordinatess Coordinatess.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>} coordinatess Coordinatess.
  * @param {number} stride Stride.
- * @param {Array.<number>=} opt_ends Ends.
- * @return {Array.<number>} Ends.
+ * @param {Array<number>=} opt_ends Ends.
+ * @return {Array<number>} Ends.
  */
 export function deflateCoordinatesArray(flatCoordinates, offset, coordinatess, stride, opt_ends) {
   const ends = opt_ends ? opt_ends : [];
@@ -59,12 +59,12 @@ export function deflateCoordinatesArray(flatCoordinates, offset, coordinatess, s
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>} coordinatesss Coordinatesss.
+ * @param {Array<Array<Array<module:ol/coordinate~Coordinate>>>} coordinatesss Coordinatesss.
  * @param {number} stride Stride.
- * @param {Array.<Array.<number>>=} opt_endss Endss.
- * @return {Array.<Array.<number>>} Endss.
+ * @param {Array<Array<number>>=} opt_endss Endss.
+ * @return {Array<Array<number>>} Endss.
  */
 export function deflateMultiCoordinatesArray(flatCoordinates, offset, coordinatesss, stride, opt_endss) {
   const endss = opt_endss ? opt_endss : [];

--- a/src/ol/geom/flat/flip.js
+++ b/src/ol/geom/flat/flip.js
@@ -4,13 +4,13 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {Array.<number>=} opt_dest Destination.
+ * @param {Array<number>=} opt_dest Destination.
  * @param {number=} opt_destOffset Destination offset.
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 export function flipXY(flatCoordinates, offset, end, stride, opt_dest, opt_destOffset) {
   let dest, destOffset;

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -10,13 +10,13 @@ import {get as getProjection, getTransform} from '../../proj.js';
  * @param {module:ol/proj~TransformFunction} transform Transform from longitude/latitude to
  *     projected coordinates.
  * @param {number} squaredTolerance Squared tolerance.
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 function line(interpolate, transform, squaredTolerance) {
   // FIXME reduce garbage generation
   // FIXME optimize stack operations
 
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const flatCoordinates = [];
 
   let geoA = interpolate(0);
@@ -25,11 +25,11 @@ function line(interpolate, transform, squaredTolerance) {
   let a = transform(geoA);
   let b = transform(geoB);
 
-  /** @type {Array.<module:ol/coordinate~Coordinate>} */
+  /** @type {Array<module:ol/coordinate~Coordinate>} */
   const geoStack = [geoB, geoA];
-  /** @type {Array.<module:ol/coordinate~Coordinate>} */
+  /** @type {Array<module:ol/coordinate~Coordinate>} */
   const stack = [b, a];
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const fractionStack = [1, 0];
 
   /** @type {!Object.<string, boolean>} */
@@ -86,7 +86,7 @@ function line(interpolate, transform, squaredTolerance) {
  * @param {number} lat2 Latitude 2 in degrees.
  * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 export function greatCircleArc(lon1, lat1, lon2, lat2, projection, squaredTolerance) {
   const geoProjection = getProjection('EPSG:4326');
@@ -130,7 +130,7 @@ export function greatCircleArc(lon1, lat1, lon2, lat2, projection, squaredTolera
  * @param {number} lat2 Latitude 2.
  * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
   const epsg4326Projection = getProjection('EPSG:4326');
@@ -153,7 +153,7 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
  * @param {number} lon2 Longitude 2.
  * @param {module:ol/proj/Projection} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 export function parallel(lat, lon1, lon2, projection, squaredTolerance) {
   const epsg4326Projection = getProjection('EPSG:4326');

--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -32,7 +32,7 @@ function line(interpolate, transform, squaredTolerance) {
   /** @type {Array<number>} */
   const fractionStack = [1, 0];
 
-  /** @type {!Object.<string, boolean>} */
+  /** @type {!Object<string, boolean>} */
   const fractions = {};
 
   let maxIterations = 1e5;

--- a/src/ol/geom/flat/inflate.js
+++ b/src/ol/geom/flat/inflate.js
@@ -4,12 +4,12 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {Array.<module:ol/coordinate~Coordinate>=} opt_coordinates Coordinates.
- * @return {Array.<module:ol/coordinate~Coordinate>} Coordinates.
+ * @param {Array<module:ol/coordinate~Coordinate>=} opt_coordinates Coordinates.
+ * @return {Array<module:ol/coordinate~Coordinate>} Coordinates.
  */
 export function inflateCoordinates(flatCoordinates, offset, end, stride, opt_coordinates) {
   const coordinates = opt_coordinates !== undefined ? opt_coordinates : [];
@@ -23,12 +23,12 @@ export function inflateCoordinates(flatCoordinates, offset, end, stride, opt_coo
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {Array.<Array.<module:ol/coordinate~Coordinate>>=} opt_coordinatess Coordinatess.
- * @return {Array.<Array.<module:ol/coordinate~Coordinate>>} Coordinatess.
+ * @param {Array<Array<module:ol/coordinate~Coordinate>>=} opt_coordinatess Coordinatess.
+ * @return {Array<Array<module:ol/coordinate~Coordinate>>} Coordinatess.
  */
 export function inflateCoordinatesArray(flatCoordinates, offset, ends, stride, opt_coordinatess) {
   const coordinatess = opt_coordinatess !== undefined ? opt_coordinatess : [];
@@ -45,13 +45,13 @@ export function inflateCoordinatesArray(flatCoordinates, offset, ends, stride, o
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
- * @param {Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>=} opt_coordinatesss
+ * @param {Array<Array<Array<module:ol/coordinate~Coordinate>>>=} opt_coordinatesss
  *     Coordinatesss.
- * @return {Array.<Array.<Array.<module:ol/coordinate~Coordinate>>>} Coordinatesss.
+ * @return {Array<Array<Array<module:ol/coordinate~Coordinate>>>} Coordinatesss.
  */
 export function inflateMultiCoordinatesArray(flatCoordinates, offset, endss, stride, opt_coordinatesss) {
   const coordinatesss = opt_coordinatesss !== undefined ? opt_coordinatesss : [];

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -8,21 +8,21 @@ import {linearRingsContainsXY} from '../flat/contains.js';
 /**
  * Calculates a point that is likely to lie in the interior of the linear rings.
  * Inspired by JTS's com.vividsolutions.jts.geom.Geometry#getInteriorPoint.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {Array.<number>} flatCenters Flat centers.
+ * @param {Array<number>} flatCenters Flat centers.
  * @param {number} flatCentersOffset Flat center offset.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Destination point as XYM coordinate, where M is the
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Destination point as XYM coordinate, where M is the
  * length of the horizontal intersection that the point belongs to.
  */
 export function getInteriorPointOfArray(flatCoordinates, offset,
   ends, stride, flatCenters, flatCentersOffset, opt_dest) {
   let i, ii, x, x1, x2, y1, y2;
   const y = flatCenters[flatCentersOffset + 1];
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const intersections = [];
   // Calculate intersections with the horizontal line
   for (let r = 0, rr = ends.length; r < rr; ++r) {
@@ -73,12 +73,12 @@ export function getInteriorPointOfArray(flatCoordinates, offset,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
- * @param {Array.<number>} flatCenters Flat centers.
- * @return {Array.<number>} Interior points as XYM coordinates, where M is the
+ * @param {Array<number>} flatCenters Flat centers.
+ * @return {Array<number>} Interior points as XYM coordinates, where M is the
  * length of the horizontal intersection that the point belongs to.
  */
 export function getInteriorPointsOfMultiArray(flatCoordinates, offset, endss, stride, flatCenters) {

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -6,13 +6,13 @@ import {lerp} from '../../math.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} fraction Fraction.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Destination.
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Destination.
  */
 export function interpolatePoint(flatCoordinates, offset, end, stride, fraction, opt_dest) {
   let pointX = NaN;
@@ -65,7 +65,7 @@ export function interpolatePoint(flatCoordinates, offset, end, stride, fraction,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -126,9 +126,9 @@ export function lineStringCoordinateAtM(flatCoordinates, offset, end, stride, m,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {number} m M.
  * @param {boolean} extrapolate Extrapolate.

--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -7,7 +7,7 @@ import {forEach as forEachSegment} from '../flat/segments.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -45,9 +45,9 @@ export function intersectsLineString(flatCoordinates, offset, end, stride, exten
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {module:ol/extent~Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
@@ -65,7 +65,7 @@ export function intersectsLineStringArray(flatCoordinates, offset, ends, stride,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -94,9 +94,9 @@ export function intersectsLinearRing(flatCoordinates, offset, end, stride, exten
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {module:ol/extent~Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.
@@ -119,9 +119,9 @@ export function intersectsLinearRingArray(flatCoordinates, offset, ends, stride,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @param {module:ol/extent~Extent} extent Extent.
  * @return {boolean} True if the geometry and the extent intersect.

--- a/src/ol/geom/flat/length.js
+++ b/src/ol/geom/flat/length.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -26,7 +26,7 @@ export function lineStringLength(flatCoordinates, offset, end, stride) {
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.

--- a/src/ol/geom/flat/orient.js
+++ b/src/ol/geom/flat/orient.js
@@ -5,7 +5,7 @@ import {coordinates as reverseCoordinates} from '../flat/reverse.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
@@ -33,9 +33,9 @@ export function linearRingIsClockwise(flatCoordinates, offset, end, stride) {
  * is tested (first ring must be clockwise, remaining rings counter-clockwise).
  * To test for right-hand orientation, use the `opt_right` argument.
  *
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Array of end indexes.
+ * @param {Array<number>} ends Array of end indexes.
  * @param {number} stride Stride.
  * @param {boolean=} opt_right Test for right-hand orientation
  *     (counter-clockwise exterior ring and clockwise interior rings).
@@ -67,9 +67,9 @@ export function linearRingIsOriented(flatCoordinates, offset, ends, stride, opt_
  * is tested (first ring must be clockwise, remaining rings counter-clockwise).
  * To test for right-hand orientation, use the `opt_right` argument.
  *
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Array of array of end indexes.
+ * @param {Array<Array<number>>} endss Array of array of end indexes.
  * @param {number} stride Stride.
  * @param {boolean=} opt_right Test for right-hand orientation
  *     (counter-clockwise exterior ring and clockwise interior rings).
@@ -92,9 +92,9 @@ export function linearRingsAreOriented(flatCoordinates, offset, endss, stride, o
  * counter-clockwise for interior rings).  To orient according to the
  * right-hand rule, use the `opt_right` argument.
  *
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {boolean=} opt_right Follow the right-hand rule for orientation.
  * @return {number} End.
@@ -123,9 +123,9 @@ export function orientLinearRings(flatCoordinates, offset, ends, stride, opt_rig
  * counter-clockwise for interior rings).  To orient according to the
  * right-hand rule, use the `opt_right` argument.
  *
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Array of array of end indexes.
+ * @param {Array<Array<number>>} endss Array of array of end indexes.
  * @param {number} stride Stride.
  * @param {boolean=} opt_right Follow the right-hand rule for orientation.
  * @return {number} End.

--- a/src/ol/geom/flat/reverse.js
+++ b/src/ol/geom/flat/reverse.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.

--- a/src/ol/geom/flat/segments.js
+++ b/src/ol/geom/flat/segments.js
@@ -7,7 +7,7 @@
  * This function calls `callback` for each segment of the flat coordinates
  * array. If the callback returns a truthy value the function returns that
  * value immediately. Otherwise the function returns `false`.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.

--- a/src/ol/geom/flat/simplify.js
+++ b/src/ol/geom/flat/simplify.js
@@ -31,15 +31,15 @@ import {squaredSegmentDistance, squaredDistance} from '../../math.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} squaredTolerance Squared tolerance.
  * @param {boolean} highQuality Highest quality.
- * @param {Array.<number>=} opt_simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>=} opt_simplifiedFlatCoordinates Simplified flat
  *     coordinates.
- * @return {Array.<number>} Simplified line string.
+ * @return {Array<number>} Simplified line string.
  */
 export function simplifyLineString(flatCoordinates, offset, end,
   stride, squaredTolerance, highQuality, opt_simplifiedFlatCoordinates) {
@@ -61,12 +61,12 @@ export function simplifyLineString(flatCoordinates, offset, end,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
  * @return {number} Simplified offset.
@@ -83,11 +83,11 @@ export function douglasPeucker(flatCoordinates, offset, end,
     }
     return simplifiedOffset;
   }
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const markers = new Array(n);
   markers[0] = 1;
   markers[n - 1] = 1;
-  /** @type {Array.<number>} */
+  /** @type {Array<number>} */
   const stack = [offset, end - stride];
   let index = 0;
   while (stack.length > 0) {
@@ -131,15 +131,15 @@ export function douglasPeucker(flatCoordinates, offset, end,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
- * @param {Array.<number>} simplifiedEnds Simplified ends.
+ * @param {Array<number>} simplifiedEnds Simplified ends.
  * @return {number} Simplified offset.
  */
 export function douglasPeuckerArray(flatCoordinates, offset,
@@ -158,15 +158,15 @@ export function douglasPeuckerArray(flatCoordinates, offset,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
- * @param {Array.<Array.<number>>} simplifiedEndss Simplified endss.
+ * @param {Array<Array<number>>} simplifiedEndss Simplified endss.
  * @return {number} Simplified offset.
  */
 export function douglasPeuckerMultiArray(
@@ -186,12 +186,12 @@ export function douglasPeuckerMultiArray(
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
  * @return {number} Simplified offset.
@@ -253,12 +253,12 @@ export function snap(value, tolerance) {
  * the common edge between two polygons will be simplified to the same line
  * string independently in both polygons.  This implementation uses a single
  * pass over the coordinates and eliminates intermediate collinear points.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} tolerance Tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
  * @return {number} Simplified offset.
@@ -337,15 +337,15 @@ export function quantize(flatCoordinates, offset, end, stride,
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<number>} ends Ends.
+ * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
  * @param {number} tolerance Tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
- * @param {Array.<number>} simplifiedEnds Simplified ends.
+ * @param {Array<number>} simplifiedEnds Simplified ends.
  * @return {number} Simplified offset.
  */
 export function quantizeArray(
@@ -366,15 +366,15 @@ export function quantizeArray(
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
- * @param {Array.<Array.<number>>} endss Endss.
+ * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
  * @param {number} tolerance Tolerance.
- * @param {Array.<number>} simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} simplifiedFlatCoordinates Simplified flat
  *     coordinates.
  * @param {number} simplifiedOffset Simplified offset.
- * @param {Array.<Array.<number>>} simplifiedEndss Simplified endss.
+ * @param {Array<Array<number>>} simplifiedEndss Simplified endss.
  * @return {number} Simplified offset.
  */
 export function quantizeMultiArray(

--- a/src/ol/geom/flat/straightchunk.js
+++ b/src/ol/geom/flat/straightchunk.js
@@ -5,11 +5,11 @@
 
 /**
  * @param {number} maxAngle Maximum acceptable angle delta between segments.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @return {Array.<number>} Start and end of the first suitable chunk of the
+ * @return {Array<number>} Start and end of the first suitable chunk of the
  * given `flatCoordinates`.
  */
 export function matchingChunk(maxAngle, flatCoordinates, offset, end, stride) {

--- a/src/ol/geom/flat/textpath.js
+++ b/src/ol/geom/flat/textpath.js
@@ -5,7 +5,7 @@ import {lerp} from '../../math.js';
 
 
 /**
- * @param {Array.<number>} flatCoordinates Path to put text on.
+ * @param {Array<number>} flatCoordinates Path to put text on.
  * @param {number} offset Start offset of the `flatCoordinates`.
  * @param {number} end End offset of the `flatCoordinates`.
  * @param {number} stride Stride.
@@ -14,7 +14,7 @@ import {lerp} from '../../math.js';
  * width of the character passed as 1st argument.
  * @param {number} startM m along the path where the text starts.
  * @param {number} maxAngle Max angle between adjacent chars in radians.
- * @return {Array.<Array.<*>>} The result array of null if `maxAngle` was
+ * @return {Array<Array<*>>} The result array of null if `maxAngle` was
  * exceeded. Entries of the array are x, y, anchorX, angle, chunk.
  */
 export function drawTextOnPath(

--- a/src/ol/geom/flat/topology.js
+++ b/src/ol/geom/flat/topology.js
@@ -5,7 +5,7 @@ import {linearRing as linearRingArea} from '../flat/area.js';
 
 /**
  * Check if the linestring is a boundary.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.

--- a/src/ol/geom/flat/transform.js
+++ b/src/ol/geom/flat/transform.js
@@ -4,13 +4,13 @@
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {module:ol/transform~Transform} transform Transform.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Transformed coordinates.
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Transformed coordinates.
  */
 export function transform2D(flatCoordinates, offset, end, stride, transform, opt_dest) {
   const dest = opt_dest ? opt_dest : [];
@@ -29,14 +29,14 @@ export function transform2D(flatCoordinates, offset, end, stride, transform, opt
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} angle Angle.
- * @param {Array.<number>} anchor Rotation anchor point.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Transformed coordinates.
+ * @param {Array<number>} anchor Rotation anchor point.
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Transformed coordinates.
  */
 export function rotate(flatCoordinates, offset, end, stride, angle, anchor, opt_dest) {
   const dest = opt_dest ? opt_dest : [];
@@ -63,15 +63,15 @@ export function rotate(flatCoordinates, offset, end, stride, angle, anchor, opt_
 
 /**
  * Scale the coordinates.
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} sx Scale factor in the x-direction.
  * @param {number} sy Scale factor in the y-direction.
- * @param {Array.<number>} anchor Scale anchor point.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Transformed coordinates.
+ * @param {Array<number>} anchor Scale anchor point.
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Transformed coordinates.
  */
 export function scale(flatCoordinates, offset, end, stride, sx, sy, anchor, opt_dest) {
   const dest = opt_dest ? opt_dest : [];
@@ -95,14 +95,14 @@ export function scale(flatCoordinates, offset, end, stride, sx, sy, anchor, opt_
 
 
 /**
- * @param {Array.<number>} flatCoordinates Flat coordinates.
+ * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} deltaX Delta X.
  * @param {number} deltaY Delta Y.
- * @param {Array.<number>=} opt_dest Destination.
- * @return {Array.<number>} Transformed coordinates.
+ * @param {Array<number>=} opt_dest Destination.
+ * @return {Array<number>} Transformed coordinates.
  */
 export function translate(flatCoordinates, offset, end, stride, deltaX, deltaY, opt_dest) {
   const dest = opt_dest ? opt_dest : [];

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -77,7 +77,7 @@ export {default as Translate} from './interaction/Translate.js';
  *
  * @param {module:ol/interaction/Interaction~DefaultsOptions=} opt_options
  * Defaults options.
- * @return {module:ol/Collection.<module:ol/interaction/Interaction>}
+ * @return {module:ol/Collection<module:ol/interaction/Interaction>}
  * A collection of interactions to be used with the {@link module:ol/Map~Map}
  * constructor's `interactions` option.
  * @api

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -13,7 +13,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @typedef {Object} Options
- * @property {Array.<function(new: module:ol/format/Feature)>} [formatConstructors] Format constructors.
+ * @property {Array<function(new: module:ol/format/Feature)>} [formatConstructors] Format constructors.
  * @property {module:ol/source/Vector} [source] Optional vector source where features will be added.  If a source is provided
  * all existing features will be removed and new features will be added when
  * they are dropped on the target.  If you want to add features to a vector
@@ -47,7 +47,7 @@ class DragAndDropEvent extends Event {
   /**
    * @param {module:ol/interaction/DragAndDrop~DragAndDropEventType} type Type.
    * @param {File} file File.
-   * @param {Array.<module:ol/Feature>=} opt_features Features.
+   * @param {Array<module:ol/Feature>=} opt_features Features.
    * @param {module:ol/proj/Projection=} opt_projection Projection.
    */
   constructor(type, file, opt_features, opt_projection) {
@@ -56,7 +56,7 @@ class DragAndDropEvent extends Event {
 
     /**
      * The features parsed from dropped data.
-     * @type {Array.<module:ol/Feature>|undefined}
+     * @type {Array<module:ol/Feature>|undefined}
      * @api
      */
     this.features = opt_features;
@@ -101,7 +101,7 @@ class DragAndDrop extends Interaction {
 
     /**
      * @private
-     * @type {Array.<function(new: module:ol/format/Feature)>}
+     * @type {Array<function(new: module:ol/format/Feature)>}
      */
     this.formatConstructors_ = options.formatConstructors ?
       options.formatConstructors : [];
@@ -115,7 +115,7 @@ class DragAndDrop extends Interaction {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.dropListenKeys_ = null;
 
@@ -220,7 +220,7 @@ class DragAndDrop extends Interaction {
    * @param {string} text Text.
    * @param {module:ol/format/Feature~ReadOptions} options Read options.
    * @private
-   * @return {Array.<module:ol/Feature>} Features.
+   * @return {Array<module:ol/Feature>} Features.
    */
   tryReadFeatures_(format, text, options) {
     try {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -56,7 +56,7 @@ import {createEditingStyle} from '../style/Style.js';
  * @property {module:ol/events/condition~Condition} [finishCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether the drawing can be finished.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
  * Style for sketch features.
  * @property {module:ol/interaction/Draw~GeometryFunction} [geometryFunction]
  * Function that is called when a geometry's coordinates are updated.
@@ -86,7 +86,7 @@ import {createEditingStyle} from '../style/Style.js';
  * arguments, and returns a geometry. The optional existing geometry is the
  * geometry that is returned when the function is called without a second
  * argument.
- * @typedef {function(!Array.<module:ol/coordinate~Coordinate>, module:ol/geom/SimpleGeometry=):
+ * @typedef {function(!Array<module:ol/coordinate~Coordinate>, module:ol/geom/SimpleGeometry=):
  *     module:ol/geom/SimpleGeometry} GeometryFunction
  */
 
@@ -272,7 +272,7 @@ class Draw extends PointerInteraction {
     if (!geometryFunction) {
       if (this.type_ === GeometryType.CIRCLE) {
         /**
-         * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates
+         * @param {!Array<module:ol/coordinate~Coordinate>} coordinates
          *     The coordinates.
          * @param {module:ol/geom/SimpleGeometry=} opt_geometry Optional geometry.
          * @return {module:ol/geom/SimpleGeometry} A geometry.
@@ -296,7 +296,7 @@ class Draw extends PointerInteraction {
           Constructor = Polygon;
         }
         /**
-         * @param {!Array.<module:ol/coordinate~Coordinate>} coordinates
+         * @param {!Array<module:ol/coordinate~Coordinate>} coordinates
          *     The coordinates.
          * @param {module:ol/geom/SimpleGeometry=} opt_geometry Optional geometry.
          * @return {module:ol/geom/SimpleGeometry} A geometry.
@@ -358,7 +358,7 @@ class Draw extends PointerInteraction {
 
     /**
      * Sketch coordinates. Used when drawing a line or polygon.
-     * @type {module:ol/coordinate~Coordinate|Array.<module:ol/coordinate~Coordinate>|Array.<Array.<module:ol/coordinate~Coordinate>>}
+     * @type {module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>}
      * @private
      */
     this.sketchCoords_ = null;
@@ -372,7 +372,7 @@ class Draw extends PointerInteraction {
 
     /**
      * Sketch line coordinates. Used when drawing a polygon or circle.
-     * @type {Array.<module:ol/coordinate~Coordinate>}
+     * @type {Array<module:ol/coordinate~Coordinate>}
      * @private
      */
     this.sketchLineCoords_ = null;
@@ -580,7 +580,7 @@ class Draw extends PointerInteraction {
     }
     last[0] = coordinate[0];
     last[1] = coordinate[1];
-    this.geometryFunction_(/** @type {!Array.<module:ol/coordinate~Coordinate>} */ (this.sketchCoords_), geometry);
+    this.geometryFunction_(/** @type {!Array<module:ol/coordinate~Coordinate>} */ (this.sketchCoords_), geometry);
     if (this.sketchPoint_) {
       const sketchPointGeom = /** @type {module:ol/geom/Point} */ (this.sketchPoint_.getGeometry());
       sketchPointGeom.setCoordinates(coordinate);

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -37,7 +37,7 @@ import {createEditingStyle} from '../style/Style.js';
  * actually add a point/vertex to the geometry being drawn.  The default of `6`
  * was chosen for the draw interaction to behave correctly on mouse as well as
  * on touch devices.
- * @property {module:ol/Collection.<module:ol/Feature>} [features]
+ * @property {module:ol/Collection<module:ol/Feature>} [features]
  * Destination collection for the drawn features.
  * @property {module:ol/source/Vector} [source] Destination source for
  * the drawn features.
@@ -208,7 +208,7 @@ class Draw extends PointerInteraction {
 
     /**
      * Target collection for drawn features.
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      * @private
      */
     this.features_ = options.features ? options.features : null;

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -20,12 +20,12 @@ import {createEditingStyle} from '../style/Style.js';
  * @typedef {Object} Options
  * @property {module:ol/extent~Extent} [extent] Initial extent. Defaults to no
  * initial extent.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [boxStyle]
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [boxStyle]
  * Style for the drawn extent box. Defaults to
  * {@link module:ol/style/Style~createEditing()['Polygon']}
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [pointerStyle]
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [pointerStyle]
  * Style for the cursor used to draw the extent. Defaults to
  * {@link module:ol/style/Style~createEditing()['Point']}
  * @property {boolean} [wrapX=false] Wrap the drawn extent across multiple maps

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -203,7 +203,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Segments intersecting {@link this.vertexFeature_} by segment uid.
-     * @type {Object.<string, boolean>}
+     * @type {Object<string, boolean>}
      * @private
      */
     this.vertexSegments_ = null;
@@ -281,7 +281,7 @@ class Modify extends PointerInteraction {
     /**
      * @const
      * @private
-     * @type {!Object.<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
+     * @type {!Object<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
      */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -93,7 +93,7 @@ const ModifyEventType = {
  * @property {module:ol/source/Vector} [source] The vector source with
  * features to modify.  If a vector source is not provided, a feature collection
  * must be provided with the features option.
- * @property {module:ol/Collection.<module:ol/Feature>} [features]
+ * @property {module:ol/Collection<module:ol/Feature>} [features]
  * The features the interaction works on.  If a feature collection is not
  * provided, a vector source must be provided with the source option.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
@@ -109,7 +109,7 @@ const ModifyEventType = {
 export class ModifyEvent extends Event {
   /**
    * @param {ModifyEventType} type Type.
-   * @param {module:ol/Collection.<module:ol/Feature>} features
+   * @param {module:ol/Collection<module:ol/Feature>} features
    * The features modified.
    * @param {module:ol/MapBrowserPointerEvent} mapBrowserPointerEvent
    * Associated {@link module:ol/MapBrowserPointerEvent}.
@@ -119,7 +119,7 @@ export class ModifyEvent extends Event {
 
     /**
      * The features being modified.
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      * @api
      */
     this.features = features;
@@ -230,7 +230,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Segment RTree for each layer
-     * @type {module:ol/structs/RBush.<module:ol/interaction/Modify~SegmentData>}
+     * @type {module:ol/structs/RBush<module:ol/interaction/Modify~SegmentData>}
      * @private
      */
     this.rBush_ = new RBush();
@@ -318,7 +318,7 @@ class Modify extends PointerInteraction {
     }
 
     /**
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      * @private
      */
     this.features_ = features;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -60,12 +60,12 @@ const ModifyEventType = {
 
 /**
  * @typedef {Object} SegmentData
- * @property {Array.<number>} [depth]
+ * @property {Array<number>} [depth]
  * @property {module:ol/Feature} feature
  * @property {module:ol/geom/SimpleGeometry} geometry
  * @property {number} index
- * @property {Array.<module:ol/extent~Extent>} segment
- * @property {Array.<module:ol/interaction/Modify~SegmentData>} [featureSegments]
+ * @property {Array<module:ol/extent~Extent>} segment
+ * @property {Array<module:ol/interaction/Modify~SegmentData>} [featureSegments]
  */
 
 
@@ -87,7 +87,7 @@ const ModifyEventType = {
  * features. Default is {@link module:ol/events/condition~always}.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
  * Style used for the features being modified. By default the default edit
  * style is used (see {@link module:ol/style}).
  * @property {module:ol/source/Vector} [source] The vector source with
@@ -388,7 +388,7 @@ class Modify extends PointerInteraction {
    */
   removeFeatureSegmentData_(feature) {
     const rBush = this.rBush_;
-    const /** @type {Array.<module:ol/interaction/Modify~SegmentData>} */ nodesToRemove = [];
+    const /** @type {Array<module:ol/interaction/Modify~SegmentData>} */ nodesToRemove = [];
     rBush.forEach(
       /**
        * @param {module:ol/interaction/Modify~SegmentData} node RTree node.
@@ -948,7 +948,7 @@ class Modify extends PointerInteraction {
   /**
    * @param {module:ol/geom/SimpleGeometry} geometry Geometry.
    * @param {number} index Index.
-   * @param {Array.<number>|undefined} depth Depth.
+   * @param {Array<number>|undefined} depth Depth.
    * @param {number} delta Delta (1 or -1).
    * @private
    */

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -136,7 +136,7 @@ class PointerInteraction extends Interaction {
     this.trackedPointers_ = {};
 
     /**
-     * @type {Array.<module:ol/pointer/PointerEvent>}
+     * @type {Array<module:ol/pointer/PointerEvent>}
      * @protected
      */
     this.targetPointers = [];
@@ -169,7 +169,7 @@ class PointerInteraction extends Interaction {
 
 
 /**
- * @param {Array.<module:ol/pointer/PointerEvent>} pointerEvents List of events.
+ * @param {Array<module:ol/pointer/PointerEvent>} pointerEvents List of events.
  * @return {module:ol/pixel~Pixel} Centroid pixel.
  */
 export function centroid(pointerEvents) {

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -130,7 +130,7 @@ class PointerInteraction extends Interaction {
     this.stopDown = options.stopDown ? options.stopDown : stopDown;
 
     /**
-     * @type {!Object.<string, module:ol/pointer/PointerEvent>}
+     * @type {!Object<string, module:ol/pointer/PointerEvent>}
      * @private
      */
     this.trackedPointers_ = {};

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -251,7 +251,7 @@ class Select extends Interaction {
      * An association between selected feature (key)
      * and layer (value)
      * @private
-     * @type {Object.<number, module:ol/layer/Layer>}
+     * @type {Object<number, module:ol/layer/Layer>}
      */
     this.featureLayerAssociation_ = {};
 

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -80,7 +80,7 @@ const SelectEventType = {
  * @property {boolean} [multi=false] A boolean that determines if the default
  * behaviour should select only single features or all (overlapping) features at
  * the clicked map position. The default of `false` means single select.
- * @property {module:ol/Collection.<module:ol/Feature>} [features]
+ * @property {module:ol/Collection<module:ol/Feature>} [features]
  * Collection where the interaction will place selected features. Optional. If
  * not set the interaction will create a collection. In any case the collection
  * used by the interaction is returned by
@@ -275,7 +275,7 @@ class Select extends Interaction {
 
   /**
    * Get the selected features.
-   * @return {module:ol/Collection.<module:ol/Feature>} Features collection.
+   * @return {module:ol/Collection<module:ol/Feature>} Features collection.
    * @api
    */
   getFeatures() {

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -55,13 +55,13 @@ const SelectEventType = {
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- * @property {Array.<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers]
+ * @property {Array<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers]
  * A list of layers from which features should be selected. Alternatively, a
  * filter function can be provided. The function will be called for each layer
  * in the map and should return `true` for layers that you want to be
  * selectable. If the option is absent, all visible layers will be considered
  * selectable.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style]
  * Style for the selected features. By default the default edit style is used
  * (see {@link module:ol/style}).
  * @property {module:ol/events/condition~Condition} [removeCondition] A function
@@ -105,8 +105,8 @@ const SelectEventType = {
 class SelectEvent extends Event {
   /**
    * @param {SelectEventType} type The event type.
-   * @param {Array.<module:ol/Feature>} selected Selected features.
-   * @param {Array.<module:ol/Feature>} deselected Deselected features.
+   * @param {Array<module:ol/Feature>} selected Selected features.
+   * @param {Array<module:ol/Feature>} deselected Deselected features.
    * @param {module:ol/MapBrowserEvent} mapBrowserEvent Associated
    *     {@link module:ol/MapBrowserEvent}.
    */
@@ -115,14 +115,14 @@ class SelectEvent extends Event {
 
     /**
      * Selected features array.
-     * @type {Array.<module:ol/Feature>}
+     * @type {Array<module:ol/Feature>}
      * @api
      */
     this.selected = selected;
 
     /**
      * Deselected features array.
-     * @type {Array.<module:ol/Feature>}
+     * @type {Array<module:ol/Feature>}
      * @api
      */
     this.deselected = deselected;

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -111,7 +111,7 @@ class Snap extends PointerInteraction {
     this.featuresListenerKeys_ = [];
 
     /**
-     * @type {Object.<number, module:ol/events~EventsKey>}
+     * @type {Object<number, module:ol/events~EventsKey>}
      * @private
      */
     this.featureChangeListenerKeys_ = {};
@@ -119,7 +119,7 @@ class Snap extends PointerInteraction {
     /**
      * Extents are preserved so indexed segment can be quickly removed
      * when its feature geometry changes
-     * @type {Object.<number, module:ol/extent~Extent>}
+     * @type {Object<number, module:ol/extent~Extent>}
      * @private
      */
     this.indexedFeaturesExtents_ = {};
@@ -128,7 +128,7 @@ class Snap extends PointerInteraction {
      * If a feature geometry changes while a pointer drag|move event occurs, the
      * feature doesn't get updated right away.  It will be at the next 'pointerup'
      * event fired.
-     * @type {!Object.<number, module:ol/Feature>}
+     * @type {!Object<number, module:ol/Feature>}
      * @private
      */
     this.pendingFeatures_ = {};
@@ -165,7 +165,7 @@ class Snap extends PointerInteraction {
     /**
     * @const
     * @private
-    * @type {Object.<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
+    * @type {Object<string, function(module:ol/Feature, module:ol/geom/Geometry)>}
     */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -35,7 +35,7 @@ import RBush from '../structs/RBush.js';
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/Collection.<module:ol/Feature>} [features] Snap to these features. Either this option or source should be provided.
+ * @property {module:ol/Collection<module:ol/Feature>} [features] Snap to these features. Either this option or source should be provided.
  * @property {boolean} [edge=true] Snap to edges.
  * @property {boolean} [vertex=true] Snap to vertices.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the pointer close enough to a segment or
@@ -99,7 +99,7 @@ class Snap extends PointerInteraction {
     this.edge_ = options.edge !== undefined ? options.edge : true;
 
     /**
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      * @private
      */
     this.features_ = options.features ? options.features : null;
@@ -156,7 +156,7 @@ class Snap extends PointerInteraction {
 
     /**
     * Segment RTree for each layer
-    * @type {module:ol/structs/RBush.<module:ol/interaction/Snap~SegmentData>}
+    * @type {module:ol/structs/RBush<module:ol/interaction/Snap~SegmentData>}
     * @private
     */
     this.rBush_ = new RBush();
@@ -224,7 +224,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @return {module:ol/Collection.<module:ol/Feature>|Array<module:ol/Feature>} Features.
+   * @return {module:ol/Collection<module:ol/Feature>|Array<module:ol/Feature>} Features.
    * @private
    */
   getFeatures_() {
@@ -235,7 +235,7 @@ class Snap extends PointerInteraction {
       features = this.source_.getFeatures();
     }
     return (
-      /** @type {!Array<module:ol/Feature>|!module:ol/Collection.<module:ol/Feature>} */ (features)
+      /** @type {!Array<module:ol/Feature>|!module:ol/Collection<module:ol/Feature>} */ (features)
     );
   }
 

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -29,7 +29,7 @@ import RBush from '../structs/RBush.js';
 /**
  * @typedef {Object} SegmentData
  * @property {module:ol/Feature} feature
- * @property {Array.<module:ol/coordinate~Coordinate>} segment
+ * @property {Array<module:ol/coordinate~Coordinate>} segment
  */
 
 
@@ -105,7 +105,7 @@ class Snap extends PointerInteraction {
     this.features_ = options.features ? options.features : null;
 
     /**
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      * @private
      */
     this.featuresListenerKeys_ = [];
@@ -224,7 +224,7 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @return {module:ol/Collection.<module:ol/Feature>|Array.<module:ol/Feature>} Features.
+   * @return {module:ol/Collection.<module:ol/Feature>|Array<module:ol/Feature>} Features.
    * @private
    */
   getFeatures_() {
@@ -235,7 +235,7 @@ class Snap extends PointerInteraction {
       features = this.source_.getFeatures();
     }
     return (
-      /** @type {!Array.<module:ol/Feature>|!module:ol/Collection.<module:ol/Feature>} */ (features)
+      /** @type {!Array<module:ol/Feature>|!module:ol/Collection.<module:ol/Feature>} */ (features)
     );
   }
 

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -38,7 +38,7 @@ const TranslateEventType = {
 
 /**
  * @typedef {Object} Options
- * @property {module:ol/Collection.<module:ol/Feature>} [features] Only features contained in this collection will be able to be translated. If
+ * @property {module:ol/Collection<module:ol/Feature>} [features] Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
  * @property {Array<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers] A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
@@ -59,7 +59,7 @@ const TranslateEventType = {
 export class TranslateEvent extends Event {
   /**
    * @param {module:ol/interaction/Translate~TranslateEventType} type Type.
-   * @param {module:ol/Collection.<module:ol/Feature>} features The features translated.
+   * @param {module:ol/Collection<module:ol/Feature>} features The features translated.
    * @param {module:ol/coordinate~Coordinate} coordinate The event coordinate.
    */
   constructor(type, features, coordinate) {
@@ -68,7 +68,7 @@ export class TranslateEvent extends Event {
 
     /**
      * The features being translated.
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      * @api
      */
     this.features = features;
@@ -116,7 +116,7 @@ class Translate extends PointerInteraction {
 
 
     /**
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      * @private
      */
     this.features_ = options.features !== undefined ? options.features : null;

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -40,7 +40,7 @@ const TranslateEventType = {
  * @typedef {Object} Options
  * @property {module:ol/Collection.<module:ol/Feature>} [features] Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
- * @property {Array.<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers] A list of layers from which features should be
+ * @property {Array<module:ol/layer/Layer>|function(module:ol/layer/Layer): boolean} [layers] A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be translatable. If the option is

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -100,17 +100,17 @@ class BaseLayer extends BaseObject {
 
   /**
   * @abstract
-  * @param {Array.<module:ol/layer/Layer>=} opt_array Array of layers (to be
+  * @param {Array<module:ol/layer/Layer>=} opt_array Array of layers (to be
   *     modified in place).
-  * @return {Array.<module:ol/layer/Layer>} Array of layers.
+  * @return {Array<module:ol/layer/Layer>} Array of layers.
   */
   getLayersArray(opt_array) {}
 
   /**
   * @abstract
-  * @param {Array.<module:ol/layer/Layer~State>=} opt_states Optional list of layer
+  * @param {Array<module:ol/layer/Layer~State>=} opt_states Optional list of layer
   *     states (to be modified in place).
-  * @return {Array.<module:ol/layer/Layer~State>} List of layer states.
+  * @return {Array<module:ol/layer/Layer~State>} List of layer states.
   */
   getLayerStatesArray(opt_states) {}
 

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -41,7 +41,7 @@ class BaseLayer extends BaseObject {
     super();
 
     /**
-    * @type {Object.<string, *>}
+    * @type {Object<string, *>}
     */
     const properties = assign({}, options);
     properties[LayerProperty.OPACITY] =

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -27,7 +27,7 @@ import SourceState from '../source/State.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {Array<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>} [layers] Child layers.
+ * @property {Array<module:ol/layer/Base>|module:ol/Collection<module:ol/layer/Base>} [layers] Child layers.
  */
 
 
@@ -161,21 +161,21 @@ class LayerGroup extends BaseLayer {
   /**
    * Returns the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
    * in this group.
-   * @return {!module:ol/Collection.<module:ol/layer/Base>} Collection of
+   * @return {!module:ol/Collection<module:ol/layer/Base>} Collection of
    *   {@link module:ol/layer/Base layers} that are part of this group.
    * @observable
    * @api
    */
   getLayers() {
     return (
-      /** @type {!module:ol/Collection.<module:ol/layer/Base>} */ (this.get(Property.LAYERS))
+      /** @type {!module:ol/Collection<module:ol/layer/Base>} */ (this.get(Property.LAYERS))
     );
   }
 
   /**
    * Set the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
    * in this group.
-   * @param {!module:ol/Collection.<module:ol/layer/Base>} layers Collection of
+   * @param {!module:ol/Collection<module:ol/layer/Base>} layers Collection of
    *   {@link module:ol/layer/Base layers} that are part of this group.
    * @observable
    * @api

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -70,7 +70,7 @@ class LayerGroup extends BaseLayer {
 
     /**
      * @private
-     * @type {Object.<string, Array<module:ol/events~EventsKey>>}
+     * @type {Object<string, Array<module:ol/events~EventsKey>>}
      */
     this.listenerKeys_ = {};
 

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -27,7 +27,7 @@ import SourceState from '../source/State.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {Array.<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>} [layers] Child layers.
+ * @property {Array<module:ol/layer/Base>|module:ol/Collection.<module:ol/layer/Base>} [layers] Child layers.
  */
 
 
@@ -64,13 +64,13 @@ class LayerGroup extends BaseLayer {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.layersListenerKeys_ = [];
 
     /**
      * @private
-     * @type {Object.<string, Array.<module:ol/events~EventsKey>>}
+     * @type {Object.<string, Array<module:ol/events~EventsKey>>}
      */
     this.listenerKeys_ = {};
 

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -24,7 +24,7 @@ import Style from '../style/Style.js';
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
- * @property {Array.<string>} [gradient=['#00f', '#0ff', '#0f0', '#ff0', '#f00']] The color gradient
+ * @property {Array<string>} [gradient=['#00f', '#0ff', '#0f0', '#ff0', '#f00']] The color gradient
  * of the heatmap, specified as an array of CSS color strings.
  * @property {number} [radius=8] Radius size in pixels.
  * @property {number} [blur=15] Blur size in pixels.
@@ -54,7 +54,7 @@ const Property = {
 
 /**
  * @const
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
 
@@ -105,7 +105,7 @@ class Heatmap extends VectorLayer {
 
     /**
      * @private
-     * @type {Array.<Array.<module:ol/style/Style>>}
+     * @type {Array<Array<module:ol/style/Style>>}
      */
     this.styleCache_ = null;
 
@@ -197,12 +197,12 @@ class Heatmap extends VectorLayer {
 
   /**
    * Return the gradient colors as array of strings.
-   * @return {Array.<string>} Colors.
+   * @return {Array<string>} Colors.
    * @api
    * @observable
    */
   getGradient() {
-    return /** @type {Array.<string>} */ (this.get(Property.GRADIENT));
+    return /** @type {Array<string>} */ (this.get(Property.GRADIENT));
   }
 
   /**
@@ -263,7 +263,7 @@ class Heatmap extends VectorLayer {
 
   /**
    * Set the gradient colors as array of strings.
-   * @param {Array.<string>} colors Gradient.
+   * @param {Array<string>} colors Gradient.
    * @api
    * @observable
    */
@@ -284,7 +284,7 @@ class Heatmap extends VectorLayer {
 
 
 /**
- * @param {Array.<string>} colors A list of colored.
+ * @param {Array<string>} colors A list of colored.
  * @return {Uint8ClampedArray} An array.
  */
 function createGradient(colors) {

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -39,7 +39,7 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  * @property {boolean} [declutter=false] Declutter images and text. Decluttering is applied to all
  * image and text styles, and the priority is defined by the z-index of the style. Lower z-index
  * means higher priority.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [updateWhileAnimating=false] When set to `true` and `renderMode`
  * is `vector`, feature batches will be recreated during animations. This means that no
@@ -117,7 +117,7 @@ class VectorLayer extends Layer {
 
     /**
     * User provided style.
-    * @type {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
+    * @type {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
     * @private
     */
     this.style_ = null;
@@ -194,7 +194,7 @@ class VectorLayer extends Layer {
   /**
   * Get the style for features.  This returns whatever was passed to the `style`
   * option at construction or to the `setStyle` method.
-  * @return {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
+  * @return {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction}
   *     Layer style.
   * @api
   */
@@ -242,7 +242,7 @@ class VectorLayer extends Layer {
   * it is `null` the layer has no style (a `null` style), so only features
   * that have their own styles will be rendered in the layer. See
   * {@link module:ol/style} for information on the default style.
-  * @param {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction|null|undefined} style Layer style.
+  * @param {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction|null|undefined} style Layer style.
   * @api
   */
   setStyle(style) {

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -68,7 +68,7 @@ export const RenderType = {
  * image and text styles, and the priority is defined by the z-index of the style. Lower z-index
  * means higher priority. When set to `true`, a `renderMode` of `'image'` will be overridden with
  * `'hybrid'`.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting
@@ -80,7 +80,7 @@ export const RenderType = {
  * means no preloading.
  * @property {module:ol/render~OrderFunction} [renderOrder] Render order. Function to be used when sorting
  * features before rendering. By default features are drawn in the order that they are created.
- * @property {module:ol/style/Style|Array.<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
+ * @property {module:ol/style/Style|Array<module:ol/style/Style>|module:ol/style/Style~StyleFunction} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [useInterimTilesOnError=true] Use interim tiles on error.
  */

--- a/src/ol/loadingstrategy.js
+++ b/src/ol/loadingstrategy.js
@@ -7,7 +7,7 @@
  * Strategy function for loading all features with a single request.
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} resolution Resolution.
- * @return {Array.<module:ol/extent~Extent>} Extents.
+ * @return {Array<module:ol/extent~Extent>} Extents.
  * @api
  */
 export function all(extent, resolution) {
@@ -20,7 +20,7 @@ export function all(extent, resolution) {
  * resolution.
  * @param {module:ol/extent~Extent} extent Extent.
  * @param {number} resolution Resolution.
- * @return {Array.<module:ol/extent~Extent>} Extents.
+ * @return {Array<module:ol/extent~Extent>} Extents.
  * @api
  */
 export function bbox(extent, resolution) {
@@ -31,7 +31,7 @@ export function bbox(extent, resolution) {
 /**
  * Creates a strategy function for loading features based on a tile grid.
  * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
- * @return {function(module:ol/extent~Extent, number): Array.<module:ol/extent~Extent>} Loading strategy.
+ * @return {function(module:ol/extent~Extent, number): Array<module:ol/extent~Extent>} Loading strategy.
  * @api
  */
 export function tile(tileGrid) {
@@ -39,12 +39,12 @@ export function tile(tileGrid) {
     /**
      * @param {module:ol/extent~Extent} extent Extent.
      * @param {number} resolution Resolution.
-     * @return {Array.<module:ol/extent~Extent>} Extents.
+     * @return {Array<module:ol/extent~Extent>} Extents.
      */
     function(extent, resolution) {
       const z = tileGrid.getZForResolution(resolution);
       const tileRange = tileGrid.getTileRangeForExtentAndZ(extent, z);
-      /** @type {Array.<module:ol/extent~Extent>} */
+      /** @type {Array<module:ol/extent~Extent>} */
       const extents = [];
       /** @type {module:ol/tilecoord~TileCoord} */
       const tileCoord = [z, 0, 0];

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -99,9 +99,9 @@ export function squaredDistance(x1, y1, x2, y2) {
 /**
  * Solves system of linear equations using Gaussian elimination method.
  *
- * @param {Array.<Array.<number>>} mat Augmented matrix (n x n + 1 column)
+ * @param {Array<Array<number>>} mat Augmented matrix (n x n + 1 column)
  *                                     in row-major order.
- * @return {Array.<number>} The resulting vector.
+ * @return {Array<number>} The resulting vector.
  */
 export function solveLinearSystem(mat) {
   const n = mat.length;

--- a/src/ol/pixel.js
+++ b/src/ol/pixel.js
@@ -1,6 +1,6 @@
 /**
  * An array with two elements, representing a pixel. The first element is the
  * x-coordinate, the second the y-coordinate of the pixel.
- * @typedef {Array.<number>} Pixel
+ * @typedef {Array<number>} Pixel
  * @api
  */

--- a/src/ol/pointer/EventSource.js
+++ b/src/ol/pointer/EventSource.js
@@ -6,7 +6,7 @@ class EventSource {
 
   /**
    * @param {module:ol/pointer/PointerEventHandler} dispatcher Event handler.
-   * @param {!Object.<string, function(Event)>} mapping Event mapping.
+   * @param {!Object<string, function(Event)>} mapping Event mapping.
    */
   constructor(dispatcher, mapping) {
 
@@ -18,7 +18,7 @@ class EventSource {
     /**
      * @private
      * @const
-     * @type {!Object.<string, function(Event)>}
+     * @type {!Object<string, function(Event)>}
      */
     this.mapping_ = mapping;
   }

--- a/src/ol/pointer/EventSource.js
+++ b/src/ol/pointer/EventSource.js
@@ -25,7 +25,7 @@ class EventSource {
 
   /**
    * List of events supported by this source.
-   * @return {Array.<string>} Event names
+   * @return {Array<string>} Event names
    */
   getEvents() {
     return Object.keys(this.mapping_);

--- a/src/ol/pointer/MouseSource.js
+++ b/src/ol/pointer/MouseSource.js
@@ -154,7 +154,7 @@ class MouseSource extends EventSource {
 
     /**
      * @const
-     * @type {Array.<module:ol/pixel~Pixel>}
+     * @type {Array<module:ol/pixel~Pixel>}
      */
     this.lastTouches = [];
   }

--- a/src/ol/pointer/MouseSource.js
+++ b/src/ol/pointer/MouseSource.js
@@ -148,7 +148,7 @@ class MouseSource extends EventSource {
 
     /**
      * @const
-     * @type {!Object.<string, Event|Object>}
+     * @type {!Object<string, Event|Object>}
      */
     this.pointerMap = dispatcher.pointerMap;
 

--- a/src/ol/pointer/MsSource.js
+++ b/src/ol/pointer/MsSource.js
@@ -157,7 +157,7 @@ class MsSource extends EventSource {
 
     /**
      * @const
-     * @type {!Object.<string, MSPointerEvent|Object>}
+     * @type {!Object<string, MSPointerEvent|Object>}
      */
     this.pointerMap = dispatcher.pointerMap;
   }

--- a/src/ol/pointer/MsSource.js
+++ b/src/ol/pointer/MsSource.js
@@ -36,7 +36,7 @@ import EventSource from '../pointer/EventSource.js';
 
 /**
  * @const
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 const POINTER_TYPES = [
   '',

--- a/src/ol/pointer/PointerEvent.js
+++ b/src/ol/pointer/PointerEvent.js
@@ -52,7 +52,7 @@ class PointerEvent extends Event {
    *
    * @param {string} type The type of the event to create.
    * @param {Event} originalEvent The event.
-   * @param {Object.<string, ?>=} opt_eventDict An optional dictionary of
+   * @param {Object<string, ?>=} opt_eventDict An optional dictionary of
    *    initial event properties.
    */
   constructor(type, originalEvent, opt_eventDict) {
@@ -202,7 +202,7 @@ class PointerEvent extends Event {
 
   /**
    * @private
-   * @param {Object.<string, ?>} eventDict The event dictionary.
+   * @param {Object<string, ?>} eventDict The event dictionary.
    * @return {number} Button indicator.
    */
   getButtons_(eventDict) {
@@ -243,7 +243,7 @@ class PointerEvent extends Event {
 
   /**
    * @private
-   * @param {Object.<string, ?>} eventDict The event dictionary.
+   * @param {Object<string, ?>} eventDict The event dictionary.
    * @param {number} buttons Button indicator.
    * @return {number} The pressure.
    */

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -45,7 +45,7 @@ import TouchSource from '../pointer/TouchSource.js';
 
 /**
  * Properties to copy when cloning an event, with default values.
- * @type {Array.<Array>}
+ * @type {Array<Array>}
  */
 const CLONE_PROPS = [
   // MouseEvent
@@ -111,7 +111,7 @@ class PointerEventHandler extends EventTarget {
     this.eventMap_ = {};
 
     /**
-     * @type {Array.<module:ol/pointer/EventSource>}
+     * @type {Array<module:ol/pointer/EventSource>}
      * @private
      */
     this.eventSourceList_ = [];
@@ -203,7 +203,7 @@ class PointerEventHandler extends EventTarget {
   /**
    * Setup listeners for the given events.
    * @private
-   * @param {Array.<string>} events List of events.
+   * @param {Array<string>} events List of events.
    */
   addEvents_(events) {
     events.forEach(function(eventName) {
@@ -214,7 +214,7 @@ class PointerEventHandler extends EventTarget {
   /**
    * Unregister listeners for the given events.
    * @private
-   * @param {Array.<string>} events List of events.
+   * @param {Array<string>} events List of events.
    */
   removeEvents_(events) {
     events.forEach(function(e) {

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -100,12 +100,12 @@ class PointerEventHandler extends EventTarget {
 
     /**
      * @const
-     * @type {!Object.<string, Event|Object>}
+     * @type {!Object<string, Event|Object>}
      */
     this.pointerMap = {};
 
     /**
-     * @type {Object.<string, function(Event)>}
+     * @type {Object<string, function(Event)>}
      * @private
      */
     this.eventMap_ = {};

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -114,7 +114,7 @@ class TouchSource extends EventSource {
 
     /**
      * @const
-     * @type {!Object.<string, Event|Object>}
+     * @type {!Object<string, Event|Object>}
      */
     this.pointerMap = dispatcher.pointerMap;
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -78,7 +78,7 @@ import {add as addTransformFunc, clear as clearTransformFuncs, get as getTransfo
  * transforms the input coordinate values, populates the output array, and
  * returns the output array.
  *
- * @typedef {function(Array.<number>, Array.<number>=, number=): Array.<number>} TransformFunction
+ * @typedef {function(Array<number>, Array<number>=, number=): Array<number>} TransformFunction
  * @api
  */
 
@@ -87,10 +87,10 @@ export {METERS_PER_UNIT};
 
 
 /**
- * @param {Array.<number>} input Input coordinate array.
- * @param {Array.<number>=} opt_output Output array of coordinate values.
+ * @param {Array<number>} input Input coordinate array.
+ * @param {Array<number>=} opt_output Output array of coordinate values.
  * @param {number=} opt_dimension Dimension.
- * @return {Array.<number>} Output coordinate array (new array, same coordinate
+ * @return {Array<number>} Output coordinate array (new array, same coordinate
  *     values).
  */
 export function cloneTransform(input, opt_output, opt_dimension) {
@@ -108,10 +108,10 @@ export function cloneTransform(input, opt_output, opt_dimension) {
 
 
 /**
- * @param {Array.<number>} input Input coordinate array.
- * @param {Array.<number>=} opt_output Output array of coordinate values.
+ * @param {Array<number>} input Input coordinate array.
+ * @param {Array<number>=} opt_output Output array of coordinate values.
  * @param {number=} opt_dimension Dimension.
- * @return {Array.<number>} Input coordinate array (same array as input).
+ * @return {Array<number>} Input coordinate array (same array as input).
  */
 export function identityTransform(input, opt_output, opt_dimension) {
   if (opt_output !== undefined && input !== opt_output) {
@@ -138,7 +138,7 @@ export function addProjection(projection) {
 
 
 /**
- * @param {Array.<module:ol/proj/Projection>} projections Projections.
+ * @param {Array<module:ol/proj/Projection>} projections Projections.
  */
 export function addProjections(projections) {
   projections.forEach(addProjection);
@@ -227,7 +227,7 @@ export function getPointResolution(projection, resolution, point, opt_units) {
  * Registers transformation functions that don't alter coordinates. Those allow
  * to transform between projections with equal meaning.
  *
- * @param {Array.<module:ol/proj/Projection>} projections Projections.
+ * @param {Array<module:ol/proj/Projection>} projections Projections.
  * @api
  */
 export function addEquivalentProjections(projections) {
@@ -246,9 +246,9 @@ export function addEquivalentProjections(projections) {
  * Registers transformation functions to convert coordinates in any projection
  * in projection1 to any projection in projection2.
  *
- * @param {Array.<module:ol/proj/Projection>} projections1 Projections with equal
+ * @param {Array<module:ol/proj/Projection>} projections1 Projections with equal
  *     meaning.
- * @param {Array.<module:ol/proj/Projection>} projections2 Projections with equal
+ * @param {Array<module:ol/proj/Projection>} projections2 Projections with equal
  *     meaning.
  * @param {module:ol/proj~TransformFunction} forwardTransform Transformation from any
  *   projection in projection1 to any projection in projection2.
@@ -302,10 +302,10 @@ export function createProjection(projection, defaultCode) {
 export function createTransformFromCoordinateTransform(coordTransform) {
   return (
     /**
-     * @param {Array.<number>} input Input.
-     * @param {Array.<number>=} opt_output Output.
+     * @param {Array<number>} input Input.
+     * @param {Array<number>=} opt_output Output.
      * @param {number=} opt_dimension Dimension.
-     * @return {Array.<number>} Output.
+     * @return {Array<number>} Output.
      */
     function(input, opt_output, opt_dimension) {
       const length = input.length;

--- a/src/ol/proj/Units.js
+++ b/src/ol/proj/Units.js
@@ -20,7 +20,7 @@ const Units = {
 /**
  * Meters per unit lookup table.
  * @const
- * @type {Object.<module:ol/proj/Units, number>}
+ * @type {Object<module:ol/proj/Units, number>}
  * @api
  */
 export const METERS_PER_UNIT = {};

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -69,7 +69,7 @@ class EPSG3857Projection extends Projection {
  * Projections equal to EPSG:3857.
  *
  * @const
- * @type {Array.<module:ol/proj/Projection>}
+ * @type {Array<module:ol/proj/Projection>}
  */
 export const PROJECTIONS = [
   new EPSG3857Projection('EPSG:3857'),
@@ -85,10 +85,10 @@ export const PROJECTIONS = [
 /**
  * Transformation from EPSG:4326 to EPSG:3857.
  *
- * @param {Array.<number>} input Input array of coordinate values.
- * @param {Array.<number>=} opt_output Output array of coordinate values.
+ * @param {Array<number>} input Input array of coordinate values.
+ * @param {Array<number>=} opt_output Output array of coordinate values.
  * @param {number=} opt_dimension Dimension (default is `2`).
- * @return {Array.<number>} Output array of coordinate values.
+ * @return {Array<number>} Output array of coordinate values.
  */
 export function fromEPSG4326(input, opt_output, opt_dimension) {
   const length = input.length;
@@ -121,10 +121,10 @@ export function fromEPSG4326(input, opt_output, opt_dimension) {
 /**
  * Transformation from EPSG:3857 to EPSG:4326.
  *
- * @param {Array.<number>} input Input array of coordinate values.
- * @param {Array.<number>=} opt_output Output array of coordinate values.
+ * @param {Array<number>} input Input array of coordinate values.
+ * @param {Array<number>=} opt_output Output array of coordinate values.
  * @param {number=} opt_dimension Dimension (default is `2`).
- * @return {Array.<number>} Output array of coordinate values.
+ * @return {Array<number>} Output array of coordinate values.
  */
 export function toEPSG4326(input, opt_output, opt_dimension) {
   const length = input.length;

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -64,7 +64,7 @@ class EPSG4326Projection extends Projection {
  * Projections equal to EPSG:4326.
  *
  * @const
- * @type {Array.<module:ol/proj/Projection>}
+ * @type {Array<module:ol/proj/Projection>}
  */
 export const PROJECTIONS = [
   new EPSG4326Projection('CRS:84'),

--- a/src/ol/proj/projections.js
+++ b/src/ol/proj/projections.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @type {Object.<string, module:ol/proj/Projection>}
+ * @type {Object<string, module:ol/proj/Projection>}
  */
 let cache = {};
 

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -6,7 +6,7 @@ import {isEmpty} from '../obj.js';
 
 /**
  * @private
- * @type {!Object.<string, Object.<string, module:ol/proj~TransformFunction>>}
+ * @type {!Object<string, Object<string, module:ol/proj~TransformFunction>>}
  */
 let transforms = {};
 

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -28,7 +28,7 @@ const tmpTransform = createTransform();
  * @param {Array<number>} flatCoordinates Flat coordinates. These always need
  *     to be right-handed for polygons.
  * @param {Array<number>|Array<Array<number>>} ends Ends or Endss.
- * @param {Object.<string, *>} properties Properties.
+ * @param {Object<string, *>} properties Properties.
  * @param {number|string|undefined} id Feature id.
  */
 class RenderFeature {
@@ -77,7 +77,7 @@ class RenderFeature {
 
     /**
     * @private
-    * @type {Object.<string, *>}
+    * @type {Object<string, *>}
     */
     this.properties_ = properties;
 
@@ -194,7 +194,7 @@ class RenderFeature {
 
   /**
   * Get the feature properties.
-  * @return {Object.<string, *>} Feature properties.
+  * @return {Object<string, *>} Feature properties.
   * @api
   */
   getProperties() {

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -25,9 +25,9 @@ const tmpTransform = createTransform();
  * through the API is limited to getting the type and extent of the geometry.
  *
  * @param {module:ol/geom/GeometryType} type Geometry type.
- * @param {Array.<number>} flatCoordinates Flat coordinates. These always need
+ * @param {Array<number>} flatCoordinates Flat coordinates. These always need
  *     to be right-handed for polygons.
- * @param {Array.<number>|Array.<Array.<number>>} ends Ends or Endss.
+ * @param {Array<number>|Array<Array<number>>} ends Ends or Endss.
  * @param {Object.<string, *>} properties Properties.
  * @param {number|string|undefined} id Feature id.
  */
@@ -53,25 +53,25 @@ class RenderFeature {
 
     /**
     * @private
-    * @type {Array.<number>}
+    * @type {Array<number>}
     */
     this.flatCoordinates_ = flatCoordinates;
 
     /**
     * @private
-    * @type {Array.<number>}
+    * @type {Array<number>}
     */
     this.flatInteriorPoints_ = null;
 
     /**
     * @private
-    * @type {Array.<number>}
+    * @type {Array<number>}
     */
     this.flatMidpoints_ = null;
 
     /**
     * @private
-    * @type {Array.<number>|Array.<Array.<number>>}
+    * @type {Array<number>|Array<Array<number>>}
     */
     this.ends_ = ends;
 
@@ -110,7 +110,7 @@ class RenderFeature {
   }
 
   /**
-  * @return {Array.<number>} Flat interior points.
+  * @return {Array<number>} Flat interior points.
   */
   getFlatInteriorPoint() {
     if (!this.flatInteriorPoints_) {
@@ -122,7 +122,7 @@ class RenderFeature {
   }
 
   /**
-  * @return {Array.<number>} Flat interior points.
+  * @return {Array<number>} Flat interior points.
   */
   getFlatInteriorPoints() {
     if (!this.flatInteriorPoints_) {
@@ -135,7 +135,7 @@ class RenderFeature {
   }
 
   /**
-  * @return {Array.<number>} Flat midpoint.
+  * @return {Array<number>} Flat midpoint.
   */
   getFlatMidpoint() {
     if (!this.flatMidpoints_) {
@@ -146,7 +146,7 @@ class RenderFeature {
   }
 
   /**
-  * @return {Array.<number>} Flat midpoints.
+  * @return {Array<number>} Flat midpoints.
   */
   getFlatMidpoints() {
     if (!this.flatMidpoints_) {
@@ -176,7 +176,7 @@ class RenderFeature {
   }
 
   /**
-  * @return {Array.<number>} Flat coordinates.
+  * @return {Array<number>} Flat coordinates.
   */
   getOrientedFlatCoordinates() {
     return this.flatCoordinates_;
@@ -240,7 +240,7 @@ class RenderFeature {
 
 
 /**
- * @return {Array.<number>|Array.<Array.<number>>} Ends or endss.
+ * @return {Array<number>|Array<Array<number>>} Ends or endss.
  */
 RenderFeature.prototype.getEnds =
 RenderFeature.prototype.getEndss = function() {
@@ -249,7 +249,7 @@ RenderFeature.prototype.getEndss = function() {
 
 
 /**
- * @return {Array.<number>} Flat coordinates.
+ * @return {Array<number>} Flat coordinates.
  */
 RenderFeature.prototype.getFlatCoordinates =
     RenderFeature.prototype.getOrientedFlatCoordinates;

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -19,7 +19,7 @@ import {create as createTransform} from '../transform.js';
  * @property {module:ol/colorlike~ColorLike} [currentFillStyle]
  * @property {module:ol/colorlike~ColorLike} [currentStrokeStyle]
  * @property {string} [currentLineCap]
- * @property {Array.<number>} currentLineDash
+ * @property {Array<number>} currentLineDash
  * @property {number} [currentLineDashOffset]
  * @property {string} [currentLineJoin]
  * @property {number} [currentLineWidth]
@@ -28,7 +28,7 @@ import {create as createTransform} from '../transform.js';
  * @property {module:ol/colorlike~ColorLike} [fillStyle]
  * @property {module:ol/colorlike~ColorLike} [strokeStyle]
  * @property {string} [lineCap]
- * @property {Array.<number>} lineDash
+ * @property {Array<number>} lineDash
  * @property {number} [lineDashOffset]
  * @property {string} [lineJoin]
  * @property {number} [lineWidth]
@@ -39,7 +39,7 @@ import {create as createTransform} from '../transform.js';
 /**
  * @typedef {Object} StrokeState
  * @property {string} lineCap
- * @property {Array.<number>} lineDash
+ * @property {Array<number>} lineDash
  * @property {number} lineDashOffset
  * @property {string} lineJoin
  * @property {number} lineWidth
@@ -65,7 +65,7 @@ import {create as createTransform} from '../transform.js';
  * in the group, i.e. 2 when an image and a text are grouped, or 1 otherwise.
  * In addition to these four elements, declutter instruction arrays (i.e. the
  * arguments to {@link module:ol/render/canvas~drawImage} are appended to the array.
- * @typedef {Array.<*>} DeclutterGroup
+ * @typedef {Array<*>} DeclutterGroup
  */
 
 
@@ -92,7 +92,7 @@ export const defaultLineCap = 'round';
 
 /**
  * @const
- * @type {Array.<number>}
+ * @type {Array<number>}
  */
 export const defaultLineDash = [];
 
@@ -141,7 +141,7 @@ export const defaultTextBaseline = 'middle';
 
 /**
  * @const
- * @type {Array.<number>}
+ * @type {Array<number>}
  */
 export const defaultPadding = [0, 0, 0, 0];
 

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -156,7 +156,7 @@ export const defaultLineWidth = 1;
 /**
  * The label cache for text rendering. To change the default cache size of 2048
  * entries, use {@link module:ol/structs/LRUCache#setSize}.
- * @type {module:ol/structs/LRUCache.<HTMLCanvasElement>}
+ * @type {module:ol/structs/LRUCache<HTMLCanvasElement>}
  * @api
  */
 export const labelCache = new LRUCache();

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -163,7 +163,7 @@ export const labelCache = new LRUCache();
 
 
 /**
- * @type {!Object.<string, number>}
+ * @type {!Object<string, number>}
  */
 export const checkedFonts = {};
 
@@ -175,7 +175,7 @@ let measureContext = null;
 
 
 /**
- * @type {!Object.<string, number>}
+ * @type {!Object<string, number>}
  */
 export const textHeights = {};
 

--- a/src/ol/render/canvas/ImageReplay.js
+++ b/src/ol/render/canvas/ImageReplay.js
@@ -103,7 +103,7 @@ class CanvasImageReplay extends CanvasReplay {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -224,7 +224,7 @@ class CanvasImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.pixelCoordinates_ = [];
 
@@ -237,7 +237,7 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -290,7 +290,7 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -339,7 +339,7 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -367,9 +367,9 @@ class CanvasImmediateRenderer extends VectorContext {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
-   * @param {Array.<number>} ends Ends.
+   * @param {Array<number>} ends Ends.
    * @param {number} stride Stride.
    * @private
    * @return {number} End.

--- a/src/ol/render/canvas/Instruction.js
+++ b/src/ol/render/canvas/Instruction.js
@@ -23,25 +23,25 @@ const Instruction = {
 
 
 /**
- * @type {Array.<Instruction>}
+ * @type {Array<Instruction>}
  */
 export const fillInstruction = [Instruction.FILL];
 
 
 /**
- * @type {Array.<Instruction>}
+ * @type {Array<Instruction>}
  */
 export const strokeInstruction = [Instruction.STROKE];
 
 
 /**
- * @type {Array.<Instruction>}
+ * @type {Array<Instruction>}
  */
 export const beginPathInstruction = [Instruction.BEGIN_PATH];
 
 
 /**
- * @type {Array.<Instruction>}
+ * @type {Array<Instruction>}
  */
 export const closePathInstruction = [Instruction.CLOSE_PATH];
 

--- a/src/ol/render/canvas/LineStringReplay.js
+++ b/src/ol/render/canvas/LineStringReplay.js
@@ -18,7 +18,7 @@ class CanvasLineStringReplay extends CanvasReplay {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.

--- a/src/ol/render/canvas/PolygonReplay.js
+++ b/src/ol/render/canvas/PolygonReplay.js
@@ -24,9 +24,9 @@ class CanvasPolygonReplay extends CanvasReplay {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
-   * @param {Array.<number>} ends Ends.
+   * @param {Array<number>} ends Ends.
    * @param {number} stride Stride.
    * @private
    * @return {number} End.

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -134,7 +134,7 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @private
-     * @type {!Object.<number,module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>>}
+     * @type {!Object<number,module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>>}
      */
     this.coordinateCache_ = {};
 
@@ -530,7 +530,7 @@ class CanvasReplay extends VectorContext {
    * @private
    * @param {CanvasRenderingContext2D} context Context.
    * @param {module:ol/transform~Transform} transform Transform.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
    * @param {Array<*>} instructions Instructions array.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
@@ -851,7 +851,7 @@ class CanvasReplay extends VectorContext {
    * @param {CanvasRenderingContext2D} context Context.
    * @param {module:ol/transform~Transform} transform Transform.
    * @param {number} viewRotation View rotation.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
    */
   replay(context, transform, viewRotation, skippedFeaturesHash) {
@@ -864,7 +864,7 @@ class CanvasReplay extends VectorContext {
    * @param {CanvasRenderingContext2D} context Context.
    * @param {module:ol/transform~Transform} transform Transform.
    * @param {number} viewRotation View rotation.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T=} opt_featureCallback
    *     Feature callback.

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -104,13 +104,13 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @private
-     * @type {Array.<*>}
+     * @type {Array<*>}
      */
     this.beginGeometryInstruction1_ = null;
 
     /**
      * @private
-     * @type {Array.<*>}
+     * @type {Array<*>}
      */
     this.beginGeometryInstruction2_ = null;
 
@@ -122,19 +122,19 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @protected
-     * @type {Array.<*>}
+     * @type {Array<*>}
      */
     this.instructions = [];
 
     /**
      * @protected
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.coordinates = [];
 
     /**
      * @private
-     * @type {!Object.<number,module:ol/coordinate~Coordinate|Array.<module:ol/coordinate~Coordinate>|Array.<Array.<module:ol/coordinate~Coordinate>>>}
+     * @type {!Object.<number,module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>>}
      */
     this.coordinateCache_ = {};
 
@@ -146,13 +146,13 @@ class CanvasReplay extends VectorContext {
 
     /**
      * @protected
-     * @type {Array.<*>}
+     * @type {Array<*>}
      */
     this.hitDetectionInstructions = [];
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.pixelCoordinates_ = null;
 
@@ -176,8 +176,8 @@ class CanvasReplay extends VectorContext {
    * @param {module:ol/coordinate~Coordinate} p2 2nd point of the background box.
    * @param {module:ol/coordinate~Coordinate} p3 3rd point of the background box.
    * @param {module:ol/coordinate~Coordinate} p4 4th point of the background box.
-   * @param {Array.<*>} fillInstruction Fill instruction.
-   * @param {Array.<*>} strokeInstruction Stroke instruction.
+   * @param {Array<*>} fillInstruction Fill instruction.
+   * @param {Array<*>} strokeInstruction Stroke instruction.
    */
   replayTextBackground_(context, p1, p2, p3, p4, fillInstruction, strokeInstruction) {
     context.beginPath();
@@ -191,7 +191,7 @@ class CanvasReplay extends VectorContext {
       this.fill_(context);
     }
     if (strokeInstruction) {
-      this.setStrokeStyle_(context, /** @type {Array.<*>} */ (strokeInstruction));
+      this.setStrokeStyle_(context, /** @type {Array<*>} */ (strokeInstruction));
       context.stroke();
     }
   }
@@ -212,9 +212,9 @@ class CanvasReplay extends VectorContext {
    * @param {number} scale Scale.
    * @param {boolean} snapToPixel Snap to pixel.
    * @param {number} width Width.
-   * @param {Array.<number>} padding Padding.
-   * @param {Array.<*>} fillInstruction Fill instruction.
-   * @param {Array.<*>} strokeInstruction Stroke instruction.
+   * @param {Array<number>} padding Padding.
+   * @param {Array<*>} fillInstruction Fill instruction.
+   * @param {Array<*>} strokeInstruction Stroke instruction.
    */
   replayImage_(
     context,
@@ -304,8 +304,8 @@ class CanvasReplay extends VectorContext {
     } else if (intersects) {
       if (fillStroke) {
         this.replayTextBackground_(context, p1, p2, p3, p4,
-          /** @type {Array.<*>} */ (fillInstruction),
-          /** @type {Array.<*>} */ (strokeInstruction));
+          /** @type {Array<*>} */ (fillInstruction),
+          /** @type {Array<*>} */ (strokeInstruction));
       }
       drawImage(context, transform, opacity, image, originX, originY, w, h, x, y, scale);
     }
@@ -313,8 +313,8 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @protected
-   * @param {Array.<number>} dashArray Dash array.
-   * @return {Array.<number>} Dash array with pixel ratio applied
+   * @param {Array<number>} dashArray Dash array.
+   * @return {Array<number>} Dash array with pixel ratio applied
    */
   applyPixelRatio(dashArray) {
     const pixelRatio = this.pixelRatio;
@@ -324,7 +324,7 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -378,11 +378,11 @@ class CanvasReplay extends VectorContext {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
-   * @param {Array.<number>} ends Ends.
+   * @param {Array<number>} ends Ends.
    * @param {number} stride Stride.
-   * @param {Array.<number>} replayEnds Replay ends.
+   * @param {Array<number>} replayEnds Replay ends.
    * @return {number} Offset.
    */
   drawCustomCoordinates_(flatCoordinates, offset, ends, stride, replayEnds) {
@@ -476,7 +476,7 @@ class CanvasReplay extends VectorContext {
   /**
    * @private
    * @param {CanvasRenderingContext2D} context Context.
-   * @param {Array.<*>} instruction Instruction.
+   * @param {Array<*>} instruction Instruction.
    */
   setStrokeStyle_(context, instruction) {
     context.strokeStyle = /** @type {module:ol/colorlike~ColorLike} */ (instruction[1]);
@@ -486,7 +486,7 @@ class CanvasReplay extends VectorContext {
     context.miterLimit = /** @type {number} */ (instruction[5]);
     if (CANVAS_LINE_DASH) {
       context.lineDashOffset = /** @type {number} */ (instruction[7]);
-      context.setLineDash(/** @type {Array.<number>} */ (instruction[6]));
+      context.setLineDash(/** @type {Array<number>} */ (instruction[6]));
     }
   }
 
@@ -532,7 +532,7 @@ class CanvasReplay extends VectorContext {
    * @param {module:ol/transform~Transform} transform Transform.
    * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
    *     to skip.
-   * @param {Array.<*>} instructions Instructions array.
+   * @param {Array<*>} instructions Instructions array.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @param {module:ol/extent~Extent=} opt_hitExtent Only check features that intersect this
    *     extent.
@@ -547,7 +547,7 @@ class CanvasReplay extends VectorContext {
     featureCallback,
     opt_hitExtent
   ) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     let pixelCoordinates;
     if (this.pixelCoordinates_ && equals(transform, this.renderedTransform_)) {
       pixelCoordinates = this.pixelCoordinates_;
@@ -677,7 +677,7 @@ class CanvasReplay extends VectorContext {
 
           let padding, backgroundFill, backgroundStroke;
           if (instruction.length > 16) {
-            padding = /** @type {Array.<number>} */ (instruction[16]);
+            padding = /** @type {Array<number>} */ (instruction[16]);
             backgroundFill = /** @type {boolean} */ (instruction[17]);
             backgroundStroke = /** @type {boolean} */ (instruction[18]);
           } else {
@@ -693,8 +693,8 @@ class CanvasReplay extends VectorContext {
               pixelCoordinates[d], pixelCoordinates[d + 1], image, anchorX, anchorY,
               declutterGroup, height, opacity, originX, originY, rotation, scale,
               snapToPixel, width, padding,
-              backgroundFill ? /** @type {Array.<*>} */ (lastFillInstruction) : null,
-              backgroundStroke ? /** @type {Array.<*>} */ (lastStrokeInstruction) : null);
+              backgroundFill ? /** @type {Array<*>} */ (lastFillInstruction) : null,
+              backgroundStroke ? /** @type {Array<*>} */ (lastStrokeInstruction) : null);
           }
           this.renderDeclutter_(declutterGroup, feature);
           ++i;
@@ -822,7 +822,7 @@ class CanvasReplay extends VectorContext {
             context.stroke();
             pendingStroke = 0;
           }
-          this.setStrokeStyle_(context, /** @type {Array.<*>} */ (instruction));
+          this.setStrokeStyle_(context, /** @type {Array<*>} */ (instruction));
           ++i;
           break;
         case CanvasInstruction.STROKE:
@@ -966,7 +966,7 @@ class CanvasReplay extends VectorContext {
   /**
    * @param {module:ol/render/canvas~FillStrokeState} state State.
    * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
-   * @return {Array.<*>} Fill instruction.
+   * @return {Array<*>} Fill instruction.
    */
   createFill(state, geometry) {
     const fillStyle = state.fillStyle;
@@ -987,7 +987,7 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @param {module:ol/render/canvas~FillStrokeState} state State.
-   * @return {Array.<*>} Stroke instruction.
+   * @return {Array<*>} Stroke instruction.
    */
   createStroke(state) {
     return [
@@ -1000,7 +1000,7 @@ class CanvasReplay extends VectorContext {
 
   /**
    * @param {module:ol/render/canvas~FillStrokeState} state State.
-   * @param {function(this:module:ol/render/canvas/Replay, module:ol/render/canvas~FillStrokeState, (module:ol/geom/Geometry|module:ol/render/Feature)):Array.<*>} createFill Create fill.
+   * @param {function(this:module:ol/render/canvas/Replay, module:ol/render/canvas~FillStrokeState, (module:ol/geom/Geometry|module:ol/render/Feature)):Array<*>} createFill Create fill.
    * @param {module:ol/geom/Geometry|module:ol/render/Feature} geometry Geometry.
    */
   updateFillStyle(state, createFill, geometry) {

--- a/src/ol/render/canvas/ReplayGroup.js
+++ b/src/ol/render/canvas/ReplayGroup.js
@@ -19,7 +19,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 
 
 /**
- * @type {Object.<module:ol/render/ReplayType,
+ * @type {Object<module:ol/render/ReplayType,
  *                function(new: module:ol/render/canvas/Replay, number, module:ol/extent~Extent,
  *                number, number, boolean, Array<module:ol/render/canvas~DeclutterGroup>)>}
  */
@@ -104,7 +104,7 @@ class CanvasReplayGroup extends ReplayGroup {
 
     /**
      * @private
-     * @type {!Object.<string, !Object.<module:ol/render/ReplayType, module:ol/render/canvas/Replay>>}
+     * @type {!Object<string, !Object<module:ol/render/ReplayType, module:ol/render/canvas/Replay>>}
      */
     this.replaysByZIndex_ = {};
 
@@ -186,9 +186,9 @@ class CanvasReplayGroup extends ReplayGroup {
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
-   * @param {Object.<string, module:ol/render/canvas~DeclutterGroup>} declutterReplays Declutter replays.
+   * @param {Object<string, module:ol/render/canvas~DeclutterGroup>} declutterReplays Declutter replays.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -335,7 +335,7 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @return {Object.<string, Object.<module:ol/render/ReplayType, module:ol/render/canvas/Replay>>} Replays.
+   * @return {Object<string, Object<module:ol/render/ReplayType, module:ol/render/canvas/Replay>>} Replays.
    */
   getReplays() {
     return this.replaysByZIndex_;
@@ -352,10 +352,10 @@ class CanvasReplayGroup extends ReplayGroup {
    * @param {CanvasRenderingContext2D} context Context.
    * @param {module:ol/transform~Transform} transform Transform.
    * @param {number} viewRotation View rotation.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {Array<module:ol/render/ReplayType>=} opt_replayTypes Ordered replay types to replay.
    *     Default is {@link module:ol/render/replay~ORDER}
-   * @param {Object.<string, module:ol/render/canvas~DeclutterGroup>=} opt_declutterReplays Declutter replays.
+   * @param {Object<string, module:ol/render/canvas~DeclutterGroup>=} opt_declutterReplays Declutter replays.
    */
   replay(
     context,
@@ -407,7 +407,7 @@ class CanvasReplayGroup extends ReplayGroup {
 /**
  * This cache is used for storing calculated pixel circles for increasing performance.
  * It is a static property to allow each Replaygroup to access it.
- * @type {Object.<number, Array<Array<(boolean|undefined)>>>}
+ * @type {Object<number, Array<Array<(boolean|undefined)>>>}
  */
 const circleArrayCache = {
   0: [[true]]
@@ -483,7 +483,7 @@ export function getCircleArray(radius) {
 
 
 /**
- * @param {!Object.<string, Array<*>>} declutterReplays Declutter replays.
+ * @param {!Object<string, Array<*>>} declutterReplays Declutter replays.
  * @param {CanvasRenderingContext2D} context Context.
  * @param {number} rotation Rotation.
  */

--- a/src/ol/render/canvas/ReplayGroup.js
+++ b/src/ol/render/canvas/ReplayGroup.js
@@ -21,7 +21,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 /**
  * @type {Object.<module:ol/render/ReplayType,
  *                function(new: module:ol/render/canvas/Replay, number, module:ol/extent~Extent,
- *                number, number, boolean, Array.<module:ol/render/canvas~DeclutterGroup>)>}
+ *                number, number, boolean, Array<module:ol/render/canvas~DeclutterGroup>)>}
  */
 const BATCH_CONSTRUCTORS = {
   'Circle': CanvasPolygonReplay,
@@ -154,7 +154,7 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {Array.<module:ol/render/ReplayType>} replays Replays.
+   * @param {Array<module:ol/render/ReplayType>} replays Replays.
    * @return {boolean} Has replays of the provided types.
    */
   hasReplays(replays) {
@@ -265,7 +265,7 @@ class CanvasReplayGroup extends ReplayGroup {
       }
     }
 
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const zs = Object.keys(this.replaysByZIndex_).map(Number);
     zs.sort(numberSafeCompareFunction);
 
@@ -300,7 +300,7 @@ class CanvasReplayGroup extends ReplayGroup {
 
   /**
    * @param {module:ol/transform~Transform} transform Transform.
-   * @return {Array.<number>} Clip coordinates.
+   * @return {Array<number>} Clip coordinates.
    */
   getClipCoords(transform) {
     const maxExtent = this.maxExtent_;
@@ -353,7 +353,7 @@ class CanvasReplayGroup extends ReplayGroup {
    * @param {module:ol/transform~Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
-   * @param {Array.<module:ol/render/ReplayType>=} opt_replayTypes Ordered replay types to replay.
+   * @param {Array<module:ol/render/ReplayType>=} opt_replayTypes Ordered replay types to replay.
    *     Default is {@link module:ol/render/replay~ORDER}
    * @param {Object.<string, module:ol/render/canvas~DeclutterGroup>=} opt_declutterReplays Declutter replays.
    */
@@ -366,7 +366,7 @@ class CanvasReplayGroup extends ReplayGroup {
     opt_declutterReplays
   ) {
 
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const zs = Object.keys(this.replaysByZIndex_).map(Number);
     zs.sort(numberSafeCompareFunction);
 
@@ -407,7 +407,7 @@ class CanvasReplayGroup extends ReplayGroup {
 /**
  * This cache is used for storing calculated pixel circles for increasing performance.
  * It is a static property to allow each Replaygroup to access it.
- * @type {Object.<number, Array.<Array.<(boolean|undefined)>>>}
+ * @type {Object.<number, Array<Array<(boolean|undefined)>>>}
  */
 const circleArrayCache = {
   0: [[true]]
@@ -417,7 +417,7 @@ const circleArrayCache = {
 /**
  * This method fills a row in the array from the given coordinate to the
  * middle with `true`.
- * @param {Array.<Array.<(boolean|undefined)>>} array The array that will be altered.
+ * @param {Array<Array<(boolean|undefined)>>} array The array that will be altered.
  * @param {number} x X coordinate.
  * @param {number} y Y coordinate.
  */
@@ -442,7 +442,7 @@ function fillCircleArrayRowToMiddle(array, x, y) {
  * It uses the midpoint circle algorithm.
  * A cache is used to increase performance.
  * @param {number} radius Radius.
- * @returns {Array.<Array.<(boolean|undefined)>>} An array with marked circle points.
+ * @returns {Array<Array<(boolean|undefined)>>} An array with marked circle points.
  */
 export function getCircleArray(radius) {
   if (circleArrayCache[radius] !== undefined) {
@@ -483,7 +483,7 @@ export function getCircleArray(radius) {
 
 
 /**
- * @param {!Object.<string, Array.<*>>} declutterReplays Declutter replays.
+ * @param {!Object.<string, Array<*>>} declutterReplays Declutter replays.
  * @param {CanvasRenderingContext2D} context Context.
  * @param {number} rotation Rotation.
  */

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -34,7 +34,7 @@ class CanvasTextReplay extends CanvasReplay {
 
     /**
      * @private
-     * @type {Array.<HTMLCanvasElement>}
+     * @type {Array<HTMLCanvasElement>}
      */
     this.labels_ = null;
 
@@ -520,8 +520,8 @@ class CanvasTextReplay extends CanvasReplay {
 
 /**
  * @param {string} font Font to use for measuring.
- * @param {Array.<string>} lines Lines to measure.
- * @param {Array.<number>} widths Array will be populated with the widths of
+ * @param {Array<string>} lines Lines to measure.
+ * @param {Array<number>} widths Array will be populated with the widths of
  * each line.
  * @return {number} Width of the whole text.
  */

--- a/src/ol/render/canvas/TextReplay.js
+++ b/src/ol/render/canvas/TextReplay.js
@@ -75,7 +75,7 @@ class CanvasTextReplay extends CanvasReplay {
     this.textFillState_ = null;
 
     /**
-     * @type {!Object.<string, module:ol/render/canvas~FillState>}
+     * @type {!Object<string, module:ol/render/canvas~FillState>}
      */
     this.fillStates = {};
 
@@ -86,7 +86,7 @@ class CanvasTextReplay extends CanvasReplay {
     this.textStrokeState_ = null;
 
     /**
-     * @type {!Object.<string, module:ol/render/canvas~StrokeState>}
+     * @type {!Object<string, module:ol/render/canvas~StrokeState>}
      */
     this.strokeStates = {};
 
@@ -97,7 +97,7 @@ class CanvasTextReplay extends CanvasReplay {
     this.textState_ = /** @type {module:ol/render/canvas~TextState} */ ({});
 
     /**
-     * @type {!Object.<string, module:ol/render/canvas~TextState>}
+     * @type {!Object<string, module:ol/render/canvas~TextState>}
      */
     this.textStates = {};
 
@@ -121,7 +121,7 @@ class CanvasTextReplay extends CanvasReplay {
 
     /**
      * @private
-     * @type {Object.<string, Object.<string, number>>}
+     * @type {Object<string, Object<string, number>>}
      */
     this.widths_ = {};
 

--- a/src/ol/render/replay.js
+++ b/src/ol/render/replay.js
@@ -6,7 +6,7 @@ import ReplayType from '../render/ReplayType.js';
 
 /**
  * @const
- * @type {Array.<module:ol/render/ReplayType>}
+ * @type {Array<module:ol/render/ReplayType>}
  */
 export const ORDER = [
   ReplayType.POLYGON,

--- a/src/ol/render/webgl.js
+++ b/src/ol/render/webgl.js
@@ -26,7 +26,7 @@ export const DEFAULT_LINECAP = 'round';
 
 /**
  * @const
- * @type {Array.<number>}
+ * @type {Array<number>}
  */
 export const DEFAULT_LINEDASH = [];
 

--- a/src/ol/render/webgl/CircleReplay.js
+++ b/src/ol/render/webgl/CircleReplay.js
@@ -31,13 +31,13 @@ class WebGLCircleReplay extends WebGLReplay {
 
     /**
      * @private
-     * @type {Array.<Array.<Array.<number>|number>>}
+     * @type {Array<Array<Array<number>|number>>}
      */
     this.styles_ = [];
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.styleIndices_ = [];
 
@@ -49,9 +49,9 @@ class WebGLCircleReplay extends WebGLReplay {
 
     /**
      * @private
-     * @type {{fillColor: (Array.<number>|null),
-     *         strokeColor: (Array.<number>|null),
-     *         lineDash: Array.<number>,
+     * @type {{fillColor: (Array<number>|null),
+     *         strokeColor: (Array<number>|null),
+     *         lineDash: Array<number>,
      *         lineDashOffset: (number|undefined),
      *         lineWidth: (number|undefined),
      *         changed: boolean}|null}
@@ -69,7 +69,7 @@ class WebGLCircleReplay extends WebGLReplay {
 
   /**
    * @private
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -136,8 +136,8 @@ class WebGLCircleReplay extends WebGLReplay {
         this.styles_.pop();
         if (this.styles_.length) {
           const lastState = this.styles_[this.styles_.length - 1];
-          this.state_.fillColor = /** @type {Array.<number>} */ (lastState[0]);
-          this.state_.strokeColor = /** @type {Array.<number>} */ (lastState[1]);
+          this.state_.fillColor = /** @type {Array<number>} */ (lastState[0]);
+          this.state_.strokeColor = /** @type {Array<number>} */ (lastState[1]);
           this.state_.lineWidth = /** @type {number} */ (lastState[2]);
           this.state_.changed = false;
         }
@@ -242,8 +242,8 @@ class WebGLCircleReplay extends WebGLReplay {
       for (i = this.styleIndices_.length - 1; i >= 0; --i) {
         start = this.styleIndices_[i];
         nextStyle = this.styles_[i];
-        this.setFillStyle_(gl, /** @type {Array.<number>} */ (nextStyle[0]));
-        this.setStrokeStyle_(gl, /** @type {Array.<number>} */ (nextStyle[1]),
+        this.setFillStyle_(gl, /** @type {Array<number>} */ (nextStyle[0]));
+        this.setStrokeStyle_(gl, /** @type {Array<number>} */ (nextStyle[1]),
           /** @type {number} */ (nextStyle[2]));
         this.drawElements(gl, context, start, end);
         end = start;
@@ -260,8 +260,8 @@ class WebGLCircleReplay extends WebGLReplay {
     end = this.startIndices[featureIndex + 1];
     for (i = this.styleIndices_.length - 1; i >= 0; --i) {
       nextStyle = this.styles_[i];
-      this.setFillStyle_(gl, /** @type {Array.<number>} */ (nextStyle[0]));
-      this.setStrokeStyle_(gl, /** @type {Array.<number>} */ (nextStyle[1]),
+      this.setFillStyle_(gl, /** @type {Array<number>} */ (nextStyle[0]));
+      this.setStrokeStyle_(gl, /** @type {Array<number>} */ (nextStyle[1]),
         /** @type {number} */ (nextStyle[2]));
       groupStart = this.styleIndices_[i];
 
@@ -305,8 +305,8 @@ class WebGLCircleReplay extends WebGLReplay {
     end = start = this.startIndices[featureIndex + 1];
     for (i = this.styleIndices_.length - 1; i >= 0; --i) {
       nextStyle = this.styles_[i];
-      this.setFillStyle_(gl, /** @type {Array.<number>} */ (nextStyle[0]));
-      this.setStrokeStyle_(gl, /** @type {Array.<number>} */ (nextStyle[1]),
+      this.setFillStyle_(gl, /** @type {Array<number>} */ (nextStyle[0]));
+      this.setStrokeStyle_(gl, /** @type {Array<number>} */ (nextStyle[1]),
         /** @type {number} */ (nextStyle[2]));
       groupStart = this.styleIndices_[i];
 
@@ -335,7 +335,7 @@ class WebGLCircleReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {Array.<number>} color Color.
+   * @param {Array<number>} color Color.
    */
   setFillStyle_(gl, color) {
     gl.uniform4fv(this.defaultLocations_.u_fillColor, color);
@@ -344,7 +344,7 @@ class WebGLCircleReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {Array.<number>} color Color.
+   * @param {Array<number>} color Color.
    * @param {number} lineWidth Line width.
    */
   setStrokeStyle_(gl, color, lineWidth) {

--- a/src/ol/render/webgl/ImageReplay.js
+++ b/src/ol/render/webgl/ImageReplay.js
@@ -14,25 +14,25 @@ class WebGLImageReplay extends WebGLTextureReplay {
     super(tolerance, maxExtent);
 
     /**
-     * @type {Array.<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>}
+     * @type {Array<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>}
      * @protected
      */
     this.images_ = [];
 
     /**
-     * @type {Array.<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>}
+     * @type {Array<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>}
      * @protected
      */
     this.hitDetectionImages_ = [];
 
     /**
-     * @type {Array.<WebGLTexture>}
+     * @type {Array<WebGLTexture>}
      * @private
      */
     this.textures_ = [];
 
     /**
-     * @type {Array.<WebGLTexture>}
+     * @type {Array<WebGLTexture>}
      * @private
      */
     this.hitDetectionTextures_ = [];

--- a/src/ol/render/webgl/ImageReplay.js
+++ b/src/ol/render/webgl/ImageReplay.js
@@ -81,7 +81,7 @@ class WebGLImageReplay extends WebGLTextureReplay {
     this.indicesBuffer = new WebGLBuffer(indices);
 
     // create textures
-    /** @type {Object.<string, WebGLTexture>} */
+    /** @type {Object<string, WebGLTexture>} */
     const texturePerImage = {};
 
     this.createTextures(this.textures_, this.images_, texturePerImage, gl);

--- a/src/ol/render/webgl/LineStringReplay.js
+++ b/src/ol/render/webgl/LineStringReplay.js
@@ -51,21 +51,21 @@ class WebGLLineStringReplay extends WebGLReplay {
 
     /**
      * @private
-     * @type {Array.<Array.<?>>}
+     * @type {Array<Array<?>>}
      */
     this.styles_ = [];
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.styleIndices_ = [];
 
     /**
      * @private
-     * @type {{strokeColor: (Array.<number>|null),
+     * @type {{strokeColor: (Array<number>|null),
      *         lineCap: (string|undefined),
-     *         lineDash: Array.<number>,
+     *         lineDash: Array<number>,
      *         lineDashOffset: (number|undefined),
      *         lineJoin: (string|undefined),
      *         lineWidth: (number|undefined),
@@ -88,7 +88,7 @@ class WebGLLineStringReplay extends WebGLReplay {
   /**
    * Draw one segment.
    * @private
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -269,9 +269,9 @@ class WebGLLineStringReplay extends WebGLReplay {
   }
 
   /**
-   * @param {Array.<number>} p0 Last coordinates.
-   * @param {Array.<number>} p1 Current coordinates.
-   * @param {Array.<number>} p2 Next coordinates.
+   * @param {Array<number>} p0 Last coordinates.
+   * @param {Array<number>} p1 Current coordinates.
+   * @param {Array<number>} p2 Next coordinates.
    * @param {number} product Sign, instruction, and rounding product.
    * @param {number} numVertices Vertex counter.
    * @return {number} Vertex counter.
@@ -291,7 +291,7 @@ class WebGLLineStringReplay extends WebGLReplay {
 
   /**
    * Check if the linestring can be drawn (i. e. valid).
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -362,8 +362,8 @@ class WebGLLineStringReplay extends WebGLReplay {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
-   * @param {Array.<Array.<number>>} holeFlatCoordinates Hole flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
+   * @param {Array<Array<number>>} holeFlatCoordinates Hole flat coordinates.
    * @param {number} stride Stride.
    */
   drawPolygonCoordinates(flatCoordinates, holeFlatCoordinates, stride) {
@@ -611,7 +611,7 @@ class WebGLLineStringReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {Array.<number>} color Color.
+   * @param {Array<number>} color Color.
    * @param {number} lineWidth Line width.
    * @param {number} miterLimit Miter limit.
    */

--- a/src/ol/render/webgl/PolygonReplay.js
+++ b/src/ol/render/webgl/PolygonReplay.js
@@ -55,19 +55,19 @@ class WebGLPolygonReplay extends WebGLReplay {
 
     /**
      * @private
-     * @type {Array.<Array.<number>>}
+     * @type {Array<Array<number>>}
      */
     this.styles_ = [];
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.styleIndices_ = [];
 
     /**
      * @private
-     * @type {{fillColor: (Array.<number>|null),
+     * @type {{fillColor: (Array<number>|null),
      *         changed: boolean}|null}
      */
     this.state_ = {
@@ -79,8 +79,8 @@ class WebGLPolygonReplay extends WebGLReplay {
 
   /**
    * Draw one polygon.
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
-   * @param {Array.<Array.<number>>} holeFlatCoordinates Hole flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
+   * @param {Array<Array<number>>} holeFlatCoordinates Hole flat coordinates.
    * @param {number} stride Stride.
    * @private
    */
@@ -141,7 +141,7 @@ class WebGLPolygonReplay extends WebGLReplay {
   /**
    * Inserts flat coordinates in a linked list and adds them to the vertex buffer.
    * @private
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} stride Stride.
    * @param {module:ol/structs/LinkedList} list Linked list.
    * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
@@ -195,7 +195,7 @@ class WebGLPolygonReplay extends WebGLReplay {
    * Returns the rightmost coordinates of a polygon on the X axis.
    * @private
    * @param {module:ol/structs/LinkedList} list Polygons ring.
-   * @return {Array.<number>} Max X coordinates.
+   * @return {Array<number>} Max X coordinates.
    */
   getMaxCoords_(list) {
     const start = list.firstItem();
@@ -643,7 +643,7 @@ class WebGLPolygonReplay extends WebGLReplay {
    * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p2 Third point.
    * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
    * @param {boolean=} opt_reflex Only include reflex points.
-   * @return {Array.<module:ol/render/webgl/PolygonReplay~PolygonVertex>} Points in the triangle.
+   * @return {Array<module:ol/render/webgl/PolygonReplay~PolygonVertex>} Points in the triangle.
    */
   getPointsInTriangle_(p0, p1, p2, rtree, opt_reflex) {
     const result = [];
@@ -670,7 +670,7 @@ class WebGLPolygonReplay extends WebGLReplay {
    * @param {module:ol/render/webgl/PolygonReplay~PolygonSegment} segment Segment.
    * @param {module:ol/structs/RBush} rtree R-Tree of the polygon.
    * @param {boolean=} opt_touch Touching segments should be considered an intersection.
-   * @return {Array.<module:ol/render/webgl/PolygonReplay~PolygonSegment>} Intersecting segments.
+   * @return {Array<module:ol/render/webgl/PolygonReplay~PolygonSegment>} Intersecting segments.
    */
   getIntersections_(segment, rtree, opt_touch) {
     const p0 = segment.p0;
@@ -698,7 +698,7 @@ class WebGLPolygonReplay extends WebGLReplay {
    * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p2 Third point.
    * @param {module:ol/render/webgl/PolygonReplay~PolygonVertex} p3 Fourth point.
    * @param {boolean=} opt_touch Touching segments should be considered an intersection.
-   * @return {Array.<number>|undefined} Intersection coordinates.
+   * @return {Array<number>|undefined} Intersection coordinates.
    */
   calculateIntersection_(p0, p1, p2, p3, opt_touch) {
     const denom = (p3.y - p2.y) * (p1.x - p0.x) - (p3.x - p2.x) * (p1.y - p0.y);
@@ -1005,7 +1005,7 @@ class WebGLPolygonReplay extends WebGLReplay {
   /**
    * @private
    * @param {WebGLRenderingContext} gl gl.
-   * @param {Array.<number>} color Color.
+   * @param {Array<number>} color Color.
    */
   setFillStyle_(gl, color) {
     gl.uniform4fv(this.defaultLocations_.u_color, color);

--- a/src/ol/render/webgl/Replay.js
+++ b/src/ol/render/webgl/Replay.js
@@ -160,7 +160,7 @@ class WebGLReplay extends VectorContext {
    * @protected
    * @param {WebGLRenderingContext} gl gl.
    * @param {module:ol/webgl/Context} context Context.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {boolean} hitDetection Hit detection mode.
    */
   drawReplay(gl, context, skippedFeaturesHash, hitDetection) {}
@@ -170,7 +170,7 @@ class WebGLReplay extends VectorContext {
    * @protected
    * @param {WebGLRenderingContext} gl gl.
    * @param {module:ol/webgl/Context} context Context.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
    * @return {T|undefined} Callback result.
@@ -182,7 +182,7 @@ class WebGLReplay extends VectorContext {
    * @protected
    * @param {WebGLRenderingContext} gl gl.
    * @param {module:ol/webgl/Context} context Context.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
    * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.
@@ -205,7 +205,7 @@ class WebGLReplay extends VectorContext {
    * @protected
    * @param {WebGLRenderingContext} gl gl.
    * @param {module:ol/webgl/Context} context Context.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @return {T|undefined} Callback result.
    * @template T
@@ -230,7 +230,7 @@ class WebGLReplay extends VectorContext {
    * @param {module:ol/size~Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
    * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting this extent are checked.

--- a/src/ol/render/webgl/Replay.js
+++ b/src/ol/render/webgl/Replay.js
@@ -66,13 +66,13 @@ class WebGLReplay extends VectorContext {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.tmpMat4_ = create();
 
     /**
      * @protected
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.indices = [];
 
@@ -85,20 +85,20 @@ class WebGLReplay extends VectorContext {
     /**
      * Start index per feature (the index).
      * @protected
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.startIndices = [];
 
     /**
      * Start index per feature (the feature).
      * @protected
-     * @type {Array.<module:ol/Feature|module:ol/render/Feature>}
+     * @type {Array<module:ol/Feature|module:ol/render/Feature>}
      */
     this.startIndicesFeature = [];
 
     /**
      * @protected
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.vertices = [];
 

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -14,7 +14,7 @@ import WebGLPolygonReplay from '../webgl/PolygonReplay.js';
 import WebGLTextReplay from '../webgl/TextReplay.js';
 
 /**
- * @type {Array.<number>}
+ * @type {Array<number>}
  */
 const HIT_DETECTION_SIZE = [1, 1];
 
@@ -160,7 +160,7 @@ class WebGLReplayGroup extends ReplayGroup {
     opacity,
     skippedFeaturesHash
   ) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const zs = Object.keys(this.replaysByZIndex_).map(Number);
     zs.sort(numberSafeCompareFunction);
 
@@ -209,7 +209,7 @@ class WebGLReplayGroup extends ReplayGroup {
     oneByOne,
     opt_hitExtent
   ) {
-    /** @type {Array.<number>} */
+    /** @type {Array<number>} */
     const zs = Object.keys(this.replaysByZIndex_).map(Number);
     zs.sort(function(a, b) {
       return b - a;

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -19,7 +19,7 @@ import WebGLTextReplay from '../webgl/TextReplay.js';
 const HIT_DETECTION_SIZE = [1, 1];
 
 /**
- * @type {Object.<module:ol/render/ReplayType,
+ * @type {Object<module:ol/render/ReplayType,
  *                function(new: module:ol/render/webgl/Replay, number,
  *                module:ol/extent~Extent)>}
  */
@@ -61,8 +61,8 @@ class WebGLReplayGroup extends ReplayGroup {
 
     /**
      * @private
-     * @type {!Object.<string,
-     *        Object.<module:ol/render/ReplayType, module:ol/render/webgl/Replay>>}
+     * @type {!Object<string,
+     *        Object<module:ol/render/ReplayType, module:ol/render/webgl/Replay>>}
      */
     this.replaysByZIndex_ = {};
 
@@ -148,7 +148,7 @@ class WebGLReplayGroup extends ReplayGroup {
    * @param {module:ol/size~Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    */
   replay(
     context,
@@ -188,7 +188,7 @@ class WebGLReplayGroup extends ReplayGroup {
    * @param {module:ol/size~Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} featureCallback Feature callback.
    * @param {boolean} oneByOne Draw features one-by-one for the hit-detecion.
    * @param {module:ol/extent~Extent=} opt_hitExtent Hit extent: Only features intersecting
@@ -242,7 +242,7 @@ class WebGLReplayGroup extends ReplayGroup {
    * @param {module:ol/size~Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @param {function((module:ol/Feature|module:ol/render/Feature)): T|undefined} callback Feature callback.
    * @return {T|undefined} Callback result.
    * @template T
@@ -303,7 +303,7 @@ class WebGLReplayGroup extends ReplayGroup {
    * @param {module:ol/size~Size} size Size.
    * @param {number} pixelRatio Pixel ratio.
    * @param {number} opacity Global opacity.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features to skip.
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features to skip.
    * @return {boolean} Is there a feature at the given coordinate?
    */
   hasFeatureAtCoordinate(

--- a/src/ol/render/webgl/TextReplay.js
+++ b/src/ol/render/webgl/TextReplay.js
@@ -32,13 +32,13 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
     /**
      * @private
-     * @type {Array.<HTMLCanvasElement>}
+     * @type {Array<HTMLCanvasElement>}
      */
     this.images_ = [];
 
     /**
      * @private
-     * @type {Array.<WebGLTexture>}
+     * @type {Array<WebGLTexture>}
      */
     this.textures_ = [];
 
@@ -52,7 +52,7 @@ class WebGLTextReplay extends WebGLTextureReplay {
      * @private
      * @type {{strokeColor: (module:ol/colorlike~ColorLike|null),
      *         lineCap: (string|undefined),
-     *         lineDash: Array.<number>,
+     *         lineDash: Array<number>,
      *         lineDashOffset: (number|undefined),
      *         lineJoin: (string|undefined),
      *         lineWidth: number,
@@ -209,8 +209,8 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
   /**
    * @private
-   * @param {Array.<string>} lines Label to draw split to lines.
-   * @return {Array.<number>} Size of the label in pixels.
+   * @param {Array<string>} lines Label to draw split to lines.
+   * @return {Array<number>} Size of the label in pixels.
    */
   getTextSize_(lines) {
     const self = this;
@@ -236,7 +236,7 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
   /**
    * @private
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -427,7 +427,7 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
   /**
    * @private
-   * @param {Array.<string|number>} params Array of parameters.
+   * @param {Array<string|number>} params Array of parameters.
    * @return {string} Hash string.
    */
   calculateHash_(params) {

--- a/src/ol/render/webgl/TextReplay.js
+++ b/src/ol/render/webgl/TextReplay.js
@@ -17,7 +17,7 @@ import WebGLBuffer from '../../webgl/Buffer.js';
 /**
  * @typedef {Object} GlyphAtlas
  * @property {module:ol/style/AtlasManager} atlas
- * @property {Object.<string, number>} width
+ * @property {Object<string, number>} width
  * @property {number} height
  */
 
@@ -106,7 +106,7 @@ class WebGLTextReplay extends WebGLTextureReplay {
 
     /**
      * @private
-     * @type {Object.<string, module:ol/render/webgl/TextReplay~GlyphAtlas>}
+     * @type {Object<string, module:ol/render/webgl/TextReplay~GlyphAtlas>}
      */
     this.atlases_ = {};
 
@@ -313,7 +313,7 @@ class WebGLTextReplay extends WebGLTextureReplay {
     this.indicesBuffer = new WebGLBuffer(this.indices);
 
     // create textures
-    /** @type {Object.<string, WebGLTexture>} */
+    /** @type {Object<string, WebGLTexture>} */
     const texturePerImage = {};
 
     this.createTextures(this.textures_, this.images_, texturePerImage, gl);

--- a/src/ol/render/webgl/TextureReplay.js
+++ b/src/ol/render/webgl/TextureReplay.js
@@ -31,13 +31,13 @@ class WebGLTextureReplay extends WebGLReplay {
     this.anchorY = undefined;
 
     /**
-     * @type {Array.<number>}
+     * @type {Array<number>}
      * @protected
      */
     this.groupIndices = [];
 
     /**
-     * @type {Array.<number>}
+     * @type {Array<number>}
      * @protected
      */
     this.hitDetectionGroupIndices = [];
@@ -130,7 +130,7 @@ class WebGLTextureReplay extends WebGLReplay {
   }
 
   /**
-   * @param {Array.<number>} flatCoordinates Flat coordinates.
+   * @param {Array<number>} flatCoordinates Flat coordinates.
    * @param {number} offset Offset.
    * @param {number} end End.
    * @param {number} stride Stride.
@@ -233,8 +233,8 @@ class WebGLTextureReplay extends WebGLReplay {
 
   /**
    * @protected
-   * @param {Array.<WebGLTexture>} textures Textures.
-   * @param {Array.<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>} images Images.
+   * @param {Array<WebGLTexture>} textures Textures.
+   * @param {Array<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>} images Images.
    * @param {!Object.<string, WebGLTexture>} texturePerImage Texture cache.
    * @param {WebGLRenderingContext} gl Gl.
    */
@@ -353,8 +353,8 @@ class WebGLTextureReplay extends WebGLReplay {
    * @param {module:ol/webgl/Context} context Context.
    * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
    *  to skip.
-   * @param {Array.<WebGLTexture>} textures Textures.
-   * @param {Array.<number>} groupIndices Texture group indices.
+   * @param {Array<WebGLTexture>} textures Textures.
+   * @param {Array<number>} groupIndices Texture group indices.
    */
   drawReplaySkipping(gl, context, skippedFeaturesHash, textures, groupIndices) {
     let featureIndex = 0;
@@ -462,14 +462,14 @@ class WebGLTextureReplay extends WebGLReplay {
    * @abstract
    * @protected
    * @param {boolean=} opt_all Return hit detection textures with regular ones.
-   * @returns {Array.<WebGLTexture>} Textures.
+   * @returns {Array<WebGLTexture>} Textures.
    */
   getTextures(opt_all) {}
 
   /**
    * @abstract
    * @protected
-   * @returns {Array.<WebGLTexture>} Textures.
+   * @returns {Array<WebGLTexture>} Textures.
    */
   getHitDetectionTextures() {}
 }

--- a/src/ol/render/webgl/TextureReplay.js
+++ b/src/ol/render/webgl/TextureReplay.js
@@ -235,7 +235,7 @@ class WebGLTextureReplay extends WebGLReplay {
    * @protected
    * @param {Array<WebGLTexture>} textures Textures.
    * @param {Array<HTMLCanvasElement|HTMLImageElement|HTMLVideoElement>} images Images.
-   * @param {!Object.<string, WebGLTexture>} texturePerImage Texture cache.
+   * @param {!Object<string, WebGLTexture>} texturePerImage Texture cache.
    * @param {WebGLRenderingContext} gl Gl.
    */
   createTextures(textures, images, texturePerImage, gl) {
@@ -351,7 +351,7 @@ class WebGLTextureReplay extends WebGLReplay {
    * @protected
    * @param {WebGLRenderingContext} gl gl.
    * @param {module:ol/webgl/Context} context Context.
-   * @param {Object.<string, boolean>} skippedFeaturesHash Ids of features
+   * @param {Object<string, boolean>} skippedFeaturesHash Ids of features
    *  to skip.
    * @param {Array<WebGLTexture>} textures Textures.
    * @param {Array<number>} groupIndices Texture group indices.

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -31,7 +31,7 @@ class LayerRenderer extends Observable {
    * Create a function that adds loaded tiles to the tile lookup.
    * @param {module:ol/source/Tile} source Tile source.
    * @param {module:ol/proj/Projection} projection Projection of the tiles.
-   * @param {Object.<number, Object.<string, module:ol/Tile>>} tiles Lookup of loaded tiles by zoom level.
+   * @param {Object<number, Object<string, module:ol/Tile>>} tiles Lookup of loaded tiles by zoom level.
    * @return {function(number, module:ol/TileRange):boolean} A function that can be
    *     called with a zoom level and a tile range to add loaded tiles to the lookup.
    * @protected
@@ -130,7 +130,7 @@ class LayerRenderer extends Observable {
   }
 
   /**
-   * @param {!Object.<string, !Object.<string, module:ol/TileRange>>} usedTiles Used tiles.
+   * @param {!Object<string, !Object<string, module:ol/TileRange>>} usedTiles Used tiles.
    * @param {module:ol/source/Tile} tileSource Tile source.
    * @param {number} z Z.
    * @param {module:ol/TileRange} tileRange Tile range.

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -40,7 +40,7 @@ class MapRenderer extends Disposable {
 
     /**
      * @private
-     * @type {Array.<module:ol/renderer/Layer>}
+     * @type {Array<module:ol/renderer/Layer>}
      */
     this.layerRendererConstructors_ = [];
 
@@ -48,7 +48,7 @@ class MapRenderer extends Disposable {
 
   /**
    * Register layer renderer constructors.
-   * @param {Array.<module:ol/renderer/Layer>} constructors Layer renderers.
+   * @param {Array<module:ol/renderer/Layer>} constructors Layer renderers.
    */
   registerLayerRenderers(constructors) {
     this.layerRendererConstructors_.push.apply(this.layerRendererConstructors_, constructors);
@@ -56,7 +56,7 @@ class MapRenderer extends Disposable {
 
   /**
    * Get the registered layer renderer constructors.
-   * @return {Array.<module:ol/renderer/Layer>} Registered layer renderers.
+   * @return {Array<module:ol/renderer/Layer>} Registered layer renderers.
    */
   getLayerRendererConstructors() {
     return this.layerRendererConstructors_;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -28,13 +28,13 @@ class MapRenderer extends Disposable {
 
     /**
      * @private
-     * @type {!Object.<string, module:ol/renderer/Layer>}
+     * @type {!Object<string, module:ol/renderer/Layer>}
      */
     this.layerRenderers_ = {};
 
     /**
      * @private
-     * @type {Object.<string, module:ol/events~EventsKey>}
+     * @type {Object<string, module:ol/events~EventsKey>}
      */
     this.layerRendererListeners_ = {};
 
@@ -242,7 +242,7 @@ class MapRenderer extends Disposable {
 
   /**
    * @protected
-   * @return {Object.<string, module:ol/renderer/Layer>} Layer renderers.
+   * @return {Object<string, module:ol/renderer/Layer>} Layer renderers.
    */
   getLayerRenderers() {
     return this.layerRenderers_;

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -40,7 +40,7 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
     this.imageTransform_ = createTransform();
 
     /**
-     * @type {!Array.<string>}
+     * @type {!Array<string>}
      */
     this.skippedFeatures_ = [];
 

--- a/src/ol/renderer/canvas/Map.js
+++ b/src/ol/renderer/canvas/Map.js
@@ -15,7 +15,7 @@ import SourceState from '../../source/State.js';
 
 
 /**
- * @type {Array.<module:ol/renderer/Layer>}
+ * @type {Array<module:ol/renderer/Layer>}
  */
 export const layerRendererConstructors = [];
 

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -163,7 +163,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
     const tilePixelRatio = tileSource.getTilePixelRatio(pixelRatio);
 
     /**
-     * @type {Object.<number, Object.<string, module:ol/Tile>>}
+     * @type {Object<number, Object<string, module:ol/Tile>>}
      */
     const tilesToDrawByZ = {};
     tilesToDrawByZ[z] = {};

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -52,7 +52,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
 
     /**
      * @protected
-     * @type {!Array.<module:ol/Tile>}
+     * @type {!Array<module:ol/Tile>}
      */
     this.renderedTiles = [];
 
@@ -241,7 +241,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
       }
 
       this.renderedTiles.length = 0;
-      /** @type {Array.<number>} */
+      /** @type {Array<number>} */
       const zs = Object.keys(tilesToDrawByZ).map(Number);
       zs.sort(function(a, b) {
         if (a === z) {

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -352,7 +352,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       }
     }.bind(this);
     if (vectorLayerRenderOrder) {
-      /** @type {Array.<module:ol/Feature>} */
+      /** @type {Array<module:ol/Feature>} */
       const features = [];
       vectorSource.forEachFeatureInExtent(extent,
         /**
@@ -384,7 +384,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @param {module:ol/Feature} feature Feature.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/style/Style|Array.<module:ol/style/Style>} styles The style or array of styles.
+   * @param {module:ol/style/Style|Array<module:ol/style/Style>} styles The style or array of styles.
    * @param {module:ol/render/canvas/ReplayGroup} replayGroup Replay group.
    * @return {boolean} `true` if an image is loading.
    */

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -234,7 +234,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       const resolution = frameState.viewState.resolution;
       const rotation = frameState.viewState.rotation;
       const layer = /** @type {module:ol/layer/Vector} */ (this.getLayer());
-      /** @type {!Object.<string, boolean>} */
+      /** @type {!Object<string, boolean>} */
       const features = {};
       const result = this.replayGroup_.forEachFeatureAtCoordinate(coordinate, resolution, rotation, hitTolerance, {},
         /**

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -28,7 +28,7 @@ import {
 
 
 /**
- * @type {!Object.<string, Array<module:ol/render/ReplayType>>}
+ * @type {!Object<string, Array<module:ol/render/ReplayType>>}
  */
 const IMAGE_REPLAYS = {
   'image': [ReplayType.POLYGON, ReplayType.CIRCLE,
@@ -38,7 +38,7 @@ const IMAGE_REPLAYS = {
 
 
 /**
- * @type {!Object.<string, Array<module:ol/render/ReplayType>>}
+ * @type {!Object<string, Array<module:ol/render/ReplayType>>}
  */
 const VECTOR_REPLAYS = {
   'image': [ReplayType.DEFAULT],
@@ -234,7 +234,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const rotation = frameState.viewState.rotation;
     hitTolerance = hitTolerance == undefined ? 0 : hitTolerance;
     const layer = this.getLayer();
-    /** @type {!Object.<string, boolean>} */
+    /** @type {!Object<string, boolean>} */
     const features = {};
 
     /** @type {Array<module:ol/VectorImageTile>} */

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -28,7 +28,7 @@ import {
 
 
 /**
- * @type {!Object.<string, Array.<module:ol/render/ReplayType>>}
+ * @type {!Object.<string, Array<module:ol/render/ReplayType>>}
  */
 const IMAGE_REPLAYS = {
   'image': [ReplayType.POLYGON, ReplayType.CIRCLE,
@@ -38,7 +38,7 @@ const IMAGE_REPLAYS = {
 
 
 /**
- * @type {!Object.<string, Array.<module:ol/render/ReplayType>>}
+ * @type {!Object.<string, Array<module:ol/render/ReplayType>>}
  */
 const VECTOR_REPLAYS = {
   'image': [ReplayType.DEFAULT],
@@ -237,7 +237,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     /** @type {!Object.<string, boolean>} */
     const features = {};
 
-    /** @type {Array.<module:ol/VectorImageTile>} */
+    /** @type {Array<module:ol/VectorImageTile>} */
     const renderedTiles = this.renderedTiles;
 
     let bufferedExtent, found;
@@ -410,7 +410,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   /**
    * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
    * @param {number} squaredTolerance Squared tolerance.
-   * @param {module:ol/style/Style|Array.<module:ol/style/Style>} styles The style or array of styles.
+   * @param {module:ol/style/Style|Array<module:ol/style/Style>} styles The style or array of styles.
    * @param {module:ol/render/canvas/ReplayGroup} replayGroup Replay group.
    * @return {boolean} `true` if an image is loading.
    */

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -16,7 +16,7 @@ const SIMPLIFY_TOLERANCE = 0.5;
 
 /**
  * @const
- * @type {Object.<module:ol/geom/GeometryType,
+ * @type {Object<module:ol/geom/GeometryType,
  *                function(module:ol/render/ReplayGroup, module:ol/geom/Geometry,
  *                         module:ol/style/Style, Object)>}
  */

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -72,7 +72,7 @@ class WebGLLayerRenderer extends LayerRenderer {
     this.projectionMatrix = createTransform();
 
     /**
-     * @type {Array.<number>}
+     * @type {Array<number>}
      * @private
      */
     this.tmpMat4_ = create();

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -129,7 +129,7 @@ class WebGLMapRenderer extends MapRenderer {
      */
     this.tileTextureQueue_ = new PriorityQueue(
       /**
-       * @param {Array.<*>} element Element.
+       * @param {Array<*>} element Element.
        * @return {number} Priority.
        * @this {module:ol/renderer/webgl/Map}
        */
@@ -142,7 +142,7 @@ class WebGLMapRenderer extends MapRenderer {
               Math.sqrt(deltaX * deltaX + deltaY * deltaY) / tileResolution;
       }).bind(this),
       /**
-       * @param {Array.<*>} element Element.
+       * @param {Array<*>} element Element.
        * @return {string} Key.
        */
       function(element) {
@@ -413,7 +413,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     this.dispatchComposeEvent_(RenderEventType.PRECOMPOSE, frameState);
 
-    /** @type {Array.<module:ol/layer/Layer~State>} */
+    /** @type {Array<module:ol/layer/Layer~State>} */
     const layerStatesToDraw = [];
     const layerStatesArray = frameState.layerStatesArray;
     stableSort(layerStatesArray, sortByZIndex);

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -113,7 +113,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     /**
      * @private
-     * @type {module:ol/structs/LRUCache.<module:ol/renderer/webgl/Map~TextureCacheEntry|null>}
+     * @type {module:ol/structs/LRUCache<module:ol/renderer/webgl/Map~TextureCacheEntry|null>}
      */
     this.textureCache_ = new LRUCache();
 
@@ -125,7 +125,7 @@ class WebGLMapRenderer extends MapRenderer {
 
     /**
      * @private
-     * @type {module:ol/structs/PriorityQueue.<Array>}
+     * @type {module:ol/structs/PriorityQueue<Array>}
      */
     this.tileTextureQueue_ = new PriorityQueue(
       /**
@@ -333,7 +333,7 @@ class WebGLMapRenderer extends MapRenderer {
   }
 
   /**
-   * @return {module:ol/structs/PriorityQueue.<Array>} Tile texture queue.
+   * @return {module:ol/structs/PriorityQueue<Array>} Tile texture queue.
    */
   getTileTextureQueue() {
     return this.tileTextureQueue_;

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -273,7 +273,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
       }
 
-      /** @type {Array.<number>} */
+      /** @type {Array<number>} */
       const zs = Object.keys(tilesToDrawByZ).map(Number);
       zs.sort(numberSafeCompareFunction);
       const u_tileOffset = new Float32Array(4);

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -214,7 +214,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
       gl.uniform1i(this.locations_.u_texture, 0);
 
       /**
-       * @type {Object.<number, Object.<string, module:ol/Tile>>}
+       * @type {Object<number, Object<string, module:ol/Tile>>}
        */
       const tilesToDrawByZ = {};
       tilesToDrawByZ[z] = {};

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -117,7 +117,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
       const viewState = frameState.viewState;
       const layer = this.getLayer();
       const layerState = this.layerState_;
-      /** @type {!Object.<string, boolean>} */
+      /** @type {!Object<string, boolean>} */
       const features = {};
       return this.replayGroup_.forEachFeatureAtCoordinate(coordinate,
         context, viewState.center, viewState.resolution, viewState.rotation,

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -247,7 +247,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
       }
     };
     if (vectorLayerRenderOrder) {
-      /** @type {Array.<module:ol/Feature>} */
+      /** @type {Array<module:ol/Feature>} */
       const features = [];
       vectorSource.forEachFeatureInExtent(extent,
         /**
@@ -276,7 +276,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
    * @param {module:ol/Feature} feature Feature.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {module:ol/style/Style|Array.<module:ol/style/Style>} styles The style or array of
+   * @param {module:ol/style/Style|Array<module:ol/style/Style>} styles The style or array of
    *     styles.
    * @param {module:ol/render/webgl/ReplayGroup} replayGroup Replay group.
    * @return {boolean} `true` if an image is loading.

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -83,7 +83,7 @@ function enlargeClipPoint(centroidX, centroidY, x, y) {
  * @param {module:ol/extent~Extent} targetExtent Target extent.
  * @param {module:ol/reproj/Triangulation} triangulation
  * Calculated triangulation.
- * @param {Array.<{extent: module:ol/extent~Extent,
+ * @param {Array<{extent: module:ol/extent~Extent,
  *                 image: (HTMLCanvasElement|HTMLImageElement|HTMLVideoElement)}>} sources
  * Array of sources.
  * @param {number} gutter Gutter of the sources.

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -98,13 +98,13 @@ class ReprojTile extends Tile {
 
     /**
      * @private
-     * @type {!Array.<module:ol/Tile>}
+     * @type {!Array<module:ol/Tile>}
      */
     this.sourceTiles_ = [];
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.sourcesListenerKeys_ = null;
 

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -64,7 +64,7 @@ class Triangulation {
      */
     this.targetProj_ = targetProj;
 
-    /** @type {!Object.<string, module:ol/coordinate~Coordinate>} */
+    /** @type {!Object<string, module:ol/coordinate~Coordinate>} */
     let transformInvCache = {};
     const transformInv = getTransform(this.targetProj_, this.sourceProj_);
 

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -10,8 +10,8 @@ import {getTransform} from '../proj.js';
 /**
  * Single triangle; consists of 3 source points and 3 target points.
  * @typedef {Object} Triangle
- * @property {Array.<module:ol/coordinate~Coordinate>} source
- * @property {Array.<module:ol/coordinate~Coordinate>} target
+ * @property {Array<module:ol/coordinate~Coordinate>} source
+ * @property {Array<module:ol/coordinate~Coordinate>} target
  */
 
 
@@ -94,7 +94,7 @@ class Triangulation {
     this.errorThresholdSquared_ = errorThreshold * errorThreshold;
 
     /**
-     * @type {Array.<module:ol/reproj/Triangulation~Triangle>}
+     * @type {Array<module:ol/reproj/Triangulation~Triangle>}
      * @private
      */
     this.triangles_ = [];
@@ -343,7 +343,7 @@ class Triangulation {
   }
 
   /**
-   * @return {Array.<module:ol/reproj/Triangulation~Triangle>} Array of the calculated triangles.
+   * @return {Array<module:ol/reproj/Triangulation~Triangle>} Array of the calculated triangles.
    */
   getTriangles() {
     return this.triangles_;

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -11,7 +11,7 @@ import {clamp} from './math.js';
 
 
 /**
- * @param {Array.<number>} resolutions Resolutions.
+ * @param {Array<number>} resolutions Resolutions.
  * @return {module:ol/resolutionconstraint~Type} Zoom function.
  */
 export function createSnapToResolutions(resolutions) {

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -5,7 +5,7 @@
 
 /**
  * An array of numbers representing a size: `[width, height]`.
- * @typedef {Array.<number>} Size
+ * @typedef {Array<number>} Size
  * @api
  */
 

--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -71,7 +71,7 @@ class CartoDB extends XYZ {
     this.config_ = options.config || {};
 
     /**
-     * @type {!Object.<string, CartoDBLayerInfo>}
+     * @type {!Object<string, CartoDBLayerInfo>}
      * @private
      */
     this.templateCache_ = {};

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -68,7 +68,7 @@ class Cluster extends VectorSource {
     this.distance = options.distance !== undefined ? options.distance : 20;
 
     /**
-     * @type {Array.<module:ol/Feature>}
+     * @type {Array<module:ol/Feature>}
      * @protected
      */
     this.features = [];
@@ -189,7 +189,7 @@ class Cluster extends VectorSource {
   }
 
   /**
-   * @param {Array.<module:ol/Feature>} features Features
+   * @param {Array<module:ol/Feature>} features Features
    * @return {module:ol/Feature} The cluster feature.
    * @protected
    */

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -159,7 +159,7 @@ class Cluster extends VectorSource {
     const features = this.source.getFeatures();
 
     /**
-     * @type {!Object.<string, boolean>}
+     * @type {!Object<string, boolean>}
      */
     const clustered = {};
 

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -72,7 +72,7 @@ class ImageSourceEvent extends Event {
  * @property {module:ol/source/Source~AttributionLike} [attributions]
  * @property {module:ol/extent~Extent} [extent]
  * @property {module:ol/proj~ProjectionLike} projection
- * @property {Array.<number>} [resolutions]
+ * @property {Array<number>} [resolutions]
  * @property {module:ol/source/State} [state]
  */
 
@@ -98,7 +98,7 @@ class ImageSource extends Source {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.resolutions_ = options.resolutions !== undefined ?
       options.resolutions : null;
@@ -119,7 +119,7 @@ class ImageSource extends Source {
   }
 
   /**
-   * @return {Array.<number>} Resolutions.
+   * @return {Array<number>} Resolutions.
    * @override
    */
   getResolutions() {

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -32,7 +32,7 @@ import {appendParams} from '../uri.js';
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,
  * `2` means twice the size of the map viewport, and so on.
- * @property {Array.<number>} [resolutions] Resolutions. If specified, requests will be made for
+ * @property {Array<number>} [resolutions] Resolutions. If specified, requests will be made for
  * these resolutions only.
  * @property {string} [url] ArcGIS Rest service URL for a Map Service or Image Service. The url
  * should include /MapServer or /ImageServer.

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -23,7 +23,7 @@ import {appendParams} from '../uri.js';
  * the remote server.
  * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given
  * a URL.
- * @property {Object.<string,*>} params ArcGIS Rest parameters. This field is optional. Service
+ * @property {Object<string,*>} params ArcGIS Rest parameters. This field is optional. Service
  * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
  * `IMAGE` by default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`, and `IMAGESR`
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -36,7 +36,7 @@ import ImageSource from '../source/Image.js';
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
  * width and height of the map viewport, and so on. Must be `1` or higher.
- * @property {Array.<number>} [resolutions] Resolutions.
+ * @property {Array<number>} [resolutions] Resolutions.
  * If specified, new canvases will be created for these resolutions
  * @property {module:ol/source/State} [state] Source state.
  */

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -25,7 +25,7 @@ import {appendParams} from '../uri.js';
  * @property {module:ol/proj~ProjectionLike} projection Projection.
  * @property {number} [ratio=1] Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or higher.
- * @property {Array.<number>} [resolutions] Resolutions.
+ * @property {Array<number>} [resolutions] Resolutions.
  * If specified, requests will be made for these resolutions only.
  * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
  * @property {Object} [params] Additional parameters.

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -195,7 +195,7 @@ class ImageMapGuide extends ImageSource {
 
   /**
    * @param {string} baseUrl The mapagent url.
-   * @param {Object.<string, string|number>} params Request parameters.
+   * @param {Object<string, string|number>} params Request parameters.
    * @param {module:ol/extent~Extent} extent Extent.
    * @param {module:ol/size~Size} size Size.
    * @param {module:ol/proj/Projection} projection Projection.

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -45,7 +45,7 @@ const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport, `2` means
  * twice the width and height of the map viewport, and so on. Must be `1` or
  * higher.
- * @property {Array.<number>} [resolutions] Resolutions.
+ * @property {Array<number>} [resolutions] Resolutions.
  * If specified, requests will be made for these resolutions only.
  * @property {string} url WMS service URL.
  */

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -37,7 +37,7 @@ const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
  * @property {module:ol/source/WMSServerType|string} [serverType] The type of
  * the remote WMS server: `mapserver`, `geoserver` or `qgis`. Only needed if `hidpi` is `true`.
  * @property {module:ol/Image~LoadFunction} [imageLoadFunction] Optional function to load an image given a URL.
- * @property {Object.<string,*>} params WMS request parameters.
+ * @property {Object<string,*>} params WMS request parameters.
  * At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -37,8 +37,8 @@ import {create as createTransform} from '../transform.js';
  * data object is accessible from raster events, where it can be initialized in
  * "beforeoperations" and accessed again in "afteroperations".
  *
- * @typedef {function((Array.<Array.<number>>|Array.<ImageData>), Object):
- *     (Array.<number>|ImageData)} Operation
+ * @typedef {function((Array<Array<number>>|Array<ImageData>), Object):
+ *     (Array<number>|ImageData)} Operation
  */
 
 
@@ -114,7 +114,7 @@ class RasterSourceEvent extends Event {
 
 /**
  * @typedef {Object} Options
- * @property {Array.<module:ol/source/Source|module:ol/layer/Layer>} sources Input
+ * @property {Array<module:ol/source/Source|module:ol/layer/Layer>} sources Input
  * sources or layers. Vector layers must be configured with `renderMode: 'image'`.
  * @property {module:ol/source/Raster~Operation} [operation] Raster operation.
  * The operation will be called with data from input sources
@@ -170,7 +170,7 @@ class RasterSource extends ImageSource {
 
     /**
      * @private
-     * @type {Array.<module:ol/renderer/canvas/Layer>}
+     * @type {Array<module:ol/renderer/canvas/Layer>}
      */
     this.renderers_ = createRenderers(options.sources);
 
@@ -455,8 +455,8 @@ function getImageData(renderer, frameState, layerState) {
 
 /**
  * Get a list of layer states from a list of renderers.
- * @param {Array.<module:ol/renderer/canvas/Layer>} renderers Layer renderers.
- * @return {Array.<module:ol/layer/Layer~State>} The layer states.
+ * @param {Array<module:ol/renderer/canvas/Layer>} renderers Layer renderers.
+ * @return {Array<module:ol/layer/Layer~State>} The layer states.
  */
 function getLayerStatesArray(renderers) {
   return renderers.map(function(renderer) {
@@ -467,8 +467,8 @@ function getLayerStatesArray(renderers) {
 
 /**
  * Create renderers for all sources.
- * @param {Array.<module:ol/source/Source>} sources The sources.
- * @return {Array.<module:ol/renderer/canvas/Layer>} Array of layer renderers.
+ * @param {Array<module:ol/source/Source>} sources The sources.
+ * @return {Array<module:ol/renderer/canvas/Layer>} Array of layer renderers.
  */
 function createRenderers(sources) {
   const len = sources.length;

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -12,7 +12,7 @@ import SourceState from '../source/State.js';
  * A function that returns a string or an array of strings representing source
  * attributions.
  *
- * @typedef {function(module:ol/PluggableMap~FrameState): (string|Array.<string>)} Attribution
+ * @typedef {function(module:ol/PluggableMap~FrameState): (string|Array<string>)} Attribution
  */
 
 
@@ -24,7 +24,7 @@ import SourceState from '../source/State.js';
  * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
  * * a function that returns a string or array of strings (`{@link module:ol/source/Source~Attribution}`)
  *
- * @typedef {string|Array.<string>|module:ol/source/Source~Attribution} AttributionLike
+ * @typedef {string|Array<string>|module:ol/source/Source~Attribution} AttributionLike
  */
 
 
@@ -124,7 +124,7 @@ class Source extends BaseObject {
 
   /**
   * @abstract
-  * @return {Array.<number>|undefined} Resolutions.
+  * @return {Array<number>|undefined} Resolutions.
   */
   getResolutions() {}
 

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -180,7 +180,7 @@ class Source extends BaseObject {
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
  * @param {number} hitTolerance Hit tolerance in pixels.
- * @param {Object.<string, boolean>} skippedFeatureUids Skipped feature uids.
+ * @param {Object<string, boolean>} skippedFeatureUids Skipped feature uids.
  * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
  * @return {T|undefined} Callback result.
  * @template T

--- a/src/ol/source/Stamen.js
+++ b/src/ol/source/Stamen.js
@@ -8,7 +8,7 @@ import XYZ from '../source/XYZ.js';
 
 /**
  * @const
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 const ATTRIBUTIONS = [
   'Map tiles by <a href="https://stamen.com/">Stamen Design</a>, ' +

--- a/src/ol/source/Stamen.js
+++ b/src/ol/source/Stamen.js
@@ -19,7 +19,7 @@ const ATTRIBUTIONS = [
 
 
 /**
- * @type {Object.<string, {extension: string, opaque: boolean}>}
+ * @type {Object<string, {extension: string, opaque: boolean}>}
  */
 const LayerConfig = {
   'terrain': {
@@ -70,7 +70,7 @@ const LayerConfig = {
 
 
 /**
- * @type {Object.<string, {minZoom: number, maxZoom: number}>}
+ * @type {Object<string, {minZoom: number, maxZoom: number}>}
  */
 const ProviderConfig = {
   'terrain': {

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -102,7 +102,7 @@ class TileSource extends Source {
 
   /**
    * @param {module:ol/proj/Projection} projection Projection.
-   * @param {!Object.<string, module:ol/TileRange>} usedTiles Used tiles.
+   * @param {!Object<string, module:ol/TileRange>} usedTiles Used tiles.
    */
   expireCache(projection, usedTiles) {
     const tileCache = this.getTileCacheForProjection(projection);

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -19,7 +19,7 @@ import {appendParams} from '../uri.js';
  * or if you want to access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
  * for more detail.
- * @property {Object.<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service defaults will be
+ * @property {Object<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
  * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
  * and `IMAGESR` will be set dynamically. Set `LAYERS` to

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -46,7 +46,7 @@ import {appendParams} from '../uri.js';
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * @property {Array.<string>} urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS
+ * @property {Array<string>} urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS
  * Service supports multiple urls for export requests.
  */
 

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -44,7 +44,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * @property {string} [url] URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
  * used instead of defining each one separately in the `urls` option.
- * @property {Array.<string>} [urls] An array of URL templates.
+ * @property {Array<string>} [urls] An array of URL templates.
  * @property {boolean} [wrapX] Whether to wrap the world horizontally. The default, is to
  * request out-of-bounds tiles from the server. When set to `false`, only one
  * world will be rendered. When set to `true`, tiles will be requested for one

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -102,13 +102,13 @@ class TileImage extends UrlTile {
 
     /**
      * @protected
-     * @type {!Object.<string, module:ol/TileCache>}
+     * @type {!Object<string, module:ol/TileCache>}
      */
     this.tileCacheForProjection = {};
 
     /**
      * @protected
-     * @type {!Object.<string, module:ol/tilegrid/TileGrid>}
+     * @type {!Object<string, module:ol/tilegrid/TileGrid>}
      */
     this.tileGridForProjection = {};
 

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -25,7 +25,7 @@ import {appendParams} from '../uri.js';
  * you must provide a `crossOrigin` value if you are using the WebGL renderer or if you want to
  * access pixel data with the Canvas renderer.  See
  * https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
- * @property {Object.<string,*>} params WMS request parameters.
+ * @property {Object<string,*>} params WMS request parameters.
  * At least a `LAYERS` param is required. `STYLES` is
  * `''` by default. `VERSION` is `1.3.0` by default. `WIDTH`, `HEIGHT`, `BBOX`
  * and `CRS` (`SRS` for WMS version < 1.3.0) will be set dynamically.

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -60,7 +60,7 @@ import {appendParams} from '../uri.js';
  * };
  * ```
  * @property {string} [url] WMS service URL.
- * @property {Array.<string>} [urls] WMS service urls.
+ * @property {Array<string>} [urls] WMS service urls.
  * Use this instead of `url` when the WMS supports multiple urls for GetMap requests.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * When set to `false`, only one world

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -51,13 +51,13 @@ export class CustomTile extends Tile {
 
     /**
      * @private
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.grid_ = null;
 
     /**
      * @private
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.keys_ = null;
 

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -63,7 +63,7 @@ export class CustomTile extends Tile {
 
     /**
      * @private
-     * @type {Object.<string, Object>|undefined}
+     * @type {Object<string, Object>|undefined}
      */
     this.data_ = null;
 

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -21,7 +21,7 @@ import {getKeyZXY} from '../tilecoord.js';
  * @property {number} [tilePixelRatio]
  * @property {module:ol/Tile~UrlFunction} [tileUrlFunction]
  * @property {string} [url]
- * @property {Array.<string>} [urls]
+ * @property {Array<string>} [urls]
  * @property {boolean} [wrapX=true]
  * @property {number} [transition]
  */
@@ -67,7 +67,7 @@ class UrlTile extends TileSource {
 
     /**
      * @protected
-     * @type {!Array.<string>|null}
+     * @type {!Array<string>|null}
      */
     this.urls = null;
 
@@ -110,7 +110,7 @@ class UrlTile extends TileSource {
    * Return the URLs used for this source.
    * When a tileUrlFunction is used instead of url or urls,
    * null will be returned.
-   * @return {!Array.<string>|null} URLs.
+   * @return {!Array<string>|null} URLs.
    * @api
    */
   getUrls() {
@@ -182,7 +182,7 @@ class UrlTile extends TileSource {
 
   /**
    * Set the URLs to use for requests.
-   * @param {Array.<string>} urls URLs.
+   * @param {Array<string>} urls URLs.
    * @api
    */
   setUrls(urls) {

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -82,7 +82,7 @@ class UrlTile extends TileSource {
 
     /**
      * @private
-     * @type {!Object.<number, boolean>}
+     * @type {!Object<number, boolean>}
      */
     this.tileLoadingKeys_ = {};
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -61,7 +61,7 @@ export class VectorSourceEvent extends Event {
 /**
  * @typedef {Object} Options
  * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
- * @property {Array<module:ol/Feature>|module:ol/Collection.<module:ol/Feature>} [features]
+ * @property {Array<module:ol/Feature>|module:ol/Collection<module:ol/Feature>} [features]
  * Features. If provided as {@link module:ol/Collection}, the features in the source
  * and the collection will stay in sync.
  * @property {module:ol/format/Feature} [format] The feature format used by the XHR
@@ -215,13 +215,13 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {module:ol/structs/RBush.<module:ol/Feature>}
+     * @type {module:ol/structs/RBush<module:ol/Feature>}
      */
     this.featuresRtree_ = useSpatialIndex ? new RBush() : null;
 
     /**
      * @private
-     * @type {module:ol/structs/RBush.<{extent: module:ol/extent~Extent}>}
+     * @type {module:ol/structs/RBush<{extent: module:ol/extent~Extent}>}
      */
     this.loadedExtentsRtree_ = new RBush();
 
@@ -253,7 +253,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {module:ol/Collection.<module:ol/Feature>}
+     * @type {module:ol/Collection<module:ol/Feature>}
      */
     this.featuresCollection_ = null;
 
@@ -417,7 +417,7 @@ VectorSource.prototype.addFeaturesInternal = function(features) {
 
 
 /**
- * @param {!module:ol/Collection.<module:ol/Feature>} collection Collection.
+ * @param {!module:ol/Collection<module:ol/Feature>} collection Collection.
  * @private
  */
 VectorSource.prototype.bindFeaturesCollection_ = function(collection) {
@@ -610,7 +610,7 @@ VectorSource.prototype.forEachFeatureIntersectingExtent = function(extent, callb
  * Get the features collection associated with this source. Will be `null`
  * unless the source was configured with `useSpatialIndex` set to `false`, or
  * with an {@link module:ol/Collection} as `features`.
- * @return {module:ol/Collection.<module:ol/Feature>} The collection of features.
+ * @return {module:ol/Collection<module:ol/Feature>} The collection of features.
  * @api
  */
 VectorSource.prototype.getFeaturesCollection = function() {

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -227,27 +227,27 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {!Object.<string, module:ol/Feature>}
+     * @type {!Object<string, module:ol/Feature>}
      */
     this.nullGeometryFeatures_ = {};
 
     /**
      * A lookup of features by id (the return from feature.getId()).
      * @private
-     * @type {!Object.<string, module:ol/Feature>}
+     * @type {!Object<string, module:ol/Feature>}
      */
     this.idIndex_ = {};
 
     /**
      * A lookup of features without id (keyed by getUid(feature)).
      * @private
-     * @type {!Object.<string, module:ol/Feature>}
+     * @type {!Object<string, module:ol/Feature>}
      */
     this.undefIdIndex_ = {};
 
     /**
      * @private
-     * @type {Object.<string, Array<module:ol/events~EventsKey>>}
+     * @type {Object<string, Array<module:ol/events~EventsKey>>}
      */
     this.featureChangeKeys_ = {};
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -26,7 +26,7 @@ import RBush from '../structs/RBush.js';
  * returns an array of {@link module:ol/extent~Extent} with the extents to load. Usually this
  * is one of the standard {@link module:ol/loadingstrategy} strategies.
  *
- * @typedef {function(module:ol/extent~Extent, number): Array.<module:ol/extent~Extent>} LoadingStrategy
+ * @typedef {function(module:ol/extent~Extent, number): Array<module:ol/extent~Extent>} LoadingStrategy
  * @api
  */
 
@@ -61,7 +61,7 @@ export class VectorSourceEvent extends Event {
 /**
  * @typedef {Object} Options
  * @property {module:ol/source/Source~AttributionLike} [attributions] Attributions.
- * @property {Array.<module:ol/Feature>|module:ol/Collection.<module:ol/Feature>} [features]
+ * @property {Array<module:ol/Feature>|module:ol/Collection.<module:ol/Feature>} [features]
  * Features. If provided as {@link module:ol/Collection}, the features in the source
  * and the collection will stay in sync.
  * @property {module:ol/format/Feature} [format] The feature format used by the XHR
@@ -247,7 +247,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {Object.<string, Array.<module:ol/events~EventsKey>>}
+     * @type {Object.<string, Array<module:ol/events~EventsKey>>}
      */
     this.featureChangeKeys_ = {};
 
@@ -365,7 +365,7 @@ VectorSource.prototype.addToIndex_ = function(featureKey, feature) {
 
 /**
  * Add a batch of features to the source.
- * @param {Array.<module:ol/Feature>} features Features to add.
+ * @param {Array<module:ol/Feature>} features Features to add.
  * @api
  */
 VectorSource.prototype.addFeatures = function(features) {
@@ -376,7 +376,7 @@ VectorSource.prototype.addFeatures = function(features) {
 
 /**
  * Add features without firing a `change` event.
- * @param {Array.<module:ol/Feature>} features Features.
+ * @param {Array<module:ol/Feature>} features Features.
  * @protected
  */
 VectorSource.prototype.addFeaturesInternal = function(features) {
@@ -620,7 +620,7 @@ VectorSource.prototype.getFeaturesCollection = function() {
 
 /**
  * Get all features on the source in random order.
- * @return {Array.<module:ol/Feature>} Features.
+ * @return {Array<module:ol/Feature>} Features.
  * @api
  */
 VectorSource.prototype.getFeatures = function() {
@@ -634,7 +634,7 @@ VectorSource.prototype.getFeatures = function() {
     }
   }
   return (
-    /** @type {Array.<module:ol/Feature>} */ (features)
+    /** @type {Array<module:ol/Feature>} */ (features)
   );
 };
 
@@ -642,7 +642,7 @@ VectorSource.prototype.getFeatures = function() {
 /**
  * Get all features whose geometry intersects the provided coordinate.
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
- * @return {Array.<module:ol/Feature>} Features.
+ * @return {Array<module:ol/Feature>} Features.
  * @api
  */
 VectorSource.prototype.getFeaturesAtCoordinate = function(coordinate) {
@@ -662,7 +662,7 @@ VectorSource.prototype.getFeaturesAtCoordinate = function(coordinate) {
  * This method is not available when the source is configured with
  * `useSpatialIndex` set to `false`.
  * @param {module:ol/extent~Extent} extent Extent.
- * @return {Array.<module:ol/Feature>} Features.
+ * @return {Array<module:ol/Feature>} Features.
  * @api
  */
 VectorSource.prototype.getFeaturesInExtent = function(extent) {

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -111,7 +111,7 @@ class VectorTile extends UrlTile {
 
     /**
        * @private
-       * @type {Object.<string, module:ol/VectorTile>}
+       * @type {Object<string, module:ol/VectorTile>}
        */
     this.sourceTiles_ = {};
 
@@ -130,7 +130,7 @@ class VectorTile extends UrlTile {
 
     /**
      * @private
-     * @type {Object.<string, module:ol/tilegrid/TileGrid>}
+     * @type {Object<string, module:ol/tilegrid/TileGrid>}
      */
     this.tileGrids_ = {};
 

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -50,7 +50,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * used instead of defining each one separately in the `urls` option.
  * @property {number} [transition] A duration for tile opacity
  * transitions in milliseconds. A duration of 0 disables the opacity transition.
- * @property {Array.<string>} [urls] An array of URL templates.
+ * @property {Array<string>} [urls] An array of URL templates.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * When set to `false`, only one world
  * will be rendered. When set to `true`, tiles will be wrapped horizontally to

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -48,7 +48,7 @@ import {appendParams} from '../uri.js';
  *   imageTile.getImage().src = src;
  * };
  * ```
- * @property {Array.<string>} [urls] An array of URLs.
+ * @property {Array<string>} [urls] An array of URLs.
  * Requests will be distributed among the URLs in this array.
  * @property {boolean} [wrapX=false] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.
@@ -328,7 +328,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   }
   const matrixSet = /** @type {string} */
     (l['TileMatrixSetLink'][idx]['TileMatrixSet']);
-  const matrixLimits = /** @type {Array.<Object>} */
+  const matrixLimits = /** @type {Array<Object>} */
     (l['TileMatrixSetLink'][idx]['TileMatrixSetLimits']);
 
   let format = /** @type {string} */ (l['Format'][0]);
@@ -399,7 +399,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
 
   const tileGrid = createFromCapabilitiesMatrixSet(matrixSetObj, extent, matrixLimits);
 
-  /** @type {!Array.<string>} */
+  /** @type {!Array<string>} */
   const urls = [];
   let requestEncoding = config['requestEncoding'];
   requestEncoding = requestEncoding !== undefined ? requestEncoding : '';

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -37,7 +37,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * @property {string} [url] URL template. Must include `{x}`, `{y}` or `{-y}`,
  * and `{z}` placeholders. A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`,
  * may be used instead of defining each one separately in the `urls` option.
- * @property {Array.<string>} [urls] An array of URL templates.
+ * @property {Array<string>} [urls] An array of URL templates.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -143,7 +143,7 @@ export function getLength(geometry, opt_options) {
  * Polygons on a Sphere", JPL Publication 07-03, Jet Propulsion
  * Laboratory, Pasadena, CA, June 2007
  *
- * @param {Array.<module:ol/coordinate~Coordinate>} coordinates List of coordinates of a linear
+ * @param {Array<module:ol/coordinate~Coordinate>} coordinates List of coordinates of a linear
  * ring. If the ring is oriented clockwise, the area will be positive,
  * otherwise it will be negative.
  * @param {number} radius The sphere radius.

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -47,7 +47,7 @@ class LRUCache extends EventTarget {
 
     /**
      * @private
-     * @type {!Object.<string, module:ol/structs/LRUCache~Entry>}
+     * @type {!Object<string, module:ol/structs/LRUCache~Entry>}
      */
     this.entries_ = {};
 

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -174,7 +174,7 @@ class LRUCache extends EventTarget {
 
 
   /**
-   * @return {Array.<string>} Keys.
+   * @return {Array<string>} Keys.
    */
   getKeys() {
     const keys = new Array(this.count_);
@@ -188,7 +188,7 @@ class LRUCache extends EventTarget {
 
 
   /**
-   * @return {Array.<T>} Values.
+   * @return {Array<T>} Values.
    */
   getValues() {
     const values = new Array(this.count_);

--- a/src/ol/structs/PriorityQueue.js
+++ b/src/ol/structs/PriorityQueue.js
@@ -56,7 +56,7 @@ class PriorityQueue {
     this.priorities_ = [];
 
     /**
-     * @type {!Object.<string, boolean>}
+     * @type {!Object<string, boolean>}
      * @private
      */
     this.queuedElements_ = {};

--- a/src/ol/structs/PriorityQueue.js
+++ b/src/ol/structs/PriorityQueue.js
@@ -44,13 +44,13 @@ class PriorityQueue {
     this.keyFunction_ = keyFunction;
 
     /**
-     * @type {Array.<T>}
+     * @type {Array<T>}
      * @private
      */
     this.elements_ = [];
 
     /**
-     * @type {Array.<number>}
+     * @type {Array<number>}
      * @private
      */
     this.priorities_ = [];

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -65,8 +65,8 @@ class RBush {
 
   /**
    * Bulk-insert values into the RBush.
-   * @param {Array.<module:ol/extent~Extent>} extents Extents.
-   * @param {Array.<T>} values Values.
+   * @param {Array<module:ol/extent~Extent>} extents Extents.
+   * @param {Array<T>} values Values.
    */
   load(extents, values) {
     const items = new Array(values.length);
@@ -122,7 +122,7 @@ class RBush {
 
   /**
    * Return all values in the RBush.
-   * @return {Array.<T>} All.
+   * @return {Array<T>} All.
    */
   getAll() {
     const items = this.rbush_.all();
@@ -135,7 +135,7 @@ class RBush {
   /**
    * Return all values in the given extent.
    * @param {module:ol/extent~Extent} extent Extent.
-   * @return {Array.<T>} All in extent.
+   * @return {Array<T>} All in extent.
    */
   getInExtent(extent) {
     /** @type {module:ol/structs/RBush~Entry} */
@@ -180,7 +180,7 @@ class RBush {
 
 
   /**
-   * @param {Array.<T>} values Values.
+   * @param {Array<T>} values Values.
    * @param {function(this: S, T): *} callback Callback.
    * @param {S=} opt_this The object to use as `this` in `callback`.
    * @private

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -37,7 +37,7 @@ class RBush {
      * A mapping between the objects added to this rbush wrapper
      * and the objects that are actually added to the internal rbush.
      * @private
-     * @type {Object.<number, module:ol/structs/RBush~Entry>}
+     * @type {Object<number, module:ol/structs/RBush~Entry>}
      */
     this.items_ = {};
 

--- a/src/ol/style/Atlas.js
+++ b/src/ol/style/Atlas.js
@@ -64,7 +64,7 @@ class Atlas {
 
     /**
      * @private
-     * @type {Object.<string, module:ol/style/Atlas~AtlasInfo>}
+     * @type {Object<string, module:ol/style/Atlas~AtlasInfo>}
      */
     this.entries_ = {};
 

--- a/src/ol/style/Atlas.js
+++ b/src/ol/style/Atlas.js
@@ -58,7 +58,7 @@ class Atlas {
 
     /**
      * @private
-     * @type {Array.<module:ol/style/Atlas~AtlasBlock>}
+     * @type {Array<module:ol/style/Atlas~AtlasBlock>}
      */
     this.emptyBlocks_ = [{x: 0, y: 0, width: size, height: size}];
 

--- a/src/ol/style/AtlasManager.js
+++ b/src/ol/style/AtlasManager.js
@@ -90,7 +90,7 @@ class AtlasManager {
 
     /**
      * @private
-     * @type {Array.<module:ol/style/Atlas>}
+     * @type {Array<module:ol/style/Atlas>}
      */
     this.atlases_ = [new Atlas(this.currentSize_, this.space_)];
 
@@ -103,7 +103,7 @@ class AtlasManager {
 
     /**
      * @private
-     * @type {Array.<module:ol/style/Atlas>}
+     * @type {Array<module:ol/style/Atlas>}
      */
     this.hitAtlases_ = [new Atlas(this.currentHitSize_, this.space_)];
   }
@@ -127,7 +127,7 @@ class AtlasManager {
 
   /**
    * @private
-   * @param {Array.<module:ol/style/Atlas>} atlases The atlases to search.
+   * @param {Array<module:ol/style/Atlas>} atlases The atlases to search.
    * @param {string} id The identifier of the entry to check.
    * @return {?module:ol/style/Atlas~AtlasInfo} The position and atlas image for the entry,
    *    or `null` if the entry is not part of the atlases.

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -15,7 +15,7 @@ import ImageStyle from '../style/Image.js';
 
 /**
  * @typedef {Object} Options
- * @property {Array.<number>} [anchor=[0.5, 0.5]] Anchor. Default value is the icon center.
+ * @property {Array<number>} [anchor=[0.5, 0.5]] Anchor. Default value is the icon center.
  * @property {module:ol/style/IconOrigin} [anchorOrigin] Origin of the anchor: `bottom-left`, `bottom-right`,
  * `top-left` or `top-right`. Default is `top-left`.
  * @property {module:ol/style/IconAnchorUnits} [anchorXUnits] Units in which the anchor x value is
@@ -32,7 +32,7 @@ import ImageStyle from '../style/Image.js';
  * @property {HTMLImageElement|HTMLCanvasElement} [img] Image object for the icon. If the `src` option is not provided then the
  * provided image must already be loaded. And in that case, it is required
  * to provide the size of the image, with the `imgSize` option.
- * @property {Array.<number>} [offset=[0, 0]] Offset, which, together with the size and the offset origin, define the
+ * @property {Array<number>} [offset=[0, 0]] Offset, which, together with the size and the offset origin, define the
  * sub-rectangle to use from the original icon image.
  * @property {module:ol/style/IconOrigin} [offsetOrigin] Origin of the offset: `bottom-left`, `bottom-right`,
  * `top-left` or `top-right`. Default is `top-left`.
@@ -101,13 +101,13 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.anchor_ = options.anchor !== undefined ? options.anchor : [0.5, 0.5];
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.normalizedAnchor_ = null;
 
@@ -186,7 +186,7 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.offset_ = options.offset !== undefined ? options.offset : [0, 0];
 
@@ -199,7 +199,7 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.origin_ = null;
 
@@ -284,7 +284,7 @@ class Icon extends ImageStyle {
    * Set the anchor point. The anchor determines the center point for the
    * symbolizer.
    *
-   * @param {Array.<number>} anchor Anchor.
+   * @param {Array<number>} anchor Anchor.
    * @api
    */
   setAnchor(anchor) {

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -54,7 +54,7 @@ class IconImage extends EventTarget {
 
     /**
      * @private
-     * @type {Array.<module:ol/events~EventsKey>}
+     * @type {Array<module:ol/events~EventsKey>}
      */
     this.imageListenerKeys_ = null;
 

--- a/src/ol/style/IconImageCache.js
+++ b/src/ol/style/IconImageCache.js
@@ -11,7 +11,7 @@ class IconImageCache {
   constructor() {
 
     /**
-    * @type {!Object.<string, module:ol/style/IconImage>}
+    * @type {!Object<string, module:ol/style/IconImage>}
     * @private
     */
     this.cache_ = {};

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -107,7 +107,7 @@ class ImageStyle {
   * Get the anchor point in pixels. The anchor determines the center point for the
   * symbolizer.
   * @abstract
-  * @return {Array.<number>} Anchor.
+  * @return {Array<number>} Anchor.
   */
   getAnchor() {}
 
@@ -147,7 +147,7 @@ class ImageStyle {
   /**
   * Get the origin of the symbolizer.
   * @abstract
-  * @return {Array.<number>} Origin.
+  * @return {Array<number>} Origin.
   */
   getOrigin() {}
 

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -39,7 +39,7 @@ import ImageStyle from '../style/Image.js';
  * @property {number} strokeWidth
  * @property {number} size
  * @property {string} lineCap
- * @property {Array.<number>} lineDash
+ * @property {Array<number>} lineDash
  * @property {number} lineDashOffset
  * @property {string} lineJoin
  * @property {number} miterLimit
@@ -80,7 +80,7 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {Array.<string>}
+     * @type {Array<string>}
      */
     this.checksums_ = null;
 
@@ -104,7 +104,7 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.origin_ = [0, 0];
 
@@ -141,7 +141,7 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.anchor_ = null;
 

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -11,7 +11,7 @@ import {getUid} from '../util.js';
  * Default null; if null, the Canvas/renderer default black will be used.
  * @property {string} [lineCap='round'] Line cap style: `butt`, `round`, or `square`.
  * @property {string} [lineJoin='round'] Line join style: `bevel`, `round`, or `miter`.
- * @property {Array.<number>} [lineDash] Line dash pattern. Default is `undefined` (no dash).
+ * @property {Array<number>} [lineDash] Line dash pattern. Default is `undefined` (no dash).
  * Please note that Internet Explorer 10 and lower do not support the `setLineDash` method on
  * the `CanvasRenderingContext2D` and therefore this option will have no visual effect in these browsers.
  * @property {number} [lineDashOffset=0] Line dash offset.
@@ -50,7 +50,7 @@ class Stroke {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.lineDash_ = options.lineDash !== undefined ? options.lineDash : null;
 
@@ -123,7 +123,7 @@ class Stroke {
 
   /**
    * Get the line dash style for the stroke.
-   * @return {Array.<number>} Line dash.
+   * @return {Array<number>} Line dash.
    * @api
    */
   getLineDash() {
@@ -197,7 +197,7 @@ class Stroke {
    *
    * [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility
    *
-   * @param {Array.<number>} lineDash Line dash.
+   * @param {Array<number>} lineDash Line dash.
    * @api
    */
   setLineDash(lineDash) {

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -100,7 +100,7 @@ import Stroke from '../style/Stroke.js';
  * vector layer can be styled.
  *
  * @typedef {function((module:ol/Feature|module:ol/render/Feature), number):
- *     (module:ol/style/Style|Array.<module:ol/style/Style>)} StyleFunction
+ *     (module:ol/style/Style|Array<module:ol/style/Style>)} StyleFunction
  */
 
 
@@ -119,7 +119,7 @@ import Stroke from '../style/Stroke.js';
  * 1. The pixel coordinates of the geometry in GeoJSON notation.
  * 2. The {@link module:ol/render~State} of the layer renderer.
  *
- * @typedef {function((module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array.<Array.<module:ol/coordinate~Coordinate>>),module:ol/render~State)}
+ * @typedef {function((module:ol/coordinate~Coordinate|Array<module:ol/coordinate~Coordinate>|Array<Array<module:ol/coordinate~Coordinate>>),module:ol/render~State)}
  * RenderFunction
  */
 
@@ -394,7 +394,7 @@ class Style {
  * Convert the provided object into a style function.  Functions passed through
  * unchanged.  Arrays of module:ol/style/Style or single style objects wrapped in a
  * new style function.
- * @param {module:ol/style/Style~StyleFunction|Array.<module:ol/style/Style>|module:ol/style/Style} obj
+ * @param {module:ol/style/Style~StyleFunction|Array<module:ol/style/Style>|module:ol/style/Style} obj
  *     A style function, a single style, or an array of styles.
  * @return {module:ol/style/Style~StyleFunction} A style function.
  */
@@ -405,7 +405,7 @@ export function toFunction(obj) {
     styleFunction = obj;
   } else {
     /**
-     * @type {Array.<module:ol/style/Style>}
+     * @type {Array<module:ol/style/Style>}
      */
     let styles;
     if (Array.isArray(obj)) {
@@ -424,7 +424,7 @@ export function toFunction(obj) {
 
 
 /**
- * @type {Array.<module:ol/style/Style>}
+ * @type {Array<module:ol/style/Style>}
  */
 let defaultStyles = null;
 
@@ -432,7 +432,7 @@ let defaultStyles = null;
 /**
  * @param {module:ol/Feature|module:ol/render/Feature} feature Feature.
  * @param {number} resolution Resolution.
- * @return {Array.<module:ol/style/Style>} Style.
+ * @return {Array<module:ol/style/Style>} Style.
  */
 export function createDefaultStyle(feature, resolution) {
   // We don't use an immediately-invoked function
@@ -466,10 +466,10 @@ export function createDefaultStyle(feature, resolution) {
 
 /**
  * Default styles for editing features.
- * @return {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style>>} Styles
+ * @return {Object.<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} Styles
  */
 export function createEditingStyle() {
-  /** @type {Object.<module:ol/geom/GeometryType, Array.<module:ol/style/Style>>} */
+  /** @type {Object.<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} */
   const styles = {};
   const white = [255, 255, 255, 1];
   const blue = [0, 153, 255, 1];

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -466,10 +466,10 @@ export function createDefaultStyle(feature, resolution) {
 
 /**
  * Default styles for editing features.
- * @return {Object.<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} Styles
+ * @return {Object<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} Styles
  */
 export function createEditingStyle() {
-  /** @type {Object.<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} */
+  /** @type {Object<module:ol/geom/GeometryType, Array<module:ol/style/Style>>} */
   const styles = {};
   const white = [255, 255, 255, 1];
   const blue = [0, 153, 255, 1];

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -40,7 +40,7 @@ const DEFAULT_FILL_COLOR = '#333';
  * `'point'`. Default is no fill.
  * @property {module:ol/style/Stroke} [backgroundStroke] Stroke style for the text background  when `placement`
  * is `'point'`. Default is no stroke.
- * @property {Array.<number>} [padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
+ * @property {Array<number>} [padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
  * values in the array is `[top, right, bottom, left]`.
  */
 
@@ -157,7 +157,7 @@ class Text {
 
     /**
     * @private
-    * @type {Array.<number>}
+    * @type {Array<number>}
     */
     this.padding_ = options.padding === undefined ? null : options.padding;
   }
@@ -334,7 +334,7 @@ class Text {
 
   /**
   * Get the padding for the text.
-  * @return {Array.<number>} Padding.
+  * @return {Array<number>} Padding.
   * @api
   */
   getPadding() {
@@ -494,7 +494,7 @@ class Text {
   /**
   * Set the padding (`[top, right, bottom, left]`).
   *
-  * @param {!Array.<number>} padding Padding.
+  * @param {!Array<number>} padding Padding.
   * @api
   */
   setPadding(padding) {

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -6,7 +6,7 @@
 /**
  * An array of three numbers representing the location of a tile in a tile
  * grid. The order is `z`, `x`, and `y`. `z` is the zoom level.
- * @typedef {Array.<number>} TileCoord
+ * @typedef {Array<number>} TileCoord
  * @api
  */
 

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -110,7 +110,7 @@ export function createXYZ(opt_options) {
  *     DEFAULT_MAX_ZOOM).
  * @param {number|module:ol/size~Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @return {!Array.<number>} Resolutions array.
+ * @return {!Array<number>} Resolutions array.
  */
 function resolutionsFromExtent(extent, opt_maxZoom, opt_tileSize) {
   const maxZoom = opt_maxZoom !== undefined ?

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -27,18 +27,18 @@ const tmpTileCoord = [0, 0, 0];
  * @property {module:ol/coordinate~Coordinate} [origin] The tile grid origin, i.e. where the `x`
  * and `y` axes meet (`[z, 0, 0]`). Tile coordinates increase left to right and upwards. If not
  * specified, `extent` or `origins` must be provided.
- * @property {Array.<module:ol/coordinate~Coordinate>} [origins] Tile grid origins, i.e. where
+ * @property {Array<module:ol/coordinate~Coordinate>} [origins] Tile grid origins, i.e. where
  * the `x` and `y` axes meet (`[z, 0, 0]`), for each zoom level. If given, the array length
  * should match the length of the `resolutions` array, i.e. each resolution can have a different
  * origin. Tile coordinates increase left to right and upwards. If not specified, `extent` or
  * `origin` must be provided.
- * @property {!Array.<number>} resolutions Resolutions. The array index of each resolution needs
+ * @property {!Array<number>} resolutions Resolutions. The array index of each resolution needs
  * to match the zoom level. This means that even if a `minZoom` is configured, the resolutions
  * array will have a length of `maxZoom + 1`.
- * @property {Array.<module:ol/size~Size>} [sizes] Sizes.
+ * @property {Array<module:ol/size~Size>} [sizes] Sizes.
  * @property {number|module:ol/size~Size} [tileSize] Tile size.
  * Default is `[256, 256]`.
- * @property {Array.<module:ol/size~Size>} [tileSizes] Tile sizes. If given, the array length
+ * @property {Array<module:ol/size~Size>} [tileSizes] Tile sizes. If given, the array length
  * should match the length of the `resolutions` array, i.e. each resolution can have a different
  * tile size.
  */
@@ -64,7 +64,7 @@ class TileGrid {
 
     /**
      * @private
-     * @type {!Array.<number>}
+     * @type {!Array<number>}
      */
     this.resolutions_ = options.resolutions;
     assert(isSorted(this.resolutions_, function(a, b) {
@@ -109,7 +109,7 @@ class TileGrid {
 
     /**
      * @private
-     * @type {Array.<module:ol/coordinate~Coordinate>}
+     * @type {Array<module:ol/coordinate~Coordinate>}
      */
     this.origins_ = null;
     if (options.origins !== undefined) {
@@ -131,7 +131,7 @@ class TileGrid {
 
     /**
      * @private
-     * @type {Array.<number|module:ol/size~Size>}
+     * @type {Array<number|module:ol/size~Size>}
      */
     this.tileSizes_ = null;
     if (options.tileSizes !== undefined) {
@@ -161,7 +161,7 @@ class TileGrid {
 
     /**
      * @private
-     * @type {Array.<module:ol/TileRange>}
+     * @type {Array<module:ol/TileRange>}
      */
     this.fullTileRanges_ = null;
 
@@ -288,7 +288,7 @@ class TileGrid {
 
   /**
    * Get the list of resolutions for the tile grid.
-   * @return {Array.<number>} Resolutions.
+   * @return {Array<number>} Resolutions.
    * @api
    */
   getResolutions() {

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -16,17 +16,17 @@ import TileGrid from '../tilegrid/TileGrid.js';
  * @property {module:ol/coordinate~Coordinate} [origin] The tile grid origin, i.e.
  * where the `x` and `y` axes meet (`[z, 0, 0]`). Tile coordinates increase left
  * to right and upwards. If not specified, `extent` or `origins` must be provided.
- * @property {Array.<module:ol/coordinate~Coordinate>} [origins] Tile grid origins,
+ * @property {Array<module:ol/coordinate~Coordinate>} [origins] Tile grid origins,
  * i.e. where the `x` and `y` axes meet (`[z, 0, 0]`), for each zoom level. If
  * given, the array length should match the length of the `resolutions` array, i.e.
  * each resolution can have a different origin. Tile coordinates increase left to
  * right and upwards. If not specified, `extent` or `origin` must be provided.
- * @property {!Array.<number>} resolutions Resolutions. The array index of each
+ * @property {!Array<number>} resolutions Resolutions. The array index of each
  * resolution needs to match the zoom level. This means that even if a `minZoom`
  * is configured, the resolutions array will have a length of `maxZoom + 1`
- * @property {!Array.<string>} matrixIds matrix IDs. The length of this array needs
+ * @property {!Array<string>} matrixIds matrix IDs. The length of this array needs
  * to match the length of the `resolutions` array.
- * @property {Array.<module:ol/size~Size>} [sizes] Number of tile rows and columns
+ * @property {Array<module:ol/size~Size>} [sizes] Number of tile rows and columns
  * of the grid for each zoom level. The values here are the `TileMatrixWidth` and
  * `TileMatrixHeight` advertised in the GetCapabilities response of the WMTS, and
  * define the grid's extent together with the `origin`.
@@ -35,9 +35,9 @@ import TileGrid from '../tilegrid/TileGrid.js';
  * the `extent` is used as `origin` or `origins`, then the `y` value must be
  * negative because OpenLayers tile coordinates increase upwards.
  * @property {number|module:ol/size~Size} [tileSize] Tile size.
- * @property {Array.<module:ol/size~Size>} [tileSizes] Tile sizes. The length of
+ * @property {Array<module:ol/size~Size>} [tileSizes] Tile sizes. The length of
  * this array needs to match the length of the `resolutions` array.
- * @property {Array.<number>} [widths] Number of tile columns that cover the grid's
+ * @property {Array<number>} [widths] Number of tile columns that cover the grid's
  * extent for each zoom level. Only required when used with a source that has `wrapX`
  * set to `true`, and only when the grid's origin differs from the one of the
  * projection's extent. The array length has to match the length of the `resolutions`
@@ -67,7 +67,7 @@ class WMTSTileGrid extends TileGrid {
 
     /**
      * @private
-     * @type {!Array.<string>}
+     * @type {!Array<string>}
      */
     this.matrixIds_ = options.matrixIds;
   }
@@ -82,7 +82,7 @@ class WMTSTileGrid extends TileGrid {
 
   /**
    * Get the list of matrix identifiers.
-   * @return {Array.<string>} MatrixIds.
+   * @return {Array<string>} MatrixIds.
    * @api
    */
   getMatrixIds() {
@@ -100,22 +100,22 @@ export default WMTSTileGrid;
  *     capabilities document.
  * @param {module:ol/extent~Extent=} opt_extent An optional extent to restrict the tile
  *     ranges the server provides.
- * @param {Array.<Object>=} opt_matrixLimits An optional object representing
+ * @param {Array<Object>=} opt_matrixLimits An optional object representing
  *     the available matrices for tileGrid.
  * @return {module:ol/tilegrid/WMTS} WMTS tileGrid instance.
  * @api
  */
 export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matrixLimits) {
 
-  /** @type {!Array.<number>} */
+  /** @type {!Array<number>} */
   const resolutions = [];
-  /** @type {!Array.<string>} */
+  /** @type {!Array<string>} */
   const matrixIds = [];
-  /** @type {!Array.<module:ol/coordinate~Coordinate>} */
+  /** @type {!Array<module:ol/coordinate~Coordinate>} */
   const origins = [];
-  /** @type {!Array.<module:ol/size~Size>} */
+  /** @type {!Array<module:ol/size~Size>} */
   const tileSizes = [];
-  /** @type {!Array.<module:ol/size~Size>} */
+  /** @type {!Array<module:ol/size~Size>} */
   const sizes = [];
 
   const matrixLimits = opt_matrixLimits !== undefined ? opt_matrixLimits : [];

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -47,7 +47,7 @@ export function createFromTemplate(template, tileGrid) {
 
 
 /**
- * @param {Array.<string>} templates Templates.
+ * @param {Array<string>} templates Templates.
  * @param {module:ol/tilegrid/TileGrid} tileGrid Tile grid.
  * @return {module:ol/Tile~UrlFunction} Tile URL function.
  */
@@ -62,7 +62,7 @@ export function createFromTemplates(templates, tileGrid) {
 
 
 /**
- * @param {Array.<module:ol/Tile~UrlFunction>} tileUrlFunctions Tile URL Functions.
+ * @param {Array<module:ol/Tile~UrlFunction>} tileUrlFunctions Tile URL Functions.
  * @return {module:ol/Tile~UrlFunction} Tile URL function.
  */
 export function createFromTileUrlFunctions(tileUrlFunctions) {
@@ -102,7 +102,7 @@ export function nullTileUrlFunction(tileCoord, pixelRatio, projection) {
 
 /**
  * @param {string} url URL.
- * @return {Array.<string>} Array of urls.
+ * @return {Array<string>} Array of urls.
  */
 export function expandUrl(url) {
   const urls = [];

--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -7,7 +7,7 @@ import {assert} from './asserts.js';
 /**
  * An array representing an affine 2d transformation for use with
  * {@link module:ol/transform} functions. The array has 6 elements.
- * @typedef {!Array.<number>} Transform
+ * @typedef {!Array<number>} Transform
  */
 
 

--- a/src/ol/vec/mat4.js
+++ b/src/ol/vec/mat4.js
@@ -4,7 +4,7 @@
 
 
 /**
- * @return {Array.<number>} 4x4 matrix representing a 3D identity transform.
+ * @return {Array<number>} 4x4 matrix representing a 3D identity transform.
  */
 export function create() {
   return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
@@ -12,9 +12,9 @@ export function create() {
 
 
 /**
- * @param {Array.<number>} mat4 Flattened 4x4 matrix receiving the result.
+ * @param {Array<number>} mat4 Flattened 4x4 matrix receiving the result.
  * @param {module:ol/transform~Transform} transform Transformation matrix.
- * @return {Array.<number>} 2D transformation matrix as flattened 4x4 matrix.
+ * @return {Array<number>} 2D transformation matrix as flattened 4x4 matrix.
  */
 export function fromTransform(mat4, transform) {
   mat4[0] = transform[0];

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -259,7 +259,7 @@ export const FRAMEBUFFER = 0x8D40;
 
 /**
  * @const
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 const CONTEXT_IDS = [
   'experimental-webgl',
@@ -308,7 +308,7 @@ let MAX_TEXTURE_SIZE; // value is set below
 
 /**
  * List of supported WebGL extensions.
- * @type {Array.<string>}
+ * @type {Array<string>}
  */
 let EXTENSIONS; // value is set below
 

--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -16,14 +16,14 @@ const BufferUsage = {
 class WebGLBuffer {
 
   /**
-   * @param {Array.<number>=} opt_arr Array.
+   * @param {Array<number>=} opt_arr Array.
    * @param {number=} opt_usage Usage.
    */
   constructor(opt_arr, opt_usage) {
 
     /**
      * @private
-     * @type {Array.<number>}
+     * @type {Array<number>}
      */
     this.arr_ = opt_arr !== undefined ? opt_arr : [];
 
@@ -36,7 +36,7 @@ class WebGLBuffer {
   }
 
   /**
-   * @return {Array.<number>} Array.
+   * @return {Array<number>} Array.
    */
   getArray() {
     return this.arr_;

--- a/src/ol/webgl/Context.js
+++ b/src/ol/webgl/Context.js
@@ -45,19 +45,19 @@ class WebGLContext extends Disposable {
 
     /**
      * @private
-     * @type {!Object.<string, module:ol/webgl/Context~BufferCacheEntry>}
+     * @type {!Object<string, module:ol/webgl/Context~BufferCacheEntry>}
      */
     this.bufferCache_ = {};
 
     /**
      * @private
-     * @type {!Object.<string, WebGLShader>}
+     * @type {!Object<string, WebGLShader>}
      */
     this.shaderCache_ = {};
 
     /**
      * @private
-     * @type {!Object.<string, WebGLProgram>}
+     * @type {!Object<string, WebGLProgram>}
      */
     this.programCache_ = {};
 

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -354,7 +354,7 @@ export const OBJECT_PROPERTY_NODE_FACTORY = makeSimpleNodeFactory();
  * Create an array of `values` to be used with {@link module:ol/xml~serialize} or
  * {@link module:ol/xml~pushSerializeAndPop}, where `orderedKeys` has to be provided as
  * `opt_key` argument.
- * @param {Object.<string, V>} object Key-value pairs for the sequence. Keys can
+ * @param {Object<string, V>} object Key-value pairs for the sequence. Keys can
  *     be a subset of the `orderedKeys`.
  * @param {Array<string>} orderedKeys Keys in the order of the sequence.
  * @return {Array<V>} Values in the order of the sequence. The resulting array
@@ -378,13 +378,13 @@ export function makeSequence(object, orderedKeys) {
  * values are version specific.
  * @param {Array<string>} namespaceURIs Namespace URIs.
  * @param {T} structure Structure.
- * @param {Object.<string, T>=} opt_structureNS Namespaced structure to add to.
- * @return {Object.<string, T>} Namespaced structure.
+ * @param {Object<string, T>=} opt_structureNS Namespaced structure to add to.
+ * @return {Object<string, T>} Namespaced structure.
  * @template T
  */
 export function makeStructureNS(namespaceURIs, structure, opt_structureNS) {
   /**
-   * @type {Object.<string, T>}
+   * @type {Object<string, T>}
    */
   const structureNS = opt_structureNS !== undefined ? opt_structureNS : {};
   let i, ii;
@@ -397,7 +397,7 @@ export function makeStructureNS(namespaceURIs, structure, opt_structureNS) {
 
 /**
  * Parse a node using the parsers and object stack.
- * @param {Object.<string, Object.<string, module:ol/xml~Parser>>} parsersNS
+ * @param {Object<string, Object<string, module:ol/xml~Parser>>} parsersNS
  *     Parsers by namespace.
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
@@ -420,7 +420,7 @@ export function parseNode(parsersNS, node, objectStack, opt_this) {
 /**
  * Push an object on top of the stack, parse and return the popped object.
  * @param {T} object Object.
- * @param {Object.<string, Object.<string, module:ol/xml~Parser>>} parsersNS
+ * @param {Object<string, Object<string, module:ol/xml~Parser>>} parsersNS
  *     Parsers by namespace.
  * @param {Node} node Node.
  * @param {Array<*>} objectStack Object stack.
@@ -437,7 +437,7 @@ export function pushParseAndPop(object, parsersNS, node, objectStack, opt_this) 
 
 /**
  * Walk through an array of `values` and call a serializer for each value.
- * @param {Object.<string, Object.<string, module:ol/xml~Serializer>>} serializersNS
+ * @param {Object<string, Object<string, module:ol/xml~Serializer>>} serializersNS
  *     Namespaced serializers.
  * @param {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)} nodeFactory
  *     Node factory. The `nodeFactory` creates the node whose namespace and name
@@ -477,7 +477,7 @@ export function serialize(
 
 /**
  * @param {O} object Object.
- * @param {Object.<string, Object.<string, module:ol/xml~Serializer>>} serializersNS
+ * @param {Object<string, Object<string, module:ol/xml~Serializer>>} serializersNS
  *     Namespaced serializers.
  * @param {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)} nodeFactory
  *     Node factory. The `nodeFactory` creates the node whose namespace and name

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -14,12 +14,12 @@ import {extend} from './array.js';
 
 
 /**
- * @typedef {function(Node, Array.<*>)} Parser
+ * @typedef {function(Node, Array<*>)} Parser
  */
 
 
 /**
- * @typedef {function(Node, *, Array.<*>)} Serializer
+ * @typedef {function(Node, *, Array<*>)} Serializer
  */
 
 
@@ -66,9 +66,9 @@ export function getAllTextContent(node, normalizeWhitespace) {
  * @param {Node} node Node.
  * @param {boolean} normalizeWhitespace Normalize whitespace: remove all line
  * breaks.
- * @param {Array.<string>} accumulator Accumulator.
+ * @param {Array<string>} accumulator Accumulator.
  * @private
- * @return {Array.<string>} Accumulator.
+ * @return {Array<string>} Accumulator.
  */
 export function getAllTextContent_(node, normalizeWhitespace, accumulator) {
   if (node.nodeType == Node.CDATA_SECTION_NODE ||
@@ -131,7 +131,7 @@ export function parse(xml) {
 /**
  * Make an array extender function for extending the array at the top of the
  * object stack.
- * @param {function(this: T, Node, Array.<*>): (Array.<*>|undefined)} valueReader Value reader.
+ * @param {function(this: T, Node, Array<*>): (Array<*>|undefined)} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
  * @template T
@@ -140,12 +140,12 @@ export function makeArrayExtender(valueReader, opt_this) {
   return (
     /**
      * @param {Node} node Node.
-     * @param {Array.<*>} objectStack Object stack.
+     * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
       const value = valueReader.call(opt_this !== undefined ? opt_this : this, node, objectStack);
       if (value !== undefined) {
-        const array = /** @type {Array.<*>} */ (objectStack[objectStack.length - 1]);
+        const array = /** @type {Array<*>} */ (objectStack[objectStack.length - 1]);
         extend(array, value);
       }
     }
@@ -156,7 +156,7 @@ export function makeArrayExtender(valueReader, opt_this) {
 /**
  * Make an array pusher function for pushing to the array at the top of the
  * object stack.
- * @param {function(this: T, Node, Array.<*>): *} valueReader Value reader.
+ * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
  * @template T
@@ -165,12 +165,12 @@ export function makeArrayPusher(valueReader, opt_this) {
   return (
     /**
      * @param {Node} node Node.
-     * @param {Array.<*>} objectStack Object stack.
+     * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
       const value = valueReader.call(opt_this !== undefined ? opt_this : this, node, objectStack);
       if (value !== undefined) {
-        const array = /** @type {Array.<*>} */ (objectStack[objectStack.length - 1]);
+        const array = /** @type {Array<*>} */ (objectStack[objectStack.length - 1]);
         array.push(value);
       }
     });
@@ -180,7 +180,7 @@ export function makeArrayPusher(valueReader, opt_this) {
 /**
  * Make an object stack replacer function for replacing the object at the
  * top of the stack.
- * @param {function(this: T, Node, Array.<*>): *} valueReader Value reader.
+ * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
  * @template T
@@ -189,7 +189,7 @@ export function makeReplacer(valueReader, opt_this) {
   return (
     /**
      * @param {Node} node Node.
-     * @param {Array.<*>} objectStack Object stack.
+     * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
       const value = valueReader.call(opt_this !== undefined ? opt_this : this, node, objectStack);
@@ -203,7 +203,7 @@ export function makeReplacer(valueReader, opt_this) {
 /**
  * Make an object property pusher function for adding a property to the
  * object at the top of the stack.
- * @param {function(this: T, Node, Array.<*>): *} valueReader Value reader.
+ * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
  * @param {string=} opt_property Property.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
@@ -213,7 +213,7 @@ export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
   return (
     /**
      * @param {Node} node Node.
-     * @param {Array.<*>} objectStack Object stack.
+     * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
       const value = valueReader.call(opt_this !== undefined ? opt_this : this, node, objectStack);
@@ -234,7 +234,7 @@ export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
 
 /**
  * Make an object property setter function.
- * @param {function(this: T, Node, Array.<*>): *} valueReader Value reader.
+ * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
  * @param {string=} opt_property Property.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
@@ -244,7 +244,7 @@ export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
   return (
     /**
      * @param {Node} node Node.
-     * @param {Array.<*>} objectStack Object stack.
+     * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
       const value = valueReader.call(opt_this !== undefined ? opt_this : this, node, objectStack);
@@ -261,7 +261,7 @@ export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
  * Create a serializer that appends nodes written by its `nodeWriter` to its
  * designated parent. The parent is the `node` of the
  * {@link module:ol/xml~NodeStackItem} at the top of the `objectStack`.
- * @param {function(this: T, Node, V, Array.<*>)} nodeWriter Node writer.
+ * @param {function(this: T, Node, V, Array<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {module:ol/xml~Serializer} Serializer.
  * @template T, V
@@ -283,7 +283,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
  * designed to serialize a single item. An example would be a LineString
  * geometry writer, which could be reused for writing MultiLineString
  * geometries.
- * @param {function(this: T, Node, V, Array.<*>)} nodeWriter Node writer.
+ * @param {function(this: T, Node, V, Array<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {module:ol/xml~Serializer} Serializer.
  * @template T, V
@@ -314,14 +314,14 @@ export function makeArraySerializer(nodeWriter, opt_this) {
  * @param {string=} opt_namespaceURI Fixed namespace URI which will be used for
  *     all created nodes. If not provided, the namespace of the parent node will
  *     be used.
- * @return {function(*, Array.<*>, string=): (Node|undefined)} Node factory.
+ * @return {function(*, Array<*>, string=): (Node|undefined)} Node factory.
  */
 export function makeSimpleNodeFactory(opt_nodeName, opt_namespaceURI) {
   const fixedNodeName = opt_nodeName;
   return (
     /**
      * @param {*} value Value.
-     * @param {Array.<*>} objectStack Object stack.
+     * @param {Array<*>} objectStack Object stack.
      * @param {string=} opt_nodeName Node name.
      * @return {Node} Node.
      */
@@ -345,7 +345,7 @@ export function makeSimpleNodeFactory(opt_nodeName, opt_namespaceURI) {
  * `nodeName` passed by {@link module:ol/xml~serialize} or
  * {@link module:ol/xml~pushSerializeAndPop} to the node factory.
  * @const
- * @type {function(*, Array.<*>, string=): (Node|undefined)}
+ * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 export const OBJECT_PROPERTY_NODE_FACTORY = makeSimpleNodeFactory();
 
@@ -356,8 +356,8 @@ export const OBJECT_PROPERTY_NODE_FACTORY = makeSimpleNodeFactory();
  * `opt_key` argument.
  * @param {Object.<string, V>} object Key-value pairs for the sequence. Keys can
  *     be a subset of the `orderedKeys`.
- * @param {Array.<string>} orderedKeys Keys in the order of the sequence.
- * @return {Array.<V>} Values in the order of the sequence. The resulting array
+ * @param {Array<string>} orderedKeys Keys in the order of the sequence.
+ * @return {Array<V>} Values in the order of the sequence. The resulting array
  *     has the same length as the `orderedKeys` array. Values that are not
  *     present in `object` will be `undefined` in the resulting array.
  * @template V
@@ -376,7 +376,7 @@ export function makeSequence(object, orderedKeys) {
  * Create a namespaced structure, using the same values for each namespace.
  * This can be used as a starting point for versioned parsers, when only a few
  * values are version specific.
- * @param {Array.<string>} namespaceURIs Namespace URIs.
+ * @param {Array<string>} namespaceURIs Namespace URIs.
  * @param {T} structure Structure.
  * @param {Object.<string, T>=} opt_structureNS Namespaced structure to add to.
  * @return {Object.<string, T>} Namespaced structure.
@@ -400,7 +400,7 @@ export function makeStructureNS(namespaceURIs, structure, opt_structureNS) {
  * @param {Object.<string, Object.<string, module:ol/xml~Parser>>} parsersNS
  *     Parsers by namespace.
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @param {*=} opt_this The object to use as `this`.
  */
 export function parseNode(parsersNS, node, objectStack, opt_this) {
@@ -423,7 +423,7 @@ export function parseNode(parsersNS, node, objectStack, opt_this) {
  * @param {Object.<string, Object.<string, module:ol/xml~Parser>>} parsersNS
  *     Parsers by namespace.
  * @param {Node} node Node.
- * @param {Array.<*>} objectStack Object stack.
+ * @param {Array<*>} objectStack Object stack.
  * @param {*=} opt_this The object to use as `this`.
  * @return {T} Object.
  * @template T
@@ -439,16 +439,16 @@ export function pushParseAndPop(object, parsersNS, node, objectStack, opt_this) 
  * Walk through an array of `values` and call a serializer for each value.
  * @param {Object.<string, Object.<string, module:ol/xml~Serializer>>} serializersNS
  *     Namespaced serializers.
- * @param {function(this: T, *, Array.<*>, (string|undefined)): (Node|undefined)} nodeFactory
+ * @param {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)} nodeFactory
  *     Node factory. The `nodeFactory` creates the node whose namespace and name
  *     will be used to choose a node writer from `serializersNS`. This
  *     separation allows us to decide what kind of node to create, depending on
  *     the value we want to serialize. An example for this would be different
  *     geometry writers based on the geometry type.
- * @param {Array.<*>} values Values to serialize. An example would be an array
+ * @param {Array<*>} values Values to serialize. An example would be an array
  *     of {@link module:ol/Feature~Feature} instances.
- * @param {Array.<*>} objectStack Node stack.
- * @param {Array.<string>=} opt_keys Keys of the `values`. Will be passed to the
+ * @param {Array<*>} objectStack Node stack.
+ * @param {Array<string>=} opt_keys Keys of the `values`. Will be passed to the
  *     `nodeFactory`. This is used for serializing object literals where the
  *     node name relates to the property key. The array length of `opt_keys` has
  *     to match the length of `values`. For serializing a sequence, `opt_keys`
@@ -479,16 +479,16 @@ export function serialize(
  * @param {O} object Object.
  * @param {Object.<string, Object.<string, module:ol/xml~Serializer>>} serializersNS
  *     Namespaced serializers.
- * @param {function(this: T, *, Array.<*>, (string|undefined)): (Node|undefined)} nodeFactory
+ * @param {function(this: T, *, Array<*>, (string|undefined)): (Node|undefined)} nodeFactory
  *     Node factory. The `nodeFactory` creates the node whose namespace and name
  *     will be used to choose a node writer from `serializersNS`. This
  *     separation allows us to decide what kind of node to create, depending on
  *     the value we want to serialize. An example for this would be different
  *     geometry writers based on the geometry type.
- * @param {Array.<*>} values Values to serialize. An example would be an array
+ * @param {Array<*>} values Values to serialize. An example would be an array
  *     of {@link module:ol/Feature~Feature} instances.
- * @param {Array.<*>} objectStack Node stack.
- * @param {Array.<string>=} opt_keys Keys of the `values`. Will be passed to the
+ * @param {Array<*>} objectStack Node stack.
+ * @param {Array<string>=} opt_keys Keys of the `values`. Will be passed to the
  *     `nodeFactory`. This is used for serializing object literals where the
  *     node name relates to the property key. The array length of `opt_keys` has
  *     to match the length of `values`. For serializing a sequence, `opt_keys`

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -14,7 +14,7 @@ async function getSymbols() {
 
 /**
  * Generate a list of imports.
- * @param {Array.<Object>} symbols List of symbols.
+ * @param {Array<Object>} symbols List of symbols.
  * @return {Promise<Array>} A list of imports sorted by export name.
  */
 function getImports(symbols) {
@@ -64,9 +64,9 @@ function formatSymbolExport(name, namespaces) {
 
 /**
  * Generate export code given a list symbol names.
- * @param {Array.<Object>} symbols List of symbols.
+ * @param {Array<Object>} symbols List of symbols.
  * @param {Object.<string, string>} namespaces Already defined namespaces.
- * @param {Array.<string>} imports List of all imports.
+ * @param {Array<string>} imports List of all imports.
  * @return {string} Export code.
  */
 function generateExports(symbols, namespaces, imports) {

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -41,7 +41,7 @@ function getImports(symbols) {
 /**
  * Generate code to export a named symbol.
  * @param {string} name Symbol name.
- * @param {Object.<string, string>} namespaces Already defined namespaces.
+ * @param {Object<string, string>} namespaces Already defined namespaces.
  * @return {string} Export code.
  */
 function formatSymbolExport(name, namespaces) {
@@ -65,7 +65,7 @@ function formatSymbolExport(name, namespaces) {
 /**
  * Generate export code given a list symbol names.
  * @param {Array<Object>} symbols List of symbols.
- * @param {Object.<string, string>} namespaces Already defined namespaces.
+ * @param {Object<string, string>} namespaces Already defined namespaces.
  * @param {Array<string>} imports List of all imports.
  * @return {string} Export code.
  */

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -109,7 +109,7 @@ function parseOutput(output) {
 
 /**
  * Spawn JSDoc.
- * @param {Array.<string>} paths Paths to source files.
+ * @param {Array<string>} paths Paths to source files.
  * @return {Promise<string>} Resolves with the JSDoc output (new metadata).
  *     If provided with an empty list of paths, resolves with null.
  */

--- a/test/spec/ol/source/tile.test.js
+++ b/test/spec/ol/source/tile.test.js
@@ -12,7 +12,7 @@ import TileGrid from '../../../../src/ol/tilegrid/TileGrid.js';
  * Tile source for tests that uses a EPSG:4326 based grid with 4 resolutions and
  * 256x256 tiles.
  *
- * @param {Object.<string, ol.TileState>} tileStates Lookup of tile key to
+ * @param {Object<string, ol.TileState>} tileStates Lookup of tile key to
  *     tile state.
  */
 class MockTile extends TileSource {


### PR DESCRIPTION
This is a cosmetic change, arguably more readable code:

 * `Array<Foo>` instead of `Array.<Foo>`
 * `Object<Foo, Bar>` instead of `Object.<Foo, Bar>`
 * `Template<Foo>` instead of `Template.<Foo>`