### PR TITLE
Explicit void

### DIFF
--- a/src/ol/Disposable.js
+++ b/src/ol/Disposable.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/Disposable
  */
-import {UNDEFINED} from './functions.js';
+import {VOID} from './functions.js';
 
 /**
  * @classdesc
@@ -30,5 +30,6 @@ Disposable.prototype.disposed_ = false;
  * Extension point for disposable objects.
  * @protected
  */
-Disposable.prototype.disposeInternal = UNDEFINED;
+Disposable.prototype.disposeInternal = VOID;
+
 export default Disposable;

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -9,7 +9,7 @@ import {listen, unlistenByKey} from './events.js';
 import {getHeight, getIntersection, getWidth} from './extent.js';
 import EventType from './events/EventType.js';
 import {loadFeaturesXhr} from './featureloader.js';
-import {UNDEFINED} from './functions.js';
+import {VOID} from './functions.js';
 
 
 /**
@@ -148,7 +148,7 @@ class VectorImageTile extends Tile {
           const tile = new VectorImageTile(tileCoord, state, sourceRevision,
             format, tileLoadFunction, urlTileCoord, tileUrlFunction,
             sourceTileGrid, tileGrid, sourceTiles, pixelRatio, projection,
-            tileClass, UNDEFINED, --zoom);
+            tileClass, VOID, --zoom);
           if (tile.state == TileState.LOADED) {
             this.interimTile = tile;
             break;

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -3,7 +3,7 @@
  */
 import {DEFAULT_TILE_SIZE} from './tilegrid/common.js';
 import {getUid} from './util.js';
-import {UNDEFINED} from './functions.js';
+import {VOID} from './functions.js';
 import {createExtent, none as centerNone} from './centerconstraint.js';
 import BaseObject from './Object.js';
 import {createSnapToResolutions, createSnapToPower} from './resolutionconstraint.js';
@@ -1057,7 +1057,7 @@ class View extends BaseObject {
     const centerX = centerRotX * cosAngle - centerRotY * sinAngle;
     const centerY = centerRotY * cosAngle + centerRotX * sinAngle;
     const center = [centerX, centerY];
-    const callback = options.callback ? options.callback : UNDEFINED;
+    const callback = options.callback ? options.callback : VOID;
 
     if (options.duration !== undefined) {
       this.animate({

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/control/Control
  */
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import MapEventType from '../MapEventType.js';
 import BaseObject from '../Object.js';
 import {removeNode} from '../dom.js';
@@ -81,7 +81,7 @@ class Control extends BaseObject {
     /**
      * @type {function(module:ol/MapEvent)}
      */
-    this.render = options.render ? options.render : UNDEFINED;
+    this.render = options.render ? options.render : VOID;
 
     if (options.target) {
       this.setTarget(options.target);
@@ -126,7 +126,7 @@ class Control extends BaseObject {
       const target = this.target_ ?
         this.target_ : map.getOverlayContainerStopEvent();
       target.appendChild(this.element);
-      if (this.render !== UNDEFINED) {
+      if (this.render !== VOID) {
         this.listenerKeys.push(listen(map,
           MapEventType.POSTRENDER, this.render, this));
       }

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -3,7 +3,7 @@
  */
 import Disposable from '../Disposable.js';
 import {unlistenAll} from '../events.js';
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import Event from '../events/Event.js';
 
 
@@ -102,7 +102,7 @@ class Target extends Disposable {
         let pendingRemovals = this.pendingRemovals_[type];
         delete this.pendingRemovals_[type];
         while (pendingRemovals--) {
-          this.removeEventListener(type, UNDEFINED);
+          this.removeEventListener(type, VOID);
         }
         delete this.dispatching_[type];
       }
@@ -149,7 +149,7 @@ class Target extends Disposable {
       const index = listeners.indexOf(listener);
       if (type in this.pendingRemovals_) {
         // make listener a no-op, and remove later in #dispatchEvent()
-        listeners[index] = UNDEFINED;
+        listeners[index] = VOID;
         ++this.pendingRemovals_[type];
       } else {
         listeners.splice(index, 1);

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/featureloader
  */
-import {UNDEFINED} from './functions.js';
+import {VOID} from './functions.js';
 import FormatType from './format/FormatType.js';
 
 
@@ -125,5 +125,5 @@ export function xhr(url, format) {
      */
     function(features, dataProjection) {
       this.addFeatures(features);
-    }, /* FIXME handle error */ UNDEFINED);
+    }, /* FIXME handle error */ VOID);
 }

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -21,6 +21,6 @@ export function FALSE() {
 /**
  * A reusable function, used e.g. as a default for callbacks.
  *
- * @return {undefined} Nothing.
+ * @return {void} Nothing.
  */
-export function UNDEFINED() {}
+export function VOID() {}

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -4,7 +4,7 @@
 // FIXME draw drag box
 import Event from '../events/Event.js';
 import {always, mouseOnly, mouseActionButton} from '../events/condition.js';
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import PointerInteraction from '../interaction/Pointer.js';
 import RenderBox from '../render/Box.js';
 
@@ -140,7 +140,7 @@ class DragBox extends PointerInteraction {
      * @type {function(this:module:ol/interaction/DragBox, module:ol/MapBrowserEvent)}
      * @private
      */
-    this.onBoxEnd_ = options.onBoxEnd ? options.onBoxEnd : UNDEFINED;
+    this.onBoxEnd_ = options.onBoxEnd ? options.onBoxEnd : VOID;
 
     /**
     * @type {module:ol/pixel~Pixel}

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/interaction/Pointer
  */
-import {FALSE, UNDEFINED} from '../functions.js';
+import {FALSE, VOID} from '../functions.js';
 import MapBrowserEventType from '../MapBrowserEventType.js';
 import MapBrowserPointerEvent from '../MapBrowserPointerEvent.js';
 import Interaction from '../interaction/Interaction.js';
@@ -12,7 +12,7 @@ import {getValues} from '../obj.js';
  * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @this {module:ol/interaction/Pointer}
  */
-const handleDragEvent = UNDEFINED;
+const handleDragEvent = VOID;
 
 
 /**
@@ -35,7 +35,7 @@ const handleDownEvent = FALSE;
  * @param {module:ol/MapBrowserPointerEvent} mapBrowserEvent Event.
  * @this {module:ol/interaction/Pointer}
  */
-const handleMoveEvent = UNDEFINED;
+const handleMoveEvent = VOID;
 
 
 /**

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/render/Feature
  */
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import {extend} from '../array.js';
 import {createOrUpdateFromCoordinate, createOrUpdateFromFlatCoordinates, getCenter, getHeight} from '../extent.js';
 import GeometryType from '../geom/GeometryType.js';
@@ -266,7 +266,7 @@ RenderFeature.prototype.getSimplifiedGeometry =
 /**
  * @return {undefined}
  */
-RenderFeature.prototype.getStyleFunction = UNDEFINED;
+RenderFeature.prototype.getStyleFunction = VOID;
 
 
 export default RenderFeature;

--- a/src/ol/render/canvas/Replay.js
+++ b/src/ol/render/canvas/Replay.js
@@ -2,7 +2,7 @@
  * @module ol/render/canvas/Replay
  */
 import {getUid} from '../../util.js';
-import {UNDEFINED} from '../../functions.js';
+import {VOID} from '../../functions.js';
 import {equals, reverseSubArray} from '../../array.js';
 import {asColorLike} from '../../colorlike.js';
 import {buffer, clone, coordinateRelationship, createEmpty, createOrUpdate,
@@ -1082,7 +1082,7 @@ class CanvasReplay extends VectorContext {
 /**
  * FIXME empty description for jsdoc
  */
-CanvasReplay.prototype.finish = UNDEFINED;
+CanvasReplay.prototype.finish = VOID;
 
 
 export default CanvasReplay;

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -7,7 +7,7 @@ import Observable from '../Observable.js';
 import TileState from '../TileState.js';
 import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
-import {FALSE, UNDEFINED} from '../functions.js';
+import {FALSE, VOID} from '../functions.js';
 import SourceState from '../source/State.js';
 
 class LayerRenderer extends Observable {
@@ -225,10 +225,10 @@ class LayerRenderer extends Observable {
  * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {function(this: S, (module:ol/Feature|module:ol/render/Feature), module:ol/layer/Layer): T} callback Feature callback.
  * @param {S} thisArg Value to use as `this` when executing `callback`.
- * @return {T|undefined} Callback result.
+ * @return {T|void} Callback result.
  * @template S,T
  */
-LayerRenderer.prototype.forEachFeatureAtCoordinate = UNDEFINED;
+LayerRenderer.prototype.forEachFeatureAtCoordinate = VOID;
 
 
 /**

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -6,7 +6,7 @@ import Disposable from '../Disposable.js';
 import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
 import {getWidth} from '../extent.js';
-import {TRUE, UNDEFINED} from '../functions.js';
+import {TRUE, VOID} from '../functions.js';
 import {visibleAtResolution} from '../layer/Layer.js';
 import {shared as iconImageCache} from '../style/IconImageCache.js';
 import {compose as composeTransform, invert as invertTransform, setFromArray as transformSetFromArray} from '../transform.js';
@@ -329,7 +329,7 @@ function expireIconCache(map, frameState) {
  * Render.
  * @param {?module:ol/PluggableMap~FrameState} frameState Frame state.
  */
-MapRenderer.prototype.renderFrame = UNDEFINED;
+MapRenderer.prototype.renderFrame = VOID;
 
 
 /**

--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -4,7 +4,7 @@
 import {scale as scaleCoordinate} from '../../coordinate.js';
 import {createCanvasContext2D} from '../../dom.js';
 import {containsExtent, intersects} from '../../extent.js';
-import {UNDEFINED} from '../../functions.js';
+import {VOID} from '../../functions.js';
 import CanvasLayerRenderer from '../canvas/Layer.js';
 import {create as createTransform, apply as applyTransform} from '../../transform.js';
 
@@ -115,7 +115,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
       return undefined;
     }
 
-    if (this.getLayer().getSource().forEachFeatureAtCoordinate !== UNDEFINED) {
+    if (this.getLayer().getSource().forEachFeatureAtCoordinate !== VOID) {
       // for ImageCanvas sources use the original hit-detection logic,
       // so that for example also transparent polygons are detected
       return CanvasLayerRenderer.prototype.forEachLayerAtCoordinate.apply(this, arguments);

--- a/src/ol/renderer/webgl/ImageLayer.js
+++ b/src/ol/renderer/webgl/ImageLayer.js
@@ -2,7 +2,7 @@
  * @module ol/renderer/webgl/ImageLayer
  */
 import {ENABLE_RASTER_REPROJECTION} from '../../reproj/common.js';
-import {TRUE, UNDEFINED} from '../../functions.js';
+import {TRUE, VOID} from '../../functions.js';
 import LayerType from '../../LayerType.js';
 import ViewHint from '../../ViewHint.js';
 import {createCanvasContext2D} from '../../dom.js';
@@ -230,7 +230,7 @@ class WebGLImageLayerRenderer extends WebGLLayerRenderer {
       return undefined;
     }
 
-    if (this.getLayer().getSource().forEachFeatureAtCoordinate !== UNDEFINED) {
+    if (this.getLayer().getSource().forEachFeatureAtCoordinate !== VOID) {
       // for ImageCanvas sources use the original hit-detection logic,
       // so that for example also transparent polygons are detected
       const coordinate = applyTransform(

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -2,7 +2,7 @@
  * @module ol/source/Source
  */
 
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import BaseObject from '../Object.js';
 import {get as getProjection} from '../proj.js';
 import SourceState from '../source/State.js';
@@ -182,10 +182,10 @@ class Source extends BaseObject {
  * @param {number} hitTolerance Hit tolerance in pixels.
  * @param {Object<string, boolean>} skippedFeatureUids Skipped feature uids.
  * @param {function((module:ol/Feature|module:ol/render/Feature)): T} callback Feature callback.
- * @return {T|undefined} Callback result.
+ * @return {T|void} Callback result.
  * @template T
  */
-Source.prototype.forEachFeatureAtCoordinate = UNDEFINED;
+Source.prototype.forEachFeatureAtCoordinate = VOID;
 
 
 export default Source;

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -2,7 +2,7 @@
  * @module ol/source/Tile
  */
 
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import TileCache from '../TileCache.js';
 import TileState from '../TileState.js';
 import Event from '../events/Event.js';
@@ -301,7 +301,7 @@ class TileSource extends Source {
  * @param {number} y Tile coordinate y.
  * @param {module:ol/proj/Projection} projection Projection.
  */
-TileSource.prototype.useTile = UNDEFINED;
+TileSource.prototype.useTile = VOID;
 
 
 /**

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -13,7 +13,7 @@ import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import {containsExtent, equals} from '../extent.js';
 import {xhr} from '../featureloader.js';
-import {TRUE, UNDEFINED} from '../functions.js';
+import {TRUE, VOID} from '../functions.js';
 import {all as allStrategy} from '../loadingstrategy.js';
 import {isEmpty, getValues} from '../obj.js';
 import Source from '../source/Source.js';
@@ -176,7 +176,7 @@ class VectorSource extends Source {
      * @private
      * @type {module:ol/featureloader~FeatureLoader}
      */
-    this.loader_ = UNDEFINED;
+    this.loader_ = VOID;
 
     /**
      * @private

--- a/src/ol/style/AtlasManager.js
+++ b/src/ol/style/AtlasManager.js
@@ -2,7 +2,7 @@
  * @module ol/style/AtlasManager
  */
 import {MAX_TEXTURE_SIZE as WEBGL_MAX_TEXTURE_SIZE} from '../webgl.js';
-import {UNDEFINED} from '../functions.js';
+import {VOID} from '../functions.js';
 import Atlas from '../style/Atlas.js';
 
 
@@ -199,7 +199,7 @@ class AtlasManager {
     // the hit-detection atlas, to make sure that the offset is the same for
     // the original image and the hit-detection image.
     const renderHitCallback = opt_renderHitCallback !== undefined ?
-      opt_renderHitCallback : UNDEFINED;
+      opt_renderHitCallback : VOID;
 
     const hitInfo = /** @type {module:ol/style/Atlas~AtlasInfo} */ (this.add_(true,
       id, width, height, renderHitCallback, opt_this));

--- a/test/spec/ol/renderer/vector.test.js
+++ b/test/spec/ol/renderer/vector.test.js
@@ -1,4 +1,4 @@
-import {UNDEFINED} from '../../../../src/ol/functions.js';
+import {VOID} from '../../../../src/ol/functions.js';
 import {getListeners} from '../../../../src/ol/events.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Point from '../../../../src/ol/geom/Point.js';
@@ -77,7 +77,7 @@ describe('ol.renderer.vector', function() {
         const imageReplay = replayGroup.getReplay(
           style.getZIndex(), 'Image');
         const setImageStyleSpy = sinon.spy(imageReplay, 'setImageStyle');
-        const drawPointSpy = sinon.stub(imageReplay, 'drawPoint').callsFake(UNDEFINED);
+        const drawPointSpy = sinon.stub(imageReplay, 'drawPoint').callsFake(VOID);
         renderFeature(replayGroup, feature,
           style, squaredTolerance, listener, listenerThis);
         expect(setImageStyleSpy.called).to.be(false);
@@ -90,7 +90,7 @@ describe('ol.renderer.vector', function() {
         const imageReplay = replayGroup.getReplay(
           style.getZIndex(), 'Image');
         const setImageStyleSpy = sinon.spy(imageReplay, 'setImageStyle');
-        const drawMultiPointSpy = sinon.stub(imageReplay, 'drawMultiPoint').callsFake(UNDEFINED);
+        const drawMultiPointSpy = sinon.stub(imageReplay, 'drawMultiPoint').callsFake(VOID);
         renderFeature(replayGroup, feature,
           style, squaredTolerance, listener, listenerThis);
         expect(setImageStyleSpy.called).to.be(false);
@@ -104,7 +104,7 @@ describe('ol.renderer.vector', function() {
           style.getZIndex(), 'LineString');
         const setFillStrokeStyleSpy = sinon.spy(lineStringReplay,
           'setFillStrokeStyle');
-        const drawLineStringSpy = sinon.stub(lineStringReplay, 'drawLineString').callsFake(UNDEFINED);
+        const drawLineStringSpy = sinon.stub(lineStringReplay, 'drawLineString').callsFake(VOID);
         renderFeature(replayGroup, feature,
           style, squaredTolerance, listener, listenerThis);
         expect(setFillStrokeStyleSpy.called).to.be(true);
@@ -119,7 +119,7 @@ describe('ol.renderer.vector', function() {
           style.getZIndex(), 'LineString');
         const setFillStrokeStyleSpy = sinon.spy(lineStringReplay,
           'setFillStrokeStyle');
-        const drawMultiLineStringSpy = sinon.stub(lineStringReplay, 'drawMultiLineString').callsFake(UNDEFINED);
+        const drawMultiLineStringSpy = sinon.stub(lineStringReplay, 'drawMultiLineString').callsFake(VOID);
         renderFeature(replayGroup, feature,
           style, squaredTolerance, listener, listenerThis);
         expect(setFillStrokeStyleSpy.called).to.be(true);
@@ -135,7 +135,7 @@ describe('ol.renderer.vector', function() {
           style.getZIndex(), 'Polygon');
         const setFillStrokeStyleSpy = sinon.spy(polygonReplay,
           'setFillStrokeStyle');
-        const drawPolygonSpy = sinon.stub(polygonReplay, 'drawPolygon').callsFake(UNDEFINED);
+        const drawPolygonSpy = sinon.stub(polygonReplay, 'drawPolygon').callsFake(VOID);
         renderFeature(replayGroup, feature,
           style, squaredTolerance, listener, listenerThis);
         expect(setFillStrokeStyleSpy.called).to.be(true);
@@ -151,7 +151,7 @@ describe('ol.renderer.vector', function() {
           style.getZIndex(), 'Polygon');
         const setFillStrokeStyleSpy = sinon.spy(polygonReplay,
           'setFillStrokeStyle');
-        const drawMultiPolygonSpy = sinon.stub(polygonReplay, 'drawMultiPolygon').callsFake(UNDEFINED);
+        const drawMultiPolygonSpy = sinon.stub(polygonReplay, 'drawMultiPolygon').callsFake(VOID);
         renderFeature(replayGroup, feature,
           style, squaredTolerance, listener, listenerThis);
         expect(setFillStrokeStyleSpy.called).to.be(true);

--- a/test/spec/ol/style/iconimagecache.test.js
+++ b/test/spec/ol/style/iconimagecache.test.js
@@ -1,4 +1,4 @@
-import {UNDEFINED} from '../../../../src/ol/functions.js';
+import {VOID} from '../../../../src/ol/functions.js';
 import {listen} from '../../../../src/ol/events.js';
 import {shared as iconImageCache} from '../../../../src/ol/style/IconImageCache.js';
 import IconImage from '../../../../src/ol/style/IconImage.js';
@@ -42,13 +42,13 @@ describe('ol.style.IconImageCache', function() {
 
       src = '0';
       iconImage = new IconImage(null, src);
-      listen(iconImage, 'change', UNDEFINED, false);
+      listen(iconImage, 'change', VOID, false);
       iconImageCache.set(src, null, null, iconImage);
       expect(iconImageCache.cacheSize_).to.eql(4);
 
       src = '4';
       iconImage = new IconImage(null, src);
-      listen(iconImage, 'change', UNDEFINED, false);
+      listen(iconImage, 'change', VOID, false);
       iconImageCache.set(src, null, null, iconImage);
       expect(iconImageCache.cacheSize_).to.eql(5);
 


### PR DESCRIPTION
The `npm run typecheck` script in #8345 revealed that we use a function with return type `undefined` on functions without an explicit return.  These need to use the `void` type instead.