### PR TITLE
Remove unimplemented functions

### DIFF
--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -175,29 +175,6 @@ class IGC extends TextFeature {
     }
   }
 
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeatureText(feature, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeaturesText(features, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeGeometryText(geometry, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  readGeometryFromText(text, opt_options) {}
 }
 
 export default IGC;

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -287,35 +287,6 @@ class MVT extends FeatureFormat {
     this.layers_ = layers;
   }
 
-  /**
-   * Not implemented.
-   * @override
-   */
-  readFeature() {}
-
-  /**
-   * Not implemented.
-   * @override
-   */
-  readGeometry() {}
-
-  /**
-   * Not implemented.
-   * @override
-   */
-  writeFeature() {}
-
-  /**
-   * Not implemented.
-   * @override
-   */
-  writeGeometry() {}
-
-  /**
-   * Not implemented.
-   * @override
-   */
-  writeFeatures() {}
 }
 
 

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -101,23 +101,6 @@ class OSMXML extends XMLFeature {
     return [];
   }
 
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeatureNode(feature, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeaturesNode(features, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeGeometryNode(geometry, opt_options) {}
 }
 
 

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -123,35 +123,6 @@ class TopoJSON extends JSONFeature {
     return this.dataProjection;
   }
 
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeatureObject(feature, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeaturesObject(features, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeGeometryObject(geometry, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @override
-   */
-  readGeometryFromObject() {}
-
-  /**
-   * Not implemented.
-   * @override
-   */
-  readFeatureFromObject() {}
 }
 
 

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -150,23 +150,6 @@ class WMSGetFeatureInfo extends XMLFeature {
     return this.readFeatures_(node, [options]);
   }
 
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeatureNode(feature, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeFeaturesNode(features, opt_options) {}
-
-  /**
-   * Not implemented.
-   * @inheritDoc
-   */
-  writeGeometryNode(geometry, opt_options) {}
 }
 
 


### PR DESCRIPTION
The TypeScript checker complain about it (see #8345).
It was a workaround for closure-compiler, it's not needed anymore.
