### PR TITLE
Fix double backtick typo

### DIFF
--- a/doc/tutorials/bundle.md
+++ b/doc/tutorials/bundle.md
@@ -45,7 +45,7 @@ const map = new Map({
 });
 ```
 
-You will also need an `ìndex.html` file that will use your bundle. Here is a simple example:
+You will also need an `index.html` file that will use your bundle. Here is a simple example:
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Heyo 👋 

this fixes a small typo in the bundle docs. (`ìndex.html` -> `index.html`)