### PR TITLE
[Needs review] Implemented ol.layer.Vector.setRenderMode() (fixes #8436)

### DIFF
--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -73,7 +73,8 @@ export const RenderType = {
  * @private
  */
 const Property = {
-  RENDER_ORDER: 'renderOrder'
+  RENDER_ORDER: 'renderOrder',
+  RENDER_MODE: 'renderMode'
 };
 
 
@@ -145,11 +146,7 @@ class VectorLayer extends Layer {
     this.updateWhileInteracting_ = options.updateWhileInteracting !== undefined ?
       options.updateWhileInteracting : false;
 
-    /**
-    * @private
-    * @type {module:ol/layer/VectorTileRenderType|string}
-    */
-    this.renderMode_ = options.renderMode || VectorRenderType.VECTOR;
+    this.setRenderMode(options.renderMode || VectorRenderType.VECTOR);
 
     /**
     * The layer type.
@@ -256,20 +253,19 @@ class VectorLayer extends Layer {
   * @return {module:ol/layer/VectorRenderType|string} The render mode.
   */
   getRenderMode() {
-    return this.renderMode_;
+    return (
+    /** @type {module:ol/render~OrderFunction|null|undefined} */ (this.get(Property.RENDER_MODE))
+    );
   }
 
   /**
    * @param {module:ol/layer/VectorRenderType|string} renderMode The render mode.
    */
+
   setRenderMode(renderMode) {
-    if (renderMode === this.renderMode_) {
-      return;
+    if (renderMode === VectorRenderType.VECTOR || renderMode === VectorRenderType.Image) {
+      this.set(Property.RENDER_MODE, renderMode);
     }
-
-    this.renderMode_ = renderMode;
-
-    this.changed();
   }
 }
 

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -258,6 +258,19 @@ class VectorLayer extends Layer {
   getRenderMode() {
     return this.renderMode_;
   }
+
+  /**
+   * @param {module:ol/layer/VectorRenderType|string} renderMode The render mode.
+   */
+  setRenderMode(renderMode) {
+    if (renderMode === this.renderMode_) {
+      return;
+    }
+
+    this.renderMode_ = renderMode;
+
+    this.changed();
+  }
 }
 
 

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -28,6 +28,12 @@ class MapRenderer extends Disposable {
 
     /**
      * @private
+     * @type {!Object.<string, module:ol/layer/Layer>}
+     */
+    this.layerListeners_ = {};
+
+    /**
+     * @private
      * @type {!Object<string, module:ol/renderer/Layer>}
      */
     this.layerRenderers_ = {};
@@ -224,6 +230,9 @@ class MapRenderer extends Disposable {
         this.layerRenderers_[layerKey] = renderer;
         this.layerRendererListeners_[layerKey] = listen(renderer,
           EventType.CHANGE, this.handleLayerRendererChange_, this);
+
+        this.layerListeners_[layerKey] = listen(layer,
+          EventType.CHANGE, this.handleLayerRenderModeChange_, this);
       } else {
         throw new Error('Unable to create renderer for layer: ' + layer.getType());
       }
@@ -264,6 +273,19 @@ class MapRenderer extends Disposable {
   }
 
   /**
+   * Handle changes of layer.renderMode.
+   * @param {ol.events.Event} event Event.
+   * @private
+   */
+  handleLayerRenderModeChange_(event) {
+    this.removeLayerRendererByKey_(getUid(event.target).toString());
+    this.getLayerRenderer(event.target);
+
+    this.handleLayerRendererChange_();
+  }
+
+
+  /**
    * @param {string} layerKey Layer key.
    * @return {module:ol/renderer/Layer} Layer renderer.
    * @private
@@ -274,6 +296,9 @@ class MapRenderer extends Disposable {
 
     unlistenByKey(this.layerRendererListeners_[layerKey]);
     delete this.layerRendererListeners_[layerKey];
+
+    unlistenByKey(this.layerListeners_[layerKey]);
+    delete this.layerListeners_[layerKey];
 
     return layerRenderer;
   }

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -232,7 +232,7 @@ class MapRenderer extends Disposable {
           EventType.CHANGE, this.handleLayerRendererChange_, this);
 
         this.layerListeners_[layerKey] = listen(layer,
-          EventType.CHANGE, this.handleLayerRenderModeChange_, this);
+          'change:renderMode', this.handleLayerRenderModeChange_, this);
       } else {
         throw new Error('Unable to create renderer for layer: ' + layer.getType());
       }
@@ -274,6 +274,7 @@ class MapRenderer extends Disposable {
 
   /**
    * Handle changes of layer.renderMode.
+   * For the layer, the current renderer is removed and a new one immediately created.
    * @param {ol.events.Event} event Event.
    * @private
    */

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -97,13 +97,13 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     });
 
     it('uses lower resolution for pure vector rendering', function() {
-      layer.renderMode_ = 'vector';
+      layer.setRenderMode('vector');
       const renderer = new CanvasVectorTileLayerRenderer(layer);
       expect(renderer.zDirection).to.be(1);
     });
 
     it('does not render images for pure vector rendering', function() {
-      layer.renderMode_ = 'vector';
+      layer.setRenderMode('vector');
       const spy = sinon.spy(CanvasVectorTileLayerRenderer.prototype,
         'renderTileImage_');
       map.renderSync();
@@ -112,7 +112,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     });
 
     it('does not render replays for pure image rendering', function() {
-      layer.renderMode_ = 'image';
+      layer.setRenderMode('image');
       const spy = sinon.spy(CanvasVectorTileLayerRenderer.prototype,
         'getTransform');
       map.renderSync();


### PR DESCRIPTION
Added `ol.layer.Vector.setRenderModer()` that allows changing the `renderMode` after a `VectorLayer` was created.
In addition, `ol.renderer.Map` was extended to listen for changes of `ol.layer.Layer`.
On change the renderer for this layer is re-created.

__ATTENTION:__
`ol.renderer.Map` listens to `EventType.CHANGE`.
Therefore, _any_ change of `ol.layer.Layer` will trigger re-creating the renderer.
As this also includes adding new features, this patch might have _serious_ implications on performance.

__Solution:__
Listen to a specific event (e.g., Property.RENDER_MODE) and thus avoid unnecessary re-creating the renderer.