### PR TITLE
Do not prevent default on pointermove

### DIFF
--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -223,6 +223,9 @@ export function handleEvent(mapBrowserEvent) {
   } else {
     if (mapBrowserEvent.type == MapBrowserEventType.POINTERDOWN) {
       const handled = this.handleDownEvent_(mapBrowserEvent);
+      if (handled) {
+        mapBrowserEvent.preventDefault();
+      }
       this.handlingDownUpSequence = handled;
       stopEvent = this.stopDown(handled);
     } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERMOVE) {

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -69,7 +69,6 @@ function touchstart(inEvent) {
  * @param {TouchEvent} inEvent The in event.
  */
 function touchmove(inEvent) {
-  inEvent.preventDefault();
   this.processTouches_(inEvent, this.moveOverOut_);
 }
 

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -72,7 +72,8 @@ describe('ol.interaction.Draw', function() {
     const event = new PointerEvent(type, {
       clientX: position.left + x + width / 2,
       clientY: position.top + y + height / 2,
-      shiftKey: shiftKey
+      shiftKey: shiftKey,
+      preventDefault: function() {}
     }, {
       pointerType: 'mouse'
     });

--- a/test/spec/ol/interaction/extent.test.js
+++ b/test/spec/ol/interaction/extent.test.js
@@ -55,7 +55,8 @@ describe('ol.interaction.Extent', function() {
       button: button,
       clientX: position.left + x + width / 2,
       clientY: position.top - y + height / 2,
-      shiftKey: shiftKey
+      shiftKey: shiftKey,
+      preventDefault: function() {}
     });
     const event = new MapBrowserPointerEvent(type, map, pointerEvent);
     event.pointerEvent.pointerId = 1;

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -86,7 +86,8 @@ describe('ol.interaction.Modify', function() {
       clientX: position.left + x + width / 2,
       clientY: position.top + y + height / 2,
       shiftKey: modifiers.shift || false,
-      altKey: modifiers.alt || false
+      altKey: modifiers.alt || false,
+      preventDefault: function() {}
     }, {
       button: button,
       isPrimary: true

--- a/test/spec/ol/interaction/pointer.test.js
+++ b/test/spec/ol/interaction/pointer.test.js
@@ -1,0 +1,47 @@
+import Map from '../../../../src/ol/Map.js';
+import MapBrowserPointerEvent from '../../../../src/ol/MapBrowserPointerEvent.js';
+import PointerEvent from '../../../../src/ol/pointer/PointerEvent.js';
+import PointerInteraction from '../../../../src/ol/interaction/Pointer.js';
+
+describe('ol.interaction.Pointer', function() {
+
+  describe('#handleEvent', function() {
+
+    let event;
+    let defaultPrevented;
+
+    beforeEach(function() {
+      const type = 'pointerdown';
+      const pointerEvent = new PointerEvent(type, {
+        type: type,
+        preventDefault: function() {
+          defaultPrevented = true;
+        }
+      });
+      event = new MapBrowserPointerEvent(type, new Map(), pointerEvent);
+      defaultPrevented = false;
+    });
+
+    it('prevents default on handled down event', function() {
+      const interaction = new PointerInteraction({
+        handleDownEvent: function() {
+          return true;
+        }
+      });
+      interaction.handleEvent(event);
+      expect(defaultPrevented).to.be(true);
+    });
+
+    it('does not prevent default on unhandled down event', function() {
+      const interaction = new PointerInteraction({
+        handleDownEvent: function() {
+          return false;
+        }
+      });
+      interaction.handleEvent(event);
+      expect(defaultPrevented).to.be(false);
+    });
+
+  });
+
+});

--- a/test/spec/ol/interaction/translate.test.js
+++ b/test/spec/ol/interaction/translate.test.js
@@ -70,7 +70,8 @@ describe('ol.interaction.Translate', function() {
       new PointerEvent(type, {
         clientX: position.left + x + width / 2,
         clientY: position.top + y + height / 2,
-        shiftKey: shiftKey
+        shiftKey: shiftKey,
+        preventDefault: function() {}
       }));
     map.handleMapBrowserEvent(event);
   }


### PR DESCRIPTION
Instead, only prevent default on handled pointerdown events. This makes 
the `focus` condition work with interactions that involve dragging on 
touch devices.

Fixes #3253.
Fixes #8458.