### PR TITLE
Expose original getGutter

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -259,7 +259,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
         currentTilePixelSize = tileSource.getTilePixelSize(currentZ, pixelRatio, projection);
         currentResolution = tileGrid.getResolution(currentZ);
         currentScale = currentResolution / tileResolution;
-        tileGutter = tilePixelRatio * tileSource.getGutter(projection);
+        tileGutter = tilePixelRatio * tileSource.getGutterForProjection(projection);
         tilesToDraw = tilesToDrawByZ[currentZ];
         for (const tileCoordKey in tilesToDraw) {
           tile = tilesToDraw[tileCoordKey];

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -161,7 +161,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     const pixelRatio = tilePixelSize[0] /
         toSize(tileGrid.getTileSize(z), this.tmpSize_)[0];
     const tilePixelResolution = tileResolution / pixelRatio;
-    const tileGutter = tileSource.getTilePixelRatio(pixelRatio) * tileSource.getGutter(projection);
+    const tileGutter = tileSource.getTilePixelRatio(pixelRatio) * tileSource.getGutterForProjection(projection);
 
     const center = viewState.center;
     const extent = frameState.extent;

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -151,7 +151,7 @@ class TileSource extends Source {
    * @param {module:ol/proj/Projection} projection Projection.
    * @return {number} Gutter.
    */
-  getGutter(projection) {
+  getGutterForProjection(projection) {
     return 0;
   }
 

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -164,20 +164,19 @@ class TileImage extends UrlTile {
   /**
    * @inheritDoc
    */
-  getGutter(projection) {
+  getGutterForProjection(projection) {
     if (ENABLE_RASTER_REPROJECTION &&
         this.getProjection() && projection && !equivalent(this.getProjection(), projection)) {
       return 0;
     } else {
-      return this.getGutterInternal();
+      return this.getGutter();
     }
   }
 
   /**
-   * @protected
    * @return {number} Gutter.
    */
-  getGutterInternal() {
+  getGutter() {
     return 0;
   }
 
@@ -289,7 +288,7 @@ class TileImage extends UrlTile {
           sourceProjection, sourceTileGrid,
           projection, targetTileGrid,
           tileCoord, wrappedTileCoord, this.getTilePixelRatio(pixelRatio),
-          this.getGutterInternal(),
+          this.getGutter(),
           function(z, x, y, pixelRatio) {
             return this.getTileInternal(z, x, y, pixelRatio, sourceProjection);
           }.bind(this), this.reprojectionErrorThreshold_,

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -214,7 +214,7 @@ class TileWMS extends TileImage {
   /**
    * @inheritDoc
    */
-  getGutterInternal() {
+  getGutter() {
     return this.gutter_;
   }
 

--- a/test/rendering/ol/reproj/tile.test.js
+++ b/test/rendering/ol/reproj/tile.test.js
@@ -12,7 +12,7 @@ describe('ol.rendering.reproj.Tile', function() {
   function testSingleTile(source, targetProjection, targetTileGrid, z, x, y,
     pixelRatio, expectedUrl, expectedRequests, done) {
     const sourceProjection = source.getProjection();
-    const sourceGutter = source.getGutter(sourceProjection);
+    const sourceGutter = source.getGutterForProjection(sourceProjection);
 
     let tilesRequested = 0;
 


### PR DESCRIPTION
`TileWMS` objects take a `gutter` option but do not have a public getter for it. This makes it convoluted for user code to recreate the object (ex: in the case of serialization/deserialization).

- the `getGutterInternal()` method is renamed to `getGutter`;
- the `getGutter(projection)` method is renamed to `getGutterForProjection`,
  which is also more explicit.

The `getGutter` method was not API and is only used by the renderer.