### PR TITLE
Expose some internal functions

### DIFF
--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -194,8 +194,10 @@ export function equals(arr1, arr2) {
 
 
 /**
+ * Sort the passed array such that the relative order of equal elements is preverved.
+ * See https://en.wikipedia.org/wiki/Sorting_algorithm#Stability for details.
  * @param {Array<*>} arr The array to sort (modifies original).
- * @param {Function} compareFnc Comparison function.
+ * @param {!function(*, *): number} compareFnc Comparison function.
  * @api
  */
 export function stableSort(arr, compareFnc) {

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -196,6 +196,7 @@ export function equals(arr1, arr2) {
 /**
  * @param {Array<*>} arr The array to sort (modifies original).
  * @param {Function} compareFnc Comparison function.
+ * @api
  */
 export function stableSort(arr, compareFnc) {
   const length = arr.length;

--- a/src/ol/util.js
+++ b/src/ol/util.js
@@ -44,6 +44,7 @@ let uidCounter_ = 0;
  *
  * @param {Object} obj The object to get the unique ID for.
  * @return {number} The unique ID for the object.
+ * @api
  */
 export function getUid(obj) {
   return obj.ol_uid || (obj.ol_uid = ++uidCounter_);


### PR DESCRIPTION
In openlayers/ol-cesium/pull/622 I am creating an example of legacy usage of the `OL-Cesium` library.
Instead of bundling `OL-Cesium` and `OpenLayers` together with webpack, the `OpenLayers` library is used standalone.

It does not work out-of-the-box though since `OL-Cesium` is using some internal` OpenLayers` APIs and the `tasks/generate-index.js` script is limiting the exported symbols to the ones marked `@api`.

In this PR 2 functions are exposed: `getUid` and `stableSort` which I think are better exposed in `OpenLayers` than reimplemented in `OL-Cesium`. With these functions exposed `OL-Cesium` is able to handle a basic map.

My goal is to provide a basic example working out-of-the-box so that people interested in this usage of `OL-Cesium` and `OpenLayers` can have an official starting point.