### PR TITLE
Don't create Polygon with null coordinates

### DIFF
--- a/examples/draw-shapes.js
+++ b/examples/draw-shapes.js
@@ -40,9 +40,6 @@ function addInteraction() {
     } else if (value === 'Star') {
       value = 'Circle';
       geometryFunction = function(coordinates, geometry) {
-        if (!geometry) {
-          geometry = new Polygon(null);
-        }
         const center = coordinates[0];
         const last = coordinates[1];
         const dx = center[0] - last[0];
@@ -59,7 +56,11 @@ function addInteraction() {
           newCoordinates.push([center[0] + offsetX, center[1] + offsetY]);
         }
         newCoordinates.push(newCoordinates[0].slice());
-        geometry.setCoordinates([newCoordinates]);
+        if (!geometry) {
+          geometry = new Polygon([newCoordinates]);
+        } else {
+          geometry.setCoordinates([newCoordinates]);
+        }
         return geometry;
       };
     }


### PR DESCRIPTION
In the [draw-shapes](https://openlayers.org/en/latest/examples/draw-shapes.html) example, a `Polygon` was created with a null coordinates parameter.

See #8362