### PR TITLE
Add new getExtent option for Graticule

### DIFF
--- a/examples/graticule.html
+++ b/examples/graticule.html
@@ -7,3 +7,4 @@ docs: >
 tags: "graticule"
 ---
 <div id="map" class="map"></div>
+<input id="swipe" type="range" value="100" style="width: 100%">

--- a/examples/graticule.js
+++ b/examples/graticule.js
@@ -5,6 +5,7 @@ import TileLayer from '../src/ol/layer/Tile.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import OSM from '../src/ol/source/OSM.js';
 import Stroke from '../src/ol/style/Stroke.js';
+import {getWidth} from '../src/ol/extent.js';
 
 
 const map = new Map({
@@ -22,8 +23,21 @@ const map = new Map({
   })
 });
 
+const swipe = document.getElementById('swipe');
+swipe.addEventListener('input', function() {
+  map.render();
+}, false);
+
+const getExtent = function(viewExtent) {
+  const extent = viewExtent.slice();
+  const ratio = swipe.value / 100;
+  extent[2] = extent[0] + (getWidth(viewExtent) * ratio);
+  return extent;
+};
+
 // Create the graticule component
 const graticule = new Graticule({
+  getExtent: getExtent,
   // the style to use for the lines, optional.
   strokeStyle: new Stroke({
     color: 'rgba(255,120,0,0.9)',

--- a/src/ol/Graticule.js
+++ b/src/ol/Graticule.js
@@ -71,6 +71,9 @@ const INTERVALS = [
  * @property {number} [latLabelPosition=1] Latitude label position in fractions
  * (0..1) of view extent. 0 means at the left of the viewport, 1 means at the
  * right.
+ * @property {function(module:ol/extent~Extent):module:ol/extent~Extent} [getExtent] An optional function
+ * that returns the extent where the graticule will be displayed.
+ * The function receives the view extent as argument.
  * @property {module:ol/style/Text} [lonLabelStyle] Longitude label text
  * style. If not provided, the following style will be used:
  * ```js
@@ -280,6 +283,12 @@ class Graticule {
        */
       this.latLabelPosition_ = options.latLabelPosition == undefined ? 1 :
         options.latLabelPosition;
+
+      /**
+       * @type {undefined|function(module:ol/extent~Extent):module:ol/extent~Extent}
+       * @private
+       */
+      this.getExtent_ = options.getExtent;
 
       /**
        * @type {module:ol/style/Text}
@@ -623,7 +632,7 @@ class Graticule {
   handlePostCompose_(e) {
     const vectorContext = e.vectorContext;
     const frameState = e.frameState;
-    const extent = frameState.extent;
+    const extent = this.getExtent_ ? this.getExtent_(frameState.extent) : frameState.extent;
     const viewState = frameState.viewState;
     const center = viewState.center;
     const projection = viewState.projection;


### PR DESCRIPTION
Adds a new `getExtent` option to the Graticule. This function takes the view extent as argument and can return a new extent. The graticule is rendered into this extent.

fixes #8427 

comments welcome