### PR TITLE
WMTS getCapabilities readCoodinates more than one whitespace delimiter

### DIFF
--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -340,7 +340,7 @@ function readLegendUrl(node, objectStack) {
  * @return {Object|undefined} Coordinates object.
  */
 function readCoordinates(node, objectStack) {
-  const coordinates = readString(node).replace(/\s\s+/g, ' ').split(' ');
+  const coordinates = readString(node).split(/\s+/g);
   if (!coordinates || coordinates.length != 2) {
     return undefined;
   }

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -340,7 +340,7 @@ function readLegendUrl(node, objectStack) {
  * @return {Object|undefined} Coordinates object.
  */
 function readCoordinates(node, objectStack) {
-  const coordinates = readString(node).split(' ');
+  const coordinates = readString(node).replace(/\s\s+/g, ' ').split(' ');
   if (!coordinates || coordinates.length != 2) {
     return undefined;
   }

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -340,7 +340,7 @@ function readLegendUrl(node, objectStack) {
  * @return {Object|undefined} Coordinates object.
  */
 function readCoordinates(node, objectStack) {
-  const coordinates = readString(node).split(/\s+/g);
+  const coordinates = readString(node).split(/\s+/);
   if (!coordinates || coordinates.length != 2) {
     return undefined;
   }


### PR DESCRIPTION
Some WMTS getCapabilities return <MatrixSet><TopLeftCorner> with more than one whitespace as delimiter between the coordinates. This leads to the layer not being displayed, because the origin_ property of ol.tilegrid.TileGrid is not set.
Error in ol.tilegrid.TileGrid.prototype.getTileCoordForXYAndZ_: JavaScript runtime error: Unable to get property '0' of undefined or null reference