### PR TITLE
More convenient select and sketch layer management

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -442,6 +442,15 @@ class Draw extends PointerInteraction {
   }
 
   /**
+   * Get the overlay layer that this interaction renders sketch features to.
+   * @return {module:ol/layer/Vector} Overlay layer.
+   * @api
+   */
+  getOverlay() {
+    return this.overlay_;
+  }
+
+  /**
    * Handle move events.
    * @param {module:ol/MapBrowserEvent} event A move event.
    * @return {boolean} Pass the event to other interactions.

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -423,6 +423,15 @@ class Modify extends PointerInteraction {
   }
 
   /**
+   * Get the overlay layer that this interaction renders sketch features to.
+   * @return {module:ol/layer/Vector} Overlay layer.
+   * @api
+   */
+  getOverlay() {
+    return this.overlay_;
+  }
+
+  /**
    * @param {module:ol/source/Vector~VectorSourceEvent} event Event.
    * @private
    */

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -255,11 +255,13 @@ class Select extends Interaction {
      */
     this.featureLayerAssociation_ = {};
 
-    const features = this.featureOverlay_.getSource().getFeaturesCollection();
-    listen(features, CollectionEventType.ADD,
-      this.addFeature_, this);
-    listen(features, CollectionEventType.REMOVE,
-      this.removeFeature_, this);
+    if (this.featureOverlay_) {
+      const features = this.featureOverlay_.getSource().getFeaturesCollection();
+      listen(features, CollectionEventType.ADD,
+        this.addFeature_, this);
+      listen(features, CollectionEventType.REMOVE,
+        this.removeFeature_, this);
+    }
 
   }
 
@@ -305,6 +307,15 @@ class Select extends Interaction {
     return (
       /** @type {module:ol/layer/Vector} */ (this.featureLayerAssociation_[key])
     );
+  }
+
+  /**
+   * Get the overlay layer that this interaction renders selected features to.
+   * @return {module:ol/layer/Vector} Overlay layer.
+   * @api
+   */
+  getOverlay() {
+    return this.featureOverlay_;
   }
 
   /**

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -13,8 +13,8 @@ import {assign} from '../obj.js';
  * @property {boolean} [visible=true] Visibility.
  * @property {module:ol/extent~Extent} [extent] The bounding extent for layer rendering.  The layer will not be
  * rendered outside of this extent.
- * @property {number} [zIndex=0] The z-index for layer rendering.  At rendering time, the layers
- * will be ordered, first by Z-index and then by position.
+ * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
+ * will be ordered, first by Z-index and then by position. When undefined, a zIndex of 0 is assumed.
  * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
@@ -48,8 +48,7 @@ class BaseLayer extends BaseObject {
        options.opacity !== undefined ? options.opacity : 1;
     properties[LayerProperty.VISIBLE] =
        options.visible !== undefined ? options.visible : true;
-    properties[LayerProperty.Z_INDEX] =
-       options.zIndex !== undefined ? options.zIndex : 0;
+    properties[LayerProperty.Z_INDEX] = options.zIndex;
     properties[LayerProperty.MAX_RESOLUTION] =
        options.maxResolution !== undefined ? options.maxResolution : Infinity;
     properties[LayerProperty.MIN_RESOLUTION] =
@@ -91,7 +90,7 @@ class BaseLayer extends BaseObject {
     this.state_.sourceState = this.getSourceState();
     this.state_.visible = this.getVisible();
     this.state_.extent = this.getExtent();
-    this.state_.zIndex = this.getZIndex();
+    this.state_.zIndex = this.getZIndex() || 0;
     this.state_.maxResolution = this.getMaxResolution();
     this.state_.minResolution = Math.max(this.getMinResolution(), 0);
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -191,7 +191,9 @@ class Layer extends BaseLayer {
       this.mapPrecomposeKey_ = listen(map, RenderEventType.PRECOMPOSE, function(evt) {
         const layerState = this.getLayerState();
         layerState.managed = false;
-        layerState.zIndex = Infinity;
+        if (this.getZIndex() === undefined) {
+          layerState.zIndex = Infinity;
+        }
         evt.frameState.layerStatesArray.push(layerState);
         evt.frameState.layerStates[getUid(this)] = layerState;
       }, this);

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -1060,6 +1060,13 @@ describe('ol.interaction.Draw', function() {
     });
   });
 
+  describe('#getOverlay', function() {
+    it('returns the feature overlay layer', function() {
+      const draw = new Draw({});
+      expect (draw.getOverlay()).to.eql(draw.overlay_);
+    });
+  });
+
   describe('createRegularPolygon', function() {
     it('creates a regular polygon in Circle mode', function() {
       const draw = new Draw({

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -712,4 +712,13 @@ describe('ol.interaction.Modify', function() {
     });
   });
 
+  describe('#getOverlay', function() {
+    it('returns the feature overlay layer', function() {
+      const modify = new Modify({
+        features: new Collection()
+      });
+      expect (modify.getOverlay()).to.eql(modify.overlay_);
+    });
+  });
+
 });

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -442,4 +442,11 @@ describe('ol.interaction.Select', function() {
       });
     });
   });
+
+  describe('#getOverlay', function() {
+    it('returns the feature overlay layer', function() {
+      const select = new Select();
+      expect (select.getOverlay()).to.eql(select.featureOverlay_);
+    });
+  });
 });

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -434,6 +434,41 @@ describe('ol.layer.Layer', function() {
 
     });
 
+    describe('zIndex for unmanaged layers', function() {
+
+      let frameState, layer;
+
+      beforeEach(function() {
+        layer = new Layer({
+          map: map
+        });
+        frameState = {
+          layerStatesArray: [],
+          layerStates: {}
+        };
+      });
+
+      afterEach(function() {
+        layer.setMap(null);
+      });
+
+      it('has Infinity as zIndex when not configured otherwise', function() {
+        map.dispatchEvent(new RenderEvent('precompose', null,
+          frameState, null, null));
+        const layerState = frameState.layerStatesArray[0];
+        expect(layerState.zIndex).to.be(Infinity);
+      });
+
+      it('respects the configured zIndex', function() {
+        layer.setZIndex(42);
+        map.dispatchEvent(new RenderEvent('precompose', null,
+          frameState, null, null));
+        const layerState = frameState.layerStatesArray[0];
+        expect(layerState.zIndex).to.be(42);
+      });
+
+    });
+
   });
 
 });


### PR DESCRIPTION
This pull request gives access to the feature overlay layers of the Select, Draw and Modify interactions. It also changes zIndex handling of unmanaged layers so users can also change the zIndex for unmanaged layers, e.g.
```js
const select = new Select();
select.getOverlay().setZIndex(0);
```

Fixes #8064 as an alternative to #8507.