### PR TITLE
Re-export Projection from ol/proj for convenience

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -85,6 +85,7 @@ import {add as addTransformFunc, clear as clearTransformFuncs, get as getTransfo
 
 export {METERS_PER_UNIT};
 
+export {Projection};
 
 /**
  * @param {Array<number>} input Input coordinate array.


### PR DESCRIPTION
This makes it possible to
```js
import {Projection} from 'ol/proj';
```

Which is pretty guessable if you are importing other constructors from places like `ol/style`, `ol/layer`, `ol/source`, `ol/format`, etc.