### PR TITLE
Add 'rendercomplete' event

### DIFF
--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -30,7 +30,7 @@ const map = new Map({
 });
 
 document.getElementById('export-png').addEventListener('click', function() {
-  map.once('postcompose', function(event) {
+  map.once('rendercomplete', function(event) {
     const canvas = event.context.canvas;
     if (navigator.msSaveBlob) {
       navigator.msSaveBlob(canvas.msToBlob(), 'map.png');

--- a/src/ol/render/EventType.js
+++ b/src/ol/render/EventType.js
@@ -20,5 +20,12 @@ export default {
    * @event module:ol/render/Event~RenderEvent#render
    * @api
    */
-  RENDER: 'render'
+  RENDER: 'render',
+  /**
+   * Triggered when rendering is complete, i.e. all sources and tiles have
+   * finished loading for the current viewport, and all tiles are faded in.
+   * @event module:ol/render/Event~RenderEvent#rendercomplete
+   * @api
+   */
+  RENDERCOMPLETE: 'rendercomplete'
 };

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -333,6 +333,13 @@ MapRenderer.prototype.renderFrame = VOID;
 
 
 /**
+ * @param {module:ol/render/EventType} type Event type.
+ * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
+ */
+MapRenderer.prototype.dispatchRenderEvent = VOID;
+
+
+/**
  * @param {module:ol/layer/Layer~State} state1 First layer state.
  * @param {module:ol/layer/Layer~State} state2 Second layer state.
  * @return {number} The zIndex difference.

--- a/src/ol/renderer/canvas/Map.js
+++ b/src/ol/renderer/canvas/Map.js
@@ -69,9 +69,8 @@ class CanvasMapRenderer extends MapRenderer {
   /**
    * @param {module:ol/render/EventType} type Event type.
    * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @private
    */
-  dispatchComposeEvent_(type, frameState) {
+  dispatchRenderEvent(type, frameState) {
     const map = this.getMap();
     const context = this.context_;
     if (map.hasListener(type)) {
@@ -135,7 +134,7 @@ class CanvasMapRenderer extends MapRenderer {
 
     this.calculateMatrices2D(frameState);
 
-    this.dispatchComposeEvent_(RenderEventType.PRECOMPOSE, frameState);
+    this.dispatchRenderEvent(RenderEventType.PRECOMPOSE, frameState);
 
     const layerStatesArray = frameState.layerStatesArray;
     stableSort(layerStatesArray, sortByZIndex);
@@ -164,7 +163,7 @@ class CanvasMapRenderer extends MapRenderer {
       context.restore();
     }
 
-    this.dispatchComposeEvent_(RenderEventType.POSTCOMPOSE, frameState);
+    this.dispatchRenderEvent(RenderEventType.POSTCOMPOSE, frameState);
 
     if (!this.renderedVisible_) {
       this.canvas_.style.display = '';

--- a/src/ol/renderer/webgl/Map.js
+++ b/src/ol/renderer/webgl/Map.js
@@ -249,9 +249,8 @@ class WebGLMapRenderer extends MapRenderer {
   /**
    * @param {module:ol/render/EventType} type Event type.
    * @param {module:ol/PluggableMap~FrameState} frameState Frame state.
-   * @private
    */
-  dispatchComposeEvent_(type, frameState) {
+  dispatchRenderEvent(type, frameState) {
     const map = this.getMap();
     if (map.hasListener(type)) {
       const context = this.context_;
@@ -411,7 +410,7 @@ class WebGLMapRenderer extends MapRenderer {
     this.textureCache_.set((-frameState.index).toString(), null);
     ++this.textureCacheFrameMarkerCount_;
 
-    this.dispatchComposeEvent_(RenderEventType.PRECOMPOSE, frameState);
+    this.dispatchRenderEvent(RenderEventType.PRECOMPOSE, frameState);
 
     /** @type {Array<module:ol/layer/Layer~State>} */
     const layerStatesToDraw = [];
@@ -470,7 +469,7 @@ class WebGLMapRenderer extends MapRenderer {
       frameState.animate = true;
     }
 
-    this.dispatchComposeEvent_(RenderEventType.POSTCOMPOSE, frameState);
+    this.dispatchRenderEvent(RenderEventType.POSTCOMPOSE, frameState);
 
     this.scheduleRemoveUnusedLayerRenderers(frameState);
     this.scheduleExpireIconCache(frameState);

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -201,16 +201,19 @@ class ImageSource extends Source {
     const image = /** @type {module:ol/Image} */ (event.target);
     switch (image.getState()) {
       case ImageState.LOADING:
+        this.loading = true;
         this.dispatchEvent(
           new ImageSourceEvent(ImageSourceEventType.IMAGELOADSTART,
             image));
         break;
       case ImageState.LOADED:
+        this.loading = false;
         this.dispatchEvent(
           new ImageSourceEvent(ImageSourceEventType.IMAGELOADEND,
             image));
         break;
       case ImageState.ERROR:
+        this.loading = false;
         this.dispatchEvent(
           new ImageSourceEvent(ImageSourceEventType.IMAGELOADERROR,
             image));

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -67,6 +67,13 @@ class Source extends BaseObject {
     this.attributions_ = this.adaptAttributions_(options.attributions);
 
     /**
+     * This source is currently loading data. Sources that defer loading to the
+     * map's tile queue never set this to `true`.
+     * @type {boolean}
+     */
+    this.loading = false;
+
+    /**
     * @private
     * @type {module:ol/source/State}
     */

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -871,6 +871,7 @@ class VectorSource extends Source {
   loadFeatures(extent, resolution, projection) {
     const loadedExtentsRtree = this.loadedExtentsRtree_;
     const extentsToLoad = this.strategy_(extent, resolution);
+    this.loading = false;
     for (let i = 0, ii = extentsToLoad.length; i < ii; ++i) {
       const extentToLoad = extentsToLoad[i];
       const alreadyLoaded = loadedExtentsRtree.forEachInExtent(extentToLoad,
@@ -884,6 +885,7 @@ class VectorSource extends Source {
       if (!alreadyLoaded) {
         this.loader_.call(this, extentToLoad, resolution, projection);
         loadedExtentsRtree.insert(extentToLoad, {extent: extentToLoad.slice()});
+        this.loading = true;
       }
     }
   }


### PR DESCRIPTION
This pull request adds a `rendercomplete` event which is triggered when the final map image has been rendered for the visible viewport.

Fixes #7969
Fixes #6447