### PR TITLE
Use 'Element' type instead of 'Node'

### DIFF
--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -95,7 +95,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/extent~Extent|undefined} Envelope.
@@ -110,7 +110,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -126,7 +126,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -146,7 +146,7 @@ class GML2 extends GMLBase {
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
-   * @return {Node|undefined} Node.
+   * @return {Element|undefined} Node.
    * @private
    */
   GEOMETRY_NODE_FACTORY_(value, objectStack, opt_nodeName) {
@@ -172,7 +172,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/Feature} feature Feature.
    * @param {Array<*>} objectStack Node stack.
    */
@@ -218,7 +218,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/LineString} geometry LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -243,7 +243,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/LineString} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -257,7 +257,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -305,7 +305,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {string} namespaceURI XML namespace.
-   * @returns {Node} coordinates node.
+   * @returns {Element} coordinates node.
    * @private
    */
   createCoordinatesNode_(namespaceURI) {
@@ -351,7 +351,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/Polygon} geometry Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -445,7 +445,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/Point} geometry Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -465,7 +465,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -497,7 +497,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -514,7 +514,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -550,7 +550,7 @@ class GML2 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/extent~Extent} extent Extent.
    * @param {Array<*>} objectStack Node stack.
    * @private

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -102,7 +102,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
@@ -120,7 +120,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
@@ -135,7 +135,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -144,7 +144,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -154,7 +154,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<(Array<number>)>|undefined} flat coordinates.
@@ -165,7 +165,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<number>|undefined} flat coordinates.
@@ -176,7 +176,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<(Array<number>)>|undefined} flat coordinates.
@@ -187,7 +187,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<number>|undefined} flat coordinates.
@@ -199,7 +199,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -215,7 +215,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -231,7 +231,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/Polygon|undefined} Polygon.
@@ -255,7 +255,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/geom/LineString|undefined} LineString.
@@ -273,7 +273,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/extent~Extent|undefined} Envelope.
@@ -333,7 +333,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<number>|undefined} Flat coordinates.
@@ -379,7 +379,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/Point} value Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -435,7 +435,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/LineString|module:ol/geom/LinearRing} value Geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -459,7 +459,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/Point} geometry Point geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -476,7 +476,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/extent~Extent} extent Extent.
    * @param {Array<*>} objectStack Node stack.
    */
@@ -496,7 +496,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/LinearRing} geometry LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -531,7 +531,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/Polygon} geometry Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -559,7 +559,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/LineString} geometry LineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -584,7 +584,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/MultiPolygon} geometry MultiPolygon geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -605,7 +605,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/MultiPoint} geometry MultiPoint geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -625,7 +625,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/geom/MultiLineString} geometry MultiLineString geometry.
    * @param {Array<*>} objectStack Node stack.
    * @private
@@ -750,7 +750,7 @@ class GML3 extends GMLBase {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {module:ol/Feature} feature Feature.
    * @param {Array<*>} objectStack Node stack.
    */
@@ -837,7 +837,7 @@ class GML3 extends GMLBase {
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
    * @param {string=} opt_nodeName Node name.
-   * @return {Node|undefined} Node.
+   * @return {Element|undefined} Node.
    * @private
    */
   GEOMETRY_NODE_FACTORY_(value, objectStack, opt_nodeName) {
@@ -892,7 +892,7 @@ class GML3 extends GMLBase {
    *
    * @param {Array<module:ol/Feature>} features Features.
    * @param {module:ol/format/Feature~WriteOptions=} opt_options Options.
-   * @return {Node} Node.
+   * @return {Element} Node.
    * @override
    * @api
    */

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -130,7 +130,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {Array<module:ol/Feature> | undefined} Features.
    */
@@ -218,7 +218,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/Geometry|undefined} Geometry.
    */
@@ -238,7 +238,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/Feature} Feature.
    */
@@ -279,7 +279,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/Point|undefined} Point.
    */
@@ -291,7 +291,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/MultiPoint|undefined} MultiPoint.
    */
@@ -307,7 +307,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
    */
@@ -321,7 +321,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/MultiPolygon|undefined} MultiPolygon.
    */
@@ -334,7 +334,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -343,7 +343,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -352,7 +352,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -361,7 +361,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/LineString|undefined} LineString.
    */
@@ -376,7 +376,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<number>|undefined} LinearRing flat coordinates.
@@ -393,7 +393,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/LinearRing|undefined} LinearRing.
    */
@@ -405,7 +405,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {module:ol/geom/Polygon|undefined} Polygon.
    */
@@ -428,7 +428,7 @@ class GMLBase extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {Array<number>} Flat coordinates.

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -489,7 +489,7 @@ function GPX_NODE_FACTORY(value, objectStack, opt_nodeName) {
 /**
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {module:ol/format/GPX~LayoutOptions} layoutOptions Layout options.
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {!Object} values Values.
  * @return {Array<number>} Flat coordinates.
  */
@@ -560,7 +560,7 @@ function applyLayoutOptions(layoutOptions, flatCoordinates, ends) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function parseLink(node, objectStack) {
@@ -584,7 +584,7 @@ function parseExtensions(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function parseRtePt(node, objectStack) {
@@ -599,7 +599,7 @@ function parseRtePt(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function parseTrkPt(node, objectStack) {
@@ -614,7 +614,7 @@ function parseTrkPt(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function parseTrkSeg(node, objectStack) {
@@ -628,7 +628,7 @@ function parseTrkSeg(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/Feature|undefined} Track.
  */
@@ -656,7 +656,7 @@ function readRte(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/Feature|undefined} Track.
  */
@@ -687,7 +687,7 @@ function readTrk(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/Feature|undefined} Waypoint.
  */
@@ -709,7 +709,7 @@ function readWpt(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {string} value Value for the link's `href` attribute.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -728,7 +728,7 @@ function writeLink(node, value, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/coordinate~Coordinate} coordinate Coordinate.
  * @param {Array<*>} objectStack Object stack.
  */
@@ -836,7 +836,7 @@ function writeTrkSeg(node, lineString, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/Feature} feature Feature.
  * @param {Array<*>} objectStack Object stack.
  */

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -480,7 +480,7 @@ class KML extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    * @return {module:ol/Feature|undefined} Feature.
@@ -523,7 +523,7 @@ class KML extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -549,7 +549,7 @@ class KML extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @private
    */
@@ -634,7 +634,7 @@ class KML extends XMLFeature {
   /**
    * Read the name of the KML.
    *
-   * @param {Document|Node|string} source Source.
+   * @param {Document|Element|string} source Source.
    * @return {string|undefined} Name.
    * @api
    */
@@ -642,7 +642,7 @@ class KML extends XMLFeature {
     if (isDocument(source)) {
       return this.readNameFromDocument(/** @type {Document} */ (source));
     } else if (isNode(source)) {
-      return this.readNameFromNode(/** @type {Node} */ (source));
+      return this.readNameFromNode(/** @type {Element} */ (source));
     } else if (typeof source === 'string') {
       const doc = parse(source);
       return this.readNameFromDocument(doc);
@@ -658,7 +658,7 @@ class KML extends XMLFeature {
   readNameFromDocument(doc) {
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
-        const name = this.readNameFromNode(n);
+        const name = this.readNameFromNode(/** @type {Element} */ (n));
         if (name) {
           return name;
         }
@@ -668,7 +668,7 @@ class KML extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @return {string|undefined} Name.
    */
   readNameFromNode(node) {
@@ -697,7 +697,7 @@ class KML extends XMLFeature {
   /**
    * Read the network links of the KML.
    *
-   * @param {Document|Node|string} source Source.
+   * @param {Document|Element|string} source Source.
    * @return {Array<Object>} Network links.
    * @api
    */
@@ -708,7 +708,7 @@ class KML extends XMLFeature {
         /** @type {Document} */ (source)));
     } else if (isNode(source)) {
       extend(networkLinks, this.readNetworkLinksFromNode(
-        /** @type {Node} */ (source)));
+        /** @type {Element} */ (source)));
     } else if (typeof source === 'string') {
       const doc = parse(source);
       extend(networkLinks, this.readNetworkLinksFromDocument(doc));
@@ -724,14 +724,14 @@ class KML extends XMLFeature {
     const networkLinks = [];
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
-        extend(networkLinks, this.readNetworkLinksFromNode(n));
+        extend(networkLinks, this.readNetworkLinksFromNode(/** @type {Element} */ (n)));
       }
     }
     return networkLinks;
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @return {Array<Object>} Network links.
    */
   readNetworkLinksFromNode(node) {
@@ -759,7 +759,7 @@ class KML extends XMLFeature {
   /**
    * Read the regions of the KML.
    *
-   * @param {Document|Node|string} source Source.
+   * @param {Document|Element|string} source Source.
    * @return {Array<Object>} Regions.
    * @api
    */
@@ -770,7 +770,7 @@ class KML extends XMLFeature {
         /** @type {Document} */ (source)));
     } else if (isNode(source)) {
       extend(regions, this.readRegionFromNode(
-        /** @type {Node} */ (source)));
+        /** @type {Element} */ (source)));
     } else if (typeof source === 'string') {
       const doc = parse(source);
       extend(regions, this.readRegionFromDocument(doc));
@@ -786,14 +786,14 @@ class KML extends XMLFeature {
     const regions = [];
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
-        extend(regions, this.readRegionFromNode(n));
+        extend(regions, this.readRegionFromNode(/** @type {Element} */ (n)));
       }
     }
     return regions;
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @return {Array<Object>} Region.
    * @api
    */
@@ -1053,7 +1053,7 @@ function readURI(node) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @return {module:ol/format/KML~Vec2} Vec2.
  */
 function readVec2(node) {
@@ -1103,7 +1103,7 @@ const STYLE_MAP_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<module:ol/style/Style>|string|undefined} StyleMap.
  */
@@ -1127,7 +1127,7 @@ const ICON_STYLE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function iconStyleParser(node, objectStack) {
@@ -1241,7 +1241,7 @@ const LABEL_STYLE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function labelStyleParser(node, objectStack) {
@@ -1276,7 +1276,7 @@ const LINE_STYLE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function lineStyleParser(node, objectStack) {
@@ -1313,7 +1313,7 @@ const POLY_STYLE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function polyStyleParser(node, objectStack) {
@@ -1351,7 +1351,7 @@ const FLAT_LINEAR_RING_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<number>} LinearRing flat coordinates.
  */
@@ -1395,7 +1395,7 @@ const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/MultiLineString|undefined} MultiLineString.
  */
@@ -1423,7 +1423,7 @@ const GX_TRACK_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/LineString|undefined} LineString.
  */
@@ -1462,7 +1462,7 @@ const ICON_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object} Icon object.
  */
@@ -1488,7 +1488,7 @@ const GEOMETRY_FLAT_COORDINATES_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<number>} Flat coordinates.
  */
@@ -1511,7 +1511,7 @@ const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/LineString|undefined} LineString.
  */
@@ -1532,7 +1532,7 @@ function readLineString(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
@@ -1567,7 +1567,7 @@ const MULTI_GEOMETRY_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Geometry} Geometry.
  */
@@ -1626,7 +1626,7 @@ function readMultiGeometry(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Point|undefined} Point.
  */
@@ -1658,7 +1658,7 @@ const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/geom/Polygon|undefined} Polygon.
  */
@@ -1698,7 +1698,7 @@ const STYLE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<module:ol/style/Style>} Style.
  */
@@ -1788,7 +1788,7 @@ const DATA_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function dataParser(node, objectStack) {
@@ -1816,7 +1816,7 @@ const EXTENDED_DATA_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function extendedDataParser(node, objectStack) {
@@ -1824,7 +1824,7 @@ function extendedDataParser(node, objectStack) {
 }
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function regionParser(node, objectStack) {
@@ -1844,7 +1844,7 @@ const PAIR_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function pairDataParser(node, objectStack) {
@@ -1871,7 +1871,7 @@ function pairDataParser(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function placemarkStyleMapParser(node, objectStack) {
@@ -1901,7 +1901,7 @@ const SCHEMA_DATA_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function schemaDataParser(node, objectStack) {
@@ -1910,7 +1910,7 @@ function schemaDataParser(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function simpleDataParser(node, objectStack) {
@@ -1940,7 +1940,7 @@ const LAT_LON_ALT_BOX_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function latLonAltBoxParser(node, objectStack) {
@@ -1976,7 +1976,7 @@ const LOD_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function lodParser(node, objectStack) {
@@ -2003,7 +2003,7 @@ const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function innerBoundaryIsParser(node, objectStack) {
@@ -2029,7 +2029,7 @@ const OUTER_BOUNDARY_IS_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function outerBoundaryIsParser(node, objectStack) {
@@ -2045,7 +2045,7 @@ function outerBoundaryIsParser(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function linkParser(node, objectStack) {
@@ -2136,7 +2136,7 @@ const EXTENDEDDATA_NODE_SERIALIZERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {{name: *, value: *}} pair Name value pair.
  * @param {Array<*>} objectStack Object stack.
  */
@@ -2657,7 +2657,7 @@ const EXTENDEDDATA_NODE_FACTORY = makeSimpleNodeFactory('ExtendedData');
 /**
  * FIXME currently we do serialize arbitrary/custom feature properties
  * (ExtendedData).
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/Feature} feature Feature.
  * @param {Array<*>} objectStack Object stack.
  * @this {module:ol/format/KML}
@@ -2915,7 +2915,7 @@ function writeStyle(node, style, objectStack) {
 
 
 /**
- * @param {Node} node Node to append a TextNode with the Vec2 to.
+ * @param {Element} node Node to append a TextNode with the Vec2 to.
  * @param {module:ol/format/KML~Vec2} vec2 Vec2.
  */
 function writeVec2(node, vec2) {

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -115,7 +115,7 @@ const NODE_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function readNode(node, objectStack) {
@@ -144,7 +144,7 @@ function readNode(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function readWay(node, objectStack) {
@@ -160,7 +160,7 @@ function readWay(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function readNd(node, objectStack) {
@@ -170,7 +170,7 @@ function readNd(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function readTag(node, objectStack) {

--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -205,7 +205,7 @@ const SERVICE_PROVIDER_PARSERS =
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The address.
  */
@@ -216,7 +216,7 @@ function readAddress(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The values.
  */
@@ -227,7 +227,7 @@ function readAllowedValues(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The constraint.
  */
@@ -243,7 +243,7 @@ function readConstraint(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The contact info.
  */
@@ -254,7 +254,7 @@ function readContactInfo(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The DCP.
  */
@@ -265,7 +265,7 @@ function readDcp(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The GET object.
  */
@@ -280,7 +280,7 @@ function readGet(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The HTTP object.
  */
@@ -290,7 +290,7 @@ function readHttp(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The operation.
  */
@@ -308,7 +308,7 @@ function readOperation(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The operations metadata.
  */
@@ -320,7 +320,7 @@ function readOperationsMetadata(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The phone.
  */
@@ -331,7 +331,7 @@ function readPhone(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The service identification.
  */
@@ -343,7 +343,7 @@ function readServiceIdentification(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The service contact.
  */
@@ -355,7 +355,7 @@ function readServiceContact(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} The service provider.
  */

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -278,7 +278,7 @@ class WFS extends XMLFeature {
   /**
    * Read transaction response of the source.
    *
-   * @param {Document|Node|Object|string} source Source.
+   * @param {Document|Element|Object|string} source Source.
    * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
    * @api
    */
@@ -287,7 +287,7 @@ class WFS extends XMLFeature {
       return this.readTransactionResponseFromDocument(
         /** @type {Document} */ (source));
     } else if (isNode(source)) {
-      return this.readTransactionResponseFromNode(/** @type {Node} */ (source));
+      return this.readTransactionResponseFromNode(/** @type {Element} */ (source));
     } else if (typeof source === 'string') {
       const doc = parse(source);
       return this.readTransactionResponseFromDocument(doc);
@@ -299,7 +299,7 @@ class WFS extends XMLFeature {
   /**
    * Read feature collection metadata of the source.
    *
-   * @param {Document|Node|Object|string} source Source.
+   * @param {Document|Element|Object|string} source Source.
    * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
    *     FeatureCollection metadata.
    * @api
@@ -310,7 +310,7 @@ class WFS extends XMLFeature {
         /** @type {Document} */ (source));
     } else if (isNode(source)) {
       return this.readFeatureCollectionMetadataFromNode(
-        /** @type {Node} */ (source));
+        /** @type {Element} */ (source));
     } else if (typeof source === 'string') {
       const doc = parse(source);
       return this.readFeatureCollectionMetadataFromDocument(doc);
@@ -327,14 +327,14 @@ class WFS extends XMLFeature {
   readFeatureCollectionMetadataFromDocument(doc) {
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
-        return this.readFeatureCollectionMetadataFromNode(n);
+        return this.readFeatureCollectionMetadataFromNode(/** @type {Element} */ (n));
       }
     }
     return undefined;
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @return {module:ol/format/WFS~FeatureCollectionMetadata|undefined}
    *     FeatureCollection metadata.
    */
@@ -355,14 +355,14 @@ class WFS extends XMLFeature {
   readTransactionResponseFromDocument(doc) {
     for (let n = doc.firstChild; n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
-        return this.readTransactionResponseFromNode(n);
+        return this.readTransactionResponseFromNode(/** @type {Element} */ (n));
       }
     }
     return undefined;
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @return {module:ol/format/WFS~TransactionResponse|undefined} Transaction response.
    */
   readTransactionResponseFromNode(node) {
@@ -537,7 +537,7 @@ class WFS extends XMLFeature {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Transaction Summary.
  */
@@ -561,7 +561,7 @@ const OGC_FID_PARSERS = {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */
 function fidParser(node, objectStack) {
@@ -581,7 +581,7 @@ const INSERT_RESULTS_PARSERS = {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<string>|undefined} Insert results.
  */
@@ -592,7 +592,7 @@ function readInsertResults(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/Feature} feature Feature.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -643,7 +643,7 @@ function getTypeName(featurePrefix, featureType) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/Feature} feature Feature.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -664,7 +664,7 @@ function writeDelete(node, feature, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/Feature} feature Feature.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -733,7 +733,7 @@ function writeProperty(node, pair, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {{vendorId: string, safeToIgnore: boolean, value: string}} nativeElement The native element.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -780,7 +780,7 @@ const GETFEATURE_SERIALIZERS = {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {string} featureType Feature type.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -951,7 +951,7 @@ function writeNotFilter(node, filter, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/format/filter/ComparisonBinary} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
@@ -993,7 +993,7 @@ function writeIsBetweenFilter(node, filter, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {module:ol/format/filter/IsLike} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -286,7 +286,7 @@ const KEYWORDLIST_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Attribution object.
  */
@@ -296,7 +296,7 @@ function readAttribution(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object} Bounding box object.
  */
@@ -322,7 +322,7 @@ function readBoundingBox(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {module:ol/extent~Extent|undefined} Bounding box object.
  */
@@ -354,7 +354,7 @@ function readEXGeographicBoundingBox(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Capability object.
  */
@@ -364,7 +364,7 @@ function readCapability(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Service object.
  */
@@ -374,7 +374,7 @@ function readService(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Contact information object.
  */
@@ -384,7 +384,7 @@ function readContactInformation(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Contact person object.
  */
@@ -394,7 +394,7 @@ function readContactPersonPrimary(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Contact address object.
  */
@@ -404,7 +404,7 @@ function readContactAddress(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<string>|undefined} Format array.
  */
@@ -414,7 +414,7 @@ function readException(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Layer object.
  */
@@ -424,7 +424,7 @@ function readCapabilityLayer(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Layer object.
  */
@@ -496,7 +496,7 @@ function readLayer(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object} Dimension object.
  */
@@ -516,7 +516,7 @@ function readDimension(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Online resource object.
  */
@@ -526,7 +526,7 @@ function readFormatOnlineresource(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Request object.
  */
@@ -536,7 +536,7 @@ function readRequest(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} DCP type object.
  */
@@ -546,7 +546,7 @@ function readDCPType(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} HTTP object.
  */
@@ -556,7 +556,7 @@ function readHTTP(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Operation type object.
  */
@@ -566,7 +566,7 @@ function readOperationType(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Online resource object.
  */
@@ -585,7 +585,7 @@ function readSizedFormatOnlineresource(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Authority URL object.
  */
@@ -600,7 +600,7 @@ function readAuthorityURL(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Metadata URL object.
  */
@@ -615,7 +615,7 @@ function readMetadataURL(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Style object.
  */
@@ -625,7 +625,7 @@ function readStyle(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Array<string>|undefined} Keyword list.
  */

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -81,7 +81,7 @@ class WMSGetFeatureInfo extends XMLFeature {
   }
 
   /**
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
    * @return {Array<module:ol/Feature>} Features.
    * @private

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -218,7 +218,7 @@ const TM_PARSERS = makeStructureNS(
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Attribution object.
  */
@@ -228,7 +228,7 @@ function readContents(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Layers object.
  */
@@ -238,7 +238,7 @@ function readLayer(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Tile Matrix Set object.
  */
@@ -248,7 +248,7 @@ function readTileMatrixSet(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Style object.
  */
@@ -265,7 +265,7 @@ function readStyle(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Tile Matrix Set Link object.
  */
@@ -275,7 +275,7 @@ function readTileMatrixSetLink(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Dimension object.
  */
@@ -285,7 +285,7 @@ function readDimensions(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Resource URL object.
  */
@@ -308,7 +308,7 @@ function readResourceUrl(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} WGS84 BBox object.
  */
@@ -322,7 +322,7 @@ function readWgs84BoundingBox(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} Legend object.
  */
@@ -354,7 +354,7 @@ function readCoordinates(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} TileMatrix object.
  */
@@ -364,7 +364,7 @@ function readTileMatrix(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} TileMatrixSetLimits Object.
  */
@@ -374,7 +374,7 @@ function readTileMatrixLimitsList(node, objectStack) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @return {Object|undefined} TileMatrixLimits Array.
  */

--- a/src/ol/format/XLink.js
+++ b/src/ol/format/XLink.js
@@ -11,7 +11,7 @@ const NAMESPACE_URI = 'http://www.w3.org/1999/xlink';
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @return {string|undefined} href.
  */
 export function readHref(node) {

--- a/src/ol/format/XML.js
+++ b/src/ol/format/XML.js
@@ -13,7 +13,7 @@ class XML {
   /**
    * Read the source document.
    *
-   * @param {Document|Node|string} source The XML source.
+   * @param {Document|Element|string} source The XML source.
    * @return {Object} An object representing the source.
    * @api
    */
@@ -21,7 +21,7 @@ class XML {
     if (isDocument(source)) {
       return this.readFromDocument(/** @type {Document} */ (source));
     } else if (isNode(source)) {
-      return this.readFromNode(/** @type {Node} */ (source));
+      return this.readFromNode(/** @type {Element} */ (source));
     } else if (typeof source === 'string') {
       const doc = parse(source);
       return this.readFromDocument(doc);
@@ -39,7 +39,7 @@ class XML {
 
   /**
    * @abstract
-   * @param {Node} node Node.
+   * @param {Element} node Node.
    * @return {Object} Object
    */
   readFromNode(node) {}

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -14,12 +14,12 @@ import {extend} from './array.js';
 
 
 /**
- * @typedef {function(Node, Array<*>)} Parser
+ * @typedef {function(Element, Array<*>)} Parser
  */
 
 
 /**
- * @typedef {function(Node, *, Array<*>)} Serializer
+ * @typedef {function(Element, *, Array<*>)} Serializer
  */
 
 
@@ -41,7 +41,7 @@ export const XML_SCHEMA_INSTANCE_URI = 'http://www.w3.org/2001/XMLSchema-instanc
 /**
  * @param {string} namespaceURI Namespace URI.
  * @param {string} qualifiedName Qualified name.
- * @return {Node} Node.
+ * @return {Element} Node.
  */
 export function createElementNS(namespaceURI, qualifiedName) {
   return DOCUMENT.createElementNS(namespaceURI, qualifiedName);
@@ -107,7 +107,7 @@ export function isNode(value) {
 
 
 /**
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {?string} namespaceURI Namespace URI.
  * @param {string} name Attribute name.
  * @return {string} Value
@@ -156,7 +156,7 @@ export function makeArrayExtender(valueReader, opt_this) {
 /**
  * Make an array pusher function for pushing to the array at the top of the
  * object stack.
- * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
+ * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
  * @template T
@@ -164,7 +164,7 @@ export function makeArrayExtender(valueReader, opt_this) {
 export function makeArrayPusher(valueReader, opt_this) {
   return (
     /**
-     * @param {Node} node Node.
+     * @param {Element} node Node.
      * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
@@ -203,7 +203,7 @@ export function makeReplacer(valueReader, opt_this) {
 /**
  * Make an object property pusher function for adding a property to the
  * object at the top of the stack.
- * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
+ * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
  * @param {string=} opt_property Property.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
@@ -212,7 +212,7 @@ export function makeReplacer(valueReader, opt_this) {
 export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
   return (
     /**
-     * @param {Node} node Node.
+     * @param {Element} node Node.
      * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
@@ -234,7 +234,7 @@ export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
 
 /**
  * Make an object property setter function.
- * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
+ * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
  * @param {string=} opt_property Property.
  * @param {T=} opt_this The object to use as `this` in `valueReader`.
  * @return {module:ol/xml~Parser} Parser.
@@ -243,7 +243,7 @@ export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
 export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
   return (
     /**
-     * @param {Node} node Node.
+     * @param {Element} node Node.
      * @param {Array<*>} objectStack Object stack.
      */
     function(node, objectStack) {
@@ -283,7 +283,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
  * designed to serialize a single item. An example would be a LineString
  * geometry writer, which could be reused for writing MultiLineString
  * geometries.
- * @param {function(this: T, Node, V, Array<*>)} nodeWriter Node writer.
+ * @param {function(this: T, Element, V, Array<*>)} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {module:ol/xml~Serializer} Serializer.
  * @template T, V
@@ -399,7 +399,7 @@ export function makeStructureNS(namespaceURIs, structure, opt_structureNS) {
  * Parse a node using the parsers and object stack.
  * @param {Object<string, Object<string, module:ol/xml~Parser>>} parsersNS
  *     Parsers by namespace.
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @param {*=} opt_this The object to use as `this`.
  */
@@ -422,7 +422,7 @@ export function parseNode(parsersNS, node, objectStack, opt_this) {
  * @param {T} object Object.
  * @param {Object<string, Object<string, module:ol/xml~Parser>>} parsersNS
  *     Parsers by namespace.
- * @param {Node} node Node.
+ * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  * @param {*=} opt_this The object to use as `this`.
  * @return {T} Object.


### PR DESCRIPTION
There is still some `Node` typing used but `npx tsc | grep "^src.*type 'Node'"` and `npx tsc | grep "^src.*type 'Element'"` are now empty.

Fixes #8560 