### PR TITLE
ScaleLine call getPointResolution with SRS identifier instead of Proj…

### DIFF
--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -177,7 +177,7 @@ class ScaleLine extends Control {
       ProjUnits.DEGREES :
       ProjUnits.METERS;
     let pointResolution =
-        getPointResolution(projection, viewState.resolution, center, pointResolutionUnits);
+        getPointResolution(projection.getCode(), viewState.resolution, center, pointResolutionUnits);
     if (projection.getUnits() != ProjUnits.DEGREES && projection.getMetersPerUnit()
       && pointResolutionUnits == ProjUnits.METERS) {
       pointResolution *= projection.getMetersPerUnit();


### PR DESCRIPTION
ScaleLine call getPointResolution with SRS identifier instead of Projection object. Is better for shared view between more maps from iframe.

fix: #8566 