### PR TITLE
Make proj~get simpler and faster

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -156,14 +156,9 @@ export function addProjections(projections) {
  * @api
  */
 export function get(projectionLike) {
-  let projection = null;
-  if (projectionLike instanceof Projection) {
-    projection = projectionLike;
-  } else if (typeof projectionLike === 'string') {
-    const code = projectionLike;
-    projection = projections.get(code);
-  }
-  return projection;
+  return typeof projectionLike === 'string' ?
+    projections.get(/** @type {string} */ (projectionLike)) :
+    (/** @type {module:ol/proj/Projection} */ (projectionLike) || null);
 }
 
 


### PR DESCRIPTION
Simpler and faster alternative to #8568, and makes `ol/proj`'s get faster than it is now (see https://jsperf.com/typeof-vs-instanceof-2).

Fixes #8566.