### PR TITLE
Better type annotation

### DIFF
--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -69,7 +69,7 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {Array<string>}
+     * @type {Array<string|number>}
      */
     this.checksums_ = null;
 


### PR DESCRIPTION
See #8345.

With this 4 (!) warnings (`error TS2367: This condition will always return 'true' since the types 'number' and 'string' have no overlap.`) will be gone.