### PR TITLE
Cast POINTER_ID before comparison

### DIFF
--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -305,7 +305,7 @@ class TouchSource extends EventSource {
         // Never remove pointerId == 1, which is mouse.
         // Touch identifiers are 2 smaller than their pointerId, which is the
         // index in pointermap.
-        if (key != POINTER_ID && !this.findTouch_(touchList, key - 2)) {
+        if (key != /** @type {string} */ (POINTER_ID) && !this.findTouch_(touchList, key - 2)) {
           d.push(value.out);
         }
       }


### PR DESCRIPTION
-1 one tsc error; `error TS2367: This condition will always return 'true' since the types 'string' and 'number' have no overlap.`

See #8345.