### PR TITLE
Cast 'originalEvent' in interactions

### DIFF
--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -41,7 +41,6 @@ class Event {
 
   /**
    * Stop event propagation.
-   * @function
    * @api
    */
   preventDefault() {
@@ -50,7 +49,6 @@ class Event {
 
   /**
    * Stop event propagation.
-   * @function
    * @api
    */
   stopPropagation() {

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -76,7 +76,6 @@ class Target extends Disposable {
    *     import("./Event.js").default|string} event Event object.
    * @return {boolean|undefined} `false` if anyone called preventDefault on the
    *     event object or if any of the listeners returned false.
-   * @function
    * @api
    */
   dispatchEvent(event) {

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -67,7 +67,6 @@ export const focus = function(event) {
  *
  * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True.
- * @function
  * @api
  */
 export const always = TRUE;
@@ -106,7 +105,6 @@ export const mouseActionButton = function(mapBrowserEvent) {
  *
  * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} False.
- * @function
  * @api
  */
 export const never = FALSE;

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -90,7 +90,6 @@ class TextFeature extends FeatureFormat {
   /**
    * Read the projection from the source.
    *
-   * @function
    * @param {Document|Node|Object|string} source Source.
    * @return {import("../proj/Projection.js").default} Projection.
    * @api
@@ -111,7 +110,6 @@ class TextFeature extends FeatureFormat {
   /**
    * Encode a feature as a string.
    *
-   * @function
    * @param {import("../Feature.js").default} feature Feature.
    * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Encoded feature.
@@ -154,7 +152,6 @@ class TextFeature extends FeatureFormat {
   /**
    * Write a single geometry.
    *
-   * @function
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
    * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
    * @return {string} Geometry.

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -79,7 +79,6 @@ class XMLFeature extends FeatureFormat {
   /**
    * Read all features from a feature collection.
    *
-   * @function
    * @param {Document|Node|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions=} opt_options Options.
    * @return {Array<import("../Feature.js").default>} Features.

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -158,10 +158,8 @@ class Geometry extends BaseObject {
    * https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
    * Douglas Peucker} algorithm.  For polygons, a quantization-based
    * simplification is used to preserve topology.
-   * @function
    * @param {number} tolerance The tolerance distance for simplification.
-   * @return {import("./Geometry.js").default} A new, simplified version of the original
-   *     geometry.
+   * @return {import("./Geometry.js").default} A new, simplified version of the original geometry.
    * @api
    */
   simplify(tolerance) {

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -55,8 +55,8 @@ class DoubleClickZoom extends Interaction {
  */
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;
-  const browserEvent = mapBrowserEvent.originalEvent;
   if (mapBrowserEvent.type == MapBrowserEventType.DBLCLICK) {
+    const browserEvent = /** @type {MouseEvent} */ (mapBrowserEvent.originalEvent);
     const map = mapBrowserEvent.map;
     const anchor = mapBrowserEvent.coordinate;
     const delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -92,7 +92,7 @@ class KeyboardPan extends Interaction {
 function handleEvent(mapBrowserEvent) {
   let stopEvent = false;
   if (mapBrowserEvent.type == EventType.KEYDOWN) {
-    const keyEvent = mapBrowserEvent.originalEvent;
+    const keyEvent = /** @type {KeyboardEvent} */ (mapBrowserEvent.originalEvent);
     const keyCode = keyEvent.keyCode;
     if (this.condition_(mapBrowserEvent) &&
         (keyCode == KeyCode.DOWN ||

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -77,7 +77,7 @@ function handleEvent(mapBrowserEvent) {
   let stopEvent = false;
   if (mapBrowserEvent.type == EventType.KEYDOWN ||
       mapBrowserEvent.type == EventType.KEYPRESS) {
-    const keyEvent = mapBrowserEvent.originalEvent;
+    const keyEvent = /** @type {KeyboardEvent} */ (mapBrowserEvent.originalEvent);
     const charCode = keyEvent.charCode;
     if (this.condition_(mapBrowserEvent) &&
         (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0))) {


### PR DESCRIPTION
Avoid `error TS2339: Property 'charCode' does not exist on type 'Event'`errors from typescript.