### PR TITLE
Add a statement to trigger TypeScript checking

### DIFF
--- a/src/ol/pixel.js
+++ b/src/ol/pixel.js
@@ -4,3 +4,5 @@
  * @typedef {Array<number>} Pixel
  * @api
  */
+
+export let nothing;


### PR DESCRIPTION
This is a workaround for Microsoft/TypeScript#26905.

There may be other cases like this.  Until that issue is addressed, we cannot have JSDoc comments at the end of a file.

Before:
```
$ npx tsc | wc -l
    1448
```

After:
```
$ npx tsc | wc -l
    1413
```