### PR TITLE
Rework createXYZ

### DIFF
--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -5,7 +5,6 @@ import {DEFAULT_MAX_ZOOM, DEFAULT_TILE_SIZE} from './tilegrid/common.js';
 import {toSize} from './size.js';
 import {containsCoordinate, createOrUpdate, getCorner, getHeight, getWidth} from './extent.js';
 import Corner from './extent/Corner.js';
-import {assign} from './obj.js';
 import {get as getProjection, METERS_PER_UNIT} from './proj.js';
 import Units from './proj/Units.js';
 import TileGrid from './tilegrid/TileGrid.js';
@@ -89,17 +88,23 @@ export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
  * @api
  */
 export function createXYZ(opt_options) {
-  const options = /** @type {import("./tilegrid/TileGrid.js").Options} */ ({});
-  assign(options, opt_options !== undefined ?
-    opt_options : /** @type {XYZOptions} */ ({}));
-  if (options.extent === undefined) {
-    options.extent = getProjection('EPSG:3857').getExtent();
-  }
-  options.resolutions = resolutionsFromExtent(
-    options.extent, options.maxZoom, options.tileSize);
-  delete options.maxZoom;
+  /** @type {XYZOptions} */
+  const xyzOptions = opt_options || {};
 
-  return new TileGrid(options);
+  const extent = xyzOptions.extent || getProjection('EPSG:3857').getExtent();
+
+  /** @type {import("./tilegrid/TileGrid.js").Options} */
+  const gridOptions = {
+    extent: extent,
+    minZoom: xyzOptions.minZoom,
+    tileSize: xyzOptions.tileSize,
+    resolutions: resolutionsFromExtent(
+      extent,
+      xyzOptions.maxZoom,
+      xyzOptions.tileSize
+    )
+  };
+  return new TileGrid(gridOptions);
 }
 
 


### PR DESCRIPTION
This reworks `createXYZ` with a bit more type safety.  Instead of assigning everything from the XYZ options to an options object for the tile grid constructor, we explicitly use the properties that are required.

Before:
```
$ npx tsc --pretty | wc -l
    5136
```

After:
```
$ npx tsc --pretty | wc -l
    5126
```

As an important side note, we should avoid type casting whenever we can.  See the code below for a demonstration:
```js
/**
 * @typedef {{foo: number}} HasFoo
 */

/** @type {HasFoo} */
const broken = {}

const oops = /** @type {HasFoo} */ {};
```

Both the `broken` and `oops` object are not the right shape (missing the `foo` property).  TypeScript catches the first case.  With the type annotation before the variable declaration, the compiler checks that the value `{}` can be assigned to a variable of the type `HasFoo`.

In the second case, the typecast (which does not need the grouping parens) forces the compiler to ignore that the value `{}` is not of the right type.
