### PR TITLE
Optional arguments and typedef properties

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -136,15 +136,15 @@ import Units from './proj/Units.js';
 
 /**
  * @typedef {Object} AnimationOptions
- * @property {import("./coordinate.js").Coordinate|undefined} center The center of the view at the end of
+ * @property {import("./coordinate.js").Coordinate=} center The center of the view at the end of
  * the animation.
- * @property {number|undefined} zoom The zoom level of the view at the end of the
+ * @property {number=} zoom The zoom level of the view at the end of the
  * animation. This takes precedence over `resolution`.
- * @property {number|undefined} resolution The resolution of the view at the end
+ * @property {number=} resolution The resolution of the view at the end
  * of the animation.  If `zoom` is also provided, this option will be ignored.
- * @property {number|undefined} rotation The rotation of the view at the end of
+ * @property {number=} rotation The rotation of the view at the end of
  * the animation.
- * @property {import("./coordinate.js").Coordinate|undefined} anchor Optional anchor to remained fixed
+ * @property {import("./coordinate.js").Coordinate=} anchor Optional anchor to remained fixed
  * during a rotation or resolution animation.
  * @property {number} [duration=1000] The duration of the animation in milliseconds.
  * @property {function(number):number} [easing] The easing function used

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -200,8 +200,7 @@ export default FeatureFormat;
 /**
  * @param {import("../geom/Geometry.js").default|import("../extent.js").Extent} geometry Geometry.
  * @param {boolean} write Set to true for writing, false for reading.
- * @param {WriteOptions|ReadOptions|undefined} opt_options
- *     Options.
+ * @param {(WriteOptions|ReadOptions)=} opt_options Options.
  * @return {import("../geom/Geometry.js").default|import("../extent.js").Extent} Transformed geometry.
  */
 export function transformWithOptions(geometry, write, opt_options) {

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -27,7 +27,7 @@ class MultiLineString extends SimpleGeometry {
    *     Coordinates or LineString geometries. (For internal use, flat coordinates in
    *     combination with `opt_layout` and `opt_ends` are also accepted.)
    * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
-   * @param {Array<number>} opt_ends Flat coordinate ends for internal use.
+   * @param {Array<number>=} opt_ends Flat coordinate ends for internal use.
    */
   constructor(coordinates, opt_layout, opt_ends) {
 

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -31,7 +31,7 @@ class MultiPolygon extends SimpleGeometry {
    * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinats in combination with `opt_layout` and `opt_endss` are also accepted.
    * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
-   * @param {Array<number>} opt_endss Array of ends for internal use with flat coordinates.
+   * @param {Array<number>=} opt_endss Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
 


### PR DESCRIPTION
This marks a few optional arguments and typedef properties as optional (not the same as `type|undefined`).

Before:
```
$ npx tsc | wc -l
    1374
```

After:
```
$ npx tsc | wc -l
    1329
```
