### PR TITLE
Listener return is boolean or void

### DIFF
--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -22,7 +22,7 @@ import {clear} from './obj.js';
  * Listener function. This function is called with an event object as argument.
  * When the function returns `false`, event propagation will stop.
  *
- * @typedef {function(import("./events/Event.js").default)|function(import("./events/Event.js").default): boolean} ListenerFunction
+ * @typedef {function(import("./events/Event.js").default): (void|boolean)} ListenerFunction
  * @api
  */
 


### PR DESCRIPTION
Minor change to the signature of event listeners.  When a function does not have a `return` statement, the type of the return is `void` (e.g. `function(): void`).  If the signature does not specify a return type (e.g. `function()`), it is assumed to be `any` - and the function must have a `return` statement to satisfy that signature.

Before:
```
$ npx tsc | wc -l
    1316
```

After:
```
$ npx tsc | wc -l
    1290
```

I think we have quite a bit of work to do on event types.  We do not consistently use the `Event` and `import("ol/events/Event.js").default` types.  It isn't clear to me where listeners are called with real `Event`s and where they are called with our synthetic events, so I decided not to dig into this any further right now.