### PR TITLE
Remove extra imports in jsdoc

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -77,7 +77,7 @@ class MapBrowserEventHandler extends EventTarget {
      * Event handler which generates pointer events for
      * the viewport element.
      *
-     * @type {import("./pointer/PointerEventHandler.js").default}
+     * @type {PointerEventHandler}
      * @private
      */
     this.pointerEventHandler_ = new PointerEventHandler(element);
@@ -86,7 +86,7 @@ class MapBrowserEventHandler extends EventTarget {
      * Event handler which generates pointer events for
      * the document (used when dragging).
      *
-     * @type {import("./pointer/PointerEventHandler.js").default}
+     * @type {PointerEventHandler}
      * @private
      */
     this.documentPointerEventHandler_ = null;

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -48,7 +48,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {Array<PostRenderFunction>} postRenderFunctions
  * @property {import("./size.js").Size} size
  * @property {!Object<string, boolean>} skippedFeatureUids
- * @property {import("./TileQueue.js").default} tileQueue
+ * @property {TileQueue} tileQueue
  * @property {Object<string, Object<string, import("./TileRange.js").default>>} usedTiles
  * @property {Array<number>} viewHints
  * @property {!Object<string, Object<string, boolean>>} wantedTiles
@@ -75,10 +75,10 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @typedef {Object} MapOptionsInternal
- * @property {import("./Collection.js").default<import("./control/Control.js").default>} [controls]
- * @property {import("./Collection.js").default<import("./interaction/Interaction.js").default>} [interactions]
+ * @property {Collection<import("./control/Control.js").default>} [controls]
+ * @property {Collection<import("./interaction/Interaction.js").default>} [interactions]
  * @property {HTMLElement|Document} keyboardEventTarget
- * @property {import("./Collection.js").default<import("./Overlay.js").default>} overlays
+ * @property {Collection<import("./Overlay.js").default>} overlays
  * @property {Object<string, *>} values
  */
 
@@ -86,12 +86,12 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 /**
  * Object literal with config options for the map.
  * @typedef {Object} MapOptions
- * @property {import("./Collection.js").default<import("./control/Control.js").default>|Array<import("./control/Control.js").default>} [controls]
+ * @property {Collection<import("./control/Control.js").default>|Array<import("./control/Control.js").default>} [controls]
  * Controls initially added to the map. If not specified,
  * {@link module:ol/control/util~defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
- * @property {import("./Collection.js").default<import("./interaction/Interaction.js").default>|Array<import("./interaction/Interaction.js").default>} [interactions]
+ * @property {Collection<import("./interaction/Interaction.js").default>|Array<import("./interaction/Interaction.js").default>} [interactions]
  * Interactions that are initially added to the map. If not specified,
  * {@link module:ol/interaction~defaults} is used.
  * @property {HTMLElement|Document|string} [keyboardEventTarget] The element to
@@ -102,7 +102,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * map target (i.e. the user-provided div for the map). If this is not
  * `document`, the target element needs to be focused for key events to be
  * emitted, requiring that the target element has a `tabindex` attribute.
- * @property {Array<import("./layer/Base.js").default>|import("./Collection.js").default<import("./layer/Base.js").default>} [layers]
+ * @property {Array<import("./layer/Base.js").default>|Collection<import("./layer/Base.js").default>} [layers]
  * Layers. If this is not defined, a map with no layers will be rendered. Note
  * that layers are rendered in the order supplied, so if you want, for example,
  * a vector layer to appear on top of a tile layer, it must come after the tile
@@ -119,13 +119,13 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {number} [moveTolerance=1] The minimum distance in pixels the
  * cursor must move to be detected as a map move event instead of a click.
  * Increasing this value can make it easier to click on the map.
- * @property {import("./Collection.js").default<import("./Overlay.js").default>|Array<import("./Overlay.js").default>} [overlays]
+ * @property {Collection<import("./Overlay.js").default>|Array<import("./Overlay.js").default>} [overlays]
  * Overlays initially added to the map. By default, no overlays are added.
  * @property {HTMLElement|string} [target] The container for the map, either the
  * element itself or the `id` of the element. If not specified at construction
  * time, {@link module:ol/Map~Map#setTarget} must be called for the map to be
  * rendered.
- * @property {import("./View.js").default} [view] The map's view.  No layer sources will be
+ * @property {View} [view] The map's view.  No layer sources will be
  * fetched unless this is specified at construction time or through
  * {@link module:ol/Map~Map#setView}.
  */
@@ -287,7 +287,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {import("./MapBrowserEventHandler.js").default}
+     * @type {MapBrowserEventHandler}
      */
     this.mapBrowserEventHandler_ = new MapBrowserEventHandler(this, options.moveTolerance);
     for (const key in MapBrowserEventType) {
@@ -312,19 +312,19 @@ class PluggableMap extends BaseObject {
     listen(this.viewport_, EventType.MOUSEWHEEL, this.handleBrowserEvent, this);
 
     /**
-     * @type {import("./Collection.js").default<import("./control/Control.js").default>}
+     * @type {Collection<import("./control/Control.js").default>}
      * @protected
      */
     this.controls = optionsInternal.controls || new Collection();
 
     /**
-     * @type {import("./Collection.js").default<import("./interaction/Interaction.js").default>}
+     * @type {Collection<import("./interaction/Interaction.js").default>}
      * @protected
      */
     this.interactions = optionsInternal.interactions || new Collection();
 
     /**
-     * @type {import("./Collection.js").default<import("./Overlay.js").default>}
+     * @type {Collection<import("./Overlay.js").default>}
      * @private
      */
     this.overlays_ = optionsInternal.overlays;
@@ -362,7 +362,7 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
-     * @type {import("./TileQueue.js").default}
+     * @type {TileQueue}
      */
     this.tileQueue_ = new TileQueue(
       this.getTilePriority.bind(this),
@@ -718,7 +718,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the map controls. Modifying this collection changes the controls
    * associated with the map.
-   * @return {import("./Collection.js").default<import("./control/Control.js").default>} Controls.
+   * @return {Collection<import("./control/Control.js").default>} Controls.
    * @api
    */
   getControls() {
@@ -728,7 +728,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get the map overlays. Modifying this collection changes the overlays
    * associated with the map.
-   * @return {import("./Collection.js").default<import("./Overlay.js").default>} Overlays.
+   * @return {Collection<import("./Overlay.js").default>} Overlays.
    * @api
    */
   getOverlays() {
@@ -753,7 +753,7 @@ class PluggableMap extends BaseObject {
    * associated with the map.
    *
    * Interactions are used for e.g. pan, zoom and rotate.
-   * @return {import("./Collection.js").default<import("./interaction/Interaction.js").default>} Interactions.
+   * @return {Collection<import("./interaction/Interaction.js").default>} Interactions.
    * @api
    */
   getInteractions() {
@@ -762,19 +762,19 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get the layergroup associated with this map.
-   * @return {import("./layer/Group.js").default} A layer group containing the layers in this map.
+   * @return {LayerGroup} A layer group containing the layers in this map.
    * @observable
    * @api
    */
   getLayerGroup() {
     return (
-      /** @type {import("./layer/Group.js").default} */ (this.get(MapProperty.LAYERGROUP))
+      /** @type {LayerGroup} */ (this.get(MapProperty.LAYERGROUP))
     );
   }
 
   /**
    * Get the collection of layers associated with this map.
-   * @return {!import("./Collection.js").default<import("./layer/Base.js").default>} Layers.
+   * @return {!Collection<import("./layer/Base.js").default>} Layers.
    * @api
    */
   getLayers() {
@@ -821,13 +821,13 @@ class PluggableMap extends BaseObject {
   /**
    * Get the view associated with this map. A view manages properties such as
    * center and resolution.
-   * @return {import("./View.js").default} The view that controls this map.
+   * @return {View} The view that controls this map.
    * @observable
    * @api
    */
   getView() {
     return (
-      /** @type {import("./View.js").default} */ (this.get(MapProperty.VIEW))
+      /** @type {View} */ (this.get(MapProperty.VIEW))
     );
   }
 
@@ -902,7 +902,7 @@ class PluggableMap extends BaseObject {
   }
 
   /**
-   * @param {import("./MapBrowserEvent.js").default} mapBrowserEvent The event to handle.
+   * @param {MapBrowserEvent} mapBrowserEvent The event to handle.
    */
   handleMapBrowserEvent(mapBrowserEvent) {
     if (!this.frameState_) {
@@ -1252,7 +1252,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Sets the layergroup of this map.
-   * @param {import("./layer/Group.js").default} layerGroup A layer group containing the layers in this map.
+   * @param {LayerGroup} layerGroup A layer group containing the layers in this map.
    * @observable
    * @api
    */
@@ -1283,7 +1283,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Set the view for this map.
-   * @param {import("./View.js").default} view The view that controls this map.
+   * @param {View} view The view that controls this map.
    * @observable
    * @api
    */

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -78,7 +78,7 @@ class Tile extends EventTarget {
 
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {import("./TileState.js").default} state State.
+   * @param {TileState} state State.
    * @param {Options=} opt_options Tile options.
    */
   constructor(tileCoord, state, opt_options) {
@@ -93,7 +93,7 @@ class Tile extends EventTarget {
 
     /**
      * @protected
-     * @type {import("./TileState.js").default}
+     * @type {TileState}
      */
     this.state = state;
 
@@ -214,7 +214,7 @@ class Tile extends EventTarget {
   }
 
   /**
-   * @return {import("./TileState.js").default} State.
+   * @return {TileState} State.
    */
   getState() {
     return this.state;
@@ -225,7 +225,7 @@ class Tile extends EventTarget {
    * it is important to set the state correctly to {@link module:ol/TileState~ERROR}
    * when the tile cannot be loaded. Otherwise the tile cannot be removed from
    * the tile queue and will block other requests.
-   * @param {import("./TileState.js").default} state State.
+   * @param {TileState} state State.
    * @api
    */
   setState(state) {

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -14,7 +14,7 @@ const DEFAULT_EXTENT = [0, 0, 4096, 4096];
 
 /**
  * @typedef {function(new: VectorTile, import("./tilecoord.js").TileCoord,
- * import("./TileState.js").default, string, ?string, import("./Tile.js").LoadFunction)} TileClass
+ * TileState, string, ?string, import("./Tile.js").LoadFunction)} TileClass
  * @api
  */
 
@@ -22,7 +22,7 @@ class VectorTile extends Tile {
 
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {import("./TileState.js").default} state State.
+   * @param {TileState} state State.
    * @param {string} src Data source url.
    * @param {import("./format/Feature.js").default} format Feature format.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -151,7 +151,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Node|Object|string} source Source.
    * @param {ReadOptions=} opt_options Read options.
-   * @return {import("../geom/Geometry.js").default} Geometry.
+   * @return {Geometry} Geometry.
    */
   readGeometry(source, opt_options) {}
 
@@ -188,7 +188,7 @@ class FeatureFormat {
    * Write a single geometry in this format.
    *
    * @abstract
-   * @param {import("../geom/Geometry.js").default} geometry Geometry.
+   * @param {Geometry} geometry Geometry.
    * @param {WriteOptions=} opt_options Write options.
    * @return {string} Result.
    */
@@ -198,10 +198,10 @@ class FeatureFormat {
 export default FeatureFormat;
 
 /**
- * @param {import("../geom/Geometry.js").default|import("../extent.js").Extent} geometry Geometry.
+ * @param {Geometry|import("../extent.js").Extent} geometry Geometry.
  * @param {boolean} write Set to true for writing, false for reading.
  * @param {(WriteOptions|ReadOptions)=} opt_options Options.
- * @return {import("../geom/Geometry.js").default|import("../extent.js").Extent} Transformed geometry.
+ * @return {Geometry|import("../extent.js").Extent} Transformed geometry.
  */
 export function transformWithOptions(geometry, write, opt_options) {
   const featureProjection = opt_options ?
@@ -209,7 +209,7 @@ export function transformWithOptions(geometry, write, opt_options) {
   const dataProjection = opt_options ?
     getProjection(opt_options.dataProjection) : null;
   /**
-   * @type {import("../geom/Geometry.js").default|import("../extent.js").Extent}
+   * @type {Geometry|import("../extent.js").Extent}
    */
   let transformed;
   if (featureProjection && dataProjection &&

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -17,7 +17,7 @@ import {clear} from '../obj.js';
 class GeometryCollection extends Geometry {
 
   /**
-   * @param {Array<import("./Geometry.js").default>=} opt_geometries Geometries.
+   * @param {Array<Geometry>=} opt_geometries Geometries.
    */
   constructor(opt_geometries) {
 
@@ -25,7 +25,7 @@ class GeometryCollection extends Geometry {
 
     /**
      * @private
-     * @type {Array<import("./Geometry.js").default>}
+     * @type {Array<Geometry>}
      */
     this.geometries_ = opt_geometries ? opt_geometries : null;
 
@@ -114,7 +114,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Return the geometries that make up this geometry collection.
-   * @return {Array<import("./Geometry.js").default>} Geometries.
+   * @return {Array<Geometry>} Geometries.
    * @api
    */
   getGeometries() {
@@ -122,7 +122,7 @@ class GeometryCollection extends Geometry {
   }
 
   /**
-   * @return {Array<import("./Geometry.js").default>} Geometries.
+   * @return {Array<Geometry>} Geometries.
    */
   getGeometriesArray() {
     return this.geometries_;
@@ -228,7 +228,7 @@ class GeometryCollection extends Geometry {
 
   /**
    * Set the geometries that make up this geometry collection.
-   * @param {Array<import("./Geometry.js").default>} geometries Geometries.
+   * @param {Array<Geometry>} geometries Geometries.
    * @api
    */
   setGeometries(geometries) {
@@ -236,7 +236,7 @@ class GeometryCollection extends Geometry {
   }
 
   /**
-   * @param {Array<import("./Geometry.js").default>} geometries Geometries.
+   * @param {Array<Geometry>} geometries Geometries.
    */
   setGeometriesArray(geometries) {
     this.unlistenGeometriesChange_();
@@ -280,8 +280,8 @@ class GeometryCollection extends Geometry {
 
 
 /**
- * @param {Array<import("./Geometry.js").default>} geometries Geometries.
- * @return {Array<import("./Geometry.js").default>} Cloned geometries.
+ * @param {Array<Geometry>} geometries Geometries.
+ * @return {Array<Geometry>} Cloned geometries.
  */
 function cloneGeometries(geometries) {
   const clonedGeometries = [];

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -26,7 +26,7 @@ class LineString extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
 
@@ -224,7 +224,7 @@ class LineString extends SimpleGeometry {
   /**
    * Set the coordinates of the linestring.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -23,7 +23,7 @@ class LinearRing extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
 
@@ -123,7 +123,7 @@ class LinearRing extends SimpleGeometry {
   /**
    * Set the coordinates of the linear ring.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -26,7 +26,7 @@ class MultiLineString extends SimpleGeometry {
    * @param {Array<Array<import("../coordinate.js").Coordinate>|import("../geom.js").MultiLineString>|Array<number>} coordinates
    *     Coordinates or LineString geometries. (For internal use, flat coordinates in
    *     combination with `opt_layout` and `opt_ends` are also accepted.)
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @param {Array<number>=} opt_ends Flat coordinate ends for internal use.
    */
   constructor(coordinates, opt_layout, opt_ends) {
@@ -76,7 +76,7 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Append the passed linestring to the multilinestring.
-   * @param {import("./LineString.js").default} lineString LineString.
+   * @param {LineString} lineString LineString.
    * @api
    */
   appendLineString(lineString) {
@@ -171,7 +171,7 @@ class MultiLineString extends SimpleGeometry {
   /**
    * Return the linestring at the specified index.
    * @param {number} index Index.
-   * @return {import("./LineString.js").default} LineString.
+   * @return {LineString} LineString.
    * @api
    */
   getLineString(index) {
@@ -184,14 +184,14 @@ class MultiLineString extends SimpleGeometry {
 
   /**
    * Return the linestrings of this multilinestring.
-   * @return {Array<import("./LineString.js").default>} LineStrings.
+   * @return {Array<LineString>} LineStrings.
    * @api
    */
   getLineStrings() {
     const flatCoordinates = this.flatCoordinates;
     const ends = this.ends_;
     const layout = this.layout;
-    /** @type {Array<import("./LineString.js").default>} */
+    /** @type {Array<LineString>} */
     const lineStrings = [];
     let offset = 0;
     for (let i = 0, ii = ends.length; i < ii; ++i) {
@@ -254,7 +254,7 @@ class MultiLineString extends SimpleGeometry {
   /**
    * Set the coordinates of the multilinestring.
    * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -34,7 +34,7 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Append the passed point to this multipoint.
-   * @param {import("./Point.js").default} point Point.
+   * @param {Point} point Point.
    * @api
    */
   appendPoint(point) {
@@ -94,7 +94,7 @@ class MultiPoint extends SimpleGeometry {
   /**
    * Return the point at the specified index.
    * @param {number} index Index.
-   * @return {import("./Point.js").default} Point.
+   * @return {Point} Point.
    * @api
    */
   getPoint(index) {
@@ -108,14 +108,14 @@ class MultiPoint extends SimpleGeometry {
 
   /**
    * Return the points of this multipoint.
-   * @return {Array<import("./Point.js").default>} Points.
+   * @return {Array<Point>} Points.
    * @api
    */
   getPoints() {
     const flatCoordinates = this.flatCoordinates;
     const layout = this.layout;
     const stride = this.stride;
-    /** @type {Array<import("./Point.js").default>} */
+    /** @type {Array<Point>} */
     const points = [];
     for (let i = 0, ii = flatCoordinates.length; i < ii; i += stride) {
       const point = new Point(flatCoordinates.slice(i, i + stride), layout);

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -30,7 +30,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinats in combination with `opt_layout` and `opt_endss` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @param {Array<number>=} opt_endss Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
@@ -111,7 +111,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Append the passed polygon to this multipolygon.
-   * @param {import("./Polygon.js").default} polygon Polygon.
+   * @param {Polygon} polygon Polygon.
    * @api
    */
   appendPolygon(polygon) {
@@ -235,7 +235,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Return the interior points as {@link module:ol/geom/MultiPoint multipoint}.
-   * @return {import("./MultiPoint.js").default} Interior points as XYM coordinates, where M is
+   * @return {MultiPoint} Interior points as XYM coordinates, where M is
    * the length of the horizontal intersection that the point belongs to.
    * @api
    */
@@ -279,7 +279,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * Return the polygon at the specified index.
    * @param {number} index Index.
-   * @return {import("./Polygon.js").default} Polygon.
+   * @return {Polygon} Polygon.
    * @api
    */
   getPolygon(index) {
@@ -305,7 +305,7 @@ class MultiPolygon extends SimpleGeometry {
 
   /**
    * Return the polygons of this multipolygon.
-   * @return {Array<import("./Polygon.js").default>} Polygons.
+   * @return {Array<Polygon>} Polygons.
    * @api
    */
   getPolygons() {
@@ -349,7 +349,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * Set the coordinates of the multipolygon.
    * @param {!Array<Array<Array<import("../coordinate.js").Coordinate>>>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -36,7 +36,7 @@ class Polygon extends SimpleGeometry {
    *     an array of vertices' coordinates where the first coordinate and the last are
    *     equivalent. (For internal use, flat coordinates in combination with
    *     `opt_layout` and `opt_ends` are also accepted.)
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @param {Array<number>=} opt_ends Ends (for internal use with flat coordinates).
    */
   constructor(coordinates, opt_layout, opt_ends) {
@@ -96,7 +96,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Append the passed linear ring to this polygon.
-   * @param {import("./LinearRing.js").default} linearRing Linear ring.
+   * @param {LinearRing} linearRing Linear ring.
    * @api
    */
   appendLinearRing(linearRing) {
@@ -203,7 +203,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Return an interior point of the polygon.
-   * @return {import("./Point.js").default} Interior point as XYM coordinate, where M is the
+   * @return {Point} Interior point as XYM coordinate, where M is the
    * length of the horizontal intersection that the point belongs to.
    * @api
    */
@@ -229,7 +229,7 @@ class Polygon extends SimpleGeometry {
    * at index `1` and beyond.
    *
    * @param {number} index Index.
-   * @return {import("./LinearRing.js").default} Linear ring.
+   * @return {LinearRing} Linear ring.
    * @api
    */
   getLinearRing(index) {
@@ -242,7 +242,7 @@ class Polygon extends SimpleGeometry {
 
   /**
    * Return the linear rings of the polygon.
-   * @return {Array<import("./LinearRing.js").default>} Linear rings.
+   * @return {Array<LinearRing>} Linear rings.
    * @api
    */
   getLinearRings() {
@@ -313,7 +313,7 @@ class Polygon extends SimpleGeometry {
   /**
    * Set the coordinates of the polygon.
    * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    * @override
    * @api
    */

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -23,7 +23,7 @@ class SimpleGeometry extends Geometry {
 
     /**
      * @protected
-     * @type {import("./GeometryLayout.js").default}
+     * @type {GeometryLayout}
      */
     this.layout = GeometryLayout.XY;
 
@@ -82,7 +82,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * Return the {@link module:ol/geom/GeometryLayout~GeometryLayout layout} of the geometry.
-   * @return {import("./GeometryLayout.js").default} Layout.
+   * @return {GeometryLayout} Layout.
    * @api
    */
   getLayout() {
@@ -145,7 +145,7 @@ class SimpleGeometry extends Geometry {
   }
 
   /**
-   * @param {import("./GeometryLayout.js").default} layout Layout.
+   * @param {GeometryLayout} layout Layout.
    * @param {Array<number>} flatCoordinates Flat coordinates.
     */
   setFlatCoordinates(layout, flatCoordinates) {
@@ -157,12 +157,12 @@ class SimpleGeometry extends Geometry {
   /**
    * @abstract
    * @param {!Array} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {GeometryLayout=} opt_layout Layout.
    */
   setCoordinates(coordinates, opt_layout) {}
 
   /**
-   * @param {import("./GeometryLayout.js").default|undefined} layout Layout.
+   * @param {GeometryLayout|undefined} layout Layout.
    * @param {Array} coordinates Coordinates.
    * @param {number} nesting Nesting.
    * @protected
@@ -257,7 +257,7 @@ class SimpleGeometry extends Geometry {
 
 /**
  * @param {number} stride Stride.
- * @return {import("./GeometryLayout.js").default} layout Layout.
+ * @return {GeometryLayout} layout Layout.
  */
 function getLayoutForStride(stride) {
   let layout;
@@ -269,13 +269,13 @@ function getLayoutForStride(stride) {
     layout = GeometryLayout.XYZM;
   }
   return (
-    /** @type {import("./GeometryLayout.js").default} */ (layout)
+    /** @type {GeometryLayout} */ (layout)
   );
 }
 
 
 /**
- * @param {import("./GeometryLayout.js").default} layout Layout.
+ * @param {GeometryLayout} layout Layout.
  * @return {number} Stride.
  */
 export function getStrideForLayout(layout) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -30,16 +30,16 @@ import {createEditingStyle} from '../style/Style.js';
 
 /**
  * @typedef {Object} Options
- * @property {import("../geom/GeometryType.js").default} type Geometry type of
+ * @property {GeometryType} type Geometry type of
  * the geometries being drawn with this instance.
  * @property {number} [clickTolerance=6] The maximum distance in pixels between
  * "down" and "up" for a "up" event to be considered a "click" event and
  * actually add a point/vertex to the geometry being drawn.  The default of `6`
  * was chosen for the draw interaction to behave correctly on mouse as well as
  * on touch devices.
- * @property {import("../Collection.js").default<import("../Feature.js").default>} [features]
+ * @property {import("../Collection.js").default<Feature>} [features]
  * Destination collection for the drawn features.
- * @property {import("../source/Vector.js").default} [source] Destination source for
+ * @property {VectorSource} [source] Destination source for
  * the drawn features.
  * @property {number} [dragVertexDelay=500] Delay in milliseconds after pointerdown
  * before the current vertex can be dragged to its exact position.
@@ -131,7 +131,7 @@ const DrawEventType = {
 class DrawEvent extends Event {
   /**
    * @param {DrawEventType} type Type.
-   * @param {import("../Feature.js").default} feature The feature drawn.
+   * @param {Feature} feature The feature drawn.
    */
   constructor(type, feature) {
 
@@ -139,7 +139,7 @@ class DrawEvent extends Event {
 
     /**
      * The feature being drawn.
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @api
      */
     this.feature = feature;
@@ -201,14 +201,14 @@ class Draw extends PointerInteraction {
 
     /**
      * Target source for drawn features.
-     * @type {import("../source/Vector.js").default}
+     * @type {VectorSource}
      * @private
      */
     this.source_ = options.source ? options.source : null;
 
     /**
      * Target collection for drawn features.
-     * @type {import("../Collection.js").default<import("../Feature.js").default>}
+     * @type {import("../Collection.js").default<Feature>}
      * @private
      */
     this.features_ = options.features ? options.features : null;
@@ -222,10 +222,10 @@ class Draw extends PointerInteraction {
 
     /**
      * Geometry type.
-     * @type {import("../geom/GeometryType.js").default}
+     * @type {GeometryType}
      * @private
      */
-    this.type_ = /** @type {import("../geom/GeometryType.js").default} */ (options.type);
+    this.type_ = /** @type {GeometryType} */ (options.type);
 
     /**
      * Drawing mode (derived from geometry type.
@@ -278,7 +278,7 @@ class Draw extends PointerInteraction {
          * @return {import("../geom/SimpleGeometry.js").default} A geometry.
          */
         geometryFunction = function(coordinates, opt_geometry) {
-          const circle = opt_geometry ? /** @type {import("../geom/Circle.js").default} */ (opt_geometry) :
+          const circle = opt_geometry ? /** @type {Circle} */ (opt_geometry) :
             new Circle([NaN, NaN]);
           const squaredLength = squaredCoordinateDistance(
             coordinates[0], coordinates[1]);
@@ -344,14 +344,14 @@ class Draw extends PointerInteraction {
 
     /**
      * Sketch feature.
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @private
      */
     this.sketchFeature_ = null;
 
     /**
      * Sketch point.
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @private
      */
     this.sketchPoint_ = null;
@@ -365,7 +365,7 @@ class Draw extends PointerInteraction {
 
     /**
      * Sketch line. Used when drawing polygon.
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @private
      */
     this.sketchLine_ = null;
@@ -389,7 +389,7 @@ class Draw extends PointerInteraction {
 
     /**
      * Draw overlay where our sketch features are drawn.
-     * @type {import("../layer/Vector.js").default}
+     * @type {VectorLayer}
      * @private
      */
     this.overlay_ = new VectorLayer({
@@ -443,7 +443,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Get the overlay layer that this interaction renders sketch features to.
-   * @return {import("../layer/Vector.js").default} Overlay layer.
+   * @return {VectorLayer} Overlay layer.
    * @api
    */
   getOverlay() {
@@ -530,7 +530,7 @@ class Draw extends PointerInteraction {
       this.sketchPoint_ = new Feature(new Point(coordinates));
       this.updateSketchFeatures_();
     } else {
-      const sketchPointGeom = /** @type {import("../geom/Point.js").default} */ (this.sketchPoint_.getGeometry());
+      const sketchPointGeom = /** @type {Point} */ (this.sketchPoint_.getGeometry());
       sketchPointGeom.setCoordinates(coordinates);
     }
   }
@@ -591,7 +591,7 @@ class Draw extends PointerInteraction {
     last[1] = coordinate[1];
     this.geometryFunction_(/** @type {!Array<import("../coordinate.js").Coordinate>} */ (this.sketchCoords_), geometry);
     if (this.sketchPoint_) {
-      const sketchPointGeom = /** @type {import("../geom/Point.js").default} */ (this.sketchPoint_.getGeometry());
+      const sketchPointGeom = /** @type {Point} */ (this.sketchPoint_.getGeometry());
       sketchPointGeom.setCoordinates(coordinate);
     }
     let sketchLineGeom;
@@ -601,7 +601,7 @@ class Draw extends PointerInteraction {
         this.sketchLine_ = new Feature();
       }
       const ring = geometry.getLinearRing(0);
-      sketchLineGeom = /** @type {import("../geom/LineString.js").default} */ (this.sketchLine_.getGeometry());
+      sketchLineGeom = /** @type {LineString} */ (this.sketchLine_.getGeometry());
       if (!sketchLineGeom) {
         sketchLineGeom = new LineString(ring.getFlatCoordinates(), ring.getLayout());
         this.sketchLine_.setGeometry(sketchLineGeom);
@@ -611,7 +611,7 @@ class Draw extends PointerInteraction {
         sketchLineGeom.changed();
       }
     } else if (this.sketchLineCoords_) {
-      sketchLineGeom = /** @type {import("../geom/LineString.js").default} */ (this.sketchLine_.getGeometry());
+      sketchLineGeom = /** @type {LineString} */ (this.sketchLine_.getGeometry());
       sketchLineGeom.setCoordinates(this.sketchLineCoords_);
     }
     this.updateSketchFeatures_();
@@ -680,7 +680,7 @@ class Draw extends PointerInteraction {
     } else if (this.mode_ === Mode.POLYGON) {
       coordinates = this.sketchCoords_[0];
       coordinates.splice(-2, 1);
-      sketchLineGeom = /** @type {import("../geom/LineString.js").default} */ (this.sketchLine_.getGeometry());
+      sketchLineGeom = /** @type {LineString} */ (this.sketchLine_.getGeometry());
       sketchLineGeom.setCoordinates(coordinates);
       this.geometryFunction_(this.sketchCoords_, geometry);
     }
@@ -739,7 +739,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Stop drawing without adding the sketch feature to the target layer.
-   * @return {import("../Feature.js").default} The sketch feature (or null if none).
+   * @return {Feature} The sketch feature (or null if none).
    * @private
    */
   abortDrawing_() {
@@ -758,12 +758,12 @@ class Draw extends PointerInteraction {
    * Extend an existing geometry by adding additional points. This only works
    * on features with `LineString` geometries, where the interaction will
    * extend lines by adding points to the end of the coordinates array.
-   * @param {!import("../Feature.js").default} feature Feature to be extended.
+   * @param {!Feature} feature Feature to be extended.
    * @api
    */
   extend(feature) {
     const geometry = feature.getGeometry();
-    const lineString = /** @type {import("../geom/LineString.js").default} */ (geometry);
+    const lineString = /** @type {LineString} */ (geometry);
     this.sketchFeature_ = feature;
     this.sketchCoords_ = lineString.getCoordinates();
     const last = this.sketchCoords_[this.sketchCoords_.length - 1];
@@ -873,7 +873,7 @@ export function handleEvent(event) {
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} event Event.
+ * @param {MapBrowserPointerEvent} event Event.
  * @return {boolean} Start drag sequence?
  * @this {Draw}
  */
@@ -901,7 +901,7 @@ function handleDownEvent(event) {
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} event Event.
+ * @param {MapBrowserPointerEvent} event Event.
  * @return {boolean} Stop drag sequence?
  * @this {Draw}
  */
@@ -963,7 +963,7 @@ export function createRegularPolygon(opt_sides, opt_angle) {
     const end = coordinates[1];
     const radius = Math.sqrt(
       squaredCoordinateDistance(center, end));
-    const geometry = opt_geometry ? /** @type {import("../geom/Polygon.js").default} */ (opt_geometry) :
+    const geometry = opt_geometry ? /** @type {Polygon} */ (opt_geometry) :
       fromCircle(new Circle(center), opt_sides);
     let angle = opt_angle;
     if (!opt_angle) {
@@ -1010,7 +1010,7 @@ export function createBox() {
 /**
  * Get the drawing mode.  The mode for mult-part geometries is the same as for
  * their single-part cousins.
- * @param {import("../geom/GeometryType.js").default} type Geometry type.
+ * @param {GeometryType} type Geometry type.
  * @return {Mode} Drawing mode.
  */
 function getMode(type) {

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -125,14 +125,14 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Feature for displaying the visible extent
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @private
      */
     this.extentFeature_ = null;
 
     /**
      * Feature for displaying the visible pointer
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @private
      */
     this.vertexFeature_ = null;
@@ -143,7 +143,7 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Layer for the extentFeature
-     * @type {import("../layer/Vector.js").default}
+     * @type {VectorLayer}
      * @private
      */
     this.extentOverlay_ = new VectorLayer({
@@ -158,7 +158,7 @@ class ExtentInteraction extends PointerInteraction {
 
     /**
      * Layer for the vertexFeature
-     * @type {import("../layer/Vector.js").default}
+     * @type {VectorLayer}
      * @private
      */
     this.vertexOverlay_ = new VectorLayer({
@@ -235,7 +235,7 @@ class ExtentInteraction extends PointerInteraction {
 
   /**
    * @param {import("../extent.js").Extent} extent extent
-   * @returns {import("../Feature.js").default} extent as featrue
+   * @returns {Feature} extent as featrue
    * @private
    */
   createOrUpdateExtentFeature_(extent) {
@@ -261,7 +261,7 @@ class ExtentInteraction extends PointerInteraction {
 
   /**
    * @param {import("../coordinate.js").Coordinate} vertex location of feature
-   * @returns {import("../Feature.js").default} vertex as feature
+   * @returns {Feature} vertex as feature
    * @private
    */
   createOrUpdatePointerFeature_(vertex) {
@@ -271,7 +271,7 @@ class ExtentInteraction extends PointerInteraction {
       this.vertexFeature_ = vertexFeature;
       this.vertexOverlay_.getSource().addFeature(vertexFeature);
     } else {
-      const geometry = /** @type {import("../geom/Point.js").default} */ (vertexFeature.getGeometry());
+      const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(vertex);
     }
     return vertexFeature;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -61,7 +61,7 @@ const ModifyEventType = {
 /**
  * @typedef {Object} SegmentData
  * @property {Array<number>} [depth]
- * @property {import("../Feature.js").default} feature
+ * @property {Feature} feature
  * @property {import("../geom/SimpleGeometry.js").default} geometry
  * @property {number} index
  * @property {Array<import("../extent.js").Extent>} segment
@@ -90,10 +90,10 @@ const ModifyEventType = {
  * @property {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction} [style]
  * Style used for the features being modified. By default the default edit
  * style is used (see {@link module:ol/style}).
- * @property {import("../source/Vector.js").default} [source] The vector source with
+ * @property {VectorSource} [source] The vector source with
  * features to modify.  If a vector source is not provided, a feature collection
  * must be provided with the features option.
- * @property {import("../Collection.js").default<import("../Feature.js").default>} [features]
+ * @property {Collection<Feature>} [features]
  * The features the interaction works on.  If a feature collection is not
  * provided, a vector source must be provided with the source option.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
@@ -109,9 +109,9 @@ const ModifyEventType = {
 export class ModifyEvent extends Event {
   /**
    * @param {ModifyEventType} type Type.
-   * @param {import("../Collection.js").default<import("../Feature.js").default>} features
+   * @param {Collection<Feature>} features
    * The features modified.
-   * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserPointerEvent
+   * @param {MapBrowserPointerEvent} mapBrowserPointerEvent
    * Associated {@link module:ol/MapBrowserPointerEvent}.
    */
   constructor(type, features, mapBrowserPointerEvent) {
@@ -119,7 +119,7 @@ export class ModifyEvent extends Event {
 
     /**
      * The features being modified.
-     * @type {import("../Collection.js").default<import("../Feature.js").default>}
+     * @type {Collection<Feature>}
      * @api
      */
     this.features = features;
@@ -196,7 +196,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Editing vertex.
-     * @type {import("../Feature.js").default}
+     * @type {Feature}
      * @private
      */
     this.vertexFeature_ = null;
@@ -230,7 +230,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Segment RTree for each layer
-     * @type {import("../structs/RBush.js").default<SegmentData>}
+     * @type {RBush<SegmentData>}
      * @private
      */
     this.rBush_ = new RBush();
@@ -264,7 +264,7 @@ class Modify extends PointerInteraction {
 
     /**
      * Draw overlay where sketch features are drawn.
-     * @type {import("../layer/Vector.js").default}
+     * @type {VectorLayer}
      * @private
      */
     this.overlay_ = new VectorLayer({
@@ -281,7 +281,7 @@ class Modify extends PointerInteraction {
     /**
      * @const
      * @private
-     * @type {!Object<string, function(import("../Feature.js").default, import("../geom/Geometry.js").default)>}
+     * @type {!Object<string, function(Feature, import("../geom/Geometry.js").default)>}
      */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,
@@ -297,7 +297,7 @@ class Modify extends PointerInteraction {
 
 
     /**
-     * @type {import("../source/Vector.js").default}
+     * @type {VectorSource}
      * @private
      */
     this.source_ = null;
@@ -318,7 +318,7 @@ class Modify extends PointerInteraction {
     }
 
     /**
-     * @type {import("../Collection.js").default<import("../Feature.js").default>}
+     * @type {Collection<Feature>}
      * @private
      */
     this.features_ = features;
@@ -330,7 +330,7 @@ class Modify extends PointerInteraction {
       this.handleFeatureRemove_, this);
 
     /**
-     * @type {import("../MapBrowserPointerEvent.js").default}
+     * @type {MapBrowserPointerEvent}
      * @private
      */
     this.lastPointerEvent_ = null;
@@ -338,7 +338,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature.
+   * @param {Feature} feature Feature.
    * @private
    */
   addFeature_(feature) {
@@ -355,7 +355,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../MapBrowserPointerEvent.js").default} evt Map browser event
+   * @param {MapBrowserPointerEvent} evt Map browser event
    * @private
    */
   willModifyFeatures_(evt) {
@@ -367,7 +367,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature.
+   * @param {Feature} feature Feature.
    * @private
    */
   removeFeature_(feature) {
@@ -383,7 +383,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature.
+   * @param {Feature} feature Feature.
    * @private
    */
   removeFeatureSegmentData_(feature) {
@@ -424,7 +424,7 @@ class Modify extends PointerInteraction {
 
   /**
    * Get the overlay layer that this interaction renders sketch features to.
-   * @return {import("../layer/Vector.js").default} Overlay layer.
+   * @return {VectorLayer} Overlay layer.
    * @api
    */
   getOverlay() {
@@ -456,7 +456,7 @@ class Modify extends PointerInteraction {
    * @private
    */
   handleFeatureAdd_(evt) {
-    this.addFeature_(/** @type {import("../Feature.js").default} */ (evt.element));
+    this.addFeature_(/** @type {Feature} */ (evt.element));
   }
 
   /**
@@ -465,7 +465,7 @@ class Modify extends PointerInteraction {
    */
   handleFeatureChange_(evt) {
     if (!this.changingFeature_) {
-      const feature = /** @type {import("../Feature.js").default} */ (evt.target);
+      const feature = /** @type {Feature} */ (evt.target);
       this.removeFeature_(feature);
       this.addFeature_(feature);
     }
@@ -476,13 +476,13 @@ class Modify extends PointerInteraction {
    * @private
    */
   handleFeatureRemove_(evt) {
-    const feature = /** @type {import("../Feature.js").default} */ (evt.element);
+    const feature = /** @type {Feature} */ (evt.element);
     this.removeFeature_(feature);
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
-   * @param {import("../geom/Point.js").default} geometry Geometry.
+   * @param {Feature} feature Feature
+   * @param {Point} geometry Geometry.
    * @private
    */
   writePointGeometry_(feature, geometry) {
@@ -496,7 +496,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
+   * @param {Feature} feature Feature
    * @param {import("../geom/MultiPoint.js").default} geometry Geometry.
    * @private
    */
@@ -516,7 +516,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
+   * @param {Feature} feature Feature
    * @param {import("../geom/LineString.js").default} geometry Geometry.
    * @private
    */
@@ -535,7 +535,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
+   * @param {Feature} feature Feature
    * @param {import("../geom/MultiLineString.js").default} geometry Geometry.
    * @private
    */
@@ -558,7 +558,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
+   * @param {Feature} feature Feature
    * @param {import("../geom/Polygon.js").default} geometry Geometry.
    * @private
    */
@@ -581,7 +581,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
+   * @param {Feature} feature Feature
    * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
    * @private
    */
@@ -613,7 +613,7 @@ class Modify extends PointerInteraction {
    * {@link CIRCLE_CIRCUMFERENCE_INDEX} is
    * the circumference, and is not a line segment.
    *
-   * @param {import("../Feature.js").default} feature Feature.
+   * @param {Feature} feature Feature.
    * @param {import("../geom/Circle.js").default} geometry Geometry.
    * @private
    */
@@ -638,7 +638,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature
+   * @param {Feature} feature Feature
    * @param {import("../geom/GeometryCollection.js").default} geometry Geometry.
    * @private
    */
@@ -651,7 +651,7 @@ class Modify extends PointerInteraction {
 
   /**
    * @param {import("../coordinate.js").Coordinate} coordinates Coordinates.
-   * @return {import("../Feature.js").default} Vertex feature.
+   * @return {Feature} Vertex feature.
    * @private
    */
   createOrUpdateVertexFeature_(coordinates) {
@@ -661,7 +661,7 @@ class Modify extends PointerInteraction {
       this.vertexFeature_ = vertexFeature;
       this.overlay_.getSource().addFeature(vertexFeature);
     } else {
-      const geometry = /** @type {import("../geom/Point.js").default} */ (vertexFeature.getGeometry());
+      const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(coordinates);
     }
     return vertexFeature;
@@ -985,7 +985,7 @@ function compareIndexes(a, b) {
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
+ * @param {MapBrowserPointerEvent} evt Event.
  * @return {boolean} Start drag sequence?
  * @this {Modify}
  */
@@ -1000,7 +1000,7 @@ function handleDownEvent(evt) {
   const vertexFeature = this.vertexFeature_;
   if (vertexFeature) {
     const insertVertices = [];
-    const geometry = /** @type {import("../geom/Point.js").default} */ (vertexFeature.getGeometry());
+    const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
     const vertex = geometry.getCoordinates();
     const vertexExtent = boundingExtent([vertex]);
     const segmentDataMatches = this.rBush_.getInExtent(vertexExtent);
@@ -1061,7 +1061,7 @@ function handleDownEvent(evt) {
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
+ * @param {MapBrowserPointerEvent} evt Event.
  * @this {Modify}
  */
 function handleDragEvent(evt) {
@@ -1137,7 +1137,7 @@ function handleDragEvent(evt) {
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} evt Event.
+ * @param {MapBrowserPointerEvent} evt Event.
  * @return {boolean} Stop drag sequence?
  * @this {Modify}
  */

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -9,14 +9,14 @@ import {getValues} from '../obj.js';
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
  * @this {PointerInteraction}
  */
 const handleDragEvent = VOID;
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Capture dragging.
  * @this {PointerInteraction}
  */
@@ -24,7 +24,7 @@ const handleUpEvent = FALSE;
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Capture dragging.
  * @this {PointerInteraction}
  */
@@ -32,7 +32,7 @@ const handleDownEvent = FALSE;
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
  * @this {PointerInteraction}
  */
 const handleMoveEvent = VOID;
@@ -40,10 +40,10 @@ const handleMoveEvent = VOID;
 
 /**
  * @typedef {Object} Options
- * @property {function(import("../MapBrowserPointerEvent.js").default):boolean} [handleDownEvent]
+ * @property {function(MapBrowserPointerEvent):boolean} [handleDownEvent]
  * Function handling "down" events. If the function returns `true` then a drag
  * sequence is started.
- * @property {function(import("../MapBrowserPointerEvent.js").default)} [handleDragEvent]
+ * @property {function(MapBrowserPointerEvent)} [handleDragEvent]
  * Function handling "drag" events. This function is called on "move" events
  * during a drag sequence.
  * @property {function(import("../MapBrowserEvent.js").default):boolean} [handleEvent]
@@ -51,11 +51,11 @@ const handleMoveEvent = VOID;
  * dispatched to the map. The function may return `false` to prevent the
  * propagation of the event to other interactions in the map's interactions
  * chain.
- * @property {function(import("../MapBrowserPointerEvent.js").default)} [handleMoveEvent]
+ * @property {function(MapBrowserPointerEvent)} [handleMoveEvent]
  * Function handling "move" events. This function is called on "move" events,
  * also during a drag sequence (so during a drag sequence both the
  * `handleDragEvent` function and this function are called).
- * @property {function(import("../MapBrowserPointerEvent.js").default):boolean} [handleUpEvent]
+ * @property {function(MapBrowserPointerEvent):boolean} [handleUpEvent]
  *  Function handling "up" events. If the function returns `false` then the
  * current drag sequence is stopped.
  * @property {function(boolean):boolean} stopDown
@@ -88,28 +88,28 @@ class PointerInteraction extends Interaction {
     });
 
     /**
-     * @type {function(import("../MapBrowserPointerEvent.js").default):boolean}
+     * @type {function(MapBrowserPointerEvent):boolean}
      * @private
      */
     this.handleDownEvent_ = options.handleDownEvent ?
       options.handleDownEvent : handleDownEvent;
 
     /**
-     * @type {function(import("../MapBrowserPointerEvent.js").default)}
+     * @type {function(MapBrowserPointerEvent)}
      * @private
      */
     this.handleDragEvent_ = options.handleDragEvent ?
       options.handleDragEvent : handleDragEvent;
 
     /**
-     * @type {function(import("../MapBrowserPointerEvent.js").default)}
+     * @type {function(MapBrowserPointerEvent)}
      * @private
      */
     this.handleMoveEvent_ = options.handleMoveEvent ?
       options.handleMoveEvent : handleMoveEvent;
 
     /**
-     * @type {function(import("../MapBrowserPointerEvent.js").default):boolean}
+     * @type {function(MapBrowserPointerEvent):boolean}
      * @private
      */
     this.handleUpEvent_ = options.handleUpEvent ?
@@ -144,7 +144,7 @@ class PointerInteraction extends Interaction {
   }
 
   /**
-   * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+   * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
    * @private
    */
   updateTrackedPointers_(mapBrowserEvent) {
@@ -185,7 +185,7 @@ export function centroid(pointerEvents) {
 
 
 /**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
+ * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
  * @return {boolean} Whether the event is a pointerdown, pointerdrag
  *     or pointerup event.
  */

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -222,7 +222,7 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {import("../layer/Vector.js").default}
+     * @type {VectorLayer}
      */
     this.featureOverlay_ = featureOverlay;
 
@@ -296,19 +296,19 @@ class Select extends Interaction {
    * programmatic method like pushing features to
    * {@link module:ol/interaction/Select~Select#getFeatures collection}.
    * @param {import("../Feature.js").default|import("../render/Feature.js").default} feature Feature
-   * @return {import("../layer/Vector.js").default} Layer.
+   * @return {VectorLayer} Layer.
    * @api
    */
   getLayer(feature) {
     const key = getUid(feature);
     return (
-      /** @type {import("../layer/Vector.js").default} */ (this.featureLayerAssociation_[key])
+      /** @type {VectorLayer} */ (this.featureLayerAssociation_[key])
     );
   }
 
   /**
    * Get the overlay layer that this interaction renders selected features to.
-   * @return {import("../layer/Vector.js").default} Overlay layer.
+   * @return {VectorLayer} Overlay layer.
    * @api
    */
   getOverlay() {

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -38,7 +38,7 @@ const TranslateEventType = {
 
 /**
  * @typedef {Object} Options
- * @property {import("../Collection.js").default<import("../Feature.js").default>} [features] Only features contained in this collection will be able to be translated. If
+ * @property {Collection<import("../Feature.js").default>} [features] Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
  * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default): boolean} [layers] A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
@@ -59,7 +59,7 @@ const TranslateEventType = {
 export class TranslateEvent extends Event {
   /**
    * @param {TranslateEventType} type Type.
-   * @param {import("../Collection.js").default<import("../Feature.js").default>} features The features translated.
+   * @param {Collection<import("../Feature.js").default>} features The features translated.
    * @param {import("../coordinate.js").Coordinate} coordinate The event coordinate.
    */
   constructor(type, features, coordinate) {
@@ -68,7 +68,7 @@ export class TranslateEvent extends Event {
 
     /**
      * The features being translated.
-     * @type {import("../Collection.js").default<import("../Feature.js").default>}
+     * @type {Collection<import("../Feature.js").default>}
      * @api
      */
     this.features = features;
@@ -116,7 +116,7 @@ class Translate extends PointerInteraction {
 
 
     /**
-     * @type {import("../Collection.js").default<import("../Feature.js").default>}
+     * @type {Collection<import("../Feature.js").default>}
      * @private
      */
     this.features_ = options.features !== undefined ? options.features : null;


### PR DESCRIPTION
The symbols are already imported (es6 import)
