### PR TITLE
Remove wrong Geometry type in KML format

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -1580,7 +1580,6 @@ function readMultiGeometry(node, objectStack) {
   if (geometries.length === 0) {
     return new GeometryCollection(geometries);
   }
-  /** @type {import("../geom/Geometry.js").default} */
   let multiGeometry;
   let homogeneous = true;
   const type = geometries[0].getType();


### PR DESCRIPTION
removes to following typescript errors:
```
Argument of type 'Geometry' is not assignable to parameter of type 'MultiPoint | MultiPolygon | MultiLineString'.
```
