### PR TITLE
Better type annotations / type casts

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -101,6 +101,7 @@ class Feature extends BaseObject {
     if (opt_geometryOrProperties !== undefined) {
       if (opt_geometryOrProperties instanceof Geometry ||
           !opt_geometryOrProperties) {
+        /** @type {?Geometry} */
         const geometry = opt_geometryOrProperties;
         this.setGeometry(geometry);
       } else {

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -26,9 +26,9 @@ class MultiPoint extends SimpleGeometry {
   constructor(coordinates, opt_layout) {
     super();
     if (opt_layout && !Array.isArray(coordinates[0])) {
-      this.setFlatCoordinates(opt_layout, coordinates);
+      this.setFlatCoordinates(opt_layout, /** @type {Array<number>} */ (coordinates));
     } else {
-      this.setCoordinates(coordinates, opt_layout);
+      this.setCoordinates(/** @type {Array<import("../coordinate.js").Coordinate>} */ (coordinates), opt_layout);
     }
   }
 


### PR DESCRIPTION
This removes three errors `error TS2345: Argument of type 'Foo' is not assignable to parameter of type 'Bar'.`

Please review.