### PR TITLE
Enable circle primitive in draw-shapes example

### DIFF
--- a/examples/draw-shapes.html
+++ b/examples/draw-shapes.html
@@ -17,6 +17,7 @@ tags: "draw, edit, freehand, vector"
 <form class="form-inline">
   <label>Shape type &nbsp;</label>
   <select id="type">
+    <option value="Circle">Circle</option>
     <option value="Square">Square</option>
     <option value="Box">Box</option>
     <option value="Star">Star</option>


### PR DESCRIPTION
For some reason the circle polygon type was not available in the select despite the example code handling drawing circles.
