### PR TITLE
fixes for optional key passing, issue #8067 for tile sources

### DIFF
--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -83,7 +83,8 @@ class TileImage extends UrlTile {
       url: options.url,
       urls: options.urls,
       wrapX: options.wrapX,
-      transition: options.transition
+      transition: options.transition,
+      opt_key: options.opt_key,
     });
 
     /**

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -84,7 +84,7 @@ class TileImage extends UrlTile {
       urls: options.urls,
       wrapX: options.wrapX,
       transition: options.transition,
-      opt_key: options.opt_key,
+      opt_key: options.opt_key
     });
 
     /**

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -64,6 +64,7 @@ class UrlTile extends TileSource {
      */
     this.tileUrlFunction = this.fixedTileUrlFunction ?
       this.fixedTileUrlFunction.bind(this) : nullTileUrlFunction;
+    this.key_ = options.opt_key || this.key_;
 
     /**
      * @protected
@@ -77,7 +78,7 @@ class UrlTile extends TileSource {
       this.setUrl(options.url);
     }
     if (options.tileUrlFunction) {
-      this.setTileUrlFunction(options.tileUrlFunction);
+      this.setTileUrlFunction(options.tileUrlFunction, options.opt_key);
     }
 
     /**


### PR DESCRIPTION
This fixes the same problem as described in #8067. While setting different tile urls setUrl() on a source the animation would always jump to the very first source url that was set. The solution was to set distinguishing optional keys for each source which would select proper tiles form cache for animation. Minor fixes were needed to make sure optional keys can be passes through tile sources.