### PR TITLE
Fix style TypeScript errors

### DIFF
--- a/src/ol/style/Atlas.js
+++ b/src/ol/style/Atlas.js
@@ -192,7 +192,7 @@ class Atlas {
    * @param {AtlasBlock} newBlock2 The 2nd block to add.
    */
   updateBlocks_(index, newBlock1, newBlock2) {
-    const args = [index, 1];
+    const args = /** @type {Array<*>} */ ([index, 1]);
     if (newBlock1.width > 0 && newBlock1.height > 0) {
       args.push(newBlock1);
     }

--- a/src/ol/style/Fill.js
+++ b/src/ol/style/Fill.js
@@ -47,7 +47,7 @@ class Fill {
   clone() {
     const color = this.getColor();
     return new Fill({
-      color: (color && color.slice) ? color.slice() : color || undefined
+      color: Array.isArray(color) ? color.slice() : color || undefined
     });
   }
 

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -149,7 +149,7 @@ class Icon extends ImageStyle {
       5); // `imgSize` must be set when `image` is provided
 
     if ((src === undefined || src.length === 0) && image) {
-      src = image.src || getUid(image).toString();
+      src = image instanceof HTMLImageElement && image.src || getUid(image).toString();
     }
     assert(src !== undefined && src.length > 0,
       6); // A defined and non-empty `src` or `image` must be provided

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -34,7 +34,7 @@ class IconImage extends EventTarget {
      */
     this.image_ = !image ? new Image() : image;
 
-    if (crossOrigin !== null) {
+    if (crossOrigin !== null && this.image_ instanceof HTMLImageElement) {
       this.image_.crossOrigin = crossOrigin;
     }
 
@@ -194,7 +194,7 @@ class IconImage extends EventTarget {
           this.handleImageLoad_, this)
       ];
       try {
-        this.image_.src = this.src_;
+        /** @type {HTMLImageElement} */ (this.image_).src = this.src_;
       } catch (e) {
         this.handleImageError_();
       }

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -52,6 +52,20 @@ class ImageStyle {
   }
 
   /**
+   * Clones the style.
+   * @return {ImageStyle} The cloned style.
+   * @api
+   */
+  clone() {
+    return new ImageStyle({
+      opacity: this.getOpacity(),
+      scale: this.getScale(),
+      rotation: this.getRotation(),
+      rotateWithView: this.getRotateWithView()
+    });
+  }
+
+  /**
    * Get the symbolizer opacity.
    * @return {number} Opacity.
    * @api

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -2,6 +2,7 @@
  * @module ol/style/RegularShape
  */
 
+import {asString} from '../color.js';
 import {asColorLike} from '../colorlike.js';
 import {createCanvasContext2D} from '../dom.js';
 import {CANVAS_LINE_DASH} from '../has.js';
@@ -301,7 +302,9 @@ class RegularShape extends ImageStyle {
   /**
    * @inheritDoc
    */
-  listenImageChange(listener, thisArg) {}
+  listenImageChange(listener, thisArg) {
+    return undefined;
+  }
 
   /**
    * @inheritDoc
@@ -471,8 +474,8 @@ class RegularShape extends ImageStyle {
         context.setLineDash(renderOptions.lineDash);
         context.lineDashOffset = renderOptions.lineDashOffset;
       }
-      context.lineCap = renderOptions.lineCap;
-      context.lineJoin = renderOptions.lineJoin;
+      context.lineCap = /** @type {CanvasLineCap} */ (renderOptions.lineCap);
+      context.lineJoin = /** @type {CanvasLineJoin} */ (renderOptions.lineJoin);
       context.miterLimit = renderOptions.miterLimit;
       context.stroke();
     }
@@ -534,7 +537,7 @@ class RegularShape extends ImageStyle {
       }
     }
 
-    context.fillStyle = defaultFillStyle;
+    context.fillStyle = asString(defaultFillStyle);
     context.fill();
     if (this.stroke_) {
       context.strokeStyle = renderOptions.strokeStyle;
@@ -575,7 +578,7 @@ class RegularShape extends ImageStyle {
         this.radius_, this.radius2_, this.angle_, this.points_];
     }
 
-    return this.checksums_[0];
+    return /** @type {string} */ (this.checksums_[0]);
   }
 }
 

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -93,7 +93,7 @@ class Stroke {
   clone() {
     const color = this.getColor();
     return new Stroke({
-      color: (color && color.slice) ? color.slice() : color || undefined,
+      color: Array.isArray(color) ? color.slice() : color || undefined,
       lineCap: this.getLineCap(),
       lineDash: this.getLineDash() ? this.getLineDash().slice() : undefined,
       lineDashOffset: this.getLineDashOffset(),

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -87,6 +87,7 @@
  * ```
  */
 import {assert} from '../asserts.js';
+import Geometry from '../geom/Geometry.js';
 import GeometryType from '../geom/GeometryType.js';
 import CircleStyle from '../style/Circle.js';
 import Fill from '../style/Fill.js';
@@ -214,7 +215,7 @@ class Style {
    */
   clone() {
     let geometry = this.getGeometry();
-    if (geometry && geometry.clone) {
+    if (geometry instanceof Geometry) {
       geometry = geometry.clone();
     }
     return new Style({


### PR DESCRIPTION
I'm researching moving our own project to ES6/TypeScript, so I hopped on some low-hanging fruit for TypeScript errors (#8448). This fixes `tsc` errors for some files in `src/ol/style`.