### PR TITLE
OverviewMap control used pixelRatio from original Map (issue #8647)

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -893,7 +893,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * Get the pixel ratio of the frame.
-   * @return {number}
+   * @return {number} The ratio between physical pixels and device-independent pixels (dips) on the device.
    * @api
    */
   getPixelRatio() {

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -892,6 +892,15 @@ class PluggableMap extends BaseObject {
   }
 
   /**
+   * Get the pixel ratio of the frame.
+   * @return {number}
+   * @api
+   */
+  getPixelRatio() {
+    return this.pixelRatio_;
+  }
+
+  /**
    * @param {Event} browserEvent Browser event.
    * @param {string=} opt_type Type.
    */

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -151,7 +151,7 @@ class OverviewMap extends Control {
       controls: new Collection(),
       interactions: new Collection(),
       view: options.view,
-      pixelRatio: this.getMap().getPixelRatio()
+      pixelRatio: this.getMap() && this.getMap().getPixelRatio()
     });
     const ovmap = this.ovmap_;
 

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -150,7 +150,8 @@ class OverviewMap extends Control {
     this.ovmap_ = new Map({
       controls: new Collection(),
       interactions: new Collection(),
-      view: options.view
+      view: options.view,
+      pixelRatio: this.getMap().getPixelRatio()
     });
     const ovmap = this.ovmap_;
 


### PR DESCRIPTION
Add `getPixelRatio()` to ol/PluggableMap and ol/control/OverviewMap used pixelRatio from associated Map for overview map.

fix: #8647 