### PR TITLE
Remove webkit specific properties from Touch

### DIFF
--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -228,9 +228,9 @@ class TouchSource extends EventSource {
     e.detail = this.clickCount_;
     e.button = 0;
     e.buttons = 1;
-    e.width = inTouch.webkitRadiusX || inTouch.radiusX || 0;
-    e.height = inTouch.webkitRadiusY || inTouch.radiusY || 0;
-    e.pressure = inTouch.webkitForce || inTouch.force || 0.5;
+    e.width = inTouch.radiusX || 0;
+    e.height = inTouch.radiusY || 0;
+    e.pressure = inTouch.force || 0.5;
     e.isPrimary = this.isPrimaryTouch_(inTouch);
     e.pointerType = POINTER_TYPE;
 


### PR DESCRIPTION
Remove the following errors from the TypeScript checks:
```
src/ol/pointer/TouchSource.js(231,23): error TS2339: Property 'webkitRadiusX' does not exist on type 'Touch'.
src/ol/pointer/TouchSource.js(232,24): error TS2339: Property 'webkitRadiusY' does not exist on type 'Touch'.
src/ol/pointer/TouchSource.js(233,26): error TS2339: Property 'webkitForce' does not exist on type 'Touch'.
```

The only reference that I've found for these properties is a warning message from Google Chrome:
```
'Touch.webkitRadiusX' is deprecated and will be removed in M47, around November 2015. Please use 'Touch.radiusX' instead.
```

We're not using these properties in OpenLayers