### PR TITLE
Explicitly define type of 'this'

### DIFF
--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -180,7 +180,7 @@ class Tile extends EventTarget {
     }
 
     let tile = this.interimTile;
-    let prev = this;
+    let prev = /** @type {Tile} */ (this);
 
     do {
       if (tile.getState() == TileState.LOADED) {


### PR DESCRIPTION
I'm not entirely sure that I like this pattern, but there does not
appear to be a better option since TypeScript would recommend:

```
function(this: SomeClass, ...)
```

tsdoc does not appear to support an associated annotation for the
function a la `@this {SomeClass}`.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
