### PR TITLE
Add vendor-specific TS declarations for the Fullscreen API.

### DIFF
--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -50,14 +50,6 @@ const getChangeType = (function() {
 
 
 /**
- * TypeScript does not define Element.ALLOW_KEYBOARD_INPUT in the var declaration, and does not support extending those
- * declarations. This is a workaround to provide the type.
- * @typedef {Object} WebkitElement
- * @property {number} [ALLOW_KEYBOARD_INPUT] If keyboard input should be allowed by the Fullscreen API.
- */
-
-
-/**
  * @classdesc
  * Provides a button that when clicked fills up the full screen with the map.
  * The full screen source element is by default the element containing the map viewport unless
@@ -261,7 +253,7 @@ function requestFullScreenWithKeys(element) {
   if (element.mozRequestFullScreenWithKeys) {
     element.mozRequestFullScreenWithKeys();
   } else if (element.webkitRequestFullscreen) {
-    element.webkitRequestFullscreen(/** @type {WebkitElement} */ (Element).ALLOW_KEYBOARD_INPUT);
+    element.webkitRequestFullscreen();
   } else {
     requestFullScreen(element);
   }

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -34,9 +34,9 @@ const getChangeType = (function() {
 /**
  * @typedef {Object} Options
  * @property {string} [className='ol-full-screen'] CSS class name.
- * @property {string|HTMLElement} [label='\u2922'] Text label to use for the button.
+ * @property {string|Text} [label='\u2922'] Text label to use for the button.
  * Instead of text, also an element (e.g. a `span` element) can be used.
- * @property {string|HTMLElement} [labelActive='\u00d7'] Text label to use for the
+ * @property {string|Text} [labelActive='\u00d7'] Text label to use for the
  * button when full-screen is active.
  * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string} [tipLabel='Toggle full-screen'] Text label to use for the button tip.
@@ -46,6 +46,14 @@ const getChangeType = (function() {
  * @property {HTMLElement|string} [source] The element to be displayed
  * fullscreen. When not provided, the element containing the map viewport will
  * be displayed fullscreen.
+ */
+
+
+/**
+ * TypeScript does not define Element.ALLOW_KEYBOARD_INPUT in the var declaration, and does not support extending those
+ * declarations. This is a workaround to provide the type.
+ * @typedef {Object} WebkitElement
+ * @property {number} [ALLOW_KEYBOARD_INPUT] If keyboard input should be allowed by the Fullscreen API.
  */
 
 
@@ -87,7 +95,7 @@ class FullScreen extends Control {
 
     /**
      * @private
-     * @type {HTMLElement}
+     * @type {Text}
      */
     this.labelNode_ = typeof label === 'string' ?
       document.createTextNode(label) : label;
@@ -96,7 +104,7 @@ class FullScreen extends Control {
 
     /**
      * @private
-     * @type {HTMLElement}
+     * @type {Text}
      */
     this.labelActiveNode_ = typeof labelActive === 'string' ?
       document.createTextNode(labelActive) : labelActive;
@@ -253,7 +261,7 @@ function requestFullScreenWithKeys(element) {
   if (element.mozRequestFullScreenWithKeys) {
     element.mozRequestFullScreenWithKeys();
   } else if (element.webkitRequestFullscreen) {
-    element.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+    element.webkitRequestFullscreen(/** @type {WebkitElement} */ (Element).ALLOW_KEYBOARD_INPUT);
   } else {
     requestFullScreen(element);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "include": [
+    "types/**/*.ts",
     "src/ol/**/*.js"
   ]
 }

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Type declarations extending TypeScript's lib/lib.dom.d.ts.
+ * https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts
+ */
+
+interface Document {
+  readonly mozFullScreen: boolean;
+  readonly webkitIsFullScreen: boolean;
+
+  readonly fullscreenElement: Element;
+  readonly mozFullScreenElement: Element;
+  readonly msFullscreenElement: Element;
+  readonly webkitFullscreenElement: Element;
+
+  readonly mozFullScreenEnabled: boolean;
+  readonly msFullscreenEnabled: boolean;
+  readonly webkitFullscreenEnabled: boolean;
+
+  mozCancelFullScreen(): void;
+  msExitFullscreen(): void;
+  webkitExitFullscreen(): void;
+}
+
+interface Element {
+  mozRequestFullScreen(): Promise<void>;
+  mozRequestFullScreenWithKeys(): Promise<void>;
+  msRequestFullscreen(): Promise<void>;
+  webkitRequestFullscreen(allowKeyboardInput?: number): Promise<void>;
+}


### PR DESCRIPTION
Fixes #8660.

I'm not fond of the `Element.ALLOW_KEYBOARD_INPUT` solution, but TypeScript does not support declaration merging for `declare var`. This prevents OpenLayers from adding vendor properties to their [Element declaration](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L4814), so a `@typedef` and cast was used as a workaround. If anyone knows a better way to do this, please let me know.