### PR TITLE
Add native Event to ListenerFunction signature.

### DIFF
--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -22,7 +22,7 @@ import {clear} from './obj.js';
  * Listener function. This function is called with an event object as argument.
  * When the function returns `false`, event propagation will stop.
  *
- * @typedef {function(import("./events/Event.js").default): (void|boolean)} ListenerFunction
+ * @typedef {function(Event|import("./events/Event.js").default): (void|boolean)} ListenerFunction
  * @api
  */
 


### PR DESCRIPTION
`EventTargetLike` can be a native `EventTarget`, so the first parameter to `ListenerFunction` should also allow the native `Event`. Resolves 24 `tsc` errors.