### PR TITLE
Fix type check errors in RBush

### DIFF
--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -233,7 +233,7 @@ class RBush {
   concat(rbush) {
     this.rbush_.load(rbush.rbush_.all());
     for (const i in rbush.items_) {
-      this.items_[i | 0] = rbush.items_[i | 0];
+      this.items_[i] = rbush.items_[i];
     }
   }
 


### PR DESCRIPTION
This was previously taking advantage of Javascript's subtle type coercions for arithmetic operations. Looping over object keys via `for...in` or the result of `Object.keys()` always results in a string key, even if the key was set via `obj[3] = "thing"`. Therefore, do the conversion explicitly (since it is happening under the hood anyway) in order to satisfy `tsc`.

Update:
Since the bitwise operations are apparently superfluous, simply removing those will satisfy `tsc` without any further additions.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
