### PR TITLE
Define UrlTile#fixedTileUrlFunction as an abstract function

### DIFF
--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -89,6 +89,13 @@ class UrlTile extends TileSource {
   }
 
   /**
+   * @type {import("../Tile.js").UrlFunction|undefined}
+   * @abstract
+   * @protected
+   */
+  fixedTileUrlFunction(tileCoord, pixelRatio, projection) {}
+
+  /**
    * Return the tile load function of the source.
    * @return {import("../Tile.js").LoadFunction} TileLoadFunction
    * @api
@@ -203,12 +210,5 @@ class UrlTile extends TileSource {
     }
   }
 }
-
-
-/**
- * @type {import("../Tile.js").UrlFunction|undefined}
- * @protected
- */
-UrlTile.prototype.fixedTileUrlFunction;
 
 export default UrlTile;


### PR DESCRIPTION
Fixes the TypeScript error:
```
Class 'TileImage' defines instance member property 'fixedTileUrlFunction', but extended class 'TileWMS' defines it as instance member function.
```
