### PR TITLE
Get width as number from number|Size

### DIFF
--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -219,7 +219,8 @@ class Zoomify extends TileImage {
                 tileCoordX +
                 tileCoordY * tierSizeInTiles[tileCoordZ][0];
             const tileSize = tileGrid.getTileSize(tileCoordZ);
-            const tileGroup = ((tileIndex + tileCountUpToTier[tileCoordZ]) / tileSize) | 0;
+            const tileWidth = Array.isArray(tileSize) ? tileSize[0] : tileSize;
+            const tileGroup = ((tileIndex + tileCountUpToTier[tileCoordZ]) / tileWidth) | 0;
             const localContext = {
               'z': tileCoordZ,
               'x': tileCoordX,


### PR DESCRIPTION
This satisfies `tsc` for `ol/source/Zoomify.js` in addition to being a bit more defensive from custom tile grids, even if using them is very uncommon for this source.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
