### PR TITLE
Type check fixes for VectorSource

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -420,6 +420,9 @@ class VectorSource extends Source {
   bindFeaturesCollection_(collection) {
     let modifyingCollection = false;
     listen(this, VectorEventType.ADDFEATURE,
+      /**
+       * @param {VectorSourceEvent} evt The vector source event
+       */
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -428,6 +431,9 @@ class VectorSource extends Source {
         }
       });
     listen(this, VectorEventType.REMOVEFEATURE,
+      /**
+       * @param {VectorSourceEvent} evt The vector source event
+       */
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -436,6 +442,9 @@ class VectorSource extends Source {
         }
       });
     listen(collection, CollectionEventType.ADD,
+      /**
+       * @param {import("../Collection.js").CollectionEvent} evt The collection event
+       */
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -444,6 +453,9 @@ class VectorSource extends Source {
         }
       }, this);
     listen(collection, CollectionEventType.REMOVE,
+      /**
+       * @param {import("../Collection.js").CollectionEvent} evt The collection event
+       */
       function(evt) {
         if (!modifyingCollection) {
           modifyingCollection = true;
@@ -511,7 +523,7 @@ class VectorSource extends Source {
     if (this.featuresRtree_) {
       return this.featuresRtree_.forEach(callback);
     } else if (this.featuresCollection_) {
-      return this.featuresCollection_.forEach(callback);
+      this.featuresCollection_.forEach(callback);
     }
   }
 
@@ -564,7 +576,7 @@ class VectorSource extends Source {
     if (this.featuresRtree_) {
       return this.featuresRtree_.forEachInExtent(extent, callback);
     } else if (this.featuresCollection_) {
-      return this.featuresCollection_.forEach(callback);
+      this.featuresCollection_.forEach(callback);
     }
   }
 
@@ -589,7 +601,6 @@ class VectorSource extends Source {
       /**
        * @param {import("../Feature.js").default} feature Feature.
        * @return {T|undefined} The return value from the last call to the callback.
-       * @template T
        */
       function(feature) {
         const geometry = feature.getGeometry();


### PR DESCRIPTION
- Added parameter types to event listeners.
- Fixed return type for feature collection branch.
- Removed duplicate template definition.

This fixes all the outstanding issues from `tsc` except those caused by `@abstract` method overrides.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
