### PR TITLE
TypeScript fixes for ol/events

### DIFF
--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -72,7 +72,8 @@ class Target extends Disposable {
    * Object with a `type` property.
    *
    * @param {{type: string,
-   *     target: (EventTargetLike|undefined)}|
+   *     target: (EventTargetLike|undefined),
+   *     propagationStopped: (boolean|undefined)}|
    *     import("./Event.js").default|string} event Event object.
    * @return {boolean|undefined} `false` if anyone called preventDefault on the
    *     event object or if any of the listeners returned false.


### PR DESCRIPTION
This fixes most remaining errors in `ol/events`. #8666 handles errors in `ol/events/condition`.

The `ol_lm` errors were fixed in a similar manner to `ol_uid`, by restricting references to that map to the `getListenerMap` call and typing the target as an Object in that call. This required adding a param to enable map creation when it didn't exist, but the function isn't exported so the change only impacts `events.js`.