### PR TITLE
Define BingMapsImageryMetadataResponse type

### DIFF
--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -46,6 +46,47 @@ const TOS_ATTRIBUTION = '<a class="ol-attribution-bing-tos" ' +
 
 
 /**
+ * @typedef {Object} BingMapsImageryMetadataResponse
+ * @property {number} statusCode The response status code
+ * @property {string} statusDescription The response status description
+ * @property {string} authenticationResultCode The authentication result code
+ * @property {Array<ResourceSet>} resourceSets The array of resource sets
+ */
+
+
+/**
+ * @typedef {Object} ResourceSet
+ * @property {Array<Resource>} resources
+ */
+
+
+/**
+ * @typedef {Object} Resource
+ * @property {number} imageHeight The image height
+ * @property {number} imageWidth The image width
+ * @property {number} zoomMin The minimum zoom level
+ * @property {string} imageUrl The image URL
+ * @property {Array<string>} imageUrlSubdomains The image URL subdomains for rotation
+ * @property {Array<ImageryProvider>} [imageryProviders] The array of ImageryProviders
+ */
+
+
+/**
+ * @typedef {Object} ImageryProvider
+ * @property {Array<CoverageArea>} coverageAreas The coverage areas
+ * @property {string} [attribution] The attribution
+ */
+
+
+/**
+ * @typedef {Object} CoverageArea
+ * @property {number} zoomMin The minimum zoom
+ * @property {number} zoomMax The maximum zoom
+ * @property {Array<number>} bbox The coverage bounding box
+ */
+
+
+/**
  * @classdesc
  * Layer source for Bing Maps tile data.
  * @api

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -65,6 +65,7 @@ const TOS_ATTRIBUTION = '<a class="ol-attribution-bing-tos" ' +
  * @property {number} imageHeight The image height
  * @property {number} imageWidth The image width
  * @property {number} zoomMin The minimum zoom level
+ * @property {number} zoomMax The maximum zoom level
  * @property {string} imageUrl The image URL
  * @property {Array<string>} imageUrlSubdomains The image URL subdomains for rotation
  * @property {Array<ImageryProvider>} [imageryProviders] The array of ImageryProviders
@@ -191,13 +192,16 @@ class BingMaps extends TileImage {
 
     const sourceProjection = this.getProjection();
     const extent = extentFromProjection(sourceProjection);
+    const scale = this.hidpi_ ? 2 : 1;
     const tileSize = resource.imageWidth == resource.imageHeight ?
-      resource.imageWidth : [resource.imageWidth, resource.imageHeight];
+      resource.imageWidth / scale :
+      [resource.imageWidth / scale, resource.imageHeight / scale];
+
     const tileGrid = createXYZ({
       extent: extent,
       minZoom: resource.zoomMin,
       maxZoom: maxZoom,
-      tileSize: tileSize / (this.hidpi_ ? 2 : 1)
+      tileSize: tileSize
     });
     this.tileGrid = tileGrid;
 


### PR DESCRIPTION
Because it didn't exist anywhere I could find. This was all reverse-engineered from the `handleImageryMetadataResponse` function.

Resolves `tsc` errors for `ol/source/BingMaps.js`.
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
