### PR TITLE
Remove extra imports in jsdoc

### DIFF
--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -133,7 +133,7 @@ class ZoomSlider extends Control {
     containerElement.className = className + ' ' + CLASS_UNSELECTABLE + ' ' + CLASS_CONTROL;
     containerElement.appendChild(thumbElement);
     /**
-     * @type {import("../pointer/PointerEventHandler.js").default}
+     * @type {PointerEventHandler}
      * @private
      */
     this.dragger_ = new PointerEventHandler(containerElement);

--- a/src/ol/control/util.js
+++ b/src/ol/control/util.js
@@ -34,7 +34,7 @@ import Zoom from './Zoom.js';
  *
  * @param {DefaultsOptions=} opt_options
  * Defaults options.
- * @return {import("../Collection.js").default<import("./Control.js").default>}
+ * @return {Collection<import("./Control.js").default>}
  * Controls.
  * @function module:ol/control.defaults
  * @api

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -366,7 +366,7 @@ class PointerEventHandler extends EventTarget {
    * @param {string} inType A string representing the type of event to create.
    * @param {Object} data Pointer event data.
    * @param {Event} event The event.
-   * @return {import("./PointerEvent.js").default} A PointerEvent of type `inType`.
+   * @return {PointerEvent} A PointerEvent of type `inType`.
    */
   makeEvent(inType, data, event) {
     return new PointerEvent(inType, event, data);
@@ -398,7 +398,7 @@ class PointerEventHandler extends EventTarget {
    * This proxy method is required for the legacy IE support.
    * @param {string} eventType The pointer event type.
    * @param {Event} event The event.
-   * @return {import("./PointerEvent.js").default} The wrapped event.
+   * @return {PointerEvent} The wrapped event.
    */
   wrapMouseEvent(eventType, event) {
     const pointerEvent = this.makeEvent(

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -61,7 +61,7 @@ export class VectorSourceEvent extends Event {
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
- * @property {Array<import("../Feature.js").default>|import("../Collection.js").default<import("../Feature.js").default>} [features]
+ * @property {Array<import("../Feature.js").default>|Collection<import("../Feature.js").default>} [features]
  * Features. If provided as {@link module:ol/Collection}, the features in the source
  * and the collection will stay in sync.
  * @property {import("../format/Feature.js").default} [format] The feature format used by the XHR
@@ -215,13 +215,13 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {import("../structs/RBush.js").default<import("../Feature.js").default>}
+     * @type {RBush<import("../Feature.js").default>}
      */
     this.featuresRtree_ = useSpatialIndex ? new RBush() : null;
 
     /**
      * @private
-     * @type {import("../structs/RBush.js").default<{extent: import("../extent.js").Extent}>}
+     * @type {RBush<{extent: import("../extent.js").Extent}>}
      */
     this.loadedExtentsRtree_ = new RBush();
 
@@ -253,7 +253,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {import("../Collection.js").default<import("../Feature.js").default>}
+     * @type {Collection<import("../Feature.js").default>}
      */
     this.featuresCollection_ = null;
 
@@ -414,7 +414,7 @@ class VectorSource extends Source {
 
 
   /**
-   * @param {!import("../Collection.js").default<import("../Feature.js").default>} collection Collection.
+   * @param {!Collection<import("../Feature.js").default>} collection Collection.
    * @private
    */
   bindFeaturesCollection_(collection) {
@@ -607,7 +607,7 @@ class VectorSource extends Source {
    * Get the features collection associated with this source. Will be `null`
    * unless the source was configured with `useSpatialIndex` set to `false`, or
    * with an {@link module:ol/Collection} as `features`.
-   * @return {import("../Collection.js").default<import("../Feature.js").default>} The collection of features.
+   * @return {Collection<import("../Feature.js").default>} The collection of features.
    * @api
    */
   getFeaturesCollection() {
@@ -789,7 +789,7 @@ class VectorSource extends Source {
 
 
   /**
-   * @param {import("../events/Event.js").default} event Event.
+   * @param {Event} event Event.
    * @private
    */
   handleFeatureChange_(event) {


### PR DESCRIPTION
The symbols are already imported (es6 import)
