### PR TITLE
Fix type checks in CartoDB

### DIFF
--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -32,6 +32,12 @@ import XYZ from '../source/XYZ.js';
 
 
 /**
+ * @typedef {Object} CartoDBLayerInfo
+ * @property {string} layergroupid The layer group ID
+ * @property {{https: string}} cdn_url The CDN URL
+ */
+
+/**
  * @classdesc
  * Layer source for the CartoDB Maps API.
  * @api
@@ -48,7 +54,6 @@ class CartoDB extends XYZ {
       maxZoom: options.maxZoom !== undefined ? options.maxZoom : 18,
       minZoom: options.minZoom,
       projection: options.projection,
-      state: SourceState.LOADING,
       wrapX: options.wrapX
     });
 


### PR DESCRIPTION
- Removed `state` from super call options because the super class doesn't use it.
- Defined `CartoDBLayerInfo` response type.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
