### PR TITLE
Fix type check errors for Image source

### DIFF
--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -91,7 +91,6 @@ class ImageSource extends Source {
   constructor(options) {
     super({
       attributions: options.attributions,
-      extent: options.extent,
       projection: options.projection,
       state: options.state
     });
@@ -232,7 +231,10 @@ class ImageSource extends Source {
  * @param {string} src Source.
  */
 export function defaultImageLoadFunction(image, src) {
-  image.getImage().src = src;
+  const img = image.getImage();
+  if (img instanceof HTMLImageElement || img instanceof HTMLVideoElement) {
+    img.src = src;
+  }
 }
 
 


### PR DESCRIPTION
The parent class does not accept an `extent` property on its options. Also check that the image is an `img` or `video` tag before setting the source as `Canvas` does not have the `src` property.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
