### PR TITLE
Fix zoom slider events

### DIFF
--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -5,7 +5,7 @@ import ViewHint from '../ViewHint.js';
 import Control from '../control/Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 import {easeOut} from '../easing.js';
-import {listen} from '../events.js';
+import {listen, unlistenByKey} from '../events.js';
 import {stopPropagation} from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import {clamp} from '../math.js';
@@ -56,6 +56,12 @@ class ZoomSlider extends Control {
       element: document.createElement('div'),
       render: options.render || render
     });
+
+    /**
+      * @type {!Array.<ol.EventsKey>}
+      * @private
+      */
+    this.dragListenerKeys_ = [];
 
     /**
      * Will hold the current resolution of the view.
@@ -231,6 +237,19 @@ class ZoomSlider extends Control {
       this.previousX_ = event.clientX;
       this.previousY_ = event.clientY;
       this.dragging_ = true;
+
+      if (this.dragListenerKeys_.length === 0) {
+        const drag = this.handleDraggerDrag_;
+        const end = this.handleDraggerEnd_;
+        this.dragListenerKeys_.push(
+          listen(document, EventType.MOUSEMOVE, drag, this),
+          listen(document, EventType.TOUCHMOVE, drag, this),
+          listen(document, PointerEventType.POINTERMOVE, drag, this),
+          listen(document, EventType.MOUSEUP, end, this),
+          listen(document, EventType.TOUCHEND, end, this),
+          listen(document, PointerEventType.POINTERUP, end, this)
+        );
+      }
     }
   }
 
@@ -273,6 +292,8 @@ class ZoomSlider extends Control {
       this.dragging_ = false;
       this.previousX_ = undefined;
       this.previousY_ = undefined;
+      this.dragListenerKeys_.forEach(unlistenByKey);
+      this.dragListenerKeys_.length = 0;
     }
   }
 

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -243,10 +243,8 @@ class ZoomSlider extends Control {
         const end = this.handleDraggerEnd_;
         this.dragListenerKeys_.push(
           listen(document, EventType.MOUSEMOVE, drag, this),
-          listen(document, EventType.TOUCHMOVE, drag, this),
           listen(document, PointerEventType.POINTERMOVE, drag, this),
           listen(document, EventType.MOUSEUP, end, this),
-          listen(document, EventType.TOUCHEND, end, this),
           listen(document, PointerEventType.POINTERUP, end, this)
         );
       }

--- a/test/spec/ol/control/zoomslider.test.js
+++ b/test/spec/ol/control/zoomslider.test.js
@@ -119,7 +119,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(16);
       expect(control.dragging_).to.be(true);
-      expect(control.dragListenerKeys_.length).to.be(6);
+      expect(control.dragListenerKeys_.length).to.be(4);
       event.type = 'pointermove';
       event.clientX = 6 * control.widthLimit_ / 8;
       event.clientY = 0;
@@ -153,7 +153,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(16);
       expect(control.dragging_).to.be(true);
-      expect(control.dragListenerKeys_.length).to.be(6);
+      expect(control.dragListenerKeys_.length).to.be(4);
       event.type = 'pointermove';
       event.clientX = 6 * control.widthLimit_ / 8;
       event.clientY = 0;
@@ -188,7 +188,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(0.0625);
       expect(control.dragging_).to.be(true);
-      expect(control.dragListenerKeys_.length).to.be(6);
+      expect(control.dragListenerKeys_.length).to.be(4);
       event.type = 'pointermove';
       event.clientX = 0;
       event.clientY = 2 * control.heightLimit_ / 8;
@@ -222,7 +222,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(0.0625);
       expect(control.dragging_).to.be(true);
-      expect(control.dragListenerKeys_.length).to.be(6);
+      expect(control.dragListenerKeys_.length).to.be(4);
       event.type = 'pointermove';
       event.clientX = 0;
       event.clientY = 2 * control.heightLimit_ / 8;

--- a/test/spec/ol/control/zoomslider.test.js
+++ b/test/spec/ol/control/zoomslider.test.js
@@ -119,6 +119,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(16);
       expect(control.dragging_).to.be(true);
+      expect(control.dragListenerKeys_.length).to.be(6);
       event.type = 'pointermove';
       event.clientX = 6 * control.widthLimit_ / 8;
       event.clientY = 0;
@@ -131,6 +132,7 @@ describe('ol.control.ZoomSlider', function() {
       event.type = 'pointerup';
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(1);
+      expect(control.dragListenerKeys_.length).to.be(0);
       expect(control.dragging_).to.be(false);
     });
     it('[vertical] handles a drag sequence', function() {
@@ -151,6 +153,7 @@ describe('ol.control.ZoomSlider', function() {
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(0.0625);
       expect(control.dragging_).to.be(true);
+      expect(control.dragListenerKeys_.length).to.be(6);
       event.type = 'pointermove';
       event.clientX = 0;
       event.clientY = 2 * control.heightLimit_ / 8;
@@ -163,6 +166,7 @@ describe('ol.control.ZoomSlider', function() {
       event.type = 'pointerup';
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(1);
+      expect(control.dragListenerKeys_.length).to.be(0);
       expect(control.dragging_).to.be(false);
     });
   });

--- a/test/spec/ol/control/zoomslider.test.js
+++ b/test/spec/ol/control/zoomslider.test.js
@@ -135,6 +135,41 @@ describe('ol.control.ZoomSlider', function() {
       expect(control.dragListenerKeys_.length).to.be(0);
       expect(control.dragging_).to.be(false);
     });
+    it('[horizontal] handles a drag sequence ending outside its bounds', function() {
+      const control = new ZoomSlider();
+      map.addControl(control);
+      map.getView().setZoom(0);
+      control.element.style.width = '500px';
+      control.element.style.height = '10px';
+      control.element.firstChild.style.width = '100px';
+      control.element.firstChild.style.height = '10px';
+      map.renderSync();
+      const dragger = control.dragger_;
+      const event = new PointerEvent('pointerdown', {
+        target: control.element.firstElementChild
+      });
+      event.clientX = control.widthLimit_;
+      event.clientY = 0;
+      dragger.dispatchEvent(event);
+      expect(control.currentResolution_).to.be(16);
+      expect(control.dragging_).to.be(true);
+      expect(control.dragListenerKeys_.length).to.be(6);
+      event.type = 'pointermove';
+      event.clientX = 6 * control.widthLimit_ / 8;
+      event.clientY = 0;
+      dragger.dispatchEvent(event);
+      expect(control.currentResolution_).to.be(4);
+      event.type = 'pointermove';
+      event.clientX = 12 * control.widthLimit_ / 8;
+      event.clientY = 0;
+      dragger.dispatchEvent(event);
+      event.type = 'pointerup';
+      event.target = 'document';
+      dragger.dispatchEvent(event);
+      expect(control.dragListenerKeys_.length).to.be(0);
+      expect(control.dragging_).to.be(false);
+      expect(control.currentResolution_).to.be(16);
+    });
     it('[vertical] handles a drag sequence', function() {
       const control = new ZoomSlider();
       control.element.style.width = '10px';
@@ -166,6 +201,40 @@ describe('ol.control.ZoomSlider', function() {
       event.type = 'pointerup';
       dragger.dispatchEvent(event);
       expect(control.currentResolution_).to.be(1);
+      expect(control.dragListenerKeys_.length).to.be(0);
+      expect(control.dragging_).to.be(false);
+    });
+    it('[vertical] handles a drag sequence ending outside its bounds', function() {
+      const control = new ZoomSlider();
+      control.element.style.width = '10px';
+      control.element.style.height = '100px';
+      control.element.firstChild.style.width = '10px';
+      control.element.firstChild.style.height = '20px';
+      map.addControl(control);
+      map.getView().setZoom(8);
+      map.renderSync();
+      const dragger = control.dragger_;
+      const event = new PointerEvent('pointerdown', {
+        target: control.element.firstElementChild
+      });
+      event.clientX = 0;
+      event.clientY = 0;
+      dragger.dispatchEvent(event);
+      expect(control.currentResolution_).to.be(0.0625);
+      expect(control.dragging_).to.be(true);
+      expect(control.dragListenerKeys_.length).to.be(6);
+      event.type = 'pointermove';
+      event.clientX = 0;
+      event.clientY = 2 * control.heightLimit_ / 8;
+      dragger.dispatchEvent(event);
+      expect(control.currentResolution_).to.be(0.25);
+      event.type = 'pointermove';
+      event.clientX = 0;
+      event.clientY = 12 * control.heightLimit_ / 8;
+      dragger.dispatchEvent(event);
+      event.type = 'pointerup';
+      dragger.dispatchEvent(event);
+      expect(control.currentResolution_).to.be(16);
       expect(control.dragListenerKeys_.length).to.be(0);
       expect(control.dragging_).to.be(false);
     });


### PR DESCRIPTION
Fix as discussed in #7485 - reverting the changes from #6422 and replacing them with a fix that leaves the intended events back in. Makes sure that if the user moves the mouse outside of the ZoomSlider, the expected events still fire correctly.