### PR TITLE
Use EsriJSON types from @types/arcgis-rest-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@openlayers/eslint-plugin": "^4.0.0-beta.1",
+    "@types/arcgis-rest-api": "^10.4.3",
     "@types/geojson": "^7946.0.4",
     "@types/topojson-specification": "^1.0.0",
     "buble": "^0.19.3",


### PR DESCRIPTION
This pulls in EsriJSON types from [@types/arcgis-rest-api](https://www.npmjs.com/package/@types/arcgis-rest-api). The ArcGIS types don't define a specific MultiPolygon, so a `@typedef` was added to fix `readMultiPolygonGeometry`.

Resolves #8597 