### PR TITLE
Fix type checks in ImageCanvas source

### DIFF
--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -32,7 +32,7 @@ import ImageSource from '../source/Image.js';
  * projection. The canvas returned by this function is cached by the source. If
  * the value returned by the function is later changed then
  * `changed` should be called on the source for the source to
- * invalidate the current cached image. See @link: {@link module:ol/Observable~Observable#changed}
+ * invalidate the current cached image. See: {@link module:ol/Observable~Observable#changed}
  * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [ratio=1.5] Ratio. 1 means canvases are the size of the map viewport, 2 means twice the
  * width and height of the map viewport, and so on. Must be `1` or higher.
@@ -49,9 +49,11 @@ import ImageSource from '../source/Image.js';
  */
 class ImageCanvasSource extends ImageSource {
   /**
-   * @param {Options=} options ImageCanvas options.
+   * @param {Options=} opt_options ImageCanvas options.
    */
-  constructor(options) {
+  constructor(opt_options) {
+
+    const options = opt_options || /** @type {Options} */ ({});
 
     super({
       attributions: options.attributions,
@@ -108,8 +110,8 @@ class ImageCanvasSource extends ImageSource {
     const height = getHeight(extent) / resolution;
     const size = [width * pixelRatio, height * pixelRatio];
 
-    const canvasElement = this.canvasFunction_(
-      extent, resolution, pixelRatio, size, projection);
+    const canvasElement = this.canvasFunction_.call(
+      this, extent, resolution, pixelRatio, size, projection);
     if (canvasElement) {
       canvas = new ImageCanvas(extent, resolution, pixelRatio, canvasElement);
     }


### PR DESCRIPTION
* Fixed constructor docs specifying optional options without a default value being set (avoids potential null reference error).
* Fixed malformed `@link` tag in description.
* The `canvasFunction` type was previously declared with the `this` type as `ImageCanvasSource`, but the `this` ref was not passed on the scope when calling the function.

We could also take the code as the source of truth and change the docs to match if that is preferable.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
