### PR TITLE
Fix type checks in TileArcGISRest

### DIFF
--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -21,7 +21,7 @@ import {appendParams} from '../uri.js';
  * for more detail.
  * @property {Object<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service defaults will be
  * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
- * default. `TRANSPARENT` is `true` by default.  `BBOX, `SIZE`, `BBOXSR`,
+ * default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`,
  * and `IMAGESR` will be set dynamically. Set `LAYERS` to
  * override the default service layer visibility. See
  * http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/
@@ -66,7 +66,7 @@ class TileArcGISRest extends TileImage {
    */
   constructor(opt_options) {
 
-    const options = opt_options || {};
+    const options = opt_options || /** @type {Options} */ ({});
 
     super({
       attributions: options.attributions,


### PR DESCRIPTION
Before:
```
$ npx tsc | wc -l
    996
```

After:
```
$ npx tsc | wc -l
    982
```
