### PR TITLE
Fix type check in ol/source/Tile

### DIFF
--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -15,7 +15,6 @@ import {wrapX, getForProjection as getTileGridForProjection} from '../tilegrid.j
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions]
  * @property {number} [cacheSize]
- * @property {import("../extent.js").Extent} [extent]
  * @property {boolean} [opaque]
  * @property {number} [tilePixelRatio]
  * @property {import("../proj.js").ProjectionLike} [projection]
@@ -41,7 +40,6 @@ class TileSource extends Source {
 
     super({
       attributions: options.attributions,
-      extent: options.extent,
       projection: options.projection,
       state: options.state,
       wrapX: options.wrapX


### PR DESCRIPTION
Remove `extent` because the parent Source class does not contain `extent` on its `Options` type or use `options.extent` in the constructor.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
