### PR TITLE
Cast to parent type to fix TS errors

### DIFF
--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -107,7 +107,7 @@ class XMLFeature extends FeatureFormat {
   readFeaturesFromDocument(doc, opt_options) {
     /** @type {Array<import("../Feature.js").default>} */
     const features = [];
-    for (let n = doc.firstChild; n; n = n.nextSibling) {
+    for (let n = /** @type {Node} */ (doc.firstChild); n; n = n.nextSibling) {
       if (n.nodeType == Node.ELEMENT_NODE) {
         extend(features, this.readFeaturesFromNode(n, opt_options));
       }


### PR DESCRIPTION
Fixes one of two errors in `ol/format/XMLFeature.js`. The other error is caused by missing `@abstract` support in TypeScript.