### PR TITLE
Fix TypeScript errors in ol/format/WMSGetFeatureInfo

### DIFF
--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -100,10 +100,12 @@ class WMSGetFeatureInfo extends XMLFeature {
         if (layer.nodeType !== Node.ELEMENT_NODE) {
           continue;
         }
+
+        const layerElement = /** @type {Element} */ (layer);
         const context = objectStack[0];
 
         const toRemove = layerIdentifier;
-        const layerName = layer.localName.replace(toRemove, '');
+        const layerName = layerElement.localName.replace(toRemove, '');
 
         if (this.layers_ && !includes(this.layers_, layerName)) {
           continue;
@@ -115,14 +117,15 @@ class WMSGetFeatureInfo extends XMLFeature {
         context['featureType'] = featureType;
         context['featureNS'] = this.featureNS_;
 
+        /** @type {Object<string, import("../xml.js").Parser>} */
         const parsers = {};
         parsers[featureType] = makeArrayPusher(
           this.gmlFormat_.readFeatureElement, this.gmlFormat_);
         const parsersNS = makeStructureNS(
           [context['featureNS'], null], parsers);
-        layer.setAttribute('namespaceURI', this.featureNS_);
+        layerElement.setAttribute('namespaceURI', this.featureNS_);
         const layerFeatures = pushParseAndPop(
-          [], parsersNS, layer, objectStack, this.gmlFormat_);
+          [], parsersNS, layerElement, objectStack, this.gmlFormat_);
         if (layerFeatures) {
           extend(features, layerFeatures);
         }


### PR DESCRIPTION
Fixes two TypeScript errors in `ol/format/WMSGetFeatureInfo.js`. Produces one additional error, which is caused by Microsoft/TypeScript/issues/27215.