### PR TITLE
Increase linestring textalign test tolerance to be Firefox compliant.

### DIFF
--- a/test/rendering/ol/style/text.test.js
+++ b/test/rendering/ol/style/text.test.js
@@ -363,7 +363,7 @@ describe('ol.rendering.style.Text', function() {
       it('renders text along a linestring with `textAlign: \'center\'`', function(done) {
         createMap('canvas');
         createLineString(uglyPath, 'center');
-        expectResemble(map, 'rendering/ol/style/expected/text-linestring-center.png', 3.6, done);
+        expectResemble(map, 'rendering/ol/style/expected/text-linestring-center.png', 3.63, done);
       });
 
       it('omits text along a linestring with `textAlign: \'left\'` when > maxAngle', function(done) {


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

As discussed in #8734, there is a broken test in Firefox. It seems to be a tolerance bypass in `test\rendering\ol\style\text.test.js`:
```
Firefox 62.0.0 (Windows 10 0.0.0) ol.rendering.style.Text #render Text along an ugly upside down path, keep text upright renders text along a linestring with `textAlign: 'center'` FAILED
Error: expected 3.62 to be below 3.6
```

I made an export of both the rendered image and the difference picture.
![canvas2](https://user-images.githubusercontent.com/3090329/46216249-248cd280-c30d-11e8-8577-664fc5fdad3c.png)
![canvas](https://user-images.githubusercontent.com/3090329/46216258-28b8f000-c30d-11e8-976a-5a45e3bee6f9.png)


As everthing looks pretty good, I just increased the tolerance from `3.6` to `3.63` to pass test on Firefox.