### PR TITLE
Fix TypeScript errors in ol/geom/*

### DIFF
--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -194,7 +194,9 @@ class Circle extends SimpleGeometry {
   /**
    * @inheritDoc
    */
-  getCoordinates() {}
+  getCoordinates() {
+    return null;
+  }
 
   /**
    * @inheritDoc

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -57,9 +57,9 @@ class LineString extends SimpleGeometry {
     this.maxDeltaRevision_ = -1;
 
     if (opt_layout !== undefined && !Array.isArray(coordinates[0])) {
-      this.setFlatCoordinates(opt_layout, coordinates);
+      this.setFlatCoordinates(opt_layout, /** @type {Array<number>} */ (coordinates));
     } else {
-      this.setCoordinates(coordinates, opt_layout);
+      this.setCoordinates(/** @type {Array<import("../coordinate.js").Coordinate>} */ (coordinates), opt_layout);
     }
 
   }

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -42,9 +42,9 @@ class LinearRing extends SimpleGeometry {
     this.maxDeltaRevision_ = -1;
 
     if (opt_layout !== undefined && !Array.isArray(coordinates[0])) {
-      this.setFlatCoordinates(opt_layout, coordinates);
+      this.setFlatCoordinates(opt_layout, /** @type {Array<number>} */ (coordinates));
     } else {
-      this.setCoordinates(coordinates, opt_layout);
+      this.setCoordinates(/** @type {Array<import("../coordinate.js").Coordinate>} */ (coordinates), opt_layout);
     }
 
   }
@@ -118,7 +118,9 @@ class LinearRing extends SimpleGeometry {
   /**
    * @inheritDoc
    */
-  intersectsExtent(extent) {}
+  intersectsExtent(extent) {
+    return false;
+  }
 
   /**
    * Set the coordinates of the linear ring.

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -52,16 +52,17 @@ class MultiLineString extends SimpleGeometry {
     this.maxDeltaRevision_ = -1;
 
     if (Array.isArray(coordinates[0])) {
-      this.setCoordinates(coordinates, opt_layout);
+      this.setCoordinates(/** @type {Array<Array<import("../coordinate.js").Coordinate>>} */ (coordinates), opt_layout);
     } else if (opt_layout !== undefined && opt_ends) {
-      this.setFlatCoordinates(opt_layout, coordinates);
+      this.setFlatCoordinates(opt_layout, /** @type {Array<number>} */ (coordinates));
       this.ends_ = opt_ends;
     } else {
       let layout = this.getLayout();
+      const lineStrings = /** @type {Array<import("../geom.js").MultiLineString>} */ (coordinates);
       const flatCoordinates = [];
       const ends = [];
-      for (let i = 0, ii = coordinates.length; i < ii; ++i) {
-        const lineString = coordinates[i];
+      for (let i = 0, ii = lineStrings.length; i < ii; ++i) {
+        const lineString = lineStrings[i];
         if (i === 0) {
           layout = lineString.getLayout();
         }

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -28,10 +28,10 @@ import {quantizeMultiArray} from '../geom/flat/simplify.js';
 class MultiPolygon extends SimpleGeometry {
 
   /**
-   * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>>|Array<number>} coordinates Coordinates.
+   * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>|Polygon>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinats in combination with `opt_layout` and `opt_endss` are also accepted.
    * @param {GeometryLayout=} opt_layout Layout.
-   * @param {Array<number>=} opt_endss Array of ends for internal use with flat coordinates.
+   * @param {Array<Array<number>>=} opt_endss Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
 
@@ -81,10 +81,11 @@ class MultiPolygon extends SimpleGeometry {
 
     if (!opt_endss && !Array.isArray(coordinates[0])) {
       let layout = this.getLayout();
+      const polygons = /** @type {Array<Polygon>} */ (coordinates);
       const flatCoordinates = [];
       const endss = [];
-      for (let i = 0, ii = coordinates.length; i < ii; ++i) {
-        const polygon = coordinates[i];
+      for (let i = 0, ii = polygons.length; i < ii; ++i) {
+        const polygon = polygons[i];
         if (i === 0) {
           layout = polygon.getLayout();
         }
@@ -101,10 +102,11 @@ class MultiPolygon extends SimpleGeometry {
       opt_endss = endss;
     }
     if (opt_layout !== undefined && opt_endss) {
-      this.setFlatCoordinates(opt_layout, coordinates);
+      this.setFlatCoordinates(opt_layout, /** @type {Array<number>} */ (coordinates));
       this.endss_ = opt_endss;
     } else {
-      this.setCoordinates(coordinates, opt_layout);
+      this.setCoordinates(/** @type {Array<Array<Array<import("../coordinate.js").Coordinate>>>} */ (coordinates),
+        opt_layout);
     }
 
   }

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -86,10 +86,10 @@ class Polygon extends SimpleGeometry {
     this.orientedFlatCoordinates_ = null;
 
     if (opt_layout !== undefined && opt_ends) {
-      this.setFlatCoordinates(opt_layout, coordinates);
+      this.setFlatCoordinates(opt_layout, /** @type {Array<number>} */ (coordinates));
       this.ends_ = opt_ends;
     } else {
-      this.setCoordinates(coordinates, opt_layout);
+      this.setCoordinates(/** @type {Array<Array<import("../coordinate.js").Coordinate>>} */ (coordinates), opt_layout);
     }
 
   }


### PR DESCRIPTION
Fixes TypeScript errors in `ol/geom/*.js`. Remaining errors in `Geometry` and `SimpleGeometry` are caused by lack of `@abstract` support in TS.