### PR TITLE
Fix type checks in Vector source

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -783,12 +783,6 @@ class VectorSource extends Source {
 
 
   /**
-   * @override
-   */
-  getResolutions() {}
-
-
-  /**
    * Get the url associated with this source.
    *
    * @return {string|import("../featureloader.js").FeatureUrlFunction|undefined} The url.


### PR DESCRIPTION
The `getResolutions` override is unnecessary because the parent implementation also returns `undefined`.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
