### PR TITLE
Fix type checks in VectorTileSource

### DIFF
--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -36,8 +36,7 @@ class VectorImageTile extends Tile {
    * @param {Object<string, import("./VectorTile.js").default>} sourceTiles Source tiles.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("./proj/Projection.js").default} projection Projection.
-   * @param {function(new: import("./VectorTile.js").default, import("./tilecoord.js").TileCoord, TileState, string,
-   *     import("./format/Feature.js").default, import("./Tile.js").LoadFunction)} tileClass Class to
+   * @param {typeof import("./VectorTile.js").default} tileClass Class to
    *     instantiate for source tiles.
    * @param {function(this: import("./source/VectorTile.js").default, import("./events/Event.js").default)} handleTileChange
    *     Function to call when a source tile's state changes.

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -12,12 +12,6 @@ import TileState from './TileState.js';
 const DEFAULT_EXTENT = [0, 0, 4096, 4096];
 
 
-/**
- * @typedef {function(new: VectorTile, import("./tilecoord.js").TileCoord,
- * TileState, string, ?string, import("./Tile.js").LoadFunction)} TileClass
- * @api
- */
-
 class VectorTile extends Tile {
 
   /**

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -22,7 +22,7 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
  * stroke operations.
  * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {import("./State.js").default} [state] Source state.
- * @property {import("../VectorTile.js").TileClass} [tileClass] Class used to instantiate image tiles.
+ * @property {typeof import("../VectorTile.js").default} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/VectorTile}.
  * @property {number} [maxZoom=22] Optional max zoom level.
  * @property {number} [minZoom] Optional min zoom level.
@@ -123,10 +123,9 @@ class VectorTile extends UrlTile {
     this.overlaps_ = options.overlaps == undefined ? true : options.overlaps;
 
     /**
-       * @protected
-       * @type {function(new: Tile, import("../tilecoord.js").TileCoord, TileState, string,
-       *        import("../format/Feature.js").default, import("../Tile.js").LoadFunction)}
-       */
+     * @protected
+     * @type {typeof import("../VectorTile.js").default}
+     */
     this.tileClass = options.tileClass ? options.tileClass : Tile;
 
     /**


### PR DESCRIPTION
Use typedef for TileClass instead of redefining the type. Also fixed the typedef since it no longer matched the constructor.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
