### PR TITLE
Fix type check in ol/math

### DIFF
--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -35,7 +35,7 @@ export const cosh = (function() {
   } else {
     // … else, use the reference implementation of MDN:
     cosh = function(x) {
-      const y = Math.exp(x);
+      const y = /** @type {Math} */ (Math).exp(x);
       return (y + 1 / y) / 2;
     };
   }


### PR DESCRIPTION
`tsc` considers everything in the else block to be of type `never`, since it thinks that `cosh` is permanently defined for `Math`. Casting back to `Math` in the `else` block fixes the error.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
