### PR TITLE
Use typeof to simplify JSDoc class types

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -8,8 +8,7 @@ import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 
 /**
- * @typedef {function(new: ImageTile, import("./tilecoord.js").TileCoord,
- * TileState, string, ?string, import("./Tile.js").LoadFunction)} TileClass
+ * @typedef {typeof ImageTile} TileClass
  * @api
  */
 

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -7,10 +7,6 @@ import {createCanvasContext2D} from './dom.js';
 import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 
-/**
- * @typedef {typeof ImageTile} TileClass
- * @api
- */
 
 class ImageTile extends Tile {
 

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -150,15 +150,7 @@ class DragAndDrop extends Interaction {
     const formatConstructors = this.formatConstructors_;
     let features = [];
     for (let i = 0, ii = formatConstructors.length; i < ii; ++i) {
-      /**
-       * Avoid "cannot instantiate abstract class" error.
-       * @type {Function}
-       */
-      const formatConstructor = formatConstructors[i];
-      /**
-       * @type {import("../format/Feature.js").default}
-       */
-      const format = new formatConstructor();
+      const format = new formatConstructors[i]();
       features = this.tryReadFeatures_(format, result, {
         featureProjection: projection
       });

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -13,7 +13,7 @@ import {get as getProjection} from '../proj.js';
 
 /**
  * @typedef {Object} Options
- * @property {Array<function(new: import("../format/Feature.js").default)>} [formatConstructors] Format constructors.
+ * @property {Array<typeof import("../format/Feature.js").default>} [formatConstructors] Format constructors.
  * @property {import("../source/Vector.js").default} [source] Optional vector source where features will be added.  If a source is provided
  * all existing features will be removed and new features will be added when
  * they are dropped on the target.  If you want to add features to a vector
@@ -101,7 +101,7 @@ class DragAndDrop extends Interaction {
 
     /**
      * @private
-     * @type {Array<function(new: import("../format/Feature.js").default)>}
+     * @type {Array<typeof import("../format/Feature.js").default>}
      */
     this.formatConstructors_ = options.formatConstructors ?
       options.formatConstructors : [];

--- a/src/ol/render/canvas/ReplayGroup.js
+++ b/src/ol/render/canvas/ReplayGroup.js
@@ -19,9 +19,7 @@ import {create as createTransform, compose as composeTransform} from '../../tran
 
 
 /**
- * @type {Object<ReplayType,
- *                function(new: CanvasReplay, number, import("../../extent.js").Extent,
- *                number, number, boolean, Array<import("../canvas.js").DeclutterGroup>)>}
+ * @type {Object<ReplayType, typeof CanvasReplay>}
  */
 const BATCH_CONSTRUCTORS = {
   'Circle': CanvasPolygonReplay,

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -19,9 +19,7 @@ import WebGLTextReplay from '../webgl/TextReplay.js';
 const HIT_DETECTION_SIZE = [1, 1];
 
 /**
- * @type {Object<import("../ReplayType.js").default,
- *                function(new: import("./Replay.js").default, number,
- *                import("../../extent.js").Extent)>}
+ * @type {Object<import("../ReplayType.js").default, typeof import("./Replay.js").default>}
  */
 const BATCH_CONSTRUCTORS = {
   'Circle': WebGLCircleReplay,

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -27,7 +27,7 @@ import {getForProjection as getTileGridForProjection} from '../tilegrid.js';
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {import("./State.js").default} [state] Source state.
- * @property {import("../ImageTile.js").TileClass} [tileClass] Class used to instantiate image tiles.
+ * @property {typeof import("../ImageTile.js").default} [tileClass] Class used to instantiate image tiles.
  * Default is {@link module:ol/ImageTile~ImageTile}.
  * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
  * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL. The default is

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -93,8 +93,7 @@ class TileImage extends UrlTile {
 
     /**
      * @protected
-     * @type {function(new: ImageTile, import("../tilecoord.js").TileCoord, TileState, string,
-     *        ?string, import("../Tile.js").LoadFunction, import("../Tile.js").Options=)}
+     * @type {typeof ImageTile}
      */
     this.tileClass = options.tileClass !== undefined ?
       options.tileClass : ImageTile;

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -43,8 +43,8 @@ import {appendParams} from '../uri.js';
  * @property {import("../proj.js").ProjectionLike} projection Projection.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
- * @property {import("../ImageTile.js").TileClass} [tileClass] Class used to instantiate image tiles.
- * Default is {@link module:ol/ImageTile~TileClass}.
+ * @property {typeof import("../ImageTile.js").default} [tileClass] Class used to instantiate image tiles.
+ * Default is {@link module:ol/ImageTile~ImageTile}.
  * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid. Base this on the resolutions,
  * tilesize and extent supported by the server.
  * If this is not defined, a default grid will be used: if there is a projection

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -27,7 +27,7 @@ import {appendParams} from '../uri.js';
  * @property {import("./WMTSRequestEncoding.js").default|string} [requestEncoding='KVP'] Request encoding.
  * @property {string} layer Layer name as advertised in the WMTS capabilities.
  * @property {string} style Style name as advertised in the WMTS capabilities.
- * @property {import("../ImageTile.js").TileClass} [tileClass]  Class used to instantiate image tiles. Default is {@link module:ol/ImageTile~ImageTile}.
+ * @property {typeof import("../ImageTile.js").default} [tileClass]  Class used to instantiate image tiles. Default is {@link module:ol/ImageTile~ImageTile}.
  * @property {number} [tilePixelRatio=1] The pixel ratio used by the tile service.
  * For example, if the tile service advertizes 256px by 256px tiles but actually sends 512px
  * by 512px images (for retina/hidpi devices) then `tilePixelRatio`


### PR DESCRIPTION
Replaces all but one use of `function(new: ...` with `typeof` to simplify JSDoc class types. The remaining case in `WKT.js` throws `tsc` errors like `Type 'typeof Point' is not assignable to type 'typeof Geometry'.`. With `tsc` this is usually caused by the constructor signatures not matching.