### PR TITLE
Fix TS error and prevent extra string conversion

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -2076,9 +2076,10 @@ function whenParser(node, objectStack) {
 function writeColorTextNode(node, color) {
   const rgba = asArray(color);
   const opacity = (rgba.length == 4) ? rgba[3] : 1;
+  /** @type {Array<string|number>} */
   const abgr = [opacity * 255, rgba[2], rgba[1], rgba[0]];
   for (let i = 0; i < 4; ++i) {
-    const hex = parseInt(abgr[i], 10).toString(16);
+    const hex = Math.floor(/** @type {number} */ (abgr[i])).toString(16);
     abgr[i] = (hex.length == 1) ? '0' + hex : hex;
   }
   writeStringTextNode(node, abgr.join(''));


### PR DESCRIPTION
`abgr` is initially an array of numbers, so the `parseInt` call was only serving to make sure the number was an integer. Since `parseInt` casts non-string values to strings, `Math.floor` is a slightly faster way to do that. I also added extra JSDoc types to continue reusing the array with both string/number values.