### PR TITLE
Allow returning RenderFeature in ol/format/Feature

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -9,6 +9,14 @@ import Geometry from './geom/Geometry.js';
 import Style from './style/Style.js';
 
 /**
+ * @typedef {typeof Feature|typeof import("./render/Feature.js").default} FeatureClass
+ */
+
+/**
+ * @typedef {Feature|import("./render/Feature.js").default} FeatureLike
+ */
+
+/**
  * @classdesc
  * A vector object for geographic features with a geometry and other
  * attribute properties, similar to the features in vector file formats like

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -7,6 +7,16 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
 
 
 /**
+ * @typedef {typeof import("../Feature.js").default|typeof import("../render/Feature.js").default} FeatureClass
+ */
+
+
+/**
+ * @typedef {import("../Feature.js").default|import("../render/Feature.js").default} FeatureLike
+ */
+
+
+/**
  * @typedef {Object} ReadOptions
  * @property {import("../proj.js").ProjectionLike} [dataProjection] Projection of the data we are reading.
  * If not provided, the projection will be derived from the data (where possible) or
@@ -131,7 +141,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Node|Object|string} source Source.
    * @param {ReadOptions=} opt_options Read options.
-   * @return {import("../Feature.js").default} Feature.
+   * @return {FeatureLike} Feature.
    */
   readFeature(source, opt_options) {}
 
@@ -141,7 +151,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Node|ArrayBuffer|Object|string} source Source.
    * @param {ReadOptions=} opt_options Read options.
-   * @return {Array<import("../Feature.js").default>} Features.
+   * @return {Array<FeatureLike>} Features.
    */
   readFeatures(source, opt_options) {}
 

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -7,16 +7,6 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
 
 
 /**
- * @typedef {typeof import("../Feature.js").default|typeof import("../render/Feature.js").default} FeatureClass
- */
-
-
-/**
- * @typedef {import("../Feature.js").default|import("../render/Feature.js").default} FeatureLike
- */
-
-
-/**
  * @typedef {Object} ReadOptions
  * @property {import("../proj.js").ProjectionLike} [dataProjection] Projection of the data we are reading.
  * If not provided, the projection will be derived from the data (where possible) or
@@ -141,7 +131,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Node|Object|string} source Source.
    * @param {ReadOptions=} opt_options Read options.
-   * @return {FeatureLike} Feature.
+   * @return {import("../Feature.js").FeatureLike} Feature.
    */
   readFeature(source, opt_options) {}
 
@@ -151,7 +141,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Node|ArrayBuffer|Object|string} source Source.
    * @param {ReadOptions=} opt_options Read options.
-   * @return {Array<FeatureLike>} Features.
+   * @return {Array<import("../Feature.js").FeatureLike>} Features.
    */
   readFeatures(source, opt_options) {}
 

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -5,8 +5,8 @@
 
 import {assert} from '../asserts.js';
 import PBF from 'pbf';
-import FeatureFormat, {transformWithOptions} from '../format/Feature.js';
-import FormatType from '../format/FormatType.js';
+import FeatureFormat, {transformWithOptions} from './Feature.js';
+import FormatType from './FormatType.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import GeometryType from '../geom/GeometryType.js';
 import LineString from '../geom/LineString.js';
@@ -23,17 +23,14 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {function((import("../geom/Geometry.js").default|Object<string,*>)=)|function(GeometryType,Array<number>,(Array<number>|Array<Array<number>>),Object<string,*>,number)} [featureClass]
- * Class for features returned by {@link module:ol/format/MVT#readFeatures}. Set to
- * {@link module:ol/Feature~Feature} to get full editing and geometry support at the cost of
- * decreased rendering performance. The default is {@link module:ol/render/Feature~RenderFeature},
- * which is optimized for rendering and hit detection.
- * @property {string} [geometryName='geometry'] Geometry name to use when creating
- * features.
- * @property {string} [layerName='layer'] Name of the feature attribute that
- * holds the layer name.
- * @property {Array<string>} [layers] Layers to read features from. If not
- * provided, features will be read from all layers.
+ * @property {import("./Feature.js").FeatureClass} [featureClass] Class for features returned by
+ * {@link module:ol/format/MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
+ * support at the cost of decreased rendering performance. The default is
+ * {@link module:ol/render/Feature~RenderFeature}, which is optimized for rendering and hit detection.
+ * @property {string} [geometryName='geometry'] Geometry name to use when creating features.
+ * @property {string} [layerName='layer'] Name of the feature attribute that holds the layer name.
+ * @property {Array<string>} [layers] Layers to read features from. If not provided, features will be read from all
+ * layers.
  */
 
 
@@ -64,12 +61,9 @@ class MVT extends FeatureFormat {
 
     /**
      * @private
-     * @type {function((import("../geom/Geometry.js").default|Object<string,*>)=)|
-     *     function(GeometryType,Array<number>,
-     *         (Array<number>|Array<Array<number>>),Object<string,*>,number)}
+     * @type {import("./Feature.js").FeatureClass}
      */
-    this.featureClass_ = options.featureClass ?
-      options.featureClass : RenderFeature;
+    this.featureClass_ = options.featureClass ? options.featureClass : RenderFeature;
 
     /**
      * @private

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -23,7 +23,7 @@ import RenderFeature from '../render/Feature.js';
 
 /**
  * @typedef {Object} Options
- * @property {import("./Feature.js").FeatureClass} [featureClass] Class for features returned by
+ * @property {import("../Feature.js").FeatureClass} [featureClass] Class for features returned by
  * {@link module:ol/format/MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
  * support at the cost of decreased rendering performance. The default is
  * {@link module:ol/render/Feature~RenderFeature}, which is optimized for rendering and hit detection.
@@ -61,7 +61,7 @@ class MVT extends FeatureFormat {
 
     /**
      * @private
-     * @type {import("./Feature.js").FeatureClass}
+     * @type {import("../Feature.js").FeatureClass}
      */
     this.featureClass_ = options.featureClass ? options.featureClass : RenderFeature;
 

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -56,7 +56,7 @@ class DragAndDropEvent extends Event {
 
     /**
      * The features parsed from dropped data.
-     * @type {Array<import("../Feature.js").default>|undefined}
+     * @type {Array<import("../format/Feature.js").FeatureLike>|undefined}
      * @api
      */
     this.features = opt_features;
@@ -220,7 +220,7 @@ class DragAndDrop extends Interaction {
    * @param {string} text Text.
    * @param {import("../format/Feature.js").ReadOptions} options Read options.
    * @private
-   * @return {Array<import("../Feature.js").default>} Features.
+   * @return {Array<import("../format/Feature.js").FeatureLike>} Features.
    */
   tryReadFeatures_(format, text, options) {
     try {

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -56,7 +56,7 @@ class DragAndDropEvent extends Event {
 
     /**
      * The features parsed from dropped data.
-     * @type {Array<import("../format/Feature.js").FeatureLike>|undefined}
+     * @type {Array<import("../Feature.js").FeatureLike>|undefined}
      * @api
      */
     this.features = opt_features;
@@ -220,7 +220,7 @@ class DragAndDrop extends Interaction {
    * @param {string} text Text.
    * @param {import("../format/Feature.js").ReadOptions} options Read options.
    * @private
-   * @return {Array<import("../format/Feature.js").FeatureLike>} Features.
+   * @return {Array<import("../Feature.js").FeatureLike>} Features.
    */
   tryReadFeatures_(format, text, options) {
     try {


### PR DESCRIPTION
This is a simple solution to #8760, and allows other feature formats to return `RenderFeature`. I'm not certain `ol/format/Feature` is the best place for these typedef's, so please advise if they should be moved (or another approach taken entirely).

This also resolves all but one TS error in `ol/format/MVT.js`. The remaining error is caused by union types with varying signatures resulting in the type not having a construct signature.