### PR TITLE
Fix type errors from interaction event handlers

### DIFF
--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -30,9 +30,6 @@ class DragPan extends PointerInteraction {
   constructor(opt_options) {
 
     super({
-      handleDownEvent: handleDownEvent,
-      handleDragEvent: handleDragEvent,
-      handleUpEvent: handleUpEvent,
       stopDown: FALSE
     });
 
@@ -73,112 +70,102 @@ class DragPan extends PointerInteraction {
 
   }
 
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @this {DragPan}
- */
-function handleDragEvent(mapBrowserEvent) {
-  if (!this.panning_) {
-    this.panning_ = true;
-    this.getMap().getView().setHint(ViewHint.INTERACTING, 1);
-  }
-  const targetPointers = this.targetPointers;
-  const centroid = centroidFromPointers(targetPointers);
-  if (targetPointers.length == this.lastPointersCount_) {
-    if (this.kinetic_) {
-      this.kinetic_.update(centroid[0], centroid[1]);
+  /**
+   * @inheritDoc
+   */
+  handleDragEvent(mapBrowserEvent) {
+    if (!this.panning_) {
+      this.panning_ = true;
+      this.getMap().getView().setHint(ViewHint.INTERACTING, 1);
     }
-    if (this.lastCentroid) {
-      const deltaX = this.lastCentroid[0] - centroid[0];
-      const deltaY = centroid[1] - this.lastCentroid[1];
-      const map = mapBrowserEvent.map;
-      const view = map.getView();
-      let center = [deltaX, deltaY];
-      scaleCoordinate(center, view.getResolution());
-      rotateCoordinate(center, view.getRotation());
-      addCoordinate(center, view.getCenter());
-      center = view.constrainCenter(center);
-      view.setCenter(center);
-    }
-  } else if (this.kinetic_) {
-    // reset so we don't overestimate the kinetic energy after
-    // after one finger down, tiny drag, second finger down
-    this.kinetic_.begin();
-  }
-  this.lastCentroid = centroid;
-  this.lastPointersCount_ = targetPointers.length;
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Stop drag sequence?
- * @this {DragPan}
- */
-function handleUpEvent(mapBrowserEvent) {
-  const map = mapBrowserEvent.map;
-  const view = map.getView();
-  if (this.targetPointers.length === 0) {
-    if (!this.noKinetic_ && this.kinetic_ && this.kinetic_.end()) {
-      const distance = this.kinetic_.getDistance();
-      const angle = this.kinetic_.getAngle();
-      const center = /** @type {!import("../coordinate.js").Coordinate} */ (view.getCenter());
-      const centerpx = map.getPixelFromCoordinate(center);
-      const dest = map.getCoordinateFromPixel([
-        centerpx[0] - distance * Math.cos(angle),
-        centerpx[1] - distance * Math.sin(angle)
-      ]);
-      view.animate({
-        center: view.constrainCenter(dest),
-        duration: 500,
-        easing: easeOut
-      });
-    }
-    if (this.panning_) {
-      this.panning_ = false;
-      view.setHint(ViewHint.INTERACTING, -1);
-    }
-    return false;
-  } else {
-    if (this.kinetic_) {
+    const targetPointers = this.targetPointers;
+    const centroid = centroidFromPointers(targetPointers);
+    if (targetPointers.length == this.lastPointersCount_) {
+      if (this.kinetic_) {
+        this.kinetic_.update(centroid[0], centroid[1]);
+      }
+      if (this.lastCentroid) {
+        const deltaX = this.lastCentroid[0] - centroid[0];
+        const deltaY = centroid[1] - this.lastCentroid[1];
+        const map = mapBrowserEvent.map;
+        const view = map.getView();
+        let center = [deltaX, deltaY];
+        scaleCoordinate(center, view.getResolution());
+        rotateCoordinate(center, view.getRotation());
+        addCoordinate(center, view.getCenter());
+        center = view.constrainCenter(center);
+        view.setCenter(center);
+      }
+    } else if (this.kinetic_) {
       // reset so we don't overestimate the kinetic energy after
-      // after one finger up, tiny drag, second finger up
+      // after one finger down, tiny drag, second finger down
       this.kinetic_.begin();
     }
-    this.lastCentroid = null;
-    return true;
+    this.lastCentroid = centroid;
+    this.lastPointersCount_ = targetPointers.length;
   }
-}
 
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Start drag sequence?
- * @this {DragPan}
- */
-function handleDownEvent(mapBrowserEvent) {
-  if (this.targetPointers.length > 0 && this.condition_(mapBrowserEvent)) {
+  /**
+   * @inheritDoc
+   */
+  handleUpEvent(mapBrowserEvent) {
     const map = mapBrowserEvent.map;
     const view = map.getView();
-    this.lastCentroid = null;
-    // stop any current animation
-    if (view.getAnimating()) {
-      view.setCenter(mapBrowserEvent.frameState.viewState.center);
+    if (this.targetPointers.length === 0) {
+      if (!this.noKinetic_ && this.kinetic_ && this.kinetic_.end()) {
+        const distance = this.kinetic_.getDistance();
+        const angle = this.kinetic_.getAngle();
+        const center = /** @type {!import("../coordinate.js").Coordinate} */ (view.getCenter());
+        const centerpx = map.getPixelFromCoordinate(center);
+        const dest = map.getCoordinateFromPixel([
+          centerpx[0] - distance * Math.cos(angle),
+          centerpx[1] - distance * Math.sin(angle)
+        ]);
+        view.animate({
+          center: view.constrainCenter(dest),
+          duration: 500,
+          easing: easeOut
+        });
+      }
+      if (this.panning_) {
+        this.panning_ = false;
+        view.setHint(ViewHint.INTERACTING, -1);
+      }
+      return false;
+    } else {
+      if (this.kinetic_) {
+        // reset so we don't overestimate the kinetic energy after
+        // after one finger up, tiny drag, second finger up
+        this.kinetic_.begin();
+      }
+      this.lastCentroid = null;
+      return true;
     }
-    if (this.kinetic_) {
-      this.kinetic_.begin();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(mapBrowserEvent) {
+    if (this.targetPointers.length > 0 && this.condition_(mapBrowserEvent)) {
+      const map = mapBrowserEvent.map;
+      const view = map.getView();
+      this.lastCentroid = null;
+      // stop any current animation
+      if (view.getAnimating()) {
+        view.setCenter(mapBrowserEvent.frameState.viewState.center);
+      }
+      if (this.kinetic_) {
+        this.kinetic_.begin();
+      }
+      // No kinetic as soon as more than one pointer on the screen is
+      // detected. This is to prevent nasty pans after pinch.
+      this.noKinetic_ = this.targetPointers.length > 1;
+      return true;
+    } else {
+      return false;
     }
-    // No kinetic as soon as more than one pointer on the screen is
-    // detected. This is to prevent nasty pans after pinch.
-    this.noKinetic_ = this.targetPointers.length > 1;
-    return true;
-  } else {
-    return false;
   }
 }
-
 
 export default DragPan;

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -38,9 +38,6 @@ class DragRotate extends PointerInteraction {
     const options = opt_options ? opt_options : {};
 
     super({
-      handleDownEvent: handleDownEvent,
-      handleDragEvent: handleDragEvent,
-      handleUpEvent: handleUpEvent,
       stopDown: FALSE
     });
 
@@ -64,72 +61,65 @@ class DragRotate extends PointerInteraction {
 
   }
 
-}
+  /**
+   * @inheritDoc
+   */
+  handleDragEvent(mapBrowserEvent) {
+    if (!mouseOnly(mapBrowserEvent)) {
+      return;
+    }
 
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @this {DragRotate}
- */
-function handleDragEvent(mapBrowserEvent) {
-  if (!mouseOnly(mapBrowserEvent)) {
-    return;
-  }
-
-  const map = mapBrowserEvent.map;
-  const view = map.getView();
-  if (view.getConstraints().rotation === disable) {
-    return;
-  }
-  const size = map.getSize();
-  const offset = mapBrowserEvent.pixel;
-  const theta =
-      Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
-  if (this.lastAngle_ !== undefined) {
-    const delta = theta - this.lastAngle_;
-    const rotation = view.getRotation();
-    rotateWithoutConstraints(view, rotation - delta);
-  }
-  this.lastAngle_ = theta;
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Stop drag sequence?
- * @this {DragRotate}
- */
-function handleUpEvent(mapBrowserEvent) {
-  if (!mouseOnly(mapBrowserEvent)) {
-    return true;
-  }
-
-  const map = mapBrowserEvent.map;
-  const view = map.getView();
-  view.setHint(ViewHint.INTERACTING, -1);
-  const rotation = view.getRotation();
-  rotate(view, rotation, undefined, this.duration_);
-  return false;
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Start drag sequence?
- * @this {DragRotate}
- */
-function handleDownEvent(mapBrowserEvent) {
-  if (!mouseOnly(mapBrowserEvent)) {
-    return false;
-  }
-
-  if (mouseActionButton(mapBrowserEvent) && this.condition_(mapBrowserEvent)) {
     const map = mapBrowserEvent.map;
-    map.getView().setHint(ViewHint.INTERACTING, 1);
-    this.lastAngle_ = undefined;
-    return true;
-  } else {
+    const view = map.getView();
+    if (view.getConstraints().rotation === disable) {
+      return;
+    }
+    const size = map.getSize();
+    const offset = mapBrowserEvent.pixel;
+    const theta =
+        Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
+    if (this.lastAngle_ !== undefined) {
+      const delta = theta - this.lastAngle_;
+      const rotation = view.getRotation();
+      rotateWithoutConstraints(view, rotation - delta);
+    }
+    this.lastAngle_ = theta;
+  }
+
+
+  /**
+   * @inheritDoc
+   */
+  handleUpEvent(mapBrowserEvent) {
+    if (!mouseOnly(mapBrowserEvent)) {
+      return true;
+    }
+
+    const map = mapBrowserEvent.map;
+    const view = map.getView();
+    view.setHint(ViewHint.INTERACTING, -1);
+    const rotation = view.getRotation();
+    rotate(view, rotation, undefined, this.duration_);
     return false;
+  }
+
+
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(mapBrowserEvent) {
+    if (!mouseOnly(mapBrowserEvent)) {
+      return false;
+    }
+
+    if (mouseActionButton(mapBrowserEvent) && this.condition_(mapBrowserEvent)) {
+      const map = mapBrowserEvent.map;
+      map.getView().setHint(ViewHint.INTERACTING, 1);
+      this.lastAngle_ = undefined;
+      return true;
+    } else {
+      return false;
+    }
   }
 }
 

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -38,11 +38,7 @@ class DragRotateAndZoom extends PointerInteraction {
 
     const options = opt_options ? opt_options : {};
 
-    super({
-      handleDownEvent: handleDownEvent,
-      handleDragEvent: handleDragEvent,
-      handleUpEvent: handleUpEvent
-    });
+    super(options);
 
     /**
      * @private
@@ -76,80 +72,71 @@ class DragRotateAndZoom extends PointerInteraction {
 
   }
 
-}
+  /**
+   * @inheritDoc
+   */
+  handleDragEvent(mapBrowserEvent) {
+    if (!mouseOnly(mapBrowserEvent)) {
+      return;
+    }
 
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @this {DragRotateAndZoom}
- */
-function handleDragEvent(mapBrowserEvent) {
-  if (!mouseOnly(mapBrowserEvent)) {
-    return;
+    const map = mapBrowserEvent.map;
+    const size = map.getSize();
+    const offset = mapBrowserEvent.pixel;
+    const deltaX = offset[0] - size[0] / 2;
+    const deltaY = size[1] / 2 - offset[1];
+    const theta = Math.atan2(deltaY, deltaX);
+    const magnitude = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    const view = map.getView();
+    if (view.getConstraints().rotation !== disable && this.lastAngle_ !== undefined) {
+      const angleDelta = theta - this.lastAngle_;
+      rotateWithoutConstraints(view, view.getRotation() - angleDelta);
+    }
+    this.lastAngle_ = theta;
+    if (this.lastMagnitude_ !== undefined) {
+      const resolution = this.lastMagnitude_ * (view.getResolution() / magnitude);
+      zoomWithoutConstraints(view, resolution);
+    }
+    if (this.lastMagnitude_ !== undefined) {
+      this.lastScaleDelta_ = this.lastMagnitude_ / magnitude;
+    }
+    this.lastMagnitude_ = magnitude;
   }
 
-  const map = mapBrowserEvent.map;
-  const size = map.getSize();
-  const offset = mapBrowserEvent.pixel;
-  const deltaX = offset[0] - size[0] / 2;
-  const deltaY = size[1] / 2 - offset[1];
-  const theta = Math.atan2(deltaY, deltaX);
-  const magnitude = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-  const view = map.getView();
-  if (view.getConstraints().rotation !== disable && this.lastAngle_ !== undefined) {
-    const angleDelta = theta - this.lastAngle_;
-    rotateWithoutConstraints(view, view.getRotation() - angleDelta);
-  }
-  this.lastAngle_ = theta;
-  if (this.lastMagnitude_ !== undefined) {
-    const resolution = this.lastMagnitude_ * (view.getResolution() / magnitude);
-    zoomWithoutConstraints(view, resolution);
-  }
-  if (this.lastMagnitude_ !== undefined) {
-    this.lastScaleDelta_ = this.lastMagnitude_ / magnitude;
-  }
-  this.lastMagnitude_ = magnitude;
-}
+  /**
+   * @inheritDoc
+   */
+  handleUpEvent(mapBrowserEvent) {
+    if (!mouseOnly(mapBrowserEvent)) {
+      return true;
+    }
 
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Stop drag sequence?
- * @this {DragRotateAndZoom}
- */
-function handleUpEvent(mapBrowserEvent) {
-  if (!mouseOnly(mapBrowserEvent)) {
-    return true;
-  }
-
-  const map = mapBrowserEvent.map;
-  const view = map.getView();
-  view.setHint(ViewHint.INTERACTING, -1);
-  const direction = this.lastScaleDelta_ - 1;
-  rotate(view, view.getRotation());
-  zoom(view, view.getResolution(), undefined, this.duration_, direction);
-  this.lastScaleDelta_ = 0;
-  return false;
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Start drag sequence?
- * @this {DragRotateAndZoom}
- */
-function handleDownEvent(mapBrowserEvent) {
-  if (!mouseOnly(mapBrowserEvent)) {
+    const map = mapBrowserEvent.map;
+    const view = map.getView();
+    view.setHint(ViewHint.INTERACTING, -1);
+    const direction = this.lastScaleDelta_ - 1;
+    rotate(view, view.getRotation());
+    zoom(view, view.getResolution(), undefined, this.duration_, direction);
+    this.lastScaleDelta_ = 0;
     return false;
   }
 
-  if (this.condition_(mapBrowserEvent)) {
-    mapBrowserEvent.map.getView().setHint(ViewHint.INTERACTING, 1);
-    this.lastAngle_ = undefined;
-    this.lastMagnitude_ = undefined;
-    return true;
-  } else {
-    return false;
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(mapBrowserEvent) {
+    if (!mouseOnly(mapBrowserEvent)) {
+      return false;
+    }
+
+    if (this.condition_(mapBrowserEvent)) {
+      mapBrowserEvent.map.getView().setHint(ViewHint.INTERACTING, 1);
+      this.lastAngle_ = undefined;
+      this.lastMagnitude_ = undefined;
+      return true;
+    } else {
+      return false;
+    }
   }
 }
 

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -38,7 +38,7 @@ class DragRotateAndZoom extends PointerInteraction {
 
     const options = opt_options ? opt_options : {};
 
-    super(options);
+    super(/** @type {import("./Pointer.js").Options} */ (options));
 
     /**
      * @private

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -10,7 +10,7 @@ import {boundingExtent, getArea} from '../extent.js';
 import GeometryType from '../geom/GeometryType.js';
 import Point from '../geom/Point.js';
 import {fromExtent as polygonFromExtent} from '../geom/Polygon.js';
-import PointerInteraction, {handleEvent as handlePointerEvent} from '../interaction/Pointer.js';
+import PointerInteraction from '../interaction/Pointer.js';
 import VectorLayer from '../layer/Vector.js';
 import VectorSource from '../source/Vector.js';
 import {createEditingStyle} from '../style/Style.js';
@@ -85,14 +85,9 @@ class ExtentInteraction extends PointerInteraction {
    */
   constructor(opt_options) {
 
-    super({
-      handleDownEvent: handleDownEvent,
-      handleDragEvent: handleDragEvent,
-      handleEvent: handleEvent,
-      handleUpEvent: handleUpEvent
-    });
-
     const options = opt_options || {};
+
+    super(/** @type {import("./Pointer.js").Options} */ (options));
 
     /**
      * Extent of the drawn box
@@ -280,6 +275,105 @@ class ExtentInteraction extends PointerInteraction {
   /**
    * @inheritDoc
    */
+  handleEvent(mapBrowserEvent) {
+    if (!(mapBrowserEvent instanceof MapBrowserPointerEvent)) {
+      return true;
+    }
+    //display pointer (if not dragging)
+    if (mapBrowserEvent.type == MapBrowserEventType.POINTERMOVE && !this.handlingDownUpSequence) {
+      this.handlePointerMove_(mapBrowserEvent);
+    }
+    //call pointer to determine up/down/drag
+    super.handleEvent(mapBrowserEvent);
+    //return false to stop propagation
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(mapBrowserEvent) {
+    const pixel = mapBrowserEvent.pixel;
+    const map = mapBrowserEvent.map;
+
+    const extent = this.getExtent();
+    let vertex = this.snapToVertex_(pixel, map);
+
+    //find the extent corner opposite the passed corner
+    const getOpposingPoint = function(point) {
+      let x_ = null;
+      let y_ = null;
+      if (point[0] == extent[0]) {
+        x_ = extent[2];
+      } else if (point[0] == extent[2]) {
+        x_ = extent[0];
+      }
+      if (point[1] == extent[1]) {
+        y_ = extent[3];
+      } else if (point[1] == extent[3]) {
+        y_ = extent[1];
+      }
+      if (x_ !== null && y_ !== null) {
+        return [x_, y_];
+      }
+      return null;
+    };
+    if (vertex && extent) {
+      const x = (vertex[0] == extent[0] || vertex[0] == extent[2]) ? vertex[0] : null;
+      const y = (vertex[1] == extent[1] || vertex[1] == extent[3]) ? vertex[1] : null;
+
+      //snap to point
+      if (x !== null && y !== null) {
+        this.pointerHandler_ = getPointHandler(getOpposingPoint(vertex));
+      //snap to edge
+      } else if (x !== null) {
+        this.pointerHandler_ = getEdgeHandler(
+          getOpposingPoint([x, extent[1]]),
+          getOpposingPoint([x, extent[3]])
+        );
+      } else if (y !== null) {
+        this.pointerHandler_ = getEdgeHandler(
+          getOpposingPoint([extent[0], y]),
+          getOpposingPoint([extent[2], y])
+        );
+      }
+    //no snap - new bbox
+    } else {
+      vertex = map.getCoordinateFromPixel(pixel);
+      this.setExtent([vertex[0], vertex[1], vertex[0], vertex[1]]);
+      this.pointerHandler_ = getPointHandler(vertex);
+    }
+    return true; //event handled; start downup sequence
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDragEvent(mapBrowserEvent) {
+    if (this.pointerHandler_) {
+      const pixelCoordinate = mapBrowserEvent.coordinate;
+      this.setExtent(this.pointerHandler_(pixelCoordinate));
+      this.createOrUpdatePointerFeature_(pixelCoordinate);
+    }
+    return true;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleUpEvent(mapBrowserEvent) {
+    this.pointerHandler_ = null;
+    //If bbox is zero area, set to null;
+    const extent = this.getExtent();
+    if (!extent || getArea(extent) === 0) {
+      this.setExtent(null);
+    }
+    return false; //Stop handling downup sequence
+  }
+
+  /**
+   * @inheritDoc
+   */
   setMap(map) {
     this.extentOverlay_.setMap(map);
     this.vertexOverlay_.setMap(map);
@@ -308,113 +402,6 @@ class ExtentInteraction extends PointerInteraction {
     this.createOrUpdateExtentFeature_(extent);
     this.dispatchEvent(new ExtentInteractionEvent(this.extent_));
   }
-}
-
-/**
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Propagate event?
- * @this {ExtentInteraction}
- */
-function handleEvent(mapBrowserEvent) {
-  if (!(mapBrowserEvent instanceof MapBrowserPointerEvent)) {
-    return true;
-  }
-  //display pointer (if not dragging)
-  if (mapBrowserEvent.type == MapBrowserEventType.POINTERMOVE && !this.handlingDownUpSequence) {
-    this.handlePointerMove_(mapBrowserEvent);
-  }
-  //call pointer to determine up/down/drag
-  handlePointerEvent.call(this, mapBrowserEvent);
-  //return false to stop propagation
-  return false;
-}
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Event handled?
- * @this {ExtentInteraction}
- */
-function handleDownEvent(mapBrowserEvent) {
-  const pixel = mapBrowserEvent.pixel;
-  const map = mapBrowserEvent.map;
-
-  const extent = this.getExtent();
-  let vertex = this.snapToVertex_(pixel, map);
-
-  //find the extent corner opposite the passed corner
-  const getOpposingPoint = function(point) {
-    let x_ = null;
-    let y_ = null;
-    if (point[0] == extent[0]) {
-      x_ = extent[2];
-    } else if (point[0] == extent[2]) {
-      x_ = extent[0];
-    }
-    if (point[1] == extent[1]) {
-      y_ = extent[3];
-    } else if (point[1] == extent[3]) {
-      y_ = extent[1];
-    }
-    if (x_ !== null && y_ !== null) {
-      return [x_, y_];
-    }
-    return null;
-  };
-  if (vertex && extent) {
-    const x = (vertex[0] == extent[0] || vertex[0] == extent[2]) ? vertex[0] : null;
-    const y = (vertex[1] == extent[1] || vertex[1] == extent[3]) ? vertex[1] : null;
-
-    //snap to point
-    if (x !== null && y !== null) {
-      this.pointerHandler_ = getPointHandler(getOpposingPoint(vertex));
-    //snap to edge
-    } else if (x !== null) {
-      this.pointerHandler_ = getEdgeHandler(
-        getOpposingPoint([x, extent[1]]),
-        getOpposingPoint([x, extent[3]])
-      );
-    } else if (y !== null) {
-      this.pointerHandler_ = getEdgeHandler(
-        getOpposingPoint([extent[0], y]),
-        getOpposingPoint([extent[2], y])
-      );
-    }
-  //no snap - new bbox
-  } else {
-    vertex = map.getCoordinateFromPixel(pixel);
-    this.setExtent([vertex[0], vertex[1], vertex[0], vertex[1]]);
-    this.pointerHandler_ = getPointHandler(vertex);
-  }
-  return true; //event handled; start downup sequence
-}
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Event handled?
- * @this {ExtentInteraction}
- */
-function handleDragEvent(mapBrowserEvent) {
-  if (this.pointerHandler_) {
-    const pixelCoordinate = mapBrowserEvent.coordinate;
-    this.setExtent(this.pointerHandler_(pixelCoordinate));
-    this.createOrUpdatePointerFeature_(pixelCoordinate);
-  }
-  return true;
-}
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Stop drag sequence?
- * @this {ExtentInteraction}
- */
-function handleUpEvent(mapBrowserEvent) {
-  this.pointerHandler_ = null;
-  //If bbox is zero area, set to null;
-  const extent = this.getExtent();
-  if (!extent || getArea(extent) === 0) {
-    this.setExtent(null);
-  }
-  return false; //Stop handling downup sequence
 }
 
 /**

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -243,7 +243,7 @@ class ExtentInteraction extends PointerInteraction {
         extentFeature = new Feature(polygonFromExtent(extent));
       }
       this.extentFeature_ = extentFeature;
-      this.extentOverlay_.getSource().addFeature(extentFeature);
+      /** @type {VectorSource} */ (this.extentOverlay_.getSource()).addFeature(extentFeature);
     } else {
       if (!extent) {
         extentFeature.setGeometry(undefined);
@@ -264,7 +264,7 @@ class ExtentInteraction extends PointerInteraction {
     if (!vertexFeature) {
       vertexFeature = new Feature(new Point(vertex));
       this.vertexFeature_ = vertexFeature;
-      this.vertexOverlay_.getSource().addFeature(vertexFeature);
+      /** @type {VectorSource} */ (this.vertexOverlay_.getSource()).addFeature(vertexFeature);
     } else {
       const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(vertex);

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -38,6 +38,10 @@ class Interaction extends BaseObject {
   constructor(options) {
     super();
 
+    if (options.handleEvent) {
+      this.handleEvent = options.handleEvent;
+    }
+
     /**
      * @private
      * @type {import("../PluggableMap.js").default}
@@ -45,12 +49,6 @@ class Interaction extends BaseObject {
     this.map_ = null;
 
     this.setActive(true);
-
-    /**
-     * @type {function(import("../MapBrowserEvent.js").default):boolean}
-     */
-    this.handleEvent = options.handleEvent;
-
   }
 
   /**
@@ -70,6 +68,16 @@ class Interaction extends BaseObject {
    */
   getMap() {
     return this.map_;
+  }
+
+  /**
+   * Handles the {@link module:ol/MapBrowserEvent map browser event}.
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+   * @return {boolean} `false` to stop event propagation.
+   * @api
+   */
+  handleEvent(mapBrowserEvent) {
+    return true;
   }
 
   /**

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -54,11 +54,9 @@ class MouseWheelZoom extends Interaction {
    */
   constructor(opt_options) {
 
-    super({
-      handleEvent: handleEvent
-    });
+    const options = opt_options ? opt_options : {};
 
-    const options = opt_options || {};
+    super(/** @type {import("./Interaction.js").InteractionOptions} */ (options));
 
     /**
      * @private
@@ -158,6 +156,127 @@ class MouseWheelZoom extends Interaction {
   }
 
   /**
+   * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a mousewheel-event) and eventually
+   * zooms the map.
+   * @override
+   */
+  handleEvent(mapBrowserEvent) {
+    if (!this.condition_(mapBrowserEvent)) {
+      return true;
+    }
+    const type = mapBrowserEvent.type;
+    if (type !== EventType.WHEEL && type !== EventType.MOUSEWHEEL) {
+      return true;
+    }
+
+    mapBrowserEvent.preventDefault();
+
+    const map = mapBrowserEvent.map;
+    const wheelEvent = /** @type {WheelEvent} */ (mapBrowserEvent.originalEvent);
+
+    if (this.useAnchor_) {
+      this.lastAnchor_ = mapBrowserEvent.coordinate;
+    }
+
+    // Delta normalisation inspired by
+    // https://github.com/mapbox/mapbox-gl-js/blob/001c7b9/js/ui/handler/scroll_zoom.js
+    let delta;
+    if (mapBrowserEvent.type == EventType.WHEEL) {
+      delta = wheelEvent.deltaY;
+      if (FIREFOX &&
+          wheelEvent.deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
+        delta /= DEVICE_PIXEL_RATIO;
+      }
+      if (wheelEvent.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+        delta *= 40;
+      }
+    } else if (mapBrowserEvent.type == EventType.MOUSEWHEEL) {
+      delta = -wheelEvent.wheelDeltaY;
+      if (SAFARI) {
+        delta /= 3;
+      }
+    }
+
+    if (delta === 0) {
+      return false;
+    }
+
+    const now = Date.now();
+
+    if (this.startTime_ === undefined) {
+      this.startTime_ = now;
+    }
+
+    if (!this.mode_ || now - this.startTime_ > this.trackpadEventGap_) {
+      this.mode_ = Math.abs(delta) < 4 ?
+        Mode.TRACKPAD :
+        Mode.WHEEL;
+    }
+
+    if (this.mode_ === Mode.TRACKPAD) {
+      const view = map.getView();
+      if (this.trackpadTimeoutId_) {
+        clearTimeout(this.trackpadTimeoutId_);
+      } else {
+        view.setHint(ViewHint.INTERACTING, 1);
+      }
+      this.trackpadTimeoutId_ = setTimeout(this.decrementInteractingHint_.bind(this), this.trackpadEventGap_);
+      let resolution = view.getResolution() * Math.pow(2, delta / this.trackpadDeltaPerZoom_);
+      const minResolution = view.getMinResolution();
+      const maxResolution = view.getMaxResolution();
+      let rebound = 0;
+      if (resolution < minResolution) {
+        resolution = Math.max(resolution, minResolution / this.trackpadZoomBuffer_);
+        rebound = 1;
+      } else if (resolution > maxResolution) {
+        resolution = Math.min(resolution, maxResolution * this.trackpadZoomBuffer_);
+        rebound = -1;
+      }
+      if (this.lastAnchor_) {
+        const center = view.calculateCenterZoom(resolution, this.lastAnchor_);
+        view.setCenter(view.constrainCenter(center));
+      }
+      view.setResolution(resolution);
+
+      if (rebound === 0 && this.constrainResolution_) {
+        view.animate({
+          resolution: view.constrainResolution(resolution, delta > 0 ? -1 : 1),
+          easing: easeOut,
+          anchor: this.lastAnchor_,
+          duration: this.duration_
+        });
+      }
+
+      if (rebound > 0) {
+        view.animate({
+          resolution: minResolution,
+          easing: easeOut,
+          anchor: this.lastAnchor_,
+          duration: 500
+        });
+      } else if (rebound < 0) {
+        view.animate({
+          resolution: maxResolution,
+          easing: easeOut,
+          anchor: this.lastAnchor_,
+          duration: 500
+        });
+      }
+      this.startTime_ = now;
+      return false;
+    }
+
+    this.delta_ += delta;
+
+    const timeLeft = Math.max(this.timeout_ - (now - this.startTime_), 0);
+
+    clearTimeout(this.timeoutId_);
+    this.timeoutId_ = setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
+
+    return false;
+  }
+
+  /**
    * @private
    * @param {import("../PluggableMap.js").default} map Map.
    */
@@ -189,130 +308,5 @@ class MouseWheelZoom extends Interaction {
     }
   }
 }
-
-
-/**
- * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
- * mousewheel-event) and eventually zooms the map.
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
- * @return {boolean} Allow event propagation.
- * @this {MouseWheelZoom}
- */
-function handleEvent(mapBrowserEvent) {
-  if (!this.condition_(mapBrowserEvent)) {
-    return true;
-  }
-  const type = mapBrowserEvent.type;
-  if (type !== EventType.WHEEL && type !== EventType.MOUSEWHEEL) {
-    return true;
-  }
-
-  mapBrowserEvent.preventDefault();
-
-  const map = mapBrowserEvent.map;
-  const wheelEvent = /** @type {WheelEvent} */ (mapBrowserEvent.originalEvent);
-
-  if (this.useAnchor_) {
-    this.lastAnchor_ = mapBrowserEvent.coordinate;
-  }
-
-  // Delta normalisation inspired by
-  // https://github.com/mapbox/mapbox-gl-js/blob/001c7b9/js/ui/handler/scroll_zoom.js
-  let delta;
-  if (mapBrowserEvent.type == EventType.WHEEL) {
-    delta = wheelEvent.deltaY;
-    if (FIREFOX &&
-        wheelEvent.deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
-      delta /= DEVICE_PIXEL_RATIO;
-    }
-    if (wheelEvent.deltaMode === WheelEvent.DOM_DELTA_LINE) {
-      delta *= 40;
-    }
-  } else if (mapBrowserEvent.type == EventType.MOUSEWHEEL) {
-    delta = -wheelEvent.wheelDeltaY;
-    if (SAFARI) {
-      delta /= 3;
-    }
-  }
-
-  if (delta === 0) {
-    return false;
-  }
-
-  const now = Date.now();
-
-  if (this.startTime_ === undefined) {
-    this.startTime_ = now;
-  }
-
-  if (!this.mode_ || now - this.startTime_ > this.trackpadEventGap_) {
-    this.mode_ = Math.abs(delta) < 4 ?
-      Mode.TRACKPAD :
-      Mode.WHEEL;
-  }
-
-  if (this.mode_ === Mode.TRACKPAD) {
-    const view = map.getView();
-    if (this.trackpadTimeoutId_) {
-      clearTimeout(this.trackpadTimeoutId_);
-    } else {
-      view.setHint(ViewHint.INTERACTING, 1);
-    }
-    this.trackpadTimeoutId_ = setTimeout(this.decrementInteractingHint_.bind(this), this.trackpadEventGap_);
-    let resolution = view.getResolution() * Math.pow(2, delta / this.trackpadDeltaPerZoom_);
-    const minResolution = view.getMinResolution();
-    const maxResolution = view.getMaxResolution();
-    let rebound = 0;
-    if (resolution < minResolution) {
-      resolution = Math.max(resolution, minResolution / this.trackpadZoomBuffer_);
-      rebound = 1;
-    } else if (resolution > maxResolution) {
-      resolution = Math.min(resolution, maxResolution * this.trackpadZoomBuffer_);
-      rebound = -1;
-    }
-    if (this.lastAnchor_) {
-      const center = view.calculateCenterZoom(resolution, this.lastAnchor_);
-      view.setCenter(view.constrainCenter(center));
-    }
-    view.setResolution(resolution);
-
-    if (rebound === 0 && this.constrainResolution_) {
-      view.animate({
-        resolution: view.constrainResolution(resolution, delta > 0 ? -1 : 1),
-        easing: easeOut,
-        anchor: this.lastAnchor_,
-        duration: this.duration_
-      });
-    }
-
-    if (rebound > 0) {
-      view.animate({
-        resolution: minResolution,
-        easing: easeOut,
-        anchor: this.lastAnchor_,
-        duration: 500
-      });
-    } else if (rebound < 0) {
-      view.animate({
-        resolution: maxResolution,
-        easing: easeOut,
-        anchor: this.lastAnchor_,
-        duration: 500
-      });
-    }
-    this.startTime_ = now;
-    return false;
-  }
-
-  this.delta_ += delta;
-
-  const timeLeft = Math.max(this.timeout_ - (now - this.startTime_), 0);
-
-  clearTimeout(this.timeoutId_);
-  this.timeoutId_ = setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
-
-  return false;
-}
-
 
 export default MouseWheelZoom;

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -28,14 +28,15 @@ class PinchRotate extends PointerInteraction {
    */
   constructor(opt_options) {
 
-    super({
-      handleDownEvent: handleDownEvent,
-      handleDragEvent: handleDragEvent,
-      handleUpEvent: handleUpEvent,
-      stopDown: FALSE
-    });
+    const options = opt_options ? opt_options : {};
 
-    const options = opt_options || {};
+    const pointerOptions = /** @type {import("./Pointer.js").Options} */ (options);
+
+    if (!pointerOptions.stopDown) {
+      pointerOptions.stopDown = FALSE;
+    }
+
+    super(pointerOptions);
 
     /**
      * @private
@@ -75,98 +76,89 @@ class PinchRotate extends PointerInteraction {
 
   }
 
-}
+  /**
+   * @inheritDoc
+   */
+  handleDragEvent(mapBrowserEvent) {
+    let rotationDelta = 0.0;
 
+    const touch0 = this.targetPointers[0];
+    const touch1 = this.targetPointers[1];
 
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @this {PinchRotate}
- */
-function handleDragEvent(mapBrowserEvent) {
-  let rotationDelta = 0.0;
+    // angle between touches
+    const angle = Math.atan2(
+      touch1.clientY - touch0.clientY,
+      touch1.clientX - touch0.clientX);
 
-  const touch0 = this.targetPointers[0];
-  const touch1 = this.targetPointers[1];
-
-  // angle between touches
-  const angle = Math.atan2(
-    touch1.clientY - touch0.clientY,
-    touch1.clientX - touch0.clientX);
-
-  if (this.lastAngle_ !== undefined) {
-    const delta = angle - this.lastAngle_;
-    this.rotationDelta_ += delta;
-    if (!this.rotating_ &&
-        Math.abs(this.rotationDelta_) > this.threshold_) {
-      this.rotating_ = true;
+    if (this.lastAngle_ !== undefined) {
+      const delta = angle - this.lastAngle_;
+      this.rotationDelta_ += delta;
+      if (!this.rotating_ &&
+          Math.abs(this.rotationDelta_) > this.threshold_) {
+        this.rotating_ = true;
+      }
+      rotationDelta = delta;
     }
-    rotationDelta = delta;
-  }
-  this.lastAngle_ = angle;
+    this.lastAngle_ = angle;
 
-  const map = mapBrowserEvent.map;
-  const view = map.getView();
-  if (view.getConstraints().rotation === disable) {
-    return;
-  }
-
-  // rotate anchor point.
-  // FIXME: should be the intersection point between the lines:
-  //     touch0,touch1 and previousTouch0,previousTouch1
-  const viewportPosition = map.getViewport().getBoundingClientRect();
-  const centroid = centroidFromPointers(this.targetPointers);
-  centroid[0] -= viewportPosition.left;
-  centroid[1] -= viewportPosition.top;
-  this.anchor_ = map.getCoordinateFromPixel(centroid);
-
-  // rotate
-  if (this.rotating_) {
-    const rotation = view.getRotation();
-    map.render();
-    rotateWithoutConstraints(view, rotation + rotationDelta, this.anchor_);
-  }
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Stop drag sequence?
- * @this {PinchRotate}
- */
-function handleUpEvent(mapBrowserEvent) {
-  if (this.targetPointers.length < 2) {
     const map = mapBrowserEvent.map;
     const view = map.getView();
-    view.setHint(ViewHint.INTERACTING, -1);
+    if (view.getConstraints().rotation === disable) {
+      return;
+    }
+
+    // rotate anchor point.
+    // FIXME: should be the intersection point between the lines:
+    //     touch0,touch1 and previousTouch0,previousTouch1
+    const viewportPosition = map.getViewport().getBoundingClientRect();
+    const centroid = centroidFromPointers(this.targetPointers);
+    centroid[0] -= viewportPosition.left;
+    centroid[1] -= viewportPosition.top;
+    this.anchor_ = map.getCoordinateFromPixel(centroid);
+
+    // rotate
     if (this.rotating_) {
       const rotation = view.getRotation();
-      rotate(view, rotation, this.anchor_, this.duration_);
+      map.render();
+      rotateWithoutConstraints(view, rotation + rotationDelta, this.anchor_);
     }
-    return false;
-  } else {
-    return true;
   }
-}
 
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Start drag sequence?
- * @this {PinchRotate}
- */
-function handleDownEvent(mapBrowserEvent) {
-  if (this.targetPointers.length >= 2) {
-    const map = mapBrowserEvent.map;
-    this.anchor_ = null;
-    this.lastAngle_ = undefined;
-    this.rotating_ = false;
-    this.rotationDelta_ = 0.0;
-    if (!this.handlingDownUpSequence) {
-      map.getView().setHint(ViewHint.INTERACTING, 1);
+  /**
+   * @inheritDoc
+   */
+  handleUpEvent(mapBrowserEvent) {
+    if (this.targetPointers.length < 2) {
+      const map = mapBrowserEvent.map;
+      const view = map.getView();
+      view.setHint(ViewHint.INTERACTING, -1);
+      if (this.rotating_) {
+        const rotation = view.getRotation();
+        rotate(view, rotation, this.anchor_, this.duration_);
+      }
+      return false;
+    } else {
+      return true;
     }
-    return true;
-  } else {
-    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(mapBrowserEvent) {
+    if (this.targetPointers.length >= 2) {
+      const map = mapBrowserEvent.map;
+      this.anchor_ = null;
+      this.lastAngle_ = undefined;
+      this.rotating_ = false;
+      this.rotationDelta_ = 0.0;
+      if (!this.handlingDownUpSequence) {
+        map.getView().setHint(ViewHint.INTERACTING, 1);
+      }
+      return true;
+    } else {
+      return false;
+    }
   }
 }
 

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -27,14 +27,15 @@ class PinchZoom extends PointerInteraction {
    */
   constructor(opt_options) {
 
-    super({
-      handleDownEvent: handleDownEvent,
-      handleDragEvent: handleDragEvent,
-      handleUpEvent: handleUpEvent,
-      stopDown: FALSE
-    });
-
     const options = opt_options ? opt_options : {};
+
+    const pointerOptions = /** @type {import("./Pointer.js").Options} */ (options);
+
+    if (!pointerOptions.stopDown) {
+      pointerOptions.stopDown = FALSE;
+    }
+
+    super(pointerOptions);
 
     /**
      * @private
@@ -68,105 +69,96 @@ class PinchZoom extends PointerInteraction {
 
   }
 
-}
+  /**
+   * @inheritDoc
+   */
+  handleDragEvent(mapBrowserEvent) {
+    let scaleDelta = 1.0;
+
+    const touch0 = this.targetPointers[0];
+    const touch1 = this.targetPointers[1];
+    const dx = touch0.clientX - touch1.clientX;
+    const dy = touch0.clientY - touch1.clientY;
+
+    // distance between touches
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    if (this.lastDistance_ !== undefined) {
+      scaleDelta = this.lastDistance_ / distance;
+    }
+    this.lastDistance_ = distance;
 
 
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @this {PinchZoom}
- */
-function handleDragEvent(mapBrowserEvent) {
-  let scaleDelta = 1.0;
-
-  const touch0 = this.targetPointers[0];
-  const touch1 = this.targetPointers[1];
-  const dx = touch0.clientX - touch1.clientX;
-  const dy = touch0.clientY - touch1.clientY;
-
-  // distance between touches
-  const distance = Math.sqrt(dx * dx + dy * dy);
-
-  if (this.lastDistance_ !== undefined) {
-    scaleDelta = this.lastDistance_ / distance;
-  }
-  this.lastDistance_ = distance;
-
-
-  const map = mapBrowserEvent.map;
-  const view = map.getView();
-  const resolution = view.getResolution();
-  const maxResolution = view.getMaxResolution();
-  const minResolution = view.getMinResolution();
-  let newResolution = resolution * scaleDelta;
-  if (newResolution > maxResolution) {
-    scaleDelta = maxResolution / resolution;
-    newResolution = maxResolution;
-  } else if (newResolution < minResolution) {
-    scaleDelta = minResolution / resolution;
-    newResolution = minResolution;
-  }
-
-  if (scaleDelta != 1.0) {
-    this.lastScaleDelta_ = scaleDelta;
-  }
-
-  // scale anchor point.
-  const viewportPosition = map.getViewport().getBoundingClientRect();
-  const centroid = centroidFromPointers(this.targetPointers);
-  centroid[0] -= viewportPosition.left;
-  centroid[1] -= viewportPosition.top;
-  this.anchor_ = map.getCoordinateFromPixel(centroid);
-
-  // scale, bypass the resolution constraint
-  map.render();
-  zoomWithoutConstraints(view, newResolution, this.anchor_);
-}
-
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Stop drag sequence?
- * @this {PinchZoom}
- */
-function handleUpEvent(mapBrowserEvent) {
-  if (this.targetPointers.length < 2) {
     const map = mapBrowserEvent.map;
     const view = map.getView();
-    view.setHint(ViewHint.INTERACTING, -1);
     const resolution = view.getResolution();
-    if (this.constrainResolution_ ||
-        resolution < view.getMinResolution() ||
-        resolution > view.getMaxResolution()) {
-      // Zoom to final resolution, with an animation, and provide a
-      // direction not to zoom out/in if user was pinching in/out.
-      // Direction is > 0 if pinching out, and < 0 if pinching in.
-      const direction = this.lastScaleDelta_ - 1;
-      zoom(view, resolution, this.anchor_, this.duration_, direction);
+    const maxResolution = view.getMaxResolution();
+    const minResolution = view.getMinResolution();
+    let newResolution = resolution * scaleDelta;
+    if (newResolution > maxResolution) {
+      scaleDelta = maxResolution / resolution;
+      newResolution = maxResolution;
+    } else if (newResolution < minResolution) {
+      scaleDelta = minResolution / resolution;
+      newResolution = minResolution;
     }
-    return false;
-  } else {
-    return true;
+
+    if (scaleDelta != 1.0) {
+      this.lastScaleDelta_ = scaleDelta;
+    }
+
+    // scale anchor point.
+    const viewportPosition = map.getViewport().getBoundingClientRect();
+    const centroid = centroidFromPointers(this.targetPointers);
+    centroid[0] -= viewportPosition.left;
+    centroid[1] -= viewportPosition.top;
+    this.anchor_ = map.getCoordinateFromPixel(centroid);
+
+    // scale, bypass the resolution constraint
+    map.render();
+    zoomWithoutConstraints(view, newResolution, this.anchor_);
   }
-}
 
-
-/**
- * @param {import("../MapBrowserPointerEvent.js").default} mapBrowserEvent Event.
- * @return {boolean} Start drag sequence?
- * @this {PinchZoom}
- */
-function handleDownEvent(mapBrowserEvent) {
-  if (this.targetPointers.length >= 2) {
-    const map = mapBrowserEvent.map;
-    this.anchor_ = null;
-    this.lastDistance_ = undefined;
-    this.lastScaleDelta_ = 1;
-    if (!this.handlingDownUpSequence) {
-      map.getView().setHint(ViewHint.INTERACTING, 1);
+  /**
+   * @inheritDoc
+   */
+  handleUpEvent(mapBrowserEvent) {
+    if (this.targetPointers.length < 2) {
+      const map = mapBrowserEvent.map;
+      const view = map.getView();
+      view.setHint(ViewHint.INTERACTING, -1);
+      const resolution = view.getResolution();
+      if (this.constrainResolution_ ||
+          resolution < view.getMinResolution() ||
+          resolution > view.getMaxResolution()) {
+        // Zoom to final resolution, with an animation, and provide a
+        // direction not to zoom out/in if user was pinching in/out.
+        // Direction is > 0 if pinching out, and < 0 if pinching in.
+        const direction = this.lastScaleDelta_ - 1;
+        zoom(view, resolution, this.anchor_, this.duration_, direction);
+      }
+      return false;
+    } else {
+      return true;
     }
-    return true;
-  } else {
-    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  handleDownEvent(mapBrowserEvent) {
+    if (this.targetPointers.length >= 2) {
+      const map = mapBrowserEvent.map;
+      this.anchor_ = null;
+      this.lastDistance_ = undefined;
+      this.lastScaleDelta_ = 1;
+      if (!this.handlingDownUpSequence) {
+        map.getView().setHint(ViewHint.INTERACTING, 1);
+      }
+      return true;
+    } else {
+      return false;
+    }
   }
 }
 

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -56,33 +56,21 @@ class PointerInteraction extends Interaction {
       handleEvent: options.handleEvent || handleEvent
     });
 
-    /**
-     * @type {function(MapBrowserPointerEvent):boolean}
-     * @private
-     */
-    this.handleDownEvent_ = options.handleDownEvent ?
-      options.handleDownEvent : this.handleDownEvent;
+    if (options.handleDownEvent) {
+      this.handleDownEvent = options.handleDownEvent;
+    }
 
-    /**
-     * @type {function(MapBrowserPointerEvent)}
-     * @private
-     */
-    this.handleDragEvent_ = options.handleDragEvent ?
-      options.handleDragEvent : this.handleDragEvent;
+    if (options.handleDragEvent) {
+      this.handleDragEvent = options.handleDragEvent;
+    }
 
-    /**
-     * @type {function(MapBrowserPointerEvent)}
-     * @private
-     */
-    this.handleMoveEvent_ = options.handleMoveEvent ?
-      options.handleMoveEvent : this.handleMoveEvent;
+    if (options.handleMoveEvent) {
+      this.handleMoveEvent = options.handleMoveEvent;
+    }
 
-    /**
-     * @type {function(MapBrowserPointerEvent):boolean}
-     * @private
-     */
-    this.handleUpEvent_ = options.handleUpEvent ?
-      options.handleUpEvent : this.handleUpEvent;
+    if (options.handleUpEvent) {
+      this.handleUpEvent = options.handleUpEvent;
+    }
 
     /**
      * @type {boolean}
@@ -218,21 +206,21 @@ export function handleEvent(mapBrowserEvent) {
   this.updateTrackedPointers_(mapBrowserEvent);
   if (this.handlingDownUpSequence) {
     if (mapBrowserEvent.type == MapBrowserEventType.POINTERDRAG) {
-      this.handleDragEvent_(mapBrowserEvent);
+      this.handleDragEvent(mapBrowserEvent);
     } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERUP) {
-      const handledUp = this.handleUpEvent_(mapBrowserEvent);
+      const handledUp = this.handleUpEvent(mapBrowserEvent);
       this.handlingDownUpSequence = handledUp && this.targetPointers.length > 0;
     }
   } else {
     if (mapBrowserEvent.type == MapBrowserEventType.POINTERDOWN) {
-      const handled = this.handleDownEvent_(mapBrowserEvent);
+      const handled = this.handleDownEvent(mapBrowserEvent);
       if (handled) {
         mapBrowserEvent.preventDefault();
       }
       this.handlingDownUpSequence = handled;
       stopEvent = this.stopDown(handled);
     } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERMOVE) {
-      this.handleMoveEvent_(mapBrowserEvent);
+      this.handleMoveEvent(mapBrowserEvent);
     }
   }
   return !stopEvent;

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -1,41 +1,10 @@
 /**
  * @module ol/interaction/Pointer
  */
-import {FALSE, VOID} from '../functions.js';
 import MapBrowserEventType from '../MapBrowserEventType.js';
 import MapBrowserPointerEvent from '../MapBrowserPointerEvent.js';
 import Interaction from '../interaction/Interaction.js';
 import {getValues} from '../obj.js';
-
-
-/**
- * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {PointerInteraction}
- */
-const handleDragEvent = VOID;
-
-
-/**
- * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
- * @return {boolean} Capture dragging.
- * @this {PointerInteraction}
- */
-const handleUpEvent = FALSE;
-
-
-/**
- * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
- * @return {boolean} Capture dragging.
- * @this {PointerInteraction}
- */
-const handleDownEvent = FALSE;
-
-
-/**
- * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
- * @this {PointerInteraction}
- */
-const handleMoveEvent = VOID;
 
 
 /**
@@ -58,7 +27,7 @@ const handleMoveEvent = VOID;
  * @property {function(MapBrowserPointerEvent):boolean} [handleUpEvent]
  *  Function handling "up" events. If the function returns `false` then the
  * current drag sequence is stopped.
- * @property {function(boolean):boolean} stopDown
+ * @property {function(boolean):boolean} [stopDown]
  * Should the down event be propagated to other interactions, or should be
  * stopped?
  */
@@ -92,28 +61,28 @@ class PointerInteraction extends Interaction {
      * @private
      */
     this.handleDownEvent_ = options.handleDownEvent ?
-      options.handleDownEvent : handleDownEvent;
+      options.handleDownEvent : this.handleDownEvent;
 
     /**
      * @type {function(MapBrowserPointerEvent)}
      * @private
      */
     this.handleDragEvent_ = options.handleDragEvent ?
-      options.handleDragEvent : handleDragEvent;
+      options.handleDragEvent : this.handleDragEvent;
 
     /**
      * @type {function(MapBrowserPointerEvent)}
      * @private
      */
     this.handleMoveEvent_ = options.handleMoveEvent ?
-      options.handleMoveEvent : handleMoveEvent;
+      options.handleMoveEvent : this.handleMoveEvent;
 
     /**
      * @type {function(MapBrowserPointerEvent):boolean}
      * @private
      */
     this.handleUpEvent_ = options.handleUpEvent ?
-      options.handleUpEvent : handleUpEvent;
+      options.handleUpEvent : this.handleUpEvent;
 
     /**
      * @type {boolean}
@@ -141,6 +110,40 @@ class PointerInteraction extends Interaction {
      */
     this.targetPointers = [];
 
+  }
+
+  /**
+   * Handle pointer down events.
+   * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
+   * @return {boolean} If the event was consumed.
+   * @protected
+   */
+  handleDownEvent(mapBrowserEvent) {
+    return false;
+  }
+
+  /**
+   * Handle pointer drag events.
+   * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
+   * @protected
+   */
+  handleDragEvent(mapBrowserEvent) {}
+
+  /**
+   * Handle pointer move events.
+   * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
+   * @protected
+   */
+  handleMoveEvent(mapBrowserEvent) {}
+
+  /**
+   * Handle pointer up events.
+   * @param {MapBrowserPointerEvent} mapBrowserEvent Event.
+   * @return {boolean} If the event was consumed.
+   * @protected
+   */
+  handleUpEvent(mapBrowserEvent) {
+    return false;
   }
 
   /**

--- a/test/spec/ol/interaction/dragrotateandzoom.test.js
+++ b/test/spec/ol/interaction/dragrotateandzoom.test.js
@@ -17,7 +17,7 @@ describe('ol.interaction.DragRotateAndZoom', function() {
 
   });
 
-  describe('#handleDragEvent_()', function() {
+  describe('#handleDragEvent()', function() {
 
     let target, map, interaction;
 
@@ -64,7 +64,7 @@ describe('ol.interaction.DragRotateAndZoom', function() {
 
       let view = map.getView();
       let spy = sinon.spy(view, 'rotate');
-      interaction.handleDragEvent_(event);
+      interaction.handleDragEvent(event);
       expect(spy.callCount).to.be(1);
       expect(interaction.lastAngle_).to.be(-0.8308214428190254);
       view.rotate.restore();
@@ -82,7 +82,7 @@ describe('ol.interaction.DragRotateAndZoom', function() {
         true);
 
       spy = sinon.spy(view, 'rotate');
-      interaction.handleDragEvent_(event);
+      interaction.handleDragEvent(event);
       expect(spy.callCount).to.be(0);
       view.rotate.restore();
     });

--- a/test/spec/ol/interaction/interaction.test.js
+++ b/test/spec/ol/interaction/interaction.test.js
@@ -2,6 +2,7 @@ import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import EventTarget from '../../../../src/ol/events/Target.js';
 import Interaction, {zoomByDelta} from '../../../../src/ol/interaction/Interaction.js';
+import {FALSE} from '../../../../src/ol/functions.js';
 
 describe('ol.interaction.Interaction', function() {
 
@@ -52,6 +53,36 @@ describe('ol.interaction.Interaction', function() {
       const interaction = new Interaction({});
       interaction.setMap(null);
       expect(interaction.getMap()).to.be(null);
+    });
+
+  });
+
+  describe('#handleEvent()', function() {
+
+    class MockInteraction extends Interaction {
+      constructor() {
+        super(...arguments);
+      }
+      handleEvent(mapBrowserEvent) {
+        return false;
+      }
+    }
+
+    it('has a default event handler', function() {
+      const interaction = new Interaction({});
+      expect(interaction.handleEvent()).to.be(true);
+    });
+
+    it('allows event handler overrides via options', function() {
+      const interaction = new Interaction({
+        handleEvent: FALSE
+      });
+      expect(interaction.handleEvent()).to.be(false);
+    });
+
+    it('allows event handler overrides via class extension', function() {
+      const interaction = new MockInteraction({});
+      expect(interaction.handleEvent()).to.be(false);
     });
 
   });

--- a/test/spec/ol/interaction/pointer.test.js
+++ b/test/spec/ol/interaction/pointer.test.js
@@ -44,4 +44,95 @@ describe('ol.interaction.Pointer', function() {
 
   });
 
+  describe('event handlers', function() {
+    let handleDownCalled, handleDragCalled, handleMoveCalled, handleUpCalled;
+
+    const flagHandleDown = function() {
+      handleDownCalled = true;
+    };
+
+    const flagHandleDrag = function() {
+      handleDragCalled = true;
+    };
+
+    const flagHandleMove = function() {
+      handleMoveCalled = true;
+    };
+
+    const flagHandleUp = function() {
+      handleUpCalled = true;
+    };
+
+    class MockPointerInteraction extends PointerInteraction {
+      constructor() {
+        super(...arguments);
+      }
+      handleDownEvent(mapBrowserEvent) {
+        flagHandleDown();
+        return super.handleDownEvent(mapBrowserEvent);
+      }
+      handleDragEvent(mapBrowserEvent) {
+        flagHandleDrag();
+      }
+      handleMoveEvent(mapBrowserEvent) {
+        flagHandleMove();
+      }
+      handleUpEvent(mapBrowserEvent) {
+        flagHandleUp();
+        return super.handleUpEvent(mapBrowserEvent);
+      }
+    }
+
+    beforeEach(function() {
+      handleDownCalled = false;
+      handleDragCalled = false;
+      handleMoveCalled = false;
+      handleUpCalled = false;
+    });
+
+    it('has default event handlers', function() {
+      const interaction = new PointerInteraction({});
+      expect(interaction.handleDownEvent()).to.be(false);
+      expect(interaction.handleUpEvent()).to.be(false);
+    });
+
+    it('allows event handler overrides via options', function() {
+      const interaction = new PointerInteraction({
+        handleDownEvent: flagHandleDown,
+        handleDragEvent: flagHandleDrag,
+        handleMoveEvent: flagHandleMove,
+        handleUpEvent: flagHandleUp
+      });
+
+      interaction.handleDownEvent();
+      expect(handleDownCalled).to.be(true);
+
+      interaction.handleDragEvent();
+      expect(handleDragCalled).to.be(true);
+
+      interaction.handleMoveEvent();
+      expect(handleMoveCalled).to.be(true);
+
+      interaction.handleUpEvent();
+      expect(handleUpCalled).to.be(true);
+    });
+
+    it('allows event handler overrides via class extension', function() {
+      const interaction = new MockPointerInteraction({});
+
+      interaction.handleDownEvent();
+      expect(handleDownCalled).to.be(true);
+
+      interaction.handleDragEvent();
+      expect(handleDragCalled).to.be(true);
+
+      interaction.handleMoveEvent();
+      expect(handleMoveCalled).to.be(true);
+
+      interaction.handleUpEvent();
+      expect(handleUpCalled).to.be(true);
+    });
+
+  });
+
 });

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -5,7 +5,7 @@ import View from '../../../../src/ol/View.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
-import Snap, {handleEvent} from '../../../../src/ol/interaction/Snap.js';
+import Snap from '../../../../src/ol/interaction/Snap.js';
 
 
 describe('ol.interaction.Snap', function() {
@@ -67,7 +67,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [0, 0],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
       // check that the coordinate is in XY and not XYZ
       expect(event.coordinate).to.eql([0, 0]);
     });
@@ -86,7 +86,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [7, 4],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
       expect(event.coordinate).to.eql([7, 0]);
     });
 
@@ -104,7 +104,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [7, 4],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
       expect(event.coordinate).to.eql([10, 0]);
     });
 
@@ -121,7 +121,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [5, 5],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
 
       expect(event.coordinate[0]).to.roughlyEqual(Math.sin(Math.PI / 4) * 10, 1e-10);
       expect(event.coordinate[1]).to.roughlyEqual(Math.sin(Math.PI / 4) * 10, 1e-10);
@@ -143,7 +143,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [7, 4],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
       expect(event.coordinate).to.eql([10, 0]);
     });
 
@@ -163,7 +163,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [7, 4],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
       expect(event.coordinate).to.eql([10, 0]);
     });
 
@@ -186,7 +186,7 @@ describe('ol.interaction.Snap', function() {
         coordinate: [7, 4],
         map: map
       };
-      handleEvent.call(snapInteraction, event);
+      snapInteraction.handleEvent(event);
       expect(event.coordinate).to.eql([10, 0]);
     });
 


### PR DESCRIPTION
There are ~20 TypeScript errors caused by interaction event handler setup. Example:

```
src/ol/interaction/DragBox.js:143:7 - error TS2322: Type 'typeof handleDownEvent' is not assignable to type '(arg0: MapBrowserPointerEvent) => boolean'.
  Type 'handleDownEvent' is not assignable to type 'boolean'.

143       handleDownEvent: handleDownEvent,
          ~~~~~~~~~~~~~~~

  src/ol/interaction/Pointer.js:43:4
    43  * @property {function(MapBrowserPointerEvent):boolean} [handleDownEvent]
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    44  * Function handling "down" events. If the function returns `true` then a drag
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    45  * sequence is started.
       ~~~~~~~~~~~~~~~~~~~~~~~
    46  * @property {function(MapBrowserPointerEvent)} [handleDragEvent]
       ~~~
    The expected type comes from property 'handleDownEvent' which is declared here on type 'Options'
```

This seems to be caused by the `handleDownEvent` function being defined in the module scope, and not being bound to an interaction instance when referenced. Binding the function would cause a `'this' is not allowed before 'super()'` error.

I would like to resolve this by defining those handlers as methods on the interaction classes. This will allow extending classes to override the functions normally, instead of passing the new function through options.

I started going down this path and it successfully fixes the typing problems with the bonus of being able to replace those functions easily in extending classes. It does require moving a lot of code within each interaction, so I would like to get feedback on this approach before moving forward. If this approach seems sound I'll continue with the refactor, but please let me know if anyone has a better/preferred solution.