### PR TITLE
Fix type check for ol/events

### DIFF
--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -119,7 +119,8 @@ function removeListeners(target, type) {
   const listeners = getListeners(target, type);
   if (listeners) {
     for (let i = 0, ii = listeners.length; i < ii; ++i) {
-      target.removeEventListener(type, listeners[i].boundListener);
+      /** @type {import("./events/Target.js").default} */ (target).
+        removeEventListener(type, listeners[i].boundListener);
       clear(listeners[i]);
     }
     listeners.length = 0;
@@ -169,7 +170,8 @@ export function listen(target, type, listener, opt_this, opt_once) {
       target: target,
       type: type
     });
-    target.addEventListener(type, bindListener(listenerObj));
+    /** @type {import("./events/Target.js").default} */ (target).
+      addEventListener(type, bindListener(listenerObj));
     listeners.push(listenerObj);
   }
 
@@ -237,7 +239,8 @@ export function unlisten(target, type, listener, opt_this) {
  */
 export function unlistenByKey(key) {
   if (key && key.target) {
-    key.target.removeEventListener(key.type, key.boundListener);
+    /** @type {import("./events/Target.js").default} */ (key.target).
+      removeEventListener(key.type, key.boundListener);
     const listeners = getListeners(key.target, key.type);
     if (listeners) {
       const i = 'deleteIndex' in key ? key.deleteIndex : listeners.indexOf(key);


### PR DESCRIPTION
Cast to ol/events/Target since the function declarations only match between `EventTarget` and `Target` for the first two parameters.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
