### PR TITLE
Fix TypeScript errors in ol/interaction/Draw

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -912,7 +912,7 @@ function handleDownEvent(event) {
     return true;
   } else if (this.condition_(event)) {
     this.lastDragTime_ = Date.now();
-    this.downTimeout_ = setTimeout(function() {
+    this.downTimeout_ = window.setTimeout(function() {
       this.handlePointerMove_(new MapBrowserPointerEvent(
         MapBrowserEventType.POINTERMOVE, event.map, event.pointerEvent, false, event.frameState));
     }.bind(this), this.dragVertexDelay_);

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -206,7 +206,7 @@ class Draw extends PointerInteraction {
     this.downPx_ = null;
 
     /**
-     * @type {number|undefined}
+     * @type {any}
      * @private
      */
     this.downTimeout_;
@@ -912,7 +912,7 @@ function handleDownEvent(event) {
     return true;
   } else if (this.condition_(event)) {
     this.lastDragTime_ = Date.now();
-    this.downTimeout_ = window.setTimeout(function() {
+    this.downTimeout_ = setTimeout(function() {
       this.handlePointerMove_(new MapBrowserPointerEvent(
         MapBrowserEventType.POINTERMOVE, event.map, event.pointerEvent, false, event.frameState));
     }.bind(this), this.dragVertexDelay_);

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -258,7 +258,7 @@ function handleEvent(mapBrowserEvent) {
     } else {
       view.setHint(ViewHint.INTERACTING, 1);
     }
-    this.trackpadTimeoutId_ = setTimeout(this.decrementInteractingHint_.bind(this), this.trackpadEventGap_);
+    this.trackpadTimeoutId_ = window.setTimeout(this.decrementInteractingHint_.bind(this), this.trackpadEventGap_);
     let resolution = view.getResolution() * Math.pow(2, delta / this.trackpadDeltaPerZoom_);
     const minResolution = view.getMinResolution();
     const maxResolution = view.getMaxResolution();
@@ -309,7 +309,7 @@ function handleEvent(mapBrowserEvent) {
   const timeLeft = Math.max(this.timeout_ - (now - this.startTime_), 0);
 
   clearTimeout(this.timeoutId_);
-  this.timeoutId_ = setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
+  this.timeoutId_ = window.setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
 
   return false;
 }

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -110,9 +110,9 @@ class MouseWheelZoom extends Interaction {
 
     /**
      * @private
-     * @type {number|undefined}
+     * @type {any}
      */
-    this.timeoutId_ = undefined;
+    this.timeoutId_;
 
     /**
      * @private
@@ -128,9 +128,9 @@ class MouseWheelZoom extends Interaction {
     this.trackpadEventGap_ = 400;
 
     /**
-     * @type {number|undefined}
+     * @type {any}
      */
-    this.trackpadTimeoutId_ = undefined;
+    this.trackpadTimeoutId_;
 
     /**
      * The number of delta values per zoom level
@@ -258,7 +258,7 @@ function handleEvent(mapBrowserEvent) {
     } else {
       view.setHint(ViewHint.INTERACTING, 1);
     }
-    this.trackpadTimeoutId_ = window.setTimeout(this.decrementInteractingHint_.bind(this), this.trackpadEventGap_);
+    this.trackpadTimeoutId_ = setTimeout(this.decrementInteractingHint_.bind(this), this.trackpadEventGap_);
     let resolution = view.getResolution() * Math.pow(2, delta / this.trackpadDeltaPerZoom_);
     const minResolution = view.getMinResolution();
     const maxResolution = view.getMaxResolution();
@@ -309,7 +309,7 @@ function handleEvent(mapBrowserEvent) {
   const timeLeft = Math.max(this.timeout_ - (now - this.startTime_), 0);
 
   clearTimeout(this.timeoutId_);
-  this.timeoutId_ = window.setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
+  this.timeoutId_ = setTimeout(this.handleWheelZoom_.bind(this, map), timeLeft);
 
   return false;
 }

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -187,7 +187,7 @@ class TouchSource extends EventSource {
    * @private
    */
   resetClickCount_() {
-    this.resetId_ = setTimeout(
+    this.resetId_ = window.setTimeout(
       this.resetClickCountHandler_.bind(this),
       CLICK_COUNT_TIMEOUT);
   }

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -137,9 +137,9 @@ class TouchSource extends EventSource {
 
     /**
      * @private
-     * @type {number|undefined}
+     * @type {any}
      */
-    this.resetId_ = undefined;
+    this.resetId_;
 
     /**
      * Mouse event timeout: This should be long enough to
@@ -187,7 +187,7 @@ class TouchSource extends EventSource {
    * @private
    */
   resetClickCount_() {
-    this.resetId_ = window.setTimeout(
+    this.resetId_ = setTimeout(
       this.resetClickCountHandler_.bind(this),
       CLICK_COUNT_TIMEOUT);
   }


### PR DESCRIPTION
This fixes most TypeScript errors in `ol/interaction/Draw.js`, and the remaining errors will be fixed in #8762.

This PR also uses `window.setTimeout` instead of `setTimeout` when the return value is used, because TypeScript with the `es2017` library uses [Node's `setTimeout` signature](https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args), which returns a Timer object. See Microsoft/TypeScript/issues/842 for more details.