### PR TITLE
Fix type check errors in ol/render/webgl

### DIFF
--- a/src/ol/render/webgl/Immediate.js
+++ b/src/ol/render/webgl/Immediate.js
@@ -96,6 +96,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.finish(context);
     // default colors
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -196,6 +197,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.finish(context);
     // default colors
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -221,6 +223,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.drawMultiPoint(geometry, data);
     replay.finish(context);
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -246,6 +249,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.drawLineString(geometry, data);
     replay.finish(context);
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -271,6 +275,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.drawMultiLineString(geometry, data);
     replay.finish(context);
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -296,6 +301,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.drawPolygon(geometry, data);
     replay.finish(context);
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -321,6 +327,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.drawMultiPolygon(geometry, data);
     replay.finish(context);
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;
@@ -346,6 +353,7 @@ class WebGLImmediateRenderer extends VectorContext {
     replay.drawCircle(geometry, data);
     replay.finish(context);
     const opacity = 1;
+    /** @type {Object<string, boolean>} */
     const skippedFeatures = {};
     let featureCallback;
     const oneByOne = false;

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -121,9 +121,6 @@ class WebGLReplayGroup extends ReplayGroup {
     }
     let replay = replays[replayType];
     if (replay === undefined) {
-      /**
-       * @type {Function}
-       */
       const Constructor = BATCH_CONSTRUCTORS[replayType];
       replay = new Constructor(this.tolerance_, this.maxExtent_);
       replays[replayType] = replay;

--- a/src/ol/render/webgl/TextReplay.js
+++ b/src/ol/render/webgl/TextReplay.js
@@ -266,8 +266,8 @@ class WebGLTextReplay extends WebGLTextureReplay {
           ctx.fillStyle = state.fillColor;
           ctx.strokeStyle = state.strokeColor;
           ctx.lineWidth = state.lineWidth;
-          ctx.lineCap = /*** @type {string} */ (state.lineCap);
-          ctx.lineJoin = /** @type {string} */ (state.lineJoin);
+          ctx.lineCap = /** @type {CanvasLineCap} */ (state.lineCap);
+          ctx.lineJoin = /** @type {CanvasLineJoin} */ (state.lineJoin);
           ctx.miterLimit = /** @type {number} */ (state.miterLimit);
           ctx.textAlign = 'left';
           ctx.textBaseline = 'top';


### PR DESCRIPTION
Fixes type check errors in `ol/render/webgl/*`.

Remaining errors are caused by lack of `@abstract` function support in `tsc`.