### PR TITLE
[wip] Added missing constrain setters from ol.View

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -775,12 +775,30 @@ class View extends BaseObject {
   }
 
   /**
+   * Set the maximum resolution of the view.
+   * @param {number} maxResolution The maximum resolution of the view.
+   * @api
+   */
+  setMaxResolution(maxResolution) {
+    this.applyOptions_(this.getUpdatedOptions_({maxResolution}));
+  }
+
+  /**
    * Get the minimum resolution of the view.
    * @return {number} The minimum resolution of the view.
    * @api
    */
   getMinResolution() {
     return this.minResolution_;
+  }
+
+  /**
+   * Set the minimum resolution of the view.
+   * @param {number} minResolution The minimum resolution of the view.
+   * @api
+   */
+  setMinResolution(minResolution) {
+    this.applyOptions_(this.getUpdatedOptions_({minResolution}));
   }
 
   /**
@@ -835,6 +853,15 @@ class View extends BaseObject {
    */
   getProjection() {
     return this.projection_;
+  }
+
+  /**
+   * Set the view projection.
+   * @param {import("./proj/Projection.js").default} projection The projection of the view.
+   * @api
+   */
+  setProjection(projection) {
+    this.applyOptions_(this.getUpdatedOptions_({projection}));
   }
 
   /**
@@ -1205,6 +1232,27 @@ class View extends BaseObject {
   }
 
   /**
+   * Sets the rotational constraints on the current view.
+   * @param {boolean|number} constrainRotation Rotation constraint. `false` means no constraint. `true` means no
+   * constraint, but snap to zero near zero. A number constrains the rotation to that number of values. For example, `4`
+   * will constrain the rotation to 0, 90, 180, and 270 degrees.
+   * @api
+   */
+  setConstrainRotation(constrainRotation) {
+    this.applyOptions_(this.getUpdatedOptions_({constrainRotation}));
+  }
+
+  /**
+   * Set the extent of the current view.
+   * @param {import("./extent.js").Extent} extent The extent that constrains the center, in other words, center cannot
+   * be set outside this extent.
+   * @api
+   */
+  setExtent(extent) {
+    this.applyOptions_(this.getUpdatedOptions_({extent}));
+  }
+
+  /**
    * @param {ViewHint} hint Hint.
    * @param {number} delta Delta.
    * @return {number} New value.
@@ -1389,8 +1437,24 @@ class View extends BaseObject {
 
     return this.constraints_.resolution(targetResolution, direction, size);
   }
-}
 
+  /**
+   * Enable rotation.
+   * @api
+   */
+  enableRotation() {
+    this.applyOptions_(this.getUpdatedOptions_({enableRotation: true}));
+  }
+
+  /**
+   * Disable rotation. A rotation constraint that always sets the rotation to zero is used. The `constrainRotation`
+   * option has no effect.
+   * @api
+   */
+  disableRotation() {
+    this.applyOptions_(this.getUpdatedOptions_({enableRotation: false}));
+  }
+}
 
 /**
  * @param {Function} callback Callback.

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1380,6 +1380,40 @@ describe('ol.View', function() {
     });
   });
 
+  describe('#enableRotation', function() {
+    it('allows rotation to be changed when view instantiated with rotation disabled', function() {
+      const view = new View({
+        resolution: 1,
+        enableRotation: false,
+        center: [0, 0]
+      });
+
+      view.enableRotation();
+      view.adjustRotation(Math.PI / 2);
+      expect(view.getRotation()).to.be(Math.PI / 2);
+      expect(view.getCenter()).to.eql([0, 0]);
+    });
+  });
+
+  describe('#disableRotation', function() {
+    it('does not change view parameters if rotation is disabled', function() {
+      const view = new View({
+        resolution: 1,
+        center: [0, 0]
+      });
+
+      view.disableRotation();
+
+      view.adjustRotation(Math.PI / 2);
+      expect(view.getRotation()).to.be(0);
+      expect(view.getCenter()).to.eql([0, 0]);
+
+      view.adjustRotation(-Math.PI * 3, [-50, 0]);
+      expect(view.getRotation()).to.be(0);
+      expect(view.getCenter()).to.eql([0, 0]);
+    });
+  });
+
   describe('#calculateExtent', function() {
     it('returns the expected extent', function() {
       const view = new View({


### PR DESCRIPTION
This adds several missing constrain setters from ol.View, and fixes #3913.

I've gone ahead and put in this PR while I had some spare time. It's lacking tests and examples, but I figured the code change itself could be discussed while I finish it up. (Also, if there's any objects to the setters I've added, I don't want to write tests for them if we end up not using them.)

## TODO:
- [ ] Tests:
  - [ ] `setMaxResolution`
  - [ ] `setMinResolution`
  - [ ] `setProjection`
  - [ ] `setConstrainRotation`
  - [ ] `setExtent`
  - [x] `enableRotation`
  - [x] `disableRotation`
- [ ] Examples:
  - [ ] `enableRotation`/ `disableRotation`
  - [ ] changing View constraints example
