### PR TITLE
Fix type check errors

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -155,7 +155,7 @@ class OverviewMap extends Control {
     const ovmap = this.ovmap_;
 
     if (options.layers) {
-      options.layers.forEach(
+      /** @type {Array<import("../layer/Layer.js").default>} */ (options.layers).forEach(
         /**
          * @param {import("../layer/Layer.js").default} layer Layer.
          */

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -115,7 +115,7 @@ class RenderFeature {
     if (!this.flatInteriorPoints_) {
       const flatCenter = getCenter(this.getExtent());
       this.flatInteriorPoints_ = getInteriorPointOfArray(
-        this.flatCoordinates_, 0, this.ends_, 2, flatCenter, 0);
+        this.flatCoordinates_, 0, /** @type {Array<number>} */ (this.ends_), 2, flatCenter, 0);
     }
     return this.flatInteriorPoints_;
   }
@@ -126,9 +126,9 @@ class RenderFeature {
   getFlatInteriorPoints() {
     if (!this.flatInteriorPoints_) {
       const flatCenters = linearRingssCenter(
-        this.flatCoordinates_, 0, this.ends_, 2);
+        this.flatCoordinates_, 0, /** @type {Array<Array<number>>} */ (this.ends_), 2);
       this.flatInteriorPoints_ = getInteriorPointsOfMultiArray(
-        this.flatCoordinates_, 0, this.ends_, 2, flatCenters);
+        this.flatCoordinates_, 0, /** @type {Array<Array<number>>} */ (this.ends_), 2, flatCenters);
     }
     return this.flatInteriorPoints_;
   }
@@ -152,7 +152,7 @@ class RenderFeature {
       this.flatMidpoints_ = [];
       const flatCoordinates = this.flatCoordinates_;
       let offset = 0;
-      const ends = this.ends_;
+      const ends = /** @type {Array<number>} */ (this.ends_);
       for (let i = 0, ii = ends.length; i < ii; ++i) {
         const end = ends[i];
         const midpoint = interpolatePoint(

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -43,6 +43,9 @@ class LayerRenderer extends Observable {
        * @return {boolean} The tile range is fully loaded.
        */
       function(zoom, tileRange) {
+        /**
+         * @param {import("../Tile.js").default} tile Tile.
+         */
         function callback(tile) {
           if (!tiles[zoom]) {
             tiles[zoom] = {};

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -112,7 +112,7 @@ class TileSource extends Source {
    * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {number} z Zoom level.
    * @param {import("../TileRange.js").default} tileRange Tile range.
-   * @param {function(import("../Tile.js").default):(boolean|undefined)} callback Called with each
+   * @param {function(import("../Tile.js").default):(boolean|void)} callback Called with each
    *     loaded tile.  If the callback returns `false`, the tile will not be
    *     considered loaded.
    * @return {boolean} The tile range is fully covered with loaded tiles.


### PR DESCRIPTION
Fixes a few more type check errors.

After this, #8711, and I believe one more incoming PR from @wallw-bits, the remaining type check errors are caused by issues with `tsc`. The most significant two are:

- Microsoft/TypeScript/issues/27215: 133 errors (`TS2322` and `TS2345`)
- Microsoft/TypeScript/issues/17227: 56+ errors (`TS2355`, possibly `TS2554` as well)