### PR TITLE
Fix missing method declaration

### DIFF
--- a/src/ol/render/ReplayGroup.js
+++ b/src/ol/render/ReplayGroup.js
@@ -18,6 +18,13 @@ class ReplayGroup {
    * @return {boolean} Is empty.
    */
   isEmpty() {}
+
+  /**
+   * @abstract
+   * @param {boolean} group Group with previous replay
+   * @return {Array<*>} The resulting instruction group
+   */
+  addDeclutter(group) {}
 }
 
 export default ReplayGroup;

--- a/src/ol/render/canvas/ReplayGroup.js
+++ b/src/ol/render/canvas/ReplayGroup.js
@@ -120,8 +120,7 @@ class CanvasReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {boolean} group Group with previous replay.
-   * @return {import("../canvas.js").DeclutterGroup} Declutter instruction group.
+   * @inheritDoc
    */
   addDeclutter(group) {
     let declutter = null;

--- a/src/ol/render/webgl/ReplayGroup.js
+++ b/src/ol/render/webgl/ReplayGroup.js
@@ -67,10 +67,11 @@ class WebGLReplayGroup extends ReplayGroup {
   }
 
   /**
-   * @param {import("../../style/Style.js").default} style Style.
-   * @param {boolean} group Group with previous replay.
+   * @inheritDoc
    */
-  addDeclutter(style, group) {}
+  addDeclutter(group) {
+    return [];
+  }
 
   /**
    * @param {import("../../webgl/Context.js").default} context WebGL context.


### PR DESCRIPTION
`ol/renderer/vector.js` makes use of `ol/render/ReplayGroup.js` types as function arguments, but many of the resulting functions use `replayGroup.addDeclutter(boolean)`. Not only does that function not exist on `ol/render/ReplayGroup.js`, but it is defined differently between the canvas and webgl replay group implementations.

Therefore, define it on the abstract `ol/render/ReplayGroup.js` class and implement it on both canvas and webgl.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
