### PR TITLE
Polygon intersectsExtent failure - Issue #8795

### DIFF
--- a/src/ol/geom/flat/intersectsextent.js
+++ b/src/ol/geom/flat/intersectsextent.js
@@ -111,7 +111,9 @@ export function intersectsLinearRingArray(flatCoordinates, offset, ends, stride,
   }
   for (let i = 1, ii = ends.length; i < ii; ++i) {
     if (linearRingContainsExtent(flatCoordinates, ends[i - 1], ends[i], stride, extent)) {
-      return false;
+      if (!intersectsLineString(flatCoordinates, ends[i - 1], ends[i], stride, extent)) {
+        return false;
+      }
     }
   }
   return true;

--- a/test/spec/ol/geom/flat/intersectsextent.test.js
+++ b/test/spec/ol/geom/flat/intersectsextent.test.js
@@ -1,4 +1,4 @@
-import {intersectsLinearRing, intersectsLineString} from '../../../../../src/ol/geom/flat/intersectsextent.js';
+import {intersectsLinearRing, intersectsLineString, intersectsLinearRingArray} from '../../../../../src/ol/geom/flat/intersectsextent.js';
 
 
 describe('ol.geom.flat.intersectsextent', function() {
@@ -89,4 +89,30 @@ describe('ol.geom.flat.intersectsextent', function() {
       });
     });
   });
+
+  describe('ol.geom.flat.intersectsextent.intersectsLinearRingArray', function() {
+    let flatCoordinates;
+    let ends;
+    beforeEach(function() {
+      flatCoordinates = [0, 0, 0, 10, 10, 10, 10, 0, 0, 0, /*hole*/2, 2, 8, 2, 8, 4, 5, 5, 8, 6, 8, 8, 2, 8, 2, 2];
+      ends = [10, flatCoordinates.length];
+    });
+    describe('ring with hole where hole contains the extent', function() {
+      it('returns true', function() {
+        const extent = [3, 3, 3.5, 3.5];
+        const r = intersectsLinearRingArray(
+          flatCoordinates, 0, ends, 2, extent);
+        expect(r).to.be(false);
+      });
+    });
+    describe('ring with hole intersects the extent', function() {
+      it('returns true', function() {
+        const extent = [3, 3, 6, 6];
+        const r = intersectsLinearRingArray(
+          flatCoordinates, 0, ends, 2, extent);
+        expect(r).to.be(true);
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
There is an algorithm error on polygons with hole at `intersectsExtent` method. It returns **false** in the case where it should return **true**. The logic error occurs when :

1. the outer ring contains the extent
2. there is a hole that contains all the 4 vertices of the extent
3. the hole border intersects with the extent

To fix the problem, the method `intersectsLinearRingArray` on "ol\geom\flat\intersectextent.js" was modified by adding a verification that the border doesnt intersect the extent before returning false.

Fixes #8795.