### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -204,7 +204,8 @@ class OverviewMap extends Control {
     };
 
     const move = function(event) {
-      const coordinates = ovmap.getEventCoordinate(computeDesiredMousePosition(event));
+      const position = /** @type {?} */ (computeDesiredMousePosition(event));
+      const coordinates = ovmap.getEventCoordinate(/** @type {Event} */ (position));
 
       overlay.setPosition(coordinates);
     };

--- a/src/ol/format/filter/And.js
+++ b/src/ol/format/filter/And.js
@@ -15,8 +15,7 @@ class And extends LogicalNary {
    * @param {...import("./Filter.js").default} conditions Conditions.
    */
   constructor(conditions) {
-    const params = ['And'].concat(Array.prototype.slice.call(arguments));
-    super(...params);
+    super('And', Array.prototype.slice.call(arguments));
   }
 
 }

--- a/src/ol/format/filter/LogicalNary.js
+++ b/src/ol/format/filter/LogicalNary.js
@@ -15,7 +15,7 @@ class LogicalNary extends Filter {
 
   /**
    * @param {!string} tagName The XML tag name for this filter.
-   * @param {...import("./Filter.js").default} conditions Conditions.
+   * @param {Array<import("./Filter.js").default>} conditions Conditions.
    */
   constructor(tagName, conditions) {
 
@@ -24,7 +24,7 @@ class LogicalNary extends Filter {
     /**
      * @type {Array<import("./Filter.js").default>}
      */
-    this.conditions = Array.prototype.slice.call(arguments, 1);
+    this.conditions = conditions;
     assert(this.conditions.length >= 2, 57); // At least 2 conditions are required.
   }
 

--- a/src/ol/format/filter/Or.js
+++ b/src/ol/format/filter/Or.js
@@ -14,8 +14,7 @@ class Or extends LogicalNary {
    * @param {...import("./Filter.js").default} conditions Conditions.
    */
   constructor(conditions) {
-    const params = ['Or'].concat(Array.prototype.slice.call(arguments));
-    super(...params);
+    super('Or', Array.prototype.slice.call(arguments));
   }
 
 }

--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -120,7 +120,7 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
     if (this.getLayer().getSource().forEachFeatureAtCoordinate !== VOID) {
       // for ImageCanvas sources use the original hit-detection logic,
       // so that for example also transparent polygons are detected
-      return super.forEachLayerAtCoordinate(arguments);
+      return super.forEachLayerAtCoordinate(coordinate, frameState, hitTolerance, callback, thisArg);
     } else {
       const pixel = applyTransform(this.coordinateToCanvasPixelTransform, coordinate.slice());
       scaleCoordinate(pixel, frameState.viewState.resolution / this.renderedResolution);

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -142,7 +142,7 @@ function renderFeatureInternal(replayGroup, feature, style, squaredTolerance) {
 
 /**
  * @param {import("../render/ReplayGroup.js").default} replayGroup Replay group.
- * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {import("../geom/Geometry.js").default|import("../render/Feature.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").FeatureLike} feature Feature.
  */


### PR DESCRIPTION
This PR fixes a number of remaining TypeScript errors that are either not caused by `tsc` issues, or can avoid errors caused by `tsc` issues. I have separated the fixes into several commits in case any of the solutions are not acceptable and I need to rebase/drop commits.

`ol/control/OverviewMap`:
This error is caused by using a fake "Event" object that only has the `clientX` and `clientY` properties required by `getEventCoordinate`. Solution is to cast to any, then to `Event`.

`ol/format/filter`:
These errors are caused by lack of spread operator support in `tsc`. This doesn't appear to be something they will fix soon, so I avoided using it. This requires `LogicalNary` to take an Array for `conditions` instead of variable arguments.

`ol/renderer/canvas/IntermediateCanvas`:
This one appears to be a bug, but the code path no longer used (see #8826). Since `fn.apply` is not used, the parameters should be passed explicitly instead of passing `arguments`. If #8827 is accepted, this commit should be discarded because the affected code is removed there.

`ol/renderer/vector`:
Fixed the JSDoc type.