### PR TITLE
Change target type from Element to HTMLElement

### DIFF
--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -27,7 +27,7 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * @property {function(import("../MapEvent.js").default)} [render] Function called when the
  * control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
- * @property {Element|string} [target] Specify a target if you want the
+ * @property {HTMLElement|string} [target] Specify a target if you want the
  * control to be rendered outside of the map's viewport.
  * @property {string} [undefinedHTML='&#160;'] Markup to show when coordinates are not
  * available (e.g. when the pointer leaves the map viewport).  By default, the last position

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -20,7 +20,7 @@ import {get as getProjection} from '../proj.js';
  * source without removing the existing features (append only), instead of
  * providing the source option listen for the "addfeatures" event.
  * @property {import("../proj.js").ProjectionLike} [projection] Target projection. By default, the map's view's projection is used.
- * @property {Element} [target] The element that is used as the drop target, default is the viewport element.
+ * @property {HTMLElement} [target] The element that is used as the drop target, default is the viewport element.
  */
 
 
@@ -127,7 +127,7 @@ class DragAndDrop extends Interaction {
 
     /**
      * @private
-     * @type {Element}
+     * @type {HTMLElement}
      */
     this.target = options.target ? options.target : null;
 


### PR DESCRIPTION
Same as the parent class type for `MousePosition` and the type returned by the
`getViewport` function.
