### PR TITLE
Set crossOrigin to anonymous in mapbox-streets-v6-style

### DIFF
--- a/examples/resources/mapbox-streets-v6-style.js
+++ b/examples/resources/mapbox-streets-v6-style.js
@@ -16,7 +16,8 @@ function createMapboxStreetsV6Style(Style, Fill, Stroke, Icon, Text) {
     if (!icon) {
       icon = new Style({image: new Icon({
         src: 'https://unpkg.com/@mapbox/maki@4.0.0/icons/' + iconName + '-15.svg',
-        imgSize: [15, 15]
+        imgSize: [15, 15],
+        crossOrigin: 'anonymous'
       })});
       iconCache[iconName] = icon;
     }


### PR DESCRIPTION
This PR suggests setting `crossOrigin` to `anonymous` in the options passed to the `Icon` constructor in mapbox-streets-v6-style. This is to be able to use mapbox-streets-v6-style with WebGL. I have checked that unpkg.com has `Access-Control-Allow-Origin: *` and it does. 