### PR TITLE
Remove RenderType enum from vector layer

### DIFF
--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -56,22 +56,6 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
 
 /**
  * @enum {string}
- * Render mode for vector layers:
- *  * `'image'`: Vector layers are rendered as images. Great performance, but
- *    point symbols and texts are always rotated with the view and pixels are
- *    scaled during zoom animations.
- *  * `'vector'`: Vector layers are rendered as vectors. Most accurate rendering
- *    even during animations, but slower performance.
- * @api
- */
-export const RenderType = {
-  IMAGE: 'image',
-  VECTOR: 'vector'
-};
-
-
-/**
- * @enum {string}
  * @private
  */
 const Property = {


### PR DESCRIPTION
We aren't using the `RenderType` enum from `ol/layer/Vector`.