### PR TITLE
Make rendercomplete work with vector sources without loader

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -889,7 +889,7 @@ class VectorSource extends Source {
       if (!alreadyLoaded) {
         this.loader_.call(this, extentToLoad, resolution, projection);
         loadedExtentsRtree.insert(extentToLoad, {extent: extentToLoad.slice()});
-        this.loading = true;
+        this.loading = this.loader_ !== VOID;
       }
     }
   }

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -4,7 +4,7 @@ import Map from '../../../src/ol/Map.js';
 import MapEvent from '../../../src/ol/MapEvent.js';
 import Overlay from '../../../src/ol/Overlay.js';
 import View from '../../../src/ol/View.js';
-import LineString from '../../../src/ol/geom/LineString.js';
+import {LineString, Point} from '../../../src/ol/geom';
 import {TOUCH} from '../../../src/ol/has.js';
 import {focus} from '../../../src/ol/events/condition.js';
 import {defaults as defaultInteractions} from '../../../src/ol/interaction.js';
@@ -219,6 +219,13 @@ describe('ol.Map', function() {
             source: new VectorSource({
               url: 'spec/ol/data/point.json',
               format: new GeoJSON()
+            })
+          }),
+          new VectorLayer({
+            source: new VectorSource({
+              features: [
+                new Feature(new Point([0, 0]))
+              ]
             })
           })
         ]


### PR DESCRIPTION
Fixes #8786.