### PR TITLE
Fix example builder

### DIFF
--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -77,7 +77,7 @@ function getJsSource(chunk, jsName) {
         return jsSource;
       }
     }
-    if (module.identifier.endsWith(jsName)) {
+    if (module.identifier.endsWith(jsName) && module.source) {
       return module.source;
     }
   }


### PR DESCRIPTION
This pull request fixes the `serve-examples` and `build-examples` tasks, which are currently broken because of a bug in the `example-builder` script. 