### PR TITLE
Add a getModifiedFeatures() function to get the features currently modified

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1008,6 +1008,25 @@ class Modify extends PointerInteraction {
   }
 
   /**
+   * Get the features currently modified.
+   * @return {Array<import("../Feature.js").default>} Features.
+   * @api
+   */
+  getModifiedFeatures() {
+    const featuresById = {};
+    let feature, i;
+    this.dragSegments_.forEach(function(s) {
+      feature = s[0].feature;
+      featuresById[getUid(feature)] = feature;
+    });
+    const features = [];
+    for (i in featuresById) {
+      features.push(featuresById[i]);
+    }
+    return features;
+  }
+
+  /**
    * Removes the vertex currently being pointed.
    * @return {boolean} True when a vertex was removed.
    * @api


### PR DESCRIPTION
The MODIFYSTART/MODIFYEND events don't returns the features modified but all the features passed to the interaction.
This function returns only the features concerned by the current modification.
The result could be added in the event or just called by the user when needed.