### PR TITLE
Use the right device orientation property in example

### DIFF
--- a/examples/device-orientation.js
+++ b/examples/device-orientation.js
@@ -29,7 +29,7 @@ gn.init().then(function() {
   gn.start(function(event) {
     const center = view.getCenter();
     const resolution = view.getResolution();
-    const alpha = toRadians(event.do.beta);
+    const alpha = toRadians(event.do.alpha);
     const beta = toRadians(event.do.beta);
     const gamma = toRadians(event.do.gamma);
 


### PR DESCRIPTION
fixes #8891