### PR TITLE
Add imageRatio option for vector layer image mode

### DIFF
--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -21,6 +21,7 @@ const map = new Map({
   layers: [
     new VectorLayer({
       renderMode: 'image',
+      imageRatio: 2,
       source: new VectorSource({
         url: 'data/geojson/countries.geojson',
         format: new GeoJSON()

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -51,6 +51,9 @@ import {createDefaultStyle, toFunction as toStyleFunction} from '../style/Style.
  * @property {boolean} [updateWhileInteracting=false] When set to `true` and `renderMode`
  * is `vector`, feature batches will be recreated during interactions. See also
  * `updateWhileAnimating`.
+ * @property {number} [imageRatio=1] Ratio by which the rendered extent should be larger than the
+ * viewport extent when in `'image'` render mode. A larger ratio avoids cut images during panning,
+ * but will cause a decrease in performance.
  */
 
 
@@ -86,6 +89,7 @@ class VectorLayer extends Layer {
     delete baseOptions.renderBuffer;
     delete baseOptions.updateWhileAnimating;
     delete baseOptions.updateWhileInteracting;
+    delete baseOptions.imageRatio;
     super(baseOptions);
 
     /**
@@ -136,6 +140,13 @@ class VectorLayer extends Layer {
     * @type {import("./VectorTileRenderType.js").default|string}
     */
     this.renderMode_ = options.renderMode || VectorRenderType.VECTOR;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.imageRatio_ = options.imageRatio !== undefined ?
+      options.imageRatio : 1;
 
     /**
     * The layer type.
@@ -236,6 +247,13 @@ class VectorLayer extends Layer {
     this.styleFunction_ = style === null ?
       undefined : toStyleFunction(this.style_);
     this.changed();
+  }
+
+  /**
+   * @return {number} Ratio between rendered extent size and viewport extent size.
+   */
+  getImageRatio() {
+    return this.imageRatio_;
   }
 
   /**

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -6,7 +6,7 @@ import ImageCanvas from '../../ImageCanvas.js';
 import LayerType from '../../LayerType.js';
 import ViewHint from '../../ViewHint.js';
 import {equals} from '../../array.js';
-import {getHeight, getIntersection, getWidth, isEmpty} from '../../extent.js';
+import {getHeight, getIntersection, getWidth, isEmpty, scaleFromCenter} from '../../extent.js';
 import VectorRenderType from '../../layer/VectorRenderType.js';
 import {assign} from '../../obj.js';
 import {layerRendererConstructors} from './Map.js';
@@ -105,6 +105,14 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
 
     const vectorRenderer = this.vectorRenderer_;
     let renderedExtent = frameState.extent;
+    if (vectorRenderer) {
+      const vectorLayer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
+      const imageRatio = vectorLayer.getImageRatio();
+      if (imageRatio !== 1) {
+        renderedExtent = renderedExtent.slice(0);
+        scaleFromCenter(renderedExtent, imageRatio);
+      }
+    }
     if (!vectorRenderer && layerState.extent !== undefined) {
       renderedExtent = getIntersection(renderedExtent, layerState.extent);
     }
@@ -126,6 +134,7 @@ class CanvasImageLayerRenderer extends IntermediateCanvasRenderer {
             getWidth(renderedExtent) / viewResolution,
             getHeight(renderedExtent) / viewResolution
           ],
+          extent: renderedExtent,
           viewState: /** @type {import("../../View.js").State} */ (assign({}, frameState.viewState, {
             rotation: 0
           }))


### PR DESCRIPTION
Alternative to #8637. The buffer is specified as a ratio here, which is more in line with the rest of the library, and we do not add to the `frameState` object.

To avoid nasty conflicts there, this should not be merged before #8848. This will need to be reworked after #8848 is merged, and tests should also be added.