### PR TITLE
Move canvas creation to intermediate canvas renderer constructor

### DIFF
--- a/src/ol/renderer/canvas/IntermediateCanvas.js
+++ b/src/ol/renderer/canvas/IntermediateCanvas.js
@@ -15,10 +15,17 @@ class IntermediateCanvasRenderer extends CanvasLayerRenderer {
 
   /**
    * @param {import("../../layer/Layer.js").default} layer Layer.
+   * @param {boolean=} opt_noContext Skip the context creation.
    */
-  constructor(layer) {
+  constructor(layer, opt_noContext) {
 
     super(layer);
+
+    /**
+     * @protected
+     * @type {CanvasRenderingContext2D}
+     */
+    this.context = opt_noContext ? null : createCanvasContext2D();
 
     /**
      * @protected

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -5,7 +5,6 @@ import {getUid} from '../../util.js';
 import TileRange from '../../TileRange.js';
 import TileState from '../../TileState.js';
 import ViewHint from '../../ViewHint.js';
-import {createCanvasContext2D} from '../../dom.js';
 import {containsExtent, createEmpty, equals, getIntersection, isEmpty} from '../../extent.js';
 import IntermediateCanvasRenderer from './IntermediateCanvas.js';
 import {create as createTransform, compose as composeTransform} from '../../transform.js';
@@ -23,13 +22,7 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
    */
   constructor(tileLayer, opt_noContext) {
 
-    super(tileLayer);
-
-    /**
-     * @protected
-     * @type {CanvasRenderingContext2D}
-     */
-    this.context = opt_noContext ? null : createCanvasContext2D();
+    super(tileLayer, opt_noContext);
 
     /**
      * @private

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -4,7 +4,6 @@
 import {getUid} from '../../util.js';
 import TileState from '../../TileState.js';
 import ViewHint from '../../ViewHint.js';
-import {createCanvasContext2D} from '../../dom.js';
 import {listen, unlisten} from '../../events.js';
 import EventType from '../../events/EventType.js';
 import rbush from 'rbush';
@@ -59,7 +58,8 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    */
   constructor(layer) {
 
-    super(layer, true);
+    const renderMode = layer.getRenderMode();
+    super(layer, renderMode === VectorTileRenderType.VECTOR);
 
     /**
      * Declutter tree.
@@ -85,14 +85,8 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
      */
     this.tmpTransform_ = createTransform();
 
-    const renderMode = layer.getRenderMode();
-
     // Use lower resolution for pure vector rendering. Closest resolution otherwise.
     this.zDirection = renderMode === VectorTileRenderType.VECTOR ? 1 : 0;
-
-    if (renderMode !== VectorTileRenderType.VECTOR) {
-      this.context = createCanvasContext2D();
-    }
 
 
     listen(labelCache, EventType.CLEAR, this.handleFontsChanged_, this);


### PR DESCRIPTION
This makes it so the intermediate canvas renderer has the responsibility of (conditionally) creating a canvas.  No change in functionality, just changing who is responsible for canvas creation.