### PR TITLE
Apply all transforms in the layer renderer

### DIFF
--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -85,8 +85,6 @@ class CompositeMapRenderer extends MapRenderer {
     const layerStatesArray = frameState.layerStatesArray;
     stableSort(layerStatesArray, sortByZIndex);
 
-    const rotation = frameState.viewState.rotation;
-
     const viewResolution = frameState.viewState.resolution;
 
     this.children_.length = 0;
@@ -100,17 +98,6 @@ class CompositeMapRenderer extends MapRenderer {
       const layerRenderer = this.getLayerRenderer(layer);
       if (layerRenderer.prepareFrame(frameState, layerState)) {
         const element = layerRenderer.renderFrame(frameState, layerState);
-
-        const opacity = layerState.opacity;
-        if (opacity !== element.style.opacity) {
-          element.style.opacity = opacity;
-        }
-
-        const transform = 'rotate(' + rotation + 'rad)';
-        if (transform !== element.style.transform) {
-          element.style.transform = transform;
-        }
-
         this.children_.push(element);
       }
     }

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -318,11 +318,23 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @inheritDoc
    */
   renderFrame(frameState, layerState) {
-    const transform = this.getTransform(frameState, 0);
-    this.preRender(frameState, transform);
+    this.preRender(frameState);
     this.render(frameState, layerState);
-    this.postRender(frameState, layerState, transform);
-    return this.context.canvas;
+    this.postRender(frameState, layerState);
+    const canvas = this.context.canvas;
+
+    const opacity = layerState.opacity;
+    if (opacity !== canvas.style.opacity) {
+      canvas.style.opacity = opacity;
+    }
+
+    const rotation = frameState.viewState.rotation;
+    const transform = 'rotate(' + rotation + 'rad)';
+    if (transform !== canvas.style.transform) {
+      canvas.style.transform = transform;
+    }
+
+    return canvas;
   }
 
   /**


### PR DESCRIPTION
Previously, the composite renderer applied transforms to elements rendered by layers.  This made it so the layer renderers themselves could not apply transforms (since they would not know if the parent renderer was going to clobber them).  Instead, the layer renderers should have the sole responsibility of rendering (and scaling, rotating, translating, etc) the element.