### PR TITLE
Layer is reponsible for its renderer

### DIFF
--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -32,11 +32,10 @@ class ImageLayer extends BaseImageLayer {
 
   /**
    * Create a renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
    * @protected
    */
-  createRenderer(mapRenderer) {
+  createRenderer() {
     return new CanvasImageLayerRenderer(this);
   }
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -224,23 +224,21 @@ class Layer extends BaseLayer {
 
   /**
    * Get the renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} The layer renderer.
    */
-  getRenderer(mapRenderer) {
+  getRenderer() {
     if (!this.renderer_) {
-      this.renderer_ = this.createRenderer(mapRenderer);
+      this.renderer_ = this.createRenderer();
     }
     return this.renderer_;
   }
 
   /**
    * Create a renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
    * @protected
    */
-  createRenderer(mapRenderer) {
+  createRenderer() {
     return null;
   }
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -173,6 +173,20 @@ class Layer extends BaseLayer {
   }
 
   /**
+   * In charge to manage the rendering of the layer. One layer type is
+   * bounded with one layer renderer.
+   * @param {?import("../PluggableMap.js").FrameState} frameState Frame state.
+   * @return {HTMLElement} The rendered element.
+   */
+  render(frameState) {
+    const layerRenderer = this.getRenderer();
+    const layerState = this.getLayerState();
+    if (layerRenderer.prepareFrame(frameState, layerState)) {
+      return layerRenderer.renderFrame(frameState, layerState);
+    }
+  }
+
+  /**
    * Sets the layer to be rendered on top of other layers on a map. The map will
    * not manage this layer in its layers collection, and the callback in
    * {@link module:ol/Map#forEachLayerAtPixel} will receive `null` as layer. This

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -31,11 +31,10 @@ class TileLayer extends BaseTileLayer {
 
   /**
    * Create a renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
    * @protected
    */
-  createRenderer(mapRenderer) {
+  createRenderer() {
     return new CanvasTileLayerRenderer(this);
   }
 

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -29,11 +29,10 @@ class VectorLayer extends BaseVectorLayer {
 
   /**
    * Create a renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
    * @protected
    */
-  createRenderer(mapRenderer) {
+  createRenderer() {
     return new CanvasVectorLayerRenderer(this);
   }
 }

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -28,11 +28,10 @@ class VectorImageLayer extends BaseVectorLayer {
 
   /**
    * Create a renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
    * @protected
    */
-  createRenderer(mapRenderer) {
+  createRenderer() {
     return new CanvasVectorImageLayerRenderer(this);
   }
 }

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -116,11 +116,10 @@ class VectorTileLayer extends BaseVectorLayer {
 
   /**
    * Create a renderer for this layer.
-   * @param {import("../renderer/Map.js").default} mapRenderer The map renderer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
    * @protected
    */
-  createRenderer(mapRenderer) {
+  createRenderer() {
     return new CanvasVectorTileLayerRenderer(this);
   }
 

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -96,11 +96,7 @@ class CompositeMapRenderer extends MapRenderer {
       }
 
       const layer = layerState.layer;
-      const layerRenderer = this.getLayerRenderer(layer);
-      if (layerRenderer.prepareFrame(frameState, layerState)) {
-        const element = layerRenderer.renderFrame(frameState, layerState);
-        this.children_.push(element);
-      }
+      this.children_.push(layer.render(frameState));
     }
 
     replaceChildren(this.element_, this.children_);


### PR DESCRIPTION
Move layer rendering logic from Map renderer to Layer.
Each layer instanciates its own renderer. The layer new `render()` method is in charge to manage the rendering of the layer.
This aims to add new layer type along with completly different rendering logic (SVG, WebGL, ...).

Start to rework the layer render do have no dependency on the map renderer, that should be removed in the end.

Work in progress, direction to be confirmed.