### PR TITLE
Serve sourcemaps from webpack during rendering tests

### DIFF
--- a/rendering/test.js
+++ b/rendering/test.js
@@ -67,7 +67,8 @@ function serve(options) {
         return;
       }
 
-      if (path.extname(req.url) === '.js') {
+      const ext = path.extname(req.url);
+      if (ext === '.js' || ext === '.map') {
         webpackHandler(req, res, notFound(req, res));
         return;
       }


### PR DESCRIPTION
This makes it easier to debug the rendering test cases.