### PR TITLE
Make the tile debug source useful for understanding tiles

### DIFF
--- a/examples/canvas-tiles.html
+++ b/examples/canvas-tiles.html
@@ -4,10 +4,7 @@ title: Canvas Tiles
 shortdesc: Renders tiles with coordinates for debugging.
 docs: >
   The black grid tiles are generated on the client with an HTML5 canvas. The
-  displayed tile coordinates are OpenLayers tile coordinates. These increase
-  from bottom to top, but standard XYZ tiling scheme coordinates increase from
-  top to bottom. To calculate the `y` for a standard XYZ tile coordinate, use
-  `-y - 1`.
+  displayed tile coordinates are the XYZ tile coordinates.
 tags: "layers, openstreetmap, canvas"
 ---
 <div id="map" class="map"></div>

--- a/examples/canvas-tiles.js
+++ b/examples/canvas-tiles.js
@@ -1,26 +1,21 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
 import {OSM, TileDebug} from '../src/ol/source.js';
 
 
-const osmSource = new OSM();
 const map = new Map({
   layers: [
     new TileLayer({
-      source: osmSource
+      source: new OSM()
     }),
     new TileLayer({
-      source: new TileDebug({
-        projection: 'EPSG:3857',
-        tileGrid: osmSource.getTileGrid()
-      })
+      source: new TileDebug()
     })
   ],
   target: 'map',
   view: new View({
-    center: fromLonLat([-0.1275, 51.507222]),
-    zoom: 10
+    center: [0, 0],
+    zoom: 1
   })
 });

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -6,7 +6,7 @@ import Tile from '../Tile.js';
 import TileState from '../TileState.js';
 import {createCanvasContext2D} from '../dom.js';
 import {toSize} from '../size.js';
-import TileSource from './Tile.js';
+import XYZ from './XYZ.js';
 import {getKeyZXY} from '../tilecoord.js';
 
 
@@ -51,10 +51,10 @@ class LabeledTile extends Tile {
       const tileSize = this.tileSize_;
       const context = createCanvasContext2D(tileSize[0], tileSize[1]);
 
-      context.strokeStyle = 'black';
+      context.strokeStyle = 'grey';
       context.strokeRect(0.5, 0.5, tileSize[0] + 0.5, tileSize[1] + 0.5);
 
-      context.fillStyle = 'black';
+      context.fillStyle = 'grey';
       context.textAlign = 'center';
       context.textBaseline = 'middle';
       context.font = '24px sans-serif';
@@ -74,7 +74,7 @@ class LabeledTile extends Tile {
 
 /**
  * @typedef {Object} Options
- * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Optional projection.
  * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  */
@@ -89,11 +89,15 @@ class LabeledTile extends Tile {
  * Uses Canvas context2d, so requires Canvas support.
  * @api
  */
-class TileDebug extends TileSource {
+class TileDebug extends XYZ {
   /**
-   * @param {Options} options Debug tile options.
+   * @param {Options=} opt_options Debug tile options.
    */
-  constructor(options) {
+  constructor(opt_options) {
+    /**
+     * @type {Options}
+     */
+    const options = opt_options || {};
 
     super({
       opaque: false,
@@ -115,8 +119,12 @@ class TileDebug extends TileSource {
       const tileSize = toSize(this.tileGrid.getTileSize(z));
       const tileCoord = [z, x, y];
       const textTileCoord = this.getTileCoordForTileUrlFunction(tileCoord);
-      const text = !textTileCoord ? '' :
-        this.getTileCoordForTileUrlFunction(textTileCoord).toString();
+      let text;
+      if (textTileCoord) {
+        text = 'z:' + textTileCoord[0] + ' x:' + textTileCoord[1] + ' y:' + (-textTileCoord[2] - 1);
+      } else {
+        text = 'none';
+      }
       const tile = new LabeledTile(tileCoord, tileSize, text);
       this.tileCache.set(tileCoordKey, tile);
       return tile;


### PR DESCRIPTION
Before (weird numbering scheme that we need to try to justify to the world):
![image](https://user-images.githubusercontent.com/41094/48490673-36c3c100-e826-11e8-99b8-d556536791bc.png)

After (what the world expects):
![image](https://user-images.githubusercontent.com/41094/48490703-4a6f2780-e826-11e8-990c-006df35d33c2.png)
