### PR TITLE
Rendering tests render message

### DIFF
--- a/rendering/cases/single-layer/main.js
+++ b/rendering/cases/single-layer/main.js
@@ -18,4 +18,4 @@ new Map({
   })
 });
 
-render();
+render('A single layer with a XZY source');


### PR DESCRIPTION
Allow a string to be passed to the `render` function.

On error, the output is now:
```
$ node rendering/test.js --force 
checking 'A single layer with a XZY source': mismatch 0.729
RENDERING TESTS FAILED
```
If no message is provided, the path to the test is used:
```
$ node rendering/test.js --force 
checked './cases/linestring-style/main.js': mismatch 0.730
RENDERING TESTS FAILED
```

