### PR TITLE
Make the map renderer tolerant of layers without renderers

### DIFF
--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -130,6 +130,9 @@ class CompositeMapRenderer extends MapRenderer {
       const layer = layerState.layer;
       if (visibleAtResolution(layerState, viewResolution) && layerFilter.call(thisArg2, layer)) {
         const layerRenderer = this.getLayerRenderer(layer);
+        if (!layerRenderer) {
+          continue;
+        }
         result = layerRenderer.forEachLayerAtCoordinate(coordinate, frameState, hitTolerance, callback, thisArg);
         if (result) {
           return result;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -141,7 +141,7 @@ class MapRenderer extends Disposable {
       if (visibleAtResolution(layerState, viewResolution) && layerFilter.call(thisArg2, layer)) {
         const layerRenderer = this.getLayerRenderer(layer);
         const source = layer.getSource();
-        if (source) {
+        if (layerRenderer && source) {
           result = layerRenderer.forEachFeatureAtCoordinate(
             source.getWrapX() ? translatedCoordinate : coordinate,
             frameState, hitTolerance, forEachFeatureAtCoordinate);
@@ -196,7 +196,7 @@ class MapRenderer extends Disposable {
   /**
    * @param {import("../layer/Layer.js").default} layer Layer.
    * @protected
-   * @return {import("./Layer.js").default} Layer renderer.
+   * @return {import("./Layer.js").default} Layer renderer. May return null.
    */
   getLayerRenderer(layer) {
     const layerKey = getUid(layer);
@@ -204,9 +204,9 @@ class MapRenderer extends Disposable {
       return this.layerRenderers_[layerKey];
     }
 
-    const renderer = layer.getRenderer(this);
+    const renderer = layer.getRenderer();
     if (!renderer) {
-      throw new Error('Unable to create renderer for layer');
+      return null;
     }
 
     this.layerRenderers_[layerKey] = renderer;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -215,15 +215,6 @@ class MapRenderer extends Disposable {
   }
 
   /**
-   * @param {string} layerKey Layer key.
-   * @protected
-   * @return {import("./Layer.js").default} Layer renderer.
-   */
-  getLayerRendererByKey(layerKey) {
-    return this.layerRenderers_[layerKey];
-  }
-
-  /**
    * @protected
    * @return {Object<string, import("./Layer.js").default>} Layer renderers.
    */


### PR DESCRIPTION
People who extend our `ol/layer/Layer` may not implement `createRenderer`.  In this case, `getRenderer` returns `null`.  The map renderer should be tolerant to this type of layer.