### PR TITLE
Remove extra key in restore_cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          - v1-dependencies-
+          key: v1-dependencies-{{ checksum "package.json" }}
 
       - run:
           name: Install Dependencies


### PR DESCRIPTION
Only `v1-dependencies-{{ checksum "package.json" }}` key is used in save_cache. Or do I miss something?