### PR TITLE
Use Object.values if available

### DIFF
--- a/src/ol/obj.js
+++ b/src/ol/obj.js
@@ -44,18 +44,20 @@ export function clear(object) {
 
 
 /**
- * Get an array of property values from an object.
- * @param {Object<K,V>} object The object from which to get the values.
+ * Polyfill for Object.values().  Get an array of property values from an object.
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values
+ *
+ * @param {!Object<K,V>} object The object from which to get the values.
  * @return {!Array<V>} The property values.
  * @template K,V
  */
-export function getValues(object) {
+export const getValues = (typeof Object.values === 'function') ? Object.values : function(object) {
   const values = [];
   for (const property in object) {
     values.push(object[property]);
   }
   return values;
-}
+};
 
 
 /**

--- a/test/spec/ol/objectutil.test.js
+++ b/test/spec/ol/objectutil.test.js
@@ -58,7 +58,7 @@ describe('ol.obj.getValues()', function() {
 
   it('gets a list of property values from an object', function() {
     expect(getValues({foo: 'bar', num: 42}).sort()).to.eql([42, 'bar']);
-    expect(getValues(null)).to.eql([]);
+    expect(getValues([])).to.eql([]);
   });
 
 });


### PR DESCRIPTION
As `Object.values`, the arguments now can't be `null` or `undefined`.
