### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-<!--
-Thank you for your interest in making OpenLayers better!
-
-If you are reporting a bug, please link to an example that reproduces the problem.  This will make it easier for people who may want to help you debug.
-
-If you have a usage question, you might want to try Stack Overflow first: https://stackoverflow.com/questions/tagged/openlayers
-
-Thanks
--->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: 
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: 
+labels:
+ - bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: 
+labels:
+ - feature request
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: 
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.


### PR DESCRIPTION
This gives us [dedicated templates](https://help.github.com/articles/about-issue-and-pull-request-templates/) for bug reports and feature requests.  Users will see options like this:

![image](https://user-images.githubusercontent.com/41094/48727283-09dd2880-ebef-11e8-862e-0c05dcb7ddef.png)
