### PR TITLE
Use standard tile coords

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,6 +4,53 @@
 
 #### Backwards incompatible changes
 
+##### New internal tile coordinates
+
+Previously, the internal tile coordinates used in the library had an unusual row order – the origin of the tile coordinate system was at the top left as expected, but the rows increased upwards.  This meant that all tile coordinates within a tile grid's extent had negative `y` values.
+
+Now, the internal tile coordinates used in the library have the same row order as standard (e.g. XYZ) tile coordinates.  The origin is at the top left (as before), and rows or `y` values increase downward.  So the top left tile of a tile grid is now `0, 0`, whereas it was `0, -1` before.
+
+```
+x, y values for tile coordinates
+
+origin
+  *__________________________
+  |        |        |        |
+  |  0, 0  |  1, 0  |  2, 0  |
+  |________|________|________|
+  |        |        |        |
+  |  0, 1  |  1, 1  |  2, 1  |
+  |________|________|________|
+  |        |        |        |
+  |  0, 2  |  1, 2  |  2, 2  |
+  |________|________|________|
+```
+
+This change should only affect you if you were using a custom `tileLoadFunction` or `tileUrlFunction`.  For example, if you used to have a `tileUrlFunction` that looked like this:
+
+```js
+// before
+function tileUrlFunction(tileCoord) {
+  const z = tileCoord[0];
+  const x = tileCoord[1];
+  const y = -tileCoord[2] - 1;
+  // do something with z, x, y
+}
+```
+
+You would now do something like this:
+```js
+// after
+function tileUrlFunction(tileCoord) {
+  const z = tileCoord[0];
+  const x = tileCoord[1];
+  const y = tileCoord[2];
+  // do something with z, x, y
+}
+```
+
+In addition (this should be exceedingly rare), if you previously created a `ol/tilegrid/WMTS` by hand and you were providing an array of `sizes`, you no longer have to provide a negative height if your tile origin is the top-left corner (the common case).  On the other hand, if you are providing a custom array of `sizes` and your origin is the bottom of the grid (this is uncommon), your height values must now be negative.
+
 ##### Removal of the "vector" render mode for vector tile layers
 
 If you were previously using `VectorTile` layers with `renderMode: 'vector'`, you have to remove this configuration option. That mode was removed. `'hybrid'` (default) and `'image'` are still available.

--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -77,7 +77,7 @@ fetch(url).then(function(response) {
     tileLoadFunction: function(tile) {
       const format = tile.getFormat();
       const tileCoord = tile.getTileCoord();
-      const data = tileIndex.getTile(tileCoord[0], tileCoord[1], -tileCoord[2] - 1);
+      const data = tileIndex.getTile(tileCoord[0], tileCoord[1], tileCoord[2]);
 
       const features = format.readFeatures(
         JSON.stringify({

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -21,7 +21,7 @@ function tileUrlFunction(tileCoord) {
       '{z}/{x}/{y}.vector.pbf?access_token=' + key)
     .replace('{z}', String(tileCoord[0] * 2 - 1))
     .replace('{x}', String(tileCoord[1]))
-    .replace('{y}', String(-tileCoord[2] - 1))
+    .replace('{y}', String(tileCoord[2]))
     .replace('{a-d}', 'abcd'.substr(
       ((tileCoord[1] << tileCoord[0]) + tileCoord[2]) % 4, 1));
 }

--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -21,7 +21,7 @@ const map = new Map({
         tileUrlFunction: function(tileCoord) {
           return urlTemplate.replace('{z}', (tileCoord[0] - 1).toString())
             .replace('{x}', tileCoord[1].toString())
-            .replace('{y}', (-tileCoord[2] - 1).toString());
+            .replace('{y}', tileCoord[2].toString());
         },
         wrapX: true
       })

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -274,7 +274,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         // Calculate integer positions and sizes so that tiles align
         const floatX = (origin[0] - (originTileCoord[1] - tileCoord[1]) * dx);
         const nextX = Math.round(floatX + dx);
-        const floatY = (origin[1] + (originTileCoord[2] - tileCoord[2]) * dy);
+        const floatY = (origin[1] - (originTileCoord[2] - tileCoord[2]) * dy);
         const nextY = Math.round(floatY + dy);
         const x = Math.round(floatX);
         const y = Math.round(floatY);

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -250,7 +250,7 @@ class BingMaps extends TileImage {
             if (!tileCoord) {
               return undefined;
             } else {
-              createOrUpdate(tileCoord[0], tileCoord[1], -tileCoord[2] - 1, quadKeyTileCoord);
+              createOrUpdate(tileCoord[0], tileCoord[1], tileCoord[2], quadKeyTileCoord);
               let url = imageUrl;
               if (hidpi) {
                 url += '&dpi=d1&device=mobile';

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -8,8 +8,33 @@ import {jsonp as requestJSONP} from '../net.js';
 import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import SourceState from './State.js';
 import TileImage from './TileImage.js';
-import {createOrUpdate, quadKey} from '../tilecoord.js';
+import {createOrUpdate} from '../tilecoord.js';
 import {createXYZ, extentFromProjection} from '../tilegrid.js';
+
+
+/**
+ * @param {import('../tilecoord.js').TileCoord} tileCoord Tile coord.
+ * @return {string} Quad key.
+ */
+export function quadKey(tileCoord) {
+  const z = tileCoord[0];
+  const digits = new Array(z);
+  let mask = 1 << (z - 1);
+  let i, charCode;
+  for (i = 0; i < z; ++i) {
+    // 48 is charCode for 0 - '0'.charCodeAt(0)
+    charCode = 48;
+    if (tileCoord[1] & mask) {
+      charCode += 1;
+    }
+    if (tileCoord[2] & mask) {
+      charCode += 2;
+    }
+    digits[i] = String.fromCharCode(charCode);
+    mask >>= 1;
+  }
+  return digits.join('');
+}
 
 
 /**
@@ -209,6 +234,7 @@ class BingMaps extends TileImage {
     const hidpi = this.hidpi_;
     this.tileUrlFunction = createFromTileUrlFunctions(
       resource.imageUrlSubdomains.map(function(subdomain) {
+        /** @type {import('../tilecoord.js').TileCoord} */
         const quadKeyTileCoord = [0, 0, 0];
         const imageUrl = resource.imageUrl
           .replace('{subdomain}', subdomain)

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -121,7 +121,7 @@ class TileDebug extends XYZ {
       const textTileCoord = this.getTileCoordForTileUrlFunction(tileCoord);
       let text;
       if (textTileCoord) {
-        text = 'z:' + textTileCoord[0] + ' x:' + textTileCoord[1] + ' y:' + (-textTileCoord[2] - 1);
+        text = 'z:' + textTileCoord[0] + ' x:' + textTileCoord[1] + ' y:' + textTileCoord[2];
       } else {
         text = 'none';
       }

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -507,7 +507,7 @@ function createFromWMTSTemplate(template) {
         const localContext = {
           'TileMatrix': tileGrid.getMatrixId(tileCoord[0]),
           'TileCol': tileCoord[1],
-          'TileRow': -tileCoord[2] - 1
+          'TileRow': tileCoord[2]
         };
         assign(localContext, dimensions);
         let url = template;

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -213,7 +213,7 @@ class Zoomify extends TileImage {
           } else {
             const tileCoordZ = tileCoord[0];
             const tileCoordX = tileCoord[1];
-            const tileCoordY = -tileCoord[2] - 1;
+            const tileCoordY = tileCoord[2];
             const tileIndex =
                 tileCoordX +
                 tileCoordY * tierSizeInTiles[tileCoordZ][0];

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -5,7 +5,7 @@
 
 /**
  * An array of three numbers representing the location of a tile in a tile
- * grid. The order is `z`, `x`, and `y`. `z` is the zoom level.
+ * grid. The order is `z` (zoom level), `x` (column), and `y` (row).
  * @typedef {Array<number>} TileCoord
  * @api
  */

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -71,31 +71,6 @@ export function hash(tileCoord) {
 
 
 /**
- * @param {TileCoord} tileCoord Tile coord.
- * @return {string} Quad key.
- */
-export function quadKey(tileCoord) {
-  const z = tileCoord[0];
-  const digits = new Array(z);
-  let mask = 1 << (z - 1);
-  let i, charCode;
-  for (i = 0; i < z; ++i) {
-    // 48 is charCode for 0 - '0'.charCodeAt(0)
-    charCode = 48;
-    if (tileCoord[1] & mask) {
-      charCode += 1;
-    }
-    if (tileCoord[2] & mask) {
-      charCode += 2;
-    }
-    digits[i] = String.fromCharCode(charCode);
-    mask >>= 1;
-  }
-  return digits.join('');
-}
-
-
-/**
  * @param {TileCoord} tileCoord Tile coordinate.
  * @param {!import("./tilegrid/TileGrid.js").default} tileGrid Tile grid.
  * @return {boolean} Tile coordinate is within extent and zoom level range.

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -342,10 +342,10 @@ class TileGrid {
    */
   getTileRangeForExtentAndZ(extent, z, opt_tileRange) {
     const tileCoord = tmpTileCoord;
-    this.getTileCoordForXYAndZ_(extent[0], extent[1], z, false, tileCoord);
+    this.getTileCoordForXYAndZ_(extent[0], extent[3], z, false, tileCoord);
     const minX = tileCoord[1];
     const minY = tileCoord[2];
-    this.getTileCoordForXYAndZ_(extent[2], extent[3], z, true, tileCoord);
+    this.getTileCoordForXYAndZ_(extent[2], extent[1], z, true, tileCoord);
     return createOrUpdateTileRange(minX, tileCoord[1], minY, tileCoord[2], opt_tileRange);
   }
 
@@ -359,7 +359,7 @@ class TileGrid {
     const tileSize = toSize(this.getTileSize(tileCoord[0]), this.tmpSize_);
     return [
       origin[0] + (tileCoord[1] + 0.5) * tileSize[0] * resolution,
-      origin[1] + (tileCoord[2] + 0.5) * tileSize[1] * resolution
+      origin[1] - (tileCoord[2] + 0.5) * tileSize[1] * resolution
     ];
   }
 
@@ -376,7 +376,7 @@ class TileGrid {
     const resolution = this.getResolution(tileCoord[0]);
     const tileSize = toSize(this.getTileSize(tileCoord[0]), this.tmpSize_);
     const minX = origin[0] + tileCoord[1] * tileSize[0] * resolution;
-    const minY = origin[1] + tileCoord[2] * tileSize[1] * resolution;
+    const minY = origin[1] - (tileCoord[2] + 1) * tileSize[1] * resolution;
     const maxX = minX + tileSize[0] * resolution;
     const maxY = minY + tileSize[1] * resolution;
     return createOrUpdate(minX, minY, maxX, maxY, opt_extent);
@@ -418,9 +418,9 @@ class TileGrid {
     const tileSize = toSize(this.getTileSize(z), this.tmpSize_);
 
     const adjustX = reverseIntersectionPolicy ? 0.5 : 0;
-    const adjustY = reverseIntersectionPolicy ? 0 : 0.5;
+    const adjustY = reverseIntersectionPolicy ? 0.5 : 0;
     const xFromOrigin = Math.floor((x - origin[0]) / resolution + adjustX);
-    const yFromOrigin = Math.floor((y - origin[1]) / resolution + adjustY);
+    const yFromOrigin = Math.floor((origin[1] - y) / resolution + adjustY);
     let tileCoordX = scale * xFromOrigin / tileSize[0];
     let tileCoordY = scale * yFromOrigin / tileSize[1];
 
@@ -456,9 +456,9 @@ class TileGrid {
     const tileSize = toSize(this.getTileSize(z), this.tmpSize_);
 
     const adjustX = reverseIntersectionPolicy ? 0.5 : 0;
-    const adjustY = reverseIntersectionPolicy ? 0 : 0.5;
+    const adjustY = reverseIntersectionPolicy ? 0.5 : 0;
     const xFromOrigin = Math.floor((x - origin[0]) / resolution + adjustX);
-    const yFromOrigin = Math.floor((y - origin[1]) / resolution + adjustY);
+    const yFromOrigin = Math.floor((origin[1] - y) / resolution + adjustY);
     let tileCoordX = xFromOrigin / tileSize[0];
     let tileCoordY = yFromOrigin / tileSize[1];
 

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -31,9 +31,9 @@ import TileGrid from './TileGrid.js';
  * `TileMatrixHeight` advertised in the GetCapabilities response of the WMTS, and
  * define the grid's extent together with the `origin`.
  * An `extent` can be configured in addition, and will further limit the extent for
- * which tile requests are made by sources. Note that when the top-left corner of
+ * which tile requests are made by sources. If the bottom-left corner of
  * the `extent` is used as `origin` or `origins`, then the `y` value must be
- * negative because OpenLayers tile coordinates increase upwards.
+ * negative because OpenLayers tile coordinates use the top left as the origin.
  * @property {number|import("../size.js").Size} [tileSize] Tile size.
  * @property {Array<import("../size.js").Size>} [tileSizes] Tile sizes. The length of
  * this array needs to match the length of the `resolutions` array.
@@ -174,8 +174,7 @@ export function createFromCapabilitiesMatrixSet(matrixSet, opt_extent, opt_matri
       resolutions.push(resolution);
       tileSizes.push(tileWidth == tileHeight ?
         tileWidth : [tileWidth, tileHeight]);
-      // top-left origin, so height is negative
-      sizes.push([elt['MatrixWidth'], -elt['MatrixHeight']]);
+      sizes.push([elt['MatrixWidth'], elt['MatrixHeight']]);
     }
   });
 

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -29,15 +29,12 @@ export function createFromTemplate(template, tileGrid) {
       } else {
         return template.replace(zRegEx, tileCoord[0].toString())
           .replace(xRegEx, tileCoord[1].toString())
-          .replace(yRegEx, function() {
-            const y = -tileCoord[2] - 1;
-            return y.toString();
-          })
+          .replace(yRegEx, tileCoord[2].toString())
           .replace(dashYRegEx, function() {
             const z = tileCoord[0];
             const range = tileGrid.getFullTileRange(z);
             assert(range, 55); // The {-y} placeholder requires a tile grid with extent
-            const y = range.getHeight() + tileCoord[2];
+            const y = range.getHeight() - tileCoord[2] - 1;
             return y.toString();
           });
       }

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -242,9 +242,10 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       sourceTile.getImage = function() {
         return document.createElement('canvas');
       };
+      const tileUrlFunction = function() {};
       const tile = new VectorImageTile([0, 0, 0], undefined, undefined, undefined,
-        undefined, [0, 0, 0], undefined, createXYZ(), createXYZ(), undefined, undefined,
-        undefined, undefined, undefined, 0);
+        undefined, [0, 0, 0], tileUrlFunction, createXYZ(), createXYZ(), {}, undefined,
+        undefined, VectorTile, undefined, 0);
       tile.transition_ = 0;
       tile.wrappedTileCoord = [0, 0, 0];
       tile.setState(TileState.LOADED);

--- a/test/spec/ol/reproj/tile.test.js
+++ b/test/spec/ol/reproj/tile.test.js
@@ -30,7 +30,7 @@ describe('ol.reproj.Tile', function() {
     return new ReprojTile(
       proj3857, createForProjection(proj3857), proj4326,
       createForProjection(proj4326, 3, opt_tileSize),
-      [3, 2, -2], null, pixelRatio, 0, function(z, x, y, pixelRatio) {
+      [3, 2, 1], null, pixelRatio, 0, function(z, x, y, pixelRatio) {
         return new ImageTile([z, x, y], 0, // IDLE
           'data:image/gif;base64,' +
               'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=', null,

--- a/test/spec/ol/source/bingmaps.test.js
+++ b/test/spec/ol/source/bingmaps.test.js
@@ -1,9 +1,16 @@
-import BingMaps from '../../../../src/ol/source/BingMaps.js';
-import {quadKey} from '../../../../src/ol/tilecoord.js';
+import BingMaps, {quadKey} from '../../../../src/ol/source/BingMaps.js';
 import {unByKey} from '../../../../src/ol/Observable.js';
 
 
 describe('ol.source.BingMaps', function() {
+
+  describe('quadKey()', function() {
+    it('returns expected string', function() {
+      const tileCoord = [3, 3, 5];
+      const s = quadKey(tileCoord);
+      expect(s).to.eql('213');
+    });
+  });
 
   describe('#tileUrlFunction()', function() {
 

--- a/test/spec/ol/source/tile.test.js
+++ b/test/spec/ol/source/tile.test.js
@@ -227,14 +227,14 @@ describe('ol.source.Tile', function() {
         wrapX: true
       });
 
-      let tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, -23]);
-      expect(tileCoord).to.eql([6, 33, -23]);
+      let tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
 
-      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 33, -23]);
-      expect(tileCoord).to.eql([6, 33, -23]);
+      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 33, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
 
-      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 97, -23]);
-      expect(tileCoord).to.eql([6, 33, -23]);
+      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 97, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
     });
 
     it('returns the expected tile coordinate - {wrapX: false}', function() {
@@ -243,13 +243,13 @@ describe('ol.source.Tile', function() {
         wrapX: false
       });
 
-      let tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, -23]);
+      let tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, 22]);
       expect(tileCoord).to.eql(null);
 
-      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 33, -23]);
-      expect(tileCoord).to.eql([6, 33, -23]);
+      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 33, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
 
-      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 97, -23]);
+      tileCoord = tileSource.getTileCoordForTileUrlFunction([6, 97, 22]);
       expect(tileCoord).to.eql(null);
     });
 
@@ -263,8 +263,8 @@ describe('ol.source.Tile', function() {
         wrapX: true
       });
 
-      const tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, -23]);
-      expect(tileCoord).to.eql([6, 33, -23]);
+      const tileCoord = tileSource.getTileCoordForTileUrlFunction([6, -31, 22]);
+      expect(tileCoord).to.eql([6, 33, 22]);
     });
   });
 

--- a/test/spec/ol/source/tilearcgisrest.test.js
+++ b/test/spec/ol/source/tilearcgisrest.test.js
@@ -17,7 +17,7 @@ describe('ol.source.TileArcGISRest', function() {
 
     it('returns a tile with the expected URL', function() {
       const source = new TileArcGISRest(options);
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(ImageTile);
       const uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -39,7 +39,7 @@ describe('ol.source.TileArcGISRest', function() {
 
     it('returns a non floating point DPI value', function() {
       const source = new TileArcGISRest(options);
-      const tile = source.getTile(3, 2, -7, 1.12, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1.12, getProjection('EPSG:3857'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('DPI')).to.be('101');
@@ -48,7 +48,7 @@ describe('ol.source.TileArcGISRest', function() {
     it('takes DPI from params if specified', function() {
       options.params.DPI = 96;
       const source = new TileArcGISRest(options);
-      const tile = source.getTile(3, 2, -7, 1.12, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1.12, getProjection('EPSG:3857'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('DPI')).to.be('108');
@@ -60,7 +60,7 @@ describe('ol.source.TileArcGISRest', function() {
       options.urls = ['http://test1.com/MapServer', 'http://test2.com/MapServer'];
       const source = new TileArcGISRest(options);
 
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(ImageTile);
       const uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -83,7 +83,7 @@ describe('ol.source.TileArcGISRest', function() {
     it('returns a tile with the expected URL for ImageServer', function() {
       options.url = 'http://example.com/ImageServer';
       const source = new TileArcGISRest(options);
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(ImageTile);
       const uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -106,7 +106,7 @@ describe('ol.source.TileArcGISRest', function() {
       options.params.FORMAT = 'png';
       options.params.TRANSPARENT = false;
       const source = new TileArcGISRest(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('png');
@@ -116,7 +116,7 @@ describe('ol.source.TileArcGISRest', function() {
     it('allows adding rest option', function() {
       options.params.LAYERS = 'show:1,3,4';
       const source = new TileArcGISRest(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('LAYERS')).to.be('show:1,3,4');
@@ -129,7 +129,7 @@ describe('ol.source.TileArcGISRest', function() {
       const source = new TileArcGISRest(options);
       source.updateParams({'TEST': 'value'});
 
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('TEST')).to.be('value');
@@ -141,7 +141,7 @@ describe('ol.source.TileArcGISRest', function() {
       const source = new TileArcGISRest(options);
       source.updateParams({'TEST': 'newValue'});
 
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('TEST')).to.be('newValue');

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -49,14 +49,13 @@ describe('ol.source.TileImage', function() {
     beforeEach(function() {
       source = createSource();
       expect(source.getKey()).to.be('');
-      source.getTileInternal(0, 0, -1, 1, getProjection('EPSG:3857'));
+      source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
       expect(source.tileCache.getCount()).to.be(1);
-      tile = source.tileCache.get(getKeyZXY(0, 0, -1));
+      tile = source.tileCache.get(getKeyZXY(0, 0, 0));
     });
 
     it('gets the tile from the cache', function() {
-      const returnedTile = source.getTileInternal(
-        0, 0, -1, 1, getProjection('EPSG:3857'));
+      const returnedTile = source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
       expect(returnedTile).to.be(tile);
     });
 
@@ -67,8 +66,7 @@ describe('ol.source.TileImage', function() {
           source.getKey = function() {
             return 'key0';
           };
-          const returnedTile = source.getTileInternal(
-            0, 0, -1, 1, getProjection('EPSG:3857'));
+          const returnedTile = source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
           expect(returnedTile).not.to.be(tile);
           expect(returnedTile.key).to.be('key0');
           expect(returnedTile.interimTile).to.be(null);
@@ -81,8 +79,7 @@ describe('ol.source.TileImage', function() {
             return 'key0';
           };
           tile.state = 2; // LOADED
-          const returnedTile = source.getTileInternal(
-            0, 0, -1, 1, getProjection('EPSG:3857'));
+          const returnedTile = source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
           expect(returnedTile).not.to.be(tile);
           expect(returnedTile.key).to.be('key0');
           expect(returnedTile.interimTile).to.be(tile);
@@ -97,11 +94,9 @@ describe('ol.source.TileImage', function() {
           };
           dynamicParamsKey = 'key0';
           tile.state = 2; // LOADED
-          returnedTile = source.getTileInternal(
-            0, 0, -1, 1, getProjection('EPSG:3857'));
+          returnedTile = source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
           dynamicParamsKey = 'key1';
-          returnedTile = source.getTileInternal(
-            0, 0, -1, 1, getProjection('EPSG:3857'));
+          returnedTile = source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
           expect(returnedTile).not.to.be(tile);
           expect(returnedTile.key).to.be('key1');
           expect(returnedTile.interimTile).to.be(tile);
@@ -115,7 +110,7 @@ describe('ol.source.TileImage', function() {
   describe('#getTile', function() {
     it('does not do reprojection for identity', function() {
       const source3857 = createSource('EPSG:3857');
-      const tile3857 = source3857.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
+      const tile3857 = source3857.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       expect(tile3857).to.be.a(ImageTile);
       expect(tile3857).not.to.be.a(ReprojTile);
 
@@ -124,7 +119,7 @@ describe('ol.source.TileImage', function() {
         units: 'degrees'
       });
       const sourceXXX = createSource(projXXX);
-      const tileXXX = sourceXXX.getTile(0, 0, -1, 1, projXXX);
+      const tileXXX = sourceXXX.getTile(0, 0, 0, 1, projXXX);
       expect(tileXXX).to.be.a(ImageTile);
       expect(tileXXX).not.to.be.a(ReprojTile);
     });
@@ -145,7 +140,7 @@ describe('ol.source.TileImage', function() {
         extent: [-180, -90, 180, 90],
         tileSize: [2, 2]
       }));
-      const tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.a(ReprojTile);
 
       listen(tile, 'change', function() {
@@ -164,7 +159,7 @@ describe('ol.source.TileImage', function() {
           extent: WORLD_EXTENT,
           tileSize: [2, 2]
         }));
-      const tile = source.getTile(0, 0, -1, 1, proj);
+      const tile = source.getTile(0, 0, 0, 1, proj);
       expect(tile).to.be.a(ReprojTile);
 
       listen(tile, 'change', function() {
@@ -194,7 +189,7 @@ describe('ol.source.TileImage', function() {
       source.on('tileloadstart', startSpy);
       const endSpy = sinon.spy();
       source.on('tileloadend', endSpy);
-      const tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       tile.load();
       expect(startSpy.callCount).to.be(1);
       expect(endSpy.callCount).to.be(1);
@@ -220,7 +215,7 @@ describe('ol.source.TileImage', function() {
         expect(errorSpy.callCount).to.be(1);
         done();
       });
-      const tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       tile.load();
     });
 
@@ -230,7 +225,7 @@ describe('ol.source.TileImage', function() {
       source.on('tileloadstart', startSpy);
       const endSpy = sinon.spy();
       source.on('tileloadend', endSpy);
-      const tile = source.getTile(0, 0, -1, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       tile.load();
       tile.dispose();
       expect(startSpy.callCount).to.be(1);

--- a/test/spec/ol/source/tilejson.test.js
+++ b/test/spec/ol/source/tilejson.test.js
@@ -58,7 +58,9 @@ describe('ol.source.TileJSON', function() {
         tilejson: '2.2.0',
         tiles: [
           'https://a.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png',
-          'https://b.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png'
+          'https://b.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png',
+          'https://c.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png',
+          'https://d.tiles.mapbox.com/v3/mapbox.geography-class/{z}/{x}/{y}.png'
         ],
         version: '1.0.0',
         webpage: 'https://a.tiles.mapbox.com/v3/mapbox.geography-class/page.html'
@@ -67,7 +69,11 @@ describe('ol.source.TileJSON', function() {
         tileJSON: tileJSON
       });
       expect(source.getState()).to.be('ready');
-      expect(source.getTileUrlFunction()([0, 0, -1])).to.be('https://b.tiles.mapbox.com/v3/mapbox.geography-class/0/0/0.png');
+      expect(source.getTileUrlFunction()([0, 0, 0])).to.be('https://a.tiles.mapbox.com/v3/mapbox.geography-class/0/0/0.png');
+      expect(source.getTileUrlFunction()([1, 0, 0])).to.be('https://a.tiles.mapbox.com/v3/mapbox.geography-class/1/0/0.png');
+      expect(source.getTileUrlFunction()([1, 0, 1])).to.be('https://b.tiles.mapbox.com/v3/mapbox.geography-class/1/0/1.png');
+      expect(source.getTileUrlFunction()([1, 1, 0])).to.be('https://c.tiles.mapbox.com/v3/mapbox.geography-class/1/1/0.png');
+      expect(source.getTileUrlFunction()([1, 1, 1])).to.be('https://d.tiles.mapbox.com/v3/mapbox.geography-class/1/1/1.png');
     });
   });
 

--- a/test/spec/ol/source/tilewms.test.js
+++ b/test/spec/ol/source/tilewms.test.js
@@ -38,7 +38,7 @@ describe('ol.source.TileWMS', function() {
 
     it('returns a tile with the expected URL', function() {
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(ImageTile);
       const uri = new URL(tile.src_);
       expect(uri.protocol).to.be('http:');
@@ -67,7 +67,7 @@ describe('ol.source.TileWMS', function() {
     it('returns a larger tile when a gutter is specified', function() {
       options.gutter = 16;
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -7, 1, getProjection('EPSG:3857'));
+      const tile = source.getTile(3, 2, 6, 1, getProjection('EPSG:3857'));
       expect(tile).to.be.an(ImageTile);
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
@@ -84,7 +84,7 @@ describe('ol.source.TileWMS', function() {
     it('sets the SRS query value instead of CRS if version < 1.3', function() {
       options.params.VERSION = '1.2';
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('CRS')).to.be(null);
@@ -95,7 +95,7 @@ describe('ol.source.TileWMS', function() {
       options.params.FORMAT = 'image/jpeg';
       options.params.TRANSPARENT = false;
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('image/jpeg');
@@ -105,7 +105,7 @@ describe('ol.source.TileWMS', function() {
     it('does not add a STYLES= option if one is specified', function() {
       options.params.STYLES = 'foo';
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('STYLES')).to.be('foo');
@@ -113,7 +113,7 @@ describe('ol.source.TileWMS', function() {
 
     it('changes the BBOX order for EN axis orientations', function() {
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-45,-90,0,-45');
@@ -122,7 +122,7 @@ describe('ol.source.TileWMS', function() {
     it('uses EN BBOX order if version < 1.3', function() {
       options.params.VERSION = '1.1.0';
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -3, 1, getProjection('CRS:84'));
+      const tile = source.getTile(3, 2, 2, 1, getProjection('CRS:84'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-90,-45,-45,0');
@@ -131,7 +131,7 @@ describe('ol.source.TileWMS', function() {
     it('sets FORMAT_OPTIONS when the server is GeoServer', function() {
       options.serverType = 'geoserver';
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, -3, 2, getProjection('CRS:84'));
+      const tile = source.getTile(3, 2, 2, 2, getProjection('CRS:84'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:180');
@@ -141,7 +141,7 @@ describe('ol.source.TileWMS', function() {
       options.serverType = 'geoserver';
       const source = new TileWMS(options);
       options.params.FORMAT_OPTIONS = 'param1:value1';
-      const tile = source.getTile(3, 2, -3, 2, getProjection('CRS:84'));
+      const tile = source.getTile(3, 2, 2, 2, getProjection('CRS:84'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT_OPTIONS')).to.be('param1:value1;dpi:180');
@@ -151,7 +151,7 @@ describe('ol.source.TileWMS', function() {
       function() {
         options.serverType = 'geoserver';
         const source = new TileWMS(options);
-        const tile = source.getTile(3, 2, -3, 1.325, getProjection('CRS:84'));
+        const tile = source.getTile(3, 2, 2, 1.325, getProjection('CRS:84'));
         const uri = new URL(tile.src_);
         const queryData = uri.searchParams;
         expect(queryData.get('FORMAT_OPTIONS')).to.be('dpi:119');
@@ -164,7 +164,7 @@ describe('ol.source.TileWMS', function() {
     it('returns a tile if it is contained within layers extent', function() {
       options.extent = [-80, -40, -50, -10];
       const source = new TileWMS(options);
-      const tileCoord = [3, 2, -3];
+      const tileCoord = [3, 2, 2];
       const url = source.tileUrlFunction(tileCoord, 1, getProjection('EPSG:4326'));
       const uri = new URL(url);
       const queryData = uri.searchParams;
@@ -174,7 +174,7 @@ describe('ol.source.TileWMS', function() {
     it('returns a tile if it intersects layers extent', function() {
       options.extent = [-80, -40, -40, -10];
       const source = new TileWMS(options);
-      const tileCoord = [3, 3, -3];
+      const tileCoord = [3, 3, 2];
       const url = source.tileUrlFunction(tileCoord, 1, getProjection('EPSG:4326'));
       const uri = new URL(url);
       const queryData = uri.searchParams;
@@ -188,7 +188,7 @@ describe('ol.source.TileWMS', function() {
         origin: [-180, -90]
       });
       const source = new TileWMS(options);
-      const tileCoord = [3, 3, -3];
+      const tileCoord = [3, 3, 2];
       const url = source.tileUrlFunction(tileCoord, 1, getProjection('EPSG:4326'));
       const uri = new URL(url);
       const queryData = uri.searchParams;

--- a/test/spec/ol/source/urltile.test.js
+++ b/test/spec/ol/source/urltile.test.js
@@ -118,18 +118,15 @@ describe('ol.source.UrlTile', function() {
       it('returns the expected URL', function() {
         const projection = tileSource.getProjection();
         let tileUrl = tileSource.tileUrlFunction(
-          tileSource.getTileCoordForTileUrlFunction(
-            [6, -31, -23], projection));
+          tileSource.getTileCoordForTileUrlFunction([6, -31, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
 
         tileUrl = tileSource.tileUrlFunction(
-          tileSource.getTileCoordForTileUrlFunction(
-            [6, 33, -23], projection));
+          tileSource.getTileCoordForTileUrlFunction([6, 33, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
 
         tileUrl = tileSource.tileUrlFunction(
-          tileSource.getTileCoordForTileUrlFunction(
-            [6, 97, -23], projection));
+          tileSource.getTileCoordForTileUrlFunction([6, 97, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
       });
 
@@ -140,18 +137,15 @@ describe('ol.source.UrlTile', function() {
       it('returns the expected URL', function() {
         const projection = tileSource.getProjection();
         let tileUrl = tileSource.tileUrlFunction(
-          tileSource.getTileCoordForTileUrlFunction(
-            [6, 33, 0], projection));
+          tileSource.getTileCoordForTileUrlFunction([6, 33, -1], projection));
         expect(tileUrl).to.be(undefined);
 
         tileUrl = tileSource.tileUrlFunction(
-          tileSource.getTileCoordForTileUrlFunction(
-            [6, 33, -23], projection));
+          tileSource.getTileCoordForTileUrlFunction([6, 33, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
 
         tileUrl = tileSource.tileUrlFunction(
-          tileSource.getTileCoordForTileUrlFunction(
-            [6, 33, -65], projection));
+          tileSource.getTileCoordForTileUrlFunction([6, 33, 64], projection));
         expect(tileUrl).to.be(undefined);
       });
 

--- a/test/spec/ol/source/utfgrid.test.js
+++ b/test/spec/ol/source/utfgrid.test.js
@@ -222,9 +222,9 @@ describe('ol.source.UTFGrid', function() {
 
       // Override getTile method to not depend on the external service. The
       // signature of the method is kept the same, but the returned tile will
-      // always be for [1, 1 -1].
+      // always be for [1, 1, 0].
       source.getTile = function(z, x, y, pixelRatio, projection) {
-        const tileCoord = [1, 1, -1]; // overwritten to match our stored JSON
+        const tileCoord = [1, 1, 0]; // overwritten to match our stored JSON
         const urlTileCoord =
             this.getTileCoordForTileUrlFunction(tileCoord, projection);
         const tileUrl = this.tileUrlFunction_(urlTileCoord, pixelRatio, projection);

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -58,7 +58,7 @@ describe('ol.source.VectorTile', function() {
 
   describe('Tile load events', function() {
     it('triggers tileloadstart and tileloadend with ol.VectorTile', function(done) {
-      tile = source.getTile(14, 8938, -5681, 1, getProjection('EPSG:3857'));
+      tile = source.getTile(14, 8938, 5680, 1, getProjection('EPSG:3857'));
       let started = false;
       source.on('tileloadstart', function() {
         started = true;
@@ -82,10 +82,10 @@ describe('ol.source.VectorTile', function() {
       loaded = [];
       requested = 0;
 
-      function tileUrlFunction(tileUrl) {
+      function tileUrlFunction(tileCoord) {
         ++requested;
-        if (tileUrl.toString() == '6,27,55') {
-          return tileUrl.join('/');
+        if (tileCoord.toString() == '6,27,-57') {
+          return tileCoord.join('/');
         }
       }
 
@@ -133,7 +133,7 @@ describe('ol.source.VectorTile', function() {
       map.renderSync();
       setTimeout(function() {
         expect(requested).to.be.greaterThan(1);
-        expect(loaded).to.eql(['6/27/55']);
+        expect(loaded).to.eql(['6/27/-57']);
         done();
       }, 0);
     });

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -198,7 +198,7 @@ describe('ol.source.WMTS', function() {
 
         const projection = getProjection('EPSG:3857');
         const url = source.tileUrlFunction(
-          source.getTileCoordForTileUrlFunction([1, 1, -2]), 1, projection);
+          source.getTileCoordForTileUrlFunction([1, 1, 1]), 1, projection);
         expect(url).to.be.eql('http://host/layer/default/EPSG:3857/1/1/1.jpg');
       });
 
@@ -215,7 +215,7 @@ describe('ol.source.WMTS', function() {
 
         const projection = getProjection('EPSG:3857');
         const url = source.tileUrlFunction(
-          source.getTileCoordForTileUrlFunction([1, 1, -2]), 1, projection);
+          source.getTileCoordForTileUrlFunction([1, 1, 1]), 1, projection);
         expect(url).to.be.eql('http://host/layer/default/EPSG:3857/1/1/1.jpg');
       });
 
@@ -233,7 +233,7 @@ describe('ol.source.WMTS', function() {
 
         const projection = getProjection('EPSG:3857');
         const url = source.tileUrlFunction(
-          source.getTileCoordForTileUrlFunction([1, 1, -2]), 1, projection);
+          source.getTileCoordForTileUrlFunction([1, 1, 1]), 1, projection);
         expect(url).to.be.eql('http://host/layer/default/42/EPSG:3857/1/1/1.jpg');
       });
   });
@@ -334,7 +334,7 @@ describe('ol.source.WMTS', function() {
         'https://b.example.com/{TileMatrix}/{TileRow}/{TileCol}.jpg'
       ];
       source.setUrls(urls);
-      const tileUrl1 = source.tileUrlFunction([2, 9, 4], 1, projection);
+      const tileUrl1 = source.tileUrlFunction([2, 9, -5], 1, projection);
       expect(tileUrl1).to.match(/https\:\/\/[ab]\.example\.com\/2\/-5\/9\.jpg/);
     });
   });

--- a/test/spec/ol/source/xyz.test.js
+++ b/test/spec/ol/source/xyz.test.js
@@ -93,18 +93,15 @@ describe('ol.source.XYZ', function() {
       it('returns the expected URL', function() {
         const projection = xyzTileSource.getProjection();
         let tileUrl = xyzTileSource.tileUrlFunction(
-          xyzTileSource.getTileCoordForTileUrlFunction(
-            [6, -31, -23], projection));
+          xyzTileSource.getTileCoordForTileUrlFunction([6, -31, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
 
         tileUrl = xyzTileSource.tileUrlFunction(
-          xyzTileSource.getTileCoordForTileUrlFunction(
-            [6, 33, -23], projection));
+          xyzTileSource.getTileCoordForTileUrlFunction([6, 33, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
 
         tileUrl = xyzTileSource.tileUrlFunction(
-          xyzTileSource.getTileCoordForTileUrlFunction(
-            [6, 97, -23], projection));
+          xyzTileSource.getTileCoordForTileUrlFunction([6, 97, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
       });
 
@@ -115,18 +112,15 @@ describe('ol.source.XYZ', function() {
       it('returns the expected URL', function() {
         const projection = xyzTileSource.getProjection();
         let tileUrl = xyzTileSource.tileUrlFunction(
-          xyzTileSource.getTileCoordForTileUrlFunction(
-            [6, 33, 0], projection));
+          xyzTileSource.getTileCoordForTileUrlFunction([6, 33, -1], projection));
         expect(tileUrl).to.be(undefined);
 
         tileUrl = xyzTileSource.tileUrlFunction(
-          xyzTileSource.getTileCoordForTileUrlFunction(
-            [6, 33, -23], projection));
+          xyzTileSource.getTileCoordForTileUrlFunction([6, 33, 22], projection));
         expect(tileUrl).to.eql('6/33/22');
 
         tileUrl = xyzTileSource.tileUrlFunction(
-          xyzTileSource.getTileCoordForTileUrlFunction(
-            [6, 33, -65], projection));
+          xyzTileSource.getTileCoordForTileUrlFunction([6, 33, 64], projection));
         expect(tileUrl).to.be(undefined);
       });
 

--- a/test/spec/ol/source/zoomify.test.js
+++ b/test/spec/ol/source/zoomify.test.js
@@ -234,23 +234,23 @@ describe('ol.source.Zoomify', function() {
       const source = getZoomifySource();
       const tileUrlFunction = source.getTileUrlFunction();
       // zoomlevel 0
-      expect(tileUrlFunction([0, 0, -1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/0-0-0.jpg');
+      expect(tileUrlFunction([0, 0, 0])).to.eql('spec/ol/source/images/zoomify/TileGroup0/0-0-0.jpg');
       // zoomlevel 1
-      expect(tileUrlFunction([1, 0, -1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-0.jpg');
-      expect(tileUrlFunction([1, 1, -1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-0.jpg');
-      expect(tileUrlFunction([1, 0, -2])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-1.jpg');
-      expect(tileUrlFunction([1, 1, -2])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-1.jpg');
+      expect(tileUrlFunction([1, 0, 0])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-0.jpg');
+      expect(tileUrlFunction([1, 1, 0])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-0.jpg');
+      expect(tileUrlFunction([1, 0, 1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-1.jpg');
+      expect(tileUrlFunction([1, 1, 1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-1.jpg');
     });
     it('creates an expected tileUrlFunction with IIP template', function() {
       const source = getIIPSource();
       const tileUrlFunction = source.getTileUrlFunction();
       // zoomlevel 0
-      expect(tileUrlFunction([0, 0, -1])).to.eql('spec/ol/source/images/zoomify?JTL=0,0');
+      expect(tileUrlFunction([0, 0, 0])).to.eql('spec/ol/source/images/zoomify?JTL=0,0');
       // zoomlevel 1
-      expect(tileUrlFunction([1, 0, -1])).to.eql('spec/ol/source/images/zoomify?JTL=1,0');
-      expect(tileUrlFunction([1, 1, -1])).to.eql('spec/ol/source/images/zoomify?JTL=1,1');
-      expect(tileUrlFunction([1, 0, -2])).to.eql('spec/ol/source/images/zoomify?JTL=1,2');
-      expect(tileUrlFunction([1, 1, -2])).to.eql('spec/ol/source/images/zoomify?JTL=1,3');
+      expect(tileUrlFunction([1, 0, 0])).to.eql('spec/ol/source/images/zoomify?JTL=1,0');
+      expect(tileUrlFunction([1, 1, 0])).to.eql('spec/ol/source/images/zoomify?JTL=1,1');
+      expect(tileUrlFunction([1, 0, 1])).to.eql('spec/ol/source/images/zoomify?JTL=1,2');
+      expect(tileUrlFunction([1, 1, 1])).to.eql('spec/ol/source/images/zoomify?JTL=1,3');
     });
 
     it('creates an expected tileUrlFunction without template', function() {
@@ -260,12 +260,12 @@ describe('ol.source.Zoomify', function() {
       });
       const tileUrlFunction = source.getTileUrlFunction();
       // zoomlevel 0
-      expect(tileUrlFunction([0, 0, -1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/0-0-0.jpg');
+      expect(tileUrlFunction([0, 0, 0])).to.eql('spec/ol/source/images/zoomify/TileGroup0/0-0-0.jpg');
       // zoomlevel 1
-      expect(tileUrlFunction([1, 0, -1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-0.jpg');
-      expect(tileUrlFunction([1, 1, -1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-0.jpg');
-      expect(tileUrlFunction([1, 0, -2])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-1.jpg');
-      expect(tileUrlFunction([1, 1, -2])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-1.jpg');
+      expect(tileUrlFunction([1, 0, 0])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-0.jpg');
+      expect(tileUrlFunction([1, 1, 0])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-0.jpg');
+      expect(tileUrlFunction([1, 0, 1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-0-1.jpg');
+      expect(tileUrlFunction([1, 1, 1])).to.eql('spec/ol/source/images/zoomify/TileGroup0/1-1-1.jpg');
     });
     it('returns undefined if no tileCoord passed', function() {
       const source = getZoomifySource();
@@ -279,17 +279,17 @@ describe('ol.source.Zoomify', function() {
 
     it('returns expected tileClass instances via "getTile"', function() {
       const source = getZoomifySource();
-      const tile = source.getTile(0, 0, -1, 1, proj);
+      const tile = source.getTile(0, 0, 0, 1, proj);
       expect(tile).to.be.a(CustomTile);
     });
 
     it('"tile.getImage" returns and caches an unloaded image', function() {
       const source = getZoomifySource();
 
-      const tile = source.getTile(0, 0, -1, 1, proj);
+      const tile = source.getTile(0, 0, 0, 1, proj);
       const img = tile.getImage();
 
-      const tile2 = source.getTile(0, 0, -1, 1, proj);
+      const tile2 = source.getTile(0, 0, 0, 1, proj);
       const img2 = tile2.getImage();
 
       expect(img).to.be.a(HTMLImageElement);
@@ -299,14 +299,14 @@ describe('ol.source.Zoomify', function() {
     it('"tile.getImage" returns and caches a loaded canvas', function(done) {
       const source = getZoomifySource();
 
-      const tile = source.getTile(0, 0, -1, 1, proj);
+      const tile = source.getTile(0, 0, 0, 1, proj);
 
       listen(tile, 'change', function() {
         if (tile.getState() == 2) { // LOADED
           const img = tile.getImage();
           expect(img).to.be.a(HTMLCanvasElement);
 
-          const tile2 = source.getTile(0, 0, -1, 1, proj);
+          const tile2 = source.getTile(0, 0, 0, 1, proj);
           expect(tile2.getState()).to.be(2); // LOADED
           const img2 = tile2.getImage();
           expect(img).to.be(img2);

--- a/test/spec/ol/tilecoord.test.js
+++ b/test/spec/ol/tilecoord.test.js
@@ -1,5 +1,4 @@
 import {
-  quadKey,
   getKey,
   fromKey,
   hash,
@@ -16,14 +15,6 @@ describe('ol.TileCoord', function() {
       expect(tileCoord[0]).to.eql(1);
       expect(tileCoord[1]).to.eql(2);
       expect(tileCoord[2]).to.eql(3);
-    });
-  });
-
-  describe('call quadKey', function() {
-    it('returns expected string', function() {
-      const tileCoord = [3, 3, 5];
-      const s = quadKey(tileCoord);
-      expect(s).to.eql('213');
     });
   });
 

--- a/test/spec/ol/tilecoord.test.js
+++ b/test/spec/ol/tilecoord.test.js
@@ -53,9 +53,9 @@ describe('ol.TileCoord', function() {
         resolutions: [2, 1],
         minZoom: 1
       });
-      expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
-      expect(withinExtentAndZ([1, 0, -1], tileGrid)).to.be(true);
-      expect(withinExtentAndZ([2, 0, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([1, 0, 0], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([2, 0, 0], tileGrid)).to.be(false);
     });
 
     it('restricts by extent when extent defines tile ranges', function() {
@@ -65,9 +65,9 @@ describe('ol.TileCoord', function() {
         tileSize: 10,
         resolutions: [1]
       });
-      expect(withinExtentAndZ([0, 1, -2], tileGrid)).to.be(true);
-      expect(withinExtentAndZ([0, 2, -1], tileGrid)).to.be(false);
-      expect(withinExtentAndZ([0, 0, -3], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, 1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 2, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 0, 2], tileGrid)).to.be(false);
     });
 
     it('restricts by extent when sizes define tile ranges', function() {
@@ -78,11 +78,27 @@ describe('ol.TileCoord', function() {
         resolutions: [1]
       });
       expect(withinExtentAndZ([0, 0, 0], tileGrid)).to.be(true);
-      expect(withinExtentAndZ([0, -1, 0], tileGrid)).to.be(false);
-      expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, 0], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 2, 0], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 0, 1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 1, 1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 2, 1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 0, 2], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 1, 2], tileGrid)).to.be(true);
       expect(withinExtentAndZ([0, 2, 2], tileGrid)).to.be(true);
+
+      expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 2, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, -1, 0], tileGrid)).to.be(false);
       expect(withinExtentAndZ([0, 3, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, -1, 1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 3, 1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, -1, 2], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 3, 2], tileGrid)).to.be(false);
       expect(withinExtentAndZ([0, 0, 3], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, 3], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 2, 3], tileGrid)).to.be(false);
     });
 
     it('restricts by extent when sizes (neg y) define tile ranges', function() {
@@ -93,11 +109,27 @@ describe('ol.TileCoord', function() {
         resolutions: [1]
       });
       expect(withinExtentAndZ([0, 0, -1], tileGrid)).to.be(true);
-      expect(withinExtentAndZ([0, -1, -1], tileGrid)).to.be(false);
-      expect(withinExtentAndZ([0, 0, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, -1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 2, -1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 0, -2], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 1, -2], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 2, -2], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 0, -3], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 1, -3], tileGrid)).to.be(true);
       expect(withinExtentAndZ([0, 2, -3], tileGrid)).to.be(true);
+
+      expect(withinExtentAndZ([0, 0, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 2, 0], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, -1, -1], tileGrid)).to.be(false);
       expect(withinExtentAndZ([0, 3, -1], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, -1, -2], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 3, -2], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, -1, -3], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 3, -3], tileGrid)).to.be(false);
       expect(withinExtentAndZ([0, 0, -4], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 1, -4], tileGrid)).to.be(false);
+      expect(withinExtentAndZ([0, 2, -4], tileGrid)).to.be(false);
     });
 
     it('does not restrict by extent with no extent or sizes', function() {
@@ -106,14 +138,10 @@ describe('ol.TileCoord', function() {
         tileSize: 10,
         resolutions: [1]
       });
-      expect(withinExtentAndZ([0, Infinity, 0], tileGrid))
-        .to.be(true);
-      expect(withinExtentAndZ([0, 0, Infinity], tileGrid))
-        .to.be(true);
-      expect(withinExtentAndZ([0, -Infinity, 0], tileGrid))
-        .to.be(true);
-      expect(withinExtentAndZ([0, 0, Infinity], tileGrid))
-        .to.be(true);
+      expect(withinExtentAndZ([0, Infinity, -1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 0, Infinity], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, -Infinity, -1], tileGrid)).to.be(true);
+      expect(withinExtentAndZ([0, 0, Infinity], tileGrid)).to.be(true);
     });
   });
 

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -195,8 +195,8 @@ describe('ol.tilegrid.TileGrid', function() {
       const fullTileRange = tileGrid.getFullTileRange(0);
       expect(fullTileRange.minX).to.equal(0);
       expect(fullTileRange.maxX).to.equal(1);
-      expect(fullTileRange.minY).to.equal(-2);
-      expect(fullTileRange.maxY).to.equal(-1);
+      expect(fullTileRange.minY).to.equal(0);
+      expect(fullTileRange.maxY).to.equal(1);
     });
   });
 
@@ -205,7 +205,7 @@ describe('ol.tilegrid.TileGrid', function() {
     beforeEach(function() {
       tileGrid = new TileGrid({
         extent: [10, 20, 30, 40],
-        sizes: [[3, -3]],
+        sizes: [[3, 3]],
         tileSize: 10,
         resolutions: [1]
       });
@@ -219,8 +219,8 @@ describe('ol.tilegrid.TileGrid', function() {
       const fullTileRange = tileGrid.getFullTileRange(0);
       expect(fullTileRange.minX).to.equal(0);
       expect(fullTileRange.maxX).to.equal(2);
-      expect(fullTileRange.minY).to.equal(-3);
-      expect(fullTileRange.maxY).to.equal(-1);
+      expect(fullTileRange.minY).to.equal(0);
+      expect(fullTileRange.maxY).to.equal(2);
     });
   });
 
@@ -229,16 +229,16 @@ describe('ol.tilegrid.TileGrid', function() {
     beforeEach(function() {
       tileGrid = new TileGrid({
         origin: [10, 40],
-        sizes: [[3, -3]],
+        sizes: [[3, 3]],
         tileSize: 10,
         resolutions: [1]
       });
     });
 
-    it('calculates correct minY and maxY for negative heights', function() {
+    it('calculates correct minY and maxY for positive heights', function() {
       const fullTileRange = tileGrid.getFullTileRange(0);
-      expect(fullTileRange.minY).to.equal(-3);
-      expect(fullTileRange.maxY).to.equal(-1);
+      expect(fullTileRange.minY).to.equal(0);
+      expect(fullTileRange.maxY).to.equal(2);
     });
   });
 
@@ -247,16 +247,16 @@ describe('ol.tilegrid.TileGrid', function() {
     beforeEach(function() {
       tileGrid = new TileGrid({
         origin: [10, 10],
-        sizes: [[3, 3]],
+        sizes: [[3, -3]],
         tileSize: 10,
         resolutions: [1]
       });
     });
 
-    it('calculates correct minX and maxX for positive heights', function() {
+    it('calculates correct minX and maxX for negative heights', function() {
       const fullTileRange = tileGrid.getFullTileRange(0);
-      expect(fullTileRange.minY).to.equal(0);
-      expect(fullTileRange.maxY).to.equal(2);
+      expect(fullTileRange.minY).to.equal(-3);
+      expect(fullTileRange.maxY).to.equal(-1);
     });
   });
 
@@ -602,7 +602,7 @@ describe('ol.tilegrid.TileGrid', function() {
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 100000], 3);
         expect(tileCoord[0]).to.eql(3);
         expect(tileCoord[1]).to.eql(0);
-        expect(tileCoord[2]).to.eql(10);
+        expect(tileCoord[2]).to.eql(-10);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 0], 3);
         expect(tileCoord[0]).to.eql(3);
@@ -612,7 +612,7 @@ describe('ol.tilegrid.TileGrid', function() {
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 100000], 3);
         expect(tileCoord[0]).to.eql(3);
         expect(tileCoord[1]).to.eql(10);
-        expect(tileCoord[2]).to.eql(10);
+        expect(tileCoord[2]).to.eql(-10);
       });
     });
 
@@ -629,7 +629,7 @@ describe('ol.tilegrid.TileGrid', function() {
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 0], 3);
         expect(tileCoord[0]).to.eql(3);
         expect(tileCoord[1]).to.eql(0);
-        expect(tileCoord[2]).to.eql(-10);
+        expect(tileCoord[2]).to.eql(10);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 100000], 3);
         expect(tileCoord[0]).to.eql(3);
@@ -639,7 +639,7 @@ describe('ol.tilegrid.TileGrid', function() {
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 0], 3);
         expect(tileCoord[0]).to.eql(3);
         expect(tileCoord[1]).to.eql(10);
-        expect(tileCoord[2]).to.eql(-10);
+        expect(tileCoord[2]).to.eql(10);
 
         tileCoord = tileGrid.getTileCoordForCoordAndZ([100000, 100000], 3);
         expect(tileCoord[0]).to.eql(3);
@@ -673,56 +673,56 @@ describe('ol.tilegrid.TileGrid', function() {
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(-1);
-      expect(tileCoord[2]).to.eql(0);
+      expect(tileCoord[2]).to.eql(-1);
 
       // gets one tile northeast of the origin
       coordinate = [1280, 1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(0);
-      expect(tileCoord[2]).to.eql(0);
+      expect(tileCoord[2]).to.eql(-1);
 
       // gets one tile southeast of the origin
       coordinate = [1280, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(0);
-      expect(tileCoord[2]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(0);
 
       // gets one tile southwest of the origin
       coordinate = [-1280, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(-1);
-      expect(tileCoord[2]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(0);
 
       // gets the tile to the east when on the edge
       coordinate = [2560, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(1);
-      expect(tileCoord[2]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(0);
 
-      // gets the tile to the north when on the edge
+      // gets the tile to the south when on the edge
       coordinate = [1280, -2560];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(0);
-      expect(tileCoord[2]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(1);
 
       // pixels are top aligned to the origin
       coordinate = [1280, -2559.999];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(0);
-      expect(tileCoord[2]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(0);
 
       // pixels are left aligned to the origin
       coordinate = [2559.999, -1280];
       tileCoord = tileGrid.getTileCoordForCoordAndResolution(coordinate, 10);
       expect(tileCoord[0]).to.eql(0);
       expect(tileCoord[1]).to.eql(0);
-      expect(tileCoord[2]).to.eql(-1);
+      expect(tileCoord[2]).to.eql(0);
     });
   });
 
@@ -749,7 +749,7 @@ describe('ol.tilegrid.TileGrid', function() {
         100000, 100000, 100, false);
       expect(tileCoord[0]).to.eql(3);
       expect(tileCoord[1]).to.eql(10);
-      expect(tileCoord[2]).to.eql(10);
+      expect(tileCoord[2]).to.eql(-10);
 
     });
 
@@ -763,18 +763,16 @@ describe('ol.tilegrid.TileGrid', function() {
       let tileCoord;
 
       // can get lower tile for edge intersection
-      tileCoord = tileGrid.getTileCoordForXYAndResolution_(
-        0, 0, 100, true);
+      tileCoord = tileGrid.getTileCoordForXYAndResolution_(0, 0, 100, true);
       expect(tileCoord[0]).to.eql(3);
       expect(tileCoord[1]).to.eql(-1);
       expect(tileCoord[2]).to.eql(-1);
 
-      // gets higher tile for edge intersection
-      tileCoord = tileGrid.getTileCoordForXYAndResolution_(
-        100000, 100000, 100, true);
+      // can get lower tile for edge intersection
+      tileCoord = tileGrid.getTileCoordForXYAndResolution_(100000, 100000, 100, true);
       expect(tileCoord[0]).to.eql(3);
       expect(tileCoord[1]).to.eql(9);
-      expect(tileCoord[2]).to.eql(9);
+      expect(tileCoord[2]).to.eql(-11);
 
     });
 
@@ -791,15 +789,15 @@ describe('ol.tilegrid.TileGrid', function() {
 
       center = tileGrid.getTileCoordCenter([0, 0, 0]);
       expect(center[0]).to.eql(50000);
-      expect(center[1]).to.eql(50000);
+      expect(center[1]).to.eql(-50000);
 
       center = tileGrid.getTileCoordCenter([3, 0, 0]);
       expect(center[0]).to.eql(5000);
-      expect(center[1]).to.eql(5000);
+      expect(center[1]).to.eql(-5000);
 
       center = tileGrid.getTileCoordCenter([3, 9, 9]);
       expect(center[0]).to.eql(95000);
-      expect(center[1]).to.eql(95000);
+      expect(center[1]).to.eql(-95000);
     });
   });
 
@@ -814,21 +812,21 @@ describe('ol.tilegrid.TileGrid', function() {
 
       tileCoordExtent = tileGrid.getTileCoordExtent([0, 0, 0]);
       expect(tileCoordExtent[0]).to.eql(0);
-      expect(tileCoordExtent[1]).to.eql(0);
+      expect(tileCoordExtent[1]).to.eql(-100000);
       expect(tileCoordExtent[2]).to.eql(100000);
-      expect(tileCoordExtent[3]).to.eql(100000);
+      expect(tileCoordExtent[3]).to.eql(0);
 
       tileCoordExtent = tileGrid.getTileCoordExtent([3, 9, 0]);
       expect(tileCoordExtent[0]).to.eql(90000);
-      expect(tileCoordExtent[1]).to.eql(0);
+      expect(tileCoordExtent[1]).to.eql(-10000);
       expect(tileCoordExtent[2]).to.eql(100000);
-      expect(tileCoordExtent[3]).to.eql(10000);
+      expect(tileCoordExtent[3]).to.eql(0);
 
       tileCoordExtent = tileGrid.getTileCoordExtent([3, 0, 9]);
       expect(tileCoordExtent[0]).to.eql(0);
-      expect(tileCoordExtent[1]).to.eql(90000);
+      expect(tileCoordExtent[1]).to.eql(-100000);
       expect(tileCoordExtent[2]).to.eql(10000);
-      expect(tileCoordExtent[3]).to.eql(100000);
+      expect(tileCoordExtent[3]).to.eql(-90000);
     });
   });
 
@@ -843,28 +841,28 @@ describe('ol.tilegrid.TileGrid', function() {
       let tileRange;
 
       tileRange = tileGrid.getTileRangeForExtentAndZ(e, 0);
-      expect(tileRange.minY).to.eql(0);
+      expect(tileRange.minY).to.eql(-1);
       expect(tileRange.minX).to.eql(0);
       expect(tileRange.maxX).to.eql(0);
-      expect(tileRange.maxY).to.eql(0);
+      expect(tileRange.maxY).to.eql(-1);
 
       tileRange = tileGrid.getTileRangeForExtentAndZ(e, 1);
       expect(tileRange.minX).to.eql(0);
-      expect(tileRange.minY).to.eql(0);
+      expect(tileRange.minY).to.eql(-1);
       expect(tileRange.maxX).to.eql(1);
-      expect(tileRange.maxY).to.eql(0);
+      expect(tileRange.maxY).to.eql(-1);
 
       tileRange = tileGrid.getTileRangeForExtentAndZ(e, 2);
       expect(tileRange.minX).to.eql(1);
-      expect(tileRange.minY).to.eql(0);
+      expect(tileRange.minY).to.eql(-1);
       expect(tileRange.maxX).to.eql(2);
-      expect(tileRange.maxY).to.eql(0);
+      expect(tileRange.maxY).to.eql(-1);
 
       tileRange = tileGrid.getTileRangeForExtentAndZ(e, 3);
       expect(tileRange.minX).to.eql(4);
-      expect(tileRange.minY).to.eql(0);
+      expect(tileRange.minY).to.eql(-2);
       expect(tileRange.maxX).to.eql(5);
-      expect(tileRange.maxY).to.eql(1);
+      expect(tileRange.maxY).to.eql(-1);
     });
   });
 
@@ -923,10 +921,10 @@ describe('ol.tilegrid.TileGrid', function() {
         tileCoords.push(tileCoord);
       });
       expect(tileCoords).to.eql([
-        [8, 138, -31],
-        [8, 138, -30],
-        [8, 139, -31],
-        [8, 139, -30]
+        [8, 138, 29],
+        [8, 138, 30],
+        [8, 139, 29],
+        [8, 139, 30]
       ]);
     });
   });

--- a/test/spec/ol/tileurlfunction.test.js
+++ b/test/spec/ol/tileurlfunction.test.js
@@ -51,12 +51,12 @@ describe('ol.TileUrlFunction', function() {
     const tileGrid = createXYZ();
     it('creates expected URL', function() {
       const tileUrl = createFromTemplate('{z}/{x}/{y}', tileGrid);
-      expect(tileUrl([3, 2, -2])).to.eql('3/2/1');
+      expect(tileUrl([3, 2, 1])).to.eql('3/2/1');
       expect(tileUrl(null)).to.be(undefined);
     });
     it('accepts {-y} placeholder', function() {
       const tileUrl = createFromTemplate('{z}/{x}/{-y}', tileGrid);
-      expect(tileUrl([3, 2, -3])).to.eql('3/2/5');
+      expect(tileUrl([3, 2, 2])).to.eql('3/2/5');
     });
     it('returns correct value for {-y} with custom tile grids', function() {
       const customTileGrid = new TileGrid({
@@ -65,11 +65,11 @@ describe('ol.TileUrlFunction', function() {
         resolutions: [360 / 256, 360 / 512, 360 / 1024, 360 / 2048]
       });
       const tileUrl = createFromTemplate('{z}/{x}/{-y}', customTileGrid);
-      expect(tileUrl([3, 2, -3])).to.eql('3/2/1');
+      expect(tileUrl([3, 2, 2])).to.eql('3/2/1');
     });
     it('replaces multiple placeholder occurrences', function() {
       const tileUrl = createFromTemplate('{z}/{z}{x}{y}', tileGrid);
-      expect(tileUrl([3, 2, -2])).to.eql('3/321');
+      expect(tileUrl([3, 2, 1])).to.eql('3/321');
     });
   });
 
@@ -80,7 +80,7 @@ describe('ol.TileUrlFunction', function() {
         'http://tile-1/{z}/{x}/{y}'
       ];
       const tileUrlFunction = createFromTemplates(templates, tileGrid);
-      const tileCoord = [3, 2, -2];
+      const tileCoord = [3, 2, 1];
 
       expect(tileUrlFunction(tileCoord)).to.eql('http://tile-1/3/2/1');
     });

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -13,8 +13,8 @@ describe('ol.VectorImageTile', function() {
   it('configures loader that sets features on the source tile', function(done) {
     const format = new GeoJSON();
     const url = 'spec/ol/data/point.json';
-    const tile = new VectorImageTile([0, 0, -1], 0, url, format,
-      defaultLoadFunction, [0, 0, -1], function() {
+    const tile = new VectorImageTile([0, 0, 0], 0, url, format,
+      defaultLoadFunction, [0, 0, 0], function() {
         return url;
       }, createXYZ(), createXYZ(), {},
       1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
@@ -38,7 +38,7 @@ describe('ol.VectorImageTile', function() {
       function(tile, url) {
         sourceTile = tile;
         defaultLoadFunction(tile, url);
-      }, [0, 0, -1], function() {
+      }, [0, 0, 0], function() {
         return url;
       }, createXYZ(), createXYZ(), {},
       1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
@@ -61,8 +61,8 @@ describe('ol.VectorImageTile', function() {
   it('sets ERROR state when source tiles fail to load', function(done) {
     const format = new GeoJSON();
     const url = 'spec/ol/data/unavailable.json';
-    const tile = new VectorImageTile([0, 0, -1], 0, url, format,
-      defaultLoadFunction, [0, 0, -1], function() {
+    const tile = new VectorImageTile([0, 0, 0], 0, url, format,
+      defaultLoadFunction, [0, 0, 0], function() {
         return url;
       }, createXYZ(), createXYZ(), {},
       1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
@@ -78,8 +78,8 @@ describe('ol.VectorImageTile', function() {
   it('sets EMPTY state when tile has only empty source tiles', function(done) {
     const format = new GeoJSON();
     const url = '';
-    const tile = new VectorImageTile([0, 0, -1], 0, url, format,
-      defaultLoadFunction, [0, 0, -1], function() {},
+    const tile = new VectorImageTile([0, 0, 0], 0, url, format,
+      defaultLoadFunction, [0, 0, 0], function() {},
       createXYZ(), createXYZ(), {},
       1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
 
@@ -100,22 +100,22 @@ describe('ol.VectorImageTile', function() {
       extent: [-88, 35, -87, 36]
     });
     const sourceTiles = {};
-    const tile = new VectorImageTile([1, 0, -1], 0, url, format,
-      defaultLoadFunction, [1, 0, -1], function(zxy) {
+    const tile = new VectorImageTile([1, 0, 0], 0, url, format,
+      defaultLoadFunction, [1, 0, 0], function(zxy) {
         return url;
       }, tileGrid,
       createXYZ({extent: [-180, -90, 180, 90], tileSize: 512}),
       sourceTiles, 1, getProjection('EPSG:4326'), VectorTile, function() {}, 1);
     tile.load();
     expect(tile.tileKeys.length).to.be(1);
-    expect(tile.getTile(tile.tileKeys[0]).tileCoord).to.eql([0, 16, -10]);
+    expect(tile.getTile(tile.tileKeys[0]).tileCoord).to.eql([0, 16, 9]);
   });
 
   it('#dispose() while loading', function() {
     const format = new GeoJSON();
     const url = 'spec/ol/data/point.json';
     const tile = new VectorImageTile([0, 0, 0] /* one world away */, 0, url, format,
-      defaultLoadFunction, [0, 0, -1], function() {
+      defaultLoadFunction, [0, 0, 0], function() {
         return url;
       }, createXYZ(), createXYZ({tileSize: 512}), {},
       1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);
@@ -134,8 +134,8 @@ describe('ol.VectorImageTile', function() {
   it('#dispose() when loaded', function(done) {
     const format = new GeoJSON();
     const url = 'spec/ol/data/point.json';
-    const tile = new VectorImageTile([0, 0, -1], 0, url, format,
-      defaultLoadFunction, [0, 0, -1], function() {
+    const tile = new VectorImageTile([0, 0, 0], 0, url, format,
+      defaultLoadFunction, [0, 0, 0], function() {
         return url;
       }, createXYZ(), createXYZ({tileSize: 512}), {},
       1, getProjection('EPSG:3857'), VectorTile, function() {}, 0);


### PR DESCRIPTION
I think it is safe to say that the majority of tile coordinate systems in widespread use have a column and row order that follows standard image coordinate systems – rows increase downward and columns increase to the right, with the origin at the top left.  This branch proposes that our tile coordinates do the same.

From the upgrade notes:

### New internal tile coordinates

Previously, the internal tile coordinates used in the library had an unusual row order – the origin of the tile coordinate system was at the top left as expected, but the rows increased upwards.  This meant that all tile coordinates within a tile grid's extent had negative `y` values.

Now, the internal tile coordinates used in the library have the same row order as standard (e.g. XYZ) tile coordinates.  The origin is at the top left (as before), and rows or `y` values increase downward.  So the top left tile of a tile grid is now `0, 0`, whereas it was `0, -1` before.

```
x, y values for tile coordinates

origin 
  *__________________________
  |        |        |        |
  |  0, 0  |  1, 0  |  2, 0  |
  |________|________|________|
  |        |        |        |
  |  0, 1  |  1, 1  |  2, 1  |
  |________|________|________|
  |        |        |        |
  |  0, 2  |  1, 2  |  2, 2  |
  |________|________|________|
```

This change should only affect you if you were using a custom `tileLoadFunction` or `tileUrlFunction`.  For example, if you used to have a `tileUrlFunction` that looked like this:

```js
// before
function tileUrlFunction(tileCoord) {
  const z = tileCoord[0];
  const x = tileCoord[1];
  const y = -tileCoord[2] - 1;
  // do something with z, x, y
}
```

You would now do something like this:
```js
// after
function tileUrlFunction(tileCoord) {
  const z = tileCoord[0];
  const x = tileCoord[1];
  const y = tileCoord[2];
  // do something with z, x, y
}
```

In addition (this should be exceedingly rare), if you previously created a `ol/tilegrid/WMTS` by hand and you were providing an array of `sizes`, you no longer have to provide a negative height if your tile origin is the top-left corner (the common case).  On the other hand, if you are providing a custom array of `sizes` and your origin is the bottom of the grid (this is uncommon), your height values must now be negative.