### PR TITLE
Simplify import path in examples

### DIFF
--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -18,6 +18,7 @@
     "turf": false
   },
   "rules": {
+    "import/no-unresolved": 0,
     "no-unused-vars": [2, {"varsIgnorePattern": "^map"}]
   }
 }

--- a/examples/accessible.js
+++ b/examples/accessible.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {easeIn, easeOut} from '../src/ol/easing.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {easeIn, easeOut} from 'ol/easing';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
 
 const london = fromLonLat([-0.12755, 51.507222]);
 const moscow = fromLonLat([37.6178, 55.7517]);

--- a/examples/arcgis-image.js
+++ b/examples/arcgis-image.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Tile as TileLayer, Image as ImageLayer} from '../src/ol/layer.js';
-import {OSM, ImageArcGISRest} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Tile as TileLayer, Image as ImageLayer} from 'ol/layer';
+import {OSM, ImageArcGISRest} from 'ol/source';
 
 const url = 'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/' +
     'Specialty/ESRI_StateCityHighway_USA/MapServer';

--- a/examples/arcgis-tiled.js
+++ b/examples/arcgis-tiled.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {OSM, TileArcGISRest} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {OSM, TileArcGISRest} from 'ol/source';
 
 const url = 'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/' +
     'Specialty/ESRI_StateCityHighway_USA/MapServer';

--- a/examples/attributions.js
+++ b/examples/attributions.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, Attribution} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, Attribution} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const attribution = new Attribution({
   collapsible: false

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
 
 
 const styles = [

--- a/examples/box-selection.js
+++ b/examples/box-selection.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {platformModifierKeyOnly} from '../src/ol/events/condition.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {DragBox, Select} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {platformModifierKeyOnly} from 'ol/events/condition';
+import GeoJSON from 'ol/format/GeoJSON';
+import {DragBox, Select} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 
 const vectorSource = new VectorSource({

--- a/examples/button-title.js
+++ b/examples/button-title.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const map = new Map({
   layers: [

--- a/examples/canvas-gradient-pattern.js
+++ b/examples/canvas-gradient-pattern.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {DEVICE_PIXEL_RATIO} from '../src/ol/has.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {DEVICE_PIXEL_RATIO} from 'ol/has';
+import VectorLayer from 'ol/layer/Vector';
+import {fromLonLat} from 'ol/proj';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Stroke, Style} from 'ol/style';
 
 const canvas = document.createElement('canvas');
 const context = canvas.getContext('2d');

--- a/examples/canvas-tiles.js
+++ b/examples/canvas-tiles.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {OSM, TileDebug} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {OSM, TileDebug} from 'ol/source';
 
 
 const map = new Map({

--- a/examples/cartodb.js
+++ b/examples/cartodb.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {CartoDB, OSM} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {CartoDB, OSM} from 'ol/source';
 
 const mapConfig = {
   'layers': [{

--- a/examples/center.js
+++ b/examples/center.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 const source = new VectorSource({
   url: 'data/geojson/switzerland.geojson',

--- a/examples/chaikin.js
+++ b/examples/chaikin.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import Draw from '../src/ol/interaction/Draw.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import Draw from 'ol/interaction/Draw';
 
 import smooth from 'chaikin-smooth';
 

--- a/examples/cluster.js
+++ b/examples/cluster.js
@@ -1,10 +1,10 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {Cluster, OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style, Text} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {Cluster, OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style, Text} from 'ol/style';
 
 
 const distance = document.getElementById('distance');

--- a/examples/color-manipulation.js
+++ b/examples/color-manipulation.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import ImageLayer from '../src/ol/layer/Image.js';
-import {Raster as RasterSource, Stamen} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import ImageLayer from 'ol/layer/Image';
+import {Raster as RasterSource, Stamen} from 'ol/source';
 
 
 /**

--- a/examples/custom-controls.js
+++ b/examples/custom-controls.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, Control} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, Control} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 //

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -1,11 +1,11 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {LineString, Point, Polygon} from '../src/ol/geom.js';
-import {defaults as defaultInteractions, Pointer as PointerInteraction} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {TileJSON, Vector as VectorSource} from '../src/ol/source.js';
-import {Fill, Icon, Stroke, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {LineString, Point, Polygon} from 'ol/geom';
+import {defaults as defaultInteractions, Pointer as PointerInteraction} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {TileJSON, Vector as VectorSource} from 'ol/source';
+import {Fill, Icon, Stroke, Style} from 'ol/style';
 
 
 /**

--- a/examples/d3.js
+++ b/examples/d3.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth, getCenter} from '../src/ol/extent.js';
-import {Layer, Tile as TileLayer} from '../src/ol/layer.js';
-import SourceState from '../src/ol/source/State';
-import {fromLonLat, toLonLat} from '../src/ol/proj.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth, getCenter} from 'ol/extent';
+import {Layer, Tile as TileLayer} from 'ol/layer';
+import SourceState from 'ol/source/State';
+import {fromLonLat, toLonLat} from 'ol/proj';
+import Stamen from 'ol/source/Stamen';
 
 class CanvasLayer extends Layer {
 

--- a/examples/device-orientation.js
+++ b/examples/device-orientation.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {toRadians} from '../src/ol/math.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {toRadians} from 'ol/math';
+import OSM from 'ol/source/OSM';
 
 const view = new View({
   center: [0, 0],

--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {GPX, GeoJSON, IGC, KML, TopoJSON} from '../src/ol/format.js';
-import {defaults as defaultInteractions, DragAndDrop} from '../src/ol/interaction.js';
-import {VectorImage as VectorImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import {BingMaps, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {GPX, GeoJSON, IGC, KML, TopoJSON} from 'ol/format';
+import {defaults as defaultInteractions, DragAndDrop} from 'ol/interaction';
+import {VectorImage as VectorImageLayer, Tile as TileLayer} from 'ol/layer';
+import {BingMaps, Vector as VectorSource} from 'ol/source';
 
 const dragAndDropInteraction = new DragAndDrop({
   formatConstructors: [

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {GPX, GeoJSON, IGC, KML, TopoJSON} from '../src/ol/format.js';
-import {defaults as defaultInteractions, DragAndDrop} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {BingMaps, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {GPX, GeoJSON, IGC, KML, TopoJSON} from 'ol/format';
+import {defaults as defaultInteractions, DragAndDrop} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {BingMaps, Vector as VectorSource} from 'ol/source';
 
 const dragAndDropInteraction = new DragAndDrop({
   formatConstructors: [

--- a/examples/drag-rotate-and-zoom.js
+++ b/examples/drag-rotate-and-zoom.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultInteractions, DragRotateAndZoom} from '../src/ol/interaction.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultInteractions, DragRotateAndZoom} from 'ol/interaction';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/draw-and-modify-features.js
+++ b/examples/draw-and-modify-features.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Draw, Modify, Snap} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Draw, Modify, Snap} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Draw from '../src/ol/interaction/Draw.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Draw from 'ol/interaction/Draw';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/draw-freehand.js
+++ b/examples/draw-freehand.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Draw from '../src/ol/interaction/Draw.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Draw from 'ol/interaction/Draw';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/draw-shapes.js
+++ b/examples/draw-shapes.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Polygon from '../src/ol/geom/Polygon.js';
-import Draw, {createRegularPolygon, createBox} from '../src/ol/interaction/Draw.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Polygon from 'ol/geom/Polygon';
+import Draw, {createRegularPolygon, createBox} from 'ol/interaction/Draw';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/dynamic-data.js
+++ b/examples/dynamic-data.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {MultiPoint, Point} from '../src/ol/geom.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
-import {getVectorContext} from '../src/ol/render.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {MultiPoint, Point} from 'ol/geom';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
+import {getVectorContext} from 'ol/render';
 
 const tileLayer = new TileLayer({
   source: new OSM()

--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {createEmpty, getWidth, getHeight, extend} from '../src/ol/extent.js';
-import KML from '../src/ol/format/KML.js';
-import {defaults as defaultInteractions, Select} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {Cluster, Stamen, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, RegularShape, Stroke, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {createEmpty, getWidth, getHeight, extend} from 'ol/extent';
+import KML from 'ol/format/KML';
+import {defaults as defaultInteractions, Select} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {Cluster, Stamen, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, RegularShape, Stroke, Style, Text} from 'ol/style';
 
 
 const earthquakeFill = new Fill({

--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -1,12 +1,12 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import KML from '../src/ol/format/KML.js';
-import Polygon from '../src/ol/geom/Polygon.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {toContext} from '../src/ol/render.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Icon, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import KML from 'ol/format/KML';
+import Polygon from 'ol/geom/Polygon';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {toContext} from 'ol/render';
+import Stamen from 'ol/source/Stamen';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Icon, Stroke, Style} from 'ol/style';
 
 
 const symbol = [[0, 0], [4, 2], [6, 0], [10, 5], [6, 3], [4, 5], [0, 0]];

--- a/examples/epsg-4326.js
+++ b/examples/epsg-4326.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, ScaleLine} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, ScaleLine} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
 
 
 const layers = [

--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const map = new Map({
   layers: [

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import WKT from '../src/ol/format/WKT.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import WKT from 'ol/format/WKT';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/extent-interaction.js
+++ b/examples/extent-interaction.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {platformModifierKeyOnly} from '../src/ol/events/condition.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import ExtentInteraction from '../src/ol/interaction/Extent.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {platformModifierKeyOnly} from 'ol/events/condition';
+import GeoJSON from 'ol/format/GeoJSON';
+import ExtentInteraction from 'ol/interaction/Extent';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const vectorSource = new VectorSource({
   url: 'data/geojson/countries.geojson',

--- a/examples/feature-animation.js
+++ b/examples/feature-animation.js
@@ -1,14 +1,14 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import {unByKey} from '../src/ol/Observable.js';
-import View from '../src/ol/View.js';
-import {easeOut} from '../src/ol/easing.js';
-import Point from '../src/ol/geom/Point.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Stroke, Style} from '../src/ol/style.js';
-import {getVectorContext} from '../src/ol/render.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import {unByKey} from 'ol/Observable';
+import View from 'ol/View';
+import {easeOut} from 'ol/easing';
+import Point from 'ol/geom/Point';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Stroke, Style} from 'ol/style';
+import {getVectorContext} from 'ol/render';
 
 const tileLayer = new TileLayer({
   source: new OSM({

--- a/examples/feature-move-animation.js
+++ b/examples/feature-move-animation.js
@@ -1,13 +1,13 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Polyline from '../src/ol/format/Polyline.js';
-import Point from '../src/ol/geom/Point.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Icon, Stroke, Style} from '../src/ol/style.js';
-import {getVectorContext} from '../src/ol/render.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Polyline from 'ol/format/Polyline';
+import Point from 'ol/geom/Point';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Icon, Stroke, Style} from 'ol/style';
+import {getVectorContext} from 'ol/render';
 
 // This long string is placed here due to jsFiddle limitations.
 // It is usually loaded with AJAX.

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -1,12 +1,12 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import LineString from '../src/ol/geom/LineString.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Stroke, Style} from '../src/ol/style.js';
-import {getVectorContext} from '../src/ol/render.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import LineString from 'ol/geom/LineString';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import Stamen from 'ol/source/Stamen';
+import VectorSource from 'ol/source/Vector';
+import {Stroke, Style} from 'ol/style';
+import {getVectorContext} from 'ol/render';
 
 const tileLayer = new TileLayer({
   source: new Stamen({

--- a/examples/fractal.js
+++ b/examples/fractal.js
@@ -1,9 +1,9 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import LineString from '../src/ol/geom/LineString.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import LineString from 'ol/geom/LineString';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
 
 const radius = 10e6;
 const cos30 = Math.cos(Math.PI / 6);

--- a/examples/full-screen-drag-rotate-and-zoom.js
+++ b/examples/full-screen-drag-rotate-and-zoom.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, FullScreen} from '../src/ol/control.js';
-import {defaults as defaultInteractions, DragRotateAndZoom} from '../src/ol/interaction.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, FullScreen} from 'ol/control';
+import {defaults as defaultInteractions, DragRotateAndZoom} from 'ol/interaction';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
 
 
 const map = new Map({

--- a/examples/full-screen-source.js
+++ b/examples/full-screen-source.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, FullScreen} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, FullScreen} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const view = new View({

--- a/examples/full-screen.js
+++ b/examples/full-screen.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, FullScreen} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, FullScreen} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
 
 
 const view = new View({

--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import OSM from '../src/ol/source/OSM.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
-import {Tile as TileLayer, VectorTile as VectorTileLayer} from '../src/ol/layer.js';
-import Projection from '../src/ol/proj/Projection.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import OSM from 'ol/source/OSM';
+import VectorTileSource from 'ol/source/VectorTile';
+import {Tile as TileLayer, VectorTile as VectorTileLayer} from 'ol/layer';
+import Projection from 'ol/proj/Projection';
 
 
 const replacer = function(key, value) {

--- a/examples/geojson.js
+++ b/examples/geojson.js
@@ -1,11 +1,11 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import Circle from '../src/ol/geom/Circle.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import Circle from 'ol/geom/Circle';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 
 const image = new CircleStyle({

--- a/examples/geolocation-orientation.js
+++ b/examples/geolocation-orientation.js
@@ -1,11 +1,11 @@
-import Geolocation from '../src/ol/Geolocation.js';
-import Map from '../src/ol/Map.js';
-import Overlay from '../src/ol/Overlay.js';
-import View from '../src/ol/View.js';
-import LineString from '../src/ol/geom/LineString.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
+import Geolocation from 'ol/Geolocation';
+import Map from 'ol/Map';
+import Overlay from 'ol/Overlay';
+import View from 'ol/View';
+import LineString from 'ol/geom/LineString';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
 
 // creating the view
 const view = new View({

--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -1,11 +1,11 @@
-import Feature from '../src/ol/Feature.js';
-import Geolocation from '../src/ol/Geolocation.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Geolocation from 'ol/Geolocation';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 const view = new View({
   center: [0, 0],

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import ImageLayer from '../src/ol/layer/Image.js';
-import ImageWMS from '../src/ol/source/ImageWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import ImageLayer from 'ol/layer/Image';
+import ImageWMS from 'ol/source/ImageWMS';
 
 
 const wmsSource = new ImageWMS({

--- a/examples/getfeatureinfo-layers.js
+++ b/examples/getfeatureinfo-layers.js
@@ -1,4 +1,4 @@
-import WMSGetFeatureInfo from '../src/ol/format/WMSGetFeatureInfo.js';
+import WMSGetFeatureInfo from 'ol/format/WMSGetFeatureInfo';
 
 fetch('data/wmsgetfeatureinfo/osm-restaurant-hotel.xml').then(function(response) {
   return response.text();

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS';
 
 
 const wmsSource = new TileWMS({

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GPX from '../src/ol/format/GPX.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GPX from 'ol/format/GPX';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 const raster = new TileLayer({
   source: new BingMaps({

--- a/examples/graticule.js
+++ b/examples/graticule.js
@@ -1,10 +1,10 @@
-import Graticule from '../src/ol/layer/Graticule.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import Stroke from '../src/ol/style/Stroke.js';
+import Graticule from 'ol/layer/Graticule';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import Stroke from 'ol/style/Stroke';
 
 
 const map = new Map({

--- a/examples/heatmap-earthquakes.js
+++ b/examples/heatmap-earthquakes.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import KML from '../src/ol/format/KML.js';
-import {Heatmap as HeatmapLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import VectorSource from '../src/ol/source/Vector.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import KML from 'ol/format/KML';
+import {Heatmap as HeatmapLayer, Tile as TileLayer} from 'ol/layer';
+import Stamen from 'ol/source/Stamen';
+import VectorSource from 'ol/source/Vector';
 
 const blur = document.getElementById('blur');
 const radius = document.getElementById('radius');

--- a/examples/here-maps.js
+++ b/examples/here-maps.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
 
 const appId = 'kDm0Jq1K4Ak7Bwtn8uvk';
 const appCode = 'xnmvc4dKZrDfGlvQHXSvwQ';

--- a/examples/hit-tolerance.js
+++ b/examples/hit-tolerance.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import Feature from '../src/ol/Feature.js';
-import LineString from '../src/ol/geom/LineString.js';
-import {Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import Feature from 'ol/Feature';
+import LineString from 'ol/geom/LineString';
+import {Stroke, Style} from 'ol/style';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -1,12 +1,12 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Icon, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import TileJSON from 'ol/source/TileJSON';
+import VectorSource from 'ol/source/Vector';
+import {Icon, Style} from 'ol/style';
 
 
 const rome = new Feature({

--- a/examples/icon-negative.js
+++ b/examples/icon-negative.js
@@ -1,12 +1,12 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import Select from '../src/ol/interaction/Select.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Icon, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import Select from 'ol/interaction/Select';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import Stamen from 'ol/source/Stamen';
+import VectorSource from 'ol/source/Vector';
+import {Icon, Style} from 'ol/style';
 
 
 function createStyle(src, img) {

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -1,12 +1,12 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import Overlay from '../src/ol/Overlay.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Icon, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import Overlay from 'ol/Overlay';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import TileJSON from 'ol/source/TileJSON';
+import VectorSource from 'ol/source/Vector';
+import {Icon, Style} from 'ol/style';
 
 
 const iconFeature = new Feature({

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -1,13 +1,13 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import IGC from '../src/ol/format/IGC.js';
-import {LineString, Point} from '../src/ol/geom.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import OSM, {ATTRIBUTION} from '../src/ol/source/OSM.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
-import {getVectorContext} from '../src/ol/render.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import IGC from 'ol/format/IGC';
+import {LineString, Point} from 'ol/geom';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import OSM, {ATTRIBUTION} from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
+import {getVectorContext} from 'ol/render';
 
 
 const colors = {

--- a/examples/image-filter.js
+++ b/examples/image-filter.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import BingMaps from 'ol/source/BingMaps';
 
 const key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
 

--- a/examples/image-load-events.js
+++ b/examples/image-load-events.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import ImageLayer from '../src/ol/layer/Image.js';
-import ImageWMS from '../src/ol/source/ImageWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import ImageLayer from 'ol/layer/Image';
+import ImageWMS from 'ol/source/ImageWMS';
 
 
 /**

--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import VectorImageLayer from '../src/ol/layer/VectorImage.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Stroke, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import VectorImageLayer from 'ol/layer/VectorImage';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Stroke, Style, Text} from 'ol/style';
 
 
 const style = new Style({

--- a/examples/interaction-options.js
+++ b/examples/interaction-options.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultInteractions} from '../src/ol/interaction.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultInteractions} from 'ol/interaction';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/jsts.js
+++ b/examples/jsts.js
@@ -1,12 +1,12 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import LinearRing from '../src/ol/geom/LinearRing.js';
-import {Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon} from '../src/ol/geom.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
+import LinearRing from 'ol/geom/LinearRing';
+import {Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon} from 'ol/geom';
 
 const source = new VectorSource();
 fetch('data/geojson/roads-seoul.geojson').then(function(response) {

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import KML from '../src/ol/format/KML.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import KML from 'ol/format/KML';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import Stamen from 'ol/source/Stamen';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 
 const styleCache = {};

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import KML from '../src/ol/format/KML.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import KML from 'ol/format/KML';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import Stamen from 'ol/source/Stamen';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Stroke, Style} from 'ol/style';
 
 
 /*

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import KML from '../src/ol/format/KML.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import KML from 'ol/format/KML';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
 
 const raster = new TileLayer({
   source: new BingMaps({

--- a/examples/layer-clipping.js
+++ b/examples/layer-clipping.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const osm = new TileLayer({
   source: new OSM()

--- a/examples/layer-extent.js
+++ b/examples/layer-extent.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {transformExtent} from '../src/ol/proj.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {transformExtent} from 'ol/proj';
+import TileJSON from 'ol/source/TileJSON';
 
 function transform(extent) {
   return transformExtent(extent, 'EPSG:4326', 'EPSG:3857');

--- a/examples/layer-group.js
+++ b/examples/layer-group.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Group as LayerGroup, Tile as TileLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Group as LayerGroup, Tile as TileLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import TileJSON from 'ol/source/TileJSON';
 
 const map = new Map({
   layers: [

--- a/examples/layer-spy.js
+++ b/examples/layer-spy.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import BingMaps from 'ol/source/BingMaps';
 
 const key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
 

--- a/examples/layer-swipe.js
+++ b/examples/layer-swipe.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
+import OSM from 'ol/source/OSM';
 
 const osm = new TileLayer({
   source: new OSM()

--- a/examples/layer-z-index.js
+++ b/examples/layer-z-index.js
@@ -1,10 +1,10 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, RegularShape, Stroke, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Fill, RegularShape, Stroke, Style} from 'ol/style';
 
 
 const stroke = new Stroke({color: 'black', width: 1});

--- a/examples/lazy-source.js
+++ b/examples/lazy-source.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const source = new OSM();
 

--- a/examples/line-arrows.js
+++ b/examples/line-arrows.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import Draw from '../src/ol/interaction/Draw.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Icon, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import Draw from 'ol/interaction/Draw';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Icon, Stroke, Style} from 'ol/style';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM, {ATTRIBUTION} from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM, {ATTRIBUTION} from 'ol/source/OSM';
 
 
 const openCycleMapLayer = new TileLayer({

--- a/examples/magnify.js
+++ b/examples/magnify.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import {getRenderPixel} from '../src/ol/render.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import BingMaps from 'ol/source/BingMaps';
+import {getRenderPixel} from 'ol/render';
 
 const key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
 

--- a/examples/mapbox-layer.js
+++ b/examples/mapbox-layer.js
@@ -1,13 +1,13 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Layer from '../src/ol/layer/Layer';
-import {assign} from '../src/ol/obj';
-import {getTransform} from '../src/ol/proj';
-import SourceState from '../src/ol/source/State';
-import {Stroke, Style} from '../src/ol/style.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Layer from 'ol/layer/Layer';
+import {assign} from 'ol/obj';
+import {getTransform} from 'ol/proj';
+import SourceState from 'ol/source/State';
+import {Stroke, Style} from 'ol/style';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import GeoJSON from 'ol/format/GeoJSON';
 
 class Mapbox extends Layer {
 

--- a/examples/mapbox-vector-tiles-advanced.js
+++ b/examples/mapbox-vector-tiles-advanced.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import MVT from '../src/ol/format/MVT.js';
-import VectorTileLayer from '../src/ol/layer/VectorTile.js';
-import {get as getProjection} from '../src/ol/proj.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
-import {Fill, Icon, Stroke, Style, Text} from '../src/ol/style.js';
-import TileGrid from '../src/ol/tilegrid/TileGrid.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import MVT from 'ol/format/MVT';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import {get as getProjection} from 'ol/proj';
+import VectorTileSource from 'ol/source/VectorTile';
+import {Fill, Icon, Stroke, Style, Text} from 'ol/style';
+import TileGrid from 'ol/tilegrid/TileGrid';
 
 
 const key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';

--- a/examples/mapbox-vector-tiles.js
+++ b/examples/mapbox-vector-tiles.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import MVT from '../src/ol/format/MVT.js';
-import VectorTileLayer from '../src/ol/layer/VectorTile.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
-import {Fill, Icon, Stroke, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import MVT from 'ol/format/MVT';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
+import {Fill, Icon, Stroke, Style, Text} from 'ol/style';
 
 
 const key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';

--- a/examples/mapguide-untiled.js
+++ b/examples/mapguide-untiled.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import ImageLayer from '../src/ol/layer/Image.js';
-import ImageMapGuide from '../src/ol/source/ImageMapGuide.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import ImageLayer from 'ol/layer/Image';
+import ImageMapGuide from 'ol/source/ImageMapGuide';
 
 const mdf = 'Library://Public/Samples/Sheboygan/Maps/Sheboygan.MapDefinition';
 const agentUrl =

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -1,13 +1,13 @@
-import Map from '../src/ol/Map.js';
-import {unByKey} from '../src/ol/Observable.js';
-import Overlay from '../src/ol/Overlay.js';
-import {getArea, getLength} from '../src/ol/sphere.js';
-import View from '../src/ol/View.js';
-import {LineString, Polygon} from '../src/ol/geom.js';
-import Draw from '../src/ol/interaction/Draw.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import {unByKey} from 'ol/Observable';
+import Overlay from 'ol/Overlay';
+import {getArea, getLength} from 'ol/sphere';
+import View from 'ol/View';
+import {LineString, Polygon} from 'ol/geom';
+import Draw from 'ol/interaction/Draw';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 
 const raster = new TileLayer({

--- a/examples/min-max-resolution.js
+++ b/examples/min-max-resolution.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import TileJSON from 'ol/source/TileJSON';
 
 
 /**

--- a/examples/min-zoom.js
+++ b/examples/min-zoom.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const viewport = document.getElementById('map');
 

--- a/examples/mobile-full-screen.js
+++ b/examples/mobile-full-screen.js
@@ -1,8 +1,8 @@
-import Geolocation from '../src/ol/Geolocation.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Geolocation from 'ol/Geolocation';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
 
 
 const view = new View({

--- a/examples/modify-features.js
+++ b/examples/modify-features.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {defaults as defaultInteractions, Modify, Select} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {defaults as defaultInteractions, Modify, Select} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 
 const raster = new TileLayer({

--- a/examples/modify-test.js
+++ b/examples/modify-test.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {defaults as defaultInteractions, Modify, Select} from '../src/ol/interaction.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {defaults as defaultInteractions, Modify, Select} from 'ol/interaction';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 
 const styleFunction = (function() {

--- a/examples/mouse-position.js
+++ b/examples/mouse-position.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls} from '../src/ol/control.js';
-import MousePosition from '../src/ol/control/MousePosition.js';
-import {createStringXY} from '../src/ol/coordinate.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls} from 'ol/control';
+import MousePosition from 'ol/control/MousePosition';
+import {createStringXY} from 'ol/coordinate';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const mousePositionControl = new MousePosition({
   coordinateFormat: createStringXY(4),

--- a/examples/moveend.js
+++ b/examples/moveend.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getBottomLeft, getTopRight} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {toLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getBottomLeft, getTopRight} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {toLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/navigation-controls.js
+++ b/examples/navigation-controls.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, ZoomToExtent} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, ZoomToExtent} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TopoJSON from '../src/ol/format/TopoJSON.js';
-import VectorTileLayer from '../src/ol/layer/VectorTile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TopoJSON from 'ol/format/TopoJSON';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import {fromLonLat} from 'ol/proj';
+import VectorTileSource from 'ol/source/VectorTile';
+import {Fill, Stroke, Style} from 'ol/style';
 
 const key = 'vector-tiles-5eJz6JX';
 

--- a/examples/overlay.js
+++ b/examples/overlay.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import Overlay from '../src/ol/Overlay.js';
-import View from '../src/ol/View.js';
-import {toStringHDMS} from '../src/ol/coordinate.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat, toLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import Overlay from 'ol/Overlay';
+import View from 'ol/View';
+import {toStringHDMS} from 'ol/coordinate';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat, toLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
 
 
 const layer = new TileLayer({

--- a/examples/overviewmap-custom.js
+++ b/examples/overviewmap-custom.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, OverviewMap} from '../src/ol/control.js';
-import {defaults as defaultInteractions, DragRotateAndZoom} from '../src/ol/interaction.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, OverviewMap} from 'ol/control';
+import {defaults as defaultInteractions, DragRotateAndZoom} from 'ol/interaction';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const overviewMapControl = new OverviewMap({

--- a/examples/overviewmap.js
+++ b/examples/overviewmap.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, OverviewMap} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, OverviewMap} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const source = new OSM();
 const overviewMapControl = new OverviewMap({

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 // default zoom, center and rotation
 let zoom = 2;

--- a/examples/pinch-zoom.js
+++ b/examples/pinch-zoom.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultInteractions, PinchZoom} from '../src/ol/interaction.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultInteractions, PinchZoom} from 'ol/interaction';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/polygon-styles.js
+++ b/examples/polygon-styles.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import MultiPoint from '../src/ol/geom/MultiPoint.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import MultiPoint from 'ol/geom/MultiPoint';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 const styles = [
   /* We are using two different styles for the polygons:

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import Overlay from '../src/ol/Overlay.js';
-import View from '../src/ol/View.js';
-import {toStringHDMS} from '../src/ol/coordinate.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {toLonLat} from '../src/ol/proj.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import Overlay from 'ol/Overlay';
+import View from 'ol/View';
+import {toStringHDMS} from 'ol/coordinate';
+import TileLayer from 'ol/layer/Tile';
+import {toLonLat} from 'ol/proj';
+import TileJSON from 'ol/source/TileJSON';
 
 
 /**

--- a/examples/preload.js
+++ b/examples/preload.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
 
 
 const view = new View({

--- a/examples/raster.js
+++ b/examples/raster.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import RasterSource from '../src/ol/source/Raster.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import BingMaps from 'ol/source/BingMaps';
+import RasterSource from 'ol/source/Raster';
 
 const minVgi = 0;
 const maxVgi = 0.25;

--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import RasterSource from '../src/ol/source/Raster.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import BingMaps from 'ol/source/BingMaps';
+import RasterSource from 'ol/source/Raster';
 
 function growRegion(inputs, data) {
   const image = inputs[0];

--- a/examples/regularshape.js
+++ b/examples/regularshape.js
@@ -1,10 +1,10 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import Point from '../src/ol/geom/Point.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, RegularShape, Stroke, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Fill, RegularShape, Stroke, Style} from 'ol/style';
 
 
 const stroke = new Stroke({color: 'black', width: 2});

--- a/examples/render-geometry.js
+++ b/examples/render-geometry.js
@@ -1,6 +1,6 @@
-import {LineString, Point, Polygon} from '../src/ol/geom.js';
-import {toContext} from '../src/ol/render.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import {LineString, Point, Polygon} from 'ol/geom';
+import {toContext} from 'ol/render';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 
 const canvas = document.getElementById('canvas');

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {applyTransform} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {get as getProjection, getTransform} from '../src/ol/proj.js';
-import {register} from '../src/ol/proj/proj4.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileImage from '../src/ol/source/TileImage.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {applyTransform} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {get as getProjection, getTransform} from 'ol/proj';
+import {register} from 'ol/proj/proj4';
+import OSM from 'ol/source/OSM';
+import TileImage from 'ol/source/TileImage';
 import proj4 from 'proj4';
 
 

--- a/examples/reprojection-image.js
+++ b/examples/reprojection-image.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getCenter} from '../src/ol/extent.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import {transform} from '../src/ol/proj.js';
-import Static from '../src/ol/source/ImageStatic.js';
-import OSM from '../src/ol/source/OSM.js';
-import {register} from '../src/ol/proj/proj4.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getCenter} from 'ol/extent';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import {transform} from 'ol/proj';
+import Static from 'ol/source/ImageStatic';
+import OSM from 'ol/source/OSM';
+import {register} from 'ol/proj/proj4';
 import proj4 from 'proj4';
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 ' +

--- a/examples/reprojection-wgs84.js
+++ b/examples/reprojection-wgs84.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 const map = new Map({
   layers: [

--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -1,13 +1,13 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth, getCenter} from '../src/ol/extent.js';
-import WMTSCapabilities from '../src/ol/format/WMTSCapabilities.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {get as getProjection} from '../src/ol/proj.js';
-import {register} from '../src/ol/proj/proj4.js';
-import {OSM, TileImage, TileWMS, XYZ} from '../src/ol/source.js';
-import WMTS, {optionsFromCapabilities} from '../src/ol/source/WMTS.js';
-import TileGrid from '../src/ol/tilegrid/TileGrid.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth, getCenter} from 'ol/extent';
+import WMTSCapabilities from 'ol/format/WMTSCapabilities';
+import TileLayer from 'ol/layer/Tile';
+import {get as getProjection} from 'ol/proj';
+import {register} from 'ol/proj/proj4';
+import {OSM, TileImage, TileWMS, XYZ} from 'ol/source';
+import WMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
+import TileGrid from 'ol/tilegrid/TileGrid';
 import proj4 from 'proj4';
 
 

--- a/examples/reusable-source.js
+++ b/examples/reusable-source.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
 
 const urls = [
   'https://{a-c}.tiles.mapbox.com/v3/mapbox.blue-marble-topo-jan/{z}/{x}/{y}.png',

--- a/examples/rotation.js
+++ b/examples/rotation.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, ScaleLine} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, ScaleLine} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const scaleLineControl = new ScaleLine();

--- a/examples/scaleline-indiana-east.js
+++ b/examples/scaleline-indiana-east.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {ScaleLine} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat, transformExtent} from '../src/ol/proj.js';
-import {register} from '../src/ol/proj/proj4.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {ScaleLine} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat, transformExtent} from 'ol/proj';
+import {register} from 'ol/proj/proj4';
+import OSM from 'ol/source/OSM';
 import proj4 from 'proj4';
 
 proj4.defs('Indiana-East', 'PROJCS["IN83-EF",GEOGCS["LL83",DATUM["NAD83",' +

--- a/examples/sea-level.js
+++ b/examples/sea-level.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import {Raster as RasterSource, TileJSON} from '../src/ol/source.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import {Raster as RasterSource, TileJSON} from 'ol/source';
+import XYZ from 'ol/source/XYZ';
 
 function flood(pixels, data) {
   const pixel = pixels[0];

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {click, pointerMove, altKeyOnly} from '../src/ol/events/condition.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import Select from '../src/ol/interaction/Select.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import OSM from '../src/ol/source/OSM.js';
-import VectorSource from '../src/ol/source/Vector.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {click, pointerMove, altKeyOnly} from 'ol/events/condition';
+import GeoJSON from 'ol/format/GeoJSON';
+import Select from 'ol/interaction/Select';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/semi-transparent-layer.js
+++ b/examples/semi-transparent-layer.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import TileJSON from 'ol/source/TileJSON';
 
 
 const map = new Map({

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import {OSM, Raster, XYZ} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import {OSM, Raster, XYZ} from 'ol/source';
 
 
 /**

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/snap.js
+++ b/examples/snap.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Draw, Modify, Select, Snap} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Draw, Modify, Select, Snap} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/sphere-mollweide.js
+++ b/examples/sphere-mollweide.js
@@ -1,11 +1,11 @@
-import Graticule from '../src/ol/layer/Graticule.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import Projection from '../src/ol/proj/Projection.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {register} from '../src/ol/proj/proj4.js';
+import Graticule from 'ol/layer/Graticule';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import VectorLayer from 'ol/layer/Vector';
+import Projection from 'ol/proj/Projection';
+import VectorSource from 'ol/source/Vector';
+import {register} from 'ol/proj/proj4';
 import proj4 from 'proj4';
 
 

--- a/examples/stamen.js
+++ b/examples/stamen.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import Stamen from 'ol/source/Stamen';
 
 
 const map = new Map({

--- a/examples/static-image.js
+++ b/examples/static-image.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getCenter} from '../src/ol/extent.js';
-import ImageLayer from '../src/ol/layer/Image.js';
-import Projection from '../src/ol/proj/Projection.js';
-import Static from '../src/ol/source/ImageStatic.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getCenter} from 'ol/extent';
+import ImageLayer from 'ol/layer/Image';
+import Projection from 'ol/proj/Projection';
+import Static from 'ol/source/ImageStatic';
 
 
 // Map views always need a projection.  Here we just want to map image

--- a/examples/street-labels.js
+++ b/examples/street-labels.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getCenter} from '../src/ol/extent.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getCenter} from 'ol/extent';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Style, Text} from 'ol/style';
 
 const style = new Style({
   text: new Text({

--- a/examples/synthetic-lines.js
+++ b/examples/synthetic-lines.js
@@ -1,10 +1,10 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import LineString from '../src/ol/geom/LineString.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Stroke, Style} from '../src/ol/style.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import LineString from 'ol/geom/LineString';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Stroke, Style} from 'ol/style';
 
 
 const count = 10000;

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -1,11 +1,11 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {LineString, Point} from '../src/ol/geom.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
-import {getVectorContext} from '../src/ol/render.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {LineString, Point} from 'ol/geom';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
+import {getVectorContext} from 'ol/render';
 
 
 const count = 20000;

--- a/examples/teleport.js
+++ b/examples/teleport.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 const map = new Map({

--- a/examples/tile-load-events.js
+++ b/examples/tile-load-events.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import TileJSON from 'ol/source/TileJSON';
 
 
 /**

--- a/examples/tile-transitions.js
+++ b/examples/tile-transitions.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
 
 const url = 'https://{a-c}.tiles.mapbox.com/v3/mapbox.world-bright/{z}/{x}/{y}.png';
 

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import TileJSON from 'ol/source/TileJSON';
 
 
 const map = new Map({

--- a/examples/tissot.js
+++ b/examples/tissot.js
@@ -1,10 +1,10 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {circular as circularPolygon} from '../src/ol/geom/Polygon.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
-import VectorSource from '../src/ol/source/Vector.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {circular as circularPolygon} from 'ol/geom/Polygon';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import TileWMS from 'ol/source/TileWMS';
+import VectorSource from 'ol/source/Vector';
 
 const vectorLayer4326 = new VectorLayer({
   source: new VectorSource()

--- a/examples/topojson.js
+++ b/examples/topojson.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TopoJSON from '../src/ol/format/TopoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TopoJSON from 'ol/format/TopoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import TileJSON from 'ol/source/TileJSON';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Stroke, Style} from 'ol/style';
 
 
 const raster = new TileLayer({

--- a/examples/topolis.js
+++ b/examples/topolis.js
@@ -1,12 +1,12 @@
-import Feature from '../src/ol/Feature.js';
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Point, LineString, Polygon} from '../src/ol/geom.js';
-import {Draw, Snap} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Fill, Circle as CircleStyle, Stroke, Style, Text} from '../src/ol/style.js';
-import MousePosition from '../src/ol/control/MousePosition.js';
+import Feature from 'ol/Feature';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Point, LineString, Polygon} from 'ol/geom';
+import {Draw, Snap} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Fill, Circle as CircleStyle, Stroke, Style, Text} from 'ol/style';
+import MousePosition from 'ol/control/MousePosition';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/translate-features.js
+++ b/examples/translate-features.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {defaults as defaultInteractions, Select, Translate} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import OSM from '../src/ol/source/OSM.js';
-import VectorSource from '../src/ol/source/Vector.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {defaults as defaultInteractions, Select, Translate} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
 
 
 const raster = new TileLayer({

--- a/examples/turf.js
+++ b/examples/turf.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {fromLonLat} from 'ol/proj';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 
 const source = new VectorSource();

--- a/examples/utfgrid.js
+++ b/examples/utfgrid.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import Overlay from '../src/ol/Overlay.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import UTFGrid from '../src/ol/source/UTFGrid.js';
+import Map from 'ol/Map';
+import Overlay from 'ol/Overlay';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import TileJSON from 'ol/source/TileJSON';
+import UTFGrid from 'ol/source/UTFGrid';
 
 const key = 'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiRk1kMWZaSSJ9.E5BkluenyWQMsBLsuByrmg';
 

--- a/examples/vector-esri-edit.js
+++ b/examples/vector-esri-edit.js
@@ -1,13 +1,13 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import EsriJSON from '../src/ol/format/EsriJSON.js';
-import {defaults as defaultInteractions, Draw, Modify, Select} from '../src/ol/interaction.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {tile as tileStrategy} from '../src/ol/loadingstrategy.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import XYZ from '../src/ol/source/XYZ.js';
-import {createXYZ} from '../src/ol/tilegrid.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import EsriJSON from 'ol/format/EsriJSON';
+import {defaults as defaultInteractions, Draw, Modify, Select} from 'ol/interaction';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {tile as tileStrategy} from 'ol/loadingstrategy';
+import {fromLonLat} from 'ol/proj';
+import VectorSource from 'ol/source/Vector';
+import XYZ from 'ol/source/XYZ';
+import {createXYZ} from 'ol/tilegrid';
 
 
 const serviceUrl = 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/' +

--- a/examples/vector-esri.js
+++ b/examples/vector-esri.js
@@ -1,13 +1,13 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import EsriJSON from '../src/ol/format/EsriJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {tile as tileStrategy} from '../src/ol/loadingstrategy.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import XYZ from '../src/ol/source/XYZ.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
-import {createXYZ} from '../src/ol/tilegrid.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import EsriJSON from 'ol/format/EsriJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {tile as tileStrategy} from 'ol/loadingstrategy';
+import {fromLonLat} from 'ol/proj';
+import VectorSource from 'ol/source/Vector';
+import XYZ from 'ol/source/XYZ';
+import {Fill, Stroke, Style} from 'ol/style';
+import {createXYZ} from 'ol/tilegrid';
 
 
 const serviceUrl = 'https://sampleserver3.arcgisonline.com/ArcGIS/rest/services/' +

--- a/examples/vector-label-decluttering.js
+++ b/examples/vector-label-decluttering.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth} from '../src/ol/extent.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Stroke, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth} from 'ol/extent';
+import GeoJSON from 'ol/format/GeoJSON';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Stroke, Style, Text} from 'ol/style';
 
 const map = new Map({
   target: 'map',

--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Circle as CircleStyle, Fill, Stroke, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
+import {Circle as CircleStyle, Fill, Stroke, Style, Text} from 'ol/style';
 
 let openSansAdded = false;
 

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Fill, Stroke, Style, Text} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import {Fill, Stroke, Style, Text} from 'ol/style';
 
 
 const style = new Style({

--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -1,12 +1,12 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import OSMXML from '../src/ol/format/OSMXML.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {bbox as bboxStrategy} from '../src/ol/loadingstrategy.js';
-import {transformExtent} from '../src/ol/proj.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import OSMXML from 'ol/format/OSMXML';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {bbox as bboxStrategy} from 'ol/loadingstrategy';
+import {transformExtent} from 'ol/proj';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
+import {Circle as CircleStyle, Fill, Stroke, Style} from 'ol/style';
 
 let map = null;
 

--- a/examples/vector-tile-info.js
+++ b/examples/vector-tile-info.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import MVT from '../src/ol/format/MVT.js';
-import VectorTileLayer from '../src/ol/layer/VectorTile.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import MVT from 'ol/format/MVT';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
 
 const map = new Map({
   target: 'map',

--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import MVT from '../src/ol/format/MVT.js';
-import VectorTileLayer from '../src/ol/layer/VectorTile.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import MVT from 'ol/format/MVT';
+import VectorTileLayer from 'ol/layer/VectorTile';
+import VectorTileSource from 'ol/source/VectorTile';
+import {Fill, Stroke, Style} from 'ol/style';
 
 // lookup for selection objects
 let selection = {};

--- a/examples/vector-wfs-getfeature.js
+++ b/examples/vector-wfs-getfeature.js
@@ -1,15 +1,15 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
 import {
   equalTo as equalToFilter,
   like as likeFilter,
   and as andFilter
-} from '../src/ol/format/filter.js';
-import {WFS, GeoJSON} from '../src/ol/format.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Stroke, Style} from '../src/ol/style.js';
+} from 'ol/format/filter';
+import {WFS, GeoJSON} from 'ol/format';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
+import {Stroke, Style} from 'ol/style';
 
 
 const vectorSource = new VectorSource();

--- a/examples/vector-wfs.js
+++ b/examples/vector-wfs.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {bbox as bboxStrategy} from '../src/ol/loadingstrategy.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
-import VectorSource from '../src/ol/source/Vector.js';
-import {Stroke, Style} from '../src/ol/style.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import GeoJSON from 'ol/format/GeoJSON';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {bbox as bboxStrategy} from 'ol/loadingstrategy';
+import BingMaps from 'ol/source/BingMaps';
+import VectorSource from 'ol/source/Vector';
+import {Stroke, Style} from 'ol/style';
 
 
 const vectorSource = new VectorSource({

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -155,7 +155,6 @@ ExampleBuilder.prototype.render = async function(dir, chunk) {
   if (!jsSource) {
     throw new Error(`No .js source for ${jsName}`);
   }
-  jsSource = jsSource.replace(/'\.\.\/src\//g, '\'');
   if (data.cloak) {
     for (const entry of data.cloak) {
       jsSource = jsSource.replace(new RegExp(entry.key, 'g'), entry.value);

--- a/examples/wkt.js
+++ b/examples/wkt.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import WKT from '../src/ol/format/WKT.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import WKT from 'ol/format/WKT';
+import {Tile as TileLayer, Vector as VectorLayer} from 'ol/layer';
+import {OSM, Vector as VectorSource} from 'ol/source';
 
 const raster = new TileLayer({
   source: new OSM()

--- a/examples/wms-capabilities.js
+++ b/examples/wms-capabilities.js
@@ -1,4 +1,4 @@
-import WMSCapabilities from '../src/ol/format/WMSCapabilities.js';
+import WMSCapabilities from 'ol/format/WMSCapabilities';
 
 const parser = new WMSCapabilities();
 

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, ScaleLine} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {addProjection, addCoordinateTransforms, transform} from '../src/ol/proj.js';
-import Projection from '../src/ol/proj/Projection.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, ScaleLine} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import {addProjection, addCoordinateTransforms, transform} from 'ol/proj';
+import Projection from 'ol/proj/Projection';
+import TileWMS from 'ol/source/TileWMS';
 
 
 // By default OpenLayers does not know about the EPSG:21781 (Swiss) projection.

--- a/examples/wms-custom-tilegrid-512x256.js
+++ b/examples/wms-custom-tilegrid-512x256.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {get as getProjection} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
-import TileGrid from '../src/ol/tilegrid/TileGrid.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {get as getProjection} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import TileWMS from 'ol/source/TileWMS';
+import TileGrid from 'ol/tilegrid/TileGrid';
 
 
 const projExtent = getProjection('EPSG:3857').getExtent();

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {defaults as defaultControls, ScaleLine} from '../src/ol/control.js';
-import ImageLayer from '../src/ol/layer/Image.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import Projection from '../src/ol/proj/Projection.js';
-import ImageWMS from '../src/ol/source/ImageWMS.js';
-import {register} from '../src/ol/proj/proj4.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {defaults as defaultControls, ScaleLine} from 'ol/control';
+import ImageLayer from 'ol/layer/Image';
+import {fromLonLat} from 'ol/proj';
+import Projection from 'ol/proj/Projection';
+import ImageWMS from 'ol/source/ImageWMS';
+import {register} from 'ol/proj/proj4';
 import proj4 from 'proj4';
 
 

--- a/examples/wms-image.js
+++ b/examples/wms-image.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import ImageWMS from '../src/ol/source/ImageWMS.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import ImageWMS from 'ol/source/ImageWMS';
+import OSM from 'ol/source/OSM';
 
 
 const layers = [

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
-import Projection from '../src/ol/proj/Projection.js';
-import ImageWMS from '../src/ol/source/ImageWMS.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {Image as ImageLayer, Tile as TileLayer} from 'ol/layer';
+import Projection from 'ol/proj/Projection';
+import ImageWMS from 'ol/source/ImageWMS';
+import TileWMS from 'ol/source/TileWMS';
 
 
 const layers = [

--- a/examples/wms-tiled-wrap-180.js
+++ b/examples/wms-tiled-wrap-180.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import TileWMS from 'ol/source/TileWMS';
 
 
 const layers = [

--- a/examples/wms-tiled.js
+++ b/examples/wms-tiled.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import TileWMS from 'ol/source/TileWMS';
 
 
 const layers = [

--- a/examples/wms-time.js
+++ b/examples/wms-time.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getCenter} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {transformExtent} from '../src/ol/proj.js';
-import Stamen from '../src/ol/source/Stamen.js';
-import TileWMS from '../src/ol/source/TileWMS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getCenter} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {transformExtent} from 'ol/proj';
+import Stamen from 'ol/source/Stamen';
+import TileWMS from 'ol/source/TileWMS';
 
 function threeHoursAgo() {
   return new Date(Math.round(Date.now() / 3600000) * 3600000 - 3600000 * 3);

--- a/examples/wmts-capabilities.js
+++ b/examples/wmts-capabilities.js
@@ -1,4 +1,4 @@
-import WMTSCapabilities from '../src/ol/format/WMTSCapabilities.js';
+import WMTSCapabilities from 'ol/format/WMTSCapabilities';
 
 const parser = new WMTSCapabilities();
 

--- a/examples/wmts-dimensions.js
+++ b/examples/wmts-dimensions.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth, getTopLeft} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {get as getProjection} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import WMTS from '../src/ol/source/WMTS.js';
-import WMTSTileGrid from '../src/ol/tilegrid/WMTS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth, getTopLeft} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {get as getProjection} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import WMTS from 'ol/source/WMTS';
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
 
 
 // create the WMTS tile grid in the google projection

--- a/examples/wmts-hidpi.js
+++ b/examples/wmts-hidpi.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import WMTSCapabilities from '../src/ol/format/WMTSCapabilities.js';
-import {DEVICE_PIXEL_RATIO} from '../src/ol/has.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import WMTS, {optionsFromCapabilities} from '../src/ol/source/WMTS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import WMTSCapabilities from 'ol/format/WMTSCapabilities';
+import {DEVICE_PIXEL_RATIO} from 'ol/has';
+import TileLayer from 'ol/layer/Tile';
+import WMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
 
 
 const capabilitiesUrl = 'https://www.basemap.at/wmts/1.0.0/WMTSCapabilities.xml';

--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -1,10 +1,10 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat, get as getProjection} from '../src/ol/proj.js';
-import WMTS from '../src/ol/source/WMTS.js';
-import WMTSTileGrid from '../src/ol/tilegrid/WMTS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat, get as getProjection} from 'ol/proj';
+import WMTS from 'ol/source/WMTS';
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
 
 
 const map = new Map({

--- a/examples/wmts-layer-from-capabilities.js
+++ b/examples/wmts-layer-from-capabilities.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import WMTSCapabilities from '../src/ol/format/WMTSCapabilities.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
-import WMTS, {optionsFromCapabilities} from '../src/ol/source/WMTS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import WMTSCapabilities from 'ol/format/WMTSCapabilities';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import WMTS, {optionsFromCapabilities} from 'ol/source/WMTS';
 
 const parser = new WMTSCapabilities();
 let map;

--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -1,11 +1,11 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {getWidth, getTopLeft} from '../src/ol/extent.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {get as getProjection} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import WMTS from '../src/ol/source/WMTS.js';
-import WMTSTileGrid from '../src/ol/tilegrid/WMTS.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {getWidth, getTopLeft} from 'ol/extent';
+import TileLayer from 'ol/layer/Tile';
+import {get as getProjection} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import WMTS from 'ol/source/WMTS';
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
 
 
 const projection = getProjection('EPSG:3857');

--- a/examples/xyz-esri-4326-512.js
+++ b/examples/xyz-esri-4326-512.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
 
 // The tile size supported by the ArcGIS tile service.
 const tileSize = 512;

--- a/examples/xyz-esri.js
+++ b/examples/xyz-esri.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {fromLonLat} from '../src/ol/proj.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {fromLonLat} from 'ol/proj';
+import XYZ from 'ol/source/XYZ';
 
 
 const map = new Map({

--- a/examples/xyz-retina.js
+++ b/examples/xyz-retina.js
@@ -1,9 +1,9 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import {transform, transformExtent} from '../src/ol/proj.js';
-import OSM from '../src/ol/source/OSM.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import {transform, transformExtent} from 'ol/proj';
+import OSM from 'ol/source/OSM';
+import XYZ from 'ol/source/XYZ';
 
 const mapMinZoom = 1;
 const mapMaxZoom = 15;

--- a/examples/xyz.js
+++ b/examples/xyz.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import XYZ from '../src/ol/source/XYZ.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
 
 
 const map = new Map({

--- a/examples/zoom-constrained.js
+++ b/examples/zoom-constrained.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import BingMaps from 'ol/source/BingMaps';
 
 
 const map = new Map({

--- a/examples/zoomify.js
+++ b/examples/zoomify.js
@@ -1,7 +1,7 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import Zoomify from '../src/ol/source/Zoomify.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import Zoomify from 'ol/source/Zoomify';
 
 const imgWidth = 9911;
 const imgHeight = 6100;

--- a/examples/zoomslider.js
+++ b/examples/zoomslider.js
@@ -1,8 +1,8 @@
-import Map from '../src/ol/Map.js';
-import View from '../src/ol/View.js';
-import {ZoomSlider} from '../src/ol/control.js';
-import TileLayer from '../src/ol/layer/Tile.js';
-import OSM from '../src/ol/source/OSM.js';
+import Map from 'ol/Map';
+import View from 'ol/View';
+import {ZoomSlider} from 'ol/control';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
 
 
 /**


### PR DESCRIPTION
To have the same path (starting with `ol/`, without `.js`) as in the documentation.
The support was added in the webpack config in #8928

The generated examples: https://477-4723248-gh.circle-artifacts.com/0/examples/index.html

