### PR TITLE
Change projection and urls properties in sources options to optional

### DIFF
--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -70,7 +70,7 @@ class ImageSourceEvent extends Event {
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions]
- * @property {import("../proj.js").ProjectionLike} projection
+ * @property {import("../proj.js").ProjectionLike} [projection]
  * @property {Array<number>} [resolutions]
  * @property {import("./State.js").default} [state]
  */

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -28,7 +28,7 @@ import {appendParams} from '../uri.js';
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
  * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
  * for further reference.
- * @property {import("../proj.js").ProjectionLike} projection Projection.
+ * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,
  * `2` means twice the size of the map viewport, and so on.
  * @property {Array<number>} [resolutions] Resolutions. If specified, requests will be made for

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -44,7 +44,7 @@ import {appendParams} from '../uri.js';
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.  To disable the opacity
  * transition, pass `transition: 0`.
- * @property {Array<string>} urls ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS
+ * @property {Array<string>} [urls] ArcGIS Rest service urls. Use this instead of `url` when the ArcGIS
  * Service supports multiple urls for export requests.
  */
 


### PR DESCRIPTION
The `projection` property is not mandatory, the view's projection is used if not provided.
The `urls` property is optional if `url` is defined.