### PR TITLE
Added scalebar option to ol.control.scaleline

### DIFF
--- a/examples/scale-line.html
+++ b/examples/scale-line.html
@@ -14,3 +14,19 @@ tags: "scale-line, openstreetmap"
   <option value="nautical">nautical mile</option>
   <option value="metric" selected>metric</option>
 </select>
+
+<select id="type">
+  <option value="scaleline">ScaleLine</option>
+  <option value="scalebar">ScaleBar</option>
+</select>
+
+<select id="steps" style="display:none">
+  <option value=2>2 steps</option>
+  <option value=4 selected>4 steps</option>
+  <option value=6>6 steps</option>
+  <option value=8>8 steps</option>
+</select>
+
+<div id="showScaleTextDiv" style="display:none">
+  <input type="checkbox" id="showScaleText" checked>Show scale text
+</div>

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -4,12 +4,27 @@ import {defaults as defaultControls, ScaleLine} from '../src/ol/control.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import OSM from '../src/ol/source/OSM.js';
 
+let scaleType = 'scaleline';
+let scaleBarSteps = 4;
+let scaleBarText = true;
+let control;
 
-const scaleLineControl = new ScaleLine();
-
+function scaleControl() {
+  if (scaleType === 'scaleline') {
+    control = new ScaleLine();
+    return control;
+  }
+  control = new ScaleLine({
+    scaleBar: true,
+    scaleBarSteps: scaleBarSteps,
+    scaleBarText: scaleBarText,
+    minWidth: 200
+  });
+  return control;
+}
 const map = new Map({
   controls: defaultControls().extend([
-    scaleLineControl
+    scaleControl()
   ]),
   layers: [
     new TileLayer({
@@ -23,10 +38,40 @@ const map = new Map({
   })
 });
 
-
 const unitsSelect = document.getElementById('units');
+const typeSelect = document.getElementById('type');
+const stepsSelect = document.getElementById('steps');
+const scaleTextCheckbox = document.getElementById('showScaleText');
+const showScaleTextDiv = document.getElementById('showScaleTextDiv');
 function onChange() {
-  scaleLineControl.setUnits(unitsSelect.value);
+  control.setUnits(unitsSelect.value);
+}
+function onChangeType() {
+  scaleType = typeSelect.value;
+  if (typeSelect.value === 'scalebar') {
+    stepsSelect.style.display = 'inline';
+    showScaleTextDiv.style.display = 'inline';
+    map.removeControl(control);
+    map.addControl(scaleControl());
+  } else {
+    stepsSelect.style.display = 'none';
+    showScaleTextDiv.style.display = 'none';
+    map.removeControl(control);
+    map.addControl(scaleControl());
+  }
+}
+function onChangeSteps() {
+  scaleBarSteps = parseInt(stepsSelect.value, 10);
+  map.removeControl(control);
+  map.addControl(scaleControl());
+}
+function onChangeScaleText() {
+  scaleBarText = scaleTextCheckbox.checked;
+  map.removeControl(control);
+  map.addControl(scaleControl());
 }
 unitsSelect.addEventListener('change', onChange);
+typeSelect.addEventListener('change', onChangeType);
+stepsSelect.addEventListener('change', onChangeSteps);
+scaleTextCheckbox.addEventListener('change', onChangeScaleText);
 onChange();

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -4,6 +4,12 @@ import {defaults as defaultControls, ScaleLine} from '../src/ol/control.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import OSM from '../src/ol/source/OSM.js';
 
+const unitsSelect = document.getElementById('units');
+const typeSelect = document.getElementById('type');
+const stepsSelect = document.getElementById('steps');
+const scaleTextCheckbox = document.getElementById('showScaleText');
+const showScaleTextDiv = document.getElementById('showScaleTextDiv');
+
 let scaleType = 'scaleline';
 let scaleBarSteps = 4;
 let scaleBarText = true;
@@ -11,14 +17,17 @@ let control;
 
 function scaleControl() {
   if (scaleType === 'scaleline') {
-    control = new ScaleLine();
+    control = new ScaleLine({
+      units: unitsSelect.value
+    });
     return control;
   }
   control = new ScaleLine({
-    scaleBar: true,
-    scaleBarSteps: scaleBarSteps,
-    scaleBarText: scaleBarText,
-    minWidth: 200
+    units: unitsSelect.value,
+    bar: true,
+    steps: scaleBarSteps,
+    text: scaleBarText,
+    minWidth: 140
   });
   return control;
 }
@@ -38,11 +47,6 @@ const map = new Map({
   })
 });
 
-const unitsSelect = document.getElementById('units');
-const typeSelect = document.getElementById('type');
-const stepsSelect = document.getElementById('steps');
-const scaleTextCheckbox = document.getElementById('showScaleText');
-const showScaleTextDiv = document.getElementById('showScaleTextDiv');
 function onChange() {
   control.setUnits(unitsSelect.value);
 }
@@ -74,4 +78,3 @@ unitsSelect.addEventListener('change', onChange);
 typeSelect.addEventListener('change', onChangeType);
 stepsSelect.addEventListener('change', onChangeSteps);
 scaleTextCheckbox.addEventListener('change', onChangeScaleText);
-onChange();

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -45,11 +45,11 @@ const LEADING_DIGITS = [1, 2, 5];
  * @property {HTMLElement|string} [target] Specify a target if you want the control
  * to be rendered outside of the map's viewport.
  * @property {Units|string} [units='metric'] Units.
- * @property {boolean} [scaleBar=false] Render scalebars instead of a line.
- * @property {number} [scaleBarSteps=4] Number of steps the scalebar should use. Use even numbers
- * for best results. Only useful when `scaleBar` is `true`.
- * @property {boolean} [scaleBarText=false] Render a scale ontop of the scalebar. Only useful
- * when `scaleBar` is `true`.
+ * @property {boolean} [bar=false] Render scalebars instead of a line.
+ * @property {number} [steps=4] Number of steps the scalebar should use. Use even numbers
+ * for best results. Only applies when `bar` is `true`.
+ * @property {boolean} [text=false] Render the text scale above of the scalebar. Only applies
+ * when `bar` is `true`.
  */
 
 
@@ -62,7 +62,7 @@ const LEADING_DIGITS = [1, 2, 5];
  * viewport center cannot be calculated in the view projection.
  * By default the scale line will show in the bottom left portion of the map,
  * but this can be changed by using the css selector `.ol-scale-line`.
- * When specifying `scaleBar` as `true`, a scalebar will be rendered instead
+ * When specifying `bar` as `true`, a scalebar will be rendered instead
  * of a scaleline.
  *
  * @api
@@ -77,7 +77,7 @@ class ScaleLine extends Control {
     const options = opt_options ? opt_options : {};
 
     const className = options.className !== undefined ? options.className :
-      options.scaleBar !== undefined ? 'ol-scale-bar' : 'ol-scale-line';
+      options.bar !== undefined ? 'ol-scale-bar' : 'ol-scale-line';
 
     super({
       element: document.createElement('div'),
@@ -135,19 +135,19 @@ class ScaleLine extends Control {
      * @private
      * @type {boolean}
      */
-    this.scaleBar_ = options.scaleBar || false;
+    this.scaleBar_ = options.bar || false;
 
     /**
      * @private
      * @type {number}
      */
-    this.scaleBarSteps_ = options.scaleBarSteps || 4;
+    this.scaleBarSteps_ = options.steps || 4;
 
     /**
      * @private
      * @type {boolean}
      */
-    this.scaleBarText_ = options.scaleBarText || false;
+    this.scaleBarText_ = options.text || false;
 
   }
 
@@ -315,8 +315,7 @@ class ScaleLine extends Control {
    * @returns {string} The stringified HTML of the scalebar.
    */
   createScaleBar(width, scale, suffix) {
-    let mapScale = Math.round(this.getScaleForResolution());
-    mapScale = '1 : ' + mapScale.toLocaleString().replace(/,/g, '.');
+    const mapScale = '1 : ' + Math.round(this.getScaleForResolution()).toLocaleString();
     const scaleSteps = [];
     const stepWidth = width / this.scaleBarSteps_;
     let backgroundColor = '#ffffff';

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -77,7 +77,7 @@ class ScaleLine extends Control {
     const options = opt_options ? opt_options : {};
 
     const className = options.className !== undefined ? options.className :
-      options.bar !== undefined ? 'ol-scale-bar' : 'ol-scale-line';
+      options.bar ? 'ol-scale-bar' : 'ol-scale-line';
 
     super({
       element: document.createElement('div'),

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -26,7 +26,43 @@
   text-align: center;
   margin: 1px;
   will-change: contents, width;
+  transition: all 0.25s;
 }
+.ol-scale-bar {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+}
+.ol-scale-step-marker {
+  width: 1px;
+  height: 15px;
+  background-color: #000000;
+  float: right;
+  z-Index: 10;
+}
+.ol-scale-step-text {
+  position: absolute;
+  bottom: -5px;
+  font-size: 12px;
+  z-Index: 11;
+  color: #000000;
+  text-shadow: -2px 0 #FFFFFF, 0 2px #FFFFFF, 2px 0 #FFFFFF, 0 -2px #FFFFFF;
+}
+.ol-scale-text {
+  position: absolute;
+  font-size: 14px;
+  text-align: center;
+  bottom: 25px;
+  color: #000000;
+  text-shadow: -2px 0 #FFFFFF, 0 2px #FFFFFF, 2px 0 #FFFFFF, 0 -2px #FFFFFF;
+}
+.ol-scale-singlebar {
+  position: relative;
+  height: 10px;
+  z-Index: 9;
+  border: 1px solid black;
+}
+
 .ol-overlay-container {
   will-change: left,right,top,bottom;
 }


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
This adds an option to show scalebars instead of a scaleline in the `ScaleLine` control.

![scalebar](https://user-images.githubusercontent.com/1381363/49162174-9fcd2d80-f32a-11e8-94e5-bc3812d097ad.png)

Example and API doc have been adjusted.