### PR TITLE
Use WebGL even with major performance caveat

### DIFF
--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -324,7 +324,7 @@ let HAS = false;
 if (typeof window !== 'undefined' && 'WebGLRenderingContext' in window) {
   try {
     const canvas = /** @type {HTMLCanvasElement} */ (document.createElement('canvas'));
-    const gl = getContext(canvas, {failIfMajorPerformanceCaveat: true});
+    const gl = getContext(canvas);
     if (gl) {
       HAS = true;
       MAX_TEXTURE_SIZE = /** @type {number} */ (gl.getParameter(gl.MAX_TEXTURE_SIZE));


### PR DESCRIPTION
Now that the library relies on WebGL for the Heatmap layer, we have to make sure WebGL can be used in as many environments as possible. This pull request makes the WebGL check pass even if there is a major performance caveat.

This change also partially resolves an issue with the rendering tests, see https://github.com/openlayers/openlayers/pull/8977#issuecomment-443199145.