### PR TITLE
Fix webgl PointsLayer not rendering anything

### DIFF
--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -205,6 +205,7 @@ class Heatmap extends VectorLayer {
         attribute vec2 a_texCoord;
         attribute float a_rotateWithView;
         attribute vec2 a_offsets;
+        attribute float a_opacity;
         
         uniform mat4 u_projectionMatrix;
         uniform mat4 u_offsetScaleMatrix;
@@ -212,6 +213,7 @@ class Heatmap extends VectorLayer {
         uniform float u_size;
         
         varying vec2 v_texCoord;
+        varying float v_opacity;
         
         void main(void) {
           mat4 offsetMatrix = u_offsetScaleMatrix;
@@ -221,6 +223,7 @@ class Heatmap extends VectorLayer {
           vec4 offsets = offsetMatrix * vec4(a_offsets, 0.0, 0.0);
           gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets * u_size;
           v_texCoord = a_texCoord;
+          v_opacity = a_opacity;
         }`,
       fragmentShader: `
         precision mediump float;
@@ -229,12 +232,13 @@ class Heatmap extends VectorLayer {
         uniform float u_blur;
         
         varying vec2 v_texCoord;
+        varying float v_opacity;
         
         void main(void) {
           gl_FragColor.rgb = vec3(1.0, 1.0, 1.0);
           vec2 texCoord = v_texCoord * 2.0 - vec2(1.0, 1.0);
           float sqRadius = texCoord.x * texCoord.x + texCoord.y * texCoord.y;
-          float alpha = 1.0 - sqRadius * sqRadius;
+          float alpha = 1.0 - sqRadius * sqRadius * v_opacity;
           if (alpha <= 0.0) {
             discard;
           }

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -77,7 +77,12 @@ const FRAGMENT_SHADER = `
  * All features will be rendered as quads (two triangles forming a square). New data will be flushed to the GPU
  * every time the vector source changes.
  *
- * Use shaders to customize the final output.
+ * Use shaders to customize the final output. The following attributes are available:
+ * * `vec2 a_position`
+ * * `vec2 a_texCoord`
+ * * `vec2 a_offsets`
+ * * `float a_rotateWithView`
+ * * `float a_opacity`
  *
  * This uses {@link module:ol/webgl/Helper~WebGLHelper} internally.
  *
@@ -90,12 +95,14 @@ const FRAGMENT_SHADER = `
  *   attribute vec2 a_texCoord;
  *   attribute float a_rotateWithView;
  *   attribute vec2 a_offsets;
+ *   attribute float a_opacity;
  *
  *   uniform mat4 u_projectionMatrix;
  *   uniform mat4 u_offsetScaleMatrix;
  *   uniform mat4 u_offsetRotateMatrix;
  *
  *   varying vec2 v_texCoord;
+ *   varying float v_opacity;
  *
  *   void main(void) {
  *     mat4 offsetMatrix = u_offsetScaleMatrix;
@@ -105,6 +112,7 @@ const FRAGMENT_SHADER = `
  *     vec4 offsets = offsetMatrix * vec4(a_offsets, 0.0, 0.0);
  *     gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
  *     v_texCoord = a_texCoord;
+ *     v_opacity = a_opacity;
  *   }
  *   ```
  *
@@ -114,10 +122,11 @@ const FRAGMENT_SHADER = `
  *   uniform float u_opacity;
  *
  *   varying vec2 v_texCoord;
+ *   varying float v_opacity;
  *
  *   void main(void) {
  *     gl_FragColor.rgb = vec3(1.0, 1.0, 1.0);
- *     float alpha = u_opacity;
+ *     float alpha = u_opacity * v_opacity;
  *     if (alpha == 0.0) {
  *       discard;
  *     }

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -619,11 +619,11 @@ class WebGLHelper extends Disposable {
     const vertexShader = this.compileShader(vertexShaderSource, gl.VERTEX_SHADER);
     this.shaderCompileErrors_ = null;
 
-    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+    if (gl.getShaderInfoLog(fragmentShader)) {
       this.shaderCompileErrors_ =
         `Fragment shader compilation failed:\n${gl.getShaderInfoLog(fragmentShader)}`;
     }
-    if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+    if (gl.getShaderInfoLog(vertexShader)) {
       this.shaderCompileErrors_ = (this.shaderCompileErrors_ || '') +
         `Vertex shader compilation failed:\n${gl.getShaderInfoLog(vertexShader)}`;
     }


### PR DESCRIPTION
Attributes were used in the shader but not bound to a buffer, which made the rendering fail in some implementations.

This should fix #9014 (to be confirmed)

Example visible at https://498-4723248-gh.circle-artifacts.com/0/examples/heatmap-earthquakes.html 