### PR TITLE
Remove unused render event

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -55,9 +55,9 @@ In addition (this should be exceedingly rare), if you previously created a `ol/t
 
 If you were previously using `VectorTile` layers with `renderMode: 'vector'`, you have to remove this configuration option. That mode was removed. `'hybrid'` (default) and `'image'` are still available.
 
-##### New `prerender` and `postrender` layer events replace old `precompose` and `postcompose` events
+##### New `prerender` and `postrender` layer events replace old `precompose`, `render` and `postcompose` events
 
-If you were previously registering for `precompose` and `postcompose` events, you should now register for `prerender` and `postrender` events on layers.  Layers are no longer composed to a single Canvas element.  Instead, they are added to the map viewport as individual elements.
+If you were previously registering for `precompose` and `postcompose` events, you should now register for `prerender` and `postrender` events on layers.  Instead of the previous `render` event, you should now listen for `postrender`. Layers are no longer composed to a single Canvas element.  Instead, they are added to the map viewport as individual elements.
 
 ##### New `getVectorContext` function provides access to the immediate vector rendering API
 

--- a/src/ol/render/EventType.js
+++ b/src/ol/render/EventType.js
@@ -15,12 +15,6 @@ export default {
   PRERENDER: 'prerender',
 
   /**
-   * @event module:ol/render/Event~RenderEvent#render
-   * @api
-   */
-  RENDER: 'render',
-
-  /**
    * Triggered after a layer is rendered.
    * @event module:ol/render/Event~RenderEvent#postrender
    * @api


### PR DESCRIPTION
This pull request removes the no longer used `render` event, and adds a note about it in the upgrade notes.