### PR TITLE
Specify the return array as coordinates

### DIFF
--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -51,7 +51,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @abstract
-   * @return {Array} Coordinates.
+   * @return {Array<import("../coordinate").Coordinate>} Coordinates.
    */
   getCoordinates() {
     return abstract();
@@ -158,7 +158,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @abstract
-   * @param {!Array} coordinates Coordinates.
+   * @param {!Array<import("../coordinate").Coordinate>} coordinates Coordinates.
    * @param {GeometryLayout=} opt_layout Layout.
    */
   setCoordinates(coordinates, opt_layout) {
@@ -167,7 +167,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @param {GeometryLayout|undefined} layout Layout.
-   * @param {Array} coordinates Coordinates.
+   * @param {Array<import("../coordinate").Coordinate>} coordinates Coordinates.
    * @param {number} nesting Nesting.
    * @protected
    */

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -51,7 +51,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @abstract
-   * @return {Array<import("../coordinate").Coordinate>} Coordinates.
+   * @return {Array<*>} Coordinates.
    */
   getCoordinates() {
     return abstract();
@@ -158,7 +158,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @abstract
-   * @param {!Array<import("../coordinate").Coordinate>} coordinates Coordinates.
+   * @param {!Array<*>} coordinates Coordinates.
    * @param {GeometryLayout=} opt_layout Layout.
    */
   setCoordinates(coordinates, opt_layout) {
@@ -167,7 +167,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @param {GeometryLayout|undefined} layout Layout.
-   * @param {Array<import("../coordinate").Coordinate>} coordinates Coordinates.
+   * @param {Array<*>} coordinates Coordinates.
    * @param {number} nesting Nesting.
    * @protected
    */


### PR DESCRIPTION
Could possibly also use `Array<*>`  like in other places, if the 
type specification would conflict with derived classes. 
