### PR TITLE
Add ': void' to non returning functions (error TS7014)

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -22,7 +22,7 @@ import {getHeight} from './extent.js';
  * post requests or - in general - through XHR requests, where the src of the
  * image element would be set to a data URI when the content is loaded.
  *
- * @typedef {function(ImageWrapper, string)} LoadFunction
+ * @typedef {function(ImageWrapper, string): void} LoadFunction
  * @api
  */
 

--- a/src/ol/ImageCanvas.js
+++ b/src/ol/ImageCanvas.js
@@ -11,7 +11,7 @@ import ImageState from './ImageState.js';
  * If any error occurs during drawing, the "done" callback should be called with
  * that error.
  *
- * @typedef {function(function(Error=))} Loader
+ * @typedef {function(function(Error=): void): void} Loader
  */
 
 

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -336,7 +336,7 @@ class PluggableMap extends BaseObject {
     this.renderer_ = this.createRenderer();
 
     /**
-     * @type {function(Event)|undefined}
+     * @type {function(Event): void|undefined}
      * @private
      */
     this.handleResize_;

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -40,7 +40,7 @@ import EventType from './events/EventType.js';
  * });
  * ```
  *
- * @typedef {function(Tile, string)} LoadFunction
+ * @typedef {function(Tile, string): void} LoadFunction
  * @api
  */
 

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -38,7 +38,7 @@ class VectorImageTile extends Tile {
    * @param {import("./proj/Projection.js").default} projection Projection.
    * @param {typeof import("./VectorTile.js").default} tileClass Class to
    *     instantiate for source tiles.
-   * @param {function(this: import("./source/VectorTile.js").default, import("./events/Event.js").default)} handleTileChange
+   * @param {function(this: import("./source/VectorTile.js").default, import("./events/Event.js").default): void} handleTileChange
    *     Function to call when a source tile's state changes.
    * @param {number} zoom Integer zoom to render the tile for.
    */

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -399,7 +399,7 @@ class View extends BaseObject {
    * calling `view.setCenter()`, `view.setResolution()`, or `view.setRotation()`
    * (or another method that calls one of these).
    *
-   * @param {...(AnimationOptions|function(boolean))} var_args Animation
+   * @param {...(AnimationOptions|function(boolean): void)} var_args Animation
    *     options.  Multiple animations can be run in series by passing multiple
    *     options objects.  To run multiple animations in parallel, call the method
    *     multiple times.  An optional callback can be provided as a final

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -79,7 +79,7 @@ class Control extends BaseObject {
     this.listenerKeys = [];
 
     /**
-     * @type {function(import("../MapEvent.js").default)}
+     * @type {function(import("../MapEvent.js").default): void}
      */
     this.render = options.render ? options.render : VOID;
 

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -17,7 +17,7 @@ import FormatType from './format/FormatType.js';
  * The function is responsible for loading the features and adding them to the
  * source.
  * @typedef {function(this:(import("./source/Vector").default|import("./VectorTile.js").default), import("./extent.js").Extent, number,
- *                    import("./proj/Projection.js").default)} FeatureLoader
+ *                    import("./proj/Projection.js").default): void} FeatureLoader
  * @api
  */
 
@@ -38,10 +38,10 @@ import FormatType from './format/FormatType.js';
 /**
  * @param {string|FeatureUrlFunction} url Feature URL service.
  * @param {import("./format/Feature.js").default} format Feature format.
- * @param {function(this:import("./VectorTile.js").default, Array<import("./Feature.js").default>, import("./proj/Projection.js").default, import("./extent.js").Extent)|function(this:import("./source/Vector").default, Array<import("./Feature.js").default>)} success
+ * @param {function(this:import("./VectorTile.js").default, Array<import("./Feature.js").default>, import("./proj/Projection.js").default, import("./extent.js").Extent): void|function(this:import("./source/Vector").default, Array<import("./Feature.js").default>): void} success
  *     Function called with the loaded features and optionally with the data
  *     projection. Called with the vector tile or source as `this`.
- * @param {function(this:import("./VectorTile.js").default)|function(this:import("./source/Vector").default)} failure
+ * @param {function(this:import("./VectorTile.js").default): void|function(this:import("./source/Vector").default): void} failure
  *     Function called when loading failed. Called with the vector tile or
  *     source as `this`.
  * @return {FeatureLoader} The feature loader.

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -132,7 +132,7 @@ class GPX extends XMLFeature {
     this.dataProjection = getProjection('EPSG:4326');
 
     /**
-     * @type {function(Feature, Node)|undefined}
+     * @type {function(Feature, Node): void|undefined}
      * @private
      */
     this.readExtensions_ = options.readExtensions;

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -133,7 +133,7 @@ class DragBox extends PointerInteraction {
 
     /**
      * Function to execute just before `onboxend` is fired
-     * @type {function(this:DragBox, import("../MapBrowserEvent.js").default)}
+     * @type {function(this:DragBox, import("../MapBrowserEvent.js").default): void}
      * @private
      */
     this.onBoxEnd_ = options.onBoxEnd ? options.onBoxEnd : VOID;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -274,7 +274,7 @@ class Modify extends PointerInteraction {
     /**
      * @const
      * @private
-     * @type {!Object<string, function(Feature, import("../geom/Geometry.js").default)>}
+     * @type {!Object<string, function(Feature, import("../geom/Geometry.js").default): void>}
      */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -181,7 +181,7 @@ class Snap extends PointerInteraction {
     /**
     * @const
     * @private
-    * @type {Object<string, function(import("../Feature.js").default, import("../geom/Geometry.js").default)>}
+    * @type {Object<string, function(import("../Feature.js").default, import("../geom/Geometry.js").default): void>}
     */
     this.SEGMENT_WRITERS_ = {
       'Point': this.writePointGeometry_,

--- a/src/ol/pointer/EventSource.js
+++ b/src/ol/pointer/EventSource.js
@@ -6,7 +6,7 @@ class EventSource {
 
   /**
    * @param {import("./PointerEventHandler.js").default} dispatcher Event handler.
-   * @param {!Object<string, function(Event)>} mapping Event mapping.
+   * @param {!Object<string, function(Event): void>} mapping Event mapping.
    */
   constructor(dispatcher, mapping) {
 
@@ -18,7 +18,7 @@ class EventSource {
     /**
      * @private
      * @const
-     * @type {!Object<string, function(Event)>}
+     * @type {!Object<string, function(Event): void>}
      */
     this.mapping_ = mapping;
   }

--- a/src/ol/pointer/PointerEventHandler.js
+++ b/src/ol/pointer/PointerEventHandler.js
@@ -105,7 +105,7 @@ class PointerEventHandler extends EventTarget {
     this.pointerMap = {};
 
     /**
-     * @type {Object<string, function(Event)>}
+     * @type {Object<string, function(Event): void>}
      * @private
      */
     this.eventMap_ = {};

--- a/src/ol/pointer/TouchSource.js
+++ b/src/ol/pointer/TouchSource.js
@@ -247,7 +247,7 @@ class TouchSource extends EventSource {
   /**
    * @private
    * @param {TouchEvent} inEvent Touch event
-   * @param {function(TouchEvent, PointerEvent)} inFunction In function.
+   * @param {function(TouchEvent, PointerEvent): void} inFunction In function.
    */
   processTouches_(inEvent, inFunction) {
     const touches = Array.prototype.slice.call(inEvent.changedTouches);

--- a/src/ol/render/canvas/Builder.js
+++ b/src/ol/render/canvas/Builder.js
@@ -397,7 +397,7 @@ class CanvasBuilder extends VectorContext {
 
   /**
    * @param {import("../canvas.js").FillStrokeState} state State.
-   * @param {function(this:CanvasBuilder, import("../canvas.js").FillStrokeState)} applyStroke Apply stroke.
+   * @param {function(this:CanvasBuilder, import("../canvas.js").FillStrokeState): void} applyStroke Apply stroke.
    */
   updateStrokeStyle(state, applyStroke) {
     const strokeStyle = state.strokeStyle;

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -18,7 +18,7 @@ const SIMPLIFY_TOLERANCE = 0.5;
  * @const
  * @type {Object<import("../geom/GeometryType.js").default,
  *                function(import("../render/canvas/BuilderGroup.js").default, import("../geom/Geometry.js").default,
- *                         import("../style/Style.js").default, Object)>}
+ *                         import("../style/Style.js").default, Object): void>}
  */
 const GEOMETRY_RENDERERS = {
   'Point': renderPointGeometry,
@@ -91,7 +91,7 @@ function renderCircleGeometry(builderGroup, geometry, style, feature) {
  * @param {import("../Feature.js").FeatureLike} feature Feature.
  * @param {import("../style/Style.js").default} style Style.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {function(this: T, import("../events/Event.js").default)} listener Listener function.
+ * @param {function(this: T, import("../events/Event.js").default): void} listener Listener function.
  * @param {T} thisArg Value to use as `this` when executing `listener`.
  * @return {boolean} `true` if style is loading.
  * @template T

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -138,7 +138,7 @@ export class CustomTile extends Tile {
    * Calls the callback (synchronously by default) with the available data
    * for given coordinate (or `null` if not yet loaded).
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @param {function(this: T, *)} callback Callback.
+   * @param {function(this: T, *): void} callback Callback.
    * @param {T=} opt_this The object to use as `this` in the callback.
    * @param {boolean=} opt_request If `true` the callback is always async.
    *                               The tile data is requested if not yet loaded.
@@ -379,7 +379,7 @@ class UTFGrid extends TileSource {
    * in case of an error).
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
-   * @param {function(*)} callback Callback.
+   * @param {function(*): void} callback Callback.
    * @param {boolean=} opt_request If `true` the callback is always async.
    *                               The tile data is requested if not yet loaded.
    * @api

--- a/src/ol/style/Atlas.js
+++ b/src/ol/style/Atlas.js
@@ -93,7 +93,7 @@ class Atlas {
    * @param {string} id The identifier of the entry to add.
    * @param {number} width The width.
    * @param {number} height The height.
-   * @param {function(CanvasRenderingContext2D, number, number)} renderCallback
+   * @param {function(CanvasRenderingContext2D, number, number): void} renderCallback
    *    Called to render the new image onto an atlas image.
    * @param {Object=} opt_this Value to use as `this` when executing
    *    `renderCallback`.

--- a/src/ol/style/AtlasManager.js
+++ b/src/ol/style/AtlasManager.js
@@ -174,7 +174,7 @@ class AtlasManager {
    * @param {string} id The identifier of the entry to add.
    * @param {number} width The width.
    * @param {number} height The height.
-   * @param {function(CanvasRenderingContext2D, number, number)} renderCallback
+   * @param {function(CanvasRenderingContext2D, number, number): void} renderCallback
    *    Called to render the new image onto an atlas image.
    * @param {function(CanvasRenderingContext2D, number, number)=} opt_renderHitCallback Called to render a hit-detection image onto a hit
    *    detection atlas image.
@@ -213,7 +213,7 @@ class AtlasManager {
    * @param {string} id The identifier of the entry to add.
    * @param {number} width The width.
    * @param {number} height The height.
-   * @param {function(CanvasRenderingContext2D, number, number)} renderCallback
+   * @param {function(CanvasRenderingContext2D, number, number): void} renderCallback
    *    Called to render the new image onto an atlas image.
    * @param {Object=} opt_this Value to use as `this` when executing
    *    `renderCallback` and `renderHitCallback`.

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -233,7 +233,7 @@ class ImageStyle {
 
   /**
    * @abstract
-   * @param {function(this: T, import("../events/Event.js").default)} listener Listener function.
+   * @param {function(this: T, import("../events/Event.js").default): void} listener Listener function.
    * @param {T} thisArg Value to use as `this` when executing `listener`.
    * @return {import("../events.js").EventsKey|undefined} Listener key.
    * @template T
@@ -252,7 +252,7 @@ class ImageStyle {
 
   /**
    * @abstract
-   * @param {function(this: T, import("../events/Event.js").default)} listener Listener function.
+   * @param {function(this: T, import("../events/Event.js").default): void} listener Listener function.
    * @param {T} thisArg Value to use as `this` when executing `listener`.
    * @template T
    */

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -122,7 +122,7 @@ import Stroke from './Stroke.js';
  * 1. The pixel coordinates of the geometry in GeoJSON notation.
  * 2. The {@link module:ol/render~State} of the layer renderer.
  *
- * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>),import("../render.js").State)}
+ * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>),import("../render.js").State): void}
  * RenderFunction
  */
 

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -189,7 +189,7 @@ class TileGrid {
    *
    * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} zoom Integer zoom level.
-   * @param {function(import("../tilecoord.js").TileCoord)} callback Function called with each tile coordinate.
+   * @param {function(import("../tilecoord.js").TileCoord): void} callback Function called with each tile coordinate.
    * @api
    */
   forEachTileCoord(extent, zoom, callback) {

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -14,12 +14,12 @@ import {extend} from './array.js';
 
 
 /**
- * @typedef {function(Element, Array<*>)} Parser
+ * @typedef {function(Element, Array<*>): void} Parser
  */
 
 
 /**
- * @typedef {function(Element, *, Array<*>)} Serializer
+ * @typedef {function(Element, *, Array<*>): void} Serializer
  */
 
 
@@ -252,7 +252,7 @@ export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
  * Create a serializer that appends nodes written by its `nodeWriter` to its
  * designated parent. The parent is the `node` of the
  * {@link module:ol/xml~NodeStackItem} at the top of the `objectStack`.
- * @param {function(this: T, Node, V, Array<*>)} nodeWriter Node writer.
+ * @param {function(this: T, Node, V, Array<*>): void} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {Serializer} Serializer.
  * @template T, V
@@ -274,7 +274,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
  * designed to serialize a single item. An example would be a LineString
  * geometry writer, which could be reused for writing MultiLineString
  * geometries.
- * @param {function(this: T, Element, V, Array<*>)} nodeWriter Node writer.
+ * @param {function(this: T, Element, V, Array<*>): void} nodeWriter Node writer.
  * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
  * @return {Serializer} Serializer.
  * @template T, V


### PR DESCRIPTION
With the upgrade of typescript (to 3.2.1) a new TS-Error has been introduced
(TS7014). It complains about functions without an explicit return 
values (mostly callbacks). This commit adds the return type 'void' 
to all the reported errors. 
The change has no influence on the docs, I checked the sha512sum 
using the following simple bash-script: 

~~~
base_dir=$1 
find $base_dir -print0 | xargs -0 sha512sum > /tmp/sums.txt 
cat /tmp/sums.txt | cut -d" " -f1 | sort | sha512sum 
~~~
