### PR TITLE
Added Base.js to ol/layer.js

### DIFF
--- a/src/ol/layer.js
+++ b/src/ol/layer.js
@@ -3,6 +3,7 @@
  * @module ol/layer
  */
 
+export {default as Base} from './layer/Base.js';
 export {default as Group} from './layer/Group.js';
 export {default as Heatmap} from './layer/Heatmap.js';
 export {default as Image} from './layer/Image.js';


### PR DESCRIPTION
Currently, ol/layer/Base is not included as an export from ol/layer when it should be according to the [documentation](https://openlayers.org/en/latest/apidoc/module-ol_layer_Base.html). 
