### PR TITLE
Move all tile loading from the VectorImageTile to the source

### DIFF
--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -5,6 +5,7 @@ import TileState from './TileState.js';
 import {easeIn} from './easing.js';
 import EventTarget from './events/Target.js';
 import EventType from './events/EventType.js';
+import {abstract} from './util.js';
 
 
 /**
@@ -104,6 +105,14 @@ class Tile extends EventTarget {
      * @type {Tile}
      */
     this.interimTile = null;
+
+    /**
+     * The tile is available at the highest possible resolution. Subclasses can
+     * set this to `false` initially. Tile load listeners will not be
+     * unregistered before this is set to `true` and a `#changed()` is called.
+     * @type {boolean}
+     */
+    this.hifi = true;
 
     /**
      * A key assigned to the tile. This is used by the tile source to determine
@@ -240,7 +249,9 @@ class Tile extends EventTarget {
    * @abstract
    * @api
    */
-  load() {}
+  load() {
+    abstract();
+  }
 
   /**
    * Get the alpha value for rendering.

--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -82,7 +82,7 @@ class TileQueue extends PriorityQueue {
   handleTileChange(event) {
     const tile = /** @type {import("./Tile.js").default} */ (event.target);
     const state = tile.getState();
-    if (state === TileState.LOADED || state === TileState.ERROR ||
+    if (tile.hifi && state === TileState.LOADED || state === TileState.ERROR ||
         state === TileState.EMPTY || state === TileState.ABORT) {
       unlisten(tile, EventType.CHANGE, this.handleTileChange, this);
       const tileKey = tile.getKey();

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -24,12 +24,11 @@ class VectorImageTile extends Tile {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {TileState} state State.
-   * @param {number} sourceRevision Source revision.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
    * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
    * @param {Object<string, import("./VectorTile.js").default>} sourceTiles Source tiles.
    */
-  constructor(tileCoord, state, sourceRevision, urlTileCoord, sourceTileGrid, sourceTiles) {
+  constructor(tileCoord, state, urlTileCoord, sourceTileGrid, sourceTiles) {
 
     super(tileCoord, state, {transition: 0});
 
@@ -99,8 +98,6 @@ class VectorImageTile extends Tile {
      * @type {Array<import("./events.js").EventsKey>}
      */
     this.sourceTileListenerKeys_ = [];
-
-    this.key = sourceRevision.toString();
   }
 
   /**
@@ -186,9 +183,10 @@ class VectorImageTile extends Tile {
           for (let i = 0, ii = tileKeys.length; i < ii; ++i) {
             this.sourceTiles_[tileKeys[i]].consumers++;
           }
-          const tile = new VectorImageTile(this.tileCoord, TileState.IDLE, Number(this.key),
+          const tile = new VectorImageTile(this.tileCoord, TileState.IDLE,
             this.wrappedTileCoord, null, this.sourceTiles_);
           tile.extent = this.extent;
+          tile.key = this.key;
           tile.tileKeys = tileKeys;
           tile.context_ = this.context_;
           setTimeout(function() {

--- a/src/ol/VectorImageTile.js
+++ b/src/ol/VectorImageTile.js
@@ -5,9 +5,6 @@ import {getUid} from './util.js';
 import Tile from './Tile.js';
 import TileState from './TileState.js';
 import {createCanvasContext2D} from './dom.js';
-import {listen, unlistenByKey} from './events.js';
-import EventType from './events/EventType.js';
-import {loadFeaturesXhr} from './featureloader.js';
 
 
 /**
@@ -16,6 +13,8 @@ import {loadFeaturesXhr} from './featureloader.js';
  * @property {null|import("./render.js").OrderFunction} renderedRenderOrder
  * @property {number} renderedTileRevision
  * @property {number} renderedRevision
+ * @property {number} renderedZ
+ * @property {number} renderedTileZ
  */
 
 
@@ -26,9 +25,12 @@ class VectorImageTile extends Tile {
    * @param {TileState} state State.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
    * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
-   * @param {Object<string, import("./VectorTile.js").default>} sourceTiles Source tiles.
+   * @param {function(VectorImageTile):Array<import("./VectorTile").default>} getSourceTiles Function
+   * to get an source tiles for this tile.
+   * @param {function(VectorImageTile):void} removeSourceTiles Function to remove this tile from its
+   * source tiles's consumer count.
    */
-  constructor(tileCoord, state, urlTileCoord, sourceTileGrid, sourceTiles) {
+  constructor(tileCoord, state, urlTileCoord, sourceTileGrid, getSourceTiles, removeSourceTiles) {
 
     super(tileCoord, state, {transition: 0});
 
@@ -39,10 +41,22 @@ class VectorImageTile extends Tile {
     this.context_ = {};
 
     /**
-     * @private
-     * @type {import("./featureloader.js").FeatureLoader}
+     * Executor groups by layer uid. Entries are read/written by the renderer.
+     * @type {Object<string, Array<import("./render/canvas/ExecutorGroup.js").default>>}
      */
-    this.loader_;
+    this.executorGroups = {};
+
+    /**
+     * Number of loading source tiles. Read/written by the source.
+     * @type {number}
+     */
+    this.loadingSourceTiles = 0;
+
+    /**
+     * Tile keys of error source tiles. Read/written by the source.
+     * @type {Object<string, boolean>}
+     */
+    this.errorSourceTileKeys = {};
 
     /**
      * @private
@@ -51,10 +65,14 @@ class VectorImageTile extends Tile {
     this.replayState_ = {};
 
     /**
-     * @private
-     * @type {Object<string, import("./VectorTile.js").default>}
+     * @type {!function(import("./VectorImageTile.js").default):Array<import("./VectorTile.js").default>}
      */
-    this.sourceTiles_ = sourceTiles;
+    this.getSourceTiles_ = getSourceTiles;
+
+    /**
+     * @type {!function(import("./VectorImageTile.js").default):void}
+     */
+    this.removeSourceTiles_ = removeSourceTiles;
 
     /**
      * @private
@@ -63,69 +81,29 @@ class VectorImageTile extends Tile {
     this.sourceTileGrid_ = sourceTileGrid;
 
     /**
-     * @private
+     * z of the source tiles of the last getSourceTiles call.
+     * @type {number}
+     */
+    this.sourceZ = -1;
+
+    /**
+     * True when all tiles for this tile's nominal resolution are available.
      * @type {boolean}
      */
-    this.sourceTilesLoaded = false;
-
-    /**
-     * Keys of source tiles used by this tile. Use with {@link #getTile}.
-     * @type {Array<string>}
-     */
-    this.tileKeys = [];
-
-    /**
-     * @type {import("./extent.js").Extent}
-     */
-    this.extent = null;
+    this.hifi = false;
 
     /**
      * @type {import("./tilecoord.js").TileCoord}
      */
     this.wrappedTileCoord = urlTileCoord;
-
-    /**
-     * @type {Array<import("./events.js").EventsKey>}
-     */
-    this.loadListenerKeys_ = [];
-
-    /**
-     * @type {boolean}
-     */
-    this.isInterimTile = !sourceTileGrid;
-
-    /**
-     * @type {Array<import("./events.js").EventsKey>}
-     */
-    this.sourceTileListenerKeys_ = [];
   }
 
   /**
    * @inheritDoc
    */
   disposeInternal() {
-    if (!this.isInterimTile) {
-      this.setState(TileState.ABORT);
-    }
-    if (this.interimTile) {
-      this.interimTile.dispose();
-      this.interimTile = null;
-    }
-    for (let i = 0, ii = this.tileKeys.length; i < ii; ++i) {
-      const sourceTileKey = this.tileKeys[i];
-      const sourceTile = this.getTile(sourceTileKey);
-      sourceTile.consumers--;
-      if (sourceTile.consumers == 0) {
-        delete this.sourceTiles_[sourceTileKey];
-        sourceTile.dispose();
-      }
-    }
-    this.tileKeys.length = 0;
-    this.sourceTiles_ = null;
-    this.loadListenerKeys_.forEach(unlistenByKey);
-    this.loadListenerKeys_.length = 0;
-    this.sourceTileListenerKeys_.forEach(unlistenByKey);
-    this.sourceTileListenerKeys_.length = 0;
+    this.removeSourceTiles_(this);
+    this.setState(TileState.ABORT);
     super.disposeInternal();
   }
 
@@ -159,50 +137,6 @@ class VectorImageTile extends Tile {
   }
 
   /**
-   * @override
-   * @return {VectorImageTile} Interim tile.
-   */
-  getInterimTile() {
-    const sourceTileGrid = this.sourceTileGrid_;
-    const state = this.getState();
-    if (state < TileState.LOADED && !this.interimTile) {
-      let z = this.tileCoord[0];
-      const minZoom = sourceTileGrid.getMinZoom();
-      while (--z > minZoom) {
-        let covered = true;
-        const tileKeys = [];
-        sourceTileGrid.forEachTileCoord(this.extent, z, function(tileCoord) {
-          const key = tileCoord.toString();
-          if (key in this.sourceTiles_ && this.sourceTiles_[key].getState() === TileState.LOADED) {
-            tileKeys.push(key);
-          } else {
-            covered = false;
-          }
-        }.bind(this));
-        if (covered && tileKeys.length) {
-          for (let i = 0, ii = tileKeys.length; i < ii; ++i) {
-            this.sourceTiles_[tileKeys[i]].consumers++;
-          }
-          const tile = new VectorImageTile(this.tileCoord, TileState.IDLE,
-            this.wrappedTileCoord, null, this.sourceTiles_);
-          tile.extent = this.extent;
-          tile.key = this.key;
-          tile.tileKeys = tileKeys;
-          tile.context_ = this.context_;
-          setTimeout(function() {
-            tile.sourceTilesLoaded = true;
-            tile.changed();
-          }, 16);
-          this.interimTile = tile;
-          break;
-        }
-      }
-    }
-    const interimTile = /** @type {VectorImageTile} */ (this.interimTile);
-    return state === TileState.LOADED ? this : (interimTile || this);
-  }
-
-  /**
    * @param {import("./layer/Layer.js").default} layer Layer.
    * @return {ReplayState} The replay state.
    */
@@ -213,103 +147,22 @@ class VectorImageTile extends Tile {
         dirty: false,
         renderedRenderOrder: null,
         renderedRevision: -1,
-        renderedTileRevision: -1
+        renderedTileRevision: -1,
+        renderedZ: -1,
+        renderedTileZ: -1
       };
     }
     return this.replayState_[key];
   }
 
   /**
-   * @param {string} tileKey Key (tileCoord) of the source tile.
-   * @return {import("./VectorTile.js").default} Source tile.
-   */
-  getTile(tileKey) {
-    return this.sourceTiles_[tileKey];
-  }
-
-  /**
    * @inheritDoc
+   * @return {Array<import("./VectorTile.js").default>} Source tiles for this tile.
    */
   load() {
-    // Source tiles with LOADED state - we just count them because once they are
-    // loaded, we're no longer listening to state changes.
-    let leftToLoad = 0;
-    // Source tiles with ERROR state - we track them because they can still have
-    // an ERROR state after another load attempt.
-    const errorSourceTiles = {};
-
-    if (this.state == TileState.IDLE) {
-      this.setState(TileState.LOADING);
-    }
-    if (this.state == TileState.LOADING) {
-      this.tileKeys.forEach(function(sourceTileKey) {
-        const sourceTile = this.getTile(sourceTileKey);
-        if (sourceTile.state == TileState.IDLE) {
-          sourceTile.setLoader(this.loader_);
-          sourceTile.load();
-        }
-        if (sourceTile.state == TileState.LOADING) {
-          const key = listen(sourceTile, EventType.CHANGE, function(e) {
-            const state = sourceTile.getState();
-            if (state == TileState.LOADED ||
-                state == TileState.ERROR) {
-              const uid = getUid(sourceTile);
-              if (state == TileState.ERROR) {
-                errorSourceTiles[uid] = true;
-              } else {
-                --leftToLoad;
-                delete errorSourceTiles[uid];
-              }
-              if (leftToLoad - Object.keys(errorSourceTiles).length == 0) {
-                this.finishLoading_();
-              }
-            }
-          }.bind(this));
-          this.loadListenerKeys_.push(key);
-          ++leftToLoad;
-        }
-      }.bind(this));
-    }
-    if (leftToLoad - Object.keys(errorSourceTiles).length == 0) {
-      setTimeout(this.finishLoading_.bind(this), 16);
-    }
-  }
-
-  /**
-   * @private
-   */
-  finishLoading_() {
-    let loaded = this.tileKeys.length;
-    let empty = 0;
-    for (let i = loaded - 1; i >= 0; --i) {
-      const state = this.getTile(this.tileKeys[i]).getState();
-      if (state != TileState.LOADED) {
-        --loaded;
-      }
-      if (state == TileState.EMPTY) {
-        ++empty;
-      }
-    }
-    if (loaded == this.tileKeys.length) {
-      this.loadListenerKeys_.forEach(unlistenByKey);
-      this.loadListenerKeys_.length = 0;
-      this.sourceTilesLoaded = true;
-      this.changed();
-    } else {
-      this.setState(empty == this.tileKeys.length ? TileState.EMPTY : TileState.ERROR);
-    }
+    return this.getSourceTiles_(this);
   }
 }
 
 
 export default VectorImageTile;
-
-/**
- * Sets the loader for a tile.
- * @param {import("./VectorTile.js").default} tile Vector tile.
- * @param {string} url URL.
- */
-export function defaultLoadFunction(tile, url) {
-  const loader = loadFeaturesXhr(url, tile.getFormat(), tile.onLoad.bind(tile), tile.onError.bind(tile));
-  tile.setLoader(loader);
-}

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -1,5 +1,5 @@
 /**
- * @module ol/VectorImageTile
+ * @module ol/VectorRenderTile
  */
 import {getUid} from './util.js';
 import Tile from './Tile.js';
@@ -18,16 +18,16 @@ import {createCanvasContext2D} from './dom.js';
  */
 
 
-class VectorImageTile extends Tile {
+class VectorRenderTile extends Tile {
 
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {TileState} state State.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
    * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
-   * @param {function(VectorImageTile):Array<import("./VectorTile").default>} getSourceTiles Function
+   * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function
    * to get an source tiles for this tile.
-   * @param {function(VectorImageTile):void} removeSourceTiles Function to remove this tile from its
+   * @param {function(VectorRenderTile):void} removeSourceTiles Function to remove this tile from its
    * source tiles's consumer count.
    */
   constructor(tileCoord, state, urlTileCoord, sourceTileGrid, getSourceTiles, removeSourceTiles) {
@@ -65,12 +65,12 @@ class VectorImageTile extends Tile {
     this.replayState_ = {};
 
     /**
-     * @type {!function(import("./VectorImageTile.js").default):Array<import("./VectorTile.js").default>}
+     * @type {!function(import("./VectorRenderTile.js").default):Array<import("./VectorTile.js").default>}
      */
     this.getSourceTiles_ = getSourceTiles;
 
     /**
-     * @type {!function(import("./VectorImageTile.js").default):void}
+     * @type {!function(import("./VectorRenderTile.js").default):void}
      */
     this.removeSourceTiles_ = removeSourceTiles;
 
@@ -165,4 +165,4 @@ class VectorImageTile extends Tile {
 }
 
 
-export default VectorImageTile;
+export default VectorRenderTile;

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -63,12 +63,6 @@ class VectorTile extends Tile {
 
     /**
      * @private
-     * @type {Object<string, import("./render/canvas/ExecutorGroup.js").default>}
-     */
-    this.executorGroups_ = {};
-
-    /**
-     * @private
      * @type {import("./Tile.js").LoadFunction}
      */
     this.tileLoadFunction_ = tileLoadFunction;
@@ -85,10 +79,7 @@ class VectorTile extends Tile {
    * @inheritDoc
    */
   disposeInternal() {
-    this.features_ = null;
-    this.executorGroups_ = {};
-    this.state = TileState.ABORT;
-    this.changed();
+    this.setState(TileState.ABORT);
     super.disposeInternal();
   }
 
@@ -135,15 +126,6 @@ class VectorTile extends Tile {
    */
   getProjection() {
     return this.projection_;
-  }
-
-  /**
-   * @param {string} layerId UID of the layer.
-   * @param {string} key Key.
-   * @return {import("./render/canvas/ExecutorGroup.js").default} Executor group.
-   */
-  getExecutorGroup(layerId, key) {
-    return this.executorGroups_[layerId + ',' + key];
   }
 
   /**
@@ -212,15 +194,6 @@ class VectorTile extends Tile {
    */
   setProjection(projection) {
     this.projection_ = projection;
-  }
-
-  /**
-   * @param {string} layerId UID of the layer.
-   * @param {string} key Key.
-   * @param {import("./render/canvas/ExecutorGroup.js").default} executorGroup Executor group.
-   */
-  setExecutorGroup(layerId, key, executorGroup) {
-    this.executorGroups_[layerId + ',' + key] = executorGroup;
   }
 
   /**

--- a/src/ol/index.js
+++ b/src/ol/index.js
@@ -26,7 +26,7 @@ export {default as Tile} from './Tile.js';
 export {default as TileCache} from './TileCache.js';
 export {default as TileQueue} from './TileQueue.js';
 export {default as TileRange} from './TileRange.js';
-export {default as VectorImageTile} from './VectorImageTile.js';
+export {default as VectorRenderTile} from './VectorRenderTile.js';
 export {default as VectorTile} from './VectorTile.js';
 export {default as View} from './View.js';
 

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -125,7 +125,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
     /**
      * @private
-     * @type {!Object<string, import("../../VectorImageTile.js").default>}
+     * @type {!Object<string, import("../../VectorRenderTile.js").default>}
      */
     this.renderTileImageQueue_ = {};
 
@@ -156,7 +156,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {import("../../VectorImageTile.js").default} tile Tile.
+   * @param {import("../../VectorRenderTile.js").default} tile Tile.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../../proj/Projection").default} projection Projection.
    */
@@ -176,7 +176,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @inheritDoc
    */
   getTile(z, x, y, pixelRatio, projection) {
-    const tile = /** @type {import("../../VectorImageTile.js").default} */ (super.getTile(z, x, y, pixelRatio, projection));
+    const tile = /** @type {import("../../VectorRenderTile.js").default} */ (super.getTile(z, x, y, pixelRatio, projection));
     this.prepareTile(tile, pixelRatio, projection);
     if (tile.getState() < TileState.LOADED) {
       const tileUid = getUid(tile);
@@ -217,7 +217,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {import("../../VectorImageTile.js").default} tile Tile.
+   * @param {import("../../VectorRenderTile.js").default} tile Tile.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../../proj/Projection.js").default} projection Projection.
    * @private
@@ -323,7 +323,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     /** @type {!Object<string, boolean>} */
     const features = {};
 
-    const renderedTiles = /** @type {Array<import("../../VectorImageTile.js").default>} */ (this.renderedTiles);
+    const renderedTiles = /** @type {Array<import("../../VectorRenderTile.js").default>} */ (this.renderedTiles);
 
     let bufferedExtent, found;
     let i, ii;
@@ -452,7 +452,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const clips = [];
     const zs = [];
     for (let i = tiles.length - 1; i >= 0; --i) {
-      const tile = /** @type {import("../../VectorImageTile.js").default} */ (tiles[i]);
+      const tile = /** @type {import("../../VectorRenderTile.js").default} */ (tiles[i]);
       if (tile.getState() == TileState.ABORT) {
         continue;
       }
@@ -564,7 +564,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {import("../../VectorImageTile.js").default} tile Tile.
+   * @param {import("../../VectorRenderTile.js").default} tile Tile.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../../proj/Projection.js").default} projection Projection.
    * @return {boolean} A new tile image was rendered.
@@ -579,7 +579,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @param {import("../../VectorImageTile.js").default} tile Tile.
+   * @param {import("../../VectorRenderTile.js").default} tile Tile.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../../proj/Projection.js").default} projection Projection.
    * @private

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -213,11 +213,11 @@ class VectorTile extends UrlTile {
       const tile = new VectorImageTile(
         tileCoord,
         urlTileCoord !== null ? TileState.IDLE : TileState.EMPTY,
-        this.getRevision(),
         urlTileCoord,
         this.tileGrid,
         this.sourceTiles_);
 
+      tile.key = this.getRevision().toString();
       this.assignTiles(tile, pixelRatio, projection);
       this.tileCache.set(tileCoordKey, tile);
       return tile;

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -3,7 +3,7 @@
  */
 
 import TileState from '../TileState.js';
-import VectorImageTile from '../VectorImageTile.js';
+import VectorRenderTile from '../VectorRenderTile.js';
 import Tile from '../VectorTile.js';
 import {toSize} from '../size.js';
 import UrlTile from './UrlTile.js';
@@ -172,7 +172,7 @@ class VectorTile extends UrlTile {
   /**
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection").default} projection Projection.
-   * @param {VectorImageTile} tile Vector image tile.
+   * @param {VectorRenderTile} tile Vector image tile.
    * @return {Array<import("../VectorTile").default>} Tile keys.
    */
   getSourceTiles(pixelRatio, projection, tile) {
@@ -272,7 +272,7 @@ class VectorTile extends UrlTile {
   }
 
   /**
-   * @param {VectorImageTile} tile Tile.
+   * @param {VectorRenderTile} tile Tile.
    * @param {Array<import("../VectorTile").default>} sourceTiles Source tiles.
    */
   addSourceTiles(tile, sourceTiles) {
@@ -283,7 +283,7 @@ class VectorTile extends UrlTile {
   }
 
   /**
-   * @param {VectorImageTile} tile Tile.
+   * @param {VectorRenderTile} tile Tile.
    */
   removeSourceTiles(tile) {
     const tileKey = getKey(tile.tileCoord);
@@ -314,7 +314,7 @@ class VectorTile extends UrlTile {
       const tileCoord = [z, x, y];
       const urlTileCoord = this.getTileCoordForTileUrlFunction(
         tileCoord, projection);
-      const tile = new VectorImageTile(
+      const tile = new VectorRenderTile(
         tileCoord,
         urlTileCoord !== null ? TileState.IDLE : TileState.EMPTY,
         urlTileCoord,

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -244,7 +244,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       sourceTile.getImage = function() {
         return document.createElement('canvas');
       };
-      const tile = new VectorImageTile([0, 0, 0], undefined, 1, [0, 0, 0], createXYZ(), {'0,0,0': sourceTile});
+      const tile = new VectorImageTile([0, 0, 0], 1, [0, 0, 0], createXYZ(), {'0,0,0': sourceTile});
       tile.transition_ = 0;
       tile.tileKeys = ['0,0,0'];
       tile.extent = getProjection('EPSG:3857').getExtent();

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -2,7 +2,7 @@ import {clear} from '../../../../../src/ol/obj.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import TileState from '../../../../../src/ol/TileState.js';
-import VectorImageTile from '../../../../../src/ol/VectorImageTile.js';
+import VectorRenderTile from '../../../../../src/ol/VectorRenderTile.js';
 import VectorTile from '../../../../../src/ol/VectorTile.js';
 import View from '../../../../../src/ol/View.js';
 import {getCenter} from '../../../../../src/ol/extent.js';
@@ -243,7 +243,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       sourceTile.getImage = function() {
         return document.createElement('canvas');
       };
-      const tile = new VectorImageTile([0, 0, 0], 1, [0, 0, 0], createXYZ(),
+      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0], createXYZ(),
         function() {
           return sourceTile;
         },
@@ -285,7 +285,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
 
   describe('#forEachFeatureAtCoordinate', function() {
     let layer, renderer, executorGroup, source;
-    class TileClass extends VectorImageTile {
+    class TileClass extends VectorRenderTile {
       constructor() {
         super(...arguments);
         this.setState(TileState.LOADED);

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -19,6 +19,7 @@ import Style from '../../../../../src/ol/style/Style.js';
 import Text from '../../../../../src/ol/style/Text.js';
 import {createXYZ} from '../../../../../src/ol/tilegrid.js';
 import VectorTileRenderType from '../../../../../src/ol/layer/VectorTileRenderType.js';
+import {getUid} from '../../../../../src/ol/util.js';
 
 
 describe('ol.renderer.canvas.VectorTileLayer', function() {

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -244,11 +244,10 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       sourceTile.getImage = function() {
         return document.createElement('canvas');
       };
-      const tile = new VectorImageTile([0, 0, 0], undefined, 1, undefined,
-        undefined, [0, 0, 0], undefined, createXYZ(), createXYZ(), {'0,0,0': sourceTile}, undefined,
-        undefined, undefined, undefined);
+      const tile = new VectorImageTile([0, 0, 0], undefined, 1, [0, 0, 0], createXYZ(), {'0,0,0': sourceTile});
       tile.transition_ = 0;
-      tile.wrappedTileCoord = [0, 0, 0];
+      tile.tileKeys = ['0,0,0'];
+      tile.extent = getProjection('EPSG:3857').getExtent();
       tile.setState(TileState.LOADED);
       tile.getSourceTile = function() {
         return sourceTile;

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -2,12 +2,15 @@ import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import VectorImageTile from '../../../../src/ol/VectorImageTile.js';
 import VectorTile from '../../../../src/ol/VectorTile.js';
+import GeoJSON from '../../../../src/ol/format/GeoJSON.js';
 import MVT from '../../../../src/ol/format/MVT.js';
 import VectorTileLayer from '../../../../src/ol/layer/VectorTile.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
 import VectorTileSource from '../../../../src/ol/source/VectorTile.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
 import TileGrid from '../../../../src/ol/tilegrid/TileGrid.js';
+import {listen, unlistenByKey} from '../../../../src/ol/events.js';
+import TileState from '../../../../src/ol/TileState.js';
 
 describe('ol.source.VectorTile', function() {
 
@@ -47,6 +50,24 @@ describe('ol.source.VectorTile', function() {
       expect(source.getTile(0, 0, 0, 1, getProjection('EPSG:3857')))
         .to.equal(tile);
     });
+    it('loads source tiles', function(done) {
+      const source = new VectorTileSource({
+        format: new GeoJSON(),
+        url: 'spec/ol/data/point.json'
+      });
+      const tile = source.getTile(0, 0, 0, 1, source.getProjection());
+
+      tile.load();
+      const key = listen(tile, 'change', function(e) {
+        if (tile.getState() === TileState.LOADED) {
+          const sourceTile = tile.load()[0];
+          expect(sourceTile.getFeatures().length).to.be.greaterThan(0);
+          unlistenByKey(key);
+          done();
+        }
+      });
+    });
+
   });
 
   describe('#getTileGridForProjection', function() {

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -1,6 +1,6 @@
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
-import VectorImageTile from '../../../../src/ol/VectorImageTile.js';
+import VectorRenderTile from '../../../../src/ol/VectorRenderTile.js';
 import VectorTile from '../../../../src/ol/VectorTile.js';
 import GeoJSON from '../../../../src/ol/format/GeoJSON.js';
 import MVT from '../../../../src/ol/format/MVT.js';
@@ -41,7 +41,7 @@ describe('ol.source.VectorTile', function() {
   describe('#getTile()', function() {
     it('creates a tile with the correct tile class', function() {
       tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
-      expect(tile).to.be.a(VectorImageTile);
+      expect(tile).to.be.a(VectorRenderTile);
     });
     it('sets the correct tileCoord on the created tile', function() {
       expect(tile.getTileCoord()).to.eql([0, 0, 0]);

--- a/test/spec/ol/vectorimagetile.test.js
+++ b/test/spec/ol/vectorimagetile.test.js
@@ -9,7 +9,7 @@ import {getKey} from '../../../src/ol/tilecoord.js';
 import EventType from '../../../src/ol/events/EventType.js';
 
 
-describe('ol.VectorImageTile', function() {
+describe('ol.VectorRenderTile', function() {
 
   it('triggers "change" when previously failed source tiles are loaded', function(done) {
     let sourceTile;

--- a/test/spec/ol/vectortile.test.js
+++ b/test/spec/ol/vectortile.test.js
@@ -1,5 +1,5 @@
 import Feature from '../../../src/ol/Feature.js';
-import {defaultLoadFunction} from '../../../src/ol/VectorImageTile.js';
+import {defaultLoadFunction} from '../../../src/ol/source/VectorTile.js';
 import VectorTile from '../../../src/ol/VectorTile.js';
 import {listen} from '../../../src/ol/events.js';
 import TextFeature from '../../../src/ol/format/TextFeature.js';


### PR DESCRIPTION
This pull request refactors tile loading for vector tile sources. The goal is to let the source manage all loading, instead of having load logic in the vector image tile.

This refactoring also results in a simplified tile load cycle, mostly by giving `ol/Tile` a new `hifi` property to indicate when a tile has data for its nominal (highest) resolution. 

This pull request is a first step towards a render tile that can get its data (i.e. render instructions) from a worker.