### PR TITLE
Avoid unexpected behavior when passing string coordinates

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -40,8 +40,8 @@ import {padNumber} from './string.js';
  * @api
  */
 export function add(coordinate, delta) {
-  coordinate[0] += delta[0];
-  coordinate[1] += delta[1];
+  coordinate[0] += +delta[0];
+  coordinate[1] += +delta[1];
   return coordinate;
 }
 

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -106,7 +106,7 @@ export function fromEPSG4326(input, opt_output, opt_dimension) {
   for (let i = 0; i < length; i += dimension) {
     output[i] = halfSize * input[i] / 180;
     let y = RADIUS *
-        Math.log(Math.tan(Math.PI * (input[i + 1] + 90) / 360));
+        Math.log(Math.tan(Math.PI * (+input[i + 1] + 90) / 360));
     if (y > halfSize) {
       y = halfSize;
     } else if (y < -halfSize) {

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -29,6 +29,14 @@ describe('ol.coordinate', function() {
       expect(coordinate[0]).to.eql(48.73);
       expect(coordinate[1]).to.eql(10.1);
     });
+
+    it('does not produce unexpected results with string delta values', function() {
+      addCoordinate(coordinate, delta.map(function(n) {
+        return String(n);
+      }));
+      expect(coordinate[0]).to.eql(48.73);
+      expect(coordinate[1]).to.eql(10.1);
+    });
   });
 
   describe('#equals', function() {

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -35,6 +35,12 @@ describe('ol/proj/epsg3857', function() {
       }
     });
 
+    it('does not produce unexpected results for string coordinates', function() {
+      const transformed = fromEPSG4326(['180', '90']);
+      expect(transformed[0]).to.roughlyEqual(HALF_SIZE, 1e-5);
+      expect(transformed[1]).to.roughlyEqual(HALF_SIZE, 1e-5);
+    });
+
   });
 
   describe('getPointResolution', function() {


### PR DESCRIPTION
As reported e.g. in #4989, #6111, #6514, #6016, #2500, accidently passing strings as coordinates causes issues that are very hard to track down. Assuming that not everyone uses a type checker, and given the fact that a fix is straightforward, I went ahead and changed the code to do explicit coercion to number rather than implicit coercion to string in two obvious cases.