### PR TITLE
Modify.removePoint returns true only when a vertex was removed

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1016,10 +1016,10 @@ class Modify extends PointerInteraction {
     if (this.lastPointerEvent_ && this.lastPointerEvent_.type != MapBrowserEventType.POINTERDRAG) {
       const evt = this.lastPointerEvent_;
       this.willModifyFeatures_(evt);
-      this.removeVertex_();
+      const removed = this.removeVertex_();
       this.dispatchEvent(new ModifyEvent(ModifyEventType.MODIFYEND, this.features_, evt));
       this.modified_ = false;
-      return true;
+      return removed;
     }
     return false;
   }


### PR DESCRIPTION
The [documentation](https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/Modify.js#L1019) states that `Modify.removePoint` returns true when a vertex was removed. This is currently not the case. This PR makes it return true only when a vertex was removed.

However, `MODIFYSTART` ([here](https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/Modify.js#L357)) and `MODIFYEND` ([here](https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/Modify.js#L1027)) events will still be dispatched, even though a vertex never was removed. Maybe a function `canRemoveVertex_` should exist and be called before `willModifyFeatures_`? This way the function will both return the correct value and not dispatch unnecessary modify events. I can implement this function if you think it sounds like a good idea.