### PR TITLE
Add a proper extent constraint for the View

### DIFF
--- a/examples/device-orientation.js
+++ b/examples/device-orientation.js
@@ -40,6 +40,6 @@ gn.init().then(function() {
     center[0] -= resolution * gamma * 25;
     center[1] += resolution * beta * 25;
 
-    view.setCenter(view.constrainCenter(center));
+    view.setCenter(center);
   });
 });

--- a/examples/extent-constrained.html
+++ b/examples/extent-constrained.html
@@ -1,0 +1,9 @@
+---
+layout: example.html
+title: Constrained Extent
+shortdesc: Example of a view with a constrained extent.
+docs: >
+  This map has a view that is constrained in an extent.  This is done using the `extent` view option. Please note that specifying `restrictOnlyCenter: true` would only apply the extent restriction to the view center.
+tags: "view, extent, constrain, restrict"
+---
+<div id="map" class="map"></div>

--- a/examples/extent-constrained.js
+++ b/examples/extent-constrained.js
@@ -1,0 +1,22 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import OSM from '../src/ol/source/OSM.js';
+
+const view = new View({
+  center: [328627.563458, 5921296.662223],
+  zoom: 8,
+  extent: [-572513.341856, 5211017.966314,
+    916327.095083, 6636950.728974],
+  restrictOnlyCenter: false
+});
+
+new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM()
+    })
+  ],
+  target: 'map',
+  view: view
+});

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1207,7 +1207,7 @@ export function createCenterConstraint(options) {
 
 /**
  * @param {ViewOptions} options View options.
- * @return {{constraint: import("./resolutionconstraint.js").Type, maxResolution: number,
+ * @return {{constraint: import('./resolutionconstraint.js').Type, maxResolution: number,
  *     minResolution: number, minZoom: number, zoomFactor: number}} The constraint.
  */
 export function createResolutionConstraint(options) {

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -2,11 +2,15 @@
  * @module ol/centerconstraint
  */
 import {clamp} from './math.js';
+import {createEmpty, getForViewAndSize, getHeight, getWidth} from './extent';
 
 
 /**
- * @typedef {function((import("./coordinate.js").Coordinate|undefined)): (import("./coordinate.js").Coordinate|undefined)} Type
+ * @typedef {function((import("./coordinate.js").Coordinate|undefined),number,number,(import("./size.js").Size),boolean):
+ *  (import("./coordinate.js").Coordinate|undefined)} Type
  */
+
+const tmpExtent = createEmpty();
 
 
 /**
@@ -17,13 +21,26 @@ export function createExtent(extent) {
   return (
     /**
      * @param {import("./coordinate.js").Coordinate=} center Center.
+     * @param {number} resolution Resolution.
+     * @param {number} rotation Rotation.
+     * @param {import("./size.js").Size=} size Viewport size. If undefined, constrain only center.
+     * @param {boolean} whileInteracting Will be true if the constraint is applied
+     * during an interaction.
      * @return {import("./coordinate.js").Coordinate|undefined} Center.
      */
-    function(center) {
+    function(center, resolution, rotation, size, whileInteracting) {
       if (center) {
+        let viewWidth = 0;
+        let viewHeight = 0;
+        if (size) {
+          const viewExtent = getForViewAndSize(center, resolution, rotation, size, tmpExtent);
+          viewWidth = getWidth(viewExtent);
+          viewHeight = getHeight(viewExtent);
+        }
+
         return [
-          clamp(center[0], extent[0], extent[2]),
-          clamp(center[1], extent[1], extent[3])
+          clamp(center[0], extent[0] + viewWidth / 2, extent[2] - viewWidth / 2),
+          clamp(center[1], extent[1] + viewHeight / 2, extent[3] - viewHeight / 2)
         ];
       } else {
         return undefined;

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -117,7 +117,13 @@ class Zoom extends Control {
     const currentResolution = view.getResolution();
     if (currentResolution) {
       const currentZoom = view.getZoomForResolution(currentResolution);
-      const newResolution = view.getResolutionForZoom(currentZoom + delta);
+      const newResolution = view.constrainResolution(
+        view.getResolutionForZoom(currentZoom + delta));
+
+      if (newResolution === currentResolution) {
+        return;
+      }
+
       if (this.duration_ > 0) {
         if (view.getAnimating()) {
           view.cancelAnimations();

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -116,7 +116,8 @@ class Zoom extends Control {
     }
     const currentResolution = view.getResolution();
     if (currentResolution) {
-      const newResolution = view.constrainResolution(currentResolution, delta);
+      const currentZoom = view.getZoomForResolution(currentResolution);
+      const newResolution = view.getResolutionForZoom(currentZoom + delta);
       if (this.duration_ > 0) {
         if (view.getAnimating()) {
           view.cancelAnimations();

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -281,11 +281,7 @@ class ZoomSlider extends Control {
       const view = this.getMap().getView();
       view.setHint(ViewHint.INTERACTING, -1);
 
-      view.animate({
-        resolution: this.currentResolution_,
-        duration: this.duration_,
-        easing: easeOut
-      });
+      view.resolveConstraints(this.duration_);
 
       this.dragging_ = false;
       this.previousX_ = undefined;

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -220,7 +220,7 @@ class ZoomSlider extends Control {
     const resolution = this.getResolutionForPosition_(relativePosition);
 
     view.animate({
-      resolution: view.constrainResolution(resolution),
+      resolution: resolution,
       duration: this.duration_,
       easing: easeOut
     });
@@ -282,7 +282,7 @@ class ZoomSlider extends Control {
       view.setHint(ViewHint.INTERACTING, -1);
 
       view.animate({
-        resolution: view.constrainResolution(this.currentResolution_),
+        resolution: this.currentResolution_,
         duration: this.duration_,
         easing: easeOut
       });

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -89,11 +89,10 @@ class DragPan extends PointerInteraction {
         const deltaY = centroid[1] - this.lastCentroid[1];
         const map = mapBrowserEvent.map;
         const view = map.getView();
-        let center = [deltaX, deltaY];
+        const center = [deltaX, deltaY];
         scaleCoordinate(center, view.getResolution());
         rotateCoordinate(center, view.getRotation());
         addCoordinate(center, view.getCenter());
-        center = view.constrainCenter(center);
         view.setCenter(center);
       }
     } else if (this.kinetic_) {
@@ -122,7 +121,7 @@ class DragPan extends PointerInteraction {
           centerpx[1] - distance * Math.sin(angle)
         ]);
         view.animate({
-          center: view.constrainCenter(dest),
+          center: dest,
           duration: 500,
           easing: easeOut
         });

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -94,8 +94,7 @@ class DragRotate extends PointerInteraction {
     const map = mapBrowserEvent.map;
     const view = map.getView();
     view.setHint(ViewHint.INTERACTING, -1);
-    const rotation = view.getRotation();
-    rotate(view, rotation, undefined, this.duration_);
+    view.resolveConstraints(this.duration_);
     return false;
   }
 

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -1,11 +1,10 @@
 /**
  * @module ol/interaction/DragRotate
  */
-import {disable} from '../rotationconstraint.js';
 import ViewHint from '../ViewHint.js';
 import {altShiftKeysOnly, mouseOnly, mouseActionButton} from '../events/condition.js';
 import {FALSE} from '../functions.js';
-import {rotate, rotateWithoutConstraints} from './Interaction.js';
+import {rotate} from './Interaction.js';
 import PointerInteraction from './Pointer.js';
 
 
@@ -71,9 +70,6 @@ class DragRotate extends PointerInteraction {
 
     const map = mapBrowserEvent.map;
     const view = map.getView();
-    if (view.getConstraints().rotation === disable) {
-      return;
-    }
     const size = map.getSize();
     const offset = mapBrowserEvent.pixel;
     const theta =
@@ -81,7 +77,7 @@ class DragRotate extends PointerInteraction {
     if (this.lastAngle_ !== undefined) {
       const delta = theta - this.lastAngle_;
       const rotation = view.getRotation();
-      rotateWithoutConstraints(view, rotation - delta);
+      rotate(view, rotation - delta);
     }
     this.lastAngle_ = theta;
   }

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -114,9 +114,7 @@ class DragRotateAndZoom extends PointerInteraction {
     const map = mapBrowserEvent.map;
     const view = map.getView();
     view.setHint(ViewHint.INTERACTING, -1);
-    const direction = this.lastScaleDelta_ - 1;
-    rotate(view, view.getRotation());
-    zoom(view, view.getResolution(), undefined, this.duration_, direction);
+    view.resolveConstraints(this.duration_);
     this.lastScaleDelta_ = 0;
     return false;
   }

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -4,7 +4,7 @@
 import {disable} from '../rotationconstraint.js';
 import ViewHint from '../ViewHint.js';
 import {shiftKeyOnly, mouseOnly} from '../events/condition.js';
-import {rotate, rotateWithoutConstraints, zoom, zoomWithoutConstraints} from './Interaction.js';
+import {rotate, zoom} from './Interaction.js';
 import PointerInteraction from './Pointer.js';
 
 
@@ -90,12 +90,12 @@ class DragRotateAndZoom extends PointerInteraction {
     const view = map.getView();
     if (view.getConstraints().rotation !== disable && this.lastAngle_ !== undefined) {
       const angleDelta = theta - this.lastAngle_;
-      rotateWithoutConstraints(view, view.getRotation() - angleDelta);
+      rotate(view, view.getRotation() - angleDelta);
     }
     this.lastAngle_ = theta;
     if (this.lastMagnitude_ !== undefined) {
       const resolution = this.lastMagnitude_ * (view.getResolution() / magnitude);
-      zoomWithoutConstraints(view, resolution);
+      zoom(view, resolution);
     }
     if (this.lastMagnitude_ !== undefined) {
       this.lastScaleDelta_ = this.lastMagnitude_ / magnitude;

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -84,7 +84,7 @@ function onBoxEnd() {
   const center = getCenter(extent);
 
   view.animate({
-    resolution: resolution,
+    resolution: view.constrainResolution(resolution, false),
     center: center,
     duration: this.duration_,
     easing: easeOut

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -80,11 +80,8 @@ function onBoxEnd() {
     extent = mapExtent;
   }
 
-  const resolution = view.constrainResolution(
-    view.getResolutionForExtent(extent, size));
-
-  let center = getCenter(extent);
-  center = view.constrainCenter(center);
+  const resolution = view.getResolutionForExtent(extent, size);
+  const center = getCenter(extent);
 
   view.animate({
     resolution: resolution,

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -110,8 +110,7 @@ class Interaction extends BaseObject {
 export function pan(view, delta, opt_duration) {
   const currentCenter = view.getCenter();
   if (currentCenter) {
-    const center = view.constrainCenter(
-      [currentCenter[0] + delta[0], currentCenter[1] + delta[1]]);
+    const center = [currentCenter[0] + delta[0], currentCenter[1] + delta[1]];
     if (opt_duration) {
       view.animate({
         duration: opt_duration,
@@ -132,18 +131,6 @@ export function pan(view, delta, opt_duration) {
  * @param {number=} opt_duration Duration.
  */
 export function rotate(view, rotation, opt_anchor, opt_duration) {
-  rotation = view.constrainRotation(rotation, 0);
-  rotateWithoutConstraints(view, rotation, opt_anchor, opt_duration);
-}
-
-
-/**
- * @param {import("../View.js").default} view View.
- * @param {number|undefined} rotation Rotation.
- * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
- * @param {number=} opt_duration Duration.
- */
-export function rotateWithoutConstraints(view, rotation, opt_anchor, opt_duration) {
   if (rotation !== undefined) {
     const currentRotation = view.getRotation();
     const currentCenter = view.getCenter();
@@ -163,6 +150,28 @@ export function rotateWithoutConstraints(view, rotation, opt_anchor, opt_duratio
 
 /**
  * @param {import("../View.js").default} view View.
+ * @param {number} delta Delta from previous zoom level.
+ * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
+ * @param {number=} opt_duration Duration.
+ */
+export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
+  const currentZoom = view.getZoom();
+  let resolution = view.getResolutionForZoom(currentZoom + delta);
+
+  if (resolution !== undefined) {
+    const resolutions = view.getResolutions();
+    resolution = clamp(
+      resolution,
+      view.getMinResolution() || resolutions[resolutions.length - 1],
+      view.getMaxResolution() || resolutions[0]);
+  }
+
+  zoom(view, resolution, opt_anchor, opt_duration);
+}
+
+
+/**
+ * @param {import("../View.js").default} view View.
  * @param {number|undefined} resolution Resolution to go to.
  * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
  * @param {number=} opt_duration Duration.
@@ -176,56 +185,6 @@ export function rotateWithoutConstraints(view, rotation, opt_anchor, opt_duratio
  *     assumed.
  */
 export function zoom(view, resolution, opt_anchor, opt_duration, opt_direction) {
-  resolution = view.constrainResolution(resolution, 0, opt_direction);
-  zoomWithoutConstraints(view, resolution, opt_anchor, opt_duration);
-}
-
-
-/**
- * @param {import("../View.js").default} view View.
- * @param {number} delta Delta from previous zoom level.
- * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
- * @param {number=} opt_duration Duration.
- */
-export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
-  const currentResolution = view.getResolution();
-  let resolution = view.constrainResolution(currentResolution, delta, 0);
-
-  if (resolution !== undefined) {
-    const resolutions = view.getResolutions();
-    resolution = clamp(
-      resolution,
-      view.getMinResolution() || resolutions[resolutions.length - 1],
-      view.getMaxResolution() || resolutions[0]);
-  }
-
-  // If we have a constraint on center, we need to change the anchor so that the
-  // new center is within the extent. We first calculate the new center, apply
-  // the constraint to it, and then calculate back the anchor
-  if (opt_anchor && resolution !== undefined && resolution !== currentResolution) {
-    const currentCenter = view.getCenter();
-    let center = view.calculateCenterZoom(resolution, opt_anchor);
-    center = view.constrainCenter(center);
-
-    opt_anchor = [
-      (resolution * currentCenter[0] - currentResolution * center[0]) /
-          (resolution - currentResolution),
-      (resolution * currentCenter[1] - currentResolution * center[1]) /
-          (resolution - currentResolution)
-    ];
-  }
-
-  zoomWithoutConstraints(view, resolution, opt_anchor, opt_duration);
-}
-
-
-/**
- * @param {import("../View.js").default} view View.
- * @param {number|undefined} resolution Resolution to go to.
- * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
- * @param {number=} opt_duration Duration.
- */
-export function zoomWithoutConstraints(view, resolution, opt_anchor, opt_duration) {
   if (resolution) {
     const currentResolution = view.getResolution();
     const currentCenter = view.getCenter();

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -144,7 +144,7 @@ export function rotate(view, rotation, opt_anchor) {
  */
 export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
   const currentZoom = view.getZoom();
-  let resolution = view.getResolutionForZoom(currentZoom + delta);
+  let resolution = view.constrainResolution(view.getResolutionForZoom(currentZoom + delta));
 
   if (resolution !== undefined) {
     const resolutions = view.getResolutions();

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -128,22 +128,10 @@ export function pan(view, delta, opt_duration) {
  * @param {import("../View.js").default} view View.
  * @param {number|undefined} rotation Rotation.
  * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate.
- * @param {number=} opt_duration Duration.
  */
-export function rotate(view, rotation, opt_anchor, opt_duration) {
+export function rotate(view, rotation, opt_anchor) {
   if (rotation !== undefined) {
-    const currentRotation = view.getRotation();
-    const currentCenter = view.getCenter();
-    if (currentRotation !== undefined && currentCenter && opt_duration > 0) {
-      view.animate({
-        rotation: rotation,
-        anchor: opt_anchor,
-        duration: opt_duration,
-        easing: easeOut
-      });
-    } else {
-      view.rotate(rotation, opt_anchor);
-    }
+    view.rotate(rotation, opt_anchor);
   }
 }
 

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -185,11 +185,11 @@ export function zoom(view, resolution, opt_anchor, opt_duration, opt_direction) 
         easing: easeOut
       });
     } else {
-      if (opt_anchor) {
-        const center = view.calculateCenterZoom(resolution, opt_anchor);
+      const center = opt_anchor && view.calculateCenterZoom(resolution, opt_anchor);
+      view.setResolution(resolution);
+      if (center) {
         view.setCenter(center);
       }
-      view.setResolution(resolution);
     }
   }
 }

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -234,13 +234,13 @@ class MouseWheelZoom extends Interaction {
       }
       if (this.lastAnchor_) {
         const center = view.calculateCenterZoom(resolution, this.lastAnchor_);
-        view.setCenter(view.constrainCenter(center));
+        view.setCenter(center);
       }
       view.setResolution(resolution);
 
       if (rebound === 0 && this.constrainResolution_) {
         view.animate({
-          resolution: view.constrainResolution(resolution, delta > 0 ? -1 : 1),
+          resolution: resolution,
           easing: easeOut,
           anchor: this.lastAnchor_,
           duration: this.duration_

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -238,9 +238,13 @@ class MouseWheelZoom extends Interaction {
       }
       view.setResolution(resolution);
 
+      if (view.getAnimating()) {
+        view.cancelAnimations();
+      }
+
       if (rebound === 0 && this.constrainResolution_) {
         view.animate({
-          resolution: resolution,
+          resolution: view.constrainResolution(resolution),
           easing: easeOut,
           anchor: this.lastAnchor_,
           duration: this.duration_
@@ -249,14 +253,14 @@ class MouseWheelZoom extends Interaction {
 
       if (rebound > 0) {
         view.animate({
-          resolution: minResolution,
+          resolution: view.constrainResolution(minResolution),
           easing: easeOut,
           anchor: this.lastAnchor_,
           duration: 500
         });
       } else if (rebound < 0) {
         view.animate({
-          resolution: maxResolution,
+          resolution: view.constrainResolution(maxResolution),
           easing: easeOut,
           anchor: this.lastAnchor_,
           duration: 500

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -3,7 +3,7 @@
  */
 import ViewHint from '../ViewHint.js';
 import {FALSE} from '../functions.js';
-import {rotate, rotateWithoutConstraints} from './Interaction.js';
+import {rotate} from './Interaction.js';
 import PointerInteraction, {centroid as centroidFromPointers} from './Pointer.js';
 import {disable} from '../rotationconstraint.js';
 
@@ -120,7 +120,7 @@ class PinchRotate extends PointerInteraction {
     if (this.rotating_) {
       const rotation = view.getRotation();
       map.render();
-      rotateWithoutConstraints(view, rotation + rotationDelta, this.anchor_);
+      rotate(view, rotation + rotationDelta, this.anchor_);
     }
   }
 

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -133,8 +133,7 @@ class PinchRotate extends PointerInteraction {
       const view = map.getView();
       view.setHint(ViewHint.INTERACTING, -1);
       if (this.rotating_) {
-        const rotation = view.getRotation();
-        rotate(view, rotation, this.anchor_, this.duration_);
+        view.resolveConstraints(this.duration_);
       }
       return false;
     } else {

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -131,11 +131,7 @@ class PinchZoom extends PointerInteraction {
       if (this.constrainResolution_ ||
           resolution < view.getMinResolution() ||
           resolution > view.getMaxResolution()) {
-        // Zoom to final resolution, with an animation, and provide a
-        // direction not to zoom out/in if user was pinching in/out.
-        // Direction is > 0 if pinching out, and < 0 if pinching in.
-        const direction = this.lastScaleDelta_ - 1;
-        zoom(view, resolution, this.anchor_, this.duration_, direction);
+        view.resolveConstraints(this.duration_);
       }
       return false;
     } else {

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -3,7 +3,7 @@
  */
 import ViewHint from '../ViewHint.js';
 import {FALSE} from '../functions.js';
-import {zoom, zoomWithoutConstraints} from './Interaction.js';
+import {zoom} from './Interaction.js';
 import PointerInteraction, {centroid as centroidFromPointers} from './Pointer.js';
 
 
@@ -116,7 +116,7 @@ class PinchZoom extends PointerInteraction {
 
     // scale, bypass the resolution constraint
     map.render();
-    zoomWithoutConstraints(view, newResolution, this.anchor_);
+    zoom(view, newResolution, this.anchor_);
   }
 
   /**

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -2,30 +2,48 @@
  * @module ol/resolutionconstraint
  */
 import {linearFindNearest} from './array.js';
-import {clamp} from './math.js';
+import {createEmpty, getHeight, getWidth} from './extent';
 
 
 /**
- * @typedef {function((number|undefined), number, number): (number|undefined)} Type
+ * @typedef {function((number|undefined), (import("./size.js").Size), boolean):
+ *  (number|undefined)} Type
  */
 
+const tmpExtent = createEmpty();
 
 /**
  * @param {Array<number>} resolutions Resolutions.
+ * @param {import("./extent.js").Extent=} opt_maxExtent Maximum allowed extent.
  * @return {Type} Zoom function.
  */
-export function createSnapToResolutions(resolutions) {
+export function createSnapToResolutions(resolutions, opt_maxExtent) {
   return (
     /**
      * @param {number|undefined} resolution Resolution.
-     * @param {number} delta Delta.
-     * @param {number} direction Direction.
+     * @param {import("./size.js").Size} size Viewport size.
+     * @param {boolean} whileInteracting Will be true if the constraint is applied
+     * during an interaction.
      * @return {number|undefined} Resolution.
      */
-    function(resolution, delta, direction) {
+    function(resolution, size, whileInteracting) {
       if (resolution !== undefined) {
-        let z = linearFindNearest(resolutions, resolution, direction);
-        z = clamp(z + delta, 0, resolutions.length - 1);
+        let cappedRes = resolution;
+
+        // apply constraint related to max extent
+        if (opt_maxExtent) {
+          const xResolution = getWidth(opt_maxExtent) / size[0];
+          const yResolution = getHeight(opt_maxExtent) / size[1];
+          cappedRes = Math.min(cappedRes, Math.min(xResolution, yResolution));
+        }
+
+        // do not snap during interaction/animation
+        if (whileInteracting) {
+          return Math.min(resolution, cappedRes);
+        }
+
+        // todo: compute direction
+        const z = linearFindNearest(resolutions, cappedRes, 0);
         const index = Math.floor(z);
         if (z != index && index < resolutions.length - 1) {
           const power = resolutions[index] / resolutions[index + 1];
@@ -42,29 +60,44 @@ export function createSnapToResolutions(resolutions) {
 
 
 /**
- * @param {number} power Power.
+ * @param {number} zoomFactor Zoom factor (default: 2).
  * @param {number} maxResolution Maximum resolution.
  * @param {number=} opt_maxLevel Maximum level.
+ * @param {import("./extent.js").Extent=} opt_maxExtent Maximum allowed extent.
  * @return {Type} Zoom function.
  */
-export function createSnapToPower(power, maxResolution, opt_maxLevel) {
+export function createSnapToPower(zoomFactor, maxResolution, opt_maxLevel, opt_maxExtent) {
   return (
     /**
      * @param {number|undefined} resolution Resolution.
-     * @param {number} delta Delta.
-     * @param {number} direction Direction.
+     * @param {import("./size.js").Size} size Viewport size.
+     * @param {boolean} whileInteracting Will be true if the constraint is applied
+     * during an interaction.
      * @return {number|undefined} Resolution.
      */
-    function(resolution, delta, direction) {
+    function(resolution, size, whileInteracting) {
       if (resolution !== undefined) {
-        const offset = -direction / 2 + 0.5;
-        const oldLevel = Math.floor(
-          Math.log(maxResolution / resolution) / Math.log(power) + offset);
-        let newLevel = Math.max(oldLevel + delta, 0);
+        let cappedRes = resolution;
+
+        // apply constraint related to max extent
+        if (opt_maxExtent) {
+          const xResolution = getWidth(opt_maxExtent) / size[0];
+          const yResolution = getHeight(opt_maxExtent) / size[1];
+          cappedRes = Math.min(cappedRes, Math.min(xResolution, yResolution));
+        }
+
+        // do not snap during interaction/animation
+        if (whileInteracting) {
+          return Math.min(resolution, cappedRes);
+        }
+
+        // todo: compute direction
+        let newLevel = Math.round(
+          Math.log(maxResolution / cappedRes) / Math.log(zoomFactor));
         if (opt_maxLevel !== undefined) {
           newLevel = Math.min(newLevel, opt_maxLevel);
         }
-        return maxResolution / Math.pow(power, newLevel);
+        return maxResolution / Math.pow(zoomFactor, newLevel);
       } else {
         return undefined;
       }

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -2,15 +2,13 @@
  * @module ol/resolutionconstraint
  */
 import {linearFindNearest} from './array.js';
-import {createEmpty, getHeight, getWidth} from './extent';
+import {getHeight, getWidth} from './extent';
 
 
 /**
  * @typedef {function((number|undefined), (import("./size.js").Size), boolean):
  *  (number|undefined)} Type
  */
-
-const tmpExtent = createEmpty();
 
 /**
  * @param {Array<number>} resolutions Resolutions.

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -5,16 +5,15 @@ import {toRadians} from './math.js';
 
 
 /**
- * @typedef {function((number|undefined), number): (number|undefined)} Type
+ * @typedef {function((number|undefined), boolean): (number|undefined)} Type
  */
 
 
 /**
  * @param {number|undefined} rotation Rotation.
- * @param {number} delta Delta.
  * @return {number|undefined} Rotation.
  */
-export function disable(rotation, delta) {
+export function disable(rotation) {
   if (rotation !== undefined) {
     return 0;
   } else {
@@ -25,12 +24,11 @@ export function disable(rotation, delta) {
 
 /**
  * @param {number|undefined} rotation Rotation.
- * @param {number} delta Delta.
  * @return {number|undefined} Rotation.
  */
-export function none(rotation, delta) {
+export function none(rotation) {
   if (rotation !== undefined) {
-    return rotation + delta;
+    return rotation;
   } else {
     return undefined;
   }
@@ -46,13 +44,16 @@ export function createSnapToN(n) {
   return (
     /**
      * @param {number|undefined} rotation Rotation.
-     * @param {number} delta Delta.
+     * @param {boolean} whileInteracting Will be true if the constraint is applied
+     * during an interaction.
      * @return {number|undefined} Rotation.
      */
-    function(rotation, delta) {
-      if (rotation !== undefined) {
-        rotation = Math.floor((rotation + delta) / theta + 0.5) * theta;
+    function(rotation, whileInteracting) {
+      if (whileInteracting) {
         return rotation;
+      }
+      if (rotation !== undefined) {
+        return Math.floor(rotation / theta + 0.5) * theta;
       } else {
         return undefined;
       }
@@ -69,15 +70,19 @@ export function createSnapToZero(opt_tolerance) {
   return (
     /**
      * @param {number|undefined} rotation Rotation.
-     * @param {number} delta Delta.
+     * @param {boolean} whileInteracting Will be true if the constraint is applied
+     * during an interaction.
      * @return {number|undefined} Rotation.
      */
-    function(rotation, delta) {
+    function(rotation, whileInteracting) {
+      if (whileInteracting) {
+        return rotation;
+      }
       if (rotation !== undefined) {
-        if (Math.abs(rotation + delta) <= tolerance) {
+        if (Math.abs(rotation) <= tolerance) {
           return 0;
         } else {
-          return rotation + delta;
+          return rotation;
         }
       } else {
         return undefined;

--- a/test/spec/ol/interaction/dragzoom.test.js
+++ b/test/spec/ol/interaction/dragzoom.test.js
@@ -103,7 +103,7 @@ describe('ol.interaction.DragZoom', function() {
         setTimeout(function() {
           const view = map.getView();
           const resolution = view.getResolution();
-          expect(resolution).to.eql(view.constrainResolution(0.5));
+          expect(resolution).to.eql(0.5);
           done();
         }, 50);
       }, 50);

--- a/test/spec/ol/interaction/dragzoom.test.js
+++ b/test/spec/ol/interaction/dragzoom.test.js
@@ -32,7 +32,8 @@ describe('ol.interaction.DragZoom', function() {
       view: new View({
         projection: 'EPSG:4326',
         center: [0, 0],
-        resolution: 1
+        resolution: 1,
+        maxResolution: 2
       })
     });
     map.once('postrender', function() {

--- a/test/spec/ol/interaction/interaction.test.js
+++ b/test/spec/ol/interaction/interaction.test.js
@@ -128,12 +128,13 @@ describe('ol.interaction.Interaction', function() {
       expect(view.getCenter()).to.eql([10, 10]);
     });
 
-    it('changes view resolution and center relative to the anchor, while respecting the extent', function() {
+    it('changes view resolution and center relative to the anchor, while respecting the extent (center only)', function() {
       const view = new View({
         center: [0, 0],
         extent: [-2.5, -2.5, 2.5, 2.5],
         resolution: 1,
-        resolutions: [4, 2, 1, 0.5, 0.25]
+        resolutions: [4, 2, 1, 0.5, 0.25],
+        constrainOnlyCenter: true
       });
 
       zoomByDelta(view, 1, [10, 10]);
@@ -147,6 +148,30 @@ describe('ol.interaction.Interaction', function() {
 
       zoomByDelta(view, -2, [0, 0]);
       expect(view.getCenter()).to.eql([2.5, 2.5]);
+    });
+
+    it('changes view resolution and center relative to the anchor, while respecting the extent', function() {
+      const map = new Map({});
+      const view = new View({
+        center: [50, 50],
+        extent: [0, 0, 100, 100],
+        resolution: 1,
+        resolutions: [4, 2, 1, 0.5, 0.25]
+      });
+      map.setView(view);
+
+      zoomByDelta(view, 1, [100, 100]);
+      expect(view.getCenter()).to.eql([75, 75]);
+
+      zoomByDelta(view, -1, [75, 75]);
+      expect(view.getCenter()).to.eql([50, 50]);
+
+      zoomByDelta(view, 2, [100, 100]);
+      expect(view.getCenter()).to.eql([87.5, 87.5]);
+
+      zoomByDelta(view, -3, [0, 0]);
+      expect(view.getCenter()).to.eql([50, 50]);
+      expect(view.getResolution()).to.eql(1);
     });
   });
 


### PR DESCRIPTION
This PR changes the default behaviour of the `extent` option to take into account the current view extent and not only its center. The previous behaviour can still be aobtained using the `constrainOnlyCenter` option.

A new example was added: (waiting for build)

This required quite a bit of refactoring as this change impacted many classes. The constraints are now always applied by the view through the `setCenter/Resolution/Rotation` functions, and controls & interactions do not need to do the constraining themselves. Two new functions were added on the `View` class:

* `applyConstraints` (private) which simply applies the constraint functions (if any) on the current view parameters
  This will have different effects depending on the current view hints of the view.

* `resolveConstraints` (public) which will animate the view parameters towards "stable"  values, ie when the dragging motion stops after a zoom in/out gesture.

Most interactions and some controls are impacted. Tests are still failing due to regressions on the previous behaviour, most notably on resolution constraint. As such, this PR is still a WIP.
- [ ] Fix the directional behaviour of the resolution constraint (ie do not only snap to nearest value)
- [ ] Fix failing tests
- [ ] Add more tests for when the view is rotated & constrained in an extent

PS: implementing a smooth "overscroll" effect when panning outside of the extent was simply not feasible with this approach IMO. The center/resolution constraints feel a bit stiff because of that.