### PR TITLE
Remove 'layerStates' property from the FrameState

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -41,7 +41,6 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * @property {null|import("./extent.js").Extent} extent
  * @property {import("./coordinate.js").Coordinate} focus
  * @property {number} index
- * @property {Object<string, import("./layer/Layer.js").State>} layerStates
  * @property {Array<import("./layer/Layer.js").State>} layerStatesArray
  * @property {import("./transform.js").Transform} pixelToCoordinateTransform
  * @property {Array<PostRenderFunction>} postRenderFunctions
@@ -1188,11 +1187,6 @@ class PluggableMap extends BaseObject {
     let frameState = null;
     if (size !== undefined && hasArea(size) && view && view.isDef()) {
       const viewHints = view.getHints(this.frameState_ ? this.frameState_.viewHints : undefined);
-      const layerStatesArray = this.getLayerGroup().getLayerStatesArray();
-      const layerStates = {};
-      for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-        layerStates[getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
-      }
       viewState = view.getState(this.pixelRatio_);
       frameState = /** @type {FrameState} */ ({
         animate: false,
@@ -1200,8 +1194,7 @@ class PluggableMap extends BaseObject {
         extent: extent,
         focus: this.focus_ ? this.focus_ : viewState.center,
         index: this.frameIndex_++,
-        layerStates: layerStates,
-        layerStatesArray: layerStatesArray,
+        layerStatesArray: this.getLayerGroup().getLayerStatesArray(),
         pixelRatio: this.pixelRatio_,
         pixelToCoordinateTransform: this.pixelToCoordinateTransform_,
         postRenderFunctions: [],

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -54,7 +54,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 
 /**
- * @typedef {function(PluggableMap, ?FrameState): boolean} PostRenderFunction
+ * @typedef {function(PluggableMap, ?FrameState): any} PostRenderFunction
  */
 
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -3,7 +3,6 @@
  */
 import {listen, unlistenByKey} from '../events.js';
 import EventType from '../events/EventType.js';
-import {getUid} from '../util.js';
 import {getChangeEventType} from '../Object.js';
 import BaseLayer from './Base.js';
 import LayerProperty from './Property.js';
@@ -219,7 +218,6 @@ class Layer extends BaseLayer {
           layerState.zIndex = Infinity;
         }
         renderEvent.frameState.layerStatesArray.push(layerState);
-        renderEvent.frameState.layerStates[getUid(this)] = layerState;
       }, this);
       this.mapRenderKey_ = listen(this, EventType.CHANGE, map.render, map);
       this.changed();

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -280,7 +280,9 @@ class MapRenderer extends Disposable {
    * @protected
    */
   scheduleExpireIconCache(frameState) {
-    frameState.postRenderFunctions.push(/** @type {import("../PluggableMap.js").PostRenderFunction} */ (expireIconCache));
+    if (iconImageCache.canExpireCache()) {
+      frameState.postRenderFunctions.push(expireIconCache);
+    }
   }
 
   /**

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -106,19 +106,14 @@ class MapRenderer extends Disposable {
     let result;
     const viewState = frameState.viewState;
     const viewResolution = viewState.resolution;
-    const managedLayers = frameState.layerStatesArray.map(function(state) {
-      if (state.managed) {
-        return getUid(state.layer);
-      }
-    });
 
     /**
+     * @param {boolean} managed Managed layer.
      * @param {import("../Feature.js").FeatureLike} feature Feature.
      * @param {import("../layer/Layer.js").default} layer Layer.
      * @return {?} Callback result.
      */
-    function forEachFeatureAtCoordinate(feature, layer) {
-      const managed = includes(managedLayers, getUid(layer));
+    function forEachFeatureAtCoordinate(managed, feature, layer) {
       if (!(getUid(feature) in frameState.skippedFeatureUids && !managed)) {
         return callback.call(thisArg, feature, managed ? layer : null);
       }
@@ -147,9 +142,10 @@ class MapRenderer extends Disposable {
         const layerRenderer = this.getLayerRenderer(layer);
         const source = layer.getSource();
         if (layerRenderer && source) {
+          const callback = forEachFeatureAtCoordinate.bind(null, layerState.managed);
           result = layerRenderer.forEachFeatureAtCoordinate(
             source.getWrapX() ? translatedCoordinate : coordinate,
-            frameState, hitTolerance, forEachFeatureAtCoordinate);
+            frameState, hitTolerance, callback);
         }
         if (result) {
           return result;

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -291,15 +291,7 @@ class MapRenderer extends Disposable {
    * @protected
    */
   scheduleRemoveUnusedLayerRenderers(frameState) {
-    const layersUids = getLayersUids(frameState.layerStatesArray);
-    for (const layerKey in this.layerRenderers_) {
-      if (!(includes(layersUids, layerKey))) {
-        frameState.postRenderFunctions.push(
-          /** @type {import("../PluggableMap.js").PostRenderFunction} */ (this.removeUnusedLayerRenderers_.bind(this))
-        );
-        return;
-      }
-    }
+    frameState.postRenderFunctions.push(this.removeUnusedLayerRenderers_.bind(this));
   }
 }
 

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -251,22 +251,6 @@ class MapRenderer extends Disposable {
   }
 
   /**
-   * @param {import("../PluggableMap.js").default} map Map.
-   * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
-   * @private
-   */
-  removeUnusedLayerRenderers_(map, frameState) {
-    if (frameState) {
-      const layerStatesMap = getLayerStatesMap(frameState.layerStatesArray);
-      for (const layerKey in this.layerRenderers_) {
-        if (!(layerKey in layerStatesMap)) {
-          this.removeLayerRendererByKey_(layerKey).dispose();
-        }
-      }
-    }
-  }
-
-  /**
    * Render.
    * @abstract
    * @param {?import("../PluggableMap.js").FrameState} frameState Frame state.
@@ -290,7 +274,14 @@ class MapRenderer extends Disposable {
    * @protected
    */
   scheduleRemoveUnusedLayerRenderers(frameState) {
-    frameState.postRenderFunctions.push(this.removeUnusedLayerRenderers_.bind(this));
+    const layerStatesMap = getLayerStatesMap(frameState.layerStatesArray);
+    for (const layerKey in this.layerRenderers_) {
+      if (!(layerKey in layerStatesMap)) {
+        frameState.postRenderFunctions.push(function() {
+          this.removeLayerRendererByKey_(layerKey).dispose();
+        }.bind(this));
+      }
+    }
   }
 }
 

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/renderer/Map
  */
-import {includes} from '../array.js';
 import {abstract, getUid} from '../util.js';
 import Disposable from '../Disposable.js';
 import {listen, unlistenByKey} from '../events.js';
@@ -258,9 +257,9 @@ class MapRenderer extends Disposable {
    */
   removeUnusedLayerRenderers_(map, frameState) {
     if (frameState) {
-      const layersUids = getLayersUids(frameState.layerStatesArray);
+      const layerStatesMap = getLayerStatesMap(frameState.layerStatesArray);
       for (const layerKey in this.layerRenderers_) {
-        if (!includes(layersUids, layerKey)) {
+        if (!(layerKey in layerStatesMap)) {
           this.removeLayerRendererByKey_(layerKey).dispose();
         }
       }
@@ -304,12 +303,13 @@ function expireIconCache(map, frameState) {
 
 /**
  * @param {Array<import("../layer/Layer.js").State>} layerStatesArray Layer states array.
- * @return {Array<string>} Layers uid.
+ * @return {Object<string, import("../layer/Layer.js").State>} States mapped by layer uid.
  */
-function getLayersUids(layerStatesArray) {
-  return layerStatesArray.map(function(state) {
-    return getUid(state.layer);
-  });
+function getLayerStatesMap(layerStatesArray) {
+  return layerStatesArray.reduce(function(acc, state) {
+    acc[getUid(state.layer)] = state;
+    return acc;
+  }, {});
 }
 
 /**

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -257,10 +257,12 @@ class MapRenderer extends Disposable {
    * @private
    */
   removeUnusedLayerRenderers_(map, frameState) {
-    const layersUids = getLayersUids(frameState.layerStatesArray);
-    for (const layerKey in this.layerRenderers_) {
-      if (!frameState || !(includes(layersUids, layerKey))) {
-        this.removeLayerRendererByKey_(layerKey).dispose();
+    if (frameState) {
+      const layersUids = getLayersUids(frameState.layerStatesArray);
+      for (const layerKey in this.layerRenderers_) {
+        if (!includes(layersUids, layerKey)) {
+          this.removeLayerRendererByKey_(layerKey).dispose();
+        }
       }
     }
   }

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/source/Raster
  */
-import {getUid} from '../util.js';
 import ImageCanvas from '../ImageCanvas.js';
 import TileQueue from '../TileQueue.js';
 import {createCanvasContext2D} from '../dom.js';
@@ -185,16 +184,6 @@ class RasterSource extends ImageSource {
       return 1;
     }, this.changed.bind(this));
 
-    const layerStatesArray = getLayerStatesArray(this.layers_);
-
-    /**
-     * @type {Object<string, import("../layer/Layer.js").State>}
-     */
-    const layerStates = {};
-    for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-      layerStates[getUid(layerStatesArray[i].layer)] = layerStatesArray[i];
-    }
-
     /**
      * The most recently requested frame state.
      * @type {import("../PluggableMap.js").FrameState}
@@ -225,8 +214,7 @@ class RasterSource extends ImageSource {
       extent: null,
       focus: null,
       index: 0,
-      layerStates: layerStates,
-      layerStatesArray: layerStatesArray,
+      layerStatesArray: getLayerStatesArray(this.layers_),
       pixelRatio: 1,
       pixelToCoordinateTransform: createTransform(),
       postRenderFunctions: [],

--- a/src/ol/style/IconImageCache.js
+++ b/src/ol/style/IconImageCache.js
@@ -38,10 +38,17 @@ class IconImageCache {
   }
 
   /**
+   * @return {boolean} Can expire cache.
+   */
+  canExpireCache() {
+    return this.cacheSize_ > this.maxCacheSize_;
+  }
+
+  /**
   * FIXME empty description for jsdoc
   */
   expire() {
-    if (this.cacheSize_ > this.maxCacheSize_) {
+    if (this.canExpireCache()) {
       let i = 0;
       for (const key in this.cache_) {
         const iconImage = this.cache_[key];

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -1,4 +1,3 @@
-import {getUid} from '../../../../src/ol/util.js';
 import Map from '../../../../src/ol/Map.js';
 import Layer, {visibleAtResolution} from '../../../../src/ol/layer/Layer.js';
 import {get as getProjection} from '../../../../src/ol/proj.js';
@@ -396,15 +395,12 @@ describe('ol.layer.Layer', function() {
           map: map
         });
         const frameState = {
-          layerStatesArray: [],
-          layerStates: {}
+          layerStatesArray: []
         };
-        map.dispatchEvent(new RenderEvent('precompose', null,
-          frameState, null, null));
+        map.dispatchEvent(new RenderEvent('precompose', null, frameState, null, null));
         expect(frameState.layerStatesArray.length).to.be(1);
         const layerState = frameState.layerStatesArray[0];
         expect(layerState.layer).to.equal(layer);
-        expect(frameState.layerStates[getUid(layer)]).to.equal(layerState);
       });
     });
 

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -1,4 +1,3 @@
-import {getUid} from '../../../../../src/ol/util.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';
@@ -203,14 +202,13 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       const spy = sinon.spy();
       const coordinate = [0, 0];
       const frameState = {
-        layerStates: {},
+        layerStatesArray: [{}],
         skippedFeatureUids: {},
         viewState: {
           resolution: 1,
           rotation: 0
         }
       };
-      frameState.layerStates[getUid(layer)] = {};
       renderer.forEachFeatureAtCoordinate(
         coordinate, frameState, 0, spy, undefined);
       expect(spy.callCount).to.be(1);

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -1,4 +1,3 @@
-import {getUid} from '../../../../../src/ol/util.js';
 import {clear} from '../../../../../src/ol/obj.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
@@ -329,7 +328,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       const spy = sinon.spy();
       const coordinate = [0, 0];
       const frameState = {
-        layerStates: {},
+        layerStatesArray: [{}],
         skippedFeatureUids: {},
         viewState: {
           projection: getProjection('EPSG:3857'),
@@ -337,7 +336,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
           rotation: 0
         }
       };
-      frameState.layerStates[getUid(layer)] = {};
       renderer.renderedTiles = [new TileClass([0, 0, -1], undefined, 1)];
       renderer.forEachFeatureAtCoordinate(
         coordinate, frameState, 0, spy, undefined);


### PR DESCRIPTION
We are currently maintaining two structures for the layers state in the frame state: `layerStates` and `layerStatesArray`. The pull request removes `layerStates`.

`layerStates` was only used in `ol/renderer/Map`.

~~An other change is that the layers removal function is now always scheduled.~~ see 1047fed