### PR TITLE
External types bugfix for jsdoc-plugin-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "istanbul": "0.4.5",
     "jquery": "3.3.1",
     "jsdoc": "3.5.5",
-    "jsdoc-plugin-typescript": "^1.0.3",
+    "jsdoc-plugin-typescript": "^1.0.4",
     "karma": "^3.1.1",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "^1.1.2",


### PR DESCRIPTION
Previous versions of jsdoc-plugin-typescript raised an exception when external types were used. This is fixed in the latest version. This pull request just updates the `devDependencies` to use that fixed version.