### PR TITLE
Always load tiles while animating and interacting

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,11 +2,6 @@
 
 ### Next version
 
-##### Removal of the AtlasManager
-
-Following the removal of the experimental WebGL renderer, the AtlasManager has been removed as well. The atlas was only used by this renderer.
-The non API `getChecksum` functions of the style is also removed.
-
 #### Backwards incompatible changes
 
 ##### New internal tile coordinates
@@ -113,6 +108,16 @@ The removed classes and components are:
 * `WebGLMap`
 * The shader build process using `mustache` and the `Makefile` at the root
 
+##### Removal of the AtlasManager
+
+Following the removal of the experimental WebGL renderer, the AtlasManager has been removed as well. The atlas was only used by this renderer.
+The non API `getChecksum` functions of the style is also removed.
+
+#### Other changes
+
+##### Always load tiles while animating or interacting
+
+`ol/PluggableMap` and subclasses no longer support the `loadTilesWhileAnimating` and `loadTilesWhileInteracting` options. These options were used to enable tile loading during animations and interactions. With the new DOM composition render strategy, it is no longer necessary to postpone tile loading until after animations or interactions.
 
 ### v5.3.0
 

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -24,9 +24,6 @@ const map = new Map({
       source: new OSM()
     })
   ],
-  // Improve user experience by loading tiles while animating. Will make
-  // animations stutter on mobile or slow devices.
-  loadTilesWhileAnimating: true,
   view: view
 });
 

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -29,9 +29,6 @@ for (i = 0, ii = styles.length; i < ii; ++i) {
 }
 const map = new Map({
   layers: layers,
-  // Improve user experience by loading tiles while dragging/zooming. Will make
-  // zooming choppy on mobile or slow devices.
-  loadTilesWhileInteracting: true,
   target: 'map',
   view: new View({
     center: [-6655.5402445057125, 6709968.258934638],

--- a/examples/feature-move-animation.js
+++ b/examples/feature-move-animation.js
@@ -124,7 +124,6 @@ const vectorLayer = new VectorLayer({
 const center = [-5639523.95, -3501274.52];
 const map = new Map({
   target: document.getElementById('map'),
-  loadTilesWhileAnimating: true,
   view: new View({
     center: center,
     zoom: 10,

--- a/examples/here-maps.js
+++ b/examples/here-maps.js
@@ -69,9 +69,6 @@ for (i = 0, ii = hereLayers.length; i < ii; ++i) {
 
 const map = new Map({
   layers: layers,
-  // Improve user experience by loading tiles while dragging/zooming. Will make
-  // zooming choppy on mobile or slow devices.
-  loadTilesWhileInteracting: true,
   target: 'map',
   view: new View({
     center: [921371.9389, 6358337.7609],

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -107,13 +107,6 @@ import {create as createTransform, apply as applyTransform} from './transform.js
  * layer.
  * @property {number} [maxTilesLoading=16] Maximum number tiles to load
  * simultaneously.
- * @property {boolean} [loadTilesWhileAnimating=false] When set to `true`, tiles
- * will be loaded during animations. This may improve the user experience, but
- * can also make animations stutter on devices with slow memory.
- * @property {boolean} [loadTilesWhileInteracting=false] When set to `true`,
- * tiles will be loaded while interacting with the map. This may improve the
- * user experience, but can also make map panning and zooming choppy on devices
- * with slow memory.
  * @property {number} [moveTolerance=1] The minimum distance in pixels the
  * cursor must move to be detected as a map move event instead of a click.
  * Increasing this value can make it easier to click on the map.
@@ -153,22 +146,6 @@ class PluggableMap extends BaseObject {
      * @private
      */
     this.maxTilesLoading_ = options.maxTilesLoading !== undefined ? options.maxTilesLoading : 16;
-
-    /**
-     * @type {boolean}
-     * @private
-     */
-    this.loadTilesWhileAnimating_ =
-        options.loadTilesWhileAnimating !== undefined ?
-          options.loadTilesWhileAnimating : false;
-
-    /**
-     * @type {boolean}
-     * @private
-     */
-    this.loadTilesWhileInteracting_ =
-        options.loadTilesWhileInteracting !== undefined ?
-          options.loadTilesWhileInteracting : false;
 
     /**
      * @private
@@ -957,12 +934,8 @@ class PluggableMap extends BaseObject {
       let maxNewLoads = maxTotalLoading;
       if (frameState) {
         const hints = frameState.viewHints;
-        if (hints[ViewHint.ANIMATING]) {
-          maxTotalLoading = this.loadTilesWhileAnimating_ ? 8 : 0;
-          maxNewLoads = 2;
-        }
-        if (hints[ViewHint.INTERACTING]) {
-          maxTotalLoading = this.loadTilesWhileInteracting_ ? 8 : 0;
+        if (hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING]) {
+          maxTotalLoading = 8;
           maxNewLoads = 2;
         }
       }


### PR DESCRIPTION
Thanks to the new DOM composition, loading tiles while animating or interacting does not negatively impact the user experience anymore. So we can remove the `loadTilesWhileAnimating` and `loadTilesWhileInteracting` options.