### PR TITLE
Make package.json valid json object

### DIFF
--- a/doc/tutorials/bundle.md
+++ b/doc/tutorials/bundle.md
@@ -11,7 +11,9 @@ In this tutorial, we will be using [Parcel](https://parceljs.org) to bundle our 
 
 ## Initial steps
 
-Create a new empty directory for your project and navigate to it by running `mkdir new-project && cd new-project`. Initialize your project using `npm init` and answer the questions asked.
+Create a new empty directory for your project and navigate to it by running `mkdir new-project && cd new-project`. Initialize your project with
+
+    npm init
 
 Add OpenLayers as dependency to your application with
 
@@ -73,11 +75,17 @@ With simple scripts you can introduce the commands `npm run build` and `npm star
 
 ```json
 {
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "parcel index.html",
     "build": "parcel build --public-url . index.html"
-  }
+  },
+  "author": "",
+  "license": "ISC"
 }
 ```
 That's it. Now to run your application, enter

--- a/doc/tutorials/bundle.md
+++ b/doc/tutorials/bundle.md
@@ -15,7 +15,7 @@ Create a new empty directory for your project and navigate to it by running `mkd
 
     npm init
 
-Add OpenLayers as dependency to your application with
+This will create a `package.json` file in your working directory. Add OpenLayers as dependency to your application with
 
     npm install ol
 
@@ -71,7 +71,7 @@ You will also need an `index.html` file that will use your bundle. Here is a sim
 
 ## Creating a bundle
 
-With simple scripts you can introduce the commands `npm run build` and `npm start` to manually build your bundle and watch for changes, respectively. Add the following to the script section in `package.json`:
+With two additional lines in `package.json` you can introduce the commands `npm run build` and `npm start` to manually build your bundle and watch for changes, respectively. The final `package.json` with the two additional commands `"start"` and `"build"` should look like this:
 
 ```json
 {

--- a/doc/tutorials/bundle.md
+++ b/doc/tutorials/bundle.md
@@ -72,10 +72,12 @@ You will also need an `index.html` file that will use your bundle. Here is a sim
 With simple scripts you can introduce the commands `npm run build` and `npm start` to manually build your bundle and watch for changes, respectively. Add the following to the script section in `package.json`:
 
 ```json
-"scripts": {
-  "test": "echo \"Error: no test specified\" && exit 1",
-  "start": "parcel index.html",
-  "build": "parcel build --public-url . index.html"
+{
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "parcel index.html",
+    "build": "parcel build --public-url . index.html"
+  }
 }
 ```
 That's it. Now to run your application, enter


### PR DESCRIPTION
Hi openlayers! I'm following the *[Building an OpenLayers Application](https://openlayers.org/en/latest/doc/tutorials/bundle.html)* tutorial and node complains the included `package.json` is not properly formatted. Ran the snippet through [JSONLint](https://jsonlint.com/) and sure enough it's missing the enclosing pair of brackets `{ }`. After wrapping in brackets `npm start` runs without complaint! Hopefully this change will prevent future tutorial-followers a couple minutes of head scratching.