### PR TITLE
Add TilePixelRatio to Zoomify

### DIFF
--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -244,6 +244,7 @@ class Zoomify extends TileImage {
       cacheSize: options.cacheSize,
       crossOrigin: options.crossOrigin,
       projection: options.projection,
+      tilePixelRatio: options.tilePixelRatio,
       reprojectionErrorThreshold: options.reprojectionErrorThreshold,
       tileClass: ZoomifyTileClass,
       tileGrid: tileGrid,

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -251,10 +251,6 @@ class Zoomify extends TileImage {
       tileUrlFunction: tileUrlFunction,
       transition: options.transition
     });
-    
-    console.log("ollll1",this.tilePixelRatio_)
-    console.log("ollll2",this._tilePixelRatio)
-    console.log("ollll3",this.tilePixelRatio)
 
   }
 

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -251,6 +251,10 @@ class Zoomify extends TileImage {
       tileUrlFunction: tileUrlFunction,
       transition: options.transition
     });
+    
+    console.log("ollll1",this.tilePixelRatio_)
+    console.log("ollll2",this._tilePixelRatio)
+    console.log("ollll3",this.tilePixelRatio)
 
   }
 

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -87,6 +87,7 @@ export class CustomTile extends ImageTile {
  * you must provide a `crossOrigin` value  you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection.
+ * @property {number} [tilePixelRatio] The pixel ratio used by the tile service. For example, if the tile service advertizes 256px by 256px tiles but actually sends 512px by 512px images (for retina/hidpi devices) then `tilePixelRatio` should be set to `2`
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {string} [url] URL template or base URL of the Zoomify service.


### PR DESCRIPTION
Fix a bug where you can't specify the pixel ratio of zoomify tiles.

I found this issue that may be related:
https://github.com/openlayers/openlayers/issues/7795

But I encountered the problem myself. I could create an issue but it is only one line of code.