### PR TITLE
Properly unregister prepareTile listeners

### DIFF
--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -281,6 +281,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       layer.changed();
       renderer.renderFrame(frameState, {});
       expect(replayState.renderedTileRevision).to.be(revision + 1);
+      expect(Object.keys(renderer.tileListenerKeys_).length).to.be(0);
     });
   });
 


### PR DESCRIPTION
#9058 left us with stale `prepareTile` listeners on not yet loaded tiles. This pull request changes things so these listeners are properly unregistered.