### PR TITLE
Use less render cycles for vector tile layers

### DIFF
--- a/examples/mapbox-style.js
+++ b/examples/mapbox-style.js
@@ -1,3 +1,3 @@
 import apply from 'ol-mapbox-style';
 
-apply('map', 'https://maps.tilehosting.com/styles/bright/style.json?key=ER67WIiPdCQvhgsUjoWK');
+apply('map', 'https://maps.tilehosting.com/styles/topo/style.json?key=ER67WIiPdCQvhgsUjoWK');

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "loglevelnext": "^3.0.0",
     "marked": "0.6.0",
     "mocha": "5.2.0",
-    "ol-mapbox-style": "^3.6.2",
+    "ol-mapbox-style": "^3.6.3",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "proj4": "2.5.0",

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -524,12 +524,10 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @param {import('../../PluggableMap.js').FrameState} frameState Frame state.
    */
   renderTileImages_(hifi, frameState) {
-    // Even when we have time to render hifi, do not spend more than 100 ms in this render frame,
-    // to avoid delays when the user starts interacting again with the map.
-    // When we don't have time to render hifi, only render lowres tiles until we have used up
+    // When we don't have time to render hifi, only render tiles until we have used up
     // half of the frame budget of 16 ms
     for (const uid in this.renderTileImageQueue_) {
-      if (Date.now() - frameState.time > (hifi ? 100 : 8)) {
+      if (!hifi && Date.now() - frameState.time > 8) {
         break;
       }
       const tile = this.renderTileImageQueue_[uid];


### PR DESCRIPTION
This pull request changes the rendering of queued tile images so the whole queue is processed when in hifi mode (i.e. not animating or interacting). This avoids excess render cycles that would also require render time for replaying declutter groups, resulting in faster overall rendering.

This also solves the problem that when more than 100 ms were already spent in a render frame, additional frames would never be rendered, causing an endless loop.

To show the benefit of this change, I also changed the style used in the `mapbox-style` example to a more resource demanding map.