### PR TITLE
Avoid clipping when rendering to tiles that don't exceed the clip extent

### DIFF
--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -55,26 +55,18 @@ const p4 = [];
 
 class Executor extends Disposable {
   /**
-   * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The replay can have overlapping geometries.
    * @param {?} declutterTree Declutter tree.
    * @param {SerializableInstructions} instructions The serializable instructions
    */
-  constructor(maxExtent, resolution, pixelRatio, overlaps, declutterTree, instructions) {
+  constructor(resolution, pixelRatio, overlaps, declutterTree, instructions) {
     super();
     /**
      * @type {?}
      */
     this.declutterTree = declutterTree;
-
-    /**
-     * @protected
-     * @const
-     * @type {import("../../extent.js").Extent}
-     */
-    this.maxExtent = maxExtent;
 
     /**
      * @protected

--- a/test/spec/ol/render/canvas/textbuilder.test.js
+++ b/test/spec/ol/render/canvas/textbuilder.test.js
@@ -28,7 +28,7 @@ function createContext() {
 function executeInstructions(builder, expectedDrawTextImageCalls, expectedBuilderImageCalls) {
   const transform = createTransform();
   const context = createContext();
-  const executor = new Executor([-180, -90, 180, 90], 0.02, 1, false, null, builder.finish());
+  const executor = new Executor(0.02, 1, false, null, builder.finish());
   sinon.spy(executor, 'drawTextImageWithPointPlacement_');
   const replayImageStub = sinon.stub(executor, 'replayImage_');
   executor.execute(context, transform);


### PR DESCRIPTION
Currently we do a lot of unnecessary and memory intensive clipping when rendering to vector tiles. This pull request changes things so we avoid these clippings.