### PR TITLE
Safer check for window.screen

### DIFF
--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -75,8 +75,9 @@ class TileSource extends Source {
       if (tileGrid) {
         toSize(tileGrid.getTileSize(tileGrid.getMinZoom()), tileSize);
       }
-      const width = screen ? (screen.availWidth || screen.width) : 1920;
-      const height = screen ? (screen.availHeight || screen.height) : 1080;
+      const canUseScreen = 'screen ' in self;
+      const width = canUseScreen ? (screen.availWidth || screen.width) : 1920;
+      const height = canUseScreen ? (screen.availHeight || screen.height) : 1080;
       cacheSize = 2 * Math.ceil(width / tileSize[0]) * Math.ceil(height / tileSize[1]);
     }
 


### PR DESCRIPTION
When a source is instantiated in an environment different than `window` (e.g. a worker), the check for availability of `window.screen` fails. This pull request fixes that.