### PR TITLE
Use type template for the source type of layers

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -891,7 +891,7 @@ class Draw extends PointerInteraction {
       this.sketchFeature_ = null;
       this.sketchPoint_ = null;
       this.sketchLine_ = null;
-      /** @type {VectorSource} */ (this.overlay_.getSource()).clear(true);
+      this.overlay_.getSource().clear(true);
     }
     return sketchFeature;
   }
@@ -930,7 +930,7 @@ class Draw extends PointerInteraction {
     if (this.sketchPoint_) {
       sketchFeatures.push(this.sketchPoint_);
     }
-    const overlaySource = /** @type {VectorSource} */ (this.overlay_.getSource());
+    const overlaySource = this.overlay_.getSource();
     overlaySource.clear(true);
     overlaySource.addFeatures(sketchFeatures);
   }

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -242,7 +242,7 @@ class ExtentInteraction extends PointerInteraction {
         extentFeature = new Feature(polygonFromExtent(extent));
       }
       this.extentFeature_ = extentFeature;
-      /** @type {VectorSource} */ (this.extentOverlay_.getSource()).addFeature(extentFeature);
+      this.extentOverlay_.getSource().addFeature(extentFeature);
     } else {
       if (!extent) {
         extentFeature.setGeometry(undefined);
@@ -263,7 +263,7 @@ class ExtentInteraction extends PointerInteraction {
     if (!vertexFeature) {
       vertexFeature = new Feature(new Point(vertex));
       this.vertexFeature_ = vertexFeature;
-      /** @type {VectorSource} */ (this.vertexOverlay_.getSource()).addFeature(vertexFeature);
+      this.vertexOverlay_.getSource().addFeature(vertexFeature);
     } else {
       const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(vertex);

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -368,7 +368,7 @@ class Modify extends PointerInteraction {
     // Remove the vertex feature if the collection of canditate features
     // is empty.
     if (this.vertexFeature_ && this.features_.getLength() === 0) {
-      /** @type {VectorSource} */ (this.overlay_.getSource()).removeFeature(this.vertexFeature_);
+      this.overlay_.getSource().removeFeature(this.vertexFeature_);
       this.vertexFeature_ = null;
     }
     unlisten(feature, EventType.CHANGE,
@@ -407,7 +407,7 @@ class Modify extends PointerInteraction {
    */
   setActive(active) {
     if (this.vertexFeature_ && !active) {
-      /** @type {VectorSource} */ (this.overlay_.getSource()).removeFeature(this.vertexFeature_);
+      this.overlay_.getSource().removeFeature(this.vertexFeature_);
       this.vertexFeature_ = null;
     }
     super.setActive(active);
@@ -658,7 +658,7 @@ class Modify extends PointerInteraction {
     if (!vertexFeature) {
       vertexFeature = new Feature(new Point(coordinates));
       this.vertexFeature_ = vertexFeature;
-      /** @type {VectorSource} */ (this.overlay_.getSource()).addFeature(vertexFeature);
+      this.overlay_.getSource().addFeature(vertexFeature);
     } else {
       const geometry = /** @type {Point} */ (vertexFeature.getGeometry());
       geometry.setCoordinates(coordinates);
@@ -944,7 +944,7 @@ class Modify extends PointerInteraction {
       }
     }
     if (this.vertexFeature_) {
-      /** @type {VectorSource} */ (this.overlay_.getSource()).removeFeature(this.vertexFeature_);
+      this.overlay_.getSource().removeFeature(this.vertexFeature_);
       this.vertexFeature_ = null;
     }
   }
@@ -1139,7 +1139,7 @@ class Modify extends PointerInteraction {
         }
         this.updateSegmentIndices_(geometry, index, segmentData.depth, -1);
         if (this.vertexFeature_) {
-          /** @type {VectorSource} */ (this.overlay_.getSource()).removeFeature(this.vertexFeature_);
+          this.overlay_.getSource().removeFeature(this.vertexFeature_);
           this.vertexFeature_ = null;
         }
         dragSegments.length = 0;

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -275,7 +275,7 @@ class Select extends Interaction {
    * @api
    */
   getFeatures() {
-    return /** @type {VectorSource} */ (this.featureOverlay_.getSource()).getFeaturesCollection();
+    return this.featureOverlay_.getSource().getFeaturesCollection();
   }
 
   /**

--- a/src/ol/layer/BaseImage.js
+++ b/src/ol/layer/BaseImage.js
@@ -34,6 +34,7 @@ import Layer from './Layer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
+ * @extends {Layer<import("../source/Image.js").default>}
  * @api
  */
 class BaseImageLayer extends Layer {
@@ -48,12 +49,4 @@ class BaseImageLayer extends Layer {
 
 }
 
-
-/**
- * Return the associated {@link module:ol/source/Image source} of the image layer.
- * @function
- * @return {import("../source/Image.js").default} Source.
- * @api
- */
-BaseImageLayer.prototype.getSource;
 export default BaseImageLayer;

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -39,6 +39,7 @@ import {assign} from '../obj.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
+ * @extends {Layer<import("../source/Tile.js").default>}
  * @api
  */
 class BaseTileLayer extends Layer {
@@ -100,15 +101,6 @@ class BaseTileLayer extends Layer {
     this.set(TileProperty.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
   }
 }
-
-
-/**
- * Return the associated {@link module:ol/source/Tile tilesource} of the layer.
- * @function
- * @return {import("../source/Tile.js").default} Source.
- * @api
- */
-BaseTileLayer.prototype.getSource;
 
 
 export default BaseTileLayer;

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -61,6 +61,8 @@ const Property = {
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
+ * @template {import("../source/Vector.js").default|import("../source/VectorTile.js").default} VectorSourceType
+ * @extends {Layer<VectorSourceType>}
  * @api
  */
 class BaseVectorLayer extends Layer {
@@ -217,15 +219,6 @@ class BaseVectorLayer extends Layer {
   }
 
 }
-
-
-/**
- * Return the associated {@link module:ol/source/Vector vectorsource} of the layer.
- * @function
- * @return {import("../source/Vector.js").default} Source.
- * @api
- */
-BaseVectorLayer.prototype.getSource;
 
 
 export default BaseVectorLayer;

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -437,7 +437,7 @@ class Graticule extends VectorLayer {
    * @param {import("../proj/Projection.js").default} projection Projection
    */
   loaderFunction(extent, resolution, projection) {
-    const source = /** @type {import("../source/Vector.js").default} */ (this.getSource());
+    const source = this.getSource();
 
     // only consider the intersection between our own extent & the requested one
     const layerExtent = this.getExtent() || [-Infinity, -Infinity, Infinity, Infinity];

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -62,6 +62,8 @@ import SourceState from '../source/State.js';
  *
  * @fires import("../render/Event.js").RenderEvent#prerender
  * @fires import("../render/Event.js").RenderEvent#postrender
+ *
+ * @template {import("../source/Source.js").default} SourceType
  */
 class Layer extends BaseLayer {
   /**
@@ -106,7 +108,7 @@ class Layer extends BaseLayer {
       getChangeEventType(LayerProperty.SOURCE),
       this.handleSourcePropertyChange_, this);
 
-    const source = options.source ? options.source : null;
+    const source = options.source ? /** @type {SourceType} */ (options.source) : null;
     this.setSource(source);
   }
 
@@ -130,15 +132,12 @@ class Layer extends BaseLayer {
 
   /**
    * Get the layer source.
-   * @return {import("../source/Source.js").default} The layer source (or `null` if not yet set).
+   * @return {SourceType} The layer source (or `null` if not yet set).
    * @observable
    * @api
    */
   getSource() {
-    const source = this.get(LayerProperty.SOURCE);
-    return (
-      /** @type {import("../source/Source.js").default} */ (source) || null
-    );
+    return /** @type {SourceType} */ (this.get(LayerProperty.SOURCE)) || null;
   }
 
   /**
@@ -227,7 +226,7 @@ class Layer extends BaseLayer {
 
   /**
    * Set the layer source.
-   * @param {import("../source/Source.js").default} source The layer source.
+   * @param {SourceType} source The layer source.
    * @observable
    * @api
    */

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -17,6 +17,7 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
+ * @extends {BaseVectorLayer<import("../source/Vector.js").default>}
  * @api
  */
 class VectorLayer extends BaseVectorLayer {

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -70,6 +70,7 @@ import {assign} from '../obj.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @param {Options=} opt_options Options.
+ * @extends {BaseVectorLayer<import("../source/VectorTile.js").default>}
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
@@ -165,11 +166,4 @@ class VectorTileLayer extends BaseVectorLayer {
 }
 
 
-/**
- * Return the associated {@link module:ol/source/VectorTile vectortilesource} of the layer.
- * @function
- * @return {import("../source/VectorTile.js").default} Source.
- * @api
- */
-VectorTileLayer.prototype.getSource;
 export default VectorTileLayer;

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -44,7 +44,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     const viewResolution = viewState.resolution;
 
     const imageLayer = /** @type {import("../../layer/Image.js").default} */ (this.getLayer());
-    const imageSource = /** @type {import("../../source/Image.js").default} */ (imageLayer.getSource());
+    const imageSource = imageLayer.getSource();
 
     const hints = frameState.viewHints;
 

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -88,7 +88,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    */
   getTile(z, x, y, pixelRatio, projection) {
     const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
-    const tileSource = /** @type {import("../../source/Tile.js").default} */ (tileLayer.getSource());
+    const tileSource = tileLayer.getSource();
     let tile = tileSource.getTile(z, x, y, pixelRatio, projection);
     if (tile.getState() == TileState.ERROR) {
       if (!tileLayer.getUseInterimTilesOnError()) {
@@ -130,7 +130,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     const pixelRatio = frameState.pixelRatio;
 
     const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
-    const tileSource = /** @type {import("../../source/Tile.js").default} */ (tileLayer.getSource());
+    const tileSource = tileLayer.getSource();
     const sourceRevision = tileSource.getRevision();
     const tileGrid = tileSource.getTileGridForProjection(projection);
     const z = tileGrid.getZForResolution(viewResolution, this.zDirection);
@@ -334,7 +334,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     const uid = getUid(this);
     const alpha = transition ? tile.getAlpha(uid, frameState.time) : 1;
     const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
-    const tileSource = /** @type {import("../../source/Tile.js").default} */ (tileLayer.getSource());
+    const tileSource = tileLayer.getSource();
     if (alpha === 1 && !tileSource.getOpaque(frameState.viewState.projection)) {
       this.context.clearRect(x, y, w, h);
     }

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -129,7 +129,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const projection = viewState.projection;
     const rotation = viewState.rotation;
     const projectionExtent = projection.getExtent();
-    const vectorSource = /** @type {import("../../source/Vector.js").default} */ (this.getLayer().getSource());
+    const vectorSource = this.getLayer().getSource();
 
     // clipped rendering if layer extent is set
     const clipExtent = layerState.extent;
@@ -239,7 +239,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    */
   prepareFrame(frameState, layerState) {
     const vectorLayer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
-    const vectorSource = /** @type {import("../../source/Vector.js").default} */ (vectorLayer.getSource());
+    const vectorSource = vectorLayer.getSource();
 
     const animating = frameState.viewHints[ViewHint.ANIMATING];
     const interacting = frameState.viewHints[ViewHint.INTERACTING];

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -229,7 +229,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @private
    */
   updateExecutorGroup_(tile, pixelRatio, projection) {
-    const layer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
+    const layer = /** @type {import("../../layer/VectorTile.js").default} */ (this.getLayer());
     const revision = layer.getRevision();
     const renderOrder = /** @type {import("../../render.js").OrderFunction} */ (layer.getRenderOrder()) || null;
 
@@ -239,7 +239,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       return;
     }
 
-    const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
+    const source = layer.getSource();
     const sourceTileGrid = source.getTileGrid();
     const tileGrid = source.getTileGridForProjection(projection);
     const zoom = tile.tileCoord[0];
@@ -334,7 +334,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const rotation = frameState.viewState.rotation;
     hitTolerance = hitTolerance == undefined ? 0 : hitTolerance;
     const layer = this.getLayer();
-    const source = /** @type {import("../../source/VectorTile").default} */ (layer.getSource());
+    const source = layer.getSource();
     const tileGrid = source.getTileGridForProjection(frameState.viewState.projection);
     /** @type {!Object<string, boolean>} */
     const features = {};
@@ -378,7 +378,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    */
   getReplayTransform_(tile, frameState) {
     const layer = this.getLayer();
-    const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
+    const source = layer.getSource();
     const tileGrid = source.getTileGrid();
     const tileCoord = tile.tileCoord;
     const tileResolution = tileGrid.getResolution(tileCoord[0]);
@@ -435,7 +435,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
     const context = this.overlayContext_;
     const declutterReplays = layer.getDeclutter() ? {} : null;
-    const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
+    const source = layer.getSource();
     const replayTypes = VECTOR_REPLAYS[renderMode];
     const pixelRatio = frameState.pixelRatio;
     const rotation = frameState.viewState.rotation;
@@ -608,7 +608,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     replayState.renderedTileZ = tile.sourceZ;
     const tileCoord = tile.wrappedTileCoord;
     const z = tileCoord[0];
-    const source = /** @type {import("../../source/VectorTile.js").default} */ (layer.getSource());
+    const source = layer.getSource();
     const tileGrid = source.getTileGridForProjection(projection);
     const resolution = tileGrid.getResolution(z);
     const context = tile.getContext(layer);

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -264,7 +264,7 @@ class WebGLPointsLayerRenderer extends LayerRenderer {
    */
   prepareFrame(frameState) {
     const vectorLayer = /** @type {import("../../layer/Vector.js").default} */ (this.getLayer());
-    const vectorSource = /** @type {import("../../source/Vector.js").default} */ (vectorLayer.getSource());
+    const vectorSource = vectorLayer.getSource();
 
     const stride = 12;
 


### PR DESCRIPTION
By using a generic type for the source type of a layer class (18c4c55), all the type casts for the `getSource` function can be removed (3d5a2e8).

(Thanks to @sbrunner for finding this!)