### PR TITLE
JSDoc fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "istanbul": "0.4.5",
     "jquery": "3.3.1",
     "jsdoc": "3.5.5",
-    "jsdoc-plugin-typescript": "^1.0.4",
+    "jsdoc-plugin-typescript": "^1.0.6",
     "karma": "^4.0.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "^1.1.2",

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -19,21 +19,21 @@ const ImageSourceEventType = {
 
   /**
    * Triggered when an image starts loading.
-   * @event ol/source/Image~ImageSourceEvent#imageloadstart
+   * @event module:ol/source/Image.ImageSourceEvent#imageloadstart
    * @api
    */
   IMAGELOADSTART: 'imageloadstart',
 
   /**
    * Triggered when an image finishes loading.
-   * @event ol/source/Image~ImageSourceEvent#imageloadend
+   * @event module:ol/source/Image.ImageSourceEvent#imageloadend
    * @api
    */
   IMAGELOADEND: 'imageloadend',
 
   /**
    * Triggered if image loading results in an error.
-   * @event ol/source/Image~ImageSourceEvent#imageloaderror
+   * @event module:ol/source/Image.ImageSourceEvent#imageloaderror
    * @api
    */
   IMAGELOADERROR: 'imageloaderror'
@@ -46,7 +46,7 @@ const ImageSourceEventType = {
  * Events emitted by {@link module:ol/source/Image~ImageSource} instances are instances of this
  * type.
  */
-class ImageSourceEvent extends Event {
+export class ImageSourceEvent extends Event {
   /**
    * @param {string} type Type.
    * @param {import("../Image.js").default} image The image.
@@ -82,6 +82,7 @@ class ImageSourceEvent extends Event {
  * instantiated in apps.
  * Base class for sources providing a single image.
  * @abstract
+ * @fires module:ol/source/Image.ImageSourceEvent
  * @api
  */
 class ImageSource extends Source {
@@ -235,6 +236,5 @@ class ImageSource extends Source {
 export function defaultImageLoadFunction(image, src) {
   /** @type {HTMLImageElement|HTMLVideoElement} */ (image.getImage()).src = src;
 }
-
 
 export default ImageSource;

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -47,7 +47,7 @@ import {appendParams} from '../uri.js';
  * take advantage of ol image caching and use
  * {@link module:ol/source/TileArcGISRest} data source.
  *
- * @fires ol/source/Image~ImageSourceEvent
+ * @fires module:ol/source/Image.ImageSourceEvent
  * @api
  */
 class ImageArcGISRest extends ImageSource {

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -35,7 +35,7 @@ import {appendParams} from '../uri.js';
  * @classdesc
  * Source for images from Mapguide servers
  *
- * @fires ol/source/Image~ImageSourceEvent
+ * @fires module:ol/source/Image.ImageSourceEvent
  * @api
  */
 class ImageMapGuide extends ImageSource {

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -54,7 +54,7 @@ const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
  * @classdesc
  * Source for WMS servers providing single, untiled images.
  *
- * @fires ol/source/Image~ImageSourceEvent
+ * @fires module:ol/source/Image.ImageSourceEvent
  * @api
  */
 class ImageWMS extends ImageSource {

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -44,14 +44,14 @@ import Source from './Source.js';
 const RasterEventType = {
   /**
    * Triggered before operations are run.
-   * @event ol/source/Raster~RasterSourceEvent#beforeoperations
+   * @event module:ol/source/Raster.RasterSourceEvent#beforeoperations
    * @api
    */
   BEFOREOPERATIONS: 'beforeoperations',
 
   /**
    * Triggered after operations are run.
-   * @event ol/source/Raster~RasterSourceEvent#afteroperations
+   * @event module:ol/source/Raster.RasterSourceEvent#afteroperations
    * @api
    */
   AFTEROPERATIONS: 'afteroperations'
@@ -73,7 +73,7 @@ const RasterOperationType = {
  * Events emitted by {@link module:ol/source/Raster} instances are instances of this
  * type.
  */
-class RasterSourceEvent extends Event {
+export class RasterSourceEvent extends Event {
   /**
    * @param {string} type Type.
    * @param {import("../PluggableMap.js").FrameState} frameState The frame state.
@@ -135,7 +135,7 @@ class RasterSourceEvent extends Event {
  * {@link module:ol/source/Raster~Operation} function to transform input pixel values into
  * output pixel values.
  *
- * @fires ol/source/Raster~RasterSourceEvent
+ * @fires module:ol/source/Raster.RasterSourceEvent
  * @api
  */
 class RasterSource extends ImageSource {

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -21,7 +21,7 @@ import SourceState from './State.js';
  * It represents either
  * * a simple string (e.g. `'© Acme Inc.'`)
  * * an array of simple strings (e.g. `['© Acme Inc.', '© Bacme Inc.']`)
- * * a function that returns a string or array of strings (`{@link module:ol/source/Source~Attribution}`)
+ * * a function that returns a string or array of strings ({@link module:ol/source/Source~Attribution})
  *
  * @typedef {string|Array<string>|Attribution} AttributionLike
  */
@@ -155,7 +155,7 @@ class Source extends BaseObject {
   /**
    * Set the attributions of the source.
    * @param {AttributionLike|undefined} attributions Attributions.
-   *     Can be passed as `string`, `Array<string>`, `{@link module:ol/source/Source~Attribution}`,
+   *     Can be passed as `string`, `Array<string>`, {@link module:ol/source/Source~Attribution},
    *     or `undefined`.
    * @api
    */

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -154,7 +154,7 @@ export class VectorSourceEvent extends Event {
  * by this source are suitable for editing. See {@link module:ol/source/VectorTile~VectorTile} for
  * vector data that is optimized for rendering.
  *
- * @fires ol/source/Vector.VectorSourceEvent
+ * @fires VectorSourceEvent
  * @api
  */
 class VectorSource extends Source {

--- a/src/ol/source/VectorEventType.js
+++ b/src/ol/source/VectorEventType.js
@@ -8,21 +8,21 @@
 export default {
   /**
    * Triggered when a feature is added to the source.
-   * @event ol/source/Vector.VectorSourceEvent#addfeature
+   * @event module:ol/source/Vector.VectorSourceEvent#addfeature
    * @api
    */
   ADDFEATURE: 'addfeature',
 
   /**
    * Triggered when a feature is updated.
-   * @event ol/source/Vector.VectorSourceEvent#changefeature
+   * @event module:ol/source/Vector.VectorSourceEvent#changefeature
    * @api
    */
   CHANGEFEATURE: 'changefeature',
 
   /**
    * Triggered when the clear method is called on the source.
-   * @event ol/source/Vector.VectorSourceEvent#clear
+   * @event module:ol/source/Vector.VectorSourceEvent#clear
    * @api
    */
   CLEAR: 'clear',
@@ -30,7 +30,7 @@ export default {
   /**
    * Triggered when a feature is removed from the source.
    * See {@link module:ol/source/Vector#clear source.clear()} for exceptions.
-   * @event ol/source/Vector.VectorSourceEvent#removefeature
+   * @event module:ol/source/Vector.VectorSourceEvent#removefeature
    * @api
    */
   REMOVEFEATURE: 'removefeature'


### PR DESCRIPTION
This pull request fixes a few issues with the API docs:

* Missing inherited methods on some classes. Fixed with an update of `jsdoc-plugin-typescript`.
* Missing documentation of some events. Fixed with correct module paths for `@event` and `@fires` and by exporting the event classes.