### PR TITLE
Add test to verify that removefeature is triggered

### DIFF
--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -259,6 +259,13 @@ describe('ol.source.Vector', function() {
         expect(listener).to.be.called();
       });
 
+      it('fires a removefeature event', function() {
+        const listener = sinon.spy();
+        listen(vectorSource, 'removefeature', listener);
+        vectorSource.removeFeature(features[0]);
+        expect(listener).to.be.called();
+      });
+
     });
 
     describe('modifying a feature\'s geometry', function() {


### PR DESCRIPTION
Attempt to reproduce #9162. Obviously the `removefeature` event is triggered, so this fixes #9162.