### PR TITLE
Fix MultiPolygon area calculation

### DIFF
--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -16,7 +16,7 @@ import {deflateMultiCoordinatesArray} from './flat/deflate.js';
 import {inflateMultiCoordinatesArray} from './flat/inflate.js';
 import {getInteriorPointsOfMultiArray} from './flat/interiorpoint.js';
 import {intersectsLinearRingMultiArray} from './flat/intersectsextent.js';
-import {linearRingsAreOriented, orientLinearRingsArray} from './flat/orient.js';
+import {linearRingssAreOriented, orientLinearRingsArray} from './flat/orient.js';
 import {quantizeMultiArray} from './flat/simplify.js';
 
 /**
@@ -251,7 +251,7 @@ class MultiPolygon extends SimpleGeometry {
   getOrientedFlatCoordinates() {
     if (this.orientedRevision_ != this.getRevision()) {
       const flatCoordinates = this.flatCoordinates;
-      if (linearRingsAreOriented(
+      if (linearRingssAreOriented(
         flatCoordinates, 0, this.endss_, this.stride)) {
         this.orientedFlatCoordinates_ = flatCoordinates;
       } else {

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -16,7 +16,7 @@ import {deflateCoordinatesArray} from './flat/deflate.js';
 import {inflateCoordinatesArray} from './flat/inflate.js';
 import {getInteriorPointOfArray} from './flat/interiorpoint.js';
 import {intersectsLinearRingArray} from './flat/intersectsextent.js';
-import {linearRingIsOriented, orientLinearRings} from './flat/orient.js';
+import {linearRingsAreOriented, orientLinearRings} from './flat/orient.js';
 import {quantizeArray} from './flat/simplify.js';
 import {modulo} from '../math.js';
 
@@ -266,7 +266,7 @@ class Polygon extends SimpleGeometry {
   getOrientedFlatCoordinates() {
     if (this.orientedRevision_ != this.getRevision()) {
       const flatCoordinates = this.flatCoordinates;
-      if (linearRingIsOriented(
+      if (linearRingsAreOriented(
         flatCoordinates, 0, this.ends_, this.stride)) {
         this.orientedFlatCoordinates_ = flatCoordinates;
       } else {

--- a/src/ol/geom/flat/orient.js
+++ b/src/ol/geom/flat/orient.js
@@ -41,7 +41,7 @@ export function linearRingIsClockwise(flatCoordinates, offset, end, stride) {
  *     (counter-clockwise exterior ring and clockwise interior rings).
  * @return {boolean} Rings are correctly oriented.
  */
-export function linearRingIsOriented(flatCoordinates, offset, ends, stride, opt_right) {
+export function linearRingsAreOriented(flatCoordinates, offset, ends, stride, opt_right) {
   const right = opt_right !== undefined ? opt_right : false;
   for (let i = 0, ii = ends.length; i < ii; ++i) {
     const end = ends[i];
@@ -75,9 +75,9 @@ export function linearRingIsOriented(flatCoordinates, offset, ends, stride, opt_
  *     (counter-clockwise exterior ring and clockwise interior rings).
  * @return {boolean} Rings are correctly oriented.
  */
-export function linearRingsAreOriented(flatCoordinates, offset, endss, stride, opt_right) {
+export function linearRingssAreOriented(flatCoordinates, offset, endss, stride, opt_right) {
   for (let i = 0, ii = endss.length; i < ii; ++i) {
-    if (!linearRingIsOriented(
+    if (!linearRingsAreOriented(
       flatCoordinates, offset, endss[i], stride, opt_right)) {
       return false;
     }

--- a/src/ol/geom/flat/orient.js
+++ b/src/ol/geom/flat/orient.js
@@ -77,9 +77,13 @@ export function linearRingsAreOriented(flatCoordinates, offset, ends, stride, op
  */
 export function linearRingssAreOriented(flatCoordinates, offset, endss, stride, opt_right) {
   for (let i = 0, ii = endss.length; i < ii; ++i) {
+    const ends = endss[i];
     if (!linearRingsAreOriented(
-      flatCoordinates, offset, endss[i], stride, opt_right)) {
+      flatCoordinates, offset, ends, stride, opt_right)) {
       return false;
+    }
+    if (ends.length) {
+      offset = ends[ends.length - 1];
     }
   }
   return true;

--- a/test/spec/ol/geom/flat/orient.test.js
+++ b/test/spec/ol/geom/flat/orient.test.js
@@ -1,5 +1,5 @@
-import {linearRingIsClockwise, linearRingIsOriented,
-  linearRingsAreOriented, orientLinearRings, orientLinearRingsArray} from '../../../../../src/ol/geom/flat/orient.js';
+import {linearRingIsClockwise, linearRingsAreOriented,
+  linearRingssAreOriented, orientLinearRings, orientLinearRingsArray} from '../../../../../src/ol/geom/flat/orient.js';
 
 
 describe('ol.geom.flat.orient', function() {
@@ -22,8 +22,8 @@ describe('ol.geom.flat.orient', function() {
 
   });
 
-  describe('ol.geom.flat.orient.linearRingIsOriented', function() {
-    const oriented = linearRingIsOriented;
+  describe('ol.geom.flat.orient.linearRingsAreOriented', function() {
+    const oriented = linearRingsAreOriented;
 
     const rightCoords = [
       -180, -90, 180, -90, 180, 90, -180, 90, -180, -90,
@@ -49,8 +49,8 @@ describe('ol.geom.flat.orient', function() {
 
   });
 
-  describe('ol.geom.flat.orient.linearRingsAreOriented', function() {
-    const oriented = linearRingsAreOriented;
+  describe('ol.geom.flat.orient.linearRingssAreOriented', function() {
+    const oriented = linearRingssAreOriented;
 
     const rightCoords = [
       -180, -90, 180, -90, 180, 90, -180, 90, -180, -90,

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -188,6 +188,17 @@ describe('ol.geom.MultiPolygon', function() {
 
   });
 
+  describe('#getArea', function() {
+
+    it('works with a clockwise and a counterclockwise Polygon', function() {
+      const multiPolygon = new MultiPolygon([
+        [[[1, 3], [1, 2], [0, 2], [1, 3]]], // clockwise polygon with area 0.5
+        [[[2, 1], [2, 0.5], [3, 1], [2, 1]]] // counterclockwise polygon with area 0.25
+      ]);
+      expect(multiPolygon.getArea()).to.be(0.75);
+    });
+  });
+
   describe('#getInteriorPoints', function() {
 
     it('returns XYM multipoint with intersection width as M', function() {


### PR DESCRIPTION
- Add failing test for `MultiPolygon#getArea`
- Rename misnamed functions in `geom/flat/orient`
  - Rename `linearRingIsOriented` => `linearRingsAreOriented`
    The function checks all linear rings of a Polygon, so the plural "rings" is more appropriate
  - Rename `linearRingsAreOriented` => `linearRingssAreOriented`
    The double s is appropriate because the check is done for all Polygons of a MultiPolygon
  - (this restores the function names from OpenLayers v4, they were changed (wrongly IMHO) in #7820.)
- Fix offset passed from linearRingssAreOriented to linearRingsAreOriented
  The offset needs to be set to the end of the previous Polygon, see `offset = orientLinearRings(...)` in function `orientLinearRingsArray`.

Fixes #9189