### PR TITLE
Only consider child range with drawable tiles

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -108,6 +108,16 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
   /**
    * @inheritDoc
    */
+  loadedTileCallback(tiles, zoom, tile) {
+    if (this.isDrawableTile(tile)) {
+      return super.loadedTileCallback(tiles, zoom, tile);
+    }
+    return false;
+  }
+
+  /**
+   * @inheritDoc
+   */
   prepareFrame(frameState, layerState) {
     return true;
   }


### PR DESCRIPTION
Probably not very frequently, but it can happen that a child tile range found by the function created with `ol/layer/Renderer#createLoadedTileFinder` contains tiles that are not drawable (yet). This pull request simply changes the callback to only consider drawable tiles.