### PR TITLE
Fix TS-suggestions to work inside Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ The `ol` package contains a `src/` folder with JSDoc annotated sources. TypeScri
 }
 ```
 
+### Angular support 
+
+Assuming you are running Angular all you need to add to 
+your `tsconfig.json` is the path to the `ol/src` folder
+and your standard app-folder.
+
+```js
+  "include": [
+    "src/**/*",
+    "node_modules/ol/src/**/*.js"
+  ]
+```
+
 ## Supported Browsers
 
 OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, [polyfills](http://polyfill.io) for `requestAnimationFrame` and `Element.prototype.classList` are required, and using the KML format requires a polyfill for `URL`.


### PR DESCRIPTION
The PR adds a simple suggestion to get Intellisense support inside of a newly created 
angular project. The current suggestion will result in a compilation error, because the 
angular project files placed in the `src/` folder will not be compiled anymore. 

Assuming that a lot of TS-related usage of OpenLayers will stem from angular users
trying to build an OL based app, the extra notification seems justified. 

Also note that the path inside the compiler Options does not need to be set. 

```js
    "paths": {
      "ol": ["node_modules/ol/src"],
      "ol/*": ["node_modules/ol/src/*"]
    }
```

Also using the `allowJs` option will not compile due to a conflict with the `declaration`
option. 

´´´
BUILD ERROR
error TS5053: Option 'allowJs' cannot be specified with option 'declaration'.
´´´
