### PR TITLE
Only check tiles with matching key in forEachLoadedTile

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -71,9 +71,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    */
   isDrawableTile(tile) {
     const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
+    const tileSource = tileLayer.getSource();
+    const key = tileSource.getKey();
     const tileState = tile.getState();
     const useInterimTilesOnError = tileLayer.getUseInterimTilesOnError();
-    return tileState == TileState.LOADED ||
+    return (tile.key === key) &&
+        tileState == TileState.LOADED ||
         tileState == TileState.EMPTY ||
         tileState == TileState.ERROR && !useInterimTilesOnError;
   }

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -140,6 +140,7 @@ class TileSource extends Source {
       return false;
     }
 
+    const key = this.getKey();
     let covered = true;
     let tile, tileCoordKey, loaded;
     for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {
@@ -148,9 +149,11 @@ class TileSource extends Source {
         loaded = false;
         if (tileCache.containsKey(tileCoordKey)) {
           tile = /** @type {!import("../Tile.js").default} */ (tileCache.get(tileCoordKey));
-          loaded = tile.getState() === TileState.LOADED;
-          if (loaded) {
-            loaded = (callback(tile) !== false);
+          if (tile.key === key) {
+            loaded = tile.getState() === TileState.LOADED;
+            if (loaded) {
+              loaded = (callback(tile) !== false);
+            }
           }
         }
         if (!loaded) {

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -140,7 +140,6 @@ class TileSource extends Source {
       return false;
     }
 
-    const key = this.getKey();
     let covered = true;
     let tile, tileCoordKey, loaded;
     for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {
@@ -149,11 +148,9 @@ class TileSource extends Source {
         loaded = false;
         if (tileCache.containsKey(tileCoordKey)) {
           tile = /** @type {!import("../Tile.js").default} */ (tileCache.get(tileCoordKey));
-          if (tile.key === key) {
-            loaded = tile.getState() === TileState.LOADED;
-            if (loaded) {
-              loaded = (callback(tile) !== false);
-            }
+          loaded = tile.getState() === TileState.LOADED;
+          if (loaded) {
+            loaded = (callback(tile) !== false);
           }
         }
         if (!loaded) {


### PR DESCRIPTION
Ensure that only tiles with the same key as the source are considered
loaded to avoid previously loaded tiles associated with another key
(different style or dimension value) being shown.

Partial fix for #9135 (1 of 2)