### PR TITLE
Remove unnecessary type cast

### DIFF
--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -26,9 +26,8 @@ const styleFunction = function(feature) {
   scale = size / 10;
   let style = styleCache[size];
   if (!style) {
-    const canvas = /** @type {HTMLCanvasElement} */ (document.createElement('canvas'));
-    const vectorContext = toContext(
-      /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d')),
+    const canvas = document.createElement('canvas');
+    const vectorContext = toContext(canvas.getContext('2d'),
       {size: [size, size], pixelRatio: 1});
     vectorContext.setStyle(new Style({
       fill: new Fill({color: 'rgba(255, 153, 0, 0.4)'}),

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -10,14 +10,14 @@
  * @return {CanvasRenderingContext2D} The context.
  */
 export function createCanvasContext2D(opt_width, opt_height) {
-  const canvas = /** @type {HTMLCanvasElement} */ (document.createElement('canvas'));
+  const canvas = document.createElement('canvas');
   if (opt_width) {
     canvas.width = opt_width;
   }
   if (opt_height) {
     canvas.height = opt_height;
   }
-  return /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+  return canvas.getContext('2d');
 }
 
 

--- a/src/ol/render/Box.js
+++ b/src/ol/render/Box.js
@@ -22,7 +22,7 @@ class RenderBox extends Disposable {
      * @type {HTMLDivElement}
      * @private
      */
-    this.element_ = /** @type {HTMLDivElement} */ (document.createElement('div'));
+    this.element_ = document.createElement('div');
     this.element_.style.position = 'absolute';
     this.element_.className = 'ol-box ' + className;
 

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -42,9 +42,7 @@ class IconImage extends EventTarget {
      * @private
      * @type {HTMLCanvasElement}
      */
-    this.canvas_ = color ?
-      /** @type {HTMLCanvasElement} */ (document.createElement('canvas')) :
-      null;
+    this.canvas_ = color ? document.createElement('canvas') : null;
 
     /**
      * @private

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -323,7 +323,7 @@ let HAS = false;
 //TODO Remove side effects
 if (typeof window !== 'undefined' && 'WebGLRenderingContext' in window) {
   try {
-    const canvas = /** @type {HTMLCanvasElement} */ (document.createElement('canvas'));
+    const canvas = document.createElement('canvas');
     const gl = getContext(canvas);
     if (gl) {
       HAS = true;


### PR DESCRIPTION
TypeScript is smart: he know's that `document.createElement` with the `'canvas'` argument returns a `HTMLCanvasElement`.