### PR TITLE
Don't resize/clear the vector renderer canvas

### DIFF
--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -82,8 +82,6 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
         if (vectorRenderer.prepareFrame(imageFrameState, layerState) &&
               (vectorRenderer.replayGroupChanged ||
               !equals(skippedFeatures, newSkippedFeatures))) {
-          context.canvas.width = imageFrameState.size[0] * pixelRatio;
-          context.canvas.height = imageFrameState.size[1] * pixelRatio;
           vectorRenderer.renderFrame(imageFrameState, layerState);
           skippedFeatures = newSkippedFeatures;
           callback();


### PR DESCRIPTION
Already done in the `renderFrame` function:
https://github.com/openlayers/openlayers/blob/666c14d1901c333077e511d714d51d5867bda009/src/ol/renderer/canvas/VectorLayer.js#L111-L123
