### PR TITLE
Remove vendor prefix for the 'transform' CSS property and fullscreen api

### DIFF
--- a/examples/full-screen-drag-rotate-and-zoom.css
+++ b/examples/full-screen-drag-rotate-and-zoom.css
@@ -1,6 +1,3 @@
-.map:-moz-full-screen {
-  height: 100%;
-}
 .map:-webkit-full-screen {
   height: 100%;
 }

--- a/examples/full-screen-source.css
+++ b/examples/full-screen-source.css
@@ -1,6 +1,3 @@
-.fullscreen:-moz-full-screen {
-  height: 100%;
-}
 .fullscreen:-webkit-full-screen {
   height: 100%;
 }

--- a/examples/full-screen.css
+++ b/examples/full-screen.css
@@ -1,6 +1,3 @@
-.map:-moz-full-screen {
-  height: 100%;
-}
 .map:-webkit-full-screen {
   height: 100%;
 }

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -7,7 +7,7 @@ import {replaceNode} from '../dom.js';
 import {listen} from '../events.js';
 import EventType from '../events/EventType.js';
 
-const events = ['fullscreenchange', 'webkitfullscreenchange', 'mozfullscreenchange', 'MSFullscreenChange'];
+const events = ['fullscreenchange', 'webkitfullscreenchange', 'MSFullscreenChange'];
 
 /**
  * @typedef {Object} Options
@@ -209,7 +209,6 @@ function isFullScreenSupported() {
   const body = document.body;
   return !!(
     body.webkitRequestFullscreen ||
-    (body.mozRequestFullScreen && document.mozFullScreenEnabled) ||
     (body.msRequestFullscreen && document.msFullscreenEnabled) ||
     (body.requestFullscreen && document.fullscreenEnabled)
   );
@@ -220,8 +219,7 @@ function isFullScreenSupported() {
  */
 function isFullScreen() {
   return !!(
-    document.webkitIsFullScreen || document.mozFullScreen ||
-    document.msFullscreenElement || document.fullscreenElement
+    document.webkitIsFullScreen || document.msFullscreenElement || document.fullscreenElement
   );
 }
 
@@ -234,8 +232,6 @@ function requestFullScreen(element) {
     element.requestFullscreen();
   } else if (element.msRequestFullscreen) {
     element.msRequestFullscreen();
-  } else if (element.mozRequestFullScreen) {
-    element.mozRequestFullScreen();
   } else if (element.webkitRequestFullscreen) {
     element.webkitRequestFullscreen();
   }
@@ -246,9 +242,7 @@ function requestFullScreen(element) {
  * @param {HTMLElement} element Element to request fullscreen
  */
 function requestFullScreenWithKeys(element) {
-  if (element.mozRequestFullScreenWithKeys) {
-    element.mozRequestFullScreenWithKeys();
-  } else if (element.webkitRequestFullscreen) {
+  if (element.webkitRequestFullscreen) {
     element.webkitRequestFullscreen();
   } else {
     requestFullScreen(element);
@@ -263,8 +257,6 @@ function exitFullScreen() {
     document.exitFullscreen();
   } else if (document.msExitFullscreen) {
     document.msExitFullscreen();
-  } else if (document.mozCancelFullScreen) {
-    document.mozCancelFullScreen();
   } else if (document.webkitExitFullscreen) {
     document.webkitExitFullscreen();
   }

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -169,8 +169,6 @@ export function render(mapEvent) {
         this.element.classList.remove(CLASS_HIDDEN);
       }
     }
-    this.label_.style.msTransform = transform;
-    this.label_.style.webkitTransform = transform;
     this.label_.style.transform = transform;
   }
   this.rotation_ = rotation;

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -27,7 +27,3 @@ interface Element {
   msRequestFullscreen(): Promise<void>;
   webkitRequestFullscreen(allowKeyboardInput?: number): Promise<void>;
 }
-
-interface CSSStyleDeclaration {
-  msTransform: string | null;
-}

--- a/types/dom.d.ts
+++ b/types/dom.d.ts
@@ -4,26 +4,20 @@
  */
 
 interface Document {
-  readonly mozFullScreen: boolean;
   readonly webkitIsFullScreen: boolean;
 
   readonly fullscreenElement: Element;
-  readonly mozFullScreenElement: Element;
   readonly msFullscreenElement: Element;
   readonly webkitFullscreenElement: Element;
 
-  readonly mozFullScreenEnabled: boolean;
   readonly msFullscreenEnabled: boolean;
   readonly webkitFullscreenEnabled: boolean;
 
-  mozCancelFullScreen(): void;
   msExitFullscreen(): void;
   webkitExitFullscreen(): void;
 }
 
 interface Element {
-  mozRequestFullScreen(): Promise<void>;
-  mozRequestFullScreenWithKeys(): Promise<void>;
   msRequestFullscreen(): Promise<void>;
   webkitRequestFullscreen(allowKeyboardInput?: number): Promise<void>;
 }


### PR DESCRIPTION
Only remove the `moz` prefix for the Full Screen API

Browser support:
* https://caniuse.com/#feat=transforms2d
* https://caniuse.com/#feat=fullscreen
