### PR TITLE
Set vector tile extent earlier

### DIFF
--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -147,8 +147,8 @@ class VectorTile extends Tile {
    */
   onLoad(features, dataProjection, extent) {
     this.setProjection(dataProjection);
-    this.setFeatures(features);
     this.setExtent(extent);
+    this.setFeatures(features);
   }
 
   /**

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -4,13 +4,6 @@
 import Tile from './Tile.js';
 import TileState from './TileState.js';
 
-/**
- * @const
- * @type {import("./extent.js").Extent}
- */
-const DEFAULT_EXTENT = [0, 0, 4096, 4096];
-
-
 class VectorTile extends Tile {
 
   /**
@@ -89,7 +82,7 @@ class VectorTile extends Tile {
    * @api
    */
   getExtent() {
-    return this.extent_ || DEFAULT_EXTENT;
+    return this.extent_;
   }
 
   /**
@@ -166,7 +159,7 @@ class VectorTile extends Tile {
    * calculated by multiplying the tile size with the tile pixel ratio. For
    * sources using {@link module:ol/format/MVT~MVT} as feature format, the
    * {@link module:ol/format/MVT~MVT#getLastExtent} method will return the correct
-   * extent. The default is `[0, 0, 4096, 4096]`.
+   * extent.
    * @param {import("./extent.js").Extent} extent The extent.
    * @api
    */

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -42,12 +42,11 @@ import {equals} from '../array.js';
  *     var data = // ... fetch data
  *     var format = tile.getFormat();
  *     tile.setProjection(format.readProjection(data));
+ *     tile.setExtent(format.getLastExtent()); // line only required for ol/format/MVT
  *     tile.setFeatures(format.readFeatures(data, {
  *       // featureProjection is not required for ol/format/MVT
  *       featureProjection: map.getView().getProjection()
  *     }));
- *     // the line below is only required for ol/format/MVT
- *     tile.setExtent(format.getLastExtent());
  *   }
  * });
  * ```

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -203,6 +203,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       let tile;
       tileCallback = function(t) {
         t.setProjection(proj);
+        t.setExtent([0, 0, 4096, 4096]);
         tile = t;
       };
       map.renderSync();


### PR DESCRIPTION
We did not catch a problem with the vector tile extent (which is needed for transforming to view coordinates), because a default was returned in `ol/VectorTile#getExtent`. This pull request removes the default and lets the loader set the extent before the features, so it is ready before we transform coordinates.