### PR TITLE
Run tests in Puppeteer and non headless mode

### DIFF
--- a/rendering/test.js
+++ b/rendering/test.js
@@ -351,7 +351,7 @@ if (require.main === module) {
     option('headless', {
       describe: 'Launch Puppeteer in headless mode',
       type: 'boolean',
-      default: process.env.CI ? false : true
+      default: false
     }).
     option('puppeteer-args', {
       describe: 'Additional args for Puppeteer',

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -74,6 +74,7 @@ module.exports = function(karma) {
     }
   });
 
+  process.env.CHROME_BIN = require('puppeteer').executablePath();
   if (process.env.CIRCLECI) {
     karma.set({
       browsers: ['Chrome'],


### PR DESCRIPTION
This pull request makes the test suite work for users that do not have Chrome installed, and makes rendering tests pass locally on MacOS where headless Puppeteer fails on the webgl points test.