### PR TITLE
add stylus only and touch only mode to drawing a shape

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -230,6 +230,19 @@ export const mouseOnly = function(mapBrowserEvent) {
   return pointerEvent.pointerType == 'mouse';
 };
 
+export const touchOnly = (mapBrowserEvent) => {
+  const pointerEvt = /** @type {import("../MapBrowserPointerEvent").default} */ (mapBrowserEvent).pointerEvent;
+  assert(pointerEvt !== undefined, 56); // mapBrowserEvent must originate from a pointer event
+  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  return pointerEvt.pointerType === 'touch';
+};
+
+export const penOnly = (mapBrowserEvent) => {
+  const pointerEvt = /** @type {import("../MapBrowserPointerEvent").default} */ (mapBrowserEvent).pointerEvent;
+  assert(pointerEvt !== undefined, 56); // mapBrowserEvent must originate from a pointer event
+  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  return pointerEvt.pointerType === 'pen';
+};
 
 /**
  * Return `true` if the event originates from a primary pointer in

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -230,14 +230,28 @@ export const mouseOnly = function(mapBrowserEvent) {
   return pointerEvent.pointerType == 'mouse';
 };
 
-export const touchOnly = (mapBrowserEvent) => {
+/**
+ * Return `true` if the event originates from a touchable device.
+ *
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+ * @return {boolean} True if the event originates from a touchable device.
+ * @api
+ */
+export const touchOnly = function(mapBrowserEvent) {
   const pointerEvt = /** @type {import("../MapBrowserPointerEvent").default} */ (mapBrowserEvent).pointerEvent;
   assert(pointerEvt !== undefined, 56); // mapBrowserEvent must originate from a pointer event
   // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
   return pointerEvt.pointerType === 'touch';
 };
 
-export const penOnly = (mapBrowserEvent) => {
+/**
+ * Return `true` if the event originates from a digital pen.
+ *
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+ * @return {boolean} True if the event originates from a digital pen.
+ * @api
+ */
+export const penOnly = function(mapBrowserEvent) {
   const pointerEvt = /** @type {import("../MapBrowserPointerEvent").default} */ (mapBrowserEvent).pointerEvent;
   assert(pointerEvt !== undefined, 56); // mapBrowserEvent must originate from a pointer event
   // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -528,7 +528,7 @@ class Draw extends PointerInteraction {
   handleDownEvent(event) {
     this.shouldHandle_ = !this.freehand_;
 
-    if (this.freehand_) {
+    if (this.freehand_ && ((this.condition_ && this.condition_(event)) || true)) {
       this.downPx_ = event.pixel;
       if (!this.finishCoordinate_) {
         this.startDrawing_(event);
@@ -547,7 +547,6 @@ class Draw extends PointerInteraction {
       return false;
     }
   }
-
 
   /**
    * @inheritDoc

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -528,7 +528,7 @@ class Draw extends PointerInteraction {
   handleDownEvent(event) {
     this.shouldHandle_ = !this.freehand_;
 
-    if (this.freehand_ && ((this.condition_ && this.condition_(event)) || true)) {
+    if (this.freehand_) {
       this.downPx_ = event.pixel;
       if (!this.finishCoordinate_) {
         this.startDrawing_(event);
@@ -547,6 +547,7 @@ class Draw extends PointerInteraction {
       return false;
     }
   }
+
 
   /**
    * @inheritDoc


### PR DESCRIPTION
**What is my problem?**
I work on a project which requires to draw and annotate on a map. I have used Openlayers as the main library to fulfill the requirement. It is good to draw on a map using a PC with a mouse but it is quite frustrated to draw on a tablet device with a stylus. While I am naturally drawing a new shape using a stylus my pinky finger frequently disrupts the drawing by accidentally touching on the tablet's screen. The unintentional touching from my smallest finger is going to draw some unexpected shape and break my current drawing.

**My solution**:
I have checked and found that browsers support to distinguish a click event by a mouse, a touch or a pen while Openlayers has currently supported mouse only. Therefore, I have just added a small patch with few lines of code to the library to support stylusOnly (or penOnly) and touchOnly which has solved my problem (to do so, I add two more variables in ol/events/condition.js). When users access to my system on their tablet they can set the Openlayer map to styleOnly mode to prevent accidentally touching by hand.

Besides, I also want free-hand drawing could work with stylus only then I have changed the condition in ol/interaction/Draw.js too.

Hope the feature is going to be accepted soon to help anyone who has the same issue. I have already created a new issue at #9243 

Thank you for reading.