### PR TITLE
Add missing ol.css in mobile-full-screen example

### DIFF
--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -14,6 +14,7 @@ cloak:
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <title>Mobile full screen example</title>
+    <link rel="stylesheet" href="../css/ol.css" type="text/css">
     <style type="text/css">
       html, body, .map {
         margin: 0;


### PR DESCRIPTION
The `ol.css` CSS file is missing in the [mobile-full-screen](https://openlayers.org/en/master/examples/mobile-full-screen.html) example