### PR TITLE
Clearer behaviour of clear() and refresh() on sources

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -124,6 +124,12 @@ The removed classes and components are:
 Following the removal of the experimental WebGL renderer, the AtlasManager has been removed as well. The atlas was only used by this renderer.
 The non API `getChecksum` functions of the style is also removed.
 
+##### Change of the behavior of the vector source's clear() and refresh() methods
+
+The `ol/source/Vector#clear()` method no longer triggers a reload of the data from the server. If you were previously using `clear()` to refetch from the server, you now have to use `refresh()`.
+
+The `ol/source/Vector#refresh()` method now triggers a reload of the data from the server. If you were previously using the `refresh()` method to re-render a vector layer, you should instead call `ol/layer/Vector#changed()`.
+
 #### Other changes
 
 ##### Allow declutter in image render mode

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -128,7 +128,7 @@ The non API `getChecksum` functions of the style is also removed.
 
 The `ol/source/Vector#clear()` method no longer triggers a reload of the data from the server. If you were previously using `clear()` to refetch from the server, you now have to use `refresh()`.
 
-The `ol/source/Vector#refresh()` method now triggers a reload of the data from the server. If you were previously using the `refresh()` method to re-render a vector layer, you should instead call `ol/layer/Vector#changed()`.
+The `ol/source/Vector#refresh()` method now removes all features from the source and triggers a reload of the data from the server. If you were previously using the `refresh()` method to re-render a vector layer, you should instead call `ol/layer/Vector#changed()`.
 
 #### Other changes
 

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -145,7 +145,7 @@ class Source extends BaseObject {
   }
 
   /**
-   * Refreshes the source and finally dispatches a 'change' event.
+   * Refreshes the source. Data from the server will be reloaded.
    * @api
    */
   refresh() {

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -145,7 +145,7 @@ class Source extends BaseObject {
   }
 
   /**
-   * Refreshes the source. Data from the server will be reloaded.
+   * Refreshes the source. The source will be cleared, and data from the server will be reloaded.
    * @api
    */
   refresh() {

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -301,11 +301,19 @@ class TileSource extends Source {
   }
 
   /**
+   * Remove all cached tiles from the source. The next render cycle will fetch new tiles.
+   * @api
+   */
+  clear() {
+    this.tileCache.clear();
+  }
+
+  /**
    * @inheritDoc
    */
   refresh() {
-    this.tileCache.clear();
-    this.changed();
+    this.clear();
+    super.refresh();
   }
 
   /**

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -498,7 +498,6 @@ class VectorSource extends Source {
     if (this.featuresRtree_) {
       this.featuresRtree_.clear();
     }
-    this.loadedExtentsRtree_.clear();
     this.nullGeometryFeatures_ = {};
 
     const clearEvent = new VectorSourceEvent(VectorEventType.CLEAR);
@@ -892,6 +891,15 @@ class VectorSource extends Source {
         this.loading = this.loader_ !== VOID;
       }
     }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  refresh() {
+    this.clear(true);
+    this.loadedExtentsRtree_.clear();
+    super.refresh();
   }
 
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -985,14 +985,23 @@ class VectorSource extends Source {
 
 
   /**
-   * Set the new loader of the source. The next loadFeatures call will use the
+   * Set the new loader of the source. The next render cycle will use the
    * new loader.
    * @param {import("../featureloader.js").FeatureLoader} loader The loader to set.
    * @api
    */
   setLoader(loader) {
-    this.loadedExtentsRtree_.clear();
     this.loader_ = loader;
+  }
+
+  /**
+   * Points the source to a new url. The next render cycle will use the new url.
+   * @param {string|import("../featureloader.js").FeatureUrlFunction} url Url.
+   * @api
+   */
+  setUrl(url) {
+    assert(this.format_, 7); // `format` must be set when `url` is set
+    this.setLoader(xhr(url, this.format_));
   }
 
 }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -991,6 +991,7 @@ class VectorSource extends Source {
    * @api
    */
   setLoader(loader) {
+    this.loadedExtentsRtree_.clear();
     this.loader_ = loader;
   }
 

--- a/test/spec/ol/source/xyz.test.js
+++ b/test/spec/ol/source/xyz.test.js
@@ -1,8 +1,11 @@
 import TileSource from '../../../../src/ol/source/Tile.js';
+import TileLayer from '../../../../src/ol/layer/Tile.js';
 import TileImage from '../../../../src/ol/source/TileImage.js';
 import UrlTile from '../../../../src/ol/source/UrlTile.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
+import View from '../../../../src/ol/View.js';
+import Map from '../../../../src/ol/Map.js';
 
 
 describe('ol.source.XYZ', function() {
@@ -179,6 +182,64 @@ describe('ol.source.XYZ', function() {
         expect(urls).to.be(null);
       });
 
+    });
+
+  });
+
+  describe('clear and refresh', function() {
+
+    let map, source;
+    let callCount = 0;
+    beforeEach(function(done) {
+      source = new XYZ({
+        url: 'spec/ol/data/osm-{z}-{x}-{y}.png',
+        tileLoadFunction: function(image, src) {
+          ++callCount;
+          image.getImage().src = src;
+        }
+      });
+      const target = document.createElement('div');
+      target.style.width = target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        layers: [
+          new TileLayer({
+            source: source
+          })
+        ],
+        view: new View({
+          center: [0, 0],
+          zoom: 0
+        })
+      });
+      map.once('rendercomplete', function() {
+        callCount = 0;
+        done();
+      });
+    });
+
+    afterEach(function() {
+      document.body.removeChild(map.getTargetElement());
+      map.setTarget(null);
+    });
+
+    it('#refresh() reloads from server', function(done) {
+      map.once('rendercomplete', function() {
+        expect(callCount).to.be(1);
+        done();
+      });
+      source.refresh();
+    });
+
+    it('#clear() clears the tile cache', function(done) {
+      map.once('rendercomplete', function() {
+        done(new Error('should not re-render'));
+      });
+      source.clear();
+      setTimeout(function() {
+        done();
+      }, 1000);
     });
 
   });


### PR DESCRIPTION
There has been some confusion about the differences between `clear()` and `refresh()`, especially for vector layers. This pull request tries to fix this confusion:

- On vector sources, `clear()` just removes all features, whereas `refresh()` removes all features and reloads data from the server.
- Vector sources get a new `setUrl()` method, which calls `setLoader()`. This is for convenience and makes sense with the new logic.
- Tile sources get a new `clear()` method which clears the tile cache. So when calling `clear()` before changing the tile url (e.g. by calling `updateParams()` on a WMS source, no interim tiles from the previous set of params can be used any more.

Replaces and fixes #7648.
Fixes #3600.
Fixes #2683
Will fix #9135 when the application calls `clear()` before `updateParams()` on the source. 