### PR TITLE
Fix cache size calculation

### DIFF
--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -75,7 +75,7 @@ class TileSource extends Source {
       if (tileGrid) {
         toSize(tileGrid.getTileSize(tileGrid.getMinZoom()), tileSize);
       }
-      const canUseScreen = 'screen ' in self;
+      const canUseScreen = 'screen' in self;
       const width = canUseScreen ? (screen.availWidth || screen.width) : 1920;
       const height = canUseScreen ? (screen.availHeight || screen.height) : 1080;
       cacheSize = 4 * Math.ceil(width / tileSize[0]) * Math.ceil(height / tileSize[1]);

--- a/test/spec/ol/source/tile.test.js
+++ b/test/spec/ol/source/tile.test.js
@@ -59,6 +59,10 @@ describe('ol.source.Tile', function() {
       expect(source).to.be.a(Source);
       expect(source).to.be.a(TileSource);
     });
+    it('sets a screen dependent cache size', function() {
+      const source = new TileSource({});
+      expect(source.tileCache.highWaterMark).to.be(4 * Math.ceil(screen.availWidth / 256) * Math.ceil(screen.availHeight / 256));
+    });
     it('sets a custom cache size', function() {
       const projection = getProjection('EPSG:4326');
       const source = new TileSource({


### PR DESCRIPTION
A typo is currently keeping the cache size calculation from working properly. This pull request fixes the typo and adds a test to avoid future regressions on this.