### PR TITLE
Add tileSize option to ol/source/TileJSON

### DIFF
--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -55,6 +55,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  *   imageTile.getImage().src = src;
  * };
  * ```
+ * @property {number|import("../size.js").Size} [tileSize=[256, 256]] The tile size used by the tile service.
  * @property {string} [url] URL to the TileJSON file. If not provided, `tileJSON` must be configured.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.
@@ -89,6 +90,12 @@ class TileJSON extends TileImage {
      * @private
      */
     this.tileJSON_ = null;
+
+    /**
+     * @type {number|import("../size.js").Size}
+     * @private
+     */
+    this.tileSize_ = options.tileSize;
 
 
     if (options.url) {
@@ -168,7 +175,8 @@ class TileJSON extends TileImage {
     const tileGrid = createXYZ({
       extent: extentFromProjection(sourceProjection),
       maxZoom: maxZoom,
-      minZoom: minZoom
+      minZoom: minZoom,
+      tileSize: this.tileSize_
     });
     this.tileGrid = tileGrid;
 

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -56,6 +56,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * };
  * ```
  * @property {number|import("../size.js").Size} [tileSize=[256, 256]] The tile size used by the tile service.
+ * Note: `tileSize` and other non-standard TileJSON properties are currently ignored.
  * @property {string} [url] URL to the TileJSON file. If not provided, `tileJSON` must be configured.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.


### PR DESCRIPTION
The TileJSON spec does not specify the tile size and there is no TileJSON property specifying the value.
(There is possibility it will be added in some form in the future: mapbox/tilejson-spec#26, but it still does not seem to be clear.)

Many providers nowadays use 512x512 tiles with TileJSON.

This PR adds `tileSize` option to the ctor to allow this to be configured. (Instead of having to fall back to `ol/source/XYZ`.)
