### PR TITLE
Update Bing's imagerySet used in examples

### DIFF
--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -12,9 +12,8 @@ cloak:
  <div id="map" class="map"></div>
  <select id="layer-select">
    <option value="Aerial">Aerial</option>
-   <option value="AerialWithLabels" selected>Aerial with labels</option>
-   <option value="Road">Road (static)</option>
-   <option value="RoadOnDemand">Road (dynamic)</option>
-   <option value="collinsBart">Collins Bart</option>
-   <option value="ordnanceSurvey">Ordnance Survey</option>
+   <option value="AerialWithLabelsOnDemand" selected>Aerial with labels</option>
+   <option value="RoadOnDemand">Road</option>
+   <option value="CanvasDark">Road dark</option>
+   <option value="OrdnanceSurvey">Ordnance Survey</option>
  </select>

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -5,12 +5,11 @@ import BingMaps from '../src/ol/source/BingMaps.js';
 
 
 const styles = [
-  'Road',
   'RoadOnDemand',
   'Aerial',
-  'AerialWithLabels',
-  'collinsBart',
-  'ordnanceSurvey'
+  'AerialWithLabelsOnDemand',
+  'CanvasDark',
+  'OrdnanceSurvey'
 ];
 const layers = [];
 let i, ii;

--- a/examples/feature-move-animation.js
+++ b/examples/feature-move-animation.js
@@ -133,7 +133,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new BingMaps({
-        imagerySet: 'AerialWithLabels',
+        imagerySet: 'AerialWithLabelsOnDemand',
         key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5'
       })
     }),

--- a/examples/layer-spy.js
+++ b/examples/layer-spy.js
@@ -7,7 +7,7 @@ import BingMaps from '../src/ol/source/BingMaps.js';
 const key = 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5';
 
 const roads = new TileLayer({
-  source: new BingMaps({key: key, imagerySet: 'Road'})
+  source: new BingMaps({key: key, imagerySet: 'RoadOnDemand'})
 });
 
 const imagery = new TileLayer({

--- a/examples/mobile-full-screen.js
+++ b/examples/mobile-full-screen.js
@@ -15,7 +15,7 @@ const map = new Map({
     new TileLayer({
       source: new BingMaps({
         key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5',
-        imagerySet: 'Road'
+        imagerySet: 'RoadOnDemand'
       })
     })
   ],

--- a/examples/preload.js
+++ b/examples/preload.js
@@ -29,7 +29,7 @@ const map2 = new Map({
       preload: 0, // default value
       source: new BingMaps({
         key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5',
-        imagerySet: 'AerialWithLabels'
+        imagerySet: 'AerialWithLabelsOnDemand'
       })
     })
   ],

--- a/test/spec/ol/source/bingmaps.test.js
+++ b/test/spec/ol/source/bingmaps.test.js
@@ -18,7 +18,7 @@ describe('ol.source.BingMaps', function() {
 
     beforeEach(function(done) {
       source = new BingMaps({
-        imagerySet: 'AerialWithLabels',
+        imagerySet: 'AerialWithLabelsOnDemand',
         key: ''
       });
 
@@ -39,7 +39,7 @@ describe('ol.source.BingMaps', function() {
     });
 
     it('getImagerySet works correctly', function() {
-      expect(source.getImagerySet()).to.equal('AerialWithLabels');
+      expect(source.getImagerySet()).to.equal('AerialWithLabelsOnDemand');
     });
 
     it('getApiKey works correctly', function() {


### PR DESCRIPTION
The `Road`, `AerialWithLabels` and `collinsBart` imagery sets are deprecated, see:
https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata
