### PR TITLE
Disable transition when an interim tile is available

### DIFF
--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -170,6 +170,9 @@ class Tile extends EventTarget {
     // cleaned up by refreshInterimChain)
     do {
       if (tile.getState() == TileState.LOADED) {
+        // Show tile immediately instead of fading it in after loading, because
+        // the interim tile is in place already
+        this.transition_ = 0;
         return tile;
       }
       tile = tile.interimTile;

--- a/test/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/tilelayer.test.js
@@ -39,13 +39,18 @@ describe('ol.renderer.canvas.TileLayer', function() {
       document.body.removeChild(target);
     });
 
-    it('properly handles interim tiles', function() {
+    it('properly handles interim tiles', function(done) {
       const layer = map.getLayers().item(0);
+      source.once('tileloadend', function(e) {
+        expect(e.tile.inTransition()).to.be(false);
+        done();
+      });
       source.updateParams({TIME: '1'});
       map.renderSync();
       const tiles = map.getRenderer().getLayerRenderer(layer).renderedTiles;
       expect(tiles.length).to.be(1);
       expect(tiles[0]).to.equal(tile);
+      expect(tile.inTransition()).to.be(true);
     });
   });
 


### PR DESCRIPTION
This change avoids flickering when a tile that has an interim tile has finished loading.

I am not sure if this is the right fix. @tschaub, can you maybe have a look at this? Thanks!

Fixes #9284.
Fixes #9286