### PR TITLE
Downgrades puppeteer to `~1.11.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "proj4": "2.5.0",
-    "puppeteer": "^1.12.2",
+    "puppeteer": "~1.11.0",
     "serve-static": "^1.13.2",
     "shx": "^0.3.2",
     "sinon": "^7.2.3",


### PR DESCRIPTION
This downgrades puppeteer to version `~1.11.0`.

Version 1.11.x will download the stable version of chromium (72.0.3582.0), while version 1.12.x downloads the beta version of chromium (73.0.3679.0).

Fixes #9288

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
