### PR TITLE
Simplify vector tile projection handling

### DIFF
--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -24,10 +24,10 @@ class VectorTile extends Tile {
     this.consumers = 0;
 
     /**
-     * @private
+     * Extent of this tile; set by the source.
      * @type {import("./extent.js").Extent}
      */
-    this.extent_ = null;
+    this.extent = null;
 
     /**
      * @private
@@ -48,11 +48,16 @@ class VectorTile extends Tile {
     this.loader_;
 
     /**
-     * Data projection
-     * @private
+     * Feature projection of this tile; set by the source.
      * @type {import("./proj/Projection.js").default}
      */
-    this.projection_ = null;
+    this.projection = null;
+
+    /**
+     * Resolution of this tile; set by the source.
+     * @type {number}
+     */
+    this.resolution;
 
     /**
      * @private
@@ -77,15 +82,6 @@ class VectorTile extends Tile {
   }
 
   /**
-   * Gets the extent of the vector tile.
-   * @return {import("./extent.js").Extent} The extent.
-   * @api
-   */
-  getExtent() {
-    return this.extent_;
-  }
-
-  /**
    * Get the feature format assigned for reading this tile's features.
    * @return {import("./format/Feature.js").default} Feature format.
    * @api
@@ -95,8 +91,7 @@ class VectorTile extends Tile {
   }
 
   /**
-   * Get the features for this tile. Geometries will be in the projection returned
-   * by {@link module:ol/VectorTile~VectorTile#getProjection}.
+   * Get the features for this tile. Geometries will be in the view projection.
    * @return {Array<import("./Feature.js").FeatureLike>} Features.
    * @api
    */
@@ -112,23 +107,13 @@ class VectorTile extends Tile {
   }
 
   /**
-   * Get the feature projection of features returned by
-   * {@link module:ol/VectorTile~VectorTile#getFeatures}.
-   * @return {import("./proj/Projection.js").default} Feature projection.
-   * @api
-   */
-  getProjection() {
-    return this.projection_;
-  }
-
-  /**
    * @inheritDoc
    */
   load() {
     if (this.state == TileState.IDLE) {
       this.setState(TileState.LOADING);
       this.tileLoadFunction_(this, this.url_);
-      this.loader_(null, NaN, null);
+      this.loader_(this.extent, this.resolution, this.projection);
     }
   }
 
@@ -136,11 +121,8 @@ class VectorTile extends Tile {
    * Handler for successful tile load.
    * @param {Array<import("./Feature.js").default>} features The loaded features.
    * @param {import("./proj/Projection.js").default} dataProjection Data projection.
-   * @param {import("./extent.js").Extent} extent Extent.
    */
-  onLoad(features, dataProjection, extent) {
-    this.setProjection(dataProjection);
-    this.setExtent(extent);
+  onLoad(features, dataProjection) {
     this.setFeatures(features);
   }
 
@@ -152,22 +134,6 @@ class VectorTile extends Tile {
   }
 
   /**
-   * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s
-   * `tileLoadFunction`. Sets the extent of the vector tile. This is only required
-   * for tiles in projections with `tile-pixels` as units. The extent should be
-   * set to `[0, 0, tilePixelSize, tilePixelSize]`, where `tilePixelSize` is
-   * calculated by multiplying the tile size with the tile pixel ratio. For
-   * sources using {@link module:ol/format/MVT~MVT} as feature format, the
-   * {@link module:ol/format/MVT~MVT#getLastExtent} method will return the correct
-   * extent.
-   * @param {import("./extent.js").Extent} extent The extent.
-   * @api
-   */
-  setExtent(extent) {
-    this.extent_ = extent;
-  }
-
-  /**
    * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
    * Sets the features for the tile.
    * @param {Array<import("./Feature.js").default>} features Features.
@@ -176,17 +142,6 @@ class VectorTile extends Tile {
   setFeatures(features) {
     this.features_ = features;
     this.setState(TileState.LOADED);
-  }
-
-  /**
-   * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
-   * Sets the projection of the features that were added with
-   * {@link module:ol/VectorTile~VectorTile#setFeatures}.
-   * @param {import("./proj/Projection.js").default} projection Feature projection.
-   * @api
-   */
-  setProjection(projection) {
-    this.projection_ = projection;
   }
 
   /**

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -83,9 +83,11 @@ export function loadFeaturesXhr(url, format, success, failure) {
             source = /** @type {ArrayBuffer} */ (xhr.response);
           }
           if (source) {
-            success.call(this, format.readFeatures(source,
-              {featureProjection: projection}),
-            format.readProjection(source), format.getLastExtent());
+            success.call(this, format.readFeatures(source, {
+              extent: extent,
+              featureProjection: projection
+            }),
+            format.readProjection(source));
           } else {
             failure.call(this);
           }

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -112,14 +112,6 @@ class FeatureFormat {
   }
 
   /**
-   * Get the extent from the source of the last {@link readFeatures} call.
-   * @return {import("../extent.js").Extent} Tile extent.
-   */
-  getLastExtent() {
-    return null;
-  }
-
-  /**
    * @abstract
    * @return {import("./FormatType.js").default} Format.
    */

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -10,8 +10,6 @@ import EventType from '../../events/EventType.js';
 import rbush from 'rbush';
 import {buffer, containsCoordinate, equals, getIntersection, getTopLeft, intersects} from '../../extent.js';
 import VectorTileRenderType from '../../layer/VectorTileRenderType.js';
-import {equivalent as equivalentProjection} from '../../proj.js';
-import Units from '../../proj/Units.js';
 import ReplayType from '../../render/canvas/BuilderType.js';
 import {labelCache} from '../../render/canvas.js';
 import CanvasBuilderGroup from '../../render/canvas/BuilderGroup.js';
@@ -264,12 +262,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       const sharedExtent = getIntersection(tileExtent, sourceTileExtent);
       const bufferedExtent = equals(sourceTileExtent, sharedExtent) ? null :
         buffer(sharedExtent, layer.getRenderBuffer() * resolution, this.tmpExtent);
-      const tileProjection = sourceTile.getProjection();
-      let reproject = false;
-      if (!equivalentProjection(projection, tileProjection)) {
-        reproject = true;
-        sourceTile.setProjection(projection);
-      }
       builderState.dirty = false;
       const builderGroup = new CanvasBuilderGroup(0, sharedExtent, resolution,
         pixelRatio, !!this.declutterTree_);
@@ -298,15 +290,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       }
       for (let i = 0, ii = features.length; i < ii; ++i) {
         const feature = features[i];
-        if (reproject) {
-          if (tileProjection.getUnits() == Units.TILE_PIXELS) {
-            // projected tile extent
-            tileProjection.setWorldExtent(sourceTileExtent);
-            // tile extent in tile pixel space
-            tileProjection.setExtent(sourceTile.getExtent());
-          }
-          feature.getGeometry().transform(tileProjection, projection);
-        }
         if (!bufferedExtent || intersects(bufferedExtent, feature.getGeometry().getExtent())) {
           render.call(this, feature);
         }

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -1,5 +1,4 @@
 import Feature from '../../../../src/ol/Feature.js';
-import {getWidth} from '../../../../src/ol/extent.js';
 import MVT from '../../../../src/ol/format/MVT.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
@@ -22,15 +21,20 @@ where('ArrayBuffer.isView').describe('ol.format.MVT', function() {
 
   describe('#readFeatures', function() {
 
+    const options = {
+      featureProjection: 'EPSG:3857',
+      extent: [1824704.739223726, 6141868.096770482, 1827150.7241288517, 6144314.081675608]
+    };
+
     it('uses ol.render.Feature as feature class by default', function() {
       const format = new MVT({layers: ['water']});
-      const features = format.readFeatures(data);
+      const features = format.readFeatures(data, options);
       expect(features[0]).to.be.a(RenderFeature);
     });
 
     it('parses only specified layers', function() {
       const format = new MVT({layers: ['water']});
-      const features = format.readFeatures(data);
+      const features = format.readFeatures(data, options);
       expect(features.length).to.be(10);
     });
 
@@ -64,21 +68,14 @@ where('ArrayBuffer.isView').describe('ol.format.MVT', function() {
         featureClass: Feature,
         layers: ['building']
       });
-      let features = format.readFeatures(data);
+      let features = format.readFeatures(data, options);
       expect(features[0].getId()).to.be(2);
       // ol.render.Feature
       format = new MVT({
         layers: ['building']
       });
-      features = format.readFeatures(data);
+      features = format.readFeatures(data, options);
       expect(features[0].getId()).to.be(2);
-    });
-
-    it('sets the extent of the last readFeatures call', function() {
-      const format = new MVT();
-      format.readFeatures(data);
-      const extent = format.getLastExtent();
-      expect(getWidth(extent)).to.be(4096);
     });
 
   });
@@ -86,6 +83,11 @@ where('ArrayBuffer.isView').describe('ol.format.MVT', function() {
 });
 
 describe('ol.format.MVT', function() {
+
+  const options = {
+    featureProjection: 'EPSG:3857',
+    extent: [1824704.739223726, 6141868.096770482, 1827150.7241288517, 6144314.081675608]
+  };
 
   describe('#createFeature_', function() {
     it('accepts a geometryName', function() {
@@ -176,7 +178,9 @@ describe('ol.format.MVT', function() {
         ends.push(10, 20);
         createdEnds = ends;
       };
-      const feature = format.createFeature_({}, rawFeature);
+      format.dataProjection.setExtent([0, 0, 4096, 4096]);
+      format.dataProjection.setWorldExtent(options.extent);
+      const feature = format.createFeature_({}, rawFeature, format.adaptOptions(options));
       expect(feature).to.be.a(RenderFeature);
       expect(feature.getType()).to.be('Polygon');
       expect(feature.getFlatCoordinates()).to.equal(createdFlatCoordinates);

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -9,8 +9,7 @@ import {getCenter} from '../../../../../src/ol/extent.js';
 import MVT from '../../../../../src/ol/format/MVT.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import VectorTileLayer from '../../../../../src/ol/layer/VectorTile.js';
-import {get as getProjection, fromLonLat} from '../../../../../src/ol/proj.js';
-import Projection from '../../../../../src/ol/proj/Projection.js';
+import {get as getProjection} from '../../../../../src/ol/proj.js';
 import {checkedFonts} from '../../../../../src/ol/render/canvas.js';
 import RenderFeature from '../../../../../src/ol/render/Feature.js';
 import CanvasVectorTileLayerRenderer from '../../../../../src/ol/renderer/canvas/VectorTileLayer.js';
@@ -64,7 +63,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         constructor() {
           super(...arguments);
           this.setFeatures([feature1, feature2, feature3]);
-          this.setProjection(getProjection('EPSG:4326'));
           this.setState(TileState.LOADED);
           tileCallback(this);
         }
@@ -188,30 +186,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       }, 1600);
     });
 
-    it('transforms geometries when tile and view projection are different', function() {
-      let tile;
-      tileCallback = function(t) {
-        tile = t;
-      };
-      map.renderSync();
-      expect(tile.getProjection()).to.equal(getProjection('EPSG:3857'));
-      expect(feature1.getGeometry().getCoordinates()).to.eql(fromLonLat([1, -1]));
-    });
-
-    it('Geometries are transformed from tile-pixels', function() {
-      const proj = new Projection({code: 'EPSG:3857', units: 'tile-pixels'});
-      let tile;
-      tileCallback = function(t) {
-        t.setProjection(proj);
-        t.setExtent([0, 0, 4096, 4096]);
-        tile = t;
-      };
-      map.renderSync();
-      expect(tile.getProjection()).to.equal(getProjection('EPSG:3857'));
-      expect(feature1.getGeometry().getCoordinates()).to.eql([-20027724.40316874, 20047292.282409746]);
-      expect(feature3.flatCoordinates_).to.eql([-20027724.40316874, 20047292.282409746]);
-    });
-
     it('works for multiple layers that use the same source', function() {
       const layer2 = new VectorTileLayer({
         source: source,
@@ -240,7 +214,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         })
       });
       const sourceTile = new VectorTile([0, 0, 0], 2);
-      sourceTile.setProjection(getProjection('EPSG:3857'));
       sourceTile.features_ = [];
       sourceTile.getImage = function() {
         return document.createElement('canvas');
@@ -299,7 +272,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     beforeEach(function() {
       const sourceTile = new VectorTile([0, 0, 0]);
       sourceTile.setState(TileState.LOADED);
-      sourceTile.setProjection(getProjection('EPSG:3857'));
       source = new VectorTileSource({
         tileClass: TileClass,
         tileGrid: createXYZ()

--- a/test/spec/ol/vectortile.test.js
+++ b/test/spec/ol/vectortile.test.js
@@ -1,38 +1,43 @@
-import Feature from '../../../src/ol/Feature.js';
 import {defaultLoadFunction} from '../../../src/ol/source/VectorTile.js';
 import VectorTile from '../../../src/ol/VectorTile.js';
 import {listen} from '../../../src/ol/events.js';
-import TextFeature from '../../../src/ol/format/TextFeature.js';
+import GeoJSON from '../../../src/ol/format/GeoJSON.js';
+import MVT from '../../../src/ol/format/MVT.js';
 import {get as getProjection} from '../../../src/ol/proj.js';
-import Projection from '../../../src/ol/proj/Projection.js';
+import {createXYZ} from '../../../src/ol/tilegrid.js';
 
 
 describe('ol.VectorTile', function() {
 
-  it('loader sets features on the tile and updates proj units', function(done) {
-    // mock format that return a tile-pixels feature
-    const format = new TextFeature();
-    format.readProjection = function(source) {
-      return new Projection({
-        code: '',
-        units: 'tile-pixels'
-      });
-    };
-    format.readFeatures = function(source, options) {
-      return [new Feature()];
-    };
-
+  it('loader reprojects GeoJSON features', function(done) {
+    const format = new GeoJSON();
     const tile = new VectorTile([0, 0, 0], null, null, format);
     const url = 'spec/ol/data/point.json';
-
     defaultLoadFunction(tile, url);
     const loader = tile.loader_;
     listen(tile, 'change', function(e) {
-      expect(tile.getFeatures().length).to.be.greaterThan(0);
-      expect(tile.getProjection().getUnits()).to.be('tile-pixels');
+      expect(tile.getFeatures()[0].getGeometry().getFlatCoordinates()).to.eql([-9724792.346778862, 4164041.638405114]);
       done();
     });
     loader.call(tile, [], 1, getProjection('EPSG:3857'));
   });
+
+  it('loader reprojects MVT features', function(done) {
+    const format = new MVT();
+    const tileGrid = createXYZ({
+      tileSize: 512
+    });
+    const tile = new VectorTile([14, 8938, 5680], null, null, format);
+    const url = 'spec/ol/data/14-8938-5680.vector.pbf';
+    defaultLoadFunction(tile, url);
+    const loader = tile.loader_;
+    listen(tile, 'change', function(e) {
+      expect(tile.getFeatures()[1246].getGeometry().getFlatCoordinates()).to.eql([1827804.0218549764, 6144812.116688028]);
+      done();
+    });
+    const extent = tileGrid.getTileCoordExtent(tile.tileCoord);
+    loader.call(tile, extent, 1, getProjection('EPSG:3857'));
+  });
+
 
 });


### PR DESCRIPTION
This pull request moves the responsibility of reprojecting vector tile features from the renderer to the loader, which brings significant simplifications.

This is the refactoring I mentioned in https://github.com/openlayers/openlayers/pull/9231#issuecomment-464690118.

Fixes #9293.