### PR TITLE
Fix transpilation

### DIFF
--- a/config/tsconfig-build.json
+++ b/config/tsconfig-build.json
@@ -37,7 +37,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Currently, `npm run build-package` and `npm run build-legacy` raise errors from the transpilation step. This pull request fixes transpilation. See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23649#issuecomment-461776771.