### PR TITLE
Change CSS class for tooltips in measure example

### DIFF
--- a/examples/measure.css
+++ b/examples/measure.css
@@ -1,4 +1,4 @@
-.tooltip {
+.ol-tooltip {
   position: relative;
   background: rgba(0, 0, 0, 0.5);
   border-radius: 4px;
@@ -6,18 +6,19 @@
   padding: 4px 8px;
   opacity: 0.7;
   white-space: nowrap;
+  font-size: 12px;
 }
-.tooltip-measure {
+.ol-tooltip-measure {
   opacity: 1;
   font-weight: bold;
 }
-.tooltip-static {
+.ol-tooltip-static {
   background-color: #ffcc33;
   color: black;
   border: 1px solid white;
 }
-.tooltip-measure:before,
-.tooltip-static:before {
+.ol-tooltip-measure:before,
+.ol-tooltip-static:before {
   border-top: 6px solid rgba(0, 0, 0, 0.5);
   border-right: 6px solid transparent;
   border-left: 6px solid transparent;
@@ -27,6 +28,6 @@
   margin-left: -7px;
   left: 50%;
 }
-.tooltip-static:before {
+.ol-tooltip-static:before {
   border-top-color: #ffcc33;
 }

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -225,7 +225,7 @@ function addInteraction() {
 
   draw.on('drawend',
     function() {
-      measureTooltipElement.className = 'tooltip tooltip-static';
+      measureTooltipElement.className = 'ol-tooltip ol-tooltip-static';
       measureTooltip.setOffset([0, -7]);
       // unset sketch
       sketch = null;
@@ -245,7 +245,7 @@ function createHelpTooltip() {
     helpTooltipElement.parentNode.removeChild(helpTooltipElement);
   }
   helpTooltipElement = document.createElement('div');
-  helpTooltipElement.className = 'tooltip hidden';
+  helpTooltipElement.className = 'ol-tooltip hidden';
   helpTooltip = new Overlay({
     element: helpTooltipElement,
     offset: [15, 0],
@@ -263,7 +263,7 @@ function createMeasureTooltip() {
     measureTooltipElement.parentNode.removeChild(measureTooltipElement);
   }
   measureTooltipElement = document.createElement('div');
-  measureTooltipElement.className = 'tooltip tooltip-measure';
+  measureTooltipElement.className = 'ol-tooltip ol-tooltip-measure';
   measureTooltip = new Overlay({
     element: measureTooltipElement,
     offset: [0, -15],


### PR DESCRIPTION
fixes #9290 

To avoid mixing rules with the `tooltip` CSS rules from [Bootstrap](https://getbootstrap.com/docs/3.3/javascript/#tooltips)