### PR TITLE
enhance tile-debug readability

### DIFF
--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -55,10 +55,12 @@ class LabeledTile extends Tile {
       context.strokeRect(0.5, 0.5, tileSize[0] + 0.5, tileSize[1] + 0.5);
 
       context.fillStyle = 'grey';
+      context.strokeStyle = 'white';
       context.textAlign = 'center';
       context.textBaseline = 'middle';
-      context.font = '24px sans-serif';
-      context.fillText(this.text_, tileSize[0] / 2, tileSize[1] / 2);
+      context.font = 'bold 24px sans-serif';
+      context.fillText(this.text_, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
+      context.strokeText(this.text_, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
 
       this.canvas_ = context.canvas;
       return context.canvas;

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -58,9 +58,10 @@ class LabeledTile extends Tile {
       context.strokeStyle = 'white';
       context.textAlign = 'center';
       context.textBaseline = 'middle';
-      context.font = 'bold 24px sans-serif';
-      context.fillText(this.text_, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
+      context.font = '24px sans-serif';
+      context.lineWidth = 4;
       context.strokeText(this.text_, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
+      context.fillText(this.text_, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
 
       this.canvas_ = context.canvas;
       return context.canvas;


### PR DESCRIPTION
As the `ol/source/TileDebug` is used for debugging only, the usability should be top priority. Unfortunately the tile coordinates can become difficult to read at aerial imagery with high visual noise:

![Screenshot 2019-03-12 at 11 51 52](https://user-images.githubusercontent.com/19506147/54198026-b6585880-44c5-11e9-99ec-5331b2c797c1.png)

This pull request tries to fix this issue by adding a canvas `strokeText` to the current text:
![Screenshot 2019-03-12 at 12 03 58](https://user-images.githubusercontent.com/19506147/54198050-c7a16500-44c5-11e9-8d78-818aa7548777.png)

Additionally, the tile coordinates are simply cut off at very high zoom levels with long coordinates:
![Screenshot 2019-03-12 at 12 20 56](https://user-images.githubusercontent.com/19506147/54198360-937a7400-44c6-11e9-9de6-6bce96835513.png)

This issue is fixed by adding a `maxWidth` to the text. The text then becomes condensed when needed, trading a bit of aesthetics for usability:

![Screenshot 2019-03-12 at 12 20 10](https://user-images.githubusercontent.com/19506147/54198426-be64c800-44c6-11e9-859b-2a190d8aac11.png)

