### PR TITLE
Fixes #9294 (missing documention for methods with `@inheritDoc`)

### DIFF
--- a/config/jsdoc/api/plugins/inheritdoc.js
+++ b/config/jsdoc/api/plugins/inheritdoc.js
@@ -1,11 +1,7 @@
 /*
  * This is a hack to prevent inheritDoc tags from entirely removing
  * documentation of the method that inherits the documentation.
- *
- * TODO: Remove this hack when https://github.com/jsdoc3/jsdoc/issues/53
- * is addressed.
  */
-
 
 exports.defineTags = function(dictionary) {
   dictionary.defineTag('inheritDoc', {
@@ -92,10 +88,15 @@ exports.handlers = {
                     incompleteDoclet.stability = stability;
                     for (key in candidate) {
                       if (candidate.hasOwnProperty(key) &&
-                          keepKeys.indexOf(key) == -1) {
+                        keepKeys.indexOf(key) == -1) {
                         incompleteDoclet[key] = candidate[key];
                       }
                     }
+                    // We have found a matching parent doc and applied it so we
+                    // don't want to ignore this doclet anymore.
+                    incompleteDoclet.ignore = false;
+                    // We found a match so we can stop break
+                    break;
                   }
                 }
               }


### PR DESCRIPTION
This fixes the missing documentation for methods tagged with `@inheritDoc` and `@api`.

- This sets `ignore = false` on a doclet if a method tagged with `@inheritdoc` has a matching ancestor. It also stops iterating when a match is found.
- This also removes the outdated "TODO" comment in the Header. As the linked issues is already solved but the plugin still seems to be necessary.

Closes #9294
