### PR TITLE
Use closest lower source resolution for render tiles

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -191,7 +191,7 @@ class VectorTile extends UrlTile {
       if (sourceExtent) {
         getIntersection(extent, sourceExtent, extent);
       }
-      const sourceZ = sourceTileGrid.getZForResolution(resolution/*, 1*/);
+      const sourceZ = sourceTileGrid.getZForResolution(resolution, 1);
       const minZoom = sourceTileGrid.getMinZoom();
 
       let loadedZ = sourceZ + 1;

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -105,7 +105,7 @@ describe('ol.source.VectorTile', function() {
 
       function tileUrlFunction(tileCoord) {
         ++requested;
-        if (tileCoord.toString() == '6,27,-57') {
+        if (tileCoord.toString() == '5,13,-29') {
           return tileCoord.join('/');
         }
       }
@@ -154,7 +154,7 @@ describe('ol.source.VectorTile', function() {
       map.renderSync();
       setTimeout(function() {
         expect(requested).to.be.greaterThan(1);
-        expect(loaded).to.eql(['6/27/-57']);
+        expect(loaded).to.eql(['5/13/-29']);
         done();
       }, 0);
     });


### PR DESCRIPTION
Currently the vector tile source fetches remote tiles for the closest resolution of the requested render tile. But given their coordinate range, vector tiles allow overzooming, so it is more efficient and less memory consuming to use the closest lower resolution.

In everyday use, this change is not relevant, because render and source tile grids match. Only in cases where the remote source provides fewer zoom levels than the render tile grid, this becomes relevant.

Example: Map view is at z16, but tiles are only available for z14 and z17. Currently, the source would request z17. After this change, it would request z14.