### PR TITLE
Create a more accurate origin for tile positioning

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -272,8 +272,8 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       const originTileCoord = tileGrid.getTileCoordForCoordAndZ(getTopLeft(canvasExtent), currentZ);
       const originTileExtent = tileGrid.getTileCoordExtent(originTileCoord);
       const origin = applyTransform(this.tempTransform_, [
-        Math.round(tilePixelRatio * (originTileExtent[0] - canvasExtent[0]) / tileResolution),
-        Math.round(tilePixelRatio * (canvasExtent[3] - originTileExtent[3]) / tileResolution)
+        tilePixelRatio * (originTileExtent[0] - canvasExtent[0]) / tileResolution,
+        tilePixelRatio * (canvasExtent[3] - originTileExtent[3]) / tileResolution
       ]);
       const tileGutter = tilePixelRatio * tileSource.getGutterForProjection(projection);
       const tilesToDraw = tilesToDrawByZ[currentZ];


### PR DESCRIPTION
The current origin for tile rendering is incorrectly rounded to integers, which results in a bad panning and zooming experience when overzoomed:
![Mar-13-2019 18-09-56](https://user-images.githubusercontent.com/211514/54299527-5c39bf00-45bb-11e9-9f4f-9f7985e33968.gif)
This pull request fixes that.