### PR TITLE
Mark layerFilter in AtPixelOptions as optional

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -60,7 +60,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 /**
  * @typedef {Object} AtPixelOptions
- * @property {undefined|function(import("./layer/Layer.js").default): boolean} layerFilter Layer filter
+ * @property {undefined|function(import("./layer/Layer.js").default): boolean} [layerFilter] Layer filter
  * function. The filter function will receive one argument, the
  * {@link module:ol/layer/Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -606,7 +606,6 @@ class PluggableMap extends BaseObject {
    * @param {import("./pixel.js").Pixel} pixel Pixel.
    * @param {AtPixelOptions=} opt_options Optional options.
    * @return {boolean} Is there a feature at the given pixel?
-   * @template U
    * @api
    */
   hasFeatureAtPixel(pixel, opt_options) {


### PR DESCRIPTION
If omitted, all visible layers will be tested.