### PR TITLE
Create codesandbox using the 'parcel' template

### DIFF
--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -38,6 +38,9 @@
           },
           "package.json": {
             content: pkgJson
+          },
+          'sandbox.config.json': {
+            content: '{"template": "parcel"}'
           }
         }
       });


### PR DESCRIPTION
See #9332

The default template is `create-react-app` and it ignores the `head` tag defined in out `index.html`
