### PR TITLE
[WIP] Render vector tiles at the exact view resolution

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -54,6 +54,7 @@ import {create as createTransform, apply as applyTransform} from './transform.js
 
 
 /**
+ * Post render function. When `true` is returned, a render frame will be requested
  * @typedef {function(PluggableMap, ?FrameState): any} PostRenderFunction
  */
 
@@ -954,10 +955,14 @@ class PluggableMap extends BaseObject {
     }
 
     const postRenderFunctions = this.postRenderFunctions_;
+    let rerender = false;
     for (let i = 0, ii = postRenderFunctions.length; i < ii; ++i) {
-      postRenderFunctions[i](this, frameState);
+      rerender = rerender || (postRenderFunctions[i](this, frameState) === true);
     }
     postRenderFunctions.length = 0;
+    if (rerender) {
+      this.render();
+    }
   }
 
   /**

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -76,6 +76,12 @@ class VectorRenderTile extends Tile {
     this.removeSourceTiles_ = removeSourceTiles;
 
     /**
+     * Resolution of the rendered tile image.
+     * @type {number}
+     */
+    this.renderedImageResolution = -1;
+
+    /**
      * @private
      * @type {import("./tilegrid/TileGrid.js").default}
      */

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -12,6 +12,7 @@ import {createCanvasContext2D} from './dom.js';
  * @property {boolean} dirty
  * @property {null|import("./render.js").OrderFunction} renderedRenderOrder
  * @property {number} renderedTileRevision
+ * @property {number} renderedResolution
  * @property {number} renderedRevision
  * @property {number} renderedZ
  * @property {number} renderedTileZ
@@ -156,6 +157,7 @@ class VectorRenderTile extends Tile {
       this.replayState_[key] = {
         dirty: false,
         renderedRenderOrder: null,
+        renderedResolution: -1,
         renderedRevision: -1,
         renderedTileRevision: -1,
         renderedZ: -1,

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -9,7 +9,7 @@ import {lineStringLength} from '../../geom/flat/length.js';
 import {drawTextOnPath} from '../../geom/flat/textpath.js';
 import {transform2D} from '../../geom/flat/transform.js';
 import {isEmpty} from '../../obj.js';
-import {drawImage, resetTransform, defaultPadding, defaultTextBaseline} from '../canvas.js';
+import {drawImage, defaultPadding, defaultTextBaseline} from '../canvas.js';
 import CanvasInstruction from './Instruction.js';
 import {TEXT_ALIGN} from './TextBuilder.js';
 import {
@@ -382,12 +382,13 @@ class Executor extends Disposable {
     if (this.alignFill_) {
       const origin = applyTransform(this.renderedTransform_, [0, 0]);
       const repeatSize = 512 * this.pixelRatio;
+      context.save();
       context.translate(origin[0] % repeatSize, origin[1] % repeatSize);
       context.rotate(this.viewRotation_);
     }
     context.fill();
     if (this.alignFill_) {
-      context.setTransform.apply(context, resetTransform);
+      context.restore();
     }
   }
 

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -4,7 +4,7 @@
 import {getUid} from '../../util.js';
 import TileRange from '../../TileRange.js';
 import TileState from '../../TileState.js';
-import {createEmpty, getIntersection, getTopLeft} from '../../extent.js';
+import {createEmpty, equals, getIntersection, getTopLeft} from '../../extent.js';
 import CanvasLayerRenderer from './Layer.js';
 import {apply as applyTransform, compose as composeTransform, makeInverse, toString as transformToString} from '../../transform.js';
 
@@ -20,6 +20,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    */
   constructor(tileLayer) {
     super(tileLayer);
+
+    /**
+     * Rendered extent has changed since the previous `renderFrame()` call
+     * @type {boolean}
+     */
+    this.extentChanged = true;
 
     /**
      * @private
@@ -301,6 +307,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     this.renderedRevision = sourceRevision;
     this.renderedResolution = tileResolution;
+    this.extentChanged = !this.renderedExtent_ || !equals(this.renderedExtent_, canvasExtent);
     this.renderedExtent_ = canvasExtent;
 
     this.manageTilePyramid(frameState, tileSource, tileGrid, pixelRatio,

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -82,11 +82,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    * @param {number} z Tile coordinate z.
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
-   * @param {number} pixelRatio Pixel ratio.
-   * @param {import("../../proj/Projection.js").default} projection Projection.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @return {!import("../../Tile.js").default} Tile.
    */
-  getTile(z, x, y, pixelRatio, projection) {
+  getTile(z, x, y, frameState) {
+    const pixelRatio = frameState.pixelRatio;
+    const projection = frameState.viewState.projection;
     const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
     const tileSource = tileLayer.getSource();
     let tile = tileSource.getTile(z, x, y, pixelRatio, projection);
@@ -186,7 +187,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     this.newTiles_ = false;
     for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {
       for (let y = tileRange.minY; y <= tileRange.maxY; ++y) {
-        const tile = this.getTile(z, x, y, pixelRatio, projection);
+        const tile = this.getTile(z, x, y, frameState);
         if (this.isDrawableTile(tile)) {
           const uid = getUid(this);
           if (tile.getState() == TileState.LOADED) {

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -431,6 +431,11 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       return this.container_;
     }
 
+    if (!isEmpty(this.renderTileImageQueue_) && !this.extentChanged) {
+      this.renderTileImages_(hifi, frameState);
+      return this.container_;
+    }
+
     const context = this.overlayContext_;
     const declutterReplays = layer.getDeclutter() ? {} : null;
     const source = layer.getSource();

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -594,7 +594,8 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const replayState = tile.getReplayState(layer);
     const revision = layer.getRevision();
     const sourceZ = tile.sourceZ;
-    return replayState.renderedTileRevision !== revision || replayState.renderedTileZ !== sourceZ;
+    const resolution = replayState.renderedResolution;
+    return replayState.renderedTileRevision !== revision || replayState.renderedTileZ !== sourceZ || tile.renderedImageResolution !== resolution;
   }
 
   /**
@@ -632,6 +633,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       translateTransform(transform, -tileExtent[0], -tileExtent[3]);
       executorGroup.execute(context, transform, 0, {}, true, IMAGE_REPLAYS[layer.getRenderMode()]);
     }
+    tile.renderedImageResolution = replayState.renderedResolution;
   }
 
   /**


### PR DESCRIPTION
This pull request changes vector tile rendering so tiles are rendered at the exact view resolution, instead of using the resolution according to the render tile's zoom level.

With this change, we need to re-render more often, so I added a performance improvement to compensate for that: instruction and declutter group execution is bypassed if we're only rendering queued image tiles.

To avoid too frequent re-renders, the frame and view state is now created only once and updated. This way, long queued tiles will be rendered at the most recent view resolution, reducing the chance that they need to be re-rendered again.

To avoid misuse of the render frame for instruction creation, instruction creation is run in post render functions. Post render functions now allow to request another render frame by returning true.

With this change, the render quality of vector tiles is greatly improved, so noone should be missing the vector render mode that we dropped a few months ago any more.

Fixes openlayers/ol-mapbox-style#138.