### PR TITLE
Render vector tiles at the view resolution

### DIFF
--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -167,10 +167,9 @@ class VectorRenderTile extends Tile {
 
   /**
    * @inheritDoc
-   * @return {Array<import("./VectorTile.js").default>} Source tiles for this tile.
    */
   load() {
-    return this.getSourceTiles_(this);
+    this.getSourceTiles_(this);
   }
 }
 

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -12,8 +12,10 @@ import {createCanvasContext2D} from './dom.js';
  * @property {boolean} dirty
  * @property {null|import("./render.js").OrderFunction} renderedRenderOrder
  * @property {number} renderedTileRevision
+ * @property {number} renderedResolution
  * @property {number} renderedRevision
  * @property {number} renderedZ
+ * @property {number} renderedTileResolution
  * @property {number} renderedTileZ
  */
 
@@ -63,6 +65,11 @@ class VectorRenderTile extends Tile {
      * @type {!Object<string, ReplayState>}
      */
     this.replayState_ = {};
+
+    /**
+     * @type {number}
+     */
+    this.wantedResolution;
 
     /**
      * @type {!function(import("./VectorRenderTile.js").default):Array<import("./VectorTile.js").default>}
@@ -156,7 +163,9 @@ class VectorRenderTile extends Tile {
       this.replayState_[key] = {
         dirty: false,
         renderedRenderOrder: null,
+        renderedResolution: NaN,
         renderedRevision: -1,
+        renderedTileResolution: NaN,
         renderedTileRevision: -1,
         renderedZ: -1,
         renderedTileZ: -1

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -9,7 +9,7 @@ import {lineStringLength} from '../../geom/flat/length.js';
 import {drawTextOnPath} from '../../geom/flat/textpath.js';
 import {transform2D} from '../../geom/flat/transform.js';
 import {isEmpty} from '../../obj.js';
-import {drawImage, resetTransform, defaultPadding, defaultTextBaseline} from '../canvas.js';
+import {drawImage, defaultPadding, defaultTextBaseline} from '../canvas.js';
 import CanvasInstruction from './Instruction.js';
 import {TEXT_ALIGN} from './TextBuilder.js';
 import {
@@ -382,12 +382,13 @@ class Executor extends Disposable {
     if (this.alignFill_) {
       const origin = applyTransform(this.renderedTransform_, [0, 0]);
       const repeatSize = 512 * this.pixelRatio;
+      context.save();
       context.translate(origin[0] % repeatSize, origin[1] % repeatSize);
       context.rotate(this.viewRotation_);
     }
     context.fill();
     if (this.alignFill_) {
-      context.setTransform.apply(context, resetTransform);
+      context.restore();
     }
   }
 

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -4,7 +4,7 @@
 import {getUid} from '../../util.js';
 import TileRange from '../../TileRange.js';
 import TileState from '../../TileState.js';
-import {createEmpty, getIntersection, getTopLeft} from '../../extent.js';
+import {createEmpty, equals, getIntersection, getTopLeft} from '../../extent.js';
 import CanvasLayerRenderer from './Layer.js';
 import {apply as applyTransform, compose as composeTransform, makeInverse, toString as transformToString} from '../../transform.js';
 
@@ -20,6 +20,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    */
   constructor(tileLayer) {
     super(tileLayer);
+
+    /**
+     * Rendered extent has changed since the previous `renderFrame()` call
+     * @type {boolean}
+     */
+    this.extentChanged = true;
 
     /**
      * @private
@@ -301,6 +307,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     this.renderedRevision = sourceRevision;
     this.renderedResolution = tileResolution;
+    this.extentChanged = !this.renderedExtent_ || !equals(this.renderedExtent_, canvasExtent);
     this.renderedExtent_ = canvasExtent;
 
     this.manageTilePyramid(frameState, tileSource, tileGrid, pixelRatio,

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -82,11 +82,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    * @param {number} z Tile coordinate z.
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
-   * @param {number} pixelRatio Pixel ratio.
-   * @param {import("../../proj/Projection.js").default} projection Projection.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @return {!import("../../Tile.js").default} Tile.
    */
-  getTile(z, x, y, pixelRatio, projection) {
+  getTile(z, x, y, frameState) {
+    const pixelRatio = frameState.pixelRatio;
+    const projection = frameState.viewState.projection;
     const tileLayer = /** @type {import("../../layer/Tile.js").default} */ (this.getLayer());
     const tileSource = tileLayer.getSource();
     let tile = tileSource.getTile(z, x, y, pixelRatio, projection);
@@ -186,7 +187,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     this.newTiles_ = false;
     for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {
       for (let y = tileRange.minY; y <= tileRange.maxY; ++y) {
-        const tile = this.getTile(z, x, y, pixelRatio, projection);
+        const tile = this.getTile(z, x, y, frameState);
         if (this.isDrawableTile(tile)) {
           const uid = getUid(this);
           if (tile.getState() == TileState.LOADED) {

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -27,7 +27,7 @@ import {
   makeInverse
 } from '../../transform.js';
 import CanvasExecutorGroup, {replayDeclutter} from '../../render/canvas/ExecutorGroup.js';
-import {clear} from '../../obj.js';
+import {clear, isEmpty} from '../../obj.js';
 
 
 /**
@@ -428,6 +428,11 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const hifi = !(viewHints[ViewHint.ANIMATING] || viewHints[ViewHint.INTERACTING]);
     const renderMode = layer.getRenderMode();
     if (renderMode === VectorTileRenderType.IMAGE) {
+      this.renderTileImages_(hifi, frameState);
+      return this.container_;
+    }
+
+    if (!isEmpty(this.renderTileImageQueue_) && !this.extentChanged) {
       this.renderTileImages_(hifi, frameState);
       return this.container_;
     }

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -243,7 +243,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const resolution = tileGrid.getResolution(zoom);
     const tileExtent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
 
-    const sourceTiles = tile.load();
+    const sourceTiles = source.getSourceTiles(pixelRatio, projection, tile);
     const layerUid = getUid(layer);
     const executorGroups = tile.executorGroups[layerUid];
     if (executorGroups) {

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -59,7 +59,7 @@ describe('ol.source.VectorTile', function() {
       tile.load();
       const key = listen(tile, 'change', function(e) {
         if (tile.getState() === TileState.LOADED) {
-          const sourceTile = tile.load()[0];
+          const sourceTile = source.getSourceTiles(1, source.getProjection(), tile)[0];
           expect(sourceTile.getFeatures().length).to.be.greaterThan(0);
           unlistenByKey(key);
           done();

--- a/test/spec/ol/vectorrendertile.test.js
+++ b/test/spec/ol/vectorrendertile.test.js
@@ -85,7 +85,7 @@ describe('ol.VectorRenderTile', function() {
     const key = listen(tile, EventType.CHANGE, function() {
       if (tile.getState() === TileState.LOADED) {
         unlistenByKey(key);
-        const sourceTiles = tile.load();
+        const sourceTiles = source.getSourceTiles(1, source.getProjection(), tile);
         expect(sourceTiles.length).to.be(1);
         expect(sourceTiles[0].tileCoord).to.eql([0, 16, 9]);
         done();
@@ -126,7 +126,7 @@ describe('ol.VectorRenderTile', function() {
     listenOnce(tile, 'change', function() {
       expect(tile.getState()).to.be(TileState.LOADED);
       expect(tile.loadingSourceTiles).to.be(0);
-      const sourceTiles = tile.load();
+      const sourceTiles = source.getSourceTiles(1, source.getProjection(), tile);
       expect(sourceTiles.length).to.be(4);
       for (let i = 0, ii = sourceTiles.length; i < ii; ++i) {
         expect(sourceTiles[i].consumers).to.be(1);


### PR DESCRIPTION
This pull request changes vector tile rendering so tiles are rendered at the exact view resolution, instead of using the resolution according to the render tile's zoom level.

With this change, we need to re-render more often, so I added a performance improvement to compensate for that: instruction and declutter group execution is bypassed if we're only rendering queued image tiles.

With this change, the render quality of vector tiles is greatly improved, so noone should be missing the vector render mode that we dropped a few months ago any more.

Fixes openlayers/ol-mapbox-style#138.