### PR TITLE
Enables attributions for the RasterSource

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -230,6 +230,20 @@ class RasterSource extends ImageSource {
       wantedTiles: {}
     };
 
+    this.setAttributions(function(frameState) {
+      const attributions = [];
+      for (let index = 0, iMax = options.sources.length; index < iMax; ++index) {
+        const sourceOrLayer = options.sources[index];
+        const source = sourceOrLayer instanceof Source ? sourceOrLayer : sourceOrLayer.getSource();
+        const attributionGetter = source.getAttributions();
+        if (typeof attributionGetter === 'function') {
+          const sourceAttribution = attributionGetter(frameState);
+          attributions.push.apply(attributions, sourceAttribution);
+        }
+      }
+      return attributions.length !== 0 ? attributions : null;
+    });
+
     if (options.operation !== undefined) {
       this.setOperation(options.operation, options.lib);
     }

--- a/test/spec/ol/source/raster.test.js
+++ b/test/spec/ol/source/raster.test.js
@@ -39,12 +39,14 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function() {
 
     redSource = new Static({
       url: red,
-      imageExtent: extent
+      imageExtent: extent,
+      attributions: ['red raster source']
     });
 
     greenSource = new Static({
       url: green,
-      imageExtent: extent
+      imageExtent: extent,
+      attributions: ['green raster source']
     });
 
     blueSource = new VectorImageLayer({
@@ -163,6 +165,54 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function() {
       view.setCenter([0, 0]);
       view.setZoom(0);
 
+    });
+
+  });
+
+  describe('config option `attributions`', function() {
+    it('handles empty attributions', function() {
+      const blue = new RasterSource({
+        operationType: 'image',
+        threads: 0,
+        sources: [blueSource],
+        operation: function(inputs) {
+          return inputs[0];
+        }
+      });
+      const blueAttributions = blue.getAttributions();
+      expect(blueAttributions()).to.be(null);
+    });
+
+    it('shows single attributions', function() {
+      const red = new RasterSource({
+        operationType: 'image',
+        threads: 0,
+        sources: [redSource],
+        operation: function(inputs) {
+          return inputs[0];
+        }
+      });
+      const redAttribtuions = red.getAttributions();
+
+      expect(redAttribtuions()).to.not.be(null);
+      expect(typeof redAttribtuions).to.be('function');
+      expect(redAttribtuions()).to.eql(['red raster source']);
+    });
+
+    it('concatinates multiple attributions', function() {
+      const redGreen = new RasterSource({
+        operationType: 'image',
+        threads: 0,
+        sources: [redSource, greenSource],
+        operation: function(inputs) {
+          return inputs[0];
+        }
+      });
+      const redGreenAttributions = redGreen.getAttributions();
+
+      expect(redGreenAttributions()).to.not.be(null);
+      expect(typeof redGreenAttributions).to.be('function');
+      expect(redGreenAttributions()).to.eql(['red raster source', 'green raster source']);
     });
 
   });


### PR DESCRIPTION
This enables attributions for the RasterSource.

- Attributions included in the passed sources are concatenated.
- Attributions of mutiple sources are concatenated.
- Empty attributions are omitted.

#closes #9281
