### PR TITLE
Fix view initialization with min/max resolution constraint

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -12,7 +12,7 @@ target values are provided and constraints are applied on these to determine the
 
 ##### Removal of the `constrainResolution` option on `View.fit`, `PinchZoom`, `MouseWheelZoom` and `ol/interaction.js`
 
-The `constrainResolution` option is now only supported by the `View` class. A `View.setResolutionConstrained` method was added as well.
+The `constrainResolution` option is now only supported by the `View` class. A `View.setConstrainResolution` method was added as well.
 
 Generally, the responsibility of applying center/rotation/resolutions constraints was moved from interactions and controls to the `View` class.
 

--- a/rendering/cases/zoomify-no-zdirection/main.js
+++ b/rendering/cases/zoomify-no-zdirection/main.js
@@ -16,7 +16,6 @@ new Map({
   target: 'map',
   view: new View({
     resolutions: [2, 1],
-    extent: [0, -200, 200, 0],
     center: [100, -100],
     zoom: 0.4
   })

--- a/rendering/cases/zoomify-zdirection/main.js
+++ b/rendering/cases/zoomify-zdirection/main.js
@@ -17,7 +17,6 @@ new Map({
   target: 'map',
   view: new View({
     resolutions: [2, 1],
-    extent: [0, -200, 200, 0],
     center: [100, -100],
     zoom: 0.4
   })

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -964,6 +964,10 @@ class PluggableMap extends BaseObject {
    * @private
    */
   handleSizeChanged_() {
+    if (this.getView()) {
+      this.getView().resolveConstraints(0);
+    }
+
     this.render();
   }
 
@@ -1051,6 +1055,8 @@ class PluggableMap extends BaseObject {
       this.viewChangeListenerKey_ = listen(
         view, EventType.CHANGE,
         this.handleViewPropertyChanged_, this);
+
+      view.resolveConstraints(0);
     }
     this.render();
   }

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -377,7 +377,7 @@ class View extends BaseObject {
     } else if (options.zoom !== undefined) {
       this.setZoom(options.zoom);
     }
-    this.resolveConstraints_(0);
+    this.resolveConstraints(0);
 
     this.setProperties(properties);
 
@@ -644,7 +644,7 @@ class View extends BaseObject {
     }
 
     if (!this.getAnimating()) {
-      setTimeout(this.resolveConstraints_.bind(this), 0);
+      setTimeout(this.resolveConstraints.bind(this), 0);
     }
   }
 
@@ -1284,9 +1284,8 @@ class View extends BaseObject {
    * @param {number=} opt_duration The animation duration in ms.
    * @param {number=} opt_resolutionDirection Which direction to zoom.
    * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
-   * @private
    */
-  resolveConstraints_(opt_duration, opt_resolutionDirection, opt_anchor) {
+  resolveConstraints(opt_duration, opt_resolutionDirection, opt_anchor) {
     const duration = opt_duration !== undefined ? opt_duration : 200;
     const direction = opt_resolutionDirection || 0;
 
@@ -1342,7 +1341,7 @@ class View extends BaseObject {
   endInteraction(opt_duration, opt_resolutionDirection, opt_anchor) {
     this.setHint(ViewHint.INTERACTING, -1);
 
-    this.resolveConstraints_(opt_duration, opt_resolutionDirection, opt_anchor);
+    this.resolveConstraints(opt_duration, opt_resolutionDirection, opt_anchor);
   }
 
   /**

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -28,6 +28,71 @@ describe('ol.View', function() {
 
   });
 
+  describe('parameter initialization with resolution/zoom constraints', function() {
+    it('correctly handles max resolution constraint', function() {
+      const view = new View({
+        maxResolution: 1000,
+        resolution: 1200
+      });
+      expect(view.getResolution()).to.eql(1000);
+      expect(view.targetResolution_).to.eql(1000);
+    });
+
+    it('correctly handles min resolution constraint', function() {
+      const view = new View({
+        maxResolution: 1024,
+        minResolution: 128,
+        resolution: 50
+      });
+      expect(view.getResolution()).to.eql(128);
+      expect(view.targetResolution_).to.eql(128);
+    });
+
+    it('correctly handles resolutions array constraint', function() {
+      let view = new View({
+        resolutions: [1024, 512, 256, 128, 64, 32],
+        resolution: 1200
+      });
+      expect(view.getResolution()).to.eql(1024);
+      expect(view.targetResolution_).to.eql(1024);
+
+      view = new View({
+        resolutions: [1024, 512, 256, 128, 64, 32],
+        resolution: 10
+      });
+      expect(view.getResolution()).to.eql(32);
+      expect(view.targetResolution_).to.eql(32);
+    });
+
+    it('correctly handles min zoom constraint', function() {
+      const view = new View({
+        minZoom: 3,
+        zoom: 2
+      });
+      expect(view.getZoom()).to.eql(3);
+      expect(view.targetResolution_).to.eql(view.getMaxResolution());
+    });
+
+    it('correctly handles max zoom constraint', function() {
+      const view = new View({
+        maxZoom: 4,
+        zoom: 5
+      });
+      expect(view.getZoom()).to.eql(4);
+      expect(view.targetResolution_).to.eql(view.getMaxResolution() / Math.pow(2, 4));
+    });
+
+    it('correctly handles extent constraint', function() {
+      // default viewport size is 100x100
+      const view = new View({
+        extent: [0, 0, 50, 50],
+        resolution: 1
+      });
+      expect(view.getResolution()).to.eql(0.5);
+      expect(view.targetResolution_).to.eql(0.5);
+    });
+  });
+
   describe('create constraints', function() {
 
     describe('create center constraint', function() {

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1053,8 +1053,7 @@ describe('ol.View', function() {
     let view;
     beforeEach(function() {
       view = new View({
-        resolutions: [1024, 512, 256, 128, 64, 32, 16, 8],
-        smoothResolutionConstraint: false
+        resolutions: [1024, 512, 256, 128, 64, 32, 16, 8]
       });
     });
 
@@ -1086,8 +1085,7 @@ describe('ol.View', function() {
 
     it('works for resolution arrays with variable zoom factors', function() {
       const view = new View({
-        resolutions: [10, 5, 2, 1],
-        smoothResolutionConstraint: false
+        resolutions: [10, 5, 2, 1]
       });
 
       view.setZoom(1);
@@ -1112,8 +1110,7 @@ describe('ol.View', function() {
     it('returns correct zoom levels', function() {
       const view = new View({
         minZoom: 10,
-        maxZoom: 20,
-        smoothResolutionConstraint: false
+        maxZoom: 20
       });
 
       view.setZoom(5);
@@ -1189,9 +1186,7 @@ describe('ol.View', function() {
   describe('#getResolutionForZoom', function() {
 
     it('returns correct zoom resolution', function() {
-      const view = new View({
-        smoothResolutionConstraint: false
-      });
+      const view = new View();
       const max = view.getMaxZoom();
       const min = view.getMinZoom();
 


### PR DESCRIPTION
Previously the view could be initialized with a `resolution` or `zoom` parameter outside of the allowed range (either specified by `resolutions` array or `maxResolution`, `minResolution`, `minZoom`, `maxZoom`).

This PR refactors the initialization to 1/ be simpler and 2/ take into account the allowed resolution range. A specific test was added for this, which adds for verbosity in `view.test.js` but IMO makes the expected behaviour more explicit.

This fixes #9366 

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
