### PR TITLE
PointsLayer added clear of the render Buffers on Source Change

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -272,6 +272,8 @@ class WebGLPointsLayerRenderer extends LayerRenderer {
 
     if (this.sourceRevision_ < vectorSource.getRevision()) {
       this.sourceRevision_ = vectorSource.getRevision();
+      this.verticesBuffer_.getArray().length = 0;
+      this.indicesBuffer_.getArray().length = 0;
 
       const viewState = frameState.viewState;
       const projection = viewState.projection;


### PR DESCRIPTION
The Renderbuffers don't got cleared if the dataScource changes. The geometry of the  features gets pushed in the back of the render Buffer simly ccreating a larger Buffer with old and new state.
The proposed fix clears the Buffers before adding the changed Features.

