### PR TITLE
Changes to parsing of KML displayName

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -682,9 +682,9 @@ class KML extends XMLFeature {
       const localName = n.localName;
       if (includes(NAMESPACE_URIS, n.namespaceURI) &&
           (localName == 'Document' ||
-           localName == 'Folder' ||
-           localName == 'Placemark' ||
-           localName == 'kml')) {
+            localName == 'Folder' ||
+            localName == 'Placemark' ||
+            localName == 'kml')) {
         const name = this.readNameFromNode(n);
         if (name) {
           return name;
@@ -748,8 +748,8 @@ class KML extends XMLFeature {
       const localName = n.localName;
       if (includes(NAMESPACE_URIS, n.namespaceURI) &&
           (localName == 'Document' ||
-           localName == 'Folder' ||
-           localName == 'kml')) {
+            localName == 'Folder' ||
+            localName == 'kml')) {
         extend(networkLinks, this.readNetworkLinksFromNode(n));
       }
     }
@@ -811,8 +811,8 @@ class KML extends XMLFeature {
       const localName = n.localName;
       if (includes(NAMESPACE_URIS, n.namespaceURI) &&
           (localName == 'Document' ||
-           localName == 'Folder' ||
-           localName == 'kml')) {
+            localName == 'Folder' ||
+            localName == 'kml')) {
         extend(regions, this.readRegionFromNode(n));
       }
     }
@@ -1797,7 +1797,12 @@ function dataParser(node, objectStack) {
   const name = node.getAttribute('name');
   parseNode(DATA_PARSERS, node, objectStack);
   const featureObject = /** @type {Object} */ (objectStack[objectStack.length - 1]);
-  if (name !== null) {
+  if (name && featureObject.displayName) {
+    featureObject[name] = {
+      value: featureObject.value,
+      displayName: featureObject.displayName
+    };
+  } else if (name !== null) {
     featureObject[name] = featureObject.value;
   } else if (featureObject.displayName !== null) {
     featureObject[featureObject.displayName] = featureObject.value;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -1800,7 +1800,10 @@ function dataParser(node, objectStack) {
   if (name && featureObject.displayName) {
     featureObject[name] = {
       value: featureObject.value,
-      displayName: featureObject.displayName
+      displayName: featureObject.displayName,
+      toString: function() {
+        return featureObject.value;
+      }
     };
   } else if (name !== null) {
     featureObject[name] = featureObject.value;

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -1670,6 +1670,25 @@ describe('ol.format.KML', function() {
           expect(f.get('bar')).to.be(undefined);
         });
 
+        it('can read ExtendedData with displayName instead of name', function() {
+          const text =
+              '<kml xmlns="http://earth.google.com/kml/2.2">' +
+              '  <Placemark xmlns="http://earth.google.com/kml/2.2">' +
+              '    <ExtendedData>' +
+              '      <Data>' +
+              '        <displayName>foo</displayName>' +
+              '        <value>bar</value>' +
+              '      </Data>' +
+              '    </ExtendedData>' +
+              '  </Placemark>' +
+              '</kml>';
+          const fs = format.readFeatures(text);
+          expect(fs).to.have.length(1);
+          const f = fs[0];
+          expect(f).to.be.an(Feature);
+          expect(f.get('foo')).to.be('bar');
+        });
+
         it('can read SchemaData', function() {
           const text =
               '<kml xmlns="http://earth.google.com/kml/2.2">' +
@@ -1711,10 +1730,8 @@ describe('ol.format.KML', function() {
           const f = fs[0];
           expect(f).to.be.an(Feature);
           expect(f.get('capital')).to.be('London');
-          expect(f.get('country')).to.eql({
-            value: 'United-Kingdom',
-            displayName: 'Country'
-          });
+          expect(f.get('country').value).to.be('United-Kingdom');
+          expect(f.get('country').displayName).to.be('Country');
         });
       });
 

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -1670,25 +1670,6 @@ describe('ol.format.KML', function() {
           expect(f.get('bar')).to.be(undefined);
         });
 
-        it('can read ExtendedData with displayName instead of name', function() {
-          const text =
-              '<kml xmlns="http://earth.google.com/kml/2.2">' +
-              '  <Placemark xmlns="http://earth.google.com/kml/2.2">' +
-              '    <ExtendedData>' +
-              '      <Data>' +
-              '        <displayName>foo</displayName>' +
-              '        <value>bar</value>' +
-              '      </Data>' +
-              '    </ExtendedData>' +
-              '  </Placemark>' +
-              '</kml>';
-          const fs = format.readFeatures(text);
-          expect(fs).to.have.length(1);
-          const f = fs[0];
-          expect(f).to.be.an(Feature);
-          expect(f.get('foo')).to.be('bar');
-        });
-
         it('can read SchemaData', function() {
           const text =
               '<kml xmlns="http://earth.google.com/kml/2.2">' +
@@ -1709,7 +1690,7 @@ describe('ol.format.KML', function() {
           expect(f.get('population')).to.be('60000000');
         });
 
-        it('can read ExtendedData with displayName when name undefined', function() {
+        it('can read ExtendedData with displayName', function() {
           const text =
               '<kml xmlns="http://earth.google.com/kml/2.2">' +
               '  <Placemark xmlns="http://earth.google.com/kml/2.2">' +
@@ -1730,7 +1711,10 @@ describe('ol.format.KML', function() {
           const f = fs[0];
           expect(f).to.be.an(Feature);
           expect(f.get('capital')).to.be('London');
-          expect(f.get('country')).to.be('United-Kingdom');
+          expect(f.get('country')).to.eql({
+            value: 'United-Kingdom',
+            displayName: 'Country'
+          });
         });
       });
 


### PR DESCRIPTION
To avoid loss of information the behaviour of parsing the displayName (if a name attribute is also given) is changed.

```xml
<kml xmlns="http://earth.google.com/kml/2.2">
  <Placemark xmlns="http://earth.google.com/kml/2.2">
    <ExtendedData>
      <Data>
        <displayName>capital</displayName>
        <value>London</value>
      </Data>
      <Data name="country">
        <displayName>Country</displayName>
        <value>United-Kingdom</value>
      </Data>
    </ExtendedData>
   </Placemark>
</kml>;
```

Previous behaviour was:
```js
feature.get('capital'); //'London'; 
feature.get('country'); //'United-Kingdom';
```

New behaviour is:
```js
feature.get('capital'); //'London'; 
feature.get('country'); //{value: 'United-Kingdom', displayName: 'Country'}
```

closes #9265
