### PR TITLE
Fix tile state condition in raster layer test

### DIFF
--- a/test/spec/ol/source/raster.test.js
+++ b/test/spec/ol/source/raster.test.js
@@ -402,7 +402,7 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function() {
       map2.once('moveend', function() {
         expect(tileCache.getCount()).to.equal(1);
         const state = tileCache.peekLast().getState();
-        expect(state === TileState.LOADED || state === TileState.LOADED).to.be(true);
+        expect(state === TileState.LOADING || state === TileState.LOADED).to.be(true);
         done();
       });
 


### PR DESCRIPTION
The state was duplicated from the beginning, see 3ddb8712a3079aba28e09eb4fca9beaf7896aca9
