### PR TITLE
Clear context when source revision changed (v5.3.x fix)

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -234,7 +234,8 @@ class CanvasTileLayerRenderer extends IntermediateCanvasRenderer {
           canvas.width = width;
           canvas.height = height;
         } else {
-          if (this.renderedExtent_ && !equals(imageExtent, this.renderedExtent_)) {
+          if ((this.renderedExtent_ && !equals(imageExtent, this.renderedExtent_)) ||
+              this.renderedRevision != sourceRevision) {
             context.clearRect(0, 0, width, height);
           }
           oversampling = this.oversampling_;


### PR DESCRIPTION
This PR fixes a bug in the Canvas TileLayer renderer. It targets the v5.3.x branch, as this bug does not exist in master.

Here is a codepen example demonstrating the problem: https://codepen.io/anon/pen/ROVpQe.

1. Click on the "Clear LAYERS" button
2. Now click on the "Add roads to LAYERS" button

You will see the topp:states layer by the time new tiles with just the sf:roads layer are loaded. This is the rendering bug fixed by this PR. When making the layer visible again the old canvas context is used without checking whether the source revision has changed, leading to visual artifacts.

This PR fixes the problem by making sure the canvas context is cleared when the source revision has changed.