### PR TITLE
Remove unused private variables, remove trailing whitespace

### DIFF
--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -27,7 +27,6 @@ import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer';
  * of the heatmap, specified as an array of CSS color strings.
  * @property {number} [radius=8] Radius size in pixels.
  * @property {number} [blur=15] Blur size in pixels.
- * @property {number} [shadow=250] Shadow size in pixels.
  * @property {string|function(import("../Feature.js").default):number} [weight='weight'] The feature
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
@@ -75,7 +74,6 @@ class Heatmap extends VectorLayer {
     delete baseOptions.gradient;
     delete baseOptions.radius;
     delete baseOptions.blur;
-    delete baseOptions.shadow;
     delete baseOptions.weight;
     super(baseOptions);
 
@@ -84,24 +82,6 @@ class Heatmap extends VectorLayer {
      * @type {HTMLCanvasElement}
      */
     this.gradient_ = null;
-
-    /**
-     * @private
-     * @type {number}
-     */
-    this.shadow_ = options.shadow !== undefined ? options.shadow : 250;
-
-    /**
-     * @private
-     * @type {string|undefined}
-     */
-    this.circleImage_ = undefined;
-
-    /**
-     * @private
-     * @type {Array<Array<import("../style/Style.js").default>>}
-     */
-    this.styleCache_ = null;
 
     listen(this,
       getChangeEventType(Property.GRADIENT),
@@ -206,15 +186,15 @@ class Heatmap extends VectorLayer {
         attribute float a_rotateWithView;
         attribute vec2 a_offsets;
         attribute float a_opacity;
-        
+
         uniform mat4 u_projectionMatrix;
         uniform mat4 u_offsetScaleMatrix;
         uniform mat4 u_offsetRotateMatrix;
         uniform float u_size;
-        
+
         varying vec2 v_texCoord;
         varying float v_opacity;
-        
+
         void main(void) {
           mat4 offsetMatrix = u_offsetScaleMatrix;
           if (a_rotateWithView == 1.0) {
@@ -229,10 +209,10 @@ class Heatmap extends VectorLayer {
         precision mediump float;
         uniform float u_resolution;
         uniform float u_blurSlope;
-        
+
         varying vec2 v_texCoord;
         varying float v_opacity;
-        
+
         void main(void) {
           vec2 texCoord = v_texCoord * 2.0 - vec2(1.0, 1.0);
           float sqRadius = texCoord.x * texCoord.x + texCoord.y * texCoord.y;
@@ -273,9 +253,7 @@ class Heatmap extends VectorLayer {
           }
         }
       ],
-      opacityCallback: function(feature) {
-        return this.weightFunction_(feature);
-      }.bind(this)
+      opacityCallback: this.weightFunction_
     });
   }
 }


### PR DESCRIPTION
Leftover from the DOM canvas implementation.