### PR TITLE
Use nearest lower resolution of vector tiles

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -138,8 +138,8 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
      */
     this.tmpTransform_ = createTransform();
 
-    // Use closest resolution.
-    this.zDirection = 0;
+    // Use nearest lower resolution.
+    this.zDirection = 1;
 
     listen(labelCache, EventType.CLEAR, this.handleFontsChanged_, this);
 

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -98,7 +98,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
     it('creates a new instance', function() {
       const renderer = new CanvasVectorTileLayerRenderer(layer);
       expect(renderer).to.be.a(CanvasVectorTileLayerRenderer);
-      expect(renderer.zDirection).to.be(0);
+      expect(renderer.zDirection).to.be(1);
     });
 
     it('does not render replays for pure image rendering', function() {


### PR DESCRIPTION
In mapbox-gl, vector tiles are loaded for the nearest lower resolution. This makes sense because the coordinate resolution of vector tiles is higher than the view resolution.

In OpenLayers, we load vector tiles for the nearest resolution, like we do for raster layers. Changing this in OpenLayers, we not only get more in line with what mapbox-gl does, but also reduce the amount of data we handle at fractional zooms.