### PR TITLE
Call the color callback once per feature

### DIFF
--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -37,7 +37,7 @@ updateStatusText();
 class WebglPointsLayer extends VectorLayer {
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
-      colorCallback: function(feature, vertex, color) {
+      colorCallback: function(feature, color) {
         // color is interpolated based on year
         const ratio = clamp((feature.get('year') - 1800) / (2013 - 1800), 0, 1);
 

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -38,7 +38,7 @@ class WebglPointsLayer extends VectorLayer {
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
       texture: texture,
-      colorCallback: function(feature, vertex, color) {
+      colorCallback: function(feature, color) {
         // color is interpolated based on year (min is 1910, max is 2013)
         // please note: most values are between 2000-2013
         const ratio = (feature.get('year') - 1950) / (2013 - 1950);


### PR DESCRIPTION
Following up on #9452, this reduces the number of times we call the WebGL points color callback for each feature from four to one.

cc @jahow 