### PR TITLE
Document events fired by interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "istanbul": "0.4.5",
     "jquery": "3.4.0",
     "jsdoc": "3.5.5",
-    "jsdoc-plugin-typescript": "^1.0.7",
+    "jsdoc-plugin-typescript": "^1.0.8",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "^1.1.2",

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -38,7 +38,7 @@ import {createEditingStyle} from '../style/Style.js';
 const ExtentEventType = {
   /**
    * Triggered after the extent is changed
-   * @event ExtentEventType#extentchanged
+   * @event ExtentEvent#extentchanged
    * @api
    */
   EXTENTCHANGED: 'extentchanged'
@@ -47,10 +47,10 @@ const ExtentEventType = {
 
 /**
  * @classdesc
- * Events emitted by {@link module:ol/interaction/Extent~ExtentInteraction} instances are
+ * Events emitted by {@link module:ol/interaction/Extent~Extent} instances are
  * instances of this type.
  */
-class ExtentInteractionEvent extends Event {
+class ExtentEvent extends Event {
 
   /**
    * @param {import("../extent.js").Extent} extent the new extent
@@ -75,10 +75,10 @@ class ExtentInteractionEvent extends Event {
  * Once drawn, the vector box can be modified by dragging its vertices or edges.
  * This interaction is only supported for mouse devices.
  *
- * @fires Event
+ * @fires ExtentEvent
  * @api
  */
-class ExtentInteraction extends PointerInteraction {
+class Extent extends PointerInteraction {
   /**
    * @param {Options=} opt_options Options.
    */
@@ -399,7 +399,7 @@ class ExtentInteraction extends PointerInteraction {
     //Null extent means no bbox
     this.extent_ = extent ? extent : null;
     this.createOrUpdateExtentFeature_(extent);
-    this.dispatchEvent(new ExtentInteractionEvent(this.extent_));
+    this.dispatchEvent(new ExtentEvent(this.extent_));
   }
 }
 
@@ -470,4 +470,4 @@ function getSegments(extent) {
 }
 
 
-export default ExtentInteraction;
+export default Extent;


### PR DESCRIPTION
The event names for our interactions are not currently showing up in the docs.  It looks like the `longname` for these doclets is not being generated correctly if the `@event` annotation doesn't have the full module path.

~~It feels like there should be an opportunity to fix this another way (supporting the existing syntax).  I'll keep digging to see where that `longname` is generated - but I think this is an ok change to merge in too~~.

**Update**: I updated this branch to pull in the changes from openlayers/jsdoc-plugin-typescript#5

Here is what the draw interaction docs look like after this change:
![image](https://user-images.githubusercontent.com/41094/56870313-e6eb4780-69ca-11e9-9d77-be287212c81e.png)

Fixes #9471 
