### PR TITLE
Tidy up the JSDoc events plugin

### DIFF
--- a/config/jsdoc/api/plugins/events.js
+++ b/config/jsdoc/api/plugins/events.js
@@ -1,5 +1,4 @@
 const events = {};
-const classes = {};
 
 exports.handlers = {
 
@@ -12,8 +11,6 @@ exports.handlers = {
         events[cls] = [];
       }
       events[cls].push(doclet.longname);
-    } else if (doclet.kind == 'class' && !(doclet.longname in classes)) {
-      classes[doclet.longname] = doclet;
     }
   },
 

--- a/config/jsdoc/api/plugins/events.js
+++ b/config/jsdoc/api/plugins/events.js
@@ -4,26 +4,26 @@ exports.handlers = {
 
   newDoclet: function(e) {
     const doclet = e.doclet;
-    let cls;
-    if (doclet.kind == 'event') {
-      cls = doclet.longname.split('#')[0];
-      if (!(cls in events)) {
-        events[cls] = [];
-      }
-      events[cls].push(doclet.longname);
+    if (doclet.kind !== 'event') {
+      return;
     }
+
+    const cls = doclet.longname.split('#')[0];
+    if (!(cls in events)) {
+      events[cls] = [];
+    }
+    events[cls].push(doclet.longname);
   },
 
   parseComplete: function(e) {
     const doclets = e.doclets;
-    let doclet, i, ii, j, jj, event, fires;
-    for (i = 0, ii = doclets.length - 1; i < ii; ++i) {
-      doclet = doclets[i];
+    for (let i = 0, ii = doclets.length - 1; i < ii; ++i) {
+      const doclet = doclets[i];
       if (doclet.fires) {
         if (doclet.kind == 'class') {
-          fires = [];
-          for (j = 0, jj = doclet.fires.length; j < jj; ++j) {
-            event = doclet.fires[j].replace('event:', '');
+          const fires = [];
+          for (let j = 0, jj = doclet.fires.length; j < jj; ++j) {
+            const event = doclet.fires[j].replace('event:', '');
             if (events[event]) {
               fires.push.apply(fires, events[event]);
             } else if (doclet.fires[j] !== 'event:ObjectEvent') {


### PR DESCRIPTION
Minor changes to the `events.js` plugin.

The first commit removes the unused `classes` lookup.  This was used when the plugin was first created (b1126c93731398b2d43029d03755c5ed95fe8091).  Use of the `classes` lookup was removed in https://github.com/openlayers/openlayers/commit/a75d944311e8949d73f396c5c2902c30d19467b2#diff-2315b0fa6968a2f0446c2937b99fe14a, but we still assigned to it.

The second change gives variables smaller block scope (instead of full function scope).