### PR TITLE
Avoid header expanding over examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -11,8 +11,24 @@
       body {
         padding-top: 70px;
       }
+      img.header-logo {
+        padding-left: 18px;
+      }
       input.search-query {
         color: #333;
+      }
+      @media (max-width: 480px) {
+        input.search-query {
+          width: 110px;
+        }
+        #count {
+          display: none;
+        }
+      }
+      @media (max-width: 374px) {
+        input.search-query {
+          display: none;
+        }
       }
       .example {
         display: block;
@@ -182,9 +198,9 @@
   <body>
 
     <header class="navbar navbar-fixed-top" role="navigation">
-      <div class="container">
+      <div class="container-fluid">
         <div class="display-table pull-left">
-          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers Examples</a>
+          <a class="navbar-brand" href="./"><img class="header-logo" src="./resources/logo-70x70.png">&nbsp;OpenLayers</a>
           <form class="navbar-form" role="search">
             <input name="q" type="text" id="keywords" class="search-query" placeholder="Search" autofocus>
             <span id="count"></span>

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -78,7 +78,7 @@
     <header class="navbar" role="navigation">
       <div class="container">
         <div class="display-table pull-left" id="navbar-logo-container">
-          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers Examples</a>
+          <a class="navbar-brand" href="./"><img src="./resources/logo-70x70.png">&nbsp;OpenLayers</a>
         </div>
         <!-- menu items that get hidden below 768px width -->
         <nav class='collapse navbar-collapse navbar-responsive-collapse'>


### PR DESCRIPTION
This makes the example index page work a bit better over a wider range of widths.

![resize](https://user-images.githubusercontent.com/41094/57114782-2afe8500-6d08-11e9-908e-10f5dd82dcf3.gif)

And here is what it looks like on a phancy new phone:

![phone](https://user-images.githubusercontent.com/41094/57114827-639e5e80-6d08-11e9-8b1d-b76efe8ec0f0.png)

The website needs a more significant overhaul.  But this is a minor improvement in the meantime.