### PR TITLE
Set the 'lang' attribute to the html tag in examples

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -122,7 +122,7 @@
           <a class="copy-button" id="copy-html-button" data-clipboard-target="#example-html-source"><i class="fa fa-clipboard"></i> Copy</a>
         </div>
         <pre><legend>index.html</legend><code id="example-html-source" class="language-markup">&lt;!DOCTYPE html&gt;
-&lt;html&gt;
+&lt;html lang="en"&gt;
   &lt;head&gt;
     &lt;title&gt;{{ title }}&lt;/title&gt;
     &lt;!-- The line below is only needed for old environments like Internet Explorer and Android 4.x --&gt;


### PR DESCRIPTION
Removes the warning display in https://codesandbox.io:
![Screenshot from 2019-05-03 11-31-20](https://user-images.githubusercontent.com/100959/57129664-65fbc980-6d97-11e9-84f7-d3e38691759d.png)
