### PR TITLE
Avoid blurry vector tiles

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -614,6 +614,8 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const tileGrid = source.getTileGridForProjection(projection);
     const resolution = tileGrid.getResolution(z);
     const context = tile.getContext(layer);
+    // Increase tile size when overzooming for low pixel ratio, to avoid blurry tiles
+    pixelRatio = Math.max(pixelRatio, renderPixelRatio / pixelRatio);
     const size = source.getTilePixelSize(z, pixelRatio, projection);
     context.canvas.width = size[0];
     context.canvas.height = size[1];


### PR DESCRIPTION
Since #9469, we use the nearest lower resolution or vector tiles. This also causes more oversampling. To compensate for that, this pull request increases the rendered tile size when the pixel ratio is low. For higher pixel ratios (e.g. on Retina displays), we continue to use the the device pixel ratio to calculate the rendered tile size.