### PR TITLE
Remove absolute position on ol-overlaycontainer divs

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -236,10 +236,6 @@ class PluggableMap extends BaseObject {
      * @type {!HTMLElement}
      */
     this.overlayContainer_ = document.createElement('div');
-    this.overlayContainer_.style.position = 'absolute';
-    this.overlayContainer_.style.zIndex = '0';
-    this.overlayContainer_.style.width = '100%';
-    this.overlayContainer_.style.height = '100%';
     this.overlayContainer_.className = 'ol-overlaycontainer';
     this.viewport_.appendChild(this.overlayContainer_);
 

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -248,10 +248,6 @@ class PluggableMap extends BaseObject {
      * @type {!HTMLElement}
      */
     this.overlayContainerStopEvent_ = document.createElement('div');
-    this.overlayContainerStopEvent_.style.position = 'absolute';
-    this.overlayContainerStopEvent_.style.zIndex = '0';
-    this.overlayContainerStopEvent_.style.width = '100%';
-    this.overlayContainerStopEvent_.style.height = '100%';
     this.overlayContainerStopEvent_.className = 'ol-overlaycontainer-stopevent';
     this.viewport_.appendChild(this.overlayContainerStopEvent_);
 

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -28,11 +28,7 @@ class CompositeMapRenderer extends MapRenderer {
      * @type {HTMLDivElement}
      */
     this.element_ = document.createElement('div');
-    const style = this.element_.style;
-    style.position = 'absolute';
-    style.width = '100%';
-    style.height = '100%';
-    style.zIndex = '0';
+    this.element_.style.zIndex = '0';
 
     this.element_.className = CLASS_UNSELECTABLE + ' ol-layers';
 


### PR DESCRIPTION
work in progress, trying to fix #9467 and #9139

The `absolute` position have been added in 898c349fbfed798d68bb570f4be55cc8c6c290d3