### PR TITLE
Upgrade ol-mapbox-style to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "loglevelnext": "^3.0.1",
     "marked": "0.6.2",
     "mocha": "6.1.4",
-    "ol-mapbox-style": "^4.3.1",
+    "ol-mapbox-style": "^5.0.0-beta.1",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.4.0",
     "proj4": "2.5.0",


### PR DESCRIPTION
Fixes the z-index render order in the mapbox-style example.