### PR TITLE
Fix hit detection for multiple layers when decluttering is off

### DIFF
--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -191,7 +191,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     } else {
       const resolution = frameState.viewState.resolution;
       const rotation = frameState.viewState.rotation;
-      const layer = this.getLayer();
+      const layer = /** @type {import("../../layer/Vector").default} */ (this.getLayer());
       /** @type {!Object<string, boolean>} */
       const features = {};
       const result = this.replayGroup_.forEachFeatureAtCoordinate(coordinate, resolution, rotation, hitTolerance, {},
@@ -205,7 +205,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
             features[key] = true;
             return callback(feature, layer);
           }
-        }, declutteredFeatures);
+        }, layer.getDeclutter() ? declutteredFeatures : null);
       return result;
     }
   }

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -357,7 +357,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
               features[key] = true;
               return callback(feature, layer);
             }
-          }, declutteredFeatures);
+          }, layer.getDeclutter() ? declutteredFeatures : null);
       }
     }
     return found;


### PR DESCRIPTION
12289b8ef9ba03fa656e759272974dcf3475a06c introduced a regression: on maps with multiple vector or vector tile layers, when only some have `declutter: true`, hit detection fails for those that have `declutter: false`. This pull request fixes that.