### PR TITLE
[WIP] Improve IIIF tile source and parser documentation

### DIFF
--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -97,9 +97,10 @@ import {assert} from '../asserts.js';
  */
 
 /**
-* @enum {string}
-*/
-export const Versions = {
+ * Enum representing the major IIIF Image API versions
+ * @enum {string}
+ */
+const Versions = {
   VERSION1: 'version1',
   VERSION2: 'version2',
   VERSION3: 'version3'
@@ -424,3 +425,4 @@ class IIIFInfo {
 }
 
 export default IIIFInfo;
+export {Versions};

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -276,7 +276,7 @@ versionFunctions[Versions.VERSION3] = generateVersion3Options;
 class IIIFInfo {
 
   /**
-   * @param {ImageInformationResponse1_0|ImageInformationResponse1_1|ImageInformationResponse2|ImageInformationResponse3|string} imageInfo
+   * @param {string|ImageInformationResponse1_0|ImageInformationResponse1_1|ImageInformationResponse2|ImageInformationResponse3} imageInfo
    * Deserialized image information JSON response object or JSON response as string
    */
   constructor(imageInfo) {
@@ -284,8 +284,8 @@ class IIIFInfo {
   }
 
   /**
-   * @param {Object|string} imageInfo Deserialized image information JSON response
-   * object or JSON response as string
+   * @param {string|ImageInformationResponse1_0|ImageInformationResponse1_1|ImageInformationResponse2|ImageInformationResponse3} imageInfo
+   * Deserialized image information JSON response object or JSON response as string
    * @api
    */
   setImageInfo(imageInfo) {

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -286,6 +286,7 @@ class IIIFInfo {
   /**
    * @param {Object|string} imageInfo Deserialized image information JSON response
    * object or JSON response as string
+   * @api
    */
   setImageInfo(imageInfo) {
     if (typeof imageInfo == 'string') {
@@ -297,6 +298,7 @@ class IIIFInfo {
 
   /**
    * @returns {Versions} Major IIIF version.
+   * @api
    */
   getImageApiVersion() {
     if (this.imageInfo === undefined) {
@@ -395,6 +397,7 @@ class IIIFInfo {
   /**
    * @param {PreferredOptions} opt_preferredOptions Optional options for preferred format and quality.
    * @returns {import("../source/IIIF.js").Options} IIIF tile source ready constructor options.
+   * @api
    */
   getTileSourceOptions(opt_preferredOptions) {
     const options = opt_preferredOptions || {},

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -57,7 +57,8 @@ function formatPercentage(percentage) {
 class IIIF extends TileImage {
 
   /**
-   * @param {Options} opt_options
+   * @param {Options} opt_options Tile source options. Use {@link import("../format/IIIFInfo.js").IIIFInfo}
+   * to parse Image API service information responses into constructor options.
    * @api
    */
   constructor(opt_options) {

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -56,6 +56,10 @@ function formatPercentage(percentage) {
  */
 class IIIF extends TileImage {
 
+  /**
+   * @param {Options} opt_options
+   * @api
+   */
   constructor(opt_options) {
 
     const options = opt_options || {};


### PR DESCRIPTION
- Exposes various `IIIFInfo` methods via doc
- Make `IIIFInfo~Versions` enum values visible in doc
- Document `IIIF` constructor
- Other improvements