### PR TITLE
WebGL / Points renderer refactoring

### DIFF
--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -11,7 +11,6 @@ import {clamp, lerp} from '../src/ol/math';
 import Stamen from '../src/ol/source/Stamen';
 
 const vectorSource = new Vector({
-  features: [],
   attributions: 'NASA'
 });
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -1,0 +1,74 @@
+/**
+ * @module ol/renderer/webgl/Layer
+ */
+import LayerRenderer from '../Layer.js';
+import WebGLHelper from '../../webgl/Helper';
+
+
+/**
+ * @typedef {Object} PostProcessesOptions
+ * @property {number} [scaleRatio] Scale ratio; if < 1, the post process will render to a texture smaller than
+ * the main canvas that will then be sampled up (useful for saving resource on blur steps).
+ * @property {string} [vertexShader] Vertex shader source
+ * @property {string} [fragmentShader] Fragment shader source
+ * @property {Object.<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process step
+ */
+
+/**
+ * @typedef {Object} Options
+ * @property {Object.<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
+ * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
+ */
+
+/**
+ * @classdesc
+ * Base WebGL renderer class.
+ * Holds all logic related to data manipulation & some common rendering logic
+ */
+class WebGLLayerRenderer extends LayerRenderer {
+
+  /**
+   * @param {import("../../layer/Layer.js").default} layer Layer.
+   * @param {Options=} [opt_options] Options.
+   */
+  constructor(layer, opt_options) {
+    super(layer);
+
+    const options = opt_options || {};
+
+    this.helper_ = new WebGLHelper({
+      postProcesses: options.postProcesses,
+      uniforms: options.uniforms
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    super.disposeInternal();
+  }
+
+  /**
+   * Will return the last shader compilation errors. If no error happened, will return null;
+   * @return {string|null} Errors, or null if last compilation was successful
+   * @api
+   */
+  getShaderCompileErrors() {
+    return this.helper_.getShaderCompileErrors();
+  }
+}
+
+/**
+ * Returns a texture of 1x1 pixel, white
+ * @private
+ * @return {ImageData} Image data.
+ */
+export function getBlankTexture() {
+  const canvas = document.createElement('canvas');
+  const image = canvas.getContext('2d').createImageData(1, 1);
+  image.data[0] = image.data[1] = image.data[2] = image.data[3] = 255;
+  return image;
+}
+
+export default WebGLLayerRenderer;

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -61,7 +61,7 @@ class WebGLLayerRenderer extends LayerRenderer {
 
 
 /**
- * Pushes vertices and indices in the given buffers using the geometry coordinates and the following properties
+ * Pushes vertices and indices to the given buffers using the geometry coordinates and the following properties
  * from the feature:
  * - `color`
  * - `opacity`
@@ -79,13 +79,13 @@ class WebGLLayerRenderer extends LayerRenderer {
  * feature and pushed in the buffer in the given order. Note: attributes can only be numerical! Any other type or
  * NaN will result in `0` being pushed in the buffer.
  */
-export function pushFeatureInBuffer(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes) {
+export function pushFeatureToBuffer(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes) {
   if (!geojsonFeature.geometry) {
     return;
   }
   switch (geojsonFeature.geometry.type) {
     case 'Point':
-      pushPointGeomInBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes);
+      pushPointFeatureToBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes);
       return;
     default:
       return;
@@ -102,7 +102,7 @@ const tmpArray_ = [];
  * @param {Array<string>} [opt_attributes] Custom attributes
  * @private
  */
-function pushPointGeomInBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes) {
+function pushPointFeatureToBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes) {
   const stride = 12 + (opt_attributes !== undefined ? opt_attributes.length : 0);
 
   const x = geojsonFeature.geometry.coordinates[0];

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -83,9 +83,11 @@ export function pushFeatureInBuffer(vertexBuffer, indexBuffer, geojsonFeature, o
   if (!geojsonFeature.geometry) {
     return;
   }
-  switch(geojsonFeature.geometry.type) {
-    case "Point":
-      pushPointGeomInBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes)
+  switch (geojsonFeature.geometry.type) {
+    case 'Point':
+      pushPointGeomInBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes);
+      return;
+    default:
       return;
   }
 }
@@ -94,10 +96,10 @@ const tmpArray_ = [];
 
 /**
  * Pushes a quad (two triangles) based on a point geometry
- * @param vertexBuffer
- * @param indexBuffer
- * @param geojsonFeature
- * @param opt_attributes
+ * @param {import("../../webgl/Buffer").default} vertexBuffer WebGL buffer
+ * @param {import("../../webgl/Buffer").default} indexBuffer WebGL buffer
+ * @param {import("../../format/GeoJSON").GeoJSONFeature} geojsonFeature Feature
+ * @param {Array<string>} [opt_attributes] Custom attributes
  * @private
  */
 function pushPointGeomInBuffer_(vertexBuffer, indexBuffer, geojsonFeature, opt_attributes) {

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -12,7 +12,6 @@ import ViewHint from '../../ViewHint';
 import {createEmpty, equals} from '../../extent';
 import {
   create as createTransform,
-  reset as resetTransform,
   makeInverse as makeInverseTransform,
   multiply as multiplyTransform,
   apply as applyTransform
@@ -350,7 +349,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
   /**
    * Rebuild internal webgl buffers based on current view extent; costly, should not be called too much
-   * @param {import("../../PluggableMap.js").FrameState} frameState
+   * @param {import("../../PluggableMap").FrameState} frameState Frame state.
    * @private
    */
   rebuildBuffers_(frameState) {

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -9,6 +9,7 @@ import WebGLLayerRenderer, {getBlankTexture, pushFeatureInBuffer} from './Layer'
 import GeoJSON from '../../format/GeoJSON';
 import {getUid} from '../../util';
 import ViewHint from '../../ViewHint';
+import {createEmpty, equals} from '../../extent';
 
 const VERTEX_SHADER = `
   precision mediump float;
@@ -240,6 +241,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
      * @private
      */
     this.geojsonFeatureCache_ = {};
+
+    this.previousExtent_ = createEmpty();
   }
 
   /**
@@ -288,8 +291,10 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       vectorSource.loadFeatures([-Infinity, -Infinity, Infinity, Infinity], resolution, projection);
     }
 
-    if (!frameState.viewHints[ViewHint.ANIMATING] && !frameState.viewHints[ViewHint.INTERACTING]) {
+    if (!frameState.viewHints[ViewHint.ANIMATING] && !frameState.viewHints[ViewHint.INTERACTING] &&
+      !equals(this.previousExtent_, frameState.extent)) {
       this.rebuildBuffers_(frameState);
+      this.previousExtent_ = frameState.extent.slice();
     }
 
     // write new data

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -5,7 +5,7 @@ import WebGLArrayBuffer from '../../webgl/Buffer';
 import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT} from '../../webgl';
 import {DefaultAttrib, DefaultUniform} from '../../webgl/Helper';
 import GeometryType from '../../geom/GeometryType';
-import WebGLLayerRenderer, {getBlankTexture, pushFeatureInBuffer} from './Layer';
+import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from './Layer';
 import GeoJSON from '../../format/GeoJSON';
 import {getUid} from '../../util';
 import ViewHint from '../../ViewHint';
@@ -391,7 +391,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       geojsonFeature.properties.opacity = this.opacityCallback_(feature);
       geojsonFeature.properties.rotateWithView = this.rotateWithViewCallback_(feature) ? 1 : 0;
 
-      pushFeatureInBuffer(this.verticesBuffer_, this.indicesBuffer_, geojsonFeature);
+      pushFeatureToBuffer(this.verticesBuffer_, this.indicesBuffer_, geojsonFeature);
     }
 
     this.helper_.flushBufferData(ARRAY_BUFFER, this.verticesBuffer_);

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -310,7 +310,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     const stride = 12;
 
     // the source has changed: clear the feature cache & reload features
-    if (this.sourceRevision_ < vectorSource.getRevision()) {
+    const sourceChanged = this.sourceRevision_ < vectorSource.getRevision();
+    if (sourceChanged) {
       this.sourceRevision_ = vectorSource.getRevision();
       this.geojsonFeatureCache_ = {};
 
@@ -319,8 +320,9 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       vectorSource.loadFeatures([-Infinity, -Infinity, Infinity, Infinity], resolution, projection);
     }
 
-    if (!frameState.viewHints[ViewHint.ANIMATING] && !frameState.viewHints[ViewHint.INTERACTING] &&
-      !equals(this.previousExtent_, frameState.extent)) {
+    const viewNotMoving = !frameState.viewHints[ViewHint.ANIMATING] && !frameState.viewHints[ViewHint.INTERACTING];
+    const extentChanged = !equals(this.previousExtent_, frameState.extent);
+    if ((sourceChanged || extentChanged) && viewNotMoving) {
       this.rebuildBuffers_(frameState);
       this.previousExtent_ = frameState.extent.slice();
     }

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -62,7 +62,7 @@ export const DefaultAttrib = {
 };
 
 /**
- * @typedef {number|Array<number>|HTMLCanvasElement|HTMLImageElement|ImageData} UniformLiteralValue
+ * @typedef {number|Array<number>|HTMLCanvasElement|HTMLImageElement|ImageData|import("../transform").Transform} UniformLiteralValue
  */
 
 /**
@@ -565,7 +565,9 @@ class WebGLHelper extends Disposable {
         // fill texture slots by increasing index
         gl.uniform1i(this.getUniformLocation(uniform.name), textureSlot++);
 
-      } else if (Array.isArray(value)) {
+      } else if (Array.isArray(value) && value.length === 6) {
+        this.setUniformMatrixValue(uniform.name, fromTransform(this.tmpMat4_, value));
+      } else if (Array.isArray(value) && value.length <= 4) {
         switch (value.length) {
           case 2:
             gl.uniform2f(this.getUniformLocation(uniform.name), value[0], value[1]);

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -1,4 +1,4 @@
-import WebGLLayerRenderer, {getBlankTexture, pushFeatureInBuffer} from '../../../../../src/ol/renderer/webgl/Layer';
+import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from '../../../../../src/ol/renderer/webgl/Layer';
 import WebGLArrayBuffer from '../../../../../src/ol/webgl/Buffer';
 import Layer from '../../../../../src/ol/layer/Layer';
 
@@ -28,7 +28,7 @@ describe('ol.renderer.webgl.Layer', function() {
 
   });
 
-  describe('pushFeatureInBuffer', function() {
+  describe('pushFeatureToBuffer', function() {
     let vertexBuffer, indexBuffer;
 
     beforeEach(function() {
@@ -46,7 +46,7 @@ describe('ol.renderer.webgl.Layer', function() {
         },
         geometry: null
       };
-      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
       expect(vertexBuffer.getArray().length).to.eql(0);
       expect(indexBuffer.getArray().length).to.eql(0);
     });
@@ -65,7 +65,7 @@ describe('ol.renderer.webgl.Layer', function() {
         }
       };
       const attributePerVertex = 12;
-      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
       expect(vertexBuffer.getArray().length).to.eql(attributePerVertex * 4);
       expect(indexBuffer.getArray().length).to.eql(6);
     });
@@ -84,8 +84,8 @@ describe('ol.renderer.webgl.Layer', function() {
         }
       };
       const attributePerVertex = 12;
-      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
-      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
+      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
       expect(vertexBuffer.getArray()[0]).to.eql(-75);
       expect(vertexBuffer.getArray()[1]).to.eql(47);
       expect(vertexBuffer.getArray()[0 + attributePerVertex]).to.eql(-75);
@@ -125,7 +125,7 @@ describe('ol.renderer.webgl.Layer', function() {
         }
       };
       const attributePerVertex = 16;
-      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature, ['custom', 'custom2', 'customString', 'customString2']);
+      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature, ['custom', 'custom2', 'customString', 'customString2']);
       expect(vertexBuffer.getArray().length).to.eql(attributePerVertex * 4);
       expect(indexBuffer.getArray().length).to.eql(6);
       expect(vertexBuffer.getArray()[12]).to.eql(4);

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -9,18 +9,18 @@ describe('ol.renderer.webgl.Layer', function() {
 
     let target;
 
-    beforeEach(function () {
+    beforeEach(function() {
       target = document.createElement('div');
       target.style.width = '256px';
       target.style.height = '256px';
       document.body.appendChild(target);
     });
 
-    afterEach(function () {
+    afterEach(function() {
       document.body.removeChild(target);
     });
 
-    it('creates a new instance', function () {
+    it('creates a new instance', function() {
       const layer = new Layer({});
       const renderer = new WebGLLayerRenderer(layer);
       expect(renderer).to.be.a(WebGLLayerRenderer);
@@ -31,17 +31,17 @@ describe('ol.renderer.webgl.Layer', function() {
   describe('pushFeatureInBuffer', function() {
     let vertexBuffer, indexBuffer;
 
-    beforeEach(function () {
+    beforeEach(function() {
       vertexBuffer = new WebGLArrayBuffer();
       indexBuffer = new WebGLArrayBuffer();
     });
 
     it('does nothing if the feature has no geometry', function() {
       const feature = {
-        type: "Feature",
-        id: "AFG",
+        type: 'Feature',
+        id: 'AFG',
         properties: {
-          color:[0.5, 1, 0.2, 0.7],
+          color: [0.5, 1, 0.2, 0.7],
           size: 3
         },
         geometry: null
@@ -53,15 +53,15 @@ describe('ol.renderer.webgl.Layer', function() {
 
     it('adds two triangles with the correct attributes for a point geometry', function() {
       const feature = {
-        type: "Feature",
-        id: "AFG",
+        type: 'Feature',
+        id: 'AFG',
         properties: {
-          color:[0.5, 1, 0.2, 0.7],
+          color: [0.5, 1, 0.2, 0.7],
           size: 3
         },
         geometry: {
-          type: "Point",
-          coordinates: [ -75, 47 ]
+          type: 'Point',
+          coordinates: [-75, 47]
         }
       };
       const attributePerVertex = 12;
@@ -72,15 +72,15 @@ describe('ol.renderer.webgl.Layer', function() {
 
     it('correctly sets indices & coordinates for several features', function() {
       const feature = {
-        type: "Feature",
-        id: "AFG",
+        type: 'Feature',
+        id: 'AFG',
         properties: {
-          color:[0.5, 1, 0.2, 0.7],
+          color: [0.5, 1, 0.2, 0.7],
           size: 3
         },
         geometry: {
-          type: "Point",
-          coordinates: [ -75, 47 ]
+          type: 'Point',
+          coordinates: [-75, 47]
         }
       };
       const attributePerVertex = 12;
@@ -110,8 +110,8 @@ describe('ol.renderer.webgl.Layer', function() {
 
     it('correctly adds custom attributes', function() {
       const feature = {
-        type: "Feature",
-        id: "AFG",
+        type: 'Feature',
+        id: 'AFG',
         properties: {
           color: [0.5, 1, 0.2, 0.7],
           custom: 4,
@@ -120,8 +120,8 @@ describe('ol.renderer.webgl.Layer', function() {
           customString2: 'abc'
         },
         geometry: {
-          type: "Point",
-          coordinates: [ -75, 47 ]
+          type: 'Point',
+          coordinates: [-75, 47]
         }
       };
       const attributePerVertex = 16;

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -1,0 +1,45 @@
+import VectorLayer from '../../../../../src/ol/layer/Vector.js';
+import VectorSource from '../../../../../src/ol/source/Vector.js';
+import WebGLLayerRenderer, {getBlankTexture} from '../../../../../src/ol/renderer/webgl/Layer';
+
+
+describe('ol.renderer.webgl.Layer', function() {
+
+  describe('constructor', function() {
+
+    let target;
+
+    beforeEach(function () {
+      target = document.createElement('div');
+      target.style.width = '256px';
+      target.style.height = '256px';
+      document.body.appendChild(target);
+    });
+
+    afterEach(function () {
+      document.body.removeChild(target);
+    });
+
+    it('creates a new instance', function () {
+      const layer = new VectorLayer({
+        source: new VectorSource()
+      });
+      const renderer = new WebGLLayerRenderer(layer);
+      expect(renderer).to.be.a(WebGLLayerRenderer);
+    });
+
+  });
+
+  describe('getBlankTexture', function() {
+    it('creates a 1x1 white texture', function() {
+      const texture = getBlankTexture();
+      expect(texture.height).to.eql(1);
+      expect(texture.width).to.eql(1);
+      expect(texture.data[0]).to.eql(255);
+      expect(texture.data[1]).to.eql(255);
+      expect(texture.data[2]).to.eql(255);
+      expect(texture.data[3]).to.eql(255);
+    });
+  });
+
+});

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -1,6 +1,6 @@
-import VectorLayer from '../../../../../src/ol/layer/Vector.js';
-import VectorSource from '../../../../../src/ol/source/Vector.js';
-import WebGLLayerRenderer, {getBlankTexture} from '../../../../../src/ol/renderer/webgl/Layer';
+import WebGLLayerRenderer, {getBlankTexture, pushFeatureInBuffer} from '../../../../../src/ol/renderer/webgl/Layer';
+import WebGLArrayBuffer from '../../../../../src/ol/webgl/Buffer';
+import Layer from '../../../../../src/ol/layer/Layer';
 
 
 describe('ol.renderer.webgl.Layer', function() {
@@ -21,13 +21,92 @@ describe('ol.renderer.webgl.Layer', function() {
     });
 
     it('creates a new instance', function () {
-      const layer = new VectorLayer({
-        source: new VectorSource()
-      });
+      const layer = new Layer({});
       const renderer = new WebGLLayerRenderer(layer);
       expect(renderer).to.be.a(WebGLLayerRenderer);
     });
 
+  });
+
+  describe('pushFeatureInBuffer', function() {
+    let vertexBuffer, indexBuffer;
+
+    beforeEach(function () {
+      vertexBuffer = new WebGLArrayBuffer();
+      indexBuffer = new WebGLArrayBuffer();
+    });
+
+    it('does nothing if the feature has no geometry', function() {
+      const feature = {
+        type: "Feature",
+        id: "AFG",
+        properties: {
+          color:[0.5, 1, 0.2, 0.7],
+          size: 3
+        },
+        geometry: null
+      };
+      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      expect(vertexBuffer.getArray().length).to.eql(0);
+      expect(indexBuffer.getArray().length).to.eql(0);
+    });
+
+    it('adds two triangles with the correct attributes for a point geometry', function() {
+      const feature = {
+        type: "Feature",
+        id: "AFG",
+        properties: {
+          color:[0.5, 1, 0.2, 0.7],
+          size: 3
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [ -75, 47 ]
+        }
+      };
+      const attributePerVertex = 12;
+      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      expect(vertexBuffer.getArray().length).to.eql(attributePerVertex * 4);
+      expect(indexBuffer.getArray().length).to.eql(6);
+    });
+
+    it('correctly sets indices & coordinates for several features', function() {
+      const feature = {
+        type: "Feature",
+        id: "AFG",
+        properties: {
+          color:[0.5, 1, 0.2, 0.7],
+          size: 3
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [ -75, 47 ]
+        }
+      };
+      const attributePerVertex = 12;
+      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature);
+      expect(vertexBuffer.getArray()[0]).to.eql(-75);
+      expect(vertexBuffer.getArray()[1]).to.eql(47);
+      expect(vertexBuffer.getArray()[0 + attributePerVertex]).to.eql(-75);
+      expect(vertexBuffer.getArray()[1 + attributePerVertex]).to.eql(47);
+
+      // first point
+      expect(indexBuffer.getArray()[0]).to.eql(0);
+      expect(indexBuffer.getArray()[1]).to.eql(1);
+      expect(indexBuffer.getArray()[2]).to.eql(3);
+      expect(indexBuffer.getArray()[3]).to.eql(1);
+      expect(indexBuffer.getArray()[4]).to.eql(2);
+      expect(indexBuffer.getArray()[5]).to.eql(3);
+
+      // second point
+      expect(indexBuffer.getArray()[6]).to.eql(4);
+      expect(indexBuffer.getArray()[7]).to.eql(5);
+      expect(indexBuffer.getArray()[8]).to.eql(7);
+      expect(indexBuffer.getArray()[9]).to.eql(5);
+      expect(indexBuffer.getArray()[10]).to.eql(6);
+      expect(indexBuffer.getArray()[11]).to.eql(7);
+    });
   });
 
   describe('getBlankTexture', function() {

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -107,6 +107,32 @@ describe('ol.renderer.webgl.Layer', function() {
       expect(indexBuffer.getArray()[10]).to.eql(6);
       expect(indexBuffer.getArray()[11]).to.eql(7);
     });
+
+    it('correctly adds custom attributes', function() {
+      const feature = {
+        type: "Feature",
+        id: "AFG",
+        properties: {
+          color: [0.5, 1, 0.2, 0.7],
+          custom: 4,
+          customString: '5',
+          custom2: 12.4,
+          customString2: 'abc'
+        },
+        geometry: {
+          type: "Point",
+          coordinates: [ -75, 47 ]
+        }
+      };
+      const attributePerVertex = 16;
+      pushFeatureInBuffer(vertexBuffer, indexBuffer, feature, ['custom', 'custom2', 'customString', 'customString2']);
+      expect(vertexBuffer.getArray().length).to.eql(attributePerVertex * 4);
+      expect(indexBuffer.getArray().length).to.eql(6);
+      expect(vertexBuffer.getArray()[12]).to.eql(4);
+      expect(vertexBuffer.getArray()[13]).to.eql(12.4);
+      expect(vertexBuffer.getArray()[14]).to.eql(5);
+      expect(vertexBuffer.getArray()[15]).to.eql(0);
+    });
   });
 
   describe('getBlankTexture', function() {

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -15,18 +15,18 @@ describe('ol.renderer.webgl.PointsLayer', function() {
 
     let target;
 
-    beforeEach(function () {
+    beforeEach(function() {
       target = document.createElement('div');
       target.style.width = '256px';
       target.style.height = '256px';
       document.body.appendChild(target);
     });
 
-    afterEach(function () {
+    afterEach(function() {
       document.body.removeChild(target);
     });
 
-    it('creates a new instance', function () {
+    it('creates a new instance', function() {
       const layer = new VectorLayer({
         source: new VectorSource()
       });

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -1,0 +1,108 @@
+import Feature from '../../../../../src/ol/Feature.js';
+import Point from '../../../../../src/ol/geom/Point.js';
+import LineString from '../../../../../src/ol/geom/LineString.js';
+import VectorLayer from '../../../../../src/ol/layer/Vector.js';
+import VectorSource from '../../../../../src/ol/source/Vector.js';
+import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer';
+import {get as getProjection} from '../../../../../src/ol/proj';
+import Polygon from '../../../../../src/ol/geom/Polygon';
+
+
+describe('ol.renderer.webgl.PointsLayer', function() {
+
+  describe('constructor', function() {
+
+    let target;
+
+    beforeEach(function () {
+      target = document.createElement('div');
+      target.style.width = '256px';
+      target.style.height = '256px';
+      document.body.appendChild(target);
+    });
+
+    afterEach(function () {
+      document.body.removeChild(target);
+    });
+
+    it('creates a new instance', function () {
+      const layer = new VectorLayer({
+        source: new VectorSource()
+      });
+      const renderer = new WebGLPointsLayerRenderer(layer);
+      expect(renderer).to.be.a(WebGLPointsLayerRenderer);
+    });
+
+  });
+
+  describe('#prepareFrame', function() {
+    let layer, renderer, frameState;
+
+    beforeEach(function() {
+      layer = new VectorLayer({
+        source: new VectorSource()
+      });
+      renderer = new WebGLPointsLayerRenderer(layer);
+      const projection = getProjection('EPSG:3857');
+      frameState = {
+        skippedFeatureUids: {},
+        viewHints: [],
+        viewState: {
+          projection: projection,
+          resolution: 1,
+          rotation: 0,
+          center: [10, 10]
+        },
+        size: [256, 256]
+      };
+    });
+
+    it('calls WebGlHelper#prepareDraw', function() {
+      const spy = sinon.spy(renderer.helper_, 'prepareDraw');
+      renderer.prepareFrame(frameState);
+      expect(spy.called).to.be(true);
+    });
+
+    it('fills up a buffer with 2 triangles per point', function() {
+      layer.getSource().addFeature(new Feature({
+        geometry: new Point([10, 20])
+      }));
+      renderer.prepareFrame(frameState);
+
+      const attributePerVertex = 12;
+      expect(renderer.verticesBuffer_.getArray().length).to.eql(4 * attributePerVertex);
+      expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
+    });
+
+    it('ignores geometries other than points', function() {
+      layer.getSource().addFeature(new Feature({
+        geometry: new LineString([[10, 20], [30, 20]])
+      }));
+      layer.getSource().addFeature(new Feature({
+        geometry: new Polygon([[10, 20], [30, 20], [30, 10], [10, 20]])
+      }));
+      renderer.prepareFrame(frameState);
+
+      expect(renderer.verticesBuffer_.getArray().length).to.eql(0);
+      expect(renderer.indicesBuffer_.getArray().length).to.eql(0);
+    });
+
+    it('clears the buffers when the features are gone', function() {
+      const source = layer.getSource();
+      source.addFeature(new Feature({
+        geometry: new Point([10, 20])
+      }));
+      source.removeFeature(source.getFeatures()[0]);
+      source.addFeature(new Feature({
+        geometry: new Point([10, 20])
+      }));
+      renderer.prepareFrame(frameState);
+
+      const attributePerVertex = 12;
+      expect(renderer.verticesBuffer_.getArray().length).to.eql(4 * attributePerVertex);
+      expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
+    });
+
+  });
+
+});

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -107,6 +107,7 @@ describe('ol.renderer.webgl.PointsLayer', function() {
 
     it('rebuilds the buffers only when not interacting or animating', function() {
       const spy = sinon.spy(renderer, 'rebuildBuffers_');
+
       frameState.viewHints[ViewHint.INTERACTING] = 1;
       frameState.viewHints[ViewHint.ANIMATING] = 0;
       renderer.prepareFrame(frameState);
@@ -123,6 +124,19 @@ describe('ol.renderer.webgl.PointsLayer', function() {
       expect(spy.called).to.be(true);
     });
 
+    it('rebuilds the buffers only when the frame extent changed', function() {
+      const spy = sinon.spy(renderer, 'rebuildBuffers_');
+
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(1);
+
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(1);
+
+      frameState.extent = [10, 20, 30, 40];
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(2);
+    });
   });
 
 });

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -6,6 +6,7 @@ import VectorSource from '../../../../../src/ol/source/Vector.js';
 import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer';
 import {get as getProjection} from '../../../../../src/ol/proj';
 import Polygon from '../../../../../src/ol/geom/Polygon';
+import ViewHint from '../../../../../src/ol/ViewHint';
 
 
 describe('ol.renderer.webgl.PointsLayer', function() {
@@ -53,7 +54,8 @@ describe('ol.renderer.webgl.PointsLayer', function() {
           rotation: 0,
           center: [10, 10]
         },
-        size: [256, 256]
+        size: [256, 256],
+        extent: [-100, -100, 100, 100]
       };
     });
 
@@ -101,6 +103,24 @@ describe('ol.renderer.webgl.PointsLayer', function() {
       const attributePerVertex = 12;
       expect(renderer.verticesBuffer_.getArray().length).to.eql(4 * attributePerVertex);
       expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
+    });
+
+    it('rebuilds the buffers only when not interacting or animating', function() {
+      const spy = sinon.spy(renderer, 'rebuildBuffers_');
+      frameState.viewHints[ViewHint.INTERACTING] = 1;
+      frameState.viewHints[ViewHint.ANIMATING] = 0;
+      renderer.prepareFrame(frameState);
+      expect(spy.called).to.be(false);
+
+      frameState.viewHints[ViewHint.INTERACTING] = 0;
+      frameState.viewHints[ViewHint.ANIMATING] = 1;
+      renderer.prepareFrame(frameState);
+      expect(spy.called).to.be(false);
+
+      frameState.viewHints[ViewHint.INTERACTING] = 0;
+      frameState.viewHints[ViewHint.ANIMATING] = 0;
+      renderer.prepareFrame(frameState);
+      expect(spy.called).to.be(true);
     });
 
   });

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,4 +1,5 @@
 import WebGLHelper from '../../../../src/ol/webgl/Helper';
+import {create as createTransform} from '../../../../src/ol/transform';
 
 
 const VERTEX_SHADER = `
@@ -95,7 +96,8 @@ describe('ol.webgl.WebGLHelper', function() {
           uniforms: {
             u_test1: 42,
             u_test2: [1, 3],
-            u_test3: document.createElement('canvas')
+            u_test3: document.createElement('canvas'),
+            u_test4: createTransform()
           }
         });
         h.useProgram(h.getProgram(FRAGMENT_SHADER, VERTEX_SHADER));
@@ -116,13 +118,15 @@ describe('ol.webgl.WebGLHelper', function() {
       });
 
       it('has processed uniforms', function() {
-        expect(h.uniforms_.length).to.eql(3);
+        expect(h.uniforms_.length).to.eql(4);
         expect(h.uniforms_[0].name).to.eql('u_test1');
         expect(h.uniforms_[1].name).to.eql('u_test2');
         expect(h.uniforms_[2].name).to.eql('u_test3');
+        expect(h.uniforms_[3].name).to.eql('u_test4');
         expect(h.uniforms_[0].location).to.not.eql(-1);
         expect(h.uniforms_[1].location).to.not.eql(-1);
         expect(h.uniforms_[2].location).to.not.eql(-1);
+        expect(h.uniforms_[3].location).to.not.eql(-1);
         expect(h.uniforms_[2].texture).to.not.eql(undefined);
       });
     });

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,5 +1,10 @@
 import WebGLHelper from '../../../../src/ol/webgl/Helper';
-import {create as createTransform} from '../../../../src/ol/transform';
+import {
+  create as createTransform,
+  multiply,
+  rotate as rotateTransform,
+  scale as scaleTransform, translate as translateTransform
+} from '../../../../src/ol/transform';
 
 
 const VERTEX_SHADER = `
@@ -182,6 +187,34 @@ describe('ol.webgl.WebGLHelper', function() {
 
       it('cannot find the uniform location', function() {
         expect(h.getUniformLocation('u_test')).to.eql(null);
+      });
+    });
+
+    describe('#makeProjectionTransform', function() {
+      let h;
+      let frameState;
+      beforeEach(function() {
+        h = new WebGLHelper();
+
+        frameState = {
+          size: [100, 150],
+          viewState: {
+            rotation: 0.4,
+            resolution: 2,
+            center: [10, 20]
+          }
+        }
+      });
+
+      it('gives out the correct transform', function() {
+        const scaleX = 2 / frameState.size[0] / frameState.viewState.resolution;
+        const scaleY = 2 / frameState.size[1] / frameState.viewState.resolution;
+        const given = createTransform();
+        const expected = createTransform();
+        scaleTransform(expected, scaleX, scaleY);
+        rotateTransform(expected, -frameState.viewState.rotation);
+        translateTransform(expected, -frameState.viewState.center[0], -frameState.viewState.center[1]);
+        expect(h.makeProjectionTransform(frameState, given)).to.eql(expected);
       });
     });
 

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,7 +1,6 @@
 import WebGLHelper from '../../../../src/ol/webgl/Helper';
 import {
   create as createTransform,
-  multiply,
   rotate as rotateTransform,
   scale as scaleTransform, translate as translateTransform
 } from '../../../../src/ol/transform';
@@ -203,7 +202,7 @@ describe('ol.webgl.WebGLHelper', function() {
             resolution: 2,
             center: [10, 20]
           }
-        }
+        };
       });
 
       it('gives out the correct transform', function() {


### PR DESCRIPTION
What this PR does:
* generalizing the way webgl buffers are generated from geometries (still only supporting points for now) ; a base `WebGLLayerRenderer` class was created, which receives common logic for rendering
* making it so that the points renderer rebuilds the buffers during navigation; also coordinates are now expressed in the view space instead of world space to avoid precision loss at high zoom levels (fixes #9479)
* improve test coverage on existing code
* allow using custom attributes for rendering geometries: *this is not yet part of the public API for the points renderer*

The buffer rebuild operation will have to be done in a worker eventually, considering its impact on performance and the fact it has to be redone regularly. This will be done in another PR.

Also now internally geojson features are used as input to create the webgl buffers for rendering. Although serializable, geojson features are not transferrable to workers so the next step is compiling the render instructions straight into typed arrays and skip the geojson feature part (will be done in another PR too).

All this was made with the objective to render tile-based geometries in mind.

Example using the refactored code: https://1298-4723248-gh.circle-artifacts.com/0/examples/filter-points-webgl.html

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
