### PR TITLE
Correct the module annotation for the vector image layer renderer

### DIFF
--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -1,5 +1,5 @@
 /**
- * @module ol/renderer/canvas/ImageLayer
+ * @module ol/renderer/canvas/VectorImageLayer
  */
 import ImageCanvas from '../../ImageCanvas.js';
 import ViewHint from '../../ViewHint.js';


### PR DESCRIPTION
It would be nice to remove these `@module` annotations altogether since they are redundant with the path to the module.  But I'm trying to back out of a JSDoc plugin rabbit hole and not wanting to fall in another.