### PR TITLE
Document existing error event type

### DIFF
--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -83,7 +83,7 @@ class GeolocationError extends Event {
  *       window.console.log(geolocation.getPosition());
  *     });
  *
- * @fires error
+ * @fires module:ol/events/Event~Event#event:error
  * @api
  */
 class Geolocation extends BaseObject {
@@ -203,12 +203,6 @@ class Geolocation extends BaseObject {
     this.set(Property.ACCURACY_GEOMETRY, geometry);
     this.changed();
   }
-
-  /**
-   * Triggered when the Geolocation returns an error.
-   * @event error
-   * @api
-   */
 
   /**
    * @private

--- a/src/ol/events/EventType.js
+++ b/src/ol/events/EventType.js
@@ -14,6 +14,13 @@ export default {
    */
   CHANGE: 'change',
 
+  /**
+   * Generic error event. Triggered when an error occurs.
+   * @event module:ol/events/Event~Event#error
+   * @api
+   */
+  ERROR: 'error',
+
   CLEAR: 'clear',
   CONTEXTMENU: 'contextmenu',
   CLICK: 'click',
@@ -21,7 +28,6 @@ export default {
   DRAGENTER: 'dragenter',
   DRAGOVER: 'dragover',
   DROP: 'drop',
-  ERROR: 'error',
   KEYDOWN: 'keydown',
   KEYPRESS: 'keypress',
   LOAD: 'load',


### PR DESCRIPTION
This makes it so the error event fired from the geolocation thing is more like the other events we fire.