### PR TITLE
chore(package): update jsdoc-plugin-typescript to version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "3.4.1",
     "jsdoc": "3.6.2",
-    "jsdoc-plugin-typescript": "^2.0.0",
+    "jsdoc-plugin-typescript": "^2.0.1",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "^1.1.2",


### PR DESCRIPTION
This removes the warning below (from `npm install`):
```
npm WARN jsdoc-plugin-typescript@2.0.0 requires a peer of jsdoc@3.6.0 but none is installed. You must install peer dependencies yourself.
```

See openlayers/jsdoc-plugin-typescript#8.