### PR TITLE
Use HTMLImageElement.decode if available

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -4,8 +4,7 @@
 import Tile from './Tile.js';
 import TileState from './TileState.js';
 import {createCanvasContext2D} from './dom.js';
-import {listenOnce, unlistenByKey} from './events.js';
-import EventType from './events/EventType.js';
+import {listenImage, unlistenImage} from './Image.js';
 
 
 class ImageTile extends Tile {
@@ -134,13 +133,12 @@ class ImageTile extends Tile {
     if (this.state == TileState.IDLE) {
       this.state = TileState.LOADING;
       this.changed();
-      this.imageListenerKeys_ = [
-        listenOnce(this.image_, EventType.ERROR,
-          this.handleImageError_, this),
-        listenOnce(this.image_, EventType.LOAD,
-          this.handleImageLoad_, this)
-      ];
       this.tileLoadFunction_(this, this.src_);
+      this.imageListenerKeys_ = listenImage(
+        this.image_,
+        this.handleImageLoad_.bind(this),
+        this.handleImageError_.bind(this)
+      );
     }
   }
 
@@ -150,8 +148,7 @@ class ImageTile extends Tile {
    * @private
    */
   unlistenImage_() {
-    this.imageListenerKeys_.forEach(unlistenByKey);
-    this.imageListenerKeys_ = null;
+    unlistenImage(this.imageListenerKeys_);
   }
 }
 

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -3,11 +3,12 @@
  */
 
 import {createCanvasContext2D} from '../dom.js';
-import {listenOnce, unlistenByKey} from '../events.js';
 import EventTarget from '../events/Target.js';
 import EventType from '../events/EventType.js';
 import ImageState from '../ImageState.js';
 import {shared as iconImageCache} from './IconImageCache.js';
+import {listenImage, unlistenImage} from '../Image.js';
+
 
 class IconImage extends EventTarget {
   /**
@@ -185,17 +186,16 @@ class IconImage extends EventTarget {
   load() {
     if (this.imageState_ == ImageState.IDLE) {
       this.imageState_ = ImageState.LOADING;
-      this.imageListenerKeys_ = [
-        listenOnce(this.image_, EventType.ERROR,
-          this.handleImageError_, this),
-        listenOnce(this.image_, EventType.LOAD,
-          this.handleImageLoad_, this)
-      ];
       try {
         /** @type {HTMLImageElement} */ (this.image_).src = this.src_;
       } catch (e) {
         this.handleImageError_();
       }
+      this.imageListenerKeys_ = listenImage(
+        this.image_,
+        this.handleImageLoad_.bind(this),
+        this.handleImageError_.bind(this)
+      );
     }
   }
 
@@ -233,8 +233,7 @@ class IconImage extends EventTarget {
    * @private
    */
   unlistenImage_() {
-    this.imageListenerKeys_.forEach(unlistenByKey);
-    this.imageListenerKeys_ = null;
+    unlistenImage(this.imageListenerKeys_);
   }
 }
 


### PR DESCRIPTION
Unlike the event system, the image are not decoded in the main thread. See this article for a detailed explanation: https://medium.com/dailyjs/image-loading-with-image-decode-b03652e7d2d2

browser support:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode#Browser_compatibility