### PR TITLE
Optimize the WebGL points renderer using a worker

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -228,3 +228,7 @@ Missing or invalid `size`.
 ### 61
 
 Cannot determine IIIF Image API version from provided image information JSON.
+
+### 62
+
+A `WebGLArrayBuffer` must either be of type `ELEMENT_ARRAY_BUFFER` or `ARRAY_BUFFER`.

--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -232,3 +232,7 @@ Cannot determine IIIF Image API version from provided image information JSON.
 ### 62
 
 A `WebGLArrayBuffer` must either be of type `ELEMENT_ARRAY_BUFFER` or `ARRAY_BUFFER`.
+
+### 63
+
+Support for the `OES_element_index_uint` WebGL extension is mandatory for WebGL layers.

--- a/examples/icon-sprite-webgl.html
+++ b/examples/icon-sprite-webgl.html
@@ -13,5 +13,8 @@ docs: >
 
   The dataset contains around 80k points and can be found here: https://www.kaggle.com/NUFORC/ufo-sightings
 tags: "webgl, icon, sprite, point, ufo"
+cloak:
+  - key: pk.eyJ1IjoidHNjaGF1YiIsImEiOiJjaW5zYW5lNHkxMTNmdWttM3JyOHZtMmNtIn0.CDIBD8H-G2Gf-cPkIuWtRg
+    value: Your Mapbox access token from https://mapbox.com/ here
 ---
 <div id="map" class="map"></div>

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -10,6 +10,8 @@ import {fromLonLat} from '../src/ol/proj.js';
 import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
 import {lerp} from '../src/ol/math.js';
 
+const key = 'pk.eyJ1IjoidHNjaGF1YiIsImEiOiJjaW5zYW5lNHkxMTNmdWttM3JyOHZtMmNtIn0.CDIBD8H-G2Gf-cPkIuWtRg';
+
 const vectorSource = new Vector({
   features: [],
   attributions: 'National UFO Reporting Center'
@@ -105,7 +107,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new TileJSON({
-        url: 'https://api.tiles.mapbox.com/v3/mapbox.world-dark.json?secure',
+        url: 'https://api.tiles.mapbox.com/v4/mapbox.world-dark.json?access_token=' + key,
         crossOrigin: 'anonymous'
       })
     }),

--- a/rendering/webpack.config.js
+++ b/rendering/webpack.config.js
@@ -22,5 +22,16 @@ module.exports = {
   context: __dirname,
   target: 'web',
   entry: entry,
-  devtool: 'source-map'
+  devtool: 'source-map',
+  module: {
+    rules: [{
+      test: /\.js$/,
+      use: {
+        loader: path.join(__dirname, '../examples/webpack/worker-loader.js')
+      },
+      include: [
+        path.join(__dirname, '../src/ol/worker')
+      ]
+    }]
+  }
 };

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -57,7 +57,11 @@ class WebGLLayerRenderer extends LayerRenderer {
 
     const options = opt_options || {};
 
-    this.helper_ = new WebGLHelper({
+    /**
+     * @type {WebGLHelper}
+     * @protected
+     */
+    this.helper = new WebGLHelper({
       postProcesses: options.postProcesses,
       uniforms: options.uniforms
     });
@@ -76,7 +80,7 @@ class WebGLLayerRenderer extends LayerRenderer {
    * @api
    */
   getShaderCompileErrors() {
-    return this.helper_.getShaderCompileErrors();
+    return this.helper.getShaderCompileErrors();
   }
 }
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -20,9 +20,10 @@ export const WebGLWorkerMessageType = {
  * Note that any addition properties present in the message *will* be sent back to the main thread.
  * @property {WebGLWorkerMessageType} type Message type
  * @property {ArrayBuffer} renderInstructions Render instructions raw binary buffer.
- * @property {ArrayBuffer=} vertexBuffer Vertices array raw binary buffer (sent by the worker).
- * @property {ArrayBuffer=} indexBuffer Indices array raw binary buffer (sent by the worker).
- * @property {number=} customAttributesCount Amount of custom attributes count in the render instructions.
+ * @property {ArrayBuffer} [vertexBuffer] Vertices array raw binary buffer (sent by the worker).
+ * @property {ArrayBuffer} [indexBuffer] Indices array raw binary buffer (sent by the worker).
+ * @property {number} [customAttributesCount] Amount of custom attributes count in the render instructions.
+ * @property {boolean} [useShortIndices] If true, Uint16Array will be used instead of Uint32Array for index buffers.
  */
 
 /**

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -23,7 +23,6 @@ export const WebGLWorkerMessageType = {
  * @property {ArrayBuffer} [vertexBuffer] Vertices array raw binary buffer (sent by the worker).
  * @property {ArrayBuffer} [indexBuffer] Indices array raw binary buffer (sent by the worker).
  * @property {number} [customAttributesCount] Amount of custom attributes count in the render instructions.
- * @property {boolean} [useShortIndices] If true, Uint16Array will be used instead of Uint32Array for index buffers.
  */
 
 /**
@@ -158,7 +157,7 @@ function writeCustomAttrs(buffer, pos, customAttrs) {
  * @param {Float32Array} instructions Array of render instructions for points.
  * @param {number} elementIndex Index from which render instructions will be read.
  * @param {Float32Array} vertexBuffer Buffer in the form of a typed array.
- * @param {Uint16Array|Uint32Array} indexBuffer Buffer in the form of a typed array.
+ * @param {Uint32Array} indexBuffer Buffer in the form of a typed array.
  * @param {BufferPositions} [bufferPositions] Buffer write positions; if not specified, positions will be set at 0.
  * @param {number} [count] Amount of render instructions that will be read. Default value is POINT_INSTRUCTIONS_COUNT
  * but a higher value can be provided; all values beyond the default count will be put in the vertices buffer as

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -6,6 +6,26 @@ import WebGLHelper from '../../webgl/Helper.js';
 
 
 /**
+ * @enum {string}
+ */
+export const WebGLWorkerMessageType = {
+  GENERATE_BUFFERS: 'GENERATE_BUFFERS'
+};
+
+/**
+ * @typedef {Object} WebGLWorkerGenerateBuffersMessage
+ * This message will trigger the generation of a vertex and an index buffer based on the given render instructions.
+ * When the buffers are generated, the worked will send a message of the same type to the main thread, with
+ * the generated buffers in it.
+ * Note that any addition properties present in the message *will* be sent back to the main thread.
+ * @property {WebGLWorkerMessageType} type Message type
+ * @property {ArrayBuffer} renderInstructions Render instructions raw binary buffer.
+ * @property {ArrayBuffer=} vertexBuffer Vertices array raw binary buffer (sent by the worker).
+ * @property {ArrayBuffer=} indexBuffer Indices array raw binary buffer (sent by the worker).
+ * @property {number=} customAttributesCount Amount of custom attributes count in the render instructions.
+ */
+
+/**
  * @typedef {Object} PostProcessesOptions
  * @property {number} [scaleRatio] Scale ratio; if < 1, the post process will render to a texture smaller than
  * the main canvas that will then be sampled up (useful for saving resource on blur steps).

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -291,6 +291,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
         // saves the projection transform for the current frame state
         this.renderTransform_ = projectionTransform;
         makeInverseTransform(this.invertRenderTransform_, this.renderTransform_);
+
+        this.renderInstructions_ = new Float32Array(event.data.renderInstructions);
       }
     }.bind(this));
   }

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -383,7 +383,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     const features = vectorSource.getFeatures();
     const totalInstructionsCount = POINT_INSTRUCTIONS_COUNT * features.length;
-    if (this.renderInstructions_.length !== totalInstructionsCount) {
+    if (!this.renderInstructions_ || this.renderInstructions_.length !== totalInstructionsCount) {
       this.renderInstructions_ = new Float32Array(totalInstructionsCount);
     }
 
@@ -427,6 +427,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     message['projectionTransform'] = projectionTransform;
 
     this.worker_.postMessage(message, [this.renderInstructions_.buffer]);
+    this.renderInstructions_ = null;
   }
 
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -2,7 +2,7 @@
  * @module ol/renderer/webgl/PointsLayer
  */
 import WebGLArrayBuffer from '../../webgl/Buffer.js';
-import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT, EXTENSIONS as WEBGL_EXTENSIONS} from '../../webgl.js';
+import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT} from '../../webgl.js';
 import {DefaultAttrib, DefaultUniform} from '../../webgl/Helper.js';
 import GeometryType from '../../geom/GeometryType.js';
 import WebGLLayerRenderer, {
@@ -19,7 +19,6 @@ import {
   apply as applyTransform
 } from '../../transform.js';
 import {create as createWebGLWorker} from '../../worker/webgl.js';
-import {includes} from '../../array.js';
 
 const VERTEX_SHADER = `
   precision mediump float;
@@ -421,7 +420,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     const message = {
       type: WebGLWorkerMessageType.GENERATE_BUFFERS,
       renderInstructions: this.renderInstructions_.buffer,
-      useShortIndices: !includes(WEBGL_EXTENSIONS, 'OES_element_index_uint')
+      useShortIndices: !this.helper.getElementIndexUintEnabled()
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -419,8 +419,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     /** @type import('./Layer').WebGLWorkerGenerateBuffersMessage */
     const message = {
       type: WebGLWorkerMessageType.GENERATE_BUFFERS,
-      renderInstructions: this.renderInstructions_.buffer,
-      useShortIndices: !this.helper.getElementIndexUintEnabled()
+      renderInstructions: this.renderInstructions_.buffer
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -2,7 +2,7 @@
  * @module ol/renderer/webgl/PointsLayer
  */
 import WebGLArrayBuffer from '../../webgl/Buffer.js';
-import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT} from '../../webgl.js';
+import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT, EXTENSIONS as WEBGL_EXTENSIONS} from '../../webgl.js';
 import {DefaultAttrib, DefaultUniform} from '../../webgl/Helper.js';
 import GeometryType from '../../geom/GeometryType.js';
 import WebGLLayerRenderer, {
@@ -19,6 +19,7 @@ import {
   apply as applyTransform
 } from '../../transform.js';
 import {create as createWebGLWorker} from '../../worker/webgl.js';
+import {includes} from '../../array.js';
 
 const VERTEX_SHADER = `
   precision mediump float;
@@ -419,7 +420,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     /** @type import('./Layer').WebGLWorkerGenerateBuffersMessage */
     const message = {
       type: WebGLWorkerMessageType.GENERATE_BUFFERS,
-      renderInstructions: this.renderInstructions_.buffer
+      renderInstructions: this.renderInstructions_.buffer,
+      useShortIndices: !includes(WEBGL_EXTENSIONS, 'OES_element_index_uint')
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -7,7 +7,7 @@ import {DefaultAttrib, DefaultUniform} from '../../webgl/Helper.js';
 import GeometryType from '../../geom/GeometryType.js';
 import WebGLLayerRenderer, {
   getBlankTexture,
-  POINT_INSTRUCTIONS_COUNT, POINT_VERTEX_STRIDE,
+  POINT_INSTRUCTIONS_COUNT, POINT_VERTEX_STRIDE, WebGLWorkerMessageType,
   writePointFeatureInstructions
 } from './Layer.js';
 import ViewHint from '../../ViewHint.js';
@@ -276,10 +276,11 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     this.worker_ = createWebGLWorker();
     this.worker_.addEventListener('message', function(event) {
-      if (event.data.type === 'buffers-generated') {
-        const projectionTransform = event.data.projectionTransform;
-        this.verticesBuffer_.fromArrayBuffer(event.data.vertexBuffer);
-        this.indicesBuffer_.fromArrayBuffer(event.data.indexBuffer);
+      const received = event.data;
+      if (received.type === WebGLWorkerMessageType.GENERATE_BUFFERS) {
+        const projectionTransform = received.projectionTransform;
+        this.verticesBuffer_.fromArrayBuffer(received.vertexBuffer);
+        this.indicesBuffer_.fromArrayBuffer(received.indexBuffer);
         this.helper_.flushBufferData(this.verticesBuffer_);
         this.helper_.flushBufferData(this.indicesBuffer_);
 
@@ -415,11 +416,15 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       );
     }
 
-    this.worker_.postMessage({
-      type: 'generate-buffer',
-      renderInstructions: this.renderInstructions_.buffer,
-      projectionTransform: projectionTransform
-    }, [this.renderInstructions_.buffer]);
+    /** @type import('./Layer').WebGLWorkerGenerateBuffersMessage */
+    const message = {
+      type: WebGLWorkerMessageType.GENERATE_BUFFERS,
+      renderInstructions: this.renderInstructions_.buffer
+    };
+    // additional properties will be sent back as-is by the worker
+    message['projectionTransform'] = projectionTransform;
+
+    this.worker_.postMessage(message, [this.renderInstructions_.buffer]);
   }
 
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -215,12 +215,12 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.verticesBuffer_ = new WebGLArrayBuffer(ARRAY_BUFFER, DYNAMIC_DRAW);
     this.indicesBuffer_ = new WebGLArrayBuffer(ELEMENT_ARRAY_BUFFER, DYNAMIC_DRAW);
 
-    this.program_ = this.helper_.getProgram(
+    this.program_ = this.helper.getProgram(
       options.fragmentShader || FRAGMENT_SHADER,
       options.vertexShader || VERTEX_SHADER
     );
 
-    this.helper_.useProgram(this.program_);
+    this.helper.useProgram(this.program_);
 
     this.sizeCallback_ = options.sizeCallback || function() {
       return 1;
@@ -282,8 +282,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
         const projectionTransform = received.projectionTransform;
         this.verticesBuffer_.fromArrayBuffer(received.vertexBuffer);
         this.indicesBuffer_.fromArrayBuffer(received.indexBuffer);
-        this.helper_.flushBufferData(this.verticesBuffer_);
-        this.helper_.flushBufferData(this.indicesBuffer_);
+        this.helper.flushBufferData(this.verticesBuffer_);
+        this.helper.flushBufferData(this.indicesBuffer_);
 
         // saves the projection transform for the current frame state
         this.renderTransform_ = projectionTransform;
@@ -306,9 +306,9 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    */
   renderFrame(frameState) {
     const renderCount = this.indicesBuffer_.getArray() ? this.indicesBuffer_.getArray().length : 0;
-    this.helper_.drawElements(0, renderCount);
-    this.helper_.finalizeDraw(frameState);
-    const canvas = this.helper_.getCanvas();
+    this.helper.drawElements(0, renderCount);
+    this.helper.finalizeDraw(frameState);
+    const canvas = this.helper.getCanvas();
 
     const layerState = frameState.layerStatesArray[frameState.layerIndex];
     const opacity = layerState.opacity;
@@ -348,22 +348,22 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     }
 
     // apply the current projection transform with the invert of the one used to fill buffers
-    this.helper_.makeProjectionTransform(frameState, this.currentTransform_);
+    this.helper.makeProjectionTransform(frameState, this.currentTransform_);
     multiplyTransform(this.currentTransform_, this.invertRenderTransform_);
 
-    this.helper_.prepareDraw(frameState);
+    this.helper.prepareDraw(frameState);
 
     // write new data
-    this.helper_.bindBuffer(this.verticesBuffer_);
-    this.helper_.bindBuffer(this.indicesBuffer_);
+    this.helper.bindBuffer(this.verticesBuffer_);
+    this.helper.bindBuffer(this.indicesBuffer_);
 
     const bytesPerFloat = Float32Array.BYTES_PER_ELEMENT;
-    this.helper_.enableAttributeArray(DefaultAttrib.POSITION, 2, FLOAT, bytesPerFloat * stride, 0);
-    this.helper_.enableAttributeArray(DefaultAttrib.OFFSETS, 2, FLOAT, bytesPerFloat * stride, bytesPerFloat * 2);
-    this.helper_.enableAttributeArray(DefaultAttrib.TEX_COORD, 2, FLOAT, bytesPerFloat * stride, bytesPerFloat * 4);
-    this.helper_.enableAttributeArray(DefaultAttrib.OPACITY, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 6);
-    this.helper_.enableAttributeArray(DefaultAttrib.ROTATE_WITH_VIEW, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 7);
-    this.helper_.enableAttributeArray(DefaultAttrib.COLOR, 4, FLOAT, bytesPerFloat * stride, bytesPerFloat * 8);
+    this.helper.enableAttributeArray(DefaultAttrib.POSITION, 2, FLOAT, bytesPerFloat * stride, 0);
+    this.helper.enableAttributeArray(DefaultAttrib.OFFSETS, 2, FLOAT, bytesPerFloat * stride, bytesPerFloat * 2);
+    this.helper.enableAttributeArray(DefaultAttrib.TEX_COORD, 2, FLOAT, bytesPerFloat * stride, bytesPerFloat * 4);
+    this.helper.enableAttributeArray(DefaultAttrib.OPACITY, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 6);
+    this.helper.enableAttributeArray(DefaultAttrib.ROTATE_WITH_VIEW, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 7);
+    this.helper.enableAttributeArray(DefaultAttrib.COLOR, 4, FLOAT, bytesPerFloat * stride, bytesPerFloat * 8);
 
     return true;
   }
@@ -379,7 +379,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     // saves the projection transform for the current frame state
     const projectionTransform = createTransform();
-    this.helper_.makeProjectionTransform(frameState, projectionTransform);
+    this.helper.makeProjectionTransform(frameState, projectionTransform);
 
     const features = vectorSource.getFeatures();
     const totalInstructionsCount = POINT_INSTRUCTIONS_COUNT * features.length;

--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -2,8 +2,7 @@
  * @module ol/webgl/Buffer
  */
 import {STATIC_DRAW, STREAM_DRAW, DYNAMIC_DRAW} from '../webgl.js';
-import {includes} from '../array.js';
-import {ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, EXTENSIONS as WEBGL_EXTENSIONS} from '../webgl.js';
+import {ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER} from '../webgl.js';
 import {assert} from '../asserts.js';
 
 /**
@@ -44,7 +43,7 @@ class WebGLArrayBuffer {
 
     /**
      * @private
-     * @type {Float32Array|Uint32Array|Uint16Array}
+     * @type {Float32Array|Uint32Array}
      */
     this.array = null;
 
@@ -96,7 +95,7 @@ class WebGLArrayBuffer {
   }
 
   /**
-   * @return {Float32Array|Uint32Array|Uint16Array} Array.
+   * @return {Float32Array|Uint32Array} Array.
    */
   getArray() {
     return this.array;
@@ -113,15 +112,14 @@ class WebGLArrayBuffer {
 /**
  * Returns a typed array constructor based on the given buffer type
  * @param {number} type Buffer type, either ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER.
- * @returns {Float32ArrayConstructor|Uint16ArrayConstructor|Uint32ArrayConstructor} The typed array class to use for this buffer.
+ * @returns {Float32ArrayConstructor|Uint32ArrayConstructor} The typed array class to use for this buffer.
  */
 export function getArrayClassForType(type) {
   switch (type) {
     case ARRAY_BUFFER:
       return Float32Array;
     case ELEMENT_ARRAY_BUFFER:
-      const hasExtension = includes(WEBGL_EXTENSIONS, 'OES_element_index_uint');
-      return hasExtension ? Uint32Array : Uint16Array;
+      return Uint32Array;
     default:
       return Float32Array;
   }

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -7,7 +7,7 @@ import Disposable from '../Disposable.js';
 import {includes} from '../array.js';
 import {listen, unlistenAll} from '../events.js';
 import {clear} from '../obj.js';
-import {ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, TEXTURE_2D, TEXTURE_WRAP_S, TEXTURE_WRAP_T} from '../webgl.js';
+import {TEXTURE_2D, TEXTURE_WRAP_S, TEXTURE_WRAP_T} from '../webgl.js';
 import ContextEventType from '../webgl/ContextEventType.js';
 import {
   create as createTransform,
@@ -347,11 +347,10 @@ class WebGLHelper extends Disposable {
    * Just bind the buffer if it's in the cache. Otherwise create
    * the WebGL buffer, bind it, populate it, and add an entry to
    * the cache.
-   * @param {number} target Target, either ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER.
    * @param {import("./Buffer").default} buffer Buffer.
    * @api
    */
-  bindBuffer(target, buffer) {
+  bindBuffer(buffer) {
     const gl = this.getGL();
     const bufferKey = getUid(buffer);
     let bufferCache = this.bufferCache_[bufferKey];
@@ -362,28 +361,19 @@ class WebGLHelper extends Disposable {
         webGlBuffer: webGlBuffer
       };
     }
-    gl.bindBuffer(target, bufferCache.webGlBuffer);
+    gl.bindBuffer(buffer.getType(), bufferCache.webGlBuffer);
   }
 
   /**
    * Update the data contained in the buffer array; this is required for the
    * new data to be rendered
-   * @param {number} target Target, either ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER.
    * @param {import("./Buffer").default} buffer Buffer.
    * @api
    */
-  flushBufferData(target, buffer) {
+  flushBufferData(buffer) {
     const gl = this.getGL();
-    const arr = buffer.getArray();
-    this.bindBuffer(target, buffer);
-    let /** @type {ArrayBufferView} */ arrayBuffer;
-    if (target == ARRAY_BUFFER) {
-      arrayBuffer = new Float32Array(arr);
-    } else if (target == ELEMENT_ARRAY_BUFFER) {
-      arrayBuffer = this.hasOESElementIndexUint ?
-        new Uint32Array(arr) : new Uint16Array(arr);
-    }
-    gl.bufferData(target, arrayBuffer, buffer.getUsage());
+    this.bindBuffer(buffer);
+    gl.bufferData(buffer.getType(), buffer.getArray(), buffer.getUsage());
   }
 
   /**

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -2,12 +2,10 @@
  * @module ol/webgl/Helper
  */
 import {getUid} from '../util.js';
-import {EXTENSIONS as WEBGL_EXTENSIONS} from '../webgl.js';
 import Disposable from '../Disposable.js';
-import {includes} from '../array.js';
 import {listen, unlistenAll} from '../events.js';
 import {clear} from '../obj.js';
-import {TEXTURE_2D, TEXTURE_WRAP_S, TEXTURE_WRAP_T} from '../webgl.js';
+import {TEXTURE_2D, TEXTURE_WRAP_S, TEXTURE_WRAP_T, EXTENSIONS as WEBGL_EXTENSIONS} from '../webgl.js';
 import ContextEventType from '../webgl/ContextEventType.js';
 import {
   create as createTransform,
@@ -19,6 +17,8 @@ import {
 import {create, fromTransform} from '../vec/mat4.js';
 import WebGLPostProcessingPass from './PostProcessingPass.js';
 import {getContext} from '../webgl.js';
+import {includes} from '../array.js';
+import {assert} from '../asserts.js';
 
 
 /**
@@ -258,16 +258,8 @@ class WebGLHelper extends Disposable {
      */
     this.currentProgram_ = null;
 
-    /**
-     * @type {boolean}
-     * @private
-     */
-    this.hasOESElementIndexUint_ = includes(WEBGL_EXTENSIONS, 'OES_element_index_uint');
-
-    // use the OES_element_index_uint extension if available
-    if (this.hasOESElementIndexUint_) {
-      gl.getExtension('OES_element_index_uint');
-    }
+    assert(includes(WEBGL_EXTENSIONS, 'OES_element_index_uint'), 63);
+    gl.getExtension('OES_element_index_uint');
 
     listen(this.canvas_, ContextEventType.LOST,
       this.handleWebGLContextLost, this);
@@ -453,9 +445,8 @@ class WebGLHelper extends Disposable {
    */
   drawElements(start, end) {
     const gl = this.getGL();
-    const elementType = this.hasOESElementIndexUint_ ?
-      gl.UNSIGNED_INT : gl.UNSIGNED_SHORT;
-    const elementSize = this.hasOESElementIndexUint_ ? 4 : 2;
+    const elementType = gl.UNSIGNED_INT;
+    const elementSize = 4;
 
     const numItems = end - start;
     const offsetInBytes = start * elementSize;
@@ -745,16 +736,6 @@ class WebGLHelper extends Disposable {
    * @private
    */
   handleWebGLContextRestored() {
-  }
-
-  /**
-   * Returns whether the `OES_element_index_uint` WebGL extension is enabled for this context.
-   * @return {boolean} If true, Uint16Array should be used for element array buffers
-   * instead of Uint8Array.
-   * @api
-   */
-  getElementIndexUintEnabled() {
-    return this.hasOESElementIndexUint_;
   }
 
   // TODO: shutdown program

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -260,11 +260,12 @@ class WebGLHelper extends Disposable {
 
     /**
      * @type {boolean}
+     * @private
      */
-    this.hasOESElementIndexUint = includes(WEBGL_EXTENSIONS, 'OES_element_index_uint');
+    this.hasOESElementIndexUint_ = includes(WEBGL_EXTENSIONS, 'OES_element_index_uint');
 
     // use the OES_element_index_uint extension if available
-    if (this.hasOESElementIndexUint) {
+    if (this.hasOESElementIndexUint_) {
       gl.getExtension('OES_element_index_uint');
     }
 
@@ -452,9 +453,9 @@ class WebGLHelper extends Disposable {
    */
   drawElements(start, end) {
     const gl = this.getGL();
-    const elementType = this.hasOESElementIndexUint ?
+    const elementType = this.hasOESElementIndexUint_ ?
       gl.UNSIGNED_INT : gl.UNSIGNED_SHORT;
-    const elementSize = this.hasOESElementIndexUint ? 4 : 2;
+    const elementSize = this.hasOESElementIndexUint_ ? 4 : 2;
 
     const numItems = end - start;
     const offsetInBytes = start * elementSize;
@@ -744,6 +745,16 @@ class WebGLHelper extends Disposable {
    * @private
    */
   handleWebGLContextRestored() {
+  }
+
+  /**
+   * Returns whether the `OES_element_index_uint` WebGL extension is enabled for this context.
+   * @return {boolean} If true, Uint16Array should be used for element array buffers
+   * instead of Uint8Array.
+   * @api
+   */
+  getElementIndexUintEnabled() {
+    return this.hasOESElementIndexUint_;
   }
 
   // TODO: shutdown program

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -16,10 +16,13 @@ onmessage = event => {
     const renderInstructions = new Float32Array(received.renderInstructions);
     const customAttributesCount = received.customAttributesCount || 0;
     const instructionsCount = POINT_INSTRUCTIONS_COUNT + customAttributesCount;
+    const useShort = received.useShortIndices;
 
     const elementsCount = renderInstructions.length / instructionsCount;
-    const indexBuffer = new Uint32Array(elementsCount * 6);
-    const vertexBuffer = new Float32Array(elementsCount * 4 * (POINT_VERTEX_STRIDE + customAttributesCount));
+    const indicesCount = elementsCount * 6;
+    const verticesCount = elementsCount * 4 * (POINT_VERTEX_STRIDE + customAttributesCount);
+    const indexBuffer = useShort ? new Uint16Array(indicesCount) : new Uint32Array(indicesCount);
+    const vertexBuffer = new Float32Array(verticesCount);
 
     let bufferPositions = null;
     for (let i = 0; i < renderInstructions.length; i += instructionsCount) {

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -30,8 +30,9 @@ onmessage = event => {
       type: 'buffers-generated',
       vertexBuffer: vertexBuffer.buffer,
       indexBuffer: indexBuffer.buffer,
+      renderInstructions: renderInstructions.buffer,
       projectionTransform
-    }, [vertexBuffer.buffer, indexBuffer.buffer]);
+    }, [vertexBuffer.buffer, indexBuffer.buffer, renderInstructions.buffer]);
   }
 };
 

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -16,12 +16,11 @@ onmessage = event => {
     const renderInstructions = new Float32Array(received.renderInstructions);
     const customAttributesCount = received.customAttributesCount || 0;
     const instructionsCount = POINT_INSTRUCTIONS_COUNT + customAttributesCount;
-    const useShort = received.useShortIndices;
 
     const elementsCount = renderInstructions.length / instructionsCount;
     const indicesCount = elementsCount * 6;
     const verticesCount = elementsCount * 4 * (POINT_VERTEX_STRIDE + customAttributesCount);
-    const indexBuffer = useShort ? new Uint16Array(indicesCount) : new Uint32Array(indicesCount);
+    const indexBuffer = new Uint32Array(indicesCount);
     const vertexBuffer = new Float32Array(verticesCount);
 
     let bufferPositions = null;

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -1,0 +1,38 @@
+/**
+ * @module ol/worker/webgl
+ * A worker that does cpu-heavy tasks related to webgl rendering
+ */
+import {POINT_INSTRUCTIONS_COUNT, POINT_VERTEX_STRIDE, writePointFeatureToBuffers} from '../renderer/webgl/Layer.js';
+
+onmessage = event => {
+  if (event.data.type === 'generate-buffer') {
+    const renderInstructions = new Float32Array(event.data.renderInstructions);
+    const customAttributesCount = event.data.customAttributesCount || 0;
+    const instructionsCount = POINT_INSTRUCTIONS_COUNT + customAttributesCount;
+    const projectionTransform = event.data.projectionTransform;
+
+    const elementsCount = renderInstructions.length / instructionsCount;
+    const indexBuffer = new Uint32Array(elementsCount * 6);
+    const vertexBuffer = new Float32Array(elementsCount * 4 * (POINT_VERTEX_STRIDE + customAttributesCount));
+
+    let bufferPositions = null;
+    for (let i = 0; i < renderInstructions.length; i += instructionsCount) {
+      bufferPositions = writePointFeatureToBuffers(
+        renderInstructions,
+        i,
+        vertexBuffer,
+        indexBuffer,
+        bufferPositions,
+        instructionsCount);
+    }
+
+    postMessage({
+      type: 'buffers-generated',
+      vertexBuffer: vertexBuffer.buffer,
+      indexBuffer: indexBuffer.buffer,
+      projectionTransform
+    }, [vertexBuffer.buffer, indexBuffer.buffer]);
+  }
+};
+
+export let create;

--- a/tasks/serialize-workers.js
+++ b/tasks/serialize-workers.js
@@ -20,6 +20,7 @@ async function build(input, {minify = true} = {}) {
     common(),
     resolve(),
     babel({
+      'externalHelpers': true,
       'presets': [
         [
           '@babel/preset-env',

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -1,5 +1,7 @@
-import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from '../../../../../src/ol/renderer/webgl/Layer.js';
-import WebGLArrayBuffer from '../../../../../src/ol/webgl/Buffer.js';
+import WebGLLayerRenderer, {
+  getBlankTexture, POINT_INSTRUCTIONS_COUNT, POINT_VERTEX_STRIDE,
+  writePointFeatureInstructions, writePointFeatureToBuffers
+} from '../../../../../src/ol/renderer/webgl/Layer.js';
 import Layer from '../../../../../src/ol/layer/Layer.js';
 
 
@@ -28,111 +30,211 @@ describe('ol.renderer.webgl.Layer', function() {
 
   });
 
-  describe('pushFeatureToBuffer', function() {
-    let vertexBuffer, indexBuffer;
+  describe('writePointFeatureInstructions', function() {
+    let instructions;
 
     beforeEach(function() {
-      vertexBuffer = new WebGLArrayBuffer();
-      indexBuffer = new WebGLArrayBuffer();
+      instructions = new Float32Array(100);
     });
 
-    it('does nothing if the feature has no geometry', function() {
-      const feature = {
-        type: 'Feature',
-        id: 'AFG',
-        properties: {
-          color: [0.5, 1, 0.2, 0.7],
-          size: 3
-        },
-        geometry: null
-      };
-      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
-      expect(vertexBuffer.getArray().length).to.eql(0);
-      expect(indexBuffer.getArray().length).to.eql(0);
+    it('writes instructions corresponding to the given parameters', function() {
+      const baseIndex = 17;
+      writePointFeatureInstructions(instructions, baseIndex,
+        1, 2, 3, 4, 5, 6,
+        7, 8, true, [10, 11, 12, 13]);
+      expect(instructions[baseIndex + 0]).to.eql(1);
+      expect(instructions[baseIndex + 1]).to.eql(2);
+      expect(instructions[baseIndex + 2]).to.eql(3);
+      expect(instructions[baseIndex + 3]).to.eql(4);
+      expect(instructions[baseIndex + 4]).to.eql(5);
+      expect(instructions[baseIndex + 5]).to.eql(6);
+      expect(instructions[baseIndex + 6]).to.eql(7);
+      expect(instructions[baseIndex + 7]).to.eql(8);
+      expect(instructions[baseIndex + 8]).to.eql(1);
+      expect(instructions[baseIndex + 9]).to.eql(10);
+      expect(instructions[baseIndex + 10]).to.eql(11);
+      expect(instructions[baseIndex + 11]).to.eql(12);
+      expect(instructions[baseIndex + 12]).to.eql(13);
     });
 
-    it('adds two triangles with the correct attributes for a point geometry', function() {
-      const feature = {
-        type: 'Feature',
-        id: 'AFG',
-        properties: {
-          color: [0.5, 1, 0.2, 0.7],
-          size: 3
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-75, 47]
-        }
-      };
-      const attributePerVertex = 12;
-      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
-      expect(vertexBuffer.getArray().length).to.eql(attributePerVertex * 4);
-      expect(indexBuffer.getArray().length).to.eql(6);
+    it('correctly chains writes', function() {
+      let baseIndex = 0;
+      baseIndex = writePointFeatureInstructions(instructions, baseIndex,
+        1, 2, 3, 4, 5, 6,
+        7, 8, true, [10, 11, 12, 13]);
+      baseIndex = writePointFeatureInstructions(instructions, baseIndex,
+        1, 2, 3, 4, 5, 6,
+        7, 8, true, [10, 11, 12, 13]);
+      writePointFeatureInstructions(instructions, baseIndex,
+        1, 2, 3, 4, 5, 6,
+        7, 8, true, [10, 11, 12, 13]);
+      expect(instructions[baseIndex + 0]).to.eql(1);
+      expect(instructions[baseIndex + 1]).to.eql(2);
+      expect(instructions[baseIndex + 2]).to.eql(3);
+      expect(instructions[baseIndex + 3]).to.eql(4);
+      expect(instructions[baseIndex + 4]).to.eql(5);
+      expect(instructions[baseIndex + 5]).to.eql(6);
+      expect(instructions[baseIndex + 6]).to.eql(7);
+      expect(instructions[baseIndex + 7]).to.eql(8);
+      expect(instructions[baseIndex + 8]).to.eql(1);
+      expect(instructions[baseIndex + 9]).to.eql(10);
+      expect(instructions[baseIndex + 10]).to.eql(11);
+      expect(instructions[baseIndex + 11]).to.eql(12);
+      expect(instructions[baseIndex + 12]).to.eql(13);
+    });
+  });
+
+  describe('writePointFeatureToBuffers', function() {
+    let vertexBuffer, indexBuffer, instructions, elementIndex;
+
+    beforeEach(function() {
+      vertexBuffer = new Float32Array(100);
+      indexBuffer = new Uint16Array(100);
+      instructions = new Float32Array(100);
+      elementIndex = 3;
+
+      writePointFeatureInstructions(instructions, elementIndex,
+        1, 2, 3, 4, 5, 6,
+        7, 8, true, [10, 11, 12, 13]);
     });
 
-    it('correctly sets indices & coordinates for several features', function() {
-      const feature = {
-        type: 'Feature',
-        id: 'AFG',
-        properties: {
-          color: [0.5, 1, 0.2, 0.7],
-          size: 3
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-75, 47]
-        }
-      };
-      const attributePerVertex = 12;
-      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
-      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature);
-      expect(vertexBuffer.getArray()[0]).to.eql(-75);
-      expect(vertexBuffer.getArray()[1]).to.eql(47);
-      expect(vertexBuffer.getArray()[0 + attributePerVertex]).to.eql(-75);
-      expect(vertexBuffer.getArray()[1 + attributePerVertex]).to.eql(47);
+    it('writes correctly to the buffers (without custom attributes)', function() {
+      const stride = POINT_VERTEX_STRIDE;
+      const positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer);
 
-      // first point
-      expect(indexBuffer.getArray()[0]).to.eql(0);
-      expect(indexBuffer.getArray()[1]).to.eql(1);
-      expect(indexBuffer.getArray()[2]).to.eql(3);
-      expect(indexBuffer.getArray()[3]).to.eql(1);
-      expect(indexBuffer.getArray()[4]).to.eql(2);
-      expect(indexBuffer.getArray()[5]).to.eql(3);
+      expect(vertexBuffer[0]).to.eql(1);
+      expect(vertexBuffer[1]).to.eql(2);
+      expect(vertexBuffer[2]).to.eql(-3.5);
+      expect(vertexBuffer[3]).to.eql(-3.5);
+      expect(vertexBuffer[4]).to.eql(3);
+      expect(vertexBuffer[5]).to.eql(4);
+      expect(vertexBuffer[6]).to.eql(8);
+      expect(vertexBuffer[7]).to.eql(1);
+      expect(vertexBuffer[8]).to.eql(10);
+      expect(vertexBuffer[9]).to.eql(11);
+      expect(vertexBuffer[10]).to.eql(12);
+      expect(vertexBuffer[11]).to.eql(13);
 
-      // second point
-      expect(indexBuffer.getArray()[6]).to.eql(4);
-      expect(indexBuffer.getArray()[7]).to.eql(5);
-      expect(indexBuffer.getArray()[8]).to.eql(7);
-      expect(indexBuffer.getArray()[9]).to.eql(5);
-      expect(indexBuffer.getArray()[10]).to.eql(6);
-      expect(indexBuffer.getArray()[11]).to.eql(7);
+      expect(vertexBuffer[stride + 0]).to.eql(1);
+      expect(vertexBuffer[stride + 1]).to.eql(2);
+      expect(vertexBuffer[stride + 2]).to.eql(+3.5);
+      expect(vertexBuffer[stride + 3]).to.eql(-3.5);
+      expect(vertexBuffer[stride + 4]).to.eql(5);
+      expect(vertexBuffer[stride + 5]).to.eql(4);
+
+      expect(vertexBuffer[stride * 2 + 0]).to.eql(1);
+      expect(vertexBuffer[stride * 2 + 1]).to.eql(2);
+      expect(vertexBuffer[stride * 2 + 2]).to.eql(+3.5);
+      expect(vertexBuffer[stride * 2 + 3]).to.eql(+3.5);
+      expect(vertexBuffer[stride * 2 + 4]).to.eql(5);
+      expect(vertexBuffer[stride * 2 + 5]).to.eql(6);
+
+      expect(vertexBuffer[stride * 3 + 0]).to.eql(1);
+      expect(vertexBuffer[stride * 3 + 1]).to.eql(2);
+      expect(vertexBuffer[stride * 3 + 2]).to.eql(-3.5);
+      expect(vertexBuffer[stride * 3 + 3]).to.eql(+3.5);
+      expect(vertexBuffer[stride * 3 + 4]).to.eql(3);
+      expect(vertexBuffer[stride * 3 + 5]).to.eql(6);
+
+      expect(indexBuffer[0]).to.eql(0);
+      expect(indexBuffer[1]).to.eql(1);
+      expect(indexBuffer[2]).to.eql(3);
+      expect(indexBuffer[3]).to.eql(1);
+      expect(indexBuffer[4]).to.eql(2);
+      expect(indexBuffer[5]).to.eql(3);
+
+      expect(positions.indexPosition).to.eql(6);
+      expect(positions.vertexPosition).to.eql(stride * 4);
     });
 
-    it('correctly adds custom attributes', function() {
-      const feature = {
-        type: 'Feature',
-        id: 'AFG',
-        properties: {
-          color: [0.5, 1, 0.2, 0.7],
-          custom: 4,
-          customString: '5',
-          custom2: 12.4,
-          customString2: 'abc'
-        },
-        geometry: {
-          type: 'Point',
-          coordinates: [-75, 47]
-        }
-      };
-      const attributePerVertex = 16;
-      pushFeatureToBuffer(vertexBuffer, indexBuffer, feature, ['custom', 'custom2', 'customString', 'customString2']);
-      expect(vertexBuffer.getArray().length).to.eql(attributePerVertex * 4);
-      expect(indexBuffer.getArray().length).to.eql(6);
-      expect(vertexBuffer.getArray()[12]).to.eql(4);
-      expect(vertexBuffer.getArray()[13]).to.eql(12.4);
-      expect(vertexBuffer.getArray()[14]).to.eql(5);
-      expect(vertexBuffer.getArray()[15]).to.eql(0);
+    it('writes correctly to the buffers (with custom attributes)', function() {
+      instructions[elementIndex + POINT_INSTRUCTIONS_COUNT] = 101;
+      instructions[elementIndex + POINT_INSTRUCTIONS_COUNT + 1] = 102;
+      instructions[elementIndex + POINT_INSTRUCTIONS_COUNT + 2] = 103;
+
+      const stride = POINT_VERTEX_STRIDE + 3;
+      const positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer,
+        undefined, POINT_INSTRUCTIONS_COUNT + 3);
+
+      expect(vertexBuffer[0]).to.eql(1);
+      expect(vertexBuffer[1]).to.eql(2);
+      expect(vertexBuffer[2]).to.eql(-3.5);
+      expect(vertexBuffer[3]).to.eql(-3.5);
+      expect(vertexBuffer[4]).to.eql(3);
+      expect(vertexBuffer[5]).to.eql(4);
+      expect(vertexBuffer[6]).to.eql(8);
+      expect(vertexBuffer[7]).to.eql(1);
+      expect(vertexBuffer[8]).to.eql(10);
+      expect(vertexBuffer[9]).to.eql(11);
+      expect(vertexBuffer[10]).to.eql(12);
+      expect(vertexBuffer[11]).to.eql(13);
+
+      expect(vertexBuffer[12]).to.eql(101);
+      expect(vertexBuffer[13]).to.eql(102);
+      expect(vertexBuffer[14]).to.eql(103);
+
+      expect(vertexBuffer[stride + 12]).to.eql(101);
+      expect(vertexBuffer[stride + 13]).to.eql(102);
+      expect(vertexBuffer[stride + 14]).to.eql(103);
+
+      expect(vertexBuffer[stride * 2 + 12]).to.eql(101);
+      expect(vertexBuffer[stride * 2 + 13]).to.eql(102);
+      expect(vertexBuffer[stride * 2 + 14]).to.eql(103);
+
+      expect(vertexBuffer[stride * 3 + 12]).to.eql(101);
+      expect(vertexBuffer[stride * 3 + 13]).to.eql(102);
+      expect(vertexBuffer[stride * 3 + 14]).to.eql(103);
+
+      expect(indexBuffer[0]).to.eql(0);
+      expect(indexBuffer[1]).to.eql(1);
+      expect(indexBuffer[2]).to.eql(3);
+      expect(indexBuffer[3]).to.eql(1);
+      expect(indexBuffer[4]).to.eql(2);
+      expect(indexBuffer[5]).to.eql(3);
+
+      expect(positions.indexPosition).to.eql(6);
+      expect(positions.vertexPosition).to.eql(stride * 4);
     });
+
+    it('correctly chains buffer writes', function() {
+      const stride = POINT_VERTEX_STRIDE;
+      let positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer);
+      positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer, positions);
+      positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer, positions);
+
+      expect(vertexBuffer[0]).to.eql(1);
+      expect(vertexBuffer[1]).to.eql(2);
+      expect(vertexBuffer[2]).to.eql(-3.5);
+      expect(vertexBuffer[3]).to.eql(-3.5);
+
+      expect(vertexBuffer[stride * 4 + 0]).to.eql(1);
+      expect(vertexBuffer[stride * 4 + 1]).to.eql(2);
+      expect(vertexBuffer[stride * 4 + 2]).to.eql(-3.5);
+      expect(vertexBuffer[stride * 4 + 3]).to.eql(-3.5);
+
+      expect(vertexBuffer[stride * 8 + 0]).to.eql(1);
+      expect(vertexBuffer[stride * 8 + 1]).to.eql(2);
+      expect(vertexBuffer[stride * 8 + 2]).to.eql(-3.5);
+      expect(vertexBuffer[stride * 8 + 3]).to.eql(-3.5);
+
+      expect(indexBuffer[6 + 0]).to.eql(4);
+      expect(indexBuffer[6 + 1]).to.eql(5);
+      expect(indexBuffer[6 + 2]).to.eql(7);
+      expect(indexBuffer[6 + 3]).to.eql(5);
+      expect(indexBuffer[6 + 4]).to.eql(6);
+      expect(indexBuffer[6 + 5]).to.eql(7);
+
+      expect(indexBuffer[6 * 2 + 0]).to.eql(8);
+      expect(indexBuffer[6 * 2 + 1]).to.eql(9);
+      expect(indexBuffer[6 * 2 + 2]).to.eql(11);
+      expect(indexBuffer[6 * 2 + 3]).to.eql(9);
+      expect(indexBuffer[6 * 2 + 4]).to.eql(10);
+      expect(indexBuffer[6 * 2 + 5]).to.eql(11);
+
+      expect(positions.indexPosition).to.eql(6 * 3);
+      expect(positions.vertexPosition).to.eql(stride * 4 * 3);
+    });
+
   });
 
   describe('getBlankTexture', function() {

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -89,7 +89,7 @@ describe('ol.renderer.webgl.Layer', function() {
 
     beforeEach(function() {
       vertexBuffer = new Float32Array(100);
-      indexBuffer = new Uint16Array(100);
+      indexBuffer = new Uint32Array(100);
       instructions = new Float32Array(100);
       elementIndex = 3;
 

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -59,7 +59,7 @@ describe('ol.renderer.webgl.PointsLayer', function() {
     });
 
     it('calls WebGlHelper#prepareDraw', function() {
-      const spy = sinon.spy(renderer.helper_, 'prepareDraw');
+      const spy = sinon.spy(renderer.helper, 'prepareDraw');
       renderer.prepareFrame(frameState);
       expect(spy.called).to.be(true);
     });

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -1,11 +1,9 @@
 import Feature from '../../../../../src/ol/Feature.js';
 import Point from '../../../../../src/ol/geom/Point.js';
-import LineString from '../../../../../src/ol/geom/LineString.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
 import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
-import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import ViewHint from '../../../../../src/ol/ViewHint.js';
 
 
@@ -52,9 +50,9 @@ describe('ol.renderer.webgl.PointsLayer', function() {
           projection: projection,
           resolution: 1,
           rotation: 0,
-          center: [10, 10]
+          center: [0, 0]
         },
-        size: [256, 256],
+        size: [2, 2],
         extent: [-100, -100, 100, 100]
       };
     });
@@ -69,24 +67,19 @@ describe('ol.renderer.webgl.PointsLayer', function() {
       layer.getSource().addFeature(new Feature({
         geometry: new Point([10, 20])
       }));
-      renderer.prepareFrame(frameState);
-
-      const attributePerVertex = 12;
-      expect(renderer.verticesBuffer_.getArray().length).to.eql(4 * attributePerVertex);
-      expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
-    });
-
-    it('ignores geometries other than points', function() {
       layer.getSource().addFeature(new Feature({
-        geometry: new LineString([[10, 20], [30, 20]])
-      }));
-      layer.getSource().addFeature(new Feature({
-        geometry: new Polygon([[10, 20], [30, 20], [30, 10], [10, 20]])
+        geometry: new Point([30, 40])
       }));
       renderer.prepareFrame(frameState);
 
-      expect(renderer.verticesBuffer_.getArray().length).to.eql(0);
-      expect(renderer.indicesBuffer_.getArray().length).to.eql(0);
+      const attributePerVertex = POINT_VERTEX_STRIDE;
+      expect(renderer.verticesBuffer_.getArray().length).to.eql(2 * 4 * attributePerVertex);
+      expect(renderer.indicesBuffer_.getArray().length).to.eql(2 * 6);
+
+      expect(renderer.verticesBuffer_.getArray()[0]).to.eql(10);
+      expect(renderer.verticesBuffer_.getArray()[1]).to.eql(20);
+      expect(renderer.verticesBuffer_.getArray()[4 * attributePerVertex + 0]).to.eql(30);
+      expect(renderer.verticesBuffer_.getArray()[4 * attributePerVertex + 1]).to.eql(40);
     });
 
     it('clears the buffers when the features are gone', function() {

--- a/test/spec/ol/webgl/buffer.test.js
+++ b/test/spec/ol/webgl/buffer.test.js
@@ -1,51 +1,82 @@
-import WebGLArrayBuffer from '../../../../src/ol/webgl/Buffer.js';
+import WebGLArrayBuffer, {getArrayClassForType} from '../../../../src/ol/webgl/Buffer.js';
+import {
+  ARRAY_BUFFER,
+  ELEMENT_ARRAY_BUFFER,
+  EXTENSIONS as WEBGL_EXTENSIONS,
+  STATIC_DRAW,
+  STREAM_DRAW
+} from '../../../../src/ol/webgl.js';
 
 
 describe('ol.webgl.Buffer', function() {
 
   describe('constructor', function() {
 
-    describe('without an argument', function() {
-
-      let b;
-      beforeEach(function() {
-        b = new WebGLArrayBuffer();
-      });
-
-      it('constructs an empty instance', function() {
-        expect(b.getArray()).to.be.empty();
-      });
-
+    it('sets the default usage when not specified', function() {
+      const b = new WebGLArrayBuffer(ARRAY_BUFFER);
+      expect(b.getUsage()).to.be(STATIC_DRAW);
     });
 
-    describe('with a single array argument', function() {
-
-      let b;
-      beforeEach(function() {
-        b = new WebGLArrayBuffer([0, 1, 2, 3]);
-      });
-
-      it('constructs a populated instance', function() {
-        expect(b.getArray()).to.eql([0, 1, 2, 3]);
-      });
-
+    it('sets the given usage when specified', function() {
+      const b = new WebGLArrayBuffer(ARRAY_BUFFER, STREAM_DRAW);
+      expect(b.getUsage()).to.be(STREAM_DRAW);
     });
 
+    it('raises an error if an incorrect type is used', function(done) {
+      try {
+        new WebGLArrayBuffer(1234);
+      } catch (e) {
+        done();
+      }
+      done(true);
+    });
   });
 
-  describe('with an empty instance', function() {
+  describe('#getArrayClassForType', function() {
+    it('returns the correct typed array constructor', function() {
+      expect(getArrayClassForType(ARRAY_BUFFER)).to.be(Float32Array);
+      expect(getArrayClassForType(ELEMENT_ARRAY_BUFFER)).to.be(Uint32Array);
+    });
+
+    it('returns the correct typed array constructor (without OES uint extension)', function() {
+      WEBGL_EXTENSIONS.length = 0;
+      expect(getArrayClassForType(ELEMENT_ARRAY_BUFFER)).to.be(Uint16Array);
+    });
+  });
+
+  describe('populate methods', function() {
 
     let b;
     beforeEach(function() {
-      b = new WebGLArrayBuffer();
+      b = new WebGLArrayBuffer(ARRAY_BUFFER);
     });
 
-    describe('getArray', function() {
+    it('initializes the array using a size', function() {
+      b.ofSize(12);
+      expect(b.getArray().length).to.be(12);
+      expect(b.getArray()[0]).to.be(0);
+      expect(b.getArray()[11]).to.be(0);
+    });
 
-      it('returns an empty array', function() {
-        expect(b.getArray()).to.be.empty();
-      });
+    it('initializes the array using an array', function() {
+      b.fromArray([1, 2, 3, 4, 5]);
+      expect(b.getArray().length).to.be(5);
+      expect(b.getArray()[0]).to.be(1);
+      expect(b.getArray()[1]).to.be(2);
+      expect(b.getArray()[2]).to.be(3);
+      expect(b.getArray()[3]).to.be(4);
+      expect(b.getArray()[4]).to.be(5);
+    });
 
+    it('initializes the array using a size', function() {
+      const a = Float32Array.of(1, 2, 3, 4, 5);
+      b.fromArrayBuffer(a.buffer);
+      expect(b.getArray().length).to.be(5);
+      expect(b.getArray()[0]).to.be(1);
+      expect(b.getArray()[1]).to.be(2);
+      expect(b.getArray()[2]).to.be(3);
+      expect(b.getArray()[3]).to.be(4);
+      expect(b.getArray()[4]).to.be(5);
     });
 
   });

--- a/test/spec/ol/webgl/buffer.test.js
+++ b/test/spec/ol/webgl/buffer.test.js
@@ -2,7 +2,6 @@ import WebGLArrayBuffer, {getArrayClassForType} from '../../../../src/ol/webgl/B
 import {
   ARRAY_BUFFER,
   ELEMENT_ARRAY_BUFFER,
-  EXTENSIONS as WEBGL_EXTENSIONS,
   STATIC_DRAW,
   STREAM_DRAW
 } from '../../../../src/ol/webgl.js';
@@ -36,11 +35,6 @@ describe('ol.webgl.Buffer', function() {
     it('returns the correct typed array constructor', function() {
       expect(getArrayClassForType(ARRAY_BUFFER)).to.be(Float32Array);
       expect(getArrayClassForType(ELEMENT_ARRAY_BUFFER)).to.be(Uint32Array);
-    });
-
-    it('returns the correct typed array constructor (without OES uint extension)', function() {
-      WEBGL_EXTENSIONS.length = 0;
-      expect(getArrayClassForType(ELEMENT_ARRAY_BUFFER)).to.be(Uint16Array);
     });
   });
 

--- a/test/spec/ol/worker/webgl.test.js
+++ b/test/spec/ol/worker/webgl.test.js
@@ -1,0 +1,46 @@
+import {create} from '../../../../src/ol/worker/webgl.js';
+import {WebGLWorkerMessageType, writePointFeatureInstructions} from '../../../../src/ol/renderer/webgl/Layer';
+
+
+describe('ol/worker/webgl', function() {
+
+  let worker;
+  beforeEach(function() {
+    worker = create();
+  });
+
+  afterEach(function() {
+    if (worker) {
+      worker.terminate();
+    }
+    worker = null;
+  });
+
+  describe('messaging', function() {
+    it('responds to GENERATE_BUFFERS message type', function(done) {
+      worker.addEventListener('error', done);
+
+      worker.addEventListener('message', function(event) {
+        expect(event.data.type).to.eql(WebGLWorkerMessageType.GENERATE_BUFFERS);
+        expect(event.data.renderInstructions.byteLength).to.greaterThan(0);
+        expect(event.data.indexBuffer.byteLength).to.greaterThan(0);
+        expect(event.data.vertexBuffer.byteLength).to.greaterThan(0);
+        expect(event.data.testInt).to.be(101);
+        expect(event.data.testString).to.be('abcd');
+        done();
+      });
+
+      const instructions = new Float32Array(100);
+
+      const message = {
+        type: WebGLWorkerMessageType.GENERATE_BUFFERS,
+        renderInstructions: instructions,
+        testInt: 101,
+        testString: 'abcd'
+      };
+
+      worker.postMessage(message);
+    });
+  });
+
+});

--- a/test/spec/ol/worker/webgl.test.js
+++ b/test/spec/ol/worker/webgl.test.js
@@ -45,25 +45,6 @@ describe('ol/worker/webgl', function() {
 
         worker.postMessage(message);
       });
-
-      it('responds with buffer data (fallback to Uint16Array)', function(done) {
-        worker.addEventListener('error', done);
-
-        worker.addEventListener('message', function(event) {
-          expect(event.data.indexBuffer).to.eql(Uint16Array.BYTES_PER_ELEMENT * 6);
-          done();
-        });
-
-        const instructions = new Float32Array(POINT_INSTRUCTIONS_COUNT);
-
-        const message = {
-          type: WebGLWorkerMessageType.GENERATE_BUFFERS,
-          renderInstructions: instructions,
-          useShortIndices: true
-        };
-
-        worker.postMessage(message);
-      });
     });
   });
 


### PR DESCRIPTION
The utilities in `ol/renderer/webgl/Layer` have been reworked (again!) with the objective to work exclusively with typed arrays.

The principle is:
* an `instructions` float-typed array receives the values that describe *how* a feature (in our case, points) should be rendered: position, size, color, rotate with view, etc.
  This is done with `writePointFeatureInstructions`.
* this array is used to write to both an index buffer (integer-typed array) and a vertex buffer (float-typed array) which are then ready to be sent to the GPU for rendering
  This is done with `writePointFeatureToBuffers` and is actually run in a worker.

Other minor improvements:
* Rendering tests now support web workers - @tschaub might have a better idea for handling this, for now I only reused the custom loader from the examples

Basing everything on typed array manipulation is a good way to improve performance and also enables using workers with almost no transfer overhead. Writing to index/vertex buffers is pretty quick for points but the gain will be even larger with lines & polygons (when running the earcut algorithm).

There are still performance bottlenecks which can be felt when navigating in the webgl examples (there is a noticeable lag when rebuilding the buffers). IMO the next optimization steps are:
* ~improve the `WebGLBuffer` class to not be based on plain arrays: this does not make sense as we might as well do everything with typed arrays; currently we fill typed arrays, then create arrays from typed arrays, then create typed arrays from arrays... all on the main thread. There's room for improvement!~
  Done, the `WebGLBuffer` class now only works with typed arrays, which brought a significant improvement.
* apparently the "styling" callbacks used by the points renderer have a significant cost in performance; this should be looked into a bit more and the API of the renderer should probably evolve at some point -> any ideas @ahocevar?

~I'm leaving this PR as draft if anyone wants to pick up the work (ping @fgravin).~

This PR is now ready for review, IMO performance is acceptable although there probably still are optimizations to make. On the filter webgl example, rebuilding the buffers takes around 50~70ms on the main thread for several thousand features, and this is only done when the view is not moving so the lag is hardly noticeable.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
