### PR TITLE
Fix @abstract and @module annotations

### DIFF
--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -116,8 +116,8 @@ class LayerRenderer extends Observable {
   }
 
   /**
-   * @abstract
    * Perform action necessary to get the layer rendered after new fonts have loaded
+   * @abstract
    */
   handleFontsChanged() {}
 

--- a/src/ol/worker/version.js
+++ b/src/ol/worker/version.js
@@ -1,6 +1,6 @@
 /**
- * @module ol/worker/version
  * A worker that responds to messages by posting a message with the version identifer.
+ * @module ol/worker/version
  */
 import {VERSION} from '../util';
 


### PR DESCRIPTION
When there is a description below an `@abstract` tag, JSDoc emits warnings like this:
```
WARNING: The @abstract tag does not permit a value; the value will be ignored. File: Layer.js, line: 118
WARNING: The @abstract tag does not permit a value; the value will be ignored. File: Layer.js, line: 122
```
(The things that are frustrating about this are the lack of path, the wrong line numbers, and the repetition.  Perhaps the repetition and wrong line numbers are due to us manipulating the file in a plugin.)

In the case above, the `@abstract` tag is not parsed (not available to a plugin that might want to do something with it) and the description is lost.  When the description is placed above the `@abstract` annotation, things are properly parsed.

Similar situation with `@module`.  But no warning here.  When there is a description below a `@module` tag, the doclet's longname includes the description.

When the description is below, the doclet includes this:
```
"longname": "ol/worker/version\nA worker that responds to messages by posting a message with the version"
```

When the description is above, the longname is properly set to "module:ol/worker/version".
