### PR TITLE
Fix for change in Zoomify.js/CustomTile signature

### DIFF
--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -75,6 +75,7 @@ class IIIF extends TileImage {
     const width = size[0];
     const height = size[1];
     const tileSize = options.tileSize;
+    const tilePixelRatio = options.tilePixelRatio || 1;
     const format = options.format || 'jpg';
     const quality = options.quality || (options.version == Versions.VERSION1 ? 'native' : 'default');
     let resolutions = options.resolutions || [];
@@ -259,8 +260,8 @@ class IIIF extends TileImage {
       }
       return baseUrl + regionParam + '/' + sizeParam + '/0/' + quality + '.' + format;
     };
-
-    const IiifTileClass = CustomTile.bind(null, tileGrid);
+    
+		const IiifTileClass = CustomTile.bind(null, tilePixelRatio, tileGrid);
 
     super({
       attributions: options.attributions,


### PR DESCRIPTION
The recent addition of tilePixelRatio to the Zoomify.js/CustomTile constructor broke parameter binding in IIIF.js/IIIF.
The fix mirrors the change in the  Zoomify.js/Zoomify constructor

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
