### PR TITLE
Fix for change in Zoomify.js/CustomTile signature

### DIFF
--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -260,7 +260,7 @@ class IIIF extends TileImage {
       }
       return baseUrl + regionParam + '/' + sizeParam + '/0/' + quality + '.' + format;
     };
-      
+
     const IiifTileClass = CustomTile.bind(null, tilePixelRatio, tileGrid);
 
     super({

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -75,6 +75,7 @@ class IIIF extends TileImage {
     const width = size[0];
     const height = size[1];
     const tileSize = options.tileSize;
+    const tilePixelRatio = options.tilePixelRatio || 1;
     const format = options.format || 'jpg';
     const quality = options.quality || (options.version == Versions.VERSION1 ? 'native' : 'default');
     let resolutions = options.resolutions || [];
@@ -259,8 +260,8 @@ class IIIF extends TileImage {
       }
       return baseUrl + regionParam + '/' + sizeParam + '/0/' + quality + '.' + format;
     };
-
-    const IiifTileClass = CustomTile.bind(null, tileGrid);
+    
+		const IiifTileClass = CustomTile.bind(null, tilePixelRatio, tileGrid);
 
     super({
       attributions: options.attributions,

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -260,8 +260,8 @@ class IIIF extends TileImage {
       }
       return baseUrl + regionParam + '/' + sizeParam + '/0/' + quality + '.' + format;
     };
-    
-		const IiifTileClass = CustomTile.bind(null, tilePixelRatio, tileGrid);
+      
+    const IiifTileClass = CustomTile.bind(null, tilePixelRatio, tileGrid);
 
     super({
       attributions: options.attributions,


### PR DESCRIPTION
The recent addition of tilePixelRatio to the Zoomify.js/CustomTile constructor broke parameter binding in IIIF.js/IIIF.
The fix mirrors the change in the Zoomify.js/Zoomify constructor