### PR TITLE
Update webpack and use mode in the loader

### DIFF
--- a/examples/webpack/worker-loader.js
+++ b/examples/webpack/worker-loader.js
@@ -2,14 +2,7 @@ const build = require('../../tasks/serialize-workers').build;
 
 function loader() {
   const callback = this.async();
-
-  let minify = false;
-
-  // TODO: remove when https://github.com/webpack/webpack/issues/6496 is addressed
-  const compilation = this._compilation;
-  if (compilation) {
-    minify = compilation.compiler.options.mode === 'production';
-  }
+  const minify = this.mode === 'production';
 
   build(this.resource, {minify})
     .then(chunk => {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "typescript": "^3.4.5",
     "url-polyfill": "^1.1.5",
     "walk": "^2.3.9",
-    "webpack": "4.31.0",
+    "webpack": "4.32.0",
     "webpack-cli": "^3.3.2",
     "webpack-dev-middleware": "^3.6.2",
     "webpack-dev-server": "^3.3.1",


### PR DESCRIPTION
Webpack now exposes `mode` to loaders (see webpack/webpack#9140).

Closes #9579.