### PR TITLE
Calculate tile grid extent from extent of bottom-level tile matrix

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -4,9 +4,8 @@
 
 import {expandUrl, createFromTileUrlFunctions, nullTileUrlFunction} from '../tileurlfunction.js';
 import {find, findIndex, includes} from '../array.js';
-import {containsExtent} from '../extent.js';
 import {assign} from '../obj.js';
-import {get as getProjection, equivalent, transformExtent} from '../proj.js';
+import {get as getProjection, equivalent} from '../proj.js';
 import TileImage from './TileImage.js';
 import WMTSRequestEncoding from './WMTSRequestEncoding.js';
 import {createFromCapabilitiesMatrixSet} from '../tilegrid/WMTS.js';
@@ -377,22 +376,25 @@ export function optionsFromCapabilities(wmtsCap, config) {
     }
   }
 
-  const wgs84BoundingBox = l['WGS84BoundingBox'];
-  let extent, wrapX;
-  if (wgs84BoundingBox !== undefined) {
-    const wgs84ProjectionExtent = getProjection('EPSG:4326').getExtent();
-    wrapX = (wgs84BoundingBox[0] == wgs84ProjectionExtent[0] &&
-        wgs84BoundingBox[2] == wgs84ProjectionExtent[2]);
-    extent = transformExtent(
-      wgs84BoundingBox, 'EPSG:4326', projection);
-    const projectionExtent = projection.getExtent();
-    if (projectionExtent) {
-      // If possible, do a sanity check on the extent - it should never be
-      // bigger than the validity extent of the projection of a matrix set.
-      if (!containsExtent(projectionExtent, extent)) {
-        extent = undefined;
-      }
-    }
+  const wrapX = false;
+
+  const matrix0 = matrixSetObj.TileMatrix[0];
+  const resolution = matrix0.ScaleDenominator * 0.00028; // WMTS 1.0.0: standardized rendering pixel size
+  const origin = projection === getProjection('EPSG:4326')
+    ? [matrix0.TopLeftCorner[1], matrix0.TopLeftCorner[0]]
+    : matrix0.TopLeftCorner;
+  const tileSpanX = matrix0.TileWidth * resolution;
+  const tileSpanY = matrix0.TileHeight * resolution;
+
+  const extent = [
+    origin[0],
+    origin[1] - tileSpanY * matrix0.MatrixHeight,
+    origin[0] + tileSpanX * matrix0.MatrixWidth,
+    origin[1]
+  ];
+
+  if (projection.getExtent() === null) {
+    projection.setExtent(extent);
   }
 
   const tileGrid = createFromCapabilitiesMatrixSet(matrixSetObj, extent, matrixLimits);

--- a/test/spec/ol/format/wmts/ogcsample.xml
+++ b/test/spec/ol/format/wmts/ogcsample.xml
@@ -92,6 +92,9 @@ access interface to some TileMatrixSets</ows:Abstract>
 			<TileMatrixSetLink>
 				<TileMatrixSet>google3857</TileMatrixSet>
 			</TileMatrixSetLink>
+      <TileMatrixSetLink>
+				<TileMatrixSet>google3857subset</TileMatrixSet>
+			</TileMatrixSetLink>
 			<ResourceURL format="image/png" resourceType="tile" template="http://www.example.com/wmts/coastlines/{TileMatrix}/{TileRow}/{TileCol}.png"/>
 			<ResourceURL format="application/gml+xml; version=3.1" resourceType="FeatureInfo" template="http://www.example.com/wmts/coastlines/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}/{J}/{I}.xml"/>
                         <Dimension>
@@ -372,6 +375,29 @@ access interface to some TileMatrixSets</ows:Abstract>
 				<MatrixHeight>7000</MatrixHeight>
 			</TileMatrix>
 		</TileMatrixSet>
-	</Contents>
+			<TileMatrixSet>
+			<!-- A custom tile matrix set based on google3857 with tiles at each level covering only part of projection space (extent) -->
+			<ows:Identifier>google3857subset</ows:Identifier>
+			<ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18:3:3857</ows:SupportedCRS>
+			<TileMatrix>
+				<ows:Identifier>18</ows:Identifier>
+				<ScaleDenominator>2132.72958385</ScaleDenominator>
+				<TopLeftCorner>-10000000 10000000</TopLeftCorner>
+				<TileWidth>256</TileWidth>
+				<TileHeight>256</TileHeight>
+				<MatrixWidth>1</MatrixWidth>
+				<MatrixHeight>1</MatrixHeight>
+			</TileMatrix>
+			<TileMatrix>
+				<ows:Identifier>18</ows:Identifier>
+				<ScaleDenominator>1066.36479193</ScaleDenominator>
+				<TopLeftCorner>-10000000 10000000</TopLeftCorner>
+				<TileWidth>256</TileWidth>
+				<TileHeight>256</TileHeight>
+				<MatrixWidth>2</MatrixWidth>
+				<MatrixHeight>2</MatrixHeight>
+			</TileMatrix>
+		</TileMatrixSet>
+  </Contents>
 	<ServiceMetadataURL xlink:href="http://www.maps.bob/wmts/1.0.0/WMTSCapabilities.xml"/>
 </Capabilities>

--- a/test/spec/ol/format/wmtscapabilities.test.js
+++ b/test/spec/ol/format/wmtscapabilities.test.js
@@ -54,11 +54,13 @@ describe('ol.format.WMTSCapabilities', function() {
       expect(layer.Style[0].LegendURL[0].format).to.be.eql('image/png');
 
       expect(layer.TileMatrixSetLink).to.be.an('array');
-      expect(layer.TileMatrixSetLink).to.have.length(2);
+      expect(layer.TileMatrixSetLink).to.have.length(3);
       expect(layer.TileMatrixSetLink[0].TileMatrixSet).to.be
         .eql('BigWorldPixel');
       expect(layer.TileMatrixSetLink[1].TileMatrixSet).to.be
         .eql('google3857');
+      expect(layer.TileMatrixSetLink[2].TileMatrixSet).to.be
+        .eql('google3857subset');
 
       const wgs84Bbox = layer.WGS84BoundingBox;
       expect(wgs84Bbox).to.be.an('array');


### PR DESCRIPTION
Prefers extent derived from the tile matrix set in the capabilities over default projection extent.

-----

It's not really a new feature or a bug fix, but a small tweak that improves WMTS experience:

It augments tile grid extent based on extent calculated from parameters of the bottom-level matrix as reported by capabilities. This works around some issues when using custom tile matrix sets, etc.

I'm no JavaScript programmer or experienced OpenLayers user, so apologies if I abused the language/library in any way. I'll be thankful for any feedback about how to improve my patch.