### PR TITLE
Include full filename in import specifier

### DIFF
--- a/examples/d3.js
+++ b/examples/d3.js
@@ -2,7 +2,7 @@ import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import {getWidth, getCenter} from '../src/ol/extent.js';
 import {Layer, Tile as TileLayer} from '../src/ol/layer.js';
-import SourceState from '../src/ol/source/State';
+import SourceState from '../src/ol/source/State.js';
 import {fromLonLat, toLonLat} from '../src/ol/proj.js';
 import Stamen from '../src/ol/source/Stamen.js';
 

--- a/examples/extent-constrained.js
+++ b/examples/extent-constrained.js
@@ -3,7 +3,7 @@ import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import OSM from '../src/ol/source/OSM.js';
 import {defaults as defaultControls} from '../src/ol/control.js';
-import ZoomSlider from '../src/ol/control/ZoomSlider';
+import ZoomSlider from '../src/ol/control/ZoomSlider.js';
 
 const view = new View({
   center: [328627.563458, 5921296.662223],

--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -1,14 +1,14 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
-import Feature from '../src/ol/Feature';
-import Point from '../src/ol/geom/Point';
-import VectorLayer from '../src/ol/layer/Vector';
-import {Vector} from '../src/ol/source';
-import {fromLonLat} from '../src/ol/proj';
-import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer';
-import {clamp, lerp} from '../src/ol/math';
-import Stamen from '../src/ol/source/Stamen';
+import Feature from '../src/ol/Feature.js';
+import Point from '../src/ol/geom/Point.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
+import {Vector} from '../src/ol/source.js';
+import {fromLonLat} from '../src/ol/proj.js';
+import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
+import {clamp, lerp} from '../src/ol/math.js';
+import Stamen from '../src/ol/source/Stamen.js';
 
 const vectorSource = new Vector({
   attributions: 'NASA'

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -1,14 +1,14 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
-import TileJSON from '../src/ol/source/TileJSON';
-import Feature from '../src/ol/Feature';
-import Point from '../src/ol/geom/Point';
-import VectorLayer from '../src/ol/layer/Vector';
-import {Vector} from '../src/ol/source';
-import {fromLonLat} from '../src/ol/proj';
-import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer';
-import {lerp} from '../src/ol/math';
+import TileJSON from '../src/ol/source/TileJSON.js';
+import Feature from '../src/ol/Feature.js';
+import Point from '../src/ol/geom/Point.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
+import {Vector} from '../src/ol/source.js';
+import {fromLonLat} from '../src/ol/proj.js';
+import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
+import {lerp} from '../src/ol/math.js';
 
 const vectorSource = new Vector({
   features: [],

--- a/examples/mapbox-layer.js
+++ b/examples/mapbox-layer.js
@@ -1,7 +1,7 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import Layer from '../src/ol/layer/Layer';
-import {toLonLat, fromLonLat} from '../src/ol/proj';
+import Layer from '../src/ol/layer/Layer.js';
+import {toLonLat, fromLonLat} from '../src/ol/proj.js';
 import {Stroke, Style} from '../src/ol/style.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';

--- a/examples/worker.js
+++ b/examples/worker.js
@@ -4,7 +4,7 @@ import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import OSM from '../src/ol/source/OSM.js';
-import {create as createVersionWorker} from '../src/ol/worker/version';
+import {create as createVersionWorker} from '../src/ol/worker/version.js';
 
 
 const map = new Map({

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "copy-webpack-plugin": "^5.0.3",
     "coveralls": "3.0.3",
     "eslint": "^5.16.0",
-    "eslint-config-openlayers": "^11.0.0",
+    "eslint-config-openlayers": "^12.0.0",
     "expect.js": "0.3.1",
     "front-matter": "^3.0.2",
     "fs-extra": "^8.0.0",

--- a/rendering/cases/heatmap-layer/main.js
+++ b/rendering/cases/heatmap-layer/main.js
@@ -1,10 +1,10 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import XYZ from '../../../src/ol/source/XYZ';
-import {Heatmap as HeatmapLayer} from '../../../src/ol/layer';
-import VectorSource from '../../../src/ol/source/Vector';
-import KML from '../../../src/ol/format/KML';
+import XYZ from '../../../src/ol/source/XYZ.js';
+import {Heatmap as HeatmapLayer} from '../../../src/ol/layer.js';
+import VectorSource from '../../../src/ol/source/Vector.js';
+import KML from '../../../src/ol/format/KML.js';
 
 const vector = new HeatmapLayer({
   source: new VectorSource({

--- a/rendering/cases/layer-image/main.js
+++ b/rendering/cases/layer-image/main.js
@@ -5,7 +5,7 @@ import {
   get as getProjection,
   transform,
   transformExtent
-} from '../../../src/ol/proj';
+} from '../../../src/ol/proj.js';
 import ImageLayer from '../../../src/ol/layer/Image.js';
 const center = transform([-122.416667, 37.783333], 'EPSG:4326', 'EPSG:3857');
 

--- a/rendering/cases/layer-tile-extent/main.js
+++ b/rendering/cases/layer-tile-extent/main.js
@@ -5,9 +5,9 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import {fromLonLat} from '../../../src/ol/proj';
+import {fromLonLat} from '../../../src/ol/proj.js';
 import {transformExtent} from '../../../src/ol/proj.js';
-import XYZ from '../../../src/ol/source/XYZ';
+import XYZ from '../../../src/ol/source/XYZ.js';
 
 const center = fromLonLat([7, 50]);
 const extent = transformExtent([2, 47, 10, 53], 'EPSG:4326', 'EPSG:3857');

--- a/rendering/cases/layer-tile-none-square/main.js
+++ b/rendering/cases/layer-tile-none-square/main.js
@@ -1,7 +1,7 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import XYZ from '../../../src/ol/source/XYZ';
+import XYZ from '../../../src/ol/source/XYZ.js';
 import {createXYZ} from '../../../src/ol/tilegrid.js';
 
 const center = [-10997148, 4569099];

--- a/rendering/cases/layer-tile-opacity/main.js
+++ b/rendering/cases/layer-tile-opacity/main.js
@@ -1,8 +1,8 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import {fromLonLat} from '../../../src/ol/proj';
-import XYZ from '../../../src/ol/source/XYZ';
+import {fromLonLat} from '../../../src/ol/proj.js';
+import XYZ from '../../../src/ol/source/XYZ.js';
 
 const center = fromLonLat([8.6, 50.1]);
 

--- a/rendering/cases/layer-tile-simple/main.js
+++ b/rendering/cases/layer-tile-simple/main.js
@@ -1,8 +1,8 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import {fromLonLat} from '../../../src/ol/proj';
-import XYZ from '../../../src/ol/source/XYZ';
+import {fromLonLat} from '../../../src/ol/proj.js';
+import XYZ from '../../../src/ol/source/XYZ.js';
 
 const center = fromLonLat([8.6, 50.1]);
 

--- a/rendering/cases/layer-tile-transition/main.js
+++ b/rendering/cases/layer-tile-transition/main.js
@@ -1,8 +1,8 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import {fromLonLat} from '../../../src/ol/proj';
-import XYZ from '../../../src/ol/source/XYZ';
+import {fromLonLat} from '../../../src/ol/proj.js';
+import XYZ from '../../../src/ol/source/XYZ.js';
 
 const center = fromLonLat([8.6, 50.1]);
 

--- a/rendering/cases/layer-tile-two-layers/main.js
+++ b/rendering/cases/layer-tile-two-layers/main.js
@@ -1,8 +1,8 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import {fromLonLat} from '../../../src/ol/proj';
-import XYZ from '../../../src/ol/source/XYZ';
+import {fromLonLat} from '../../../src/ol/proj.js';
+import XYZ from '../../../src/ol/source/XYZ.js';
 
 const center = fromLonLat([8.6, 50.1]);
 

--- a/rendering/cases/layer-vectortile-rotate-hidpi/main.js
+++ b/rendering/cases/layer-vectortile-rotate-hidpi/main.js
@@ -1,9 +1,9 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
-import VectorTileSource from '../../../src/ol/source/VectorTile';
-import MVT from '../../../src/ol/format/MVT';
-import {createXYZ} from '../../../src/ol/tilegrid';
-import VectorTileLayer from '../../../src/ol/layer/VectorTile';
+import VectorTileSource from '../../../src/ol/source/VectorTile.js';
+import MVT from '../../../src/ol/format/MVT.js';
+import {createXYZ} from '../../../src/ol/tilegrid.js';
+import VectorTileLayer from '../../../src/ol/layer/VectorTile.js';
 
 const map = new Map({
   pixelRatio: 2,

--- a/rendering/cases/layer-vectortile-rotate-vector/main.js
+++ b/rendering/cases/layer-vectortile-rotate-vector/main.js
@@ -1,16 +1,16 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
-import VectorTileSource from '../../../src/ol/source/VectorTile';
-import MVT from '../../../src/ol/format/MVT';
-import {createXYZ} from '../../../src/ol/tilegrid';
-import VectorTileLayer from '../../../src/ol/layer/VectorTile';
-import VectorSource from '../../../src/ol/source/Vector';
-import Feature from '../../../src/ol/Feature';
-import Point from '../../../src/ol/geom/Point';
-import VectorLayer from '../../../src/ol/layer/Vector';
-import Style from '../../../src/ol/style/Style';
-import CircleStyle from '../../../src/ol/style/Circle';
-import Fill from '../../../src/ol/style/Fill';
+import VectorTileSource from '../../../src/ol/source/VectorTile.js';
+import MVT from '../../../src/ol/format/MVT.js';
+import {createXYZ} from '../../../src/ol/tilegrid.js';
+import VectorTileLayer from '../../../src/ol/layer/VectorTile.js';
+import VectorSource from '../../../src/ol/source/Vector.js';
+import Feature from '../../../src/ol/Feature.js';
+import Point from '../../../src/ol/geom/Point.js';
+import VectorLayer from '../../../src/ol/layer/Vector.js';
+import Style from '../../../src/ol/style/Style.js';
+import CircleStyle from '../../../src/ol/style/Circle.js';
+import Fill from '../../../src/ol/style/Fill.js';
 
 const vectorSource = new VectorSource({
   features: [

--- a/rendering/cases/layer-vectortile-rotate/main.js
+++ b/rendering/cases/layer-vectortile-rotate/main.js
@@ -1,9 +1,9 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
-import VectorTileSource from '../../../src/ol/source/VectorTile';
-import MVT from '../../../src/ol/format/MVT';
-import {createXYZ} from '../../../src/ol/tilegrid';
-import VectorTileLayer from '../../../src/ol/layer/VectorTile';
+import VectorTileSource from '../../../src/ol/source/VectorTile.js';
+import MVT from '../../../src/ol/format/MVT.js';
+import {createXYZ} from '../../../src/ol/tilegrid.js';
+import VectorTileLayer from '../../../src/ol/layer/VectorTile.js';
 
 const map = new Map({
   layers: [

--- a/rendering/cases/layer-vectortile-simple/main.js
+++ b/rendering/cases/layer-vectortile-simple/main.js
@@ -1,9 +1,9 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
-import VectorTileSource from '../../../src/ol/source/VectorTile';
-import MVT from '../../../src/ol/format/MVT';
-import {createXYZ} from '../../../src/ol/tilegrid';
-import VectorTileLayer from '../../../src/ol/layer/VectorTile';
+import VectorTileSource from '../../../src/ol/source/VectorTile.js';
+import MVT from '../../../src/ol/format/MVT.js';
+import {createXYZ} from '../../../src/ol/tilegrid.js';
+import VectorTileLayer from '../../../src/ol/layer/VectorTile.js';
 
 new Map({
   layers: [

--- a/rendering/cases/webgl-points/main.js
+++ b/rendering/cases/webgl-points/main.js
@@ -1,11 +1,11 @@
 import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
-import XYZ from '../../../src/ol/source/XYZ';
-import {Vector as VectorLayer} from '../../../src/ol/layer';
-import VectorSource from '../../../src/ol/source/Vector';
-import KML from '../../../src/ol/format/KML';
-import WebGLPointsLayerRenderer from '../../../src/ol/renderer/webgl/PointsLayer';
+import XYZ from '../../../src/ol/source/XYZ.js';
+import {Vector as VectorLayer} from '../../../src/ol/layer.js';
+import VectorSource from '../../../src/ol/source/Vector.js';
+import KML from '../../../src/ol/format/KML.js';
+import WebGLPointsLayerRenderer from '../../../src/ol/renderer/webgl/PointsLayer.js';
 
 class CustomLayer extends VectorLayer {
   createRenderer() {

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -21,9 +21,9 @@ import {clamp, modulo} from './math.js';
 import {assign} from './obj.js';
 import {createProjection, METERS_PER_UNIT} from './proj.js';
 import Units from './proj/Units.js';
-import {equals} from './coordinate';
-import {easeOut} from './easing';
-import {createMinMaxResolution} from './resolutionconstraint';
+import {equals} from './coordinate.js';
+import {easeOut} from './easing.js';
+import {createMinMaxResolution} from './resolutionconstraint.js';
 
 
 /**

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -3,27 +3,27 @@
  */
 import VectorLayer from './Vector.js';
 import {assign} from '../obj.js';
-import {degreesToStringHDMS} from '../coordinate';
-import Text from '../style/Text';
-import Fill from '../style/Fill';
-import Stroke from '../style/Stroke';
+import {degreesToStringHDMS} from '../coordinate.js';
+import Text from '../style/Text.js';
+import Fill from '../style/Fill.js';
+import Stroke from '../style/Stroke.js';
 import LineString from '../geom/LineString.js';
-import VectorSource from '../source/Vector';
+import VectorSource from '../source/Vector.js';
 import {
   equivalent as equivalentProjection,
   get as getProjection,
   getTransform,
   transformExtent
-} from '../proj';
-import {getCenter, intersects, equals, getIntersection, isEmpty} from '../extent';
-import {clamp} from '../math';
-import Style from '../style/Style';
-import Feature from '../Feature';
-import {bbox} from '../loadingstrategy';
-import {meridian, parallel} from '../geom/flat/geodesic';
-import GeometryLayout from '../geom/GeometryLayout';
-import Point from '../geom/Point';
-import Collection from '../Collection';
+} from '../proj.js';
+import {getCenter, intersects, equals, getIntersection, isEmpty} from '../extent.js';
+import {clamp} from '../math.js';
+import Style from '../style/Style.js';
+import Feature from '../Feature.js';
+import {bbox} from '../loadingstrategy.js';
+import {meridian, parallel} from '../geom/flat/geodesic.js';
+import GeometryLayout from '../geom/GeometryLayout.js';
+import Point from '../geom/Point.js';
+import Collection from '../Collection.js';
 
 
 /**

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -6,7 +6,7 @@ import {getChangeEventType} from '../Object.js';
 import {createCanvasContext2D} from '../dom.js';
 import VectorLayer from './Vector.js';
 import {assign} from '../obj.js';
-import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer';
+import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
 
 
 /**

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -2,7 +2,7 @@
  * @module ol/renderer/webgl/Layer
  */
 import LayerRenderer from '../Layer.js';
-import WebGLHelper from '../../webgl/Helper';
+import WebGLHelper from '../../webgl/Helper.js';
 
 
 /**

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -1,21 +1,21 @@
 /**
  * @module ol/renderer/webgl/PointsLayer
  */
-import WebGLArrayBuffer from '../../webgl/Buffer';
-import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT} from '../../webgl';
-import {DefaultAttrib, DefaultUniform} from '../../webgl/Helper';
-import GeometryType from '../../geom/GeometryType';
-import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from './Layer';
-import GeoJSON from '../../format/GeoJSON';
-import {getUid} from '../../util';
-import ViewHint from '../../ViewHint';
-import {createEmpty, equals} from '../../extent';
+import WebGLArrayBuffer from '../../webgl/Buffer.js';
+import {DYNAMIC_DRAW, ARRAY_BUFFER, ELEMENT_ARRAY_BUFFER, FLOAT} from '../../webgl.js';
+import {DefaultAttrib, DefaultUniform} from '../../webgl/Helper.js';
+import GeometryType from '../../geom/GeometryType.js';
+import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from './Layer.js';
+import GeoJSON from '../../format/GeoJSON.js';
+import {getUid} from '../../util.js';
+import ViewHint from '../../ViewHint.js';
+import {createEmpty, equals} from '../../extent.js';
 import {
   create as createTransform,
   makeInverse as makeInverseTransform,
   multiply as multiplyTransform,
   apply as applyTransform
-} from '../../transform';
+} from '../../transform.js';
 
 const VERTEX_SHADER = `
   precision mediump float;

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -2,8 +2,8 @@
  * @module ol/resolutionconstraint
  */
 import {linearFindNearest} from './array.js';
-import {getHeight, getWidth} from './extent';
-import {clamp} from './math';
+import {getHeight, getWidth} from './extent.js';
+import {clamp} from './math.js';
 
 
 /**

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -7,7 +7,7 @@ import {createCanvasContext2D} from '../dom.js';
 import {listen} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
-import {Processor} from 'pixelworks/lib/index';
+import {Processor} from 'pixelworks/lib/index.js';
 import {equals, getCenter, getHeight, getWidth} from '../extent.js';
 import ImageLayer from '../layer/Image.js';
 import TileLayer from '../layer/Tile.js';

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -15,10 +15,10 @@ import {
   rotate as rotateTransform,
   scale as scaleTransform,
   translate as translateTransform
-} from '../transform';
-import {create, fromTransform} from '../vec/mat4';
-import WebGLPostProcessingPass from './PostProcessingPass';
-import {getContext} from '../webgl';
+} from '../transform.js';
+import {create, fromTransform} from '../vec/mat4.js';
+import WebGLPostProcessingPass from './PostProcessingPass.js';
+import {getContext} from '../webgl.js';
 
 
 /**

--- a/src/ol/worker/version.js
+++ b/src/ol/worker/version.js
@@ -2,7 +2,7 @@
  * A worker that responds to messages by posting a message with the version identifer.
  * @module ol/worker/version
  */
-import {VERSION} from '../util';
+import {VERSION} from '../util.js';
 
 onmessage = event => {
   console.log('version worker received message:', event.data); // eslint-disable-line

--- a/test/spec/ol/graticule.test.js
+++ b/test/spec/ol/graticule.test.js
@@ -3,7 +3,7 @@ import Map from '../../../src/ol/Map.js';
 import {get as getProjection} from '../../../src/ol/proj.js';
 import Stroke from '../../../src/ol/style/Stroke.js';
 import Text from '../../../src/ol/style/Text.js';
-import Feature from '../../../src/ol/Feature';
+import Feature from '../../../src/ol/Feature.js';
 
 describe('ol.layer.Graticule', function() {
   let graticule;

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -4,7 +4,7 @@ import Map from '../../../src/ol/Map.js';
 import MapEvent from '../../../src/ol/MapEvent.js';
 import Overlay from '../../../src/ol/Overlay.js';
 import View from '../../../src/ol/View.js';
-import {LineString, Point} from '../../../src/ol/geom';
+import {LineString, Point} from '../../../src/ol/geom.js';
 import {TOUCH} from '../../../src/ol/has.js';
 import {focus} from '../../../src/ol/events/condition.js';
 import {defaults as defaultInteractions} from '../../../src/ol/interaction.js';

--- a/test/spec/ol/render/canvas/labelcache.test.js
+++ b/test/spec/ol/render/canvas/labelcache.test.js
@@ -1,4 +1,4 @@
-import LabelCache from '../../../../../src/ol/render/canvas/LabelCache';
+import LabelCache from '../../../../../src/ol/render/canvas/LabelCache.js';
 
 describe('ol.render.canvas.LabelCache', function() {
 

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -1,6 +1,6 @@
-import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from '../../../../../src/ol/renderer/webgl/Layer';
-import WebGLArrayBuffer from '../../../../../src/ol/webgl/Buffer';
-import Layer from '../../../../../src/ol/layer/Layer';
+import WebGLLayerRenderer, {getBlankTexture, pushFeatureToBuffer} from '../../../../../src/ol/renderer/webgl/Layer.js';
+import WebGLArrayBuffer from '../../../../../src/ol/webgl/Buffer.js';
+import Layer from '../../../../../src/ol/layer/Layer.js';
 
 
 describe('ol.renderer.webgl.Layer', function() {

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -3,10 +3,10 @@ import Point from '../../../../../src/ol/geom/Point.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
-import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer';
-import {get as getProjection} from '../../../../../src/ol/proj';
-import Polygon from '../../../../../src/ol/geom/Polygon';
-import ViewHint from '../../../../../src/ol/ViewHint';
+import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer.js';
+import {get as getProjection} from '../../../../../src/ol/proj.js';
+import Polygon from '../../../../../src/ol/geom/Polygon.js';
+import ViewHint from '../../../../../src/ol/ViewHint.js';
 
 
 describe('ol.renderer.webgl.PointsLayer', function() {

--- a/test/spec/ol/resolutionconstraint.test.js
+++ b/test/spec/ol/resolutionconstraint.test.js
@@ -1,5 +1,5 @@
 import {createSnapToResolutions, createSnapToPower} from '../../../src/ol/resolutionconstraint.js';
-import {createMinMaxResolution} from '../../../src/ol/resolutionconstraint';
+import {createMinMaxResolution} from '../../../src/ol/resolutionconstraint.js';
 
 
 describe('ol.resolutionconstraint', function() {

--- a/test/spec/ol/webgl/buffer.test.js
+++ b/test/spec/ol/webgl/buffer.test.js
@@ -1,4 +1,4 @@
-import WebGLArrayBuffer from '../../../../src/ol/webgl/Buffer';
+import WebGLArrayBuffer from '../../../../src/ol/webgl/Buffer.js';
 
 
 describe('ol.webgl.Buffer', function() {

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,9 +1,9 @@
-import WebGLHelper from '../../../../src/ol/webgl/Helper';
+import WebGLHelper from '../../../../src/ol/webgl/Helper.js';
 import {
   create as createTransform,
   rotate as rotateTransform,
   scale as scaleTransform, translate as translateTransform
-} from '../../../../src/ol/transform';
+} from '../../../../src/ol/transform.js';
 
 
 const VERTEX_SHADER = `


### PR DESCRIPTION
We are not consistent with our use of file extensions in import specifiers.  We were originally trying to use extensions consistently, but as @mogoh points out, we have gotten inconsistent (see https://github.com/openlayers/openlayers/issues/9609#issuecomment-496586788).

This updates the version of `eslint-config-openlayers` that we use to a version that treats this inconsistency as an error.

![image](https://user-images.githubusercontent.com/41094/58566910-a875c200-81ee-11e9-9e87-a8f32a0f26be.png)

Closes #9614.