### PR TITLE
Remove old Android workaround

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -260,12 +260,6 @@ class MapBrowserEventHandler extends EventTarget {
         this.dragging_);
       this.dispatchEvent(newEvent);
     }
-
-    // Some native android browser triggers mousemove events during small period
-    // of time. See: https://code.google.com/p/android/issues/detail?id=5491 or
-    // https://code.google.com/p/android/issues/detail?id=19827
-    // ex: Galaxy Tab P3110 + Android 4.1.1
-    pointerEvent.preventDefault();
   }
 
   /**


### PR DESCRIPTION
This pull request removes an old workaround that prevents the `focus` condition to work properly on contemporary devices. On pointer event devices, the [interaction-options.html](https://openlayers.org/en/master/examples/interaction-options.html) example does not allow page srcolling when touching the map, even when the map does not have the focus.