### PR TITLE
Remove and move code from ol/webgl

### DIFF
--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -38,5 +38,3 @@ export const MAC = ua.indexOf('macintosh') !== -1;
  * @api
  */
 export const DEVICE_PIXEL_RATIO = window.devicePixelRatio || 1;
-
-export {HAS as WEBGL} from './webgl.js';

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -7,56 +7,6 @@
  * Constants taken from goog.webgl
  */
 
-
-/**
- * @const
- * @type {number}
- */
-export const ONE = 1;
-
-
-/**
- * @const
- * @type {number}
- */
-export const SRC_ALPHA = 0x0302;
-
-
-/**
- * @const
- * @type {number}
- */
-export const COLOR_ATTACHMENT0 = 0x8CE0;
-
-
-/**
- * @const
- * @type {number}
- */
-export const COLOR_BUFFER_BIT = 0x00004000;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TRIANGLES = 0x0004;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TRIANGLE_STRIP = 0x0005;
-
-
-/**
- * @const
- * @type {number}
- */
-export const ONE_MINUS_SRC_ALPHA = 0x0303;
-
-
 /**
  * Used by {@link module:ol/webgl/Helper~WebGLHelper} for buffers containing vertices data, such as
  * position, color, texture coordinate, etc. These vertices are then referenced by an index buffer
@@ -110,41 +60,6 @@ export const DYNAMIC_DRAW = 0x88E8;
  * @const
  * @type {number}
  */
-export const CULL_FACE = 0x0B44;
-
-
-/**
- * @const
- * @type {number}
- */
-export const BLEND = 0x0BE2;
-
-
-/**
- * @const
- * @type {number}
- */
-export const STENCIL_TEST = 0x0B90;
-
-
-/**
- * @const
- * @type {number}
- */
-export const DEPTH_TEST = 0x0B71;
-
-
-/**
- * @const
- * @type {number}
- */
-export const SCISSOR_TEST = 0x0C11;
-
-
-/**
- * @const
- * @type {number}
- */
 export const UNSIGNED_BYTE = 0x1401;
 
 
@@ -167,105 +82,6 @@ export const UNSIGNED_INT = 0x1405;
  * @type {number}
  */
 export const FLOAT = 0x1406;
-
-
-/**
- * @const
- * @type {number}
- */
-export const RGBA = 0x1908;
-
-
-/**
- * @const
- * @type {number}
- */
-export const FRAGMENT_SHADER = 0x8B30;
-
-
-/**
- * @const
- * @type {number}
- */
-export const VERTEX_SHADER = 0x8B31;
-
-
-/**
- * @const
- * @type {number}
- */
-export const LINK_STATUS = 0x8B82;
-
-
-/**
- * @const
- * @type {number}
- */
-export const LINEAR = 0x2601;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TEXTURE_MAG_FILTER = 0x2800;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TEXTURE_MIN_FILTER = 0x2801;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TEXTURE_WRAP_S = 0x2802;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TEXTURE_WRAP_T = 0x2803;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TEXTURE_2D = 0x0DE1;
-
-
-/**
- * @const
- * @type {number}
- */
-export const TEXTURE0 = 0x84C0;
-
-
-/**
- * @const
- * @type {number}
- */
-export const CLAMP_TO_EDGE = 0x812F;
-
-
-/**
- * @const
- * @type {number}
- */
-export const COMPILE_STATUS = 0x8B81;
-
-
-/**
- * @const
- * @type {number}
- */
-export const FRAMEBUFFER = 0x8D40;
-
 
 /** end of goog.webgl constants
  */
@@ -303,50 +119,21 @@ export function getContext(canvas, opt_attributes) {
   return null;
 }
 
-
 /**
- * Include debuggable shader sources.  Default is `true`. This should be set to
- * `false` for production builds.
- * @type {boolean}
- */
-export const DEBUG = true;
-
-
-/**
- * The maximum supported WebGL texture size in pixels. If WebGL is not
- * supported, the value is set to `undefined`.
- * @type {number|undefined}
- */
-let MAX_TEXTURE_SIZE; // value is set below
-
-
-/**
- * List of supported WebGL extensions.
  * @type {Array<string>}
  */
-let EXTENSIONS; // value is set below
-
+let supportedExtensions;
 
 /**
- * True if both OpenLayers and browser support WebGL.
- * @type {boolean}
- * @api
+ * @return {Array<string>} List of supported WebGL extensions.
  */
-let HAS = false;
-
-//TODO Remove side effects
-if (typeof window !== 'undefined' && 'WebGLRenderingContext' in window) {
-  try {
+export function getSupportedExtensions() {
+  if (!supportedExtensions) {
     const canvas = document.createElement('canvas');
     const gl = getContext(canvas);
     if (gl) {
-      HAS = true;
-      MAX_TEXTURE_SIZE = /** @type {number} */ (gl.getParameter(gl.MAX_TEXTURE_SIZE));
-      EXTENSIONS = gl.getSupportedExtensions();
+      supportedExtensions = gl.getSupportedExtensions();
     }
-  } catch (e) {
-    // pass
   }
+  return supportedExtensions;
 }
-
-export {HAS, MAX_TEXTURE_SIZE, EXTENSIONS};

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -5,7 +5,6 @@ import {getUid} from '../util.js';
 import Disposable from '../Disposable.js';
 import {listen, unlistenAll} from '../events.js';
 import {clear} from '../obj.js';
-import {TEXTURE_2D, TEXTURE_WRAP_S, TEXTURE_WRAP_T, EXTENSIONS as WEBGL_EXTENSIONS} from '../webgl.js';
 import ContextEventType from '../webgl/ContextEventType.js';
 import {
   compose as composeTransform,
@@ -16,7 +15,7 @@ import {
 } from '../transform.js';
 import {create, fromTransform} from '../vec/mat4.js';
 import WebGLPostProcessingPass from './PostProcessingPass.js';
-import {getContext} from '../webgl.js';
+import {getContext, getSupportedExtensions} from '../webgl.js';
 import {includes} from '../array.js';
 import {assert} from '../asserts.js';
 
@@ -258,7 +257,7 @@ class WebGLHelper extends Disposable {
      */
     this.currentProgram_ = null;
 
-    assert(includes(WEBGL_EXTENSIONS, 'OES_element_index_uint'), 63);
+    assert(includes(getSupportedExtensions(), 'OES_element_index_uint'), 63);
     gl.getExtension('OES_element_index_uint');
 
     listen(this.canvas_, ContextEventType.LOST,
@@ -757,11 +756,11 @@ class WebGLHelper extends Disposable {
 
     if (opt_wrapS !== undefined) {
       gl.texParameteri(
-        TEXTURE_2D, TEXTURE_WRAP_S, opt_wrapS);
+        gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, opt_wrapS);
     }
     if (opt_wrapT !== undefined) {
       gl.texParameteri(
-        TEXTURE_2D, TEXTURE_WRAP_T, opt_wrapT);
+        gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, opt_wrapT);
     }
 
     return texture;

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,7 +5,6 @@
   "globals": {
     "IMAGE_TOLERANCE": false,
     "afterLoadText": false,
-    "assertWebGL": false,
     "createMapDiv": true,
     "disposeMap": true,
     "expect": false,

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -1,5 +1,4 @@
 import {equals} from '../src/ol/array.js';
-import {WEBGL} from '../src/ol/has.js';
 // avoid importing anything that results in an instanceof check
 // since these extensions are global, instanceof checks fail with modules
 
@@ -374,12 +373,6 @@ import {WEBGL} from '../src/ol/has.js';
       target.parentNode.removeChild(target);
     }
     map.dispose();
-  };
-
-  global.assertWebGL = function(map) {
-    if (!WEBGL) {
-      expect().fail('No WebGL support!');
-    }
   };
 
   function resembleCanvas(canvas, referenceImage, tolerance, done) {


### PR DESCRIPTION
Remove some leftover WebGL code from ol/webgl. The `EXTENSIONS`array was moved to the webgl helper class.

@jahow can you please take a look?