### PR TITLE
Import options directly instead of importing a typedef

### DIFF
--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -6,11 +6,6 @@ import CanvasTileLayerRenderer from '../renderer/canvas/TileLayer.js';
 
 
 /**
- * @typedef {import("./BaseTile.js").Options} Options
- */
-
-
-/**
  * @classdesc
  * For layer sources that provide pre-rendered, tiled images in grids that are
  * organized by zoom levels for specific resolutions.
@@ -23,7 +18,7 @@ import CanvasTileLayerRenderer from '../renderer/canvas/TileLayer.js';
 class TileLayer extends BaseTileLayer {
 
   /**
-   * @param {Options=} opt_options Tile layer options.
+   * @param {import("./BaseTile.js").Options=} opt_options Tile layer options.
    */
   constructor(opt_options) {
     super(opt_options);

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -6,11 +6,6 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
 
 
 /**
- * @typedef {import("./BaseVector.js").Options} Options
- */
-
-
-/**
  * @classdesc
  * Vector data that is rendered client-side.
  * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
@@ -22,7 +17,7 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  */
 class VectorLayer extends BaseVectorLayer {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {import("./BaseVector.js").Options=} opt_options Options.
    */
   constructor(opt_options) {
     super(opt_options);


### PR DESCRIPTION
Neither our API doc generator, nor the TypeScript engine used for IntelliSense in VS Code understand typedefs from imported JSDoc typedefs. With this change, the types are imported directly instead of going through a typedef.