### PR TITLE
Handle case of no used tiles

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -416,7 +416,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     // Unqueue tiles from the image queue when we don't need any more
     const usedTiles = frameState.usedTiles[getUid(source)];
     for (const tileUid in this.renderTileImageQueue_) {
-      if (!(tileUid in usedTiles)) {
+      if (!usedTiles || !(tileUid in usedTiles)) {
         delete this.renderTileImageQueue_[tileUid];
       }
     }


### PR DESCRIPTION
When tiles are already queued for rendering before the first rendered frame, the `usedTiles` object for the source is not populated yet. In this case we can remove the tile from the render queue, because it will not be used.