### PR TITLE
Don't use HTMLImageElement.decode method on Safari

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -6,6 +6,7 @@ import ImageState from './ImageState.js';
 import {listenOnce, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
 import {getHeight} from './extent.js';
+import {SAFARI} from './has.js';
 
 
 /**
@@ -157,7 +158,11 @@ class ImageWrapper extends ImageBase {
  */
 export function listenImage(image, loadHandler, errorHandler) {
   const img = /** @type {HTMLImageElement} */ (image);
-  if (img.decode) {
+
+  // The decode function is supported by Safari but not when the image is a svg file.
+  // FIXME: remove `!SAFARI` in the test when this bug is fixed upstream.
+  //        See: https://bugs.webkit.org/show_bug.cgi?id=198527
+  if (!SAFARI && img.decode) {
     const promise = img.decode();
     let listening = true;
     const unlisten = function() {


### PR DESCRIPTION
The decode function is supported by Safari but not when the image is a svg file.
Upstream bug report: https://bugs.webkit.org/show_bug.cgi?id=198527

fixes #9628