### PR TITLE
Take the view rotation into account in box-selection example

### DIFF
--- a/examples/box-selection.js
+++ b/examples/box-selection.js
@@ -45,8 +45,10 @@ map.addInteraction(dragBox);
 dragBox.on('boxend', function() {
   // features that intersect the box are added to the collection of
   // selected features
-  const extent = dragBox.getGeometry().getExtent();
-  vectorSource.forEachFeatureIntersectingExtent(extent, function(feature) {
+  const geometry = dragBox.getGeometry().clone();
+  geometry.rotate(-map.getView().getRotation());
+
+  vectorSource.forEachFeatureIntersectingExtent(geometry.getExtent(), function(feature) {
     selectedFeatures.push(feature);
   });
 });

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -150,10 +150,11 @@ class Geometry extends BaseObject {
    * coordinates in place.
    * @abstract
    * @param {number} angle Rotation angle in radians.
-   * @param {import("../coordinate.js").Coordinate} anchor The rotation center.
+   * @param {import("../coordinate.js").Coordinate=} opt_anchor The rotation center.
+   *     Defaults to the center of the geometry extent.
    * @api
    */
-  rotate(angle, anchor) {
+  rotate(angle, opt_anchor) {
     abstract();
   }
 

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -208,10 +208,11 @@ class SimpleGeometry extends Geometry {
    * @inheritDoc
    * @api
    */
-  rotate(angle, anchor) {
+  rotate(angle, opt_anchor) {
     const flatCoordinates = this.getFlatCoordinates();
     if (flatCoordinates) {
       const stride = this.getStride();
+      const anchor = opt_anchor !== undefined ? opt_anchor : getCenter(this.getExtent());
       rotate(
         flatCoordinates, 0, flatCoordinates.length,
         stride, angle, anchor, flatCoordinates);


### PR DESCRIPTION
Fixes #5496
Fixes #9656

And mark the rotation anchor as optional in ol/geom/Geometry class. The center of the geometry extent as the default value was already implemented for the `scale` method.