### PR TITLE
Fix for workers in a leagacy build

### DIFF
--- a/tasks/serialize-workers.js
+++ b/tasks/serialize-workers.js
@@ -52,7 +52,7 @@ async function build(input, {minify = true} = {}) {
   });
 
   const bundle = await rollup.rollup({input, plugins});
-  const {output} = await bundle.generate({format: 'es'});
+  const {output} = await bundle.generate({format: 'iife', name: 'worker'});
 
   if (output.length !== 1) {
     throw new Error(`Unexpected output length: ${output.length}`);


### PR DESCRIPTION
Fix for the new workers and the leagacy build.

An alternative would be:
return new Worker(url, {type: 'module'});
But for now this is in Chrome hidden behind the --enable-experimental-web-platform-features flag
