### PR TITLE
Add support for tile pixel projection in feature formats

### DIFF
--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -13,8 +13,10 @@ import {get as getProjection, equivalent as equivalentProjection, transformExten
  * the `dataProjection` of the format is assigned (where set). If the projection
  * can not be derived from the data and if no `dataProjection` is set for a format,
  * the features will not be reprojected.
- * @property {import("../extent.js").Extent} [extent] Tile extent of the tile being read. This is only used and
- * required for {@link module:ol/format/MVT}.
+ * @property {import("../extent.js").Extent} [extent] Tile extent in map units of the tile being read.
+ * This is only required when reading data with tile pixels as geometry units. When configured,
+ * a `dataProjection` with `TILE_PIXELS` as `units` and the tile's pixel extent as `extent` needs to be
+ * provided.
  * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection of the feature geometries
  * created by the format reader. If not provided, features will be returned in the
  * `dataProjection`.
@@ -86,9 +88,14 @@ class FeatureFormat {
   getReadOptions(source, opt_options) {
     let options;
     if (opt_options) {
+      let dataProjection = opt_options.dataProjection ?
+        opt_options.dataProjection : this.readProjection(source);
+      if (opt_options.extent) {
+        dataProjection = getProjection(dataProjection);
+        dataProjection.setWorldExtent(opt_options.extent);
+      }
       options = {
-        dataProjection: opt_options.dataProjection ?
-          opt_options.dataProjection : this.readProjection(source),
+        dataProjection: dataProjection,
         featureProjection: opt_options.featureProjection
       };
     }

--- a/test/spec/ol/format/geojson.test.js
+++ b/test/spec/ol/format/geojson.test.js
@@ -8,7 +8,7 @@ import LinearRing from '../../../../src/ol/geom/LinearRing.js';
 import MultiPolygon from '../../../../src/ol/geom/MultiPolygon.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
-import {fromLonLat, get as getProjection, toLonLat, transform} from '../../../../src/ol/proj.js';
+import {fromLonLat, get as getProjection, toLonLat, transform, Projection} from '../../../../src/ol/proj.js';
 
 
 describe('ol.format.GeoJSON', function() {
@@ -258,6 +258,28 @@ describe('ol.format.GeoJSON', function() {
         readFeature(pointGeoJSON);
       expect(feature.getGeometryName()).to.be('the_geom');
       expect(feature.getGeometry()).to.be.an(Point);
+    });
+
+    it('transforms tile pixel coordinates', function() {
+      const geojson = {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [1024, 1024]
+        }
+      };
+      const format = new GeoJSON({
+        dataProjection: new Projection({
+          code: '',
+          units: 'tile-pixels',
+          extent: [0, 0, 4096, 4096]
+        })
+      });
+      const feature = format.readFeature(geojson, {
+        extent: [-180, -90, 180, 90],
+        featureProjection: 'EPSG:3857'
+      });
+      expect(feature.getGeometry().getCoordinates()).to.eql([-135, 45]);
     });
 
   });


### PR DESCRIPTION
This pull request fixes the geojson-vt example, which is currently broken. To achieve this, I added support for tile pixel projections in `ol/format/Feature`, like we already have and use for `ol/format/MVT`.