### PR TITLE
Remove duplicates from api docs and make navigation more usable

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -59,7 +59,9 @@ function includeAugments(doclet) {
           });
         }
         cls._hideConstructor = true;
-        delete cls.undocumented;
+        if (!cls.undocumented) {
+          cls._documented = true;
+        }
       }
     }
   }
@@ -149,6 +151,9 @@ exports.handlers = {
       } else if (doclet.undocumented !== false && !doclet._hideConstructor && !(doclet.kind == 'typedef' && doclet.longname in types)) {
         // Remove all other undocumented symbols
         doclet.undocumented = true;
+      }
+      if (doclet._documented) {
+        delete doclet.undocumented;
       }
     }
   }

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -222,6 +222,10 @@ function buildNav(members) {
           type: 'module',
           longname: v.longname,
           name: v.name,
+          classes: find({
+            kind: 'class',
+            memberof: v.longname
+          }),
           members: find({
             kind: 'member',
             memberof: v.longname
@@ -234,30 +238,6 @@ function buildNav(members) {
             kind: 'typedef',
             memberof: v.longname
           }),
-          events: find({
-            kind: 'event',
-            memberof: v.longname
-          })
-        });
-      }
-      if (v.kind == 'class') {
-        nav.push({
-          type: 'class',
-          longname: v.longname,
-          name: v.name,
-          members: find({
-            kind: 'member',
-            memberof: v.longname
-          }),
-          methods: find({
-            kind: 'function',
-            memberof: v.longname
-          }),
-          typedefs: find({
-            kind: 'typedef',
-            memberof: v.longname
-          }),
-          fires: v.fires,
           events: find({
             kind: 'event',
             memberof: v.longname

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -22,6 +22,20 @@ function toShortName(name) {
             </span>
             <ul class="members itemMembers">
             <?js
+            if (item.classes.length) {
+            ?>
+            <span class="subtitle">Classes</span>
+            <?js
+                item.classes.forEach(function (v) {
+            ?>
+                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, toShortName(v.name)) ?></li>
+            <?js
+                });
+            }
+            ?>
+            </ul>
+            <ul class="members itemMembers">
+            <?js
             if (item.members.length) {
             ?>
             <span class="subtitle">Members</span>


### PR DESCRIPTION
This pull request removes duplicate entries from the API docs. These duplicates were caused by deleting the `undocumented` flag from doclets, which apparently has more meaning in JSDoc internals than I thought. So instead of deleting it from arbitrary doclets, we now only delete it from classes that we know we want documented.

A side effect of this brute-force removal of the `undocumented` flag was a strange condition with constructor options, which sometimes were not shown for arbitrary classes.

I also decided to restructure the navigation sidebar a bit, to make it more usable. Instead of listing classes next to modules, the sidebar now only contains modules at the top level, and adds a "Classes" subcategory". This makes the navigation sidebar easier to navigate and to read, and it now also matches the structure of the module entry pages.