### PR TITLE
List complete classes in doc navigation

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -214,35 +214,39 @@ function buildNav(members) {
     }
     return 0;
   });
+
+  function createEntry(type, v) {
+    return {
+      type: type,
+      longname: v.longname,
+      name: v.name,
+      classes: find({
+        kind: 'class',
+        memberof: v.longname
+      }).map(createEntry.bind(this, 'class')),
+      members: find({
+        kind: 'member',
+        memberof: v.longname
+      }),
+      methods: find({
+        kind: 'function',
+        memberof: v.longname
+      }),
+      typedefs: find({
+        kind: 'typedef',
+        memberof: v.longname
+      }),
+      events: find({
+        kind: 'event',
+        memberof: v.longname
+      })
+    };
+  }
   _.each(merged, function(v) {
     // exclude interfaces from sidebar
     if (v.interface !== true) {
       if (v.kind == 'module') {
-        nav.push({
-          type: 'module',
-          longname: v.longname,
-          name: v.name,
-          classes: find({
-            kind: 'class',
-            memberof: v.longname
-          }),
-          members: find({
-            kind: 'member',
-            memberof: v.longname
-          }),
-          methods: find({
-            kind: 'function',
-            memberof: v.longname
-          }),
-          typedefs: find({
-            kind: 'typedef',
-            memberof: v.longname
-          }),
-          events: find({
-            kind: 'event',
-            memberof: v.longname
-          })
-        });
+        nav.push(createEntry('module', v));
       }
     }
   });

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -12,13 +12,18 @@ $(function () {
                 var $item = $(v);
 
                 if ($item.data('name') && regexp.test($item.data('name'))) {
+                    const container = $item.parent().parent().parent();
+                    container.show();
+                    container.closest('.itemMembers').show();
+                    container.closest('.item').show();
                     $item.show();
                     $item.closest('.itemMembers').show();
                     $item.closest('.item').show();
                 }
             });
         } else {
-            $el.find('.item, .itemMembers').show();
+            $el.find('.item, .itemMembers').hide();
+            $('.navigation>ul>li').show();
         }
 
         $el.find('.list').scrollTop(0);

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -10,11 +10,12 @@ function toShortName(name) {
     </div>
     <ul class="list">
     <?js
-    this.nav.forEach(function (item) {
+    let navbuilder;
+    this.nav.forEach(navbuilder = function (item) {
     ?>
         <li class="item" data-name="<?js= item.longname ?>">
             <span class="title">
-                <?js= self.linkto(item.longname, item.longname.replace('module:', '')) ?>
+                <?js= self.linkto(item.longname, item.type === 'module' ? item.longname.replace('module:', '') : item.name) ?>
                 <?js if (item.type === 'namespace' &&
                         (item.members.length + item.typedefs.length + item.methods.length +
                          item.events.length > 0)) { ?>
@@ -27,9 +28,7 @@ function toShortName(name) {
             <span class="subtitle">Classes</span>
             <?js
                 item.classes.forEach(function (v) {
-            ?>
-                <li data-name="<?js= v.longname ?>"><?js= self.linkto(v.longname, toShortName(v.name)) ?></li>
-            <?js
+                    navbuilder(v);
                 });
             }
             ?>


### PR DESCRIPTION
#9681 removed all class members and methods from the navigation bar. This pull request adds them back, by putting the classes in a hierarchy below the modules. This change makes the search field work again for class members and methods.