### PR TITLE
Fix MapTiler API usage

### DIFF
--- a/examples/mapbox-layer.html
+++ b/examples/mapbox-layer.html
@@ -3,13 +3,13 @@ layout: example.html
 title: Mapbox-gl Layer
 shortdesc: Example of a Mapbox-gl-js layer integration.
 docs: >
-  Show how to add a mapbox-gl-js layer in an openlayers map. **Note**: Make sure to get your own Mapbox API key when using this example. No map will be visible when the API key has expired.
-tags: "simple, mapbox, vector, tiles"
+  Show how to add a mapbox-gl-js layer in an openlayers map. **Note**: Make sure to get your own API key at https://www.maptiler.com/cloud/ when using this example. No map will be visible when the API key has expired.
+tags: "simple, mapbox, vector, tiles, maptiler"
 resources:
   - https://unpkg.com/mapbox-gl@0.54.0/dist/mapbox-gl.js
   - https://unpkg.com/mapbox-gl@0.54.0/dist/mapbox-gl.css
 cloak:
   - key: ER67WIiPdCQvhgsUjoWK
-    value: Your Mapbox access token from https://mapbox.com/ here
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>

--- a/examples/mapbox-layer.js
+++ b/examples/mapbox-layer.js
@@ -11,7 +11,7 @@ const center = [-98.8, 37.9];
 const key = 'ER67WIiPdCQvhgsUjoWK';
 
 const mbMap = new mapboxgl.Map({
-  style: 'https://maps.tilehosting.com/styles/bright/style.json?key=' + key,
+  style: 'https://api.maptiler.com/maps/bright/style.json?key=' + key,
   attributionControl: false,
   boxZoom: false,
   center: center,

--- a/examples/mapbox-style.html
+++ b/examples/mapbox-style.html
@@ -2,10 +2,10 @@
 layout: example-verbatim.html
 title: Vector tiles created from a Mapbox Style object
 shortdesc: Example of using ol-mapbox-style with tiles from tilehosting.com.
-tags: "vector tiles, mapbox style, ol-mapbox-style"
+tags: "vector tiles, mapbox style, ol-mapbox-style, maptiler"
 cloak:
-  - key: lirfd6Fegsjkvs0lshxe
-    value: Your API key from http://tilehosting.com/ here
+  - key: ER67WIiPdCQvhgsUjoWK
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <!doctype html>
 <html lang="en">

--- a/examples/mapbox-style.js
+++ b/examples/mapbox-style.js
@@ -1,3 +1,3 @@
 import apply from 'ol-mapbox-style';
 
-apply('map', 'https://maps.tilehosting.com/styles/topo/style.json?key=ER67WIiPdCQvhgsUjoWK');
+apply('map', 'https://api.maptiler.com/maps/topo/style.json?key=ER67WIiPdCQvhgsUjoWK');


### PR DESCRIPTION
This PR "fixes" the usage of MapTiler API (previously called TileHosting):

- Fixed "get your own key" links -- the examples use MapTiler infrastructure, but were saying "get your own Mapbox API key", but the Mapbox keys are obviously not usable with the MapTiler API URLs :-)
- New URLs (api.maptiler.com instead of maps.tilehosting.com) (https://www.maptiler.com/blog/2019/04/maptiler-cloud-infrastructure-upgrade.html). The old URLs are now obsolete and redirect to the new domain.

@ahocevar I see the example now use your personal free key (which has 100k requests/month limit). If needed, maybe we could provide a special key with higher limits for the OpenLayers examples.
