### PR TITLE
Handle container reuse properly when layers are added/removed

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -129,12 +129,9 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     }
     const containerReused = this.containerReused;
     super.useContainer(target, transform, opacity);
-    if (containerReused && !this.containerReused && !overlayContext) {
-      this.overlayContext_ = null;
-      this.overlayContextUid_ = undefined;
-    }
-    if (this.containerReused && overlayContext) {
-      this.overlayContext_ = overlayContext;
+    if (containerReused) {
+      this.overlayContext_ = overlayContext || null;
+      this.overlayContextUid_ = overlayContext ? getUid(overlayContext) : undefined;
     }
     if (!this.overlayContext_) {
       const overlayContext = createCanvasContext2D();


### PR DESCRIPTION
The mapbox-style example sometimes enters a state where labels and points do not get cleared from the overlay canvas. This is caused by incorrect assignment of an exiting overlay container to the first layer of a layer stack.

This pull request simplifies things a bit and solves the issue.