### PR TITLE
Do not use self to check browser features

### DIFF
--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -75,7 +75,7 @@ class TileSource extends Source {
       if (tileGrid) {
         toSize(tileGrid.getTileSize(tileGrid.getMinZoom()), tileSize);
       }
-      const canUseScreen = 'screen' in self;
+      const canUseScreen = typeof screen !== 'undefined';
       const width = canUseScreen ? (screen.availWidth || screen.width) : 1920;
       const height = canUseScreen ? (screen.availHeight || screen.height) : 1080;
       cacheSize = 4 * Math.ceil(width / tileSize[0]) * Math.ceil(height / tileSize[1]);


### PR DESCRIPTION
A small change to not rely on `self`, which is not available in non-browser environments.