### PR TITLE
Additional Typescript compliance fixes

### DIFF
--- a/src/ol/worker/version.js
+++ b/src/ol/worker/version.js
@@ -4,9 +4,12 @@
  */
 import {VERSION} from '../util.js';
 
-onmessage = event => {
+/** @type {any} */
+const worker = self;
+
+worker.onmessage = event => {
   console.log('version worker received message:', event.data); // eslint-disable-line
-  postMessage(`version: ${VERSION}`);
+  worker.postMessage(`version: ${VERSION}`);
 };
 
 export let create;

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -10,7 +10,10 @@ import {
 } from '../renderer/webgl/Layer.js';
 import {assign} from '../obj.js';
 
-onmessage = event => {
+/** @type {any} */
+const worker = self;
+
+worker.onmessage = event => {
   const received = event.data;
   if (received.type === WebGLWorkerMessageType.GENERATE_BUFFERS) {
     const renderInstructions = new Float32Array(received.renderInstructions);
@@ -41,7 +44,7 @@ onmessage = event => {
       renderInstructions: renderInstructions.buffer
     }, received);
 
-    postMessage(message, [vertexBuffer.buffer, indexBuffer.buffer, renderInstructions.buffer]);
+    worker.postMessage(message, [vertexBuffer.buffer, indexBuffer.buffer, renderInstructions.buffer]);
   }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2017", "dom", "webworker"],    /* Specify library files to be included in the compilation. */
+    "lib": ["es2017", "dom"],                 /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     "checkJs": true,                          /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
Related to #9692

Some more typing fixes for:
* `MouseWheelZoom` interaction: using `any` because we rely on [`MouseWheelEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseWheelEvent) which is non standard
* `CanvasVectorImageLayerRenderer`
* web workers: the `webworker` lib was removed from tsconfig.json because it was causing conflicts; also, in worker sources, the type of the context had to be explicitly defined to avoid conflict with the `window.postMessage` function

With this PR the only remaining typecheck errors are on the formats (unless I missed something).