### PR TITLE
Allow an arbitrary tag to be used as feature id

### DIFF
--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -31,6 +31,7 @@ import {get} from '../proj.js';
  * @property {string} [geometryName='geometry'] Geometry name to use when creating features.
  * @property {string} [layerName='layer'] Name of the feature attribute that holds the layer name.
  * @property {Array<string>} [layers] Layers to read features from. If not provided, features will be read from all
+ * @property {string} [idProperty] Optional property that will be assigned as the feature id and removed from the properties.
  * layers.
  */
 
@@ -83,6 +84,12 @@ class MVT extends FeatureFormat {
      * @type {Array<string>}
      */
     this.layers_ = options.layers ? options.layers : null;
+
+    /**
+     * @private
+     * @type {string}
+     */
+    this.idProperty_ = options.idProperty;
 
   }
 
@@ -164,8 +171,16 @@ class MVT extends FeatureFormat {
     }
 
     let feature;
-    const id = rawFeature.id;
     const values = rawFeature.properties;
+
+    let id;
+    if (!this.idProperty_) {
+      id = rawFeature.id;
+    } else {
+      id = values[this.idProperty_];
+      delete values[this.idProperty_];
+    }
+
     values[this.layerName_] = rawFeature.layer.name;
 
     const flatCoordinates = [];

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -78,6 +78,44 @@ where('ArrayBuffer.isView').describe('ol.format.MVT', function() {
       expect(features[0].getId()).to.be(2);
     });
 
+    it('accepts custom idProperty', function() {
+      const format = new MVT({
+        featureClass: Feature,
+        layers: ['poi_label'],
+        idProperty: 'osm_id'
+      });
+      const features = format.readFeatures(data, options);
+
+      const first = features[0];
+      expect(first.getId()).to.be(1000000057590683);
+      expect(first.get('osm_id')).to.be(undefined);
+    });
+
+    it('accepts custom idProperty (render features)', function() {
+      const format = new MVT({
+        layers: ['poi_label'],
+        idProperty: 'osm_id'
+      });
+
+      const features = format.readFeatures(data, options);
+
+      const first = features[0];
+      expect(first.getId()).to.be(1000000057590683);
+      expect(first.get('osm_id')).to.be(undefined);
+    });
+
+    it('works if you provide a bogus idProperty', function() {
+      const format = new MVT({
+        layers: ['poi_label'],
+        idProperty: 'bogus'
+      });
+
+      const features = format.readFeatures(data, options);
+
+      const first = features[0];
+      expect(first.getId()).to.be(undefined);
+    });
+
   });
 
 });


### PR DESCRIPTION
The MVT spec requires integer feature ids.  This is awkward for applications that would like to preserve server assigned identifiers that are not integers.  It sounds like the MVT 3 spec may consider supporting string identifiers (see mapbox/vector-tile-spec#94).  Until then, we can allow application developers to promote any arbitrary property (or tag) to be a feature identifier.
