### PR TITLE
Use special MapTiler API key dedicated for OpenLayers examples

### DIFF
--- a/examples/mapbox-layer.html
+++ b/examples/mapbox-layer.html
@@ -9,7 +9,7 @@ resources:
   - https://unpkg.com/mapbox-gl@0.54.0/dist/mapbox-gl.js
   - https://unpkg.com/mapbox-gl@0.54.0/dist/mapbox-gl.css
 cloak:
-  - key: ER67WIiPdCQvhgsUjoWK
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
     value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>

--- a/examples/mapbox-layer.js
+++ b/examples/mapbox-layer.js
@@ -8,7 +8,7 @@ import VectorSource from '../src/ol/source/Vector.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 
 const center = [-98.8, 37.9];
-const key = 'ER67WIiPdCQvhgsUjoWK';
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
 
 const mbMap = new mapboxgl.Map({
   style: 'https://api.maptiler.com/maps/bright/style.json?key=' + key,

--- a/examples/mapbox-style.html
+++ b/examples/mapbox-style.html
@@ -4,7 +4,7 @@ title: Vector tiles created from a Mapbox Style object
 shortdesc: Example of using ol-mapbox-style with tiles from tilehosting.com.
 tags: "vector tiles, mapbox style, ol-mapbox-style, maptiler"
 cloak:
-  - key: ER67WIiPdCQvhgsUjoWK
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
     value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <!doctype html>

--- a/examples/mapbox-style.js
+++ b/examples/mapbox-style.js
@@ -1,3 +1,3 @@
 import apply from 'ol-mapbox-style';
 
-apply('map', 'https://api.maptiler.com/maps/topo/style.json?key=ER67WIiPdCQvhgsUjoWK');
+apply('map', 'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB');


### PR DESCRIPTION
("continuation" of #9699)

This PR replaces @ahocevar's personal MapTiler API key with a special one with higher limits.
The key is intended only for OpenLayers examples so it clearly indicates "get your own" right in the key itself to make it even more clear to potential copy-pasters.
