### PR TITLE
Get rid of JSDoc warnings and fix fires arguments

### DIFF
--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -65,7 +65,7 @@ class IIIF extends TileImage {
   constructor(opt_options) {
 
     /**
-     * @type {Partial<Options>} options
+     * @type {Partial<Options>}
      */
     const options = opt_options || {};
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -155,7 +155,7 @@ export class VectorSourceEvent extends Event {
  * by this source are suitable for editing. See {@link module:ol/source/VectorTile~VectorTile} for
  * vector data that is optimized for rendering.
  *
- * @fires VectorSourceEvent<Geometry>
+ * @fires VectorSourceEvent
  * @api
  * @template {import("../geom/Geometry.js").default} Geometry
  */


### PR DESCRIPTION
Fixes the documentation of `ol/source/Vector` events and gets rid of warnings when running jsdoc.