### PR TITLE
Finalize IIIF Image API version 3

### DIFF
--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -265,10 +265,7 @@ function generateVersion3Options(iiifInfo) {
     formats: formats,
     qualities: iiifInfo.imageInfo.extraQualities === undefined ? levelProfile.qualities :
       [...levelProfile.supports, ...iiifInfo.imageInfo.extraQualities],
-    preferredFormat: preferredFormat,
-    maxWidth: undefined,
-    maxHeight: undefined,
-    maxArea: undefined
+    preferredFormat: preferredFormat
   };
 }
 

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -264,7 +264,7 @@ function generateVersion3Options(iiifInfo) {
       [...levelProfile.supports, ...iiifInfo.imageInfo.extraFeatures],
     formats: formats,
     qualities: iiifInfo.imageInfo.extraQualities === undefined ? levelProfile.qualities :
-      [...levelProfile.supports, ...iiifInfo.imageInfo.extraQualities],
+      [...levelProfile.qualities, ...iiifInfo.imageInfo.extraQualities],
     preferredFormat: preferredFormat
   };
 }

--- a/test/spec/ol/format/iiif.test.js
+++ b/test/spec/ol/format/iiif.test.js
@@ -323,7 +323,22 @@ describe('ol.format.IIIFInfo', function() {
         height: 1500,
         profile: ['http://iiif.io/api/image/2/level2.json']
       });
-      const options = iiifInfo.getTileSourceOptions({
+      let options = iiifInfo.getTileSourceOptions({
+        quality: 'bitonal',
+        format: 'png'
+      });
+      expect(options).to.have.property('quality', 'bitonal');
+      expect(options).to.have.property('format', 'png');
+
+      iiifInfo.setImageInfo({
+        '@context': 'http://iiif.io/api/image/3/context.json',
+        '@id': 'http://iiif.test/version3/id',
+        width: 2000,
+        height: 1500,
+        profile: 'level2',
+        extraQualities: ['gray', 'bitonal']
+      });
+      options = iiifInfo.getTileSourceOptions({
         quality: 'bitonal',
         format: 'png'
       });
@@ -341,7 +356,21 @@ describe('ol.format.IIIFInfo', function() {
         height: 1500,
         profile: ['http://iiif.io/api/image/2/level1.json']
       });
-      const options = iiifInfo.getTileSourceOptions({
+      let options = iiifInfo.getTileSourceOptions({
+        quality: 'bitonal',
+        format: 'png'
+      });
+      expect(options).to.have.property('quality', 'default');
+      expect(options).to.have.property('format', 'jpg');
+
+      iiifInfo.setImageInfo({
+        '@context': 'http://iiif.io/api/image/3/context.json',
+        '@id': 'http://iiif.test/version3/id',
+        width: 2000,
+        height: 1500,
+        profile: 'level1',
+      });
+      options = iiifInfo.getTileSourceOptions({
         quality: 'bitonal',
         format: 'png'
       });
@@ -482,6 +511,26 @@ describe('ol.format.IIIFInfo', function() {
       expect(options.tileSize[0]).to.be(512);
       expect(options.tileSize[1]).to.be(1024);
 
+      iiifInfo.setImageInfo({
+        '@context': 'http://iiif.io/api/image/3/context.json',
+        '@id': 'http://iiif.test/id',
+        profile: 'level0',
+        tiles: [{
+          scaleFactors: [1, 2, 4, 8],
+          width: 512,
+          height: 256
+        }]
+      });
+      options = iiifInfo.getTileSourceOptions();
+      expect(options.resolutions).to.have.length(4);
+      expect(options.resolutions).to.contain(1);
+      expect(options.resolutions).to.contain(2);
+      expect(options.resolutions).to.contain(4);
+      expect(options.resolutions).to.contain(8);
+      expect(options.tileSize).to.have.length(2);
+      expect(options.tileSize[0]).to.be(512);
+      expect(options.tileSize[1]).to.be(256);
+
     });
 
   });
@@ -504,7 +553,7 @@ describe('ol.format.IIIFInfo', function() {
         height: 250
       }]
     });
-    const options = iiifInfo.getTileSourceOptions();
+    let options = iiifInfo.getTileSourceOptions();
     expect(options.sizes).to.have.length(3);
     expect(options.sizes[0]).to.have.length(2);
     expect(options.sizes[0][0]).to.be(2000);
@@ -515,6 +564,20 @@ describe('ol.format.IIIFInfo', function() {
     expect(options.sizes[2]).to.have.length(2);
     expect(options.sizes[2][0]).to.be(500);
     expect(options.sizes[2][1]).to.be(250);
+
+    iiifInfo.setImageInfo({
+      '@context': 'http://iiif.io/api/image/3/context.json',
+      '@id': 'http://iiif.test/id',
+      'sizes': [{
+        width: 1500,
+        height: 800
+      }]
+    });
+    options = iiifInfo.getTileSourceOptions();
+    expect(options.sizes).to.have.length(1);
+    expect(options.sizes[0]).to.have.length(2);
+    expect(options.sizes[0][0]).to.be(1500);
+    expect(options.sizes[0][1]).to.be(800);
 
   });
 

--- a/test/spec/ol/format/iiif.test.js
+++ b/test/spec/ol/format/iiif.test.js
@@ -219,7 +219,40 @@ describe('ol.format.IIIFInfo', function() {
       expect(level.supports).to.contain('sizeByDistortedWh');
       expect(level.supports).to.contain('sizeByWh');
 
-      // TODO test version 3 compliance level features once version 3 is final
+      iiifInfo.setImageInfo({
+        '@context': 'http://iiif.io/api/image/3/context.json',
+        profile: 'level0'
+      });
+      level = iiifInfo.getComplianceLevelSupportedFeatures();
+      expect(level.supports).to.be.empty();
+
+      iiifInfo.setImageInfo({
+        '@context': 'http://iiif.io/api/image/3/context.json',
+        profile: 'level1'
+      });
+      level = iiifInfo.getComplianceLevelSupportedFeatures();
+      expect(level.supports).to.have.length(5);
+      expect(level.supports).to.contain('regionByPx');
+      expect(level.supports).to.contain('regionSquare');
+      expect(level.supports).to.contain('sizeByW');
+      expect(level.supports).to.contain('sizeByH');
+      expect(level.supports).to.contain('sizeByWh');
+
+      iiifInfo.setImageInfo({
+        '@context': 'http://iiif.io/api/image/3/context.json',
+        profile: 'level2'
+      });
+      level = iiifInfo.getComplianceLevelSupportedFeatures();
+      expect(level.supports).to.have.length(8);
+      expect(level.supports).to.contain('regionByPx');
+      expect(level.supports).to.contain('regionByPct');
+      expect(level.supports).to.contain('regionSquare');
+      expect(level.supports).to.contain('sizeByW');
+      expect(level.supports).to.contain('sizeByH');
+      expect(level.supports).to.contain('sizeByWh');
+      expect(level.supports).to.contain('sizeByConfinedWh');
+      expect(level.supports).to.contain('sizeByPct');
+
     });
 
   });
@@ -350,7 +383,8 @@ describe('ol.format.IIIFInfo', function() {
       expect(options.supports).to.contain('regionSquare');
       expect(options.supports).to.contain('sizeByW');
       expect(options.supports).to.contain('sizeByH');
-      expect(options.supports).to.have.length(6);
+      expect(options.supports).to.contain('sizeByWh');
+      expect(options.supports).to.have.length(7);
 
     });
 
@@ -483,5 +517,47 @@ describe('ol.format.IIIFInfo', function() {
     expect(options.sizes[2][1]).to.be(250);
 
   });
+
+  it('respects the preferred image formats', function() {
+
+    iiifInfo.setImageInfo({
+      '@context': 'http://iiif.io/api/image/3/context.json',
+      'id': 'http://iiif.test/id',
+      'profile': 'level0',
+      'preferredFormats': ['png', 'gif']
+    });
+    let options = iiifInfo.getTileSourceOptions();
+    expect(options.format).to.be('jpg');
+
+    iiifInfo.setImageInfo({
+      '@context': 'http://iiif.io/api/image/3/context.json',
+      'id': 'http://iiif.test/id',
+      'profile': 'level1',
+      'preferredFormats': ['png', 'gif']
+    });
+    options = iiifInfo.getTileSourceOptions();
+    expect(options.format).to.be('jpg');
+
+    iiifInfo.setImageInfo({
+      '@context': 'http://iiif.io/api/image/3/context.json',
+      'id': 'http://iiif.test/id',
+      'profile': 'level1',
+      'extraFormats': ['webp', 'gif'],
+      'preferredFormats': ['webp', 'png', 'gif']
+    });
+    options = iiifInfo.getTileSourceOptions();
+    expect(options.format).to.be('gif');
+
+    iiifInfo.setImageInfo({
+      '@context': 'http://iiif.io/api/image/3/context.json',
+      'id': 'http://iiif.test/id',
+      'profile': 'level2',
+      'preferredFormats': ['png', 'gif']
+    });
+    options = iiifInfo.getTileSourceOptions();
+    expect(options.format).to.be('png');
+
+  });
+
 
 });

--- a/test/spec/ol/format/iiif.test.js
+++ b/test/spec/ol/format/iiif.test.js
@@ -368,7 +368,7 @@ describe('ol.format.IIIFInfo', function() {
         '@id': 'http://iiif.test/version3/id',
         width: 2000,
         height: 1500,
-        profile: 'level1',
+        profile: 'level1'
       });
       options = iiifInfo.getTileSourceOptions({
         quality: 'bitonal',

--- a/test/spec/ol/source/iiif.test.js
+++ b/test/spec/ol/source/iiif.test.js
@@ -201,6 +201,21 @@ describe('ol.source.IIIF', function() {
       expect(tileUrlFunction([2, 0, 0])).to.be('http://iiif.test/image-id/full/full/0/default.jpg');
       expect(tileUrlFunction([3, 0, 0])).to.be(undefined);
 
+      tileUrlFunction = getSource({
+        version: Versions.VERSION3,
+        sizes: [[2000, 1500], [1000, 750], [500, 375]]
+      }).getTileUrlFunction();
+
+      expect(tileUrlFunction([0, 0, 0])).to.be('http://iiif.test/image-id/full/500,375/0/default.jpg');
+      expect(tileUrlFunction([1, 0, 0])).to.be('http://iiif.test/image-id/full/1000,750/0/default.jpg');
+      expect(tileUrlFunction([2, 0, 0])).to.be('http://iiif.test/image-id/full/max/0/default.jpg');
+      expect(tileUrlFunction([3, 0, 0])).to.be(undefined);
+      expect(tileUrlFunction([-1, 0, 0])).to.be(undefined);
+      expect(tileUrlFunction([0, 1, 0])).to.be(undefined);
+      expect(tileUrlFunction([0, 0, 1])).to.be(undefined);
+      expect(tileUrlFunction([1, 1, 0])).to.be(undefined);
+      expect(tileUrlFunction([1, 0, 1])).to.be(undefined);
+
     });
 
     it('cannot provide scaled tiles without provided tilesize or supported features', function() {


### PR DESCRIPTION
Following the announcement that [version 3.0](https://iiif.io/api/image/3.0/) of the IIIF Image API is now in [beta status and ready for implementation](https://iiif.io/news/2019/07/01/newsletter/#image-and-presentation-apis-30-beta), this pull requests contains finishing work on the IIIF Image API version 3.0 functionality. In Detail:
- reflects changes to the Image API compliance levels
- fixes a minor error
- adds support for version 3.0 image information response property `preferredFormat`
- extends test coverage for IIIF Image API version 3.0 tile source and information response parsing
