### PR TITLE
Fix hit detection for webgl layers on retina devices

### DIFF
--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -449,6 +449,7 @@ class WebGLHelper extends Disposable {
     const gl = this.getGL();
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, renderTarget.getFramebuffer());
+    gl.viewport(0, 0, frameState.size[0], frameState.size[1]);
     gl.bindTexture(gl.TEXTURE_2D, renderTarget.getTexture());
     gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT);


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
Fixes #9736

The solution was actually a missing call to [`gl.viewport`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/viewport). Since this was not called when rendering to the hit detection render target, a previous value was probably used which eventually broke this specific render.

I have added a new test with a pixel ratio > 1, but to my surprise it was not failing even without the fix... Could not find a way to make it fail so, at least it's there!
