### PR TITLE
Use Image.prototype.decode only when src is already set

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -159,7 +159,7 @@ class ImageWrapper extends ImageBase {
 export function listenImage(image, loadHandler, errorHandler) {
   const img = /** @type {HTMLImageElement} */ (image);
 
-  if (IMAGE_DECODE) {
+  if (img.src && IMAGE_DECODE) {
     const promise = img.decode();
     let listening = true;
     const unlisten = function() {

--- a/test/spec/ol/image.test.js
+++ b/test/spec/ol/image.test.js
@@ -21,6 +21,17 @@ describe('HTML Image loading', function() {
     }, 200);
   });
 
+  it('handles load event when src is set later', function(done) {
+    listenImage(img, handleLoad, handleError);
+    img.src = 'spec/ol/data/dot.png';
+
+    setTimeout(function() {
+      expect(handleLoad).to.be.called();
+      expect(handleError).not.to.be.called();
+      done();
+    }, 200);
+  });
+
   it('handles error event', function(done) {
     img.src = 'invalid.jpeg';
     listenImage(img, handleLoad, handleError);


### PR DESCRIPTION
When a tile load function does not immediately set the `src` on its image, e.g. because it needs to get data asynchronously, image loading fails now because `decode()` is called on an `Image` without `src` throws an exception.

This pull request changes things so `decode()` is only used when the image's `src` is already set.