### PR TITLE
Fix linting error (import extension missing)

### DIFF
--- a/rendering/cases/reproj-image/main.js
+++ b/rendering/cases/reproj-image/main.js
@@ -26,4 +26,6 @@ new Map({
   })
 });
 
-render();
+render({
+  tolerance: 0.001
+});

--- a/rendering/cases/reproj-image/main.js
+++ b/rendering/cases/reproj-image/main.js
@@ -4,7 +4,7 @@ import Static from '../../../src/ol/source/ImageStatic.js';
 import {
   get as getProjection,
   transformExtent
-} from '../../../src/ol/proj';
+} from '../../../src/ol/proj.js';
 import ImageLayer from '../../../src/ol/layer/Image.js';
 
 const source = new Static({


### PR DESCRIPTION
This makes linting work again. It was broken in the aftermath of #9375 

Before:
```
$ npm run lint

> ol@6.0.0-beta.11 lint /home/mjansen/code/openlayers
> eslint tasks test rendering src/ol examples config


/home/mjansen/code/openlayers/rendering/cases/reproj-image/main.js
  7:8  error  Missing file extension "js" for "../../../src/ol/proj"  import/extensions

✖ 1 problem (1 error, 0 warnings)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ol@6.0.0-beta.11 lint: `eslint tasks test rendering src/ol examples config`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the ol@6.0.0-beta.11 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/mjansen/.npm/_logs/2019-07-23T09_41_35_294Z-debug.log
```

This PR removes the above error.

Please review.
