### PR TITLE
Avoid false positives for line and polygon hit detection

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -344,11 +344,13 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     let i, ii;
     for (i = 0, ii = renderedTiles.length; i < ii; ++i) {
       const tile = renderedTiles[i];
+      const tileExtent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
+      const tileContainsCoordinate = containsCoordinate(tileExtent, coordinate);
+
       if (!declutter) {
         // When not decluttering, we only need to consider the tile that contains the given
         // coordinate, because each feature will be rendered for each tile that contains it.
-        const tileExtent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
-        if (!containsCoordinate(tileExtent, coordinate)) {
+        if (!tileContainsCoordinate) {
           continue;
         }
       }
@@ -361,13 +363,15 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
            * @return {?} Callback result.
            */
           function(feature) {
-            let key = feature.getId();
-            if (key === undefined) {
-              key = getUid(feature);
-            }
-            if (!(key in features)) {
-              features[key] = true;
-              return callback(feature, layer);
+            if (tileContainsCoordinate || (declutteredFeatures && declutteredFeatures.indexOf(feature) !== -1)) {
+              let key = feature.getId();
+              if (key === undefined) {
+                key = getUid(feature);
+              }
+              if (!(key in features)) {
+                features[key] = true;
+                return callback(feature, layer);
+              }
             }
           }, layer.getDeclutter() ? declutteredFeatures : null);
       }


### PR DESCRIPTION
This pull request adds stricter selection criteria of candidates for hit detection on vector tiles: Currently, when decluttering is on, features from any tile will be considered for a clicked coordinate. This works well for points. But for lines and polygons, the geometries will very likely be clipped and oversimplified on any tile but the one that is rendered, i.e. contains the clicked coordinate.

By adding an additional check, we can avoid false positives resulting from oversimplified geometries outside the tile boundary.