### PR TITLE
Remove unused variable in MousePosition control

### DIFF
--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -108,12 +108,6 @@ class MousePosition extends Control {
      */
     this.transform_ = null;
 
-    /**
-     * @private
-     * @type {import("../pixel.js").Pixel}
-     */
-    this.lastMouseMovePixel_ = null;
-
   }
 
   /**
@@ -156,8 +150,7 @@ class MousePosition extends Control {
    */
   handleMouseMove(event) {
     const map = this.getMap();
-    this.lastMouseMovePixel_ = map.getEventPixel(event);
-    this.updateHTML_(this.lastMouseMovePixel_);
+    this.updateHTML_(map.getEventPixel(event));
   }
 
   /**
@@ -166,7 +159,6 @@ class MousePosition extends Control {
    */
   handleMouseOut(event) {
     this.updateHTML_(null);
-    this.lastMouseMovePixel_ = null;
   }
 
   /**


### PR DESCRIPTION
`this.lastMouseMovePixel_` value is never read.
