### PR TITLE
Replacement for the Shared Views example

### DIFF
--- a/examples/side-by-side.css
+++ b/examples/side-by-side.css
@@ -1,0 +1,7 @@
+@media (min-width: 800px) {
+  .half {
+    padding: 0 10px;
+    width: 50%;
+    float: left;
+  }
+}

--- a/examples/side-by-side.html
+++ b/examples/side-by-side.html
@@ -1,0 +1,16 @@
+---
+layout: example.html
+title: Shared Views
+shortdesc: Two maps with different renderers share view properties
+docs: >
+  Two maps (one with the Canvas renderer, one with the WebGL renderer) share the same center, resolution, rotation and layers.
+tags: "side-by-side, canvas, webgl"
+---
+<div class="half">
+  <h4>Canvas</h4>
+  <div id="canvasMap" class="map"></div>
+</div>
+<div class="half">
+  <h4>WebGL</h4>
+  <div id="webglMap" class="map"></div>
+</div>

--- a/examples/side-by-side.html
+++ b/examples/side-by-side.html
@@ -1,16 +1,19 @@
 ---
 layout: example.html
 title: Shared Views
-shortdesc: Two maps with different renderers share view properties
+shortdesc: Two maps share view properties
 docs: >
-  Two maps (one with the Canvas renderer, one with the WebGL renderer) share the same center, resolution, rotation and layers.
-tags: "side-by-side, canvas, webgl"
+  Two maps (one Road, one Aerial) share the same center, resolution and rotation.
+tags: "side-by-side, bing, bing-maps"
+cloak:
+  - key: As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5
+    value: Your Bing Maps Key from http://www.bingmapsportal.com/ here
 ---
 <div class="half">
-  <h4>Canvas</h4>
-  <div id="canvasMap" class="map"></div>
+  <h4>Road</h4>
+  <div id="roadMap" class="map"></div>
 </div>
 <div class="half">
-  <h4>WebGL</h4>
-  <div id="webglMap" class="map"></div>
+  <h4>Aerial</h4>
+  <div id="aerialMap" class="map"></div>
 </div>

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -1,16 +1,22 @@
 import Map from '../src/ol/Map.js';
-import WebGLMap from '../src/ol/WebGLMap.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
-import WebGLTileLayer from '../src/ol/layer/WebGLTile.js';
-import OSM from '../src/ol/source/OSM.js';
+import BingMaps from '../src/ol/source/BingMaps.js';
 
-const layer = new TileLayer({
-  source: new OSM()
+const roadLayer = new TileLayer({
+  source: new BingMaps({
+    key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5',
+    imagerySet: 'RoadOnDemand',
+    maxZoom: 19
+  })
 });
 
-const webGLLayer = new WebGLTileLayer({
-  source: new OSM()
+const aerialLayer = new TileLayer({
+  source: new BingMaps({
+    key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5',
+    imagerySet: 'Aerial',
+    maxZoom: 19
+  })
 });
 
 const view = new View({
@@ -19,13 +25,13 @@ const view = new View({
 });
 
 const map1 = new Map({
-  target: 'canvasMap',
-  layers: [layer],
+  target: 'roadMap',
+  layers: [roadLayer],
   view: view
 });
 
 const map2 = new WebGLMap({
-  target: 'webglMap',
-  layers: [webGLLayer],
+  target: 'aerialMap',
+  layers: [aerialLayer],
   view: view
 });

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -30,7 +30,7 @@ const map1 = new Map({
   view: view
 });
 
-const map2 = new WebGLMap({
+const map2 = new Map({
   target: 'aerialMap',
   layers: [aerialLayer],
   view: view

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -20,8 +20,8 @@ const aerialLayer = new TileLayer({
 });
 
 const view = new View({
-  center: [0, 0],
-  zoom: 1
+  center: [-6655.5402445057125, 6709968.258934638],
+  zoom: 13
 });
 
 const map1 = new Map({

--- a/examples/side-by-side.js
+++ b/examples/side-by-side.js
@@ -1,0 +1,31 @@
+import Map from '../src/ol/Map.js';
+import WebGLMap from '../src/ol/WebGLMap.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import WebGLTileLayer from '../src/ol/layer/WebGLTile.js';
+import OSM from '../src/ol/source/OSM.js';
+
+const layer = new TileLayer({
+  source: new OSM()
+});
+
+const webGLLayer = new WebGLTileLayer({
+  source: new OSM()
+});
+
+const view = new View({
+  center: [0, 0],
+  zoom: 1
+});
+
+const map1 = new Map({
+  target: 'canvasMap',
+  layers: [layer],
+  view: view
+});
+
+const map2 = new WebGLMap({
+  target: 'webglMap',
+  layers: [webGLLayer],
+  view: view
+});


### PR DESCRIPTION
Fixes #9799

A replacement side-by-shared Shared Views example derived from the previous canvas/webGL maps example but substituting Road and Aerial maps from the Bing Maps example.
