### PR TITLE
Store the state of the ScaleLine control

### DIFF
--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -102,6 +102,15 @@ class ScaleLine extends Control {
     this.viewState_ = null;
 
     /**
+     * @type {{width: number, count: number, suffix: string}}
+     */
+    this.state = {
+      width: undefined,
+      count: undefined,
+      suffix: undefined
+    };
+
+    /**
      * @private
      * @type {number}
      */
@@ -276,6 +285,11 @@ class ScaleLine extends Control {
       ++i;
     }
     let html;
+
+    this.state.width = width;
+    this.state.count = count;
+    this.state.suffix = suffix;
+
     if (this.scaleBar_) {
       html = this.createScaleBar(width, count, suffix);
     } else {

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -277,6 +277,9 @@ describe('ol.control.ScaleLine', function() {
       }));
       map.renderSync();
       expect(ctrl.element.innerText).to.be('2000 km');
+      expect(ctrl.state.count).to.be(2000);
+      expect(ctrl.state.suffix).to.be('km');
+      expect(ctrl.state.width).to.be(83);
       map.setView(new View({
         center: [7, 52],
         multiWorld: true,
@@ -285,6 +288,9 @@ describe('ol.control.ScaleLine', function() {
       }));
       map.renderSync();
       expect(ctrl.element.innerText).to.be('5000 km');
+      expect(ctrl.state.count).to.be(5000);
+      expect(ctrl.state.suffix).to.be('km');
+      expect(ctrl.state.width).to.be(158);
       map.setView(new View({
         center: fromLonLat([-85.685, 39.891], 'Indiana-East'),
         zoom: 7,
@@ -292,6 +298,9 @@ describe('ol.control.ScaleLine', function() {
       }));
       map.renderSync();
       expect(ctrl.element.innerText).to.be('100 km');
+      expect(ctrl.state.count).to.be(100);
+      expect(ctrl.state.suffix).to.be('km');
+      expect(ctrl.state.width).to.be(82);
     });
 
     it('shows the same scale for different projections at higher resolutions', function() {
@@ -339,16 +348,27 @@ describe('ol.control.ScaleLine', function() {
 
       ctrl.setUnits('metric');
       expect(ctrl.element.innerText).to.be('100 m');
+      expect(ctrl.state.count).to.be(100);
+      expect(ctrl.state.suffix).to.be('m');
+      expect(ctrl.state.width).to.be(100);
 
       ctrl.setUnits('imperial');
       expect(ctrl.element.innerText).to.be('500 ft');
+      expect(ctrl.state.count).to.be(500);
+      expect(ctrl.state.suffix).to.be('ft');
+      expect(ctrl.state.width).to.be(152);
 
       ctrl.setUnits('nautical');
       expect(ctrl.element.innerText).to.be('0.05 nm');
+      expect(ctrl.state.count).to.be(0.05);
+      expect(ctrl.state.suffix).to.be('nm');
+      expect(ctrl.state.width).to.be(93);
 
       ctrl.setUnits('us');
       expect(ctrl.element.innerText).to.be('500 ft');
-
+      expect(ctrl.state.count).to.be(500);
+      expect(ctrl.state.suffix).to.be('ft');
+      expect(ctrl.state.width).to.be(152);
 
       map.setView(new View({
         center: [0, 0],


### PR DESCRIPTION
Provides the state of the scale line control: width in pixels, count and unit suffix

Fixes #9725