### PR TITLE
Enable regeneration of image in ol.style.RegularShape

### DIFF
--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -299,7 +299,8 @@ class RegularShape extends ImageStyle {
   unlistenImageChange(listener, thisArg) {}
 
   /**
-   * @protected
+   * Regenerate the shape.
+   * @api
    */
   render() {
     let lineCap = defaultLineCap;


### PR DESCRIPTION
Closes #9820 
Note that `ol.style.Circle.getRadius` no longer calls `render`, which makes this commit backwards incompatible.