### PR TITLE
Use nextzen for osm-vector-tiles example

### DIFF
--- a/examples/osm-vector-tiles.html
+++ b/examples/osm-vector-tiles.html
@@ -6,7 +6,7 @@ docs: >
   A simple vector tiles map with Mapzen vector tiles. This example uses the TopoJSON format's `layerName` option to determine the layer ("water", "roads", "buildings") for styling. **Note**: [`ol/format/MVT`] is an even more efficient format for vector tiles.
 tags: "vector, tiles, osm, mapzen"
 cloak:
-  - key: vector-tiles-5eJz6JX
-    value: Your Mapzen API key from https://mapzen.com/developers
+  - key: uZNs91nMR-muUTP99MyBSg
+    value: Your Nextzen API key from https://developers.nextzen.org/
 ---
 <div id="map" class="map"></div>

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -6,7 +6,7 @@ import {fromLonLat} from '../src/ol/proj.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
 import {Fill, Stroke, Style} from '../src/ol/style.js';
 
-const key = 'vector-tiles-5eJz6JX';
+const key = 'uZNs91nMR-muUTP99MyBSg';
 
 const roadStyleCache = {};
 const roadColor = {
@@ -67,7 +67,7 @@ const map = new Map({
           layers: ['water', 'roads', 'buildings']
         }),
         maxZoom: 19,
-        url: 'https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson?api_key=' + key
+        url: 'https://tile.nextzen.org/tilezen/vector/v1/all/{z}/{x}/{y}.topojson?api_key=' + key
       }),
       style: function(feature, resolution) {
         switch (feature.get('layer')) {


### PR DESCRIPTION
Fixes #9822.
Closes #7672.