### PR TITLE
Enable correct display of side-by-side example when not using the examples template

### DIFF
--- a/examples/side-by-side.css
+++ b/examples/side-by-side.css
@@ -1,4 +1,7 @@
 @media (min-width: 800px) {
+  .wrapper {
+    display: flex;
+  }
   .half {
     padding: 0 10px;
     width: 50%;

--- a/examples/side-by-side.html
+++ b/examples/side-by-side.html
@@ -9,11 +9,13 @@ cloak:
   - key: As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5
     value: Your Bing Maps Key from http://www.bingmapsportal.com/ here
 ---
-<div class="half">
-  <h4>Road</h4>
-  <div id="roadMap" class="map"></div>
-</div>
-<div class="half">
-  <h4>Aerial</h4>
-  <div id="aerialMap" class="map"></div>
+<div class="wrapper">
+  <div class="half">
+    <h4>Road</h4>
+    <div id="roadMap" class="map"></div>
+  </div>
+  <div class="half">
+    <h4>Aerial</h4>
+    <div id="aerialMap" class="map"></div>
+  </div>
 </div>


### PR DESCRIPTION
Fixes #9837

Use wrapper div to enable side by side display in codesandbox and when using copied code as it currently only displays as expected on the example page (where it is placed inside the the examples template).