### PR TITLE
Make API work with user projected coordinates

### DIFF
--- a/examples/geographic.html
+++ b/examples/geographic.html
@@ -1,0 +1,13 @@
+---
+layout: example.html
+title: Geographic Coordinates
+shortdesc: Using geographic coordinates for the map view.
+docs: >
+  Calling the <code>useGeographic</code> function in the <code>'ol/proj'</code> module
+  makes it so the map view uses geographic coordinates (even if the view projection is
+  not geographic).
+tags: "geographic"
+---
+<div id="map" class="map"></div>
+<div id="info"></div>
+

--- a/examples/geographic.js
+++ b/examples/geographic.js
@@ -1,0 +1,27 @@
+import {useGeographic} from '../src/ol/proj.js';
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import OSM from '../src/ol/source/OSM.js';
+
+useGeographic();
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM()
+    })
+  ],
+  target: 'map',
+  view: new View({
+    center: [-110, 45],
+    zoom: 8
+  })
+});
+
+const info = document.getElementById('info');
+map.on('moveend', function() {
+  const view = map.getView();
+  const center = view.getCenter();
+  info.innerText = `lon: ${center[0].toFixed(2)}, lat: ${center[1].toFixed(2)}`;
+});

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -418,14 +418,14 @@ class Overlay extends BaseObject {
       }
 
       if (delta[0] !== 0 || delta[1] !== 0) {
-        const center = /** @type {import("./coordinate.js").Coordinate} */ (map.getView().getCenter());
+        const center = /** @type {import("./coordinate.js").Coordinate} */ (map.getView().getCenterInternal());
         const centerPx = map.getPixelFromCoordinate(center);
         const newCenterPx = [
           centerPx[0] + delta[0],
           centerPx[1] + delta[1]
         ];
 
-        map.getView().animate({
+        map.getView().animateInternal({
           center: map.getCoordinateFromPixel(newCenterPx),
           duration: this.autoPanAnimation.duration,
           easing: this.autoPanAnimation.easing

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -11,6 +11,7 @@ import Overlay from '../Overlay.js';
 import OverlayPositioning from '../OverlayPositioning.js';
 import ViewProperty from '../ViewProperty.js';
 import Control from './Control.js';
+import {fromExtent as polygonFromExtent} from '../geom/Polygon.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE, CLASS_COLLAPSED} from '../css.js';
 import {replaceNode} from '../dom.js';
 import {listen, listenOnce} from '../events.js';
@@ -230,7 +231,7 @@ class OverviewMap extends Control {
     const endMoving = function(event) {
       const coordinates = ovmap.getEventCoordinate(event);
 
-      scope.getMap().getView().setCenter(coordinates);
+      scope.getMap().getView().setCenterInternal(coordinates);
 
       window.removeEventListener('mousemove', move);
       window.removeEventListener('mouseup', endMoving);
@@ -346,7 +347,7 @@ class OverviewMap extends Control {
     const mapSize = /** @type {import("../size.js").Size} */ (map.getSize());
 
     const view = map.getView();
-    const extent = view.calculateExtent(mapSize);
+    const extent = view.calculateExtentInternal(mapSize);
 
     if (this.viewExtent_ && equalsExtent(extent, this.viewExtent_)) {
       // repeats of the same extent may indicate constraint conflicts leading to an endless cycle
@@ -357,7 +358,7 @@ class OverviewMap extends Control {
     const ovmapSize = /** @type {import("../size.js").Size} */ (ovmap.getSize());
 
     const ovview = ovmap.getView();
-    const ovextent = ovview.calculateExtent(ovmapSize);
+    const ovextent = ovview.calculateExtentInternal(ovmapSize);
 
     const topLeftPixel =
         ovmap.getPixelFromCoordinate(getTopLeft(extent));
@@ -396,7 +397,7 @@ class OverviewMap extends Control {
     const mapSize = /** @type {import("../size.js").Size} */ (map.getSize());
 
     const view = map.getView();
-    const extent = view.calculateExtent(mapSize);
+    const extent = view.calculateExtentInternal(mapSize);
 
     const ovview = ovmap.getView();
 
@@ -407,7 +408,7 @@ class OverviewMap extends Control {
       MAX_RATIO / MIN_RATIO) / Math.LN2;
     const ratio = 1 / (Math.pow(2, steps / 2) * MIN_RATIO);
     scaleFromCenter(extent, ratio);
-    ovview.fit(extent);
+    ovview.fitInternal(polygonFromExtent(extent));
   }
 
   /**
@@ -423,7 +424,7 @@ class OverviewMap extends Control {
 
     const ovview = ovmap.getView();
 
-    ovview.setCenter(view.getCenter());
+    ovview.setCenterInternal(view.getCenterInternal());
   }
 
   /**
@@ -448,7 +449,7 @@ class OverviewMap extends Control {
 
     const overlay = this.boxOverlay_;
     const box = this.boxOverlay_.getElement();
-    const center = view.getCenter();
+    const center = view.getCenterInternal();
     const resolution = view.getResolution();
     const ovresolution = ovview.getResolution();
     const width = mapSize[0] * resolution / ovresolution;

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -204,7 +204,7 @@ class ZoomSlider extends Control {
     const resolution = this.getResolutionForPosition_(relativePosition);
     const zoom = view.getConstrainedZoom(view.getZoomForResolution(resolution));
 
-    view.animate({
+    view.animateInternal({
       zoom: zoom,
       duration: this.duration_,
       easing: easeOut

--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -2,6 +2,7 @@
  * @module ol/control/ZoomToExtent
  */
 import EventType from '../events/EventType.js';
+import {fromExtent as polygonFromExtent} from '../geom/Polygon.js';
 import Control from './Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 
@@ -80,7 +81,7 @@ class ZoomToExtent extends Control {
     const map = this.getMap();
     const view = map.getView();
     const extent = !this.extent ? view.getProjection().getExtent() : this.extent;
-    view.fit(extent);
+    view.fitInternal(polygonFromExtent(extent));
   }
 }
 

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -92,7 +92,7 @@ class DragPan extends PointerInteraction {
         const view = map.getView();
         scaleCoordinate(delta, view.getResolution());
         rotateCoordinate(delta, view.getRotation());
-        view.adjustCenter(delta);
+        view.adjustCenterInternal(delta);
       }
     } else if (this.kinetic_) {
       // reset so we don't overestimate the kinetic energy after
@@ -113,13 +113,13 @@ class DragPan extends PointerInteraction {
       if (!this.noKinetic_ && this.kinetic_ && this.kinetic_.end()) {
         const distance = this.kinetic_.getDistance();
         const angle = this.kinetic_.getAngle();
-        const center = /** @type {!import("../coordinate.js").Coordinate} */ (view.getCenter());
+        const center = view.getCenterInternal();
         const centerpx = map.getPixelFromCoordinate(center);
         const dest = map.getCoordinateFromPixel([
           centerpx[0] - distance * Math.cos(angle),
           centerpx[1] - distance * Math.sin(angle)
         ]);
-        view.animate({
+        view.animateInternal({
           center: view.getConstrainedCenter(dest),
           duration: 500,
           easing: easeOut

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -78,7 +78,7 @@ class DragRotate extends PointerInteraction {
         Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
     if (this.lastAngle_ !== undefined) {
       const delta = theta - this.lastAngle_;
-      view.adjustRotation(-delta);
+      view.adjustRotationInternal(-delta);
     }
     this.lastAngle_ = theta;
   }

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -87,7 +87,7 @@ class DragRotateAndZoom extends PointerInteraction {
     const view = map.getView();
     if (this.lastAngle_ !== undefined) {
       const angleDelta = this.lastAngle_ - theta;
-      view.adjustRotation(angleDelta);
+      view.adjustRotationInternal(angleDelta);
     }
     this.lastAngle_ = theta;
     if (this.lastMagnitude_ !== undefined) {

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -73,20 +73,20 @@ function onBoxEnd() {
   let extent = this.getGeometry().getExtent();
 
   if (this.out_) {
-    const mapExtent = view.calculateExtent(size);
+    const mapExtent = view.calculateExtentInternal(size);
     const boxPixelExtent = createOrUpdateFromCoordinates([
       map.getPixelFromCoordinate(getBottomLeft(extent)),
       map.getPixelFromCoordinate(getTopRight(extent))]);
-    const factor = view.getResolutionForExtent(boxPixelExtent, size);
+    const factor = view.getResolutionForExtentInternal(boxPixelExtent, size);
 
     scaleFromCenter(mapExtent, 1 / factor);
     extent = mapExtent;
   }
 
-  const resolution = view.getConstrainedResolution(view.getResolutionForExtent(extent, size));
+  const resolution = view.getConstrainedResolution(view.getResolutionForExtentInternal(extent, size));
   const center = view.getConstrainedCenter(getCenter(extent), resolution);
 
-  view.animate({
+  view.animateInternal({
     resolution: resolution,
     center: center,
     duration: this.duration_,

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -108,10 +108,10 @@ class Interaction extends BaseObject {
  * @param {number=} opt_duration Duration.
  */
 export function pan(view, delta, opt_duration) {
-  const currentCenter = view.getCenter();
+  const currentCenter = view.getCenterInternal();
   if (currentCenter) {
     const center = [currentCenter[0] + delta[0], currentCenter[1] + delta[1]];
-    view.animate_({
+    view.animateInternal({
       duration: opt_duration !== undefined ? opt_duration : 250,
       easing: linear,
       center: view.getConstrainedCenter(center)
@@ -138,7 +138,7 @@ export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
   if (view.getAnimating()) {
     view.cancelAnimations();
   }
-  view.animate({
+  view.animateInternal({
     resolution: newResolution,
     anchor: opt_anchor,
     duration: opt_duration !== undefined ? opt_duration : 250,

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -117,7 +117,7 @@ class PinchRotate extends PointerInteraction {
     // rotate
     if (this.rotating_) {
       map.render();
-      view.adjustRotation(rotationDelta, this.anchor_);
+      view.adjustRotationInternal(rotationDelta, this.anchor_);
     }
   }
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -499,6 +499,105 @@ export function transformWithProjections(point, sourceProjection, destinationPro
 }
 
 /**
+ * @type {Projection}
+ */
+let userProjection = null;
+
+/**
+ * Set the projection for coordinates supplied from and returned by API methods.
+ * Note that this method is not yet a part of the stable API.  Support for user
+ * projections is not yet complete and should be considered experimental.
+ * @param {ProjectionLike} projection The user projection.
+ */
+export function setUserProjection(projection) {
+  userProjection = get(projection);
+}
+
+/**
+ * Clear the user projection if set.  Note that this method is not yet a part of
+ * the stable API.  Support for user projections is not yet complete and should
+ * be considered experimental.
+ */
+export function clearUserProjection() {
+  userProjection = null;
+}
+
+/**
+ * Get the projection for coordinates supplied from and returned by API methods.
+ * Note that this method is not yet a part of the stable API.  Support for user
+ * projections is not yet complete and should be considered experimental.
+ * @returns {Projection} The user projection (or null if not set).
+ */
+export function getUserProjection() {
+  return userProjection;
+}
+
+/**
+ * Use geographic coordinates (WGS-84 datum) in API methods.  Note that this
+ * method is not yet a part of the stable API.  Support for user projections is
+ * not yet complete and should be considered experimental.
+ */
+export function useGeographic() {
+  setUserProjection('EPSG:4326');
+}
+
+/**
+ * Return a coordinate transformed into the user projection.  If no user projection
+ * is set, the original coordinate is returned.
+ * @param {Array<number>} coordinate Input coordinate.
+ * @param {ProjectionLike} sourceProjection The input coordinate projection.
+ * @returns {Array<number>} The input coordinate in the user projection.
+ */
+export function toUserCoordinate(coordinate, sourceProjection) {
+  if (!userProjection) {
+    return coordinate;
+  }
+  return transform(coordinate, sourceProjection, userProjection);
+}
+
+/**
+ * Return a coordinate transformed from the user projection.  If no user projection
+ * is set, the original coordinate is returned.
+ * @param {Array<number>} coordinate Input coordinate.
+ * @param {ProjectionLike} destProjection The destination projection.
+ * @returns {Array<number>} The input coordinate transformed.
+ */
+export function fromUserCoordinate(coordinate, destProjection) {
+  if (!userProjection) {
+    return coordinate;
+  }
+  return transform(coordinate, userProjection, destProjection);
+}
+
+/**
+ * Return an extent transformed into the user projection.  If no user projection
+ * is set, the original extent is returned.
+ * @param {import("./extent.js").Extent} extent Input extent.
+ * @param {ProjectionLike} sourceProjection The input extent projection.
+ * @returns {import("./extent.js").Extent} The input extent in the user projection.
+ */
+export function toUserExtent(extent, sourceProjection) {
+  if (!userProjection) {
+    return extent;
+  }
+  return transformExtent(extent, sourceProjection, userProjection);
+}
+
+/**
+ * Return an extent transformed from the user projection.  If no user projection
+ * is set, the original extent is returned.
+ * @param {import("./extent.js").Extent} extent Input extent.
+ * @param {ProjectionLike} destProjection The destination projection.
+ * @returns {import("./extent.js").Extent} The input extent transformed.
+ */
+export function fromUserExtent(extent, destProjection) {
+  if (!userProjection) {
+    return extent;
+  }
+  return transformExtent(extent, userProjection, destProjection);
+}
+
+/**
  * Add transforms to and from EPSG:4326 and EPSG:3857.  This function is called
  * by when this module is executed and should only need to be called again after
  * `clearAllProjections()` is called (e.g. in tests).

--- a/test/spec/ol/interaction/dragzoom.test.js
+++ b/test/spec/ol/interaction/dragzoom.test.js
@@ -78,7 +78,7 @@ describe('ol.interaction.DragZoom', function() {
       interaction.onBoxEnd_();
       setTimeout(function() {
         const view = map.getView();
-        const center = view.getCenter();
+        const center = view.getCenterInternal();
         expect(center).to.eql(getCenter(extent));
         done();
       }, 50);

--- a/test/spec/ol/interaction/keyboardpan.test.js
+++ b/test/spec/ol/interaction/keyboardpan.test.js
@@ -24,7 +24,7 @@ describe('ol.interaction.KeyboardPan', function() {
   describe('handleEvent()', function() {
     it('pans on arrow keys', function() {
       const view = map.getView();
-      const spy = sinon.spy(view, 'animate_');
+      const spy = sinon.spy(view, 'animateInternal');
       const event = new MapBrowserEvent('keydown', map, {
         type: 'keydown',
         target: map.getTargetElement(),
@@ -51,7 +51,7 @@ describe('ol.interaction.KeyboardPan', function() {
       expect(spy.getCall(3).args[0].center).to.eql([128, 0]);
       view.setCenter([0, 0]);
 
-      view.animate_.restore();
+      view.animateInternal.restore();
     });
   });
 

--- a/test/spec/ol/interaction/keyboardzoom.test.js
+++ b/test/spec/ol/interaction/keyboardzoom.test.js
@@ -24,7 +24,7 @@ describe('ol.interaction.KeyboardZoom', function() {
   describe('handleEvent()', function() {
     it('zooms on + and - keys', function() {
       const view = map.getView();
-      const spy = sinon.spy(view, 'animate');
+      const spy = sinon.spy(view, 'animateInternal');
       const event = new MapBrowserEvent('keydown', map, {
         type: 'keydown',
         target: map.getTargetElement(),
@@ -41,7 +41,7 @@ describe('ol.interaction.KeyboardZoom', function() {
       expect(spy.getCall(1).args[0].resolution).to.eql(4);
       view.setResolution(2);
 
-      view.animate.restore();
+      view.animateInternal.restore();
     });
   });
 

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -99,20 +99,20 @@ describe('ol.interaction.MouseWheelZoom', function() {
       });
     }
 
-    describe('spying on view.animate()', function() {
+    describe('spying on view.animateInternal()', function() {
       let view;
       beforeEach(function() {
         view = map.getView();
-        sinon.spy(view, 'animate');
+        sinon.spy(view, 'animateInternal');
       });
 
       afterEach(function() {
-        view.animate.restore();
+        view.animateInternal.restore();
       });
 
       it('works in DOM_DELTA_LINE mode (wheel)', function(done) {
         map.once('postrender', function() {
-          const call = view.animate.getCall(0);
+          const call = view.animateInternal.getCall(0);
           expect(call.args[0].resolution).to.be(2);
           expect(call.args[0].anchor).to.eql([0, 0]);
           done();
@@ -132,7 +132,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
 
       it('works on all browsers (wheel)', function(done) {
         map.once('postrender', function() {
-          const call = view.animate.getCall(0);
+          const call = view.animateInternal.getCall(0);
           expect(call.args[0].resolution).to.be(2);
           expect(call.args[0].anchor).to.eql([0, 0]);
           done();

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -1,4 +1,12 @@
 import {
+  useGeographic,
+  getUserProjection,
+  setUserProjection,
+  clearUserProjection,
+  toUserCoordinate,
+  fromUserCoordinate,
+  toUserExtent,
+  fromUserExtent,
   addCommon,
   clearAllProjections,
   equivalent,
@@ -22,7 +30,112 @@ describe('ol.proj', function() {
 
   afterEach(function() {
     clearAllProjections();
+    clearUserProjection();
     addCommon();
+  });
+
+  describe('useGeographic()', function() {
+    it('sets the user projection to Geographic/WGS-84', function() {
+      useGeographic();
+      const projection = getUserProjection();
+      expect(projection).to.be(getProjection('EPSG:4326'));
+    });
+  });
+
+  describe('getUserProjection()', function() {
+    it('returns null by default', function() {
+      expect(getUserProjection()).to.be(null);
+    });
+
+    it('returns the user projection if set', function() {
+      const projection = getProjection('EPSG:4326');
+      setUserProjection(projection);
+      expect(getUserProjection()).to.be(projection);
+    });
+  });
+
+  describe('setUserProjection()', function() {
+    it('accepts a string identifier', function() {
+      const projection = getProjection('EPSG:4326');
+      setUserProjection('EPSG:4326');
+      expect(getUserProjection()).to.be(projection);
+    });
+  });
+
+  describe('clearUserProjection()', function() {
+    it('clears the user projection', function() {
+      useGeographic();
+      clearUserProjection();
+      expect(getUserProjection()).to.be(null);
+    });
+  });
+
+  describe('toUserCoordinate()', function() {
+    it('transforms a point to the user projection', function() {
+      useGeographic();
+      const coordinate = fromLonLat([-110, 45]);
+      const user = toUserCoordinate(coordinate, 'EPSG:3857');
+      const transformed = transform(coordinate, 'EPSG:3857', 'EPSG:4326');
+      expect(user).to.eql(transformed);
+      expect(user).not.to.eql(coordinate);
+    });
+
+    it('returns the original if no user projection is set', function() {
+      const coordinate = fromLonLat([-110, 45]);
+      const user = toUserCoordinate(coordinate, 'EPSG:3857');
+      expect(user).to.be(coordinate);
+    });
+  });
+
+  describe('fromUserCoordinate()', function() {
+    it('transforms a point from the user projection', function() {
+      useGeographic();
+      const user = [-110, 45];
+      const coordinate = fromUserCoordinate(user, 'EPSG:3857');
+      const transformed = transform(user, 'EPSG:4326', 'EPSG:3857');
+      expect(coordinate).to.eql(transformed);
+      expect(user).not.to.eql(coordinate);
+    });
+
+    it('returns the original if no user projection is set', function() {
+      const user = fromLonLat([-110, 45]);
+      const coordinate = fromUserCoordinate(user, 'EPSG:3857');
+      expect(coordinate).to.be(user);
+    });
+  });
+
+  describe('toUserExtent()', function() {
+    it('transforms an extent to the user projection', function() {
+      useGeographic();
+      const extent = transformExtent([-110, 45, -100, 50], 'EPSG:4326', 'EPSG:3857');
+      const user = toUserExtent(extent, 'EPSG:3857');
+      const transformed = transformExtent(extent, 'EPSG:3857', 'EPSG:4326');
+      expect(user).to.eql(transformed);
+      expect(user).not.to.eql(extent);
+    });
+
+    it('returns the original if no user projection is set', function() {
+      const extent = transformExtent([-110, 45, -100, 50], 'EPSG:4326', 'EPSG:3857');
+      const user = toUserExtent(extent, 'EPSG:3857');
+      expect(user).to.be(extent);
+    });
+  });
+
+  describe('fromUserExtent()', function() {
+    it('transforms an extent from the user projection', function() {
+      useGeographic();
+      const user = [-110, 45, -100, 50];
+      const extent = fromUserExtent(user, 'EPSG:3857');
+      const transformed = transformExtent(user, 'EPSG:4326', 'EPSG:3857');
+      expect(extent).to.eql(transformed);
+      expect(extent).not.to.eql(user);
+    });
+
+    it('returns the original if no user projection is set', function() {
+      const user = transformExtent([-110, 45, -100, 50], 'EPSG:4326', 'EPSG:3857');
+      const extent = fromUserExtent(user, 'EPSG:3857');
+      expect(extent).to.be(user);
+    });
   });
 
   describe('toLonLat()', function() {


### PR DESCRIPTION
The goal of this branch is to support a "user projection" – which will most likely be geographic (WGS-84) – that is different from the view projection.  The justification is that many people want a Web Mercator view (often without knowing it) and want to use geographic coordinates for doing things like setting the map center, adding data, etc.

To support this, all API methods need be updated to take and return coordinates (extents, geometries, etc.) in the user projection.  And we can create "internal" methods that are not part of the API for dealing with the view (rendered) projection.  For example, `view.setCenter()` is the API method that will take a coordinate in the user projection and call `view.setCenterInternal()` with the coordinate transformed to the view projection.

In implementing this, I think we can tackle one API method at a time, creating an "internal" counterpart and renaming the existing one to something with "external" in it.  After fixing everything that breaks, we can rename the "external" one back to the nicer, short name (e.g. initially we will have `view.setCenterExternal()` and then it will be renamed to `view.setCenter()` after everything works).

In case the objective isn't clear, here is [a simple example](https://1850-4723248-gh.circle-artifacts.com/0/examples/geographic.html) that should be supported by this change:
```js
import {useGeographic} from 'ol/proj';
import {Map, View} from 'ol';
import TileLayer from 'ol/layer/Tile';
import OSM from 'ol/source/OSM';

useGeographic(); // <-- this makes things work

const map = new Map({
  layers: [
    new TileLayer({
      source: new OSM()
    })
  ],
  target: 'map',
  view: new View({
    center: [-110, 45],
    zoom: 8
  })
});

const info = document.getElementById('info');
map.on('moveend', function() {
  const view = map.getView();
  const center = view.getCenter();
  info.innerText = `lon: ${center[0].toFixed(2)}, lat: ${center[1].toFixed(2)}`;
});
```

In the [example above](https://1850-4723248-gh.circle-artifacts.com/0/examples/geographic.html), the view is constructed with a center in geographic coordinates.  And the user can call `view.getCenter()` at any time to get geographic coordinates (as shown in the `moveend` listener).  So the rendered projection is Web Mercator, but the user can work with coordinates that they are familiar with.

I imagine this will be work in progress for a while.  A list of API things that need work:

`ol/View`
 - [x] `new View()`
 - [x] `view.getCenter()`
 - [x] `view.setCenter()`
 - [x] `view.animate()`
 - [x] `view.adjustCenter()`
 - [x] `view.fit()`
 - [x] `view.calculateExtent()`
 - [x] `view.centerOn()`
 - [x] `view.adjustRotation()`
 - [x] `view.getResolutionForExtent()`

`ol/Map`
 - [ ] `map.getPixelFromCoordinate()`
 - [ ] `map.getCoordinateFromPixel()`
 - [ ] `mapBrowserEvent.coordinate`

`ol/Overlay`
 - [ ] `overlay.setPosition()`

`ol/layer`
 - [ ] `layer.getExtent()`
 - [ ] `layer.setExtent()`

And lots more.