### PR TITLE
Make sure vector tile load handler is called

### DIFF
--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -9,6 +9,7 @@ import {getCenter} from '../../../../../src/ol/extent.js';
 import MVT from '../../../../../src/ol/format/MVT.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import VectorTileLayer from '../../../../../src/ol/layer/VectorTile.js';
+import {getKey} from '../../../../../src/ol/tilecoord.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
 import {checkedFonts} from '../../../../../src/ol/render/canvas.js';
 import RenderFeature from '../../../../../src/ol/render/Feature.js';
@@ -300,12 +301,8 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         tileClass: TileClass,
         tileGrid: createXYZ()
       });
-      source.sourceTiles_ = {
-        '0/0/0': sourceTile
-      };
-      source.sourceTilesByTileKey_ = {
-        '0/0/0': [sourceTile]
-      };
+      source.sourceTileByCoordKey_[getKey(sourceTile.tileCoord)] = sourceTile;
+      source.sourceTilesByTileKey_[sourceTile.getKey()] = [sourceTile];
       executorGroup = {};
       source.getTile = function() {
         const tile = VectorTileSource.prototype.getTile.apply(source, arguments);

--- a/test/spec/ol/vectorrendertile.test.js
+++ b/test/spec/ol/vectorrendertile.test.js
@@ -5,7 +5,6 @@ import {listen, listenOnce, unlistenByKey} from '../../../src/ol/events.js';
 import GeoJSON from '../../../src/ol/format/GeoJSON.js';
 import {createXYZ} from '../../../src/ol/tilegrid.js';
 import TileGrid from '../../../src/ol/tilegrid/TileGrid.js';
-import {getKey} from '../../../src/ol/tilecoord.js';
 import EventType from '../../../src/ol/events/EventType.js';
 
 
@@ -107,7 +106,7 @@ describe('ol.VectorRenderTile', function() {
     tile.load();
     expect(tile.getState()).to.be(TileState.LOADING);
     tile.dispose();
-    expect(source.sourceTilesByTileKey_[getKey(tile)]).to.be(undefined);
+    expect(source.sourceTilesByTileKey_[tile.getKey()]).to.be(undefined);
     expect(tile.getState()).to.be(TileState.ABORT);
   });
 


### PR DESCRIPTION
After #9778 the tile load handler is not always called for vector tiles.  So the queue fills up, loading of other layers slows, and eventually nothing loads.

This happens when calling `source.setUrl()` for a vector tile source multiple times.  Previously, tiles were keyed by the tile coordinate in the lookups for existing source tiles.  This branch changes that lookup to use the tile key instead of the coordinate key.  Since the tile key changes on `source.setUrl()` calls, we don't try reusing the wrong source tiles.