### PR TITLE
Set xhr.withCredentials = true in loadFeaturesXhr()

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -62,6 +62,7 @@ export function loadFeaturesXhr(url, format, success, failure) {
       if (format.getType() == FormatType.ARRAY_BUFFER) {
         xhr.responseType = 'arraybuffer';
       }
+      xhr.withCredentials = true;
       /**
        * @param {Event} event Event.
        * @private

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -62,7 +62,9 @@ export function loadFeaturesXhr(url, format, success, failure) {
       if (format.getType() == FormatType.ARRAY_BUFFER) {
         xhr.responseType = 'arraybuffer';
       }
-      xhr.withCredentials = true;
+      if (window.withCredentials) {
+        xhr.withCredentials = window.withCredentials;
+      }
       /**
        * @param {Event} event Event.
        * @private
@@ -131,4 +133,15 @@ export function xhr(url, format) {
         /** @type {import("./source/Vector").default} */ (sourceOrTile).addFeatures(features);
       }
     }, /* FIXME handle error */ VOID);
+}
+
+
+/**
+ * Sets a global withCredentials variable that will be used in
+ * loadFeaturesXhr() above.
+ * @param {bool} bool Boolean that will be used in xhr.withCredentials.
+ * @api
+ */
+export function setWithCredentials(bool) {
+  window.withCredentials = bool;
 }


### PR DESCRIPTION
This pull request is related to #5244.

It adds `xhr.withCredentials = true;` to `loadFeaturesXhr()` so that cookies are sent when pulling GeoJSON from a cross-origin domain.

Currently, adding a GeoJSON source from another domain that is authenticated via a session cookie returns a 403 response, while opening the same URL in another tab returns a 200.