### PR TITLE
Only get squared tolerance once per render

### DIFF
--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -362,10 +362,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     }
     let loading = false;
     if (Array.isArray(styles)) {
+      const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
       for (let i = 0, ii = styles.length; i < ii; ++i) {
         loading = renderFeature(
-          builderGroup, feature, styles[i],
-          getSquaredRenderTolerance(resolution, pixelRatio),
+          builderGroup, feature, styles[i], squaredTolerance,
           this.handleStyleImageChange_, this) || loading;
       }
     } else {

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -299,6 +299,8 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
     vectorSource.loadFeatures(extent, resolution, projection);
 
+    const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
+
     /**
      * @param {import("../../Feature.js").default} feature Feature.
      * @this {CanvasVectorLayerRenderer}
@@ -310,11 +312,11 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
         styles = styleFunction(feature, resolution);
       }
       if (styles) {
-        const dirty = this.renderFeature(
-          feature, resolution, pixelRatio, styles, replayGroup);
+        const dirty = this.renderFeature(feature, squaredTolerance, styles, replayGroup);
         this.dirty_ = this.dirty_ || dirty;
       }
     }.bind(this);
+
     if (vectorLayerRenderOrder) {
       /** @type {Array<import("../../Feature.js").default>} */
       const features = [];
@@ -350,19 +352,17 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
   /**
    * @param {import("../../Feature.js").default} feature Feature.
-   * @param {number} resolution Resolution.
-   * @param {number} pixelRatio Pixel ratio.
+   * @param {number} squaredTolerance Squared render tolerance.
    * @param {import("../../style/Style.js").default|Array<import("../../style/Style.js").default>} styles The style or array of styles.
    * @param {import("../../render/canvas/BuilderGroup.js").default} builderGroup Builder group.
    * @return {boolean} `true` if an image is loading.
    */
-  renderFeature(feature, resolution, pixelRatio, styles, builderGroup) {
+  renderFeature(feature, squaredTolerance, styles, builderGroup) {
     if (!styles) {
       return false;
     }
     let loading = false;
     if (Array.isArray(styles)) {
-      const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
       for (let i = 0, ii = styles.length; i < ii; ++i) {
         loading = renderFeature(
           builderGroup, feature, styles[i], squaredTolerance,
@@ -370,8 +370,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       }
     } else {
       loading = renderFeature(
-        builderGroup, feature, styles,
-        getSquaredRenderTolerance(resolution, pixelRatio),
+        builderGroup, feature, styles, squaredTolerance,
         this.handleStyleImageChange_, this);
     }
     return loading;

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -75,11 +75,10 @@ describe('ol.renderer.canvas.VectorLayer', function() {
         style: layerStyle
       });
       map.addLayer(layer);
-      const spy = sinon.spy(layer.getRenderer(),
-        'renderFeature');
+      const spy = sinon.spy(layer.getRenderer(), 'renderFeature');
       map.renderSync();
-      expect(spy.getCall(0).args[3]).to.be(layerStyle);
-      expect(spy.getCall(1).args[3]).to.be(featureStyle);
+      expect(spy.getCall(0).args[2]).to.be(layerStyle);
+      expect(spy.getCall(1).args[2]).to.be(featureStyle);
       document.body.removeChild(target);
     });
 


### PR DESCRIPTION
The resolution and pixelRatio variables do not change in the loop, thus it should be safe to only calculate the squared render tolerance once per call to renderFeature.