### PR TITLE
Only check extent when a url tile coordinate is available

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -334,7 +334,7 @@ class VectorTile extends UrlTile {
     const tileCoord = [z, x, y];
     let urlTileCoord = this.getTileCoordForTileUrlFunction(tileCoord, projection);
     const sourceExtent = this.getTileGrid().getExtent();
-    if (sourceExtent) {
+    if (urlTileCoord && sourceExtent) {
       const tileGrid = this.getTileGridForProjection(projection);
       const tileExtent = tileGrid.getTileCoordExtent(urlTileCoord);
       // make extent 1 pixel smaller so we don't load tiles for < 0.5 pixel render space

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -95,6 +95,20 @@ describe('ol.source.VectorTile', function() {
       expect(tile.getState()).to.be(TileState.EMPTY);
     });
 
+    it('creates empty tiles outside the world extent when wrapX === false', function() {
+      const source = new VectorTileSource({
+        wrapX: false
+      });
+      const tile = source.getTile(0, -1, 0, 1, source.getProjection());
+      expect(tile.getState()).to.be(TileState.EMPTY);
+    });
+
+    it('creates non-empty tiles outside the world extent when wrapX === true', function() {
+      const source = new VectorTileSource({});
+      const tile = source.getTile(0, -1, 0, 1, source.getProjection());
+      expect(tile.getState()).to.be(TileState.IDLE);
+    });
+
     it('creates new tile when source key changes', function() {
       source.setKey('key1');
       const tile1 = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));


### PR DESCRIPTION
#9872 introduced another regression for vector tile loading, so I decided to add more tests and fix the issue that sources with `wrapX: false` caused an error because `urlTileCoord` was null before the extent check.