### PR TITLE
Fix -1 pixel buffer for vector tile extent

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -190,7 +190,7 @@ class VectorTile extends UrlTile {
     const z = urlTileCoord[0];
     const resolution = tileGrid.getResolution(z);
     // make extent 1 pixel smaller so we don't load tiles for < 0.5 pixel render space
-    bufferExtent(extent, -1 / resolution, extent);
+    bufferExtent(extent, -resolution, extent);
     const sourceTileGrid = this.tileGrid;
     const sourceExtent = sourceTileGrid.getExtent();
     if (sourceExtent) {
@@ -338,7 +338,7 @@ class VectorTile extends UrlTile {
       const tileGrid = this.getTileGridForProjection(projection);
       const tileExtent = tileGrid.getTileCoordExtent(urlTileCoord);
       // make extent 1 pixel smaller so we don't load tiles for < 0.5 pixel render space
-      bufferExtent(tileExtent, -1 / tileGrid.getResolution(z), tileExtent);
+      bufferExtent(tileExtent, -tileGrid.getResolution(z), tileExtent);
       if (!intersects(sourceExtent, tileExtent)) {
         urlTileCoord = null;
       }

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -109,6 +109,15 @@ describe('ol.source.VectorTile', function() {
       expect(tile.getState()).to.be(TileState.IDLE);
     });
 
+    it('creates non-empty tiles for overzoomed resolutions', function() {
+      const source = new VectorTileSource({
+        maxZoom: 16
+      });
+      const tile = source.getTile(24, 9119385, 5820434, 1, source.getProjection());
+      tile.load();
+      expect(tile.getState()).to.be(TileState.LOADING);
+    });
+
     it('creates new tile when source key changes', function() {
       source.setKey('key1');
       const tile1 = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));


### PR DESCRIPTION
The buffer that was intended to avoid tiles that take up less than 1 pixel render space was calculated in a wrong way!