### PR TITLE
Do not precalculate coordinate and pixel on MapBrowserEvent

### DIFF
--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -51,13 +51,13 @@ class Drag extends PointerInteraction {
 function handleDownEvent(evt) {
   const map = evt.map;
 
-  const feature = map.forEachFeatureAtPixel(evt.pixel,
+  const feature = map.forEachFeatureAtPixel(evt.getPixel(),
     function(feature) {
       return feature;
     });
 
   if (feature) {
-    this.coordinate_ = evt.coordinate;
+    this.coordinate_ = evt.getCoordinate();
     this.feature_ = feature;
   }
 
@@ -69,14 +69,15 @@ function handleDownEvent(evt) {
  * @param {import("../src/ol/MapBrowserEvent.js").default} evt Map browser event.
  */
 function handleDragEvent(evt) {
-  const deltaX = evt.coordinate[0] - this.coordinate_[0];
-  const deltaY = evt.coordinate[1] - this.coordinate_[1];
+  const coordinate = evt.getCoordinate();
+  const deltaX = coordinate[0] - this.coordinate_[0];
+  const deltaY = coordinate[1] - this.coordinate_[1];
 
   const geometry = this.feature_.getGeometry();
   geometry.translate(deltaX, deltaY);
 
-  this.coordinate_[0] = evt.coordinate[0];
-  this.coordinate_[1] = evt.coordinate[1];
+  this.coordinate_[0] = coordinate[0];
+  this.coordinate_[1] = coordinate[1];
 }
 
 
@@ -86,7 +87,7 @@ function handleDragEvent(evt) {
 function handleMoveEvent(evt) {
   if (this.cursor_) {
     const map = evt.map;
-    const feature = map.forEachFeatureAtPixel(evt.pixel,
+    const feature = map.forEachFeatureAtPixel(evt.getPixel(),
       function(feature) {
         return feature;
       });

--- a/examples/drag-and-drop-image-vector.js
+++ b/examples/drag-and-drop-image-vector.js
@@ -68,5 +68,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/drag-and-drop.js
+++ b/examples/drag-and-drop.js
@@ -68,5 +68,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -30,7 +30,7 @@ map.on('singleclick', function(evt) {
   document.getElementById('info').innerHTML = '';
   const viewResolution = /** @type {number} */ (view.getResolution());
   const url = wmsSource.getFeatureInfoUrl(
-    evt.coordinate, viewResolution, 'EPSG:3857',
+    evt.getCoordinate(), viewResolution, 'EPSG:3857',
     {'INFO_FORMAT': 'text/html'});
   if (url) {
     fetch(url)

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -30,7 +30,7 @@ map.on('singleclick', function(evt) {
   document.getElementById('info').innerHTML = '';
   const viewResolution = /** @type {number} */ (view.getResolution());
   const url = wmsSource.getFeatureInfoUrl(
-    evt.coordinate, viewResolution, 'EPSG:3857',
+    evt.getCoordinate(), viewResolution, 'EPSG:3857',
     {'INFO_FORMAT': 'text/html'});
   if (url) {
     fetch(url)

--- a/examples/gpx.js
+++ b/examples/gpx.js
@@ -87,5 +87,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/hit-tolerance.js
+++ b/examples/hit-tolerance.js
@@ -41,7 +41,7 @@ const statusElement = document.getElementById('status');
 
 map.on('singleclick', function(e) {
   let hit = false;
-  map.forEachFeatureAtPixel(e.pixel, function() {
+  map.forEachFeatureAtPixel(e.getPixel(), function() {
     hit = true;
   }, {
     hitTolerance: hitTolerance

--- a/examples/icon-negative.js
+++ b/examples/icon-negative.js
@@ -68,5 +68,5 @@ map.addInteraction(select);
 
 map.on('pointermove', function(evt) {
   map.getTargetElement().style.cursor =
-      map.hasFeatureAtPixel(evt.pixel) ? 'pointer' : '';
+      map.hasFeatureAtPixel(evt.getPixel()) ? 'pointer' : '';
 });

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -127,7 +127,7 @@ map.on('pointermove', function(evt) {
   if (map.getView().getInteracting()) {
     return;
   }
-  const pixel = evt.pixel;
+  const pixel = evt.getPixel();
   info.innerText = '';
   map.forEachFeatureAtPixel(pixel, function(feature) {
     const datetime = feature.get('datetime');

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -63,7 +63,7 @@ map.addOverlay(popup);
 
 // display popup on click
 map.on('click', function(evt) {
-  const feature = map.forEachFeatureAtPixel(evt.pixel,
+  const feature = map.forEachFeatureAtPixel(evt.getPixel(),
     function(feature) {
       return feature;
     });

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -140,7 +140,7 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displaySnap(evt.coordinate);
+  displaySnap(evt.getCoordinate());
 });
 
 const stroke = new Stroke({

--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -88,5 +88,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -92,5 +92,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -100,5 +100,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/kml.js
+++ b/examples/kml.js
@@ -57,5 +57,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -106,7 +106,7 @@ const pointerMoveHandler = function(evt) {
   }
 
   helpTooltipElement.innerHTML = helpMsg;
-  helpTooltip.setPosition(evt.coordinate);
+  helpTooltip.setPosition(evt.getCoordinate());
 
   helpTooltipElement.classList.remove('hidden');
 };
@@ -206,7 +206,7 @@ function addInteraction() {
       sketch = evt.feature;
 
       /** @type {import("../src/ol/coordinate.js").Coordinate|undefined} */
-      let tooltipCoord = evt.coordinate;
+      let tooltipCoord = evt.getCoordinate();
 
       listener = sketch.getGeometry().on('change', function(evt) {
         const geom = evt.target;

--- a/examples/overlay.js
+++ b/examples/overlay.js
@@ -46,7 +46,7 @@ map.addOverlay(popup);
 
 map.on('click', function(evt) {
   const element = popup.getElement();
-  const coordinate = evt.coordinate;
+  const coordinate = evt.getCoordinate();
   const hdms = toStringHDMS(toLonLat(coordinate));
 
   $(element).popover('destroy');

--- a/examples/popup.js
+++ b/examples/popup.js
@@ -64,7 +64,7 @@ const map = new Map({
  * Add a click handler to the map to render the popup.
  */
 map.on('singleclick', function(evt) {
-  const coordinate = evt.coordinate;
+  const coordinate = evt.getCoordinate();
   const hdms = toStringHDMS(toLonLat(coordinate));
 
   content.innerHTML = '<p>You clicked here:</p><code>' + hdms +

--- a/examples/region-growing.js
+++ b/examples/region-growing.js
@@ -106,7 +106,7 @@ const map = new Map({
 let coordinate;
 
 map.on('click', function(event) {
-  coordinate = event.coordinate;
+  coordinate = event.getCoordinate();
   raster.changed();
 });
 

--- a/examples/synthetic-points.js
+++ b/examples/synthetic-points.js
@@ -90,7 +90,7 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displaySnap(evt.coordinate);
+  displaySnap(evt.getCoordinate());
 });
 
 const stroke = new Stroke({

--- a/examples/utfgrid.js
+++ b/examples/utfgrid.js
@@ -68,5 +68,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayCountryInfo(evt.coordinate);
+  displayCountryInfo(evt.getCoordinate());
 });

--- a/examples/vector-esri.js
+++ b/examples/vector-esri.js
@@ -138,5 +138,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -110,5 +110,5 @@ map.on('pointermove', function(evt) {
 });
 
 map.on('click', function(evt) {
-  displayFeatureInfo(evt.pixel);
+  displayFeatureInfo(evt.getPixel());
 });

--- a/examples/vector-tile-info.js
+++ b/examples/vector-tile-info.js
@@ -22,7 +22,7 @@ map.on('pointermove', showInfo);
 
 const info = document.getElementById('info');
 function showInfo(event) {
-  const features = map.getFeaturesAtPixel(event.pixel);
+  const features = map.getFeaturesAtPixel(event.getPixel());
   if (!features) {
     info.innerText = '';
     info.style.opacity = 0;

--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -45,7 +45,7 @@ const map = new Map({
 const selectElement = document.getElementById('type');
 
 map.on('click', function(event) {
-  const features = map.getFeaturesAtPixel(event.pixel);
+  const features = map.getFeaturesAtPixel(event.getPixel());
   if (!features) {
     selection = {};
     // force redraw of layer style

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -32,16 +32,14 @@ class MapBrowserEvent extends MapEvent {
     /**
      * The map pixel relative to the viewport corresponding to the original browser event.
      * @type {import("./pixel.js").Pixel}
-     * @api
      */
-    this.pixel = map.getEventPixel(browserEvent);
+    this.pixel_ = null;
 
     /**
      * The coordinate in view projection corresponding to the original browser event.
      * @type {import("./coordinate.js").Coordinate}
-     * @api
      */
-    this.coordinate = map.getCoordinateFromPixel(this.pixel);
+    this.coordinate_ = null;
 
     /**
      * Indicates if the map is currently being dragged. Only set for
@@ -52,6 +50,28 @@ class MapBrowserEvent extends MapEvent {
      */
     this.dragging = opt_dragging !== undefined ? opt_dragging : false;
 
+  }
+
+  /**
+   * @return {import("./pixel.js").Pixel} The map pixel relative to the viewport corresponding to the original browser event.
+   * @api
+   */
+  getPixel() {
+    if (!this.pixel_) {
+      this.pixel_ = this.map.getEventPixel(this.originalEvent);
+    }
+    return this.pixel_;
+  }
+
+  /**
+   * @return {import("./coordinate.js").Coordinate} The coordinate in view projection corresponding to the original browser event.
+   * @api
+   */
+  getCoordinate() {
+    if (!this.coordinate_) {
+      this.coordinate_ = this.map.getCoordinateFromPixel(this.getPixel());
+    }
+    return this.coordinate_;
   }
 
   /**

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -931,7 +931,7 @@ class PluggableMap extends BaseObject {
       }
       target = target.parentElement;
     }
-    this.focus_ = mapBrowserEvent.coordinate;
+    this.focus_ = mapBrowserEvent.getCoordinate();
     mapBrowserEvent.frameState = this.frameState_;
     const interactionsArray = this.getInteractions().getArray();
     if (this.dispatchEvent(mapBrowserEvent) !== false) {

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -58,7 +58,7 @@ function handleEvent(mapBrowserEvent) {
   if (mapBrowserEvent.type == MapBrowserEventType.DBLCLICK) {
     const browserEvent = /** @type {MouseEvent} */ (mapBrowserEvent.originalEvent);
     const map = mapBrowserEvent.map;
-    const anchor = mapBrowserEvent.coordinate;
+    const anchor = mapBrowserEvent.getCoordinate();
     const delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;
     const view = map.getView();
     zoomByDelta(view, delta, anchor, this.duration_);

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -190,10 +190,10 @@ class DragBox extends PointerInteraction {
       return;
     }
 
-    this.box_.setPixels(this.startPixel_, mapBrowserEvent.pixel);
+    this.box_.setPixels(this.startPixel_, mapBrowserEvent.getPixel());
 
     this.dispatchEvent(new DragBoxEvent(DragBoxEventType.BOXDRAG,
-      mapBrowserEvent.coordinate, mapBrowserEvent));
+      mapBrowserEvent.getCoordinate(), mapBrowserEvent));
   }
 
   /**
@@ -206,10 +206,10 @@ class DragBox extends PointerInteraction {
 
     this.box_.setMap(null);
 
-    if (this.boxEndCondition_(mapBrowserEvent, this.startPixel_, mapBrowserEvent.pixel)) {
+    if (this.boxEndCondition_(mapBrowserEvent, this.startPixel_, mapBrowserEvent.getPixel())) {
       this.onBoxEnd_(mapBrowserEvent);
       this.dispatchEvent(new DragBoxEvent(DragBoxEventType.BOXEND,
-        mapBrowserEvent.coordinate, mapBrowserEvent));
+        mapBrowserEvent.getCoordinate(), mapBrowserEvent));
     }
     return false;
   }
@@ -224,11 +224,11 @@ class DragBox extends PointerInteraction {
 
     if (mouseActionButton(mapBrowserEvent) &&
         this.condition_(mapBrowserEvent)) {
-      this.startPixel_ = mapBrowserEvent.pixel;
+      this.startPixel_ = mapBrowserEvent.getPixel();
       this.box_.setMap(mapBrowserEvent.map);
       this.box_.setPixels(this.startPixel_, this.startPixel_);
       this.dispatchEvent(new DragBoxEvent(DragBoxEventType.BOXSTART,
-        mapBrowserEvent.coordinate, mapBrowserEvent));
+        mapBrowserEvent.getCoordinate(), mapBrowserEvent));
       return true;
     } else {
       return false;

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -73,7 +73,7 @@ class DragRotate extends PointerInteraction {
       return;
     }
     const size = map.getSize();
-    const offset = mapBrowserEvent.pixel;
+    const offset = mapBrowserEvent.getPixel();
     const theta =
         Math.atan2(size[1] / 2 - offset[1], offset[0] - size[0] / 2);
     if (this.lastAngle_ !== undefined) {

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -79,7 +79,7 @@ class DragRotateAndZoom extends PointerInteraction {
 
     const map = mapBrowserEvent.map;
     const size = map.getSize();
-    const offset = mapBrowserEvent.pixel;
+    const offset = mapBrowserEvent.getPixel();
     const deltaX = offset[0] - size[0] / 2;
     const deltaY = size[1] / 2 - offset[1];
     const theta = Math.atan2(deltaY, deltaX);

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -484,7 +484,7 @@ class Draw extends PointerInteraction {
     if (!this.freehand_ && this.lastDragTime_ && event.type === MapBrowserEventType.POINTERDRAG) {
       const now = Date.now();
       if (now - this.lastDragTime_ >= this.dragVertexDelay_) {
-        this.downPx_ = event.pixel;
+        this.downPx_ = event.getPixel();
         this.shouldHandle_ = !this.freehand_;
         move = true;
       } else {
@@ -525,7 +525,7 @@ class Draw extends PointerInteraction {
     this.shouldHandle_ = !this.freehand_;
 
     if (this.freehand_) {
-      this.downPx_ = event.pixel;
+      this.downPx_ = event.getPixel();
       if (!this.finishCoordinate_) {
         this.startDrawing_(event);
       }
@@ -536,7 +536,7 @@ class Draw extends PointerInteraction {
         this.handlePointerMove_(new MapBrowserPointerEvent(
           MapBrowserEventType.POINTERMOVE, event.map, event.pointerEvent, false, event.frameState));
       }.bind(this), this.dragVertexDelay_);
-      this.downPx_ = event.pixel;
+      this.downPx_ = event.getPixel();
       return true;
     } else {
       this.lastDragTime_ = undefined;
@@ -597,7 +597,7 @@ class Draw extends PointerInteraction {
         ((!this.freehand_ && this.shouldHandle_) ||
         (this.freehand_ && !this.shouldHandle_))) {
       const downPx = this.downPx_;
-      const clickPx = event.pixel;
+      const clickPx = event.getPixel();
       const dx = downPx[0] - clickPx[0];
       const dy = downPx[1] - clickPx[1];
       const squaredDistance = dx * dx + dy * dy;
@@ -640,7 +640,7 @@ class Draw extends PointerInteraction {
         for (let i = 0, ii = potentiallyFinishCoordinates.length; i < ii; i++) {
           const finishCoordinate = potentiallyFinishCoordinates[i];
           const finishPixel = map.getPixelFromCoordinate(finishCoordinate);
-          const pixel = event.pixel;
+          const pixel = event.getPixel();
           const dx = pixel[0] - finishPixel[0];
           const dy = pixel[1] - finishPixel[1];
           const snapTolerance = this.freehand_ ? 1 : this.snapTolerance_;
@@ -660,7 +660,7 @@ class Draw extends PointerInteraction {
    * @private
    */
   createOrUpdateSketchPoint_(event) {
-    const coordinates = event.coordinate.slice();
+    const coordinates = event.getCoordinate().slice();
     if (!this.sketchPoint_) {
       this.sketchPoint_ = new Feature(new Point(coordinates));
       this.updateSketchFeatures_();
@@ -676,7 +676,7 @@ class Draw extends PointerInteraction {
    * @private
    */
   startDrawing_(event) {
-    const start = event.coordinate;
+    const start = event.getCoordinate();
     this.finishCoordinate_ = start;
     if (this.mode_ === Mode.POINT) {
       this.sketchCoords_ = start.slice();
@@ -706,7 +706,7 @@ class Draw extends PointerInteraction {
    * @private
    */
   modifyDrawing_(event) {
-    let coordinate = event.coordinate;
+    let coordinate = event.getCoordinate();
     const geometry = this.sketchFeature_.getGeometry();
     let coordinates, last;
     if (this.mode_ === Mode.POINT) {
@@ -759,7 +759,7 @@ class Draw extends PointerInteraction {
    * @private
    */
   addToDrawing_(event) {
-    const coordinate = event.coordinate;
+    const coordinate = event.getCoordinate();
     const geometry = this.sketchFeature_.getGeometry();
     let done;
     let coordinates;

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -217,7 +217,7 @@ class Extent extends PointerInteraction {
    * @private
    */
   handlePointerMove_(mapBrowserEvent) {
-    const pixel = mapBrowserEvent.pixel;
+    const pixel = mapBrowserEvent.getPixel();
     const map = mapBrowserEvent.map;
 
     let vertex = this.snapToVertex_(pixel, map);
@@ -292,7 +292,7 @@ class Extent extends PointerInteraction {
    * @inheritDoc
    */
   handleDownEvent(mapBrowserEvent) {
-    const pixel = mapBrowserEvent.pixel;
+    const pixel = mapBrowserEvent.getPixel();
     const map = mapBrowserEvent.map;
 
     const extent = this.getExtent();
@@ -350,7 +350,7 @@ class Extent extends PointerInteraction {
    */
   handleDragEvent(mapBrowserEvent) {
     if (this.pointerHandler_) {
-      const pixelCoordinate = mapBrowserEvent.coordinate;
+      const pixelCoordinate = mapBrowserEvent.getCoordinate();
       this.setExtent(this.pointerHandler_(pixelCoordinate));
       this.createOrUpdatePointerFeature_(pixelCoordinate);
     }

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -163,7 +163,7 @@ class MouseWheelZoom extends Interaction {
     const wheelEvent = /** @type {WheelEvent} */ (mapBrowserEvent.originalEvent);
 
     if (this.useAnchor_) {
-      this.lastAnchor_ = mapBrowserEvent.coordinate;
+      this.lastAnchor_ = mapBrowserEvent.getCoordinate();
     }
 
     // Delta normalisation inspired by

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -394,7 +394,7 @@ function handleEvent(mapBrowserEvent) {
     // pixel, or clear the selected feature(s) if there is no feature at
     // the pixel.
     clear(this.featureLayerAssociation_);
-    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
+    map.forEachFeatureAtPixel(mapBrowserEvent.getPixel(),
       (
         /**
          * @param {import("../Feature.js").FeatureLike} feature Feature.
@@ -427,7 +427,7 @@ function handleEvent(mapBrowserEvent) {
     }
   } else {
     // Modify the currently selected feature(s).
-    map.forEachFeatureAtPixel(mapBrowserEvent.pixel,
+    map.forEachFeatureAtPixel(mapBrowserEvent.getPixel(),
       (
         /**
          * @param {import("../Feature.js").FeatureLike} feature Feature.

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -172,9 +172,9 @@ class Translate extends PointerInteraction {
    * @inheritDoc
    */
   handleDownEvent(event) {
-    this.lastFeature_ = this.featuresAtPixel_(event.pixel, event.map);
+    this.lastFeature_ = this.featuresAtPixel_(event.getPixel(), event.map);
     if (!this.lastCoordinate_ && this.lastFeature_) {
-      this.lastCoordinate_ = event.coordinate;
+      this.lastCoordinate_ = event.getCoordinate();
       this.handleMoveEvent(event);
 
       const features = this.features_ || new Collection([this.lastFeature_]);
@@ -182,7 +182,7 @@ class Translate extends PointerInteraction {
       this.dispatchEvent(
         new TranslateEvent(
           TranslateEventType.TRANSLATESTART, features,
-          event.coordinate));
+          event.getCoordinate()));
       return true;
     }
     return false;
@@ -201,7 +201,7 @@ class Translate extends PointerInteraction {
       this.dispatchEvent(
         new TranslateEvent(
           TranslateEventType.TRANSLATEEND, features,
-          event.coordinate));
+          event.getCoordinate()));
       return true;
     }
     return false;
@@ -212,7 +212,7 @@ class Translate extends PointerInteraction {
    */
   handleDragEvent(event) {
     if (this.lastCoordinate_) {
-      const newCoordinate = event.coordinate;
+      const newCoordinate = event.getCoordinate();
       const deltaX = newCoordinate[0] - this.lastCoordinate_[0];
       const deltaY = newCoordinate[1] - this.lastCoordinate_[1];
 
@@ -240,7 +240,7 @@ class Translate extends PointerInteraction {
 
     // Change the cursor to grab/grabbing if hovering any of the features managed
     // by the interaction
-    if (this.featuresAtPixel_(event.pixel, event.map)) {
+    if (this.featuresAtPixel_(event.getPixel(), event.map)) {
       elem.classList.remove(this.lastCoordinate_ ? 'ol-grab' : 'ol-grabbing');
       elem.classList.add(this.lastCoordinate_ ? 'ol-grabbing' : 'ol-grab');
     } else {

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -539,7 +539,7 @@ describe('ol.interaction.Draw', function() {
         source: source,
         type: 'LineString',
         finishCondition: function(event) {
-          if (equals(event.coordinate, [30, -20])) {
+          if (equals(event.getCoordinate(), [30, -20])) {
             return true;
           }
           return false;
@@ -1152,7 +1152,7 @@ describe('ol.interaction.Draw', function() {
       // move to first quadrant
       simulateEvent('pointermove', 79, 80);
       let event = simulateEvent('pointermove', 80, 80);
-      let coordinate = event.coordinate;
+      let coordinate = event.getCoordinate();
       const firstQuadrantCoordinate = draw.sketchFeature_.getGeometry().getFirstCoordinate();
       expect(firstQuadrantCoordinate[0]).to.roughlyEqual(coordinate[0], 1e-9);
       expect(firstQuadrantCoordinate[1]).to.roughlyEqual(coordinate[1], 1e-9);
@@ -1160,7 +1160,7 @@ describe('ol.interaction.Draw', function() {
       // move to second quadrant
       simulateEvent('pointermove', 41, 80);
       event = simulateEvent('pointermove', 40, 80);
-      coordinate = event.coordinate;
+      coordinate = event.getCoordinate();
       const secondQuadrantCoordinate = draw.sketchFeature_.getGeometry().getFirstCoordinate();
       expect(secondQuadrantCoordinate[0]).to.roughlyEqual(coordinate[0], 1e-9);
       expect(secondQuadrantCoordinate[1]).to.roughlyEqual(coordinate[1], 1e-9);
@@ -1168,7 +1168,7 @@ describe('ol.interaction.Draw', function() {
       // move to third quadrant
       simulateEvent('pointermove', 40, 41);
       event = simulateEvent('pointermove', 40, 40);
-      coordinate = event.coordinate;
+      coordinate = event.getCoordinate();
       const thirdQuadrantCoordinate = draw.sketchFeature_.getGeometry().getFirstCoordinate();
       expect(thirdQuadrantCoordinate[0]).to.roughlyEqual(coordinate[0], 1e-9);
       expect(thirdQuadrantCoordinate[1]).to.roughlyEqual(coordinate[1], 1e-9);
@@ -1176,7 +1176,7 @@ describe('ol.interaction.Draw', function() {
       // move to fourth quadrant
       simulateEvent('pointermove', 79, 40);
       event = simulateEvent('pointermove', 80, 40);
-      coordinate = event.coordinate;
+      coordinate = event.getCoordinate();
       const fourthQuadrantCoordinate = draw.sketchFeature_.getGeometry().getFirstCoordinate();
       expect(fourthQuadrantCoordinate[0]).to.roughlyEqual(coordinate[0], 1e-9);
       expect(fourthQuadrantCoordinate[1]).to.roughlyEqual(coordinate[1], 1e-9);

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -2,7 +2,7 @@ import Map from '../../../../src/ol/Map.js';
 import MapBrowserEvent from '../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../src/ol/View.js';
 import Event from '../../../../src/ol/events/Event.js';
-import {DEVICE_PIXEL_RATIO, FIREFOX} from '../../../../src/ol/has.js';
+import {DEVICE_PIXEL_RATIO, FIREFOX, SAFARI} from '../../../../src/ol/has.js';
 import MouseWheelZoom, {Mode} from '../../../../src/ol/interaction/MouseWheelZoom.js';
 
 
@@ -76,7 +76,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
           target: map.getViewport(),
           preventDefault: Event.prototype.preventDefault
         });
-        event.coordinate = [0, 0];
+        event.coordinate_ = [0, 0];
         map.handleMapBrowserEvent(event);
       });
     }
@@ -94,7 +94,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
           target: map.getViewport(),
           preventDefault: Event.prototype.preventDefault
         });
-        event.coordinate = [0, 0];
+        event.coordinate_ = [0, 0];
         map.handleMapBrowserEvent(event);
       });
     }
@@ -125,29 +125,52 @@ describe('ol.interaction.MouseWheelZoom', function() {
           target: map.getViewport(),
           preventDefault: Event.prototype.preventDefault
         });
-        event.coordinate = [0, 0];
+        event.coordinate_ = [0, 0];
 
         map.handleMapBrowserEvent(event);
       });
 
-      it('works on all browsers (wheel)', function(done) {
-        map.once('postrender', function() {
-          const call = view.animateInternal.getCall(0);
-          expect(call.args[0].resolution).to.be(2);
-          expect(call.args[0].anchor).to.eql([0, 0]);
-          done();
-        });
+      if (SAFARI) {
+        it('works on Safari (wheel)', function(done) {
+          map.once('postrender', function() {
+            const call = view.animate.getCall(0);
+            expect(call.args[0].resolution).to.be(2);
+            expect(call.args[0].anchor).to.eql([0, 0]);
+            done();
+          });
 
-        const event = new MapBrowserEvent('wheel', map, {
-          type: 'wheel',
-          deltaY: 120,
-          target: map.getViewport(),
-          preventDefault: Event.prototype.preventDefault
-        });
-        event.coordinate = [0, 0];
+          const event = new MapBrowserEvent('mousewheel', map, {
+            type: 'mousewheel',
+            wheelDeltaY: -50,
+            target: map.getViewport(),
+            preventDefault: Event.prototype.preventDefault
+          });
+          event.coordinate_ = [0, 0];
 
-        map.handleMapBrowserEvent(event);
-      });
+          map.handleMapBrowserEvent(event);
+        });
+      }
+
+      if (!SAFARI) {
+        it('works on other browsers (wheel)', function(done) {
+          map.once('postrender', function() {
+            const call = view.animate.getCall(0);
+            expect(call.args[0].resolution).to.be(2);
+            expect(call.args[0].anchor).to.eql([0, 0]);
+            done();
+          });
+
+          const event = new MapBrowserEvent('mousewheel', map, {
+            type: 'mousewheel',
+            wheelDeltaY: -120,
+            target: map.getViewport(),
+            preventDefault: Event.prototype.preventDefault
+          });
+          event.coordinate_ = [0, 0];
+
+          map.handleMapBrowserEvent(event);
+        });
+      }
 
     });
 

--- a/test/spec/ol/interaction/snap.test.js
+++ b/test/spec/ol/interaction/snap.test.js
@@ -69,7 +69,7 @@ describe('ol.interaction.Snap', function() {
       };
       snapInteraction.handleEvent(event);
       // check that the coordinate is in XY and not XYZ
-      expect(event.coordinate).to.eql([0, 0]);
+      expect(event.getCoordinate()).to.eql([0, 0]);
     });
 
     it('snaps to edges only', function() {
@@ -87,7 +87,7 @@ describe('ol.interaction.Snap', function() {
         map: map
       };
       snapInteraction.handleEvent(event);
-      expect(event.coordinate).to.eql([7, 0]);
+      expect(event.getCoordinate()).to.eql([7, 0]);
     });
 
     it('snaps to vertices only', function() {
@@ -105,7 +105,7 @@ describe('ol.interaction.Snap', function() {
         map: map
       };
       snapInteraction.handleEvent(event);
-      expect(event.coordinate).to.eql([10, 0]);
+      expect(event.getCoordinate()).to.eql([10, 0]);
     });
 
     it('snaps to circle', function() {
@@ -123,8 +123,9 @@ describe('ol.interaction.Snap', function() {
       };
       snapInteraction.handleEvent(event);
 
-      expect(event.coordinate[0]).to.roughlyEqual(Math.sin(Math.PI / 4) * 10, 1e-10);
-      expect(event.coordinate[1]).to.roughlyEqual(Math.sin(Math.PI / 4) * 10, 1e-10);
+      const coordinate = event.getCoordinate();
+      expect(coordinate[0]).to.roughlyEqual(Math.sin(Math.PI / 4) * 10, 1e-10);
+      expect(coordinate[1]).to.roughlyEqual(Math.sin(Math.PI / 4) * 10, 1e-10);
     });
 
     it('handle feature without geometry', function() {
@@ -144,7 +145,7 @@ describe('ol.interaction.Snap', function() {
         map: map
       };
       snapInteraction.handleEvent(event);
-      expect(event.coordinate).to.eql([10, 0]);
+      expect(event.getCoordinate()).to.eql([10, 0]);
     });
 
     it('handle geometry changes', function() {
@@ -164,7 +165,7 @@ describe('ol.interaction.Snap', function() {
         map: map
       };
       snapInteraction.handleEvent(event);
-      expect(event.coordinate).to.eql([10, 0]);
+      expect(event.getCoordinate()).to.eql([10, 0]);
     });
 
     it('handle geometry name changes', function() {
@@ -187,7 +188,7 @@ describe('ol.interaction.Snap', function() {
         map: map
       };
       snapInteraction.handleEvent(event);
-      expect(event.coordinate).to.eql([10, 0]);
+      expect(event.getCoordinate()).to.eql([10, 0]);
     });
 
 


### PR DESCRIPTION
With this breaking change we save a lot of useless work pre-calculating pixel and coordinate of a `MapBrowserEvent`. Instead, we now provide `getCoordinate()` and `getPixel()` functions on the event object.

See #9403.