### PR TITLE
Fix "Box" value example

### DIFF
--- a/examples/draw-shapes.js
+++ b/examples/draw-shapes.js
@@ -35,7 +35,7 @@ function addInteraction() {
       value = 'Circle';
       geometryFunction = createRegularPolygon(4);
     } else if (value === 'Box') {
-      value = 'Circle';
+      value = 'Box';
       geometryFunction = createBox();
     } else if (value === 'Star') {
       value = 'Circle';


### PR DESCRIPTION
The "Box" example was previously using "Circle".  This simply fixes the example.