### PR TITLE
Fix WebGL warnings (closes #9730)

### DIFF
--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -192,6 +192,8 @@ class Heatmap extends VectorLayer {
 
         varying vec2 v_texCoord;
         varying float v_opacity;
+        varying vec4 v_color;
+
 
         void main(void) {
           vec4 offsets = u_offsetScaleMatrix * vec4(a_offsets, 0.0, 0.0);


### PR DESCRIPTION
Hey.

This, at least here on my tests on both Chrome and Firefox, fix the WebGL warnings reported by #9730. I don't know if this is the optimal solution, even because I don't know WebGL a lot....but given the firefox error (reported below) I was able to fix the problem.

![image](https://user-images.githubusercontent.com/529864/64050994-157f5780-cb50-11e9-87d2-44d819e2d8fa.png)

I'm not sure about how to add regression/tests so this warning never happens again. I accept ideas here. :)
