### PR TITLE
Misc. WebGL fixes

### DIFF
--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -17,7 +17,7 @@ const vectorSource = new Vector({
   attributions: 'National UFO Reporting Center'
 });
 
-const texture = document.createElement('img');
+const texture = new Image();
 texture.src = 'data/ufo_shapes.png';
 
 // This describes the content of the associated sprite sheet
@@ -135,4 +135,8 @@ map.on('pointermove', function(evt) {
     const shape = feature.get('shape');
     info.innerText = 'On ' + datetime + ', lasted ' + duration + ' seconds and had a "' + shape + '" shape.';
   });
+});
+
+texture.addEventListener('load', function() {
+  map.render();
 });

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -544,6 +544,12 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    * @param {import("../../PluggableMap.js").FrameState} frameState current frame state
    */
   renderHitDetection(frameState) {
+    // skip render entirely if vertices buffers for display & hit detection have different sizes
+    // this typically means both buffers are temporarily out of sync
+    if (this.hitVerticesBuffer_.getSize() !== this.verticesBuffer_.getSize()) {
+      return;
+    }
+
     this.hitRenderTarget_.setSize(frameState.size);
 
     this.helper.useProgram(this.hitProgram_);

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -344,7 +344,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    * @inheritDoc
    */
   renderFrame(frameState) {
-    const renderCount = this.indicesBuffer_.getArray() ? this.indicesBuffer_.getArray().length : 0;
+    const renderCount = this.indicesBuffer_.getSize();
     this.helper.drawElements(0, renderCount);
     this.helper.finalizeDraw(frameState);
     const canvas = this.helper.getCanvas();
@@ -561,7 +561,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.helper.enableAttributeArray(DefaultAttrib.ROTATE_WITH_VIEW, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 7);
     this.helper.enableAttributeArray(DefaultAttrib.COLOR, 4, FLOAT, bytesPerFloat * stride, bytesPerFloat * 8);
 
-    const renderCount = this.indicesBuffer_.getArray() ? this.indicesBuffer_.getArray().length : 0;
+    const renderCount = this.indicesBuffer_.getSize();
     this.helper.drawElements(0, renderCount);
   }
 }

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -245,7 +245,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     );
     this.hitProgram_ = this.helper.getProgram(
       HIT_FRAGMENT_SHADER,
-      options.vertexShader || VERTEX_SHADER
+      VERTEX_SHADER
     );
 
     this.sizeCallback_ = options.sizeCallback || function() {

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -336,6 +336,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
         } else {
           this.renderInstructions_ = new Float32Array(event.data.renderInstructions);
         }
+
+        this.getLayer().changed();
       }
     }.bind(this));
   }

--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -95,6 +95,7 @@ class WebGLArrayBuffer {
   }
 
   /**
+   * Will return null if the buffer was not initialized
    * @return {Float32Array|Uint32Array} Array.
    */
   getArray() {
@@ -106,6 +107,14 @@ class WebGLArrayBuffer {
    */
   getUsage() {
     return this.usage;
+  }
+
+  /**
+   * Will return 0 if the buffer is not initialized
+   * @return {number} Array size
+   */
+  getSize() {
+    return this.array ? this.array.length : 0;
   }
 }
 

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -539,7 +539,6 @@ class WebGLHelper extends Disposable {
     let textureSlot = 0;
     this.uniforms_.forEach(function(uniform) {
       value = typeof uniform.value === 'function' ? uniform.value(frameState) : uniform.value;
-
       // apply value based on type
       if (value instanceof HTMLCanvasElement || value instanceof HTMLImageElement || value instanceof ImageData) {
         // create a texture & put data
@@ -551,7 +550,11 @@ class WebGLHelper extends Disposable {
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, value);
+
+        const imageReady = !(value instanceof HTMLImageElement) || /** @type {HTMLImageElement} */(value).complete;
+        if (imageReady) {
+          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, value);
+        }
 
         // fill texture slots by increasing index
         gl.uniform1i(this.getUniformLocation(uniform.name), textureSlot++);

--- a/test/spec/ol/webgl/buffer.test.js
+++ b/test/spec/ol/webgl/buffer.test.js
@@ -75,4 +75,21 @@ describe('ol.webgl.Buffer', function() {
 
   });
 
+  describe('#getSize', function() {
+    let b;
+    beforeEach(function() {
+      b = new WebGLArrayBuffer(ARRAY_BUFFER);
+    });
+
+    it('returns 0 when the buffer array is not initialized', function() {
+      expect(b.getSize()).to.be(0);
+    });
+
+    it('returns the size of the array otherwise', function() {
+      b.ofSize(12);
+      expect(b.getSize()).to.be(12);
+    });
+
+  });
+
 });


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
Small changes in the internals of the webgl points renderer to avoid having warnings in the console.

Also the `icon-sprite-webgl` example now always renders correctly initially.

This is related to:
https://github.com/openlayers/openlayers/issues/9734
https://github.com/openlayers/openlayers/issues/9735
(hopefully it fixes all the errors but I'll have to double check in all browsers)

And fixes https://github.com/openlayers/openlayers/issues/9730
