### PR TITLE
Respect multiWorld: false when an explicit extent constraint would be respected

### DIFF
--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -82,6 +82,9 @@ export function createSnapToResolutions(resolutions, opt_smooth, opt_maxExtent) 
 
         const capped = Math.min(cappedMaxRes, resolution);
         const z = Math.floor(linearFindNearest(resolutions, capped, direction));
+        if (resolutions[z] > cappedMaxRes && z < resolutions.length - 1) {
+          return resolutions[z + 1];
+        }
         return resolutions[z];
       } else {
         return undefined;

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -430,6 +430,8 @@ describe('ol.View', function() {
 
         const defaultMaxRes = 156543.03392804097;
         const size = [512, 512];
+        const maxResolution = 160000;
+        const resolutions = [160000, 80000, 40000, 20000, 10000, 5000];
         function getConstraint(options) {
           return createResolutionConstraint(options).constraint;
         }
@@ -439,11 +441,60 @@ describe('ol.View', function() {
           expect(fn(defaultMaxRes, 0, size)).to.be(defaultMaxRes / 2);
         });
 
-        it('can be enabled by setting multiWorld to truet', function() {
+        it('can be enabled by setting multiWorld to true', function() {
           const fn = getConstraint({
             multiWorld: true
           });
           expect(fn(defaultMaxRes, 0, size)).to.be(defaultMaxRes);
+        });
+
+        it('disabled, with constrainResolution', function() {
+          const fn = getConstraint({
+            maxResolution: maxResolution,
+            constrainResolution: true
+          });
+          expect(fn(defaultMaxRes, 0, size)).to.be(defaultMaxRes / 2);
+        });
+
+        it('enabled, with constrainResolution', function() {
+          const fn = getConstraint({
+            maxResolution: maxResolution,
+            constrainResolution: true,
+            multiWorld: true
+          });
+          expect(fn(defaultMaxRes, 0, size)).to.be(maxResolution);
+        });
+
+        it('disabled, with resolutions array', function() {
+          const fn = getConstraint({
+            resolutions: resolutions
+          });
+          expect(fn(defaultMaxRes, 0, size)).to.be(defaultMaxRes / 2);
+        });
+
+        it('enabled, with resolutions array', function() {
+          const fn = getConstraint({
+            resolutions: resolutions,
+            multiWorld: true
+          });
+          expect(fn(defaultMaxRes, 0, size)).to.be(defaultMaxRes);
+        });
+
+        it('disabled, with resolutions array and constrainResolution', function() {
+          const fn = getConstraint({
+            resolutions: resolutions,
+            constrainResolution: true
+          });
+          expect(fn(defaultMaxRes, 0, size)).to.be(resolutions[2]);
+        });
+
+        it('enabled, with resolutions array and constrainResolution', function() {
+          const fn = getConstraint({
+            resolutions: resolutions,
+            constrainResolution: true,
+            multiWorld: true
+          });
+          expect(fn(defaultMaxRes, 0, size)).to.be(resolutions[0]);
         });
       });
 


### PR DESCRIPTION
Fixes #9577
Fixes #9937

The multiWorld: false constraint is currently not taken into account when constrainResolution is set or when an explicit resolutions array is specified, while an explicit extent constraint is respected in the same situations.  This pull request takes a global projection extent into consideration in that same situations that an explicit extent would be.  Also includes fix for #9937 which affected this but isn't specific to multiWorld: false

