### PR TITLE
caching of repetitive hitDetectionInstructions

### DIFF
--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -51,6 +51,7 @@ import {assign} from '../obj.js';
  * is defined by the z-index of the layer, the `zIndex` of the style and the render order of features.
  * Higher z-index means higher priority. Within the same z-index, a feature rendered before another has
  * higher priority.
+ * @property {boolean} [staticStyles=false] static styles, reduces memory-emptiness.
  * @property {import("../style/Style.js").StyleLike} [style] Layer style. See
  * {@link module:ol/style} for default style which will be used if this is not defined.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
@@ -89,6 +90,11 @@ class VectorTileLayer extends BaseVectorLayer {
 
     super(/** @type {import("./BaseVector.js").Options} */ (baseOptions));
 
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.staticStyles_ = options.staticStyles !== undefined ? options.staticStyles : false;
     const renderMode = options.renderMode || VectorTileRenderType.HYBRID;
     assert(renderMode == undefined ||
         renderMode == VectorTileRenderType.IMAGE ||
@@ -114,6 +120,13 @@ class VectorTileLayer extends BaseVectorLayer {
    */
   createRenderer() {
     return new CanvasVectorTileLayerRenderer(this);
+  }
+
+  /**
+   * @return {boolean} Static Styles.
+   */
+  getStaticStyles() {
+    return this.staticStyles_;
   }
 
   /**

--- a/src/ol/render/canvas/BuilderGroup.js
+++ b/src/ol/render/canvas/BuilderGroup.js
@@ -30,8 +30,9 @@ class BuilderGroup {
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} declutter Decluttering enabled.
+   * @param {object} cacheInstructions Shared hitDetectionInstructions cache, for the entire layer.
    */
-  constructor(tolerance, maxExtent, resolution, pixelRatio, declutter) {
+  constructor(tolerance, maxExtent, resolution, pixelRatio, declutter, cacheInstructions) {
 
     /**
      * @type {boolean}
@@ -74,6 +75,12 @@ class BuilderGroup {
      * @type {!Object<string, !Object<import("./BuilderType").default, Builder>>}
      */
     this.buildersByZIndex_ = {};
+
+    /**
+     * @private
+     * @type {object}
+     */
+    this.cacheInstructions_ = cacheInstructions || {};
   }
 
   /**
@@ -126,7 +133,7 @@ class BuilderGroup {
     if (replay === undefined) {
       const Constructor = BATCH_CONSTRUCTORS[builderType];
       replay = new Constructor(this.tolerance_, this.maxExtent_,
-        this.resolution_, this.pixelRatio_);
+        this.resolution_, this.pixelRatio_, this.cacheInstructions_);
       replays[builderType] = replay;
     }
     return replay;

--- a/src/ol/render/canvas/BuilderGroup.js
+++ b/src/ol/render/canvas/BuilderGroup.js
@@ -32,7 +32,7 @@ class BuilderGroup {
    * @param {boolean} declutter Decluttering enabled.
    * @param {object} cacheInstructions Shared hitDetectionInstructions cache, for the entire layer.
    */
-  constructor(tolerance, maxExtent, resolution, pixelRatio, declutter, cacheInstructions) {
+  constructor(tolerance, maxExtent, resolution, pixelRatio, declutter, cacheInstructions = {}) {
 
     /**
      * @type {boolean}

--- a/src/ol/render/canvas/LineStringBuilder.js
+++ b/src/ol/render/canvas/LineStringBuilder.js
@@ -58,13 +58,13 @@ class CanvasLineStringBuilder extends CanvasBuilder {
       state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
       state.miterLimit, state.lineDash, state.lineDashOffset
     ];
-		const keyHash = JSON.stringify(arr);
-		if (keyHash in this.cacheInstructions_) {
-			arr = this.cacheInstructions_[keyHash];
-		} else {
-			this.cacheInstructions_[keyHash] = arr;
-		}
-		this.hitDetectionInstructions.push(arr, beginPathInstruction);
+    const keyHash = JSON.stringify(arr);
+    if (keyHash in this.cacheInstructions_) {
+      arr = this.cacheInstructions_[keyHash];
+    } else {
+      this.cacheInstructions_[keyHash] = arr;
+    }
+    this.hitDetectionInstructions.push(arr, beginPathInstruction);
 
     const flatCoordinates = lineStringGeometry.getFlatCoordinates();
     const stride = lineStringGeometry.getStride();
@@ -91,12 +91,12 @@ class CanvasLineStringBuilder extends CanvasBuilder {
       state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
       state.miterLimit, state.lineDash, state.lineDashOffset
     ];
-		const keyHash = JSON.stringify(arr);
-		if (keyHash in this.cacheInstructions_) {
-			arr = this.cacheInstructions_[keyHash];
-		} else {
-			this.cacheInstructions_[keyHash] = arr;
-		}
+    const keyHash = JSON.stringify(arr);
+    if (keyHash in this.cacheInstructions_) {
+      arr = this.cacheInstructions_[keyHash];
+    } else {
+      this.cacheInstructions_[keyHash] = arr;
+    }
     this.hitDetectionInstructions.push(arr, beginPathInstruction);
     
     const ends = multiLineStringGeometry.getEnds();

--- a/src/ol/render/canvas/LineStringBuilder.js
+++ b/src/ol/render/canvas/LineStringBuilder.js
@@ -98,7 +98,7 @@ class CanvasLineStringBuilder extends CanvasBuilder {
       this.cacheInstructions_[keyHash] = arr;
     }
     this.hitDetectionInstructions.push(arr, beginPathInstruction);
-    
+
     const ends = multiLineStringGeometry.getEnds();
     const flatCoordinates = multiLineStringGeometry.getFlatCoordinates();
     const stride = multiLineStringGeometry.getStride();

--- a/src/ol/render/canvas/PolygonBuilder.js
+++ b/src/ol/render/canvas/PolygonBuilder.js
@@ -15,9 +15,15 @@ class CanvasPolygonBuilder extends CanvasBuilder {
    * @param {import("../../extent.js").Extent} maxExtent Maximum extent.
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
+   * @param {object} cacheInstructions Shared hitDetectionInstructions cache, for the entire layer.
    */
-  constructor(tolerance, maxExtent, resolution, pixelRatio) {
+  constructor(tolerance, maxExtent, resolution, pixelRatio, cacheInstructions) {
     super(tolerance, maxExtent, resolution, pixelRatio);
+    /**
+     * @private
+     * @type {object}
+     */
+    this.cacheInstructions_ = cacheInstructions || {};
   }
 
   /**
@@ -74,17 +80,31 @@ class CanvasPolygonBuilder extends CanvasBuilder {
     this.setFillStrokeStyles_();
     this.beginGeometry(circleGeometry, feature);
     if (state.fillStyle !== undefined) {
-      this.hitDetectionInstructions.push([
+      let arr = [
         CanvasInstruction.SET_FILL_STYLE,
         defaultFillStyle
-      ]);
+      ];
+      const keyHash = JSON.stringify(arr);
+      if (keyHash in this.cacheInstructions_) {
+        arr = this.cacheInstructions_[keyHash];
+      } else {
+        this.cacheInstructions_[keyHash] = arr;
+      }
+      this.hitDetectionInstructions.push(arr);
     }
     if (state.strokeStyle !== undefined) {
-      this.hitDetectionInstructions.push([
+      let arr = [
         CanvasInstruction.SET_STROKE_STYLE,
         state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
         state.miterLimit, state.lineDash, state.lineDashOffset
-      ]);
+      ];
+      const keyHash = JSON.stringify(arr);
+      if (keyHash in this.cacheInstructions_) {
+        arr = this.cacheInstructions_[keyHash];
+      } else {
+        this.cacheInstructions_[keyHash] = arr;
+      }
+      this.hitDetectionInstructions.push(arr);
     }
     const flatCoordinates = circleGeometry.getFlatCoordinates();
     const stride = circleGeometry.getStride();
@@ -118,17 +138,31 @@ class CanvasPolygonBuilder extends CanvasBuilder {
     this.setFillStrokeStyles_();
     this.beginGeometry(polygonGeometry, feature);
     if (state.fillStyle !== undefined) {
-      this.hitDetectionInstructions.push([
+      let arr = [
         CanvasInstruction.SET_FILL_STYLE,
         defaultFillStyle
-      ]);
+      ];
+      const keyHash = JSON.stringify(arr);
+      if (keyHash in this.cacheInstructions_) {
+        arr = this.cacheInstructions_[keyHash];
+      } else {
+        this.cacheInstructions_[keyHash] = arr;
+      }
+      this.hitDetectionInstructions.push(arr);
     }
     if (state.strokeStyle !== undefined) {
-      this.hitDetectionInstructions.push([
+      let arr = [
         CanvasInstruction.SET_STROKE_STYLE,
         state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
         state.miterLimit, state.lineDash, state.lineDashOffset
-      ]);
+      ];
+      const keyHash = JSON.stringify(arr);
+      if (keyHash in this.cacheInstructions_) {
+        arr = this.cacheInstructions_[keyHash];
+      } else {
+        this.cacheInstructions_[keyHash] = arr;
+      }
+      this.hitDetectionInstructions.push(arr);
     }
     const ends = polygonGeometry.getEnds();
     const flatCoordinates = polygonGeometry.getOrientedFlatCoordinates();
@@ -150,17 +184,31 @@ class CanvasPolygonBuilder extends CanvasBuilder {
     this.setFillStrokeStyles_();
     this.beginGeometry(multiPolygonGeometry, feature);
     if (state.fillStyle !== undefined) {
-      this.hitDetectionInstructions.push([
+      let arr = [
         CanvasInstruction.SET_FILL_STYLE,
         defaultFillStyle
-      ]);
+      ];
+      const keyHash = JSON.stringify(arr);
+      if (keyHash in this.cacheInstructions_) {
+        arr = this.cacheInstructions_[keyHash];
+      } else {
+        this.cacheInstructions_[keyHash] = arr;
+      }
+      this.hitDetectionInstructions.push(arr);
     }
     if (state.strokeStyle !== undefined) {
-      this.hitDetectionInstructions.push([
+      let arr = [
         CanvasInstruction.SET_STROKE_STYLE,
         state.strokeStyle, state.lineWidth, state.lineCap, state.lineJoin,
         state.miterLimit, state.lineDash, state.lineDashOffset
-      ]);
+      ];
+      const keyHash = JSON.stringify(arr);
+      if (keyHash in this.cacheInstructions_) {
+        arr = this.cacheInstructions_[keyHash];
+      } else {
+        this.cacheInstructions_[keyHash] = arr;
+      }
+      this.hitDetectionInstructions.push(arr);
     }
     const endss = multiPolygonGeometry.getEndss();
     const flatCoordinates = multiPolygonGeometry.getOrientedFlatCoordinates();

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -95,6 +95,12 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
     /**
      * @private
+     * @type {object}
+     */
+    this.cacheInstructions_ = layer.getStaticStyles() ? {} : undefined;
+
+    /**
+     * @private
      * @type {number}
      */
     this.renderedLayerRevision_;
@@ -279,7 +285,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
         buffer(sharedExtent, layer.getRenderBuffer() * resolution, this.tmpExtent);
       builderState.dirty = false;
       const builderGroup = new CanvasBuilderGroup(0, sharedExtent, resolution,
-        pixelRatio, layer.getDeclutter());
+        pixelRatio, layer.getDeclutter(), this.cacheInstructions_);
       const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
 
       /**


### PR DESCRIPTION
caching of repetitive `hitDetectionInstructions` in `LineStringBuilder.js`, `PolygonBuilder.js` for render `VectorTileLayer.js`

as the `staticStyles` option in `VectorTileLayer.js`, it reduces memory map of identical arrays with style instructions
effect visible with a large number of repetitive styles

https://github.com/openlayers/openlayers/issues/9875