### PR TITLE
Clone the text's padding

### DIFF
--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -184,7 +184,8 @@ class Text {
       offsetX: this.getOffsetX(),
       offsetY: this.getOffsetY(),
       backgroundFill: this.getBackgroundFill() ? this.getBackgroundFill().clone() : undefined,
-      backgroundStroke: this.getBackgroundStroke() ? this.getBackgroundStroke().clone() : undefined
+      backgroundStroke: this.getBackgroundStroke() ? this.getBackgroundStroke().clone() : undefined,
+      padding: this.getPadding()
     });
   }
 

--- a/test/spec/ol/style/text.test.js
+++ b/test/spec/ol/style/text.test.js
@@ -58,7 +58,8 @@ describe('ol.style.Text', function() {
         }),
         backgroundStroke: new Stroke({
           color: 'black'
-        })
+        }),
+        padding: [10, 11, 12, 13]
       });
       const clone = original.clone();
       expect(original.getFont()).to.eql(clone.getFont());
@@ -74,6 +75,7 @@ describe('ol.style.Text', function() {
       expect(original.getFill().getColor()).to.eql(clone.getFill().getColor());
       expect(original.getBackgroundStroke().getColor()).to.eql(clone.getBackgroundStroke().getColor());
       expect(original.getBackgroundFill().getColor()).to.eql(clone.getBackgroundFill().getColor());
+      expect(original.getPadding()).to.eql(clone.getPadding());
     });
 
     it('the clone does not reference the same objects as the original', function() {


### PR DESCRIPTION
When cloning an `ol.style.Text`, the padding was not cloned.
