### PR TITLE
Cancel postrender before disposing renderer

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -168,6 +168,12 @@ class PluggableMap extends BaseObject {
 
     /**
      * @private
+     * @type {*}
+     */
+    this.postRenderTimeoutHandle_;
+
+    /**
+     * @private
      * @type {number|undefined}
      */
     this.animationDelayKey_;
@@ -1022,6 +1028,8 @@ class PluggableMap extends BaseObject {
 
     if (!targetElement) {
       if (this.renderer_) {
+        clearTimeout(this.postRenderTimeoutHandle_);
+        this.postRenderFunctions_.length = 0;
         this.renderer_.dispose();
         this.renderer_ = null;
       }
@@ -1284,7 +1292,7 @@ class PluggableMap extends BaseObject {
 
     this.dispatchEvent(new MapEvent(MapEventType.POSTRENDER, this, frameState));
 
-    setTimeout(this.handlePostRender.bind(this), 0);
+    this.postRenderTimeoutHandle_ = setTimeout(this.handlePostRender.bind(this), 0);
 
   }
 


### PR DESCRIPTION
This pull request fixes issues like the one described in #9354. I encountered a similar issue when updating an Openlayers v5 application to v6: when `Map#setTarget` is used to show and hide the map, it can happen that `handlePostRender` is called after the renderer has been disposed of, so the `dispatchRenderEvent` call for the `rendercomplete` event fails. To avoid this, we need to cancel the `handlePostRender` timeout.