### PR TITLE
Correct extent clipping in ImageLayer

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -121,7 +121,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
           !containsExtent(extent, frameState.extent) &&
           intersects(extent, frameState.extent);
     if (clipped) {
-      this.clip(context, frameState, extent);
+      this.clipUnrotated(context, frameState, extent);
     }
 
     const img = image.getImage();


### PR DESCRIPTION
Fixes #9585

Clipping in image layers does not need to consider view rotation