### PR TITLE
Renaming getGetFeatureInfoUrl

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,7 +4,7 @@
 
 #### Backwards incompatible changes
 
-#### Removal of `TOUCH` constant from `ol/has`
+##### Removal of `TOUCH` constant from `ol/has`
 
 If you were previously using this constant, you can check if `'ontouchstart'` is defined in `window` instead.
 
@@ -14,7 +14,7 @@ if ('ontouchstart' in window) {
 }
 ```
 
-#### Removal of `GEOLOCATION` constant from `ol/has`
+##### Removal of `GEOLOCATION` constant from `ol/has`
 
 If you were previously using this constant, you can check if `'geolocation'` is defined in `navigator` instead.
 
@@ -24,7 +24,7 @@ if ('geolocation' in navigator) {
 }
 ```
 
-#### Removal of CSS print rules
+##### Removal of CSS print rules
 
 The CSS media print rules were removed from the `ol.css` file. To get the previous behavior, use the following CSS:
 
@@ -36,7 +36,7 @@ The CSS media print rules were removed from the `ol.css` file. To get the previo
 }
 ```
 
-#### Removal of optional this arguments
+##### Removal of optional this arguments
 
 The optional this (i.e. opt_this) arguments were removed from the following methods.
 Please use closures, the es6 arrow function or the bind method to achieve this effect (Bind is explained here:

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -254,6 +254,10 @@ The `ol/source/Vector#clear()` method no longer triggers a reload of the data fr
 
 The `ol/source/Vector#refresh()` method now removes all features from the source and triggers a reload of the data from the server. If you were previously using the `refresh()` method to re-render a vector layer, you should instead call `ol/layer/Vector#changed()`.
 
+##### Renaming of `getGetFeatureInfoUrl` to `getFeatureInfoUrl`
+
+The `getGetFeatureInfoUrl` of `ol/source/ImageWMS` and `ol/source/TileWMS` is now called `getFeatureInfoUrl`.
+
 #### Other changes
 
 ##### Allow declutter in image render mode

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -29,7 +29,7 @@ const map = new Map({
 map.on('singleclick', function(evt) {
   document.getElementById('info').innerHTML = '';
   const viewResolution = /** @type {number} */ (view.getResolution());
-  const url = wmsSource.getGetFeatureInfoUrl(
+  const url = wmsSource.getFeatureInfoUrl(
     evt.coordinate, viewResolution, 'EPSG:3857',
     {'INFO_FORMAT': 'text/html'});
   if (url) {

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -29,7 +29,7 @@ const map = new Map({
 map.on('singleclick', function(evt) {
   document.getElementById('info').innerHTML = '';
   const viewResolution = /** @type {number} */ (view.getResolution());
-  const url = wmsSource.getGetFeatureInfoUrl(
+  const url = wmsSource.getFeatureInfoUrl(
     evt.coordinate, viewResolution, 'EPSG:3857',
     {'INFO_FORMAT': 'text/html'});
   if (url) {

--- a/examples/wms-getlegendgraphic.html
+++ b/examples/wms-getlegendgraphic.html
@@ -4,11 +4,11 @@ title: WMS GetLegendGraphic
 shortdesc: Example of a WMS GetLegendGraphic.
 docs: >
   WMS supports the [getLegendGraphic request](https://docs.geoserver.org/latest/en/user/services/wms/get_legend_graphic/index.html).
-  This example demonstrates the use of the `getGetLegendGraphicUrl` method.
+  This example demonstrates the use of the `getLegendUrl` method.
 
 
   As a legend can be responsive to the scale it is updated on every change of the resolution.
-tags: "GetLegendGraphic, getGetLegendGraphicURL, WMS"
+tags: "GetLegendGraphic, getLegendUrl, WMS"
 ---
 <div id="map" class="map"></div>
 Legend:

--- a/examples/wms-getlegendgraphic.js
+++ b/examples/wms-getlegendgraphic.js
@@ -12,7 +12,7 @@ const wmsSource = new ImageWMS({
 });
 
 const updateLegend = function(resolution) {
-  const graphicUrl = wmsSource.getGetLegendGraphicUrl(resolution);
+  const graphicUrl = wmsSource.getLegendUrl(resolution);
   const img = document.getElementById('legend');
   img.src = graphicUrl;
 };

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -155,7 +155,7 @@ class ImageWMS extends ImageSource {
    * @return {string|undefined} GetFeatureInfo URL.
    * @api
    */
-  getGetFeatureInfoUrl(coordinate, resolution, projection, params) {
+  getFeatureInfoUrl(coordinate, resolution, projection, params) {
     if (this.url_ === undefined) {
       return undefined;
     }
@@ -202,7 +202,7 @@ class ImageWMS extends ImageSource {
    * @return {string|undefined} GetLegendGraphic URL.
    * @api
    */
-  getGetLegendGraphicUrl(resolution, params) {
+  getLegendUrl(resolution, params) {
     const layers = this.params_.LAYERS;
     const isSingleLayer = !Array.isArray(layers) || this.params_['LAYERS'].length === 1;
     if (this.url_ === undefined || !isSingleLayer) {

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -159,7 +159,7 @@ class TileWMS extends TileImage {
    * @return {string|undefined} GetFeatureInfo URL.
    * @api
    */
-  getGetFeatureInfoUrl(coordinate, resolution, projection, params) {
+  getFeatureInfoUrl(coordinate, resolution, projection, params) {
     const projectionObj = getProjection(projection);
     const sourceProjectionObj = this.getProjection();
 
@@ -224,7 +224,7 @@ class TileWMS extends TileImage {
    * @return {string|undefined} GetLegendGraphic URL.
    * @api
    */
-  getGetLegendGraphicUrl(resolution, params) {
+  getLegendUrl(resolution, params) {
     const layers = this.params_.LAYERS;
     const isSingleLayer = !Array.isArray(layers) || this.params_['LAYERS'].length === 1;
     if (this.urls[0] === undefined || !isSingleLayer) {

--- a/test/spec/ol/source/imagewms.test.js
+++ b/test/spec/ol/source/imagewms.test.js
@@ -243,11 +243,11 @@ describe('ol.source.ImageWMS', function() {
 
   });
 
-  describe('#getGetFeatureInfoUrl', function() {
+  describe('#getFeatureInfoUrl', function() {
 
     it('returns the expected GetFeatureInfo URL', function() {
       const source = new ImageWMS(options);
-      const url = source.getGetFeatureInfoUrl(
+      const url = source.getFeatureInfoUrl(
         [20, 30], resolution, projection,
         {INFO_FORMAT: 'text/plain'});
       const uri = new URL(url);
@@ -275,7 +275,7 @@ describe('ol.source.ImageWMS', function() {
 
     it('returns the expected GetFeatureInfo URL when source\'s projection is different from the parameter', function() {
       const source = new ImageWMS(optionsReproj);
-      const url = source.getGetFeatureInfoUrl(
+      const url = source.getFeatureInfoUrl(
         [20, 30], resolution, projection,
         {INFO_FORMAT: 'text/plain'});
       const uri = new URL(url);
@@ -303,7 +303,7 @@ describe('ol.source.ImageWMS', function() {
 
     it('sets the QUERY_LAYERS param as expected', function() {
       const source = new ImageWMS(options);
-      const url = source.getGetFeatureInfoUrl(
+      const url = source.getFeatureInfoUrl(
         [20, 30], resolution, projection,
         {INFO_FORMAT: 'text/plain', QUERY_LAYERS: 'foo,bar'});
       const uri = new URL(url);
@@ -330,11 +330,11 @@ describe('ol.source.ImageWMS', function() {
     });
   });
 
-  describe('#getGetLegendGraphicUrl', function() {
+  describe('#getLegendUrl', function() {
 
-    it('returns the getLegendGraphic url as expected', function() {
+    it('returns the GetLegendGraphic url as expected', function() {
       const source = new ImageWMS(options);
-      const url = source.getGetLegendGraphicUrl(resolution);
+      const url = source.getLegendUrl(resolution);
       const uri = new URL(url);
       expect(uri.protocol).to.be('http:');
       expect(uri.hostname).to.be('example.com');
@@ -350,7 +350,7 @@ describe('ol.source.ImageWMS', function() {
 
     it('does not include SCALE if no resolution was provided', function() {
       const source = new ImageWMS(options);
-      const url = source.getGetLegendGraphicUrl();
+      const url = source.getLegendUrl();
       const uri = new URL(url);
       const queryData = uri.searchParams;
       expect(queryData.get('SCALE')).to.be(null);
@@ -358,7 +358,7 @@ describe('ol.source.ImageWMS', function() {
 
     it('adds additional params as expected', function() {
       const source = new ImageWMS(options);
-      const url = source.getGetLegendGraphicUrl(resolution, {
+      const url = source.getLegendUrl(resolution, {
         STYLE: 'STYLE_VALUE',
         FEATURETYPE: 'FEATURETYPE_VALUE',
         RULE: 'RULE_VALUE',

--- a/test/spec/ol/source/tilewms.test.js
+++ b/test/spec/ol/source/tilewms.test.js
@@ -198,12 +198,12 @@ describe('ol.source.TileWMS', function() {
 
   });
 
-  describe('#getGetFeatureInfoUrl', function() {
+  describe('#getFeatureInfoUrl', function() {
 
     it('returns the expected GetFeatureInfo URL', function() {
       const source = new TileWMS(options);
       source.pixelRatio_ = 1;
-      const url = source.getGetFeatureInfoUrl(
+      const url = source.getFeatureInfoUrl(
         [-7000000, -12000000],
         19567.87924100512, getProjection('EPSG:3857'),
         {INFO_FORMAT: 'text/plain'});
@@ -237,7 +237,7 @@ describe('ol.source.TileWMS', function() {
     it('returns the expected GetFeatureInfo URL when source\'s projection is different from the parameter', function() {
       const source = new TileWMS(optionsReproj);
       source.pixelRatio_ = 1;
-      const url = source.getGetFeatureInfoUrl(
+      const url = source.getFeatureInfoUrl(
         [-7000000, -12000000],
         19567.87924100512, getProjection('EPSG:3857'),
         {INFO_FORMAT: 'text/plain'});
@@ -267,7 +267,7 @@ describe('ol.source.TileWMS', function() {
     it('sets the QUERY_LAYERS param as expected', function() {
       const source = new TileWMS(options);
       source.pixelRatio_ = 1;
-      const url = source.getGetFeatureInfoUrl(
+      const url = source.getFeatureInfoUrl(
         [-7000000, -12000000],
         19567.87924100512, getProjection('EPSG:3857'),
         {INFO_FORMAT: 'text/plain', QUERY_LAYERS: 'foo,bar'});
@@ -299,11 +299,11 @@ describe('ol.source.TileWMS', function() {
     });
   });
 
-  describe('#getGetLegendGraphicUrl', function() {
+  describe('#getLegendGraphicUrl', function() {
 
     it('returns the getLegenGraphic url as expected', function() {
       const source = new TileWMS(options);
-      const url = source.getGetLegendGraphicUrl(0.1);
+      const url = source.getLegendUrl(0.1);
       const uri = new URL(url);
       expect(uri.protocol).to.be('http:');
       expect(uri.hostname).to.be('example.com');
@@ -319,7 +319,7 @@ describe('ol.source.TileWMS', function() {
 
     it('does not include SCALE if no resolution was provided', function() {
       const source = new TileWMS(options);
-      const url = source.getGetLegendGraphicUrl();
+      const url = source.getLegendUrl();
       const uri = new URL(url);
       const queryData = uri.searchParams;
       expect(queryData.get('SCALE')).to.be(null);
@@ -327,7 +327,7 @@ describe('ol.source.TileWMS', function() {
 
     it('adds additional params as expected', function() {
       const source = new TileWMS(options);
-      const url = source.getGetLegendGraphicUrl(0.1, {
+      const url = source.getLegendUrl(0.1, {
         STYLE: 'STYLE_VALUE',
         FEATURETYPE: 'FEATURETYPE_VALUE',
         RULE: 'RULE_VALUE',


### PR DESCRIPTION
As discussed in #9831 here is a renaming of the `getGetFeatureInfoUrl` and `getGetLegendGraphicUrl` methods to `getFeatureInfoUrl` and `getLegendUrl`.

I found that some headlines in the upgrade notes were not formatted correctly so I changed that. If I should make a different PR for this, just say.