### PR TITLE
Use next lower resolution in constrained array if snap value exceeds extent cap

### DIFF
--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -82,6 +82,9 @@ export function createSnapToResolutions(resolutions, opt_smooth, opt_maxExtent) 
 
         const capped = Math.min(cappedMaxRes, resolution);
         const z = Math.floor(linearFindNearest(resolutions, capped, direction));
+        if (resolutions[z] > cappedMaxRes && z < resolutions.length - 1) {
+          return resolutions[z + 1];
+        }
         return resolutions[z];
       } else {
         return undefined;


### PR DESCRIPTION
Fixes #9937

Separated from #9903 so that commits for that can be simplified.  Merging this change is a prerequisite for a simplified version of #9903 as the tests require this fix.