### PR TITLE
Always dispatch pointermove events, but calculate event pixel and coordinate lazily

### DIFF
--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -32,16 +32,14 @@ class MapBrowserEvent extends MapEvent {
     /**
      * The map pixel relative to the viewport corresponding to the original browser event.
      * @type {import("./pixel.js").Pixel}
-     * @api
      */
-    this.pixel = map.getEventPixel(browserEvent);
+    this.pixel_ = null;
 
     /**
      * The coordinate in view projection corresponding to the original browser event.
      * @type {import("./coordinate.js").Coordinate}
-     * @api
      */
-    this.coordinate = map.getCoordinateFromPixel(this.pixel);
+    this.coordinate_ = null;
 
     /**
      * Indicates if the map is currently being dragged. Only set for
@@ -52,6 +50,36 @@ class MapBrowserEvent extends MapEvent {
      */
     this.dragging = opt_dragging !== undefined ? opt_dragging : false;
 
+  }
+
+  /**
+   * The map pixel relative to the viewport corresponding to the original browser event.
+   * @type {import("./pixel.js").Pixel}
+   * @api
+   */
+  get pixel() {
+    if (!this.pixel_) {
+      this.pixel_ = this.map.getEventPixel(this.originalEvent);
+    }
+    return this.pixel_;
+  }
+  set pixel(pixel) {
+    this.pixel_ = pixel;
+  }
+
+  /**
+   * The coordinate in view projection corresponding to the original browser event.
+   * @type {import("./coordinate.js").Coordinate}
+   * @api
+   */
+  get coordinate() {
+    if (!this.coordinate_) {
+      this.coordinate_ = this.map.getCoordinateFromPixel(this.pixel);
+    }
+    return this.coordinate_;
+  }
+  set coordinate(coordinate) {
+    this.coordinate_ = coordinate;
   }
 
   /**

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -247,11 +247,9 @@ class MapBrowserEventHandler extends EventTarget {
    * @private
    */
   relayEvent_(pointerEvent) {
-    if (this.map_.hasListener(pointerEvent.type)) {
-      const dragging = !!(this.down_ && this.isMoving_(pointerEvent));
-      this.dispatchEvent(new MapBrowserPointerEvent(
-        pointerEvent.type, this.map_, pointerEvent, dragging));
-    }
+    const dragging = !!(this.down_ && this.isMoving_(pointerEvent));
+    this.dispatchEvent(new MapBrowserPointerEvent(
+      pointerEvent.type, this.map_, pointerEvent, dragging));
   }
 
   /**

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -212,7 +212,6 @@ class RasterSource extends ImageSource {
       animate: false,
       coordinateToPixelTransform: createTransform(),
       extent: null,
-      focus: null,
       index: 0,
       layerIndex: 0,
       layerStatesArray: getLayerStatesArray(this.layers_),
@@ -286,7 +285,6 @@ class RasterSource extends ImageSource {
     const center = getCenter(extent);
 
     frameState.extent = extent.slice();
-    frameState.focus = center;
     frameState.size[0] = Math.round(getWidth(extent) / resolution);
     frameState.size[1] = Math.round(getHeight(extent) / resolution);
     frameState.time = Infinity;


### PR DESCRIPTION
With the changes made in #9889, it is no longer possible to set a condition on an interaction that involves a `pointermove` event.

This change makes it so we return to always dispatching `pointermove` events, but lazily calculate the coordinate and pixel of the event, which was the main reason for not always dispatching `pointermove`.

To avoid the need for pixel and coordinate calculation, I also removed the frame state's `focus` property, which was only used to prioritize tile loading. We now use the map center instead.