### PR TITLE
Enable HTTPS on Mapbox tile layer in webgl sprite example

### DIFF
--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -107,7 +107,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new TileJSON({
-        url: 'https://api.tiles.mapbox.com/v4/mapbox.world-dark.json?access_token=' + key,
+        url: 'https://api.tiles.mapbox.com/v4/mapbox.world-dark.json?secure&access_token=' + key,
         crossOrigin: 'anonymous'
       })
     }),


### PR DESCRIPTION
This addresses the mixed-content errors mentioned here: https://github.com/openlayers/openlayers/issues/9734#issuecomment-526830280

Thanks for any review