### PR TITLE
Dev version based on time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm ci
       - name: Publish
         run: |
-          VERSION=$(npx semver $(npm view ol@dev version) --increment prerelease --preid dev)
+          VERSION=$(node tasks/next-dev-version.js)
           npm --no-git-tag-version version ${VERSION}
           npm run build-package
           cd build/ol

--- a/tasks/next-dev-version.js
+++ b/tasks/next-dev-version.js
@@ -1,0 +1,14 @@
+const version = require('../package.json').version;
+const semver = require('semver');
+
+function nextVersion() {
+  const s = semver.parse(version);
+  if (!s) {
+    throw new Error(`Invalid version ${version}`);
+  }
+  return `${s.major}.${s.minor}.${s.patch}-dev.${Date.now()}`;
+}
+
+if (require.main === module) {
+  process.stdout.write(`${nextVersion()}\n`);
+}


### PR DESCRIPTION
Currently, we pick increment the prerelease id based on the latest `dev` release published to npm.  This means that if we merge two pull requests in close succession, the second will fail if it checked the latest version before the first was complete.

This branch changes things so we still have a race, but it only occurs if two jobs start in the same millisecond.