### PR TITLE
Introduces the _withCredentials flag

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -5,6 +5,13 @@ import {VOID} from './functions.js';
 import FormatType from './format/FormatType.js';
 
 /**
+ *
+ * @type {boolean} withCredentials Compare https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/
+ * @private
+ */
+let withCredentials = false;
+
+/**
  * {@link module:ol/source/Vector} sources use a function of this type to
  * load features.
  *
@@ -62,6 +69,7 @@ export function loadFeaturesXhr(url, format, success, failure) {
       if (format.getType() == FormatType.ARRAY_BUFFER) {
         xhr.responseType = 'arraybuffer';
       }
+      xhr.withCredentials = withCredentials;
       /**
        * @param {Event} event Event.
        * @private
@@ -130,4 +138,15 @@ export function xhr(url, format) {
         /** @type {import("./source/Vector").default} */ (sourceOrTile).addFeatures(features);
       }
     }, /* FIXME handle error */ VOID);
+}
+
+/**
+ * Setter for the withCredentials configuration for the XHR.
+ *
+ * @param {boolean} xhrWithCredentials The value of withCredentials to set.
+ * Compare https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/
+ * @api
+ */
+export function setWithCredentials(xhrWithCredentials) {
+  withCredentials = xhrWithCredentials;
 }


### PR DESCRIPTION
This introduces the `_withCredentials` flag and the corresponding setter `setWithCredentials` to the `featureloader`.

It is an adaption of #9865 created by @mstenta.
Thx for your work. :muscle: 

Closes #9865  

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
