### PR TITLE
Handle empty source tiles and queue them properly

### DIFF
--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -112,10 +112,12 @@ class TileQueue extends PriorityQueue {
       if (state === TileState.ABORT) {
         abortedTiles = true;
       } else if (state === TileState.IDLE && !(tileKey in this.tilesLoadingKeys_)) {
-        this.tilesLoadingKeys_[tileKey] = true;
-        ++this.tilesLoading_;
-        ++newLoads;
         tile.load();
+        if (tile.getState() === TileState.LOADING) {
+          this.tilesLoadingKeys_[tileKey] = true;
+          ++this.tilesLoading_;
+          ++newLoads;
+        }
       }
     }
     if (newLoads === 0 && abortedTiles) {

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -236,15 +236,17 @@ class VectorTile extends UrlTile {
               empty = false;
               sourceTile.addEventListener(EventType.CHANGE, this.handleTileChange.bind(this));
               sourceTile.load();
+            } else {
+              sourceTile = null;
             }
           } else {
             empty = false;
           }
           covered = false;
-          if (!sourceTile) {
+          if (sourceTile === undefined) {
             return;
           }
-          if (sourceTile.getState() !== TileState.EMPTY && tile.getState() === TileState.IDLE) {
+          if (sourceTile !== null && tile.getState() === TileState.IDLE) {
             tile.loadingSourceTiles++;
             const key = listen(sourceTile, EventType.CHANGE, function() {
               const state = sourceTile.getState();


### PR DESCRIPTION
I updated an application that has a vector tile layer with a custom tileUrlFunction. That function returns `undefined` for tiles that are known to be not available. Returning `undefined` from a tileUrlFunction is something we support, and it means that the tile is not available (i.e. has an `EMPTY` state). But we did not handle that properly for a vector tile's source tile.

This pull request makes sure we not only set the state of such source tiles properly. I also needed to modify the TileQueue to handle tiles that get an `EMPTY` state after `IDLE`.