### PR TITLE
Remove simplified geometry cache

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -47,12 +47,6 @@ class Geometry extends BaseObject {
 
     /**
      * @protected
-     * @type {Object<string, Geometry>}
-     */
-    this.simplifiedGeometryCache = {};
-
-    /**
-     * @protected
      * @type {number}
      */
     this.simplifiedGeometryMaxMinSquaredTolerance = 0;

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -6,7 +6,6 @@ import EventType from '../events/EventType.js';
 import {createOrUpdateEmpty, closestSquaredDistanceXY, extend, getCenter} from '../extent.js';
 import Geometry from './Geometry.js';
 import GeometryType from './GeometryType.js';
-import {clear} from '../obj.js';
 
 /**
  * @classdesc
@@ -131,8 +130,7 @@ class GeometryCollection extends Geometry {
    * @inheritDoc
    */
   getSimplifiedGeometry(squaredTolerance) {
-    if (this.simplifiedGeometryRevision != this.getRevision()) {
-      clear(this.simplifiedGeometryCache);
+    if (this.simplifiedGeometryRevision !== this.getRevision()) {
       this.simplifiedGeometryMaxMinSquaredTolerance = 0;
       this.simplifiedGeometryRevision = this.getRevision();
     }
@@ -141,30 +139,25 @@ class GeometryCollection extends Geometry {
          squaredTolerance < this.simplifiedGeometryMaxMinSquaredTolerance)) {
       return this;
     }
-    const key = squaredTolerance.toString();
-    if (this.simplifiedGeometryCache.hasOwnProperty(key)) {
-      return this.simplifiedGeometryCache[key];
+
+    const simplifiedGeometries = [];
+    const geometries = this.geometries_;
+    let simplified = false;
+    for (let i = 0, ii = geometries.length; i < ii; ++i) {
+      const geometry = geometries[i];
+      const simplifiedGeometry = geometry.getSimplifiedGeometry(squaredTolerance);
+      simplifiedGeometries.push(simplifiedGeometry);
+      if (simplifiedGeometry !== geometry) {
+        simplified = true;
+      }
+    }
+    if (simplified) {
+      const simplifiedGeometryCollection = new GeometryCollection(null);
+      simplifiedGeometryCollection.setGeometriesArray(simplifiedGeometries);
+      return simplifiedGeometryCollection;
     } else {
-      const simplifiedGeometries = [];
-      const geometries = this.geometries_;
-      let simplified = false;
-      for (let i = 0, ii = geometries.length; i < ii; ++i) {
-        const geometry = geometries[i];
-        const simplifiedGeometry = geometry.getSimplifiedGeometry(squaredTolerance);
-        simplifiedGeometries.push(simplifiedGeometry);
-        if (simplifiedGeometry !== geometry) {
-          simplified = true;
-        }
-      }
-      if (simplified) {
-        const simplifiedGeometryCollection = new GeometryCollection(null);
-        simplifiedGeometryCollection.setGeometriesArray(simplifiedGeometries);
-        this.simplifiedGeometryCache[key] = simplifiedGeometryCollection;
-        return simplifiedGeometryCollection;
-      } else {
-        this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
-        return this;
-      }
+      this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
+      return this;
     }
   }
 

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -6,7 +6,6 @@ import {createOrUpdateFromFlatCoordinates, getCenter} from '../extent.js';
 import Geometry from './Geometry.js';
 import GeometryLayout from './GeometryLayout.js';
 import {rotate, scale, translate, transform2D} from './flat/transform.js';
-import {clear} from '../obj.js';
 
 /**
  * @classdesc
@@ -95,8 +94,7 @@ class SimpleGeometry extends Geometry {
    * @inheritDoc
    */
   getSimplifiedGeometry(squaredTolerance) {
-    if (this.simplifiedGeometryRevision != this.getRevision()) {
-      clear(this.simplifiedGeometryCache);
+    if (this.simplifiedGeometryRevision !== this.getRevision()) {
       this.simplifiedGeometryMaxMinSquaredTolerance = 0;
       this.simplifiedGeometryRevision = this.getRevision();
     }
@@ -107,26 +105,21 @@ class SimpleGeometry extends Geometry {
          squaredTolerance <= this.simplifiedGeometryMaxMinSquaredTolerance)) {
       return this;
     }
-    const key = squaredTolerance.toString();
-    if (this.simplifiedGeometryCache.hasOwnProperty(key)) {
-      return this.simplifiedGeometryCache[key];
+
+    const simplifiedGeometry =
+        this.getSimplifiedGeometryInternal(squaredTolerance);
+    const simplifiedFlatCoordinates = simplifiedGeometry.getFlatCoordinates();
+    if (simplifiedFlatCoordinates.length < this.flatCoordinates.length) {
+      return simplifiedGeometry;
     } else {
-      const simplifiedGeometry =
-          this.getSimplifiedGeometryInternal(squaredTolerance);
-      const simplifiedFlatCoordinates = simplifiedGeometry.getFlatCoordinates();
-      if (simplifiedFlatCoordinates.length < this.flatCoordinates.length) {
-        this.simplifiedGeometryCache[key] = simplifiedGeometry;
-        return simplifiedGeometry;
-      } else {
-        // Simplification did not actually remove any coordinates.  We now know
-        // that any calls to getSimplifiedGeometry with a squaredTolerance less
-        // than or equal to the current squaredTolerance will also not have any
-        // effect.  This allows us to short circuit simplification (saving CPU
-        // cycles) and prevents the cache of simplified geometries from filling
-        // up with useless identical copies of this geometry (saving memory).
-        this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
-        return this;
-      }
+      // Simplification did not actually remove any coordinates.  We now know
+      // that any calls to getSimplifiedGeometry with a squaredTolerance less
+      // than or equal to the current squaredTolerance will also not have any
+      // effect.  This allows us to short circuit simplification (saving CPU
+      // cycles) and prevents the cache of simplified geometries from filling
+      // up with useless identical copies of this geometry (saving memory).
+      this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
+      return this;
     }
   }
 

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -336,19 +336,6 @@ describe('ol.geom.LineString', function() {
           [[0, 0], [3, 3], [5, 1], [7, 5]]);
       });
 
-      it('caches by resolution', function() {
-        const simplifiedGeometry1 = lineString.getSimplifiedGeometry(1);
-        const simplifiedGeometry2 = lineString.getSimplifiedGeometry(1);
-        expect(simplifiedGeometry1).to.be(simplifiedGeometry2);
-      });
-
-      it('invalidates the cache when the geometry changes', function() {
-        const simplifiedGeometry1 = lineString.getSimplifiedGeometry(1);
-        lineString.setCoordinates(lineString.getCoordinates());
-        const simplifiedGeometry2 = lineString.getSimplifiedGeometry(1);
-        expect(simplifiedGeometry1).not.to.be(simplifiedGeometry2);
-      });
-
       it('remembers the minimum squared tolerance', function() {
         sinon.spy(lineString, 'getSimplifiedGeometryInternal');
         const simplifiedGeometry1 = lineString.getSimplifiedGeometry(0.05);

--- a/test/spec/ol/geom/polygon.test.js
+++ b/test/spec/ol/geom/polygon.test.js
@@ -496,15 +496,6 @@ describe('ol/geom/Polygon', function() {
           [[[3, 0], [0, 3], [0, 6], [6, 6], [3, 3]]]);
       });
 
-      it('caches multiple simplified geometries', function() {
-        const simplifiedGeometry1 = polygon.getSimplifiedGeometry(4);
-        const simplifiedGeometry2 = polygon.getSimplifiedGeometry(9);
-        const simplifiedGeometry3 = polygon.getSimplifiedGeometry(4);
-        const simplifiedGeometry4 = polygon.getSimplifiedGeometry(9);
-        expect(simplifiedGeometry1).to.be(simplifiedGeometry3);
-        expect(simplifiedGeometry2).to.be(simplifiedGeometry4);
-      });
-
     });
   });
 


### PR DESCRIPTION
Removed simplified geometry cache because it would bloat memory usage if used with non-integer zoom levels.
