### PR TITLE
Don't use vendor prefixes for the transform property

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -463,8 +463,6 @@ class OverviewMap extends Control {
       box.style.width = width + 'px';
       box.style.height = height + 'px';
       const transform = 'rotate(' + rotation + 'rad)';
-      box.style.msTransform = transform;
-      box.style.webkitTransform = transform;
       box.style.transform = transform;
     }
   }


### PR DESCRIPTION
We are already not using the prefixes in other part of the library.
For example:
https://github.com/openlayers/openlayers/blob/v6.0.0-beta.15/src/ol/renderer/canvas/TileLayer.js#L356
