### PR TITLE
Don't attempt to render when there is no source

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -122,7 +122,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    * @inheritDoc
    */
   prepareFrame(frameState) {
-    return true;
+    return !!this.getLayer().getSource();
   }
 
   /**


### PR DESCRIPTION
Another issue I found when I upgraded an application from v5 to v6: when a tile layer is constructed without a source (in my case it was a vector tile layer), we are in trouble. The renderer takes the source for granted, but cannot access it, which is causing this error:

![](https://user-images.githubusercontent.com/36012148/65525395-bb27ab80-deef-11e9-9959-4ae05f457114.png)
