### PR TITLE
Make Circle geometry hit detection consistent with Polygon

### DIFF
--- a/src/ol/render/canvas/PolygonBuilder.js
+++ b/src/ol/render/canvas/PolygonBuilder.js
@@ -31,7 +31,7 @@ class CanvasPolygonBuilder extends CanvasBuilder {
   drawFlatCoordinatess_(flatCoordinates, offset, ends, stride) {
     const state = this.state;
     const fill = state.fillStyle !== undefined;
-    const stroke = state.strokeStyle != undefined;
+    const stroke = state.strokeStyle !== undefined;
     const numEnds = ends.length;
     this.instructions.push(beginPathInstruction);
     this.hitDetectionInstructions.push(beginPathInstruction);
@@ -94,9 +94,9 @@ class CanvasPolygonBuilder extends CanvasBuilder {
     const circleInstruction = [CanvasInstruction.CIRCLE, myBegin];
     this.instructions.push(beginPathInstruction, circleInstruction);
     this.hitDetectionInstructions.push(beginPathInstruction, circleInstruction);
-    this.hitDetectionInstructions.push(fillInstruction);
     if (state.fillStyle !== undefined) {
       this.instructions.push(fillInstruction);
+      this.hitDetectionInstructions.push(fillInstruction);
     }
     if (state.strokeStyle !== undefined) {
       this.instructions.push(strokeInstruction);


### PR DESCRIPTION
Resolves one of the inconsistencies seen in #9395 (but don't close the issue as CircleStyle remains inconsistent)

Also adds hit detection tests for no fill and transparent fill based on the example used in #9395  The tests currently expect the inconsistent behaviour seen when using CircleStyle.