### PR TITLE
Correct getFeaturesAtPixel spelling and grammar

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -279,9 +279,9 @@ The `getGetFeatureInfoUrl` of `ol/source/ImageWMS` and `ol/source/TileWMS` is no
 
 The `SelectInteraction` is removed. There are two examples ([Select Features by Hover](https://openlayers.org/en/master/examples/select-hover-features.html) and [Select multiple Features](https://openlayers.org/en/master/examples/select-multiple-features.html) which show how similar results can be achieved by using more basic methods.
 
-##### `getFeatureAtPixel` returns always an array
+##### `getFeaturesAtPixel` always returns an array
 
-`getFeatureAtPixel` returns now an empty array instead of `null` if no features were found. 
+`getFeaturesAtPixel` now returns an empty array instead of `null` if no features were found. 
 
 #### Other changes
 


### PR DESCRIPTION
the last update missed the "s" from the name, plus non-English word order in the description
