### PR TITLE
Add a new layer type: WebGLPointsLayer

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -244,3 +244,7 @@ Layer opacity must be a number.
 ### 65
 
 A symbol literal representation must be defined on the style supplied to a `WebGLPointsLayer` instance.
+
+### 66
+
+`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled.

--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -240,3 +240,7 @@ Support for the `OES_element_index_uint` WebGL extension is mandatory for WebGL 
 ### 64
 
 Layer opacity must be a number.
+
+### 65
+
+A symbol literal representation must be defined on the style supplied to a `WebGLPointsLayer` instance.

--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -248,3 +248,4 @@ A symbol literal representation must be defined on the style supplied to a `WebG
 ### 66
 
 `forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled.
+This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`.

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -79,6 +79,7 @@ class WebglPointsLayer extends VectorLayer {
         'varying float v_year;',
 
         'void main(void) {',
+
         // color is interpolated based on year
         '  float ratio = clamp((v_year - 1950.0) / (2013.0 - 1950.0), 0.0, 1.1);',
         '  vec3 color = mix(vec3(' + formatColor(oldColor) + '),',
@@ -86,6 +87,37 @@ class WebglPointsLayer extends VectorLayer {
 
         '  gl_FragColor = vec4(color, 1.0);',
         '  gl_FragColor.rgb *= gl_FragColor.a;',
+        '}'
+      ].join(' '),
+      hitVertexShader: [
+        'precision mediump float;',
+
+        'uniform mat4 u_projectionMatrix;',
+        'uniform mat4 u_offsetScaleMatrix;',
+        'uniform mat4 u_offsetRotateMatrix;',
+        'attribute vec2 a_position;',
+        'attribute float a_index;',
+        'attribute vec4 a_hitColor;',
+        'varying vec4 v_hitColor;',
+
+        'void main(void) {',
+        '  mat4 offsetMatrix = u_offsetScaleMatrix;',
+        '  float offsetX = a_index == 0.0 || a_index == 3.0 ? ',
+        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '  float offsetY = a_index == 0.0 || a_index == 1.0 ? ',
+        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
+        '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
+        '  v_hitColor = a_hitColor;',
+        '}'
+      ].join(' '),
+      hitFragmentShader: [
+        'precision mediump float;',
+
+        'varying vec4 v_hitColor;',
+
+        'void main(void) {',
+        '  gl_FragColor = v_hitColor;',
         '}'
       ].join(' '),
       texture: texture // FIXME: this doesn't work yet

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -8,7 +8,7 @@ import VectorLayer from '../src/ol/layer/Vector.js';
 import {Vector} from '../src/ol/source.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
-import {lerp} from '../src/ol/math.js';
+import {formatColor, formatNumber} from '../src/ol/webgl/ShaderBuilder.js';
 
 const key = 'pk.eyJ1IjoidHNjaGF1YiIsImEiOiJjaW5zYW5lNHkxMTNmdWttM3JyOHZtMmNtIn0.CDIBD8H-G2Gf-cPkIuWtRg';
 
@@ -35,33 +35,60 @@ const shapeTextureCoords = {
 
 const oldColor = [255, 160, 110];
 const newColor = [180, 255, 200];
+const size = 16;
 
 class WebglPointsLayer extends VectorLayer {
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
-      texture: texture,
-      colorCallback: function(feature, color) {
-        // color is interpolated based on year (min is 1910, max is 2013)
-        // please note: most values are between 2000-2013
-        const ratio = (feature.get('year') - 1950) / (2013 - 1950);
-
-        color[0] = lerp(oldColor[0], newColor[0], ratio * ratio) / 255;
-        color[1] = lerp(oldColor[1], newColor[1], ratio * ratio) / 255;
-        color[2] = lerp(oldColor[2], newColor[2], ratio * ratio) / 255;
-        color[3] = 1;
-
-        return color;
-      },
-      texCoordCallback: function(feature, component) {
-        let coords = shapeTextureCoords[feature.get('shape')];
-        if (!coords) {
-          coords = shapeTextureCoords['default'];
+      attributes: [
+        {
+          name: 'year',
+          callback: function(feature) {
+            return feature.get('year');
+          }
         }
-        return coords[component];
-      },
-      sizeCallback: function() {
-        return 16;
-      }
+      ],
+      vertexShader: [
+        'precision mediump float;',
+
+        'uniform mat4 u_projectionMatrix;',
+        'uniform mat4 u_offsetScaleMatrix;',
+        'uniform mat4 u_offsetRotateMatrix;',
+        'attribute vec2 a_position;',
+        'attribute float a_index;',
+        'attribute float a_year;',
+        'varying float v_year;',
+
+        'void main(void) {',
+        '  mat4 offsetMatrix = u_offsetScaleMatrix;',
+        '  float offsetX = a_index == 0.0 || a_index == 3.0 ? ',
+        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '  float offsetY = a_index == 0.0 || a_index == 1.0 ? ',
+        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
+        '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
+        '  v_year = a_year;',
+        '}'
+      ].join(' '),
+      fragmentShader: [
+        'precision mediump float;',
+
+        'uniform float u_time;',
+        'uniform float u_minYear;',
+        'uniform float u_maxYear;',
+        'varying float v_year;',
+
+        'void main(void) {',
+        // color is interpolated based on year
+        '  float ratio = clamp((v_year - 1950.0) / (2013.0 - 1950.0), 0.0, 1.1);',
+        '  vec3 color = mix(vec3(' + formatColor(oldColor) + '),',
+        '    vec3(' + formatColor(newColor) + '), ratio);',
+
+        '  gl_FragColor = vec4(color, 1.0);',
+        '  gl_FragColor.rgb *= gl_FragColor.a;',
+        '}'
+      ].join(' '),
+      texture: texture // FIXME: this doesn't work yet
     });
   }
 }

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -22,16 +22,17 @@ texture.src = 'data/ufo_shapes.png';
 
 // This describes the content of the associated sprite sheet
 // coords are u0, v0, u1, v1 for a given shape
-const shapeTextureCoords = {
-  'light': [0, 0.5, 0.25, 0],
-  'sphere': [0.25, 0.5, 0.5, 0],
-  'circle': [0.25, 0.5, 0.5, 0],
-  'disc': [0.5, 0.5, 0.75, 0],
-  'oval': [0.5, 0.5, 0.75, 0],
-  'triangle': [0.75, 0.5, 1, 0],
-  'fireball': [0, 1, 0.25, 0.5],
-  'default': [0.75, 1, 1, 0.5]
-};
+// FIXME: re enable this
+// const shapeTextureCoords = {
+//   'light': [0, 0.5, 0.25, 0],
+//   'sphere': [0.25, 0.5, 0.5, 0],
+//   'circle': [0.25, 0.5, 0.5, 0],
+//   'disc': [0.5, 0.5, 0.75, 0],
+//   'oval': [0.5, 0.5, 0.75, 0],
+//   'triangle': [0.75, 0.5, 1, 0],
+//   'fireball': [0, 1, 0.25, 0.5],
+//   'default': [0.75, 1, 1, 0.5]
+// };
 
 const oldColor = [255, 160, 110];
 const newColor = [180, 255, 200];

--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -1,0 +1,19 @@
+---
+layout: example.html
+title: WebGL points layer
+shortdesc: Using a WebGL-optimized layer to render a large quantities of points
+docs: >
+  <p>This example shows how to use a `WebGLPointsLayer` to show a large amount of points on the map.</p>
+
+tags: "webgl, point, layer, feature"
+---
+
+<div id="map" class="map"></div>
+<label>Current style used for the layer</label>
+<textarea style="width: 100%; height: 20rem; font-family: monospace; font-size: small;" id="style-editor"></textarea>
+<small id="style-valid" style="display: none; color: forestgreen">
+  ✓ style is valid
+</small>
+<small id="style-invalid" style="display: none; color: grey">
+  ✗ style not yet valid...
+</small>

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -43,7 +43,7 @@ function refreshLayer() {
   }
   pointsLayer = new WebGLPointsLayer({
     source: vectorSource,
-    literalStyle: literalStyle
+    style: literalStyle
   });
   map.addLayer(pointsLayer);
   editor.value = JSON.stringify(literalStyle, null, ' ');

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -1,0 +1,66 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import WebGLPointsLayer from '../src/ol/layer/WebGLPoints.js';
+import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Vector from '../src/ol/source/Vector.js';
+import OSM from '../src/ol/source/OSM.js';
+
+const vectorSource = new Vector({
+  url: 'data/geojson/world-cities.geojson',
+  format: new GeoJSON()
+});
+
+let literalStyle = {
+  symbol: {
+    size: 4,
+    color: '#3388FF',
+    rotateWithView: false,
+    offset: [0, 0],
+    opacity: 1
+  }
+};
+let pointsLayer;
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM()
+    })
+  ],
+  target: document.getElementById('map'),
+  view: new View({
+    center: [0, 0],
+    zoom: 2
+  })
+});
+
+const editor = document.getElementById('style-editor');
+
+function refreshLayer() {
+  if (pointsLayer) {
+    map.removeLayer(pointsLayer);
+  }
+  pointsLayer = new WebGLPointsLayer({
+    source: vectorSource,
+    literalStyle: literalStyle
+  });
+  map.addLayer(pointsLayer);
+  editor.value = JSON.stringify(literalStyle, null, ' ');
+}
+
+function setStyleStatus(valid) {
+  document.getElementById('style-valid').style.display = valid ? 'initial' : 'none';
+  document.getElementById('style-invalid').style.display = !valid ? 'initial' : 'none';
+}
+
+editor.addEventListener('input', function() {
+  try {
+    literalStyle = JSON.parse(editor.value);
+    refreshLayer();
+    setStyleStatus(true);
+  } catch (e) {
+    setStyleStatus(false);
+  }
+});
+refreshLayer();

--- a/rendering/cases/webgl-points/main.js
+++ b/rendering/cases/webgl-points/main.js
@@ -13,7 +13,7 @@ const vector = new WebGLPointsLayer({
       extractStyles: false
     })
   }),
-  literalStyle: {
+  style: {
     symbol: {
       size: 4,
       color: 'white'

--- a/rendering/cases/webgl-points/main.js
+++ b/rendering/cases/webgl-points/main.js
@@ -2,28 +2,23 @@ import Map from '../../../src/ol/Map.js';
 import View from '../../../src/ol/View.js';
 import TileLayer from '../../../src/ol/layer/Tile.js';
 import XYZ from '../../../src/ol/source/XYZ.js';
-import {Vector as VectorLayer} from '../../../src/ol/layer.js';
 import VectorSource from '../../../src/ol/source/Vector.js';
 import KML from '../../../src/ol/format/KML.js';
-import WebGLPointsLayerRenderer from '../../../src/ol/renderer/webgl/PointsLayer.js';
+import WebGLPointsLayer from '../../../src/ol/layer/WebGLPoints.js';
 
-class CustomLayer extends VectorLayer {
-  createRenderer() {
-    return new WebGLPointsLayerRenderer(this, {
-      sizeCallback: function() {
-        return 4;
-      }
-    });
-  }
-}
-
-const vector = new CustomLayer({
+const vector = new WebGLPointsLayer({
   source: new VectorSource({
     url: '/data/2012_Earthquakes_Mag5.kml',
     format: new KML({
       extractStyles: false
     })
-  })
+  }),
+  literalStyle: {
+    symbol: {
+      size: 4,
+      color: 'white'
+    }
+  }
 });
 
 const raster = new TileLayer({

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -177,38 +177,47 @@ class Heatmap extends VectorLayer {
    */
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
+      attributes: [
+        {
+          name: 'weight',
+          callback: this.weightFunction_
+        }
+      ],
       vertexShader: `
         precision mediump float;
-        attribute vec2 a_position;
-        attribute vec2 a_texCoord;
-        attribute vec2 a_offsets;
-        attribute float a_opacity;
-
         uniform mat4 u_projectionMatrix;
         uniform mat4 u_offsetScaleMatrix;
         uniform float u_size;
+        attribute vec2 a_position;
+        attribute float a_index;
+        attribute float a_weight;
 
         varying vec2 v_texCoord;
-        varying float v_opacity;
+        varying float v_weight;
 
         void main(void) {
-          vec4 offsets = u_offsetScaleMatrix * vec4(a_offsets, 0.0, 0.0);
-          gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets * u_size;
-          v_texCoord = a_texCoord;
-          v_opacity = a_opacity;
+          mat4 offsetMatrix = u_offsetScaleMatrix;
+          float offsetX = a_index == 0.0 || a_index == 3.0 ? -u_size / 2.0 : u_size / 2.0;
+          float offsetY = a_index == 0.0 || a_index == 1.0 ? -u_size / 2.0 : u_size / 2.0;
+          vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+          gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+          float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
+          float v = a_index == 0.0 || a_index == 1.0 ? 0.0 : 1.0;
+          v_texCoord = vec2(u, v);
+          v_weight = a_weight;
         }`,
       fragmentShader: `
         precision mediump float;
         uniform float u_blurSlope;
 
         varying vec2 v_texCoord;
-        varying float v_opacity;
+        varying float v_weight;
 
         void main(void) {
           vec2 texCoord = v_texCoord * 2.0 - vec2(1.0, 1.0);
           float sqRadius = texCoord.x * texCoord.x + texCoord.y * texCoord.y;
           float value = (1.0 - sqrt(sqRadius)) * u_blurSlope;
-          float alpha = smoothstep(0.0, 1.0, value) * v_opacity;
+          float alpha = smoothstep(0.0, 1.0, value) * v_weight;
           gl_FragColor = vec4(alpha, alpha, alpha, alpha);
         }`,
       uniforms: {
@@ -239,8 +248,7 @@ class Heatmap extends VectorLayer {
             u_gradientTexture: this.gradient_
           }
         }
-      ],
-      opacityCallback: this.weightFunction_
+      ]
     });
   }
 }

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -17,7 +17,7 @@ import Layer from './Layer.js';
 
 /**
  * @typedef {Object} Options
- * @property {import('../style/LiteralStyle.js').LiteralStyle} literalStyle Literal style to apply to the layer features.
+ * @property {import('../style/LiteralStyle.js').LiteralStyle} style Literal style to apply to the layer features.
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
@@ -37,7 +37,7 @@ import Layer from './Layer.js';
 
 /**
  * @classdesc
- * Layer optimized for rendering large point datasets. Takes a so-called *literalStyle* property which
+ * Layer optimized for rendering large point datasets. Takes a `style` property which
  * is a serializable JSON object describing how the layer should be rendered.
  *
  * Here are a few samples of literal style objects:
@@ -81,16 +81,16 @@ class WebGLPointsLayer extends Layer {
     /**
      * @type {import('../style/LiteralStyle.js').LiteralStyle}
      */
-    this.literalStyle = options.literalStyle;
+    this.style = options.style;
 
-    assert(this.literalStyle.symbol !== undefined, 65);
+    assert(this.style.symbol !== undefined, 65);
   }
 
   /**
    * @inheritDoc
    */
   createRenderer() {
-    const symbolStyle = this.literalStyle.symbol;
+    const symbolStyle = this.style.symbol;
     const size = Array.isArray(symbolStyle.size) ?
       formatArray(symbolStyle.size) : formatNumber(symbolStyle.size);
     const color = symbolStyle.color !== undefined ?

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -4,8 +4,15 @@
 import VectorLayer from './Vector.js';
 import {assign} from '../obj.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
-import {getSymbolFragmentShader, getSymbolVertexShader} from '../webgl/ShaderBuilder.js';
+import {
+  formatArray,
+  formatColor,
+  formatNumber,
+  getSymbolFragmentShader,
+  getSymbolVertexShader
+} from '../webgl/ShaderBuilder.js';
 import {assert} from '../asserts.js';
+import {asArray} from '../color.js';
 
 
 /**
@@ -59,9 +66,42 @@ class WebGLPointsLayer extends VectorLayer {
    * @inheritDoc
    */
   createRenderer() {
+    const symbolStyle = this.literalStyle.symbol;
+    const size = Array.isArray(symbolStyle.size) ?
+      formatArray(symbolStyle.size) : formatNumber(symbolStyle.size);
+    const color = symbolStyle.color !== undefined ?
+      (typeof symbolStyle.color === 'string' ? asArray(symbolStyle.color) : symbolStyle.color) :
+      [255, 255, 255, 1];
+    const texCoord = symbolStyle.textureCoord || [0, 0, 1, 1];
+    const offset = symbolStyle.offset || [0, 0];
+    const opacity = symbolStyle.opacity !== undefined ? symbolStyle.opacity : 1;
+
+    /** @type {import('../webgl/ShaderBuilder.js').ShaderParameters} */
+    const params = {
+      uniforms: [],
+      colorExpression: 'vec4(' + formatColor(color) + ') * vec4(1.0, 1.0, 1.0, ' + formatNumber(opacity) + ')',
+      sizeExpression: 'vec2(' + size + ')',
+      offsetExpression: 'vec2(' + formatArray(offset) + ')',
+      texCoordExpression: 'vec4(' + formatArray(texCoord) + ')',
+      rotateWithView: !!symbolStyle.rotateWithView
+    };
+
+    /** @type {Object.<string,import("../webgl/Helper").UniformValue>} */
+    const uniforms = {};
+
+    if (symbolStyle.symbolType === 'image' && symbolStyle.src) {
+      const texture = new Image();
+      texture.src = symbolStyle.src;
+      params.uniforms.push('sampler2D u_texture');
+      params.colorExpression = params.colorExpression +
+        ' * texture2D(u_texture, v_texCoord);';
+      uniforms['u_texture'] = texture;
+    }
+
     return new WebGLPointsLayerRenderer(this, {
-      vertexShader: getSymbolVertexShader(this.literalStyle.symbol),
-      fragmentShader: getSymbolFragmentShader()
+      vertexShader: getSymbolVertexShader(params),
+      fragmentShader: getSymbolFragmentShader(params),
+      uniforms: uniforms
     });
   }
 }

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/layer/WebGLPoints
  */
-import VectorLayer from './Vector.js';
 import {assign} from '../obj.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
 import {
@@ -13,6 +12,7 @@ import {
 } from '../webgl/ShaderBuilder.js';
 import {assert} from '../asserts.js';
 import {asArray} from '../color.js';
+import Layer from './Layer.js';
 
 
 /**
@@ -37,15 +37,39 @@ import {asArray} from '../color.js';
 
 /**
  * @classdesc
- * Layer optimized for rendering large point datasets.
+ * Layer optimized for rendering large point datasets. Takes a so-called *literalStyle* property which
+ * is a serializable JSON object describing how the layer should be rendered.
+ *
+ * Here are a few samples of literal style objects:
+ * ```js
+ * const style = {
+ *   symbol: {
+ *     symbolType: 'circle',
+ *     size: 8,
+ *     color: '#33AAFF',
+ *     opacity: 0.9
+ *   }
+ * }
+ * ```
+ *
+ * ```js
+ * const style = {
+ *   symbol: {
+ *     symbolType: 'image',
+ *     offset: [0, 12],
+ *     size: [4, 8],
+ *     src: '../static/exclamation-mark.png'
+ *   }
+ * }
+ * ```
+ *
  * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @api
  */
-class WebGLPointsLayer extends VectorLayer {
+class WebGLPointsLayer extends Layer {
   /**
    * @param {Options} options Options.
    */

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -1,0 +1,69 @@
+/**
+ * @module ol/layer/WebGLPoints
+ */
+import VectorLayer from './Vector.js';
+import {assign} from '../obj.js';
+import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
+import {getSymbolFragmentShader, getSymbolVertexShader} from '../webgl/ShaderBuilder.js';
+import {assert} from '../asserts.js';
+
+
+/**
+ * @typedef {Object} Options
+ * @property {import('../style/LiteralStyle.js').LiteralStyle} literalStyle Literal style to apply to the layer features.
+ * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
+ * @property {number} [opacity=1] Opacity (0, 1).
+ * @property {boolean} [visible=true] Visibility.
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * rendered outside of this extent.
+ * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
+ * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
+ * for layers that are added to the map's `layers` collection, or `Infinity` when the layer's `setMap()`
+ * method was used.
+ * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
+ * visible.
+ * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
+ * be visible.
+ * @property {import("../source/Vector.js").default} [source] Source.
+ */
+
+
+/**
+ * @classdesc
+ * Layer optimized for rendering large point datasets.
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * property on the layer object; for example, setting `title: 'My Title'` in the
+ * options means that `title` is observable, and has get/set accessors.
+ *
+ * @fires import("../render/Event.js").RenderEvent
+ * @api
+ */
+class WebGLPointsLayer extends VectorLayer {
+  /**
+   * @param {Options} options Options.
+   */
+  constructor(options) {
+    const baseOptions = assign({}, options);
+
+    super(baseOptions);
+
+    /**
+     * @type {import('../style/LiteralStyle.js').LiteralStyle}
+     */
+    this.literalStyle = options.literalStyle;
+
+    assert(this.literalStyle.symbol !== undefined, 65);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  createRenderer() {
+    return new WebGLPointsLayerRenderer(this, {
+      vertexShader: getSymbolVertexShader(this.literalStyle.symbol),
+      fragmentShader: getSymbolFragmentShader()
+    });
+  }
+}
+
+export default WebGLPointsLayer;

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -123,9 +123,9 @@ const tmpArray_ = [];
 const bufferPositions_ = {vertexPosition: 0, indexPosition: 0};
 
 export const POINT_INSTRUCTIONS_COUNT = 13;
-export const POINT_VERTEX_STRIDE = 12;
+export const POINT_VERTEX_STRIDE = 13;
 
-function writePointVertex(buffer, pos, x, y, offsetX, offsetY, u, v, opacity, rotateWithView, red, green, blue, alpha) {
+function writePointVertex(buffer, pos, x, y, offsetX, offsetY, u, v, opacity, rotateWithView, red, green, blue, alpha, index) {
   buffer[pos + 0] = x;
   buffer[pos + 1] = y;
   buffer[pos + 2] = offsetX;
@@ -138,6 +138,7 @@ function writePointVertex(buffer, pos, x, y, offsetX, offsetY, u, v, opacity, ro
   buffer[pos + 9] = green;
   buffer[pos + 10] = blue;
   buffer[pos + 11] = alpha;
+  buffer[pos + 12] = index;
 }
 
 function writeCustomAttrs(buffer, pos, customAttrs) {
@@ -202,19 +203,19 @@ export function writePointFeatureToBuffers(instructions, elementIndex, vertexBuf
   const baseIndex = vPos / stride;
 
   // push vertices for each of the four quad corners (first standard then custom attributes)
-  writePointVertex(vertexBuffer, vPos, x, y, -size / 2, -size / 2, u0, v0, opacity, rotateWithView, red, green, blue, alpha);
+  writePointVertex(vertexBuffer, vPos, x, y, -size / 2, -size / 2, u0, v0, opacity, rotateWithView, red, green, blue, alpha, 0);
   writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
   vPos += stride;
 
-  writePointVertex(vertexBuffer, vPos, x, y, +size / 2, -size / 2, u1, v0, opacity, rotateWithView, red, green, blue, alpha);
+  writePointVertex(vertexBuffer, vPos, x, y, +size / 2, -size / 2, u1, v0, opacity, rotateWithView, red, green, blue, alpha, 1);
   writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
   vPos += stride;
 
-  writePointVertex(vertexBuffer, vPos, x, y, +size / 2, +size / 2, u1, v1, opacity, rotateWithView, red, green, blue, alpha);
+  writePointVertex(vertexBuffer, vPos, x, y, +size / 2, +size / 2, u1, v1, opacity, rotateWithView, red, green, blue, alpha, 2);
   writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
   vPos += stride;
 
-  writePointVertex(vertexBuffer, vPos, x, y, -size / 2, +size / 2, u0, v1, opacity, rotateWithView, red, green, blue, alpha);
+  writePointVertex(vertexBuffer, vPos, x, y, -size / 2, +size / 2, u0, v1, opacity, rotateWithView, red, green, blue, alpha, 3);
   writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
   vPos += stride;
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -85,67 +85,13 @@ class WebGLLayerRenderer extends LayerRenderer {
 
 }
 
-
-/**
- * @param {Float32Array} instructions Instructons array in which to write.
- * @param {number} elementIndex Index from which render instructions will be written.
- * @param {number} x Point center X coordinate
- * @param {number} y Point center Y coordinate
- * @param {number} u0 Left texture coordinate
- * @param {number} v0 Bottom texture coordinate
- * @param {number} u1 Right texture coordinate
- * @param {number} v1 Top texture coordinate
- * @param {number} size Radius of the point
- * @param {number} opacity Opacity
- * @param {boolean} rotateWithView If true, the point will stay aligned with the view
- * @param {Array<number>} color Array holding red, green, blue, alpha values
- * @return {number} Index from which the next element should be written
- * @private
- */
-export function writePointFeatureInstructions(instructions, elementIndex, x, y, u0, v0, u1, v1, size, opacity, rotateWithView, color) {
-  let i = elementIndex;
-  instructions[i++] = x;
-  instructions[i++] = y;
-  instructions[i++] = u0;
-  instructions[i++] = v0;
-  instructions[i++] = u1;
-  instructions[i++] = v1;
-  instructions[i++] = size;
-  instructions[i++] = opacity;
-  instructions[i++] = rotateWithView ? 1 : 0;
-  instructions[i++] = color[0];
-  instructions[i++] = color[1];
-  instructions[i++] = color[2];
-  instructions[i++] = color[3];
-  return i;
-}
-
 const tmpArray_ = [];
 const bufferPositions_ = {vertexPosition: 0, indexPosition: 0};
 
-export const POINT_INSTRUCTIONS_COUNT = 13;
-export const POINT_VERTEX_STRIDE = 13;
-
-function writePointVertex(buffer, pos, x, y, offsetX, offsetY, u, v, opacity, rotateWithView, red, green, blue, alpha, index) {
+function writePointVertex(buffer, pos, x, y, index) {
   buffer[pos + 0] = x;
   buffer[pos + 1] = y;
-  buffer[pos + 2] = offsetX;
-  buffer[pos + 3] = offsetY;
-  buffer[pos + 4] = u;
-  buffer[pos + 5] = v;
-  buffer[pos + 6] = opacity;
-  buffer[pos + 7] = rotateWithView;
-  buffer[pos + 8] = red;
-  buffer[pos + 9] = green;
-  buffer[pos + 10] = blue;
-  buffer[pos + 11] = alpha;
-  buffer[pos + 12] = index;
-}
-
-function writeCustomAttrs(buffer, pos, customAttrs) {
-  if (customAttrs.length) {
-    buffer.set(customAttrs, pos);
-  }
+  buffer[pos + 2] = index;
 }
 
 /**
@@ -161,42 +107,27 @@ function writeCustomAttrs(buffer, pos, customAttrs) {
  * @param {number} elementIndex Index from which render instructions will be read.
  * @param {Float32Array} vertexBuffer Buffer in the form of a typed array.
  * @param {Uint32Array} indexBuffer Buffer in the form of a typed array.
+ * @param {number} customAttributesCount Amount of custom attributes for each element.
  * @param {BufferPositions} [bufferPositions] Buffer write positions; if not specified, positions will be set at 0.
- * @param {number} [count] Amount of render instructions that will be read. Default value is POINT_INSTRUCTIONS_COUNT
- * but a higher value can be provided; all values beyond the default count will be put in the vertices buffer as
- * is, thus allowing specifying custom attributes. Please note: this value should not vary inside the same buffer or
- * rendering will break.
  * @return {BufferPositions} New buffer positions where to write next
  * @property {number} vertexPosition New position in the vertex buffer where future writes should start.
  * @property {number} indexPosition New position in the index buffer where future writes should start.
  * @private
  */
-export function writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer, bufferPositions, count) {
-  const count_ = count > POINT_INSTRUCTIONS_COUNT ? count : POINT_INSTRUCTIONS_COUNT;
+export function writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer, customAttributesCount, bufferPositions) {
+  // This is for x, y and index
+  const baseVertexAttrsCount = 3;
+  const baseInstructionsCount = 2;
+  const stride = baseVertexAttrsCount + customAttributesCount;
 
   const x = instructions[elementIndex + 0];
   const y = instructions[elementIndex + 1];
-  const u0 = instructions[elementIndex + 2];
-  const v0 = instructions[elementIndex + 3];
-  const u1 = instructions[elementIndex + 4];
-  const v1 = instructions[elementIndex + 5];
-  const size = instructions[elementIndex + 6];
-  const opacity = instructions[elementIndex + 7];
-  const rotateWithView = instructions[elementIndex + 8];
-  const red = instructions[elementIndex + 9];
-  const green = instructions[elementIndex + 10];
-  const blue = instructions[elementIndex + 11];
-  const alpha = instructions[elementIndex + 12];
-
-  // the default vertex buffer stride is 12, plus additional custom values if any
-  const baseStride = POINT_VERTEX_STRIDE;
-  const stride = baseStride + count_ - POINT_INSTRUCTIONS_COUNT;
 
   // read custom numerical attributes on the feature
   const customAttrs = tmpArray_;
-  customAttrs.length = count_ - POINT_INSTRUCTIONS_COUNT;
+  customAttrs.length = customAttributesCount;
   for (let i = 0; i < customAttrs.length; i++) {
-    customAttrs[i] = instructions[elementIndex + POINT_INSTRUCTIONS_COUNT + i];
+    customAttrs[i] = instructions[elementIndex + baseInstructionsCount + i];
   }
 
   let vPos = bufferPositions ? bufferPositions.vertexPosition : 0;
@@ -204,20 +135,20 @@ export function writePointFeatureToBuffers(instructions, elementIndex, vertexBuf
   const baseIndex = vPos / stride;
 
   // push vertices for each of the four quad corners (first standard then custom attributes)
-  writePointVertex(vertexBuffer, vPos, x, y, -size / 2, -size / 2, u0, v0, opacity, rotateWithView, red, green, blue, alpha, 0);
-  writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
+  writePointVertex(vertexBuffer, vPos, x, y, 0);
+  customAttrs.length && vertexBuffer.set(customAttrs, vPos + baseVertexAttrsCount);
   vPos += stride;
 
-  writePointVertex(vertexBuffer, vPos, x, y, +size / 2, -size / 2, u1, v0, opacity, rotateWithView, red, green, blue, alpha, 1);
-  writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
+  writePointVertex(vertexBuffer, vPos, x, y, 1);
+  customAttrs.length && vertexBuffer.set(customAttrs, vPos + baseVertexAttrsCount);
   vPos += stride;
 
-  writePointVertex(vertexBuffer, vPos, x, y, +size / 2, +size / 2, u1, v1, opacity, rotateWithView, red, green, blue, alpha, 2);
-  writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
+  writePointVertex(vertexBuffer, vPos, x, y, 2);
+  customAttrs.length && vertexBuffer.set(customAttrs, vPos + baseVertexAttrsCount);
   vPos += stride;
 
-  writePointVertex(vertexBuffer, vPos, x, y, -size / 2, +size / 2, u0, v1, opacity, rotateWithView, red, green, blue, alpha, 3);
-  writeCustomAttrs(vertexBuffer, vPos + baseStride, customAttrs);
+  writePointVertex(vertexBuffer, vPos, x, y, 3);
+  customAttrs.length && vertexBuffer.set(customAttrs, vPos + baseVertexAttrsCount);
   vPos += stride;
 
   indexBuffer[iPos++] = baseIndex; indexBuffer[iPos++] = baseIndex + 1; indexBuffer[iPos++] = baseIndex + 3;

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -70,6 +70,7 @@ class WebGLLayerRenderer extends LayerRenderer {
    * @inheritDoc
    */
   disposeInternal() {
+    this.helper.disposeInternal();
     super.disposeInternal();
   }
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -5,7 +5,7 @@ import WebGLArrayBuffer from '../../webgl/Buffer.js';
 import {ARRAY_BUFFER, DYNAMIC_DRAW, ELEMENT_ARRAY_BUFFER} from '../../webgl.js';
 import {AttributeType, DefaultUniform} from '../../webgl/Helper.js';
 import GeometryType from '../../geom/GeometryType.js';
-import WebGLLayerRenderer, {colorDecodeId, colorEncodeId, getBlankImageData, WebGLWorkerMessageType} from './Layer.js';
+import WebGLLayerRenderer, {colorDecodeId, colorEncodeId, WebGLWorkerMessageType} from './Layer.js';
 import ViewHint from '../../ViewHint.js';
 import {createEmpty, equals} from '../../extent.js';
 import {

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -113,7 +113,6 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    */
   constructor(vectorLayer, options) {
     const uniforms = options.uniforms || {};
-    uniforms.u_texture = getBlankImageData();
     const projectionMatrixTransform = createTransform();
     uniforms[DefaultUniform.PROJECTION_MATRIX] = projectionMatrixTransform;
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -574,6 +574,14 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     const renderCount = this.indicesBuffer_.getSize();
     this.helper.drawElements(0, renderCount);
   }
+
+  /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    this.worker_.terminate();
+    super.disposeInternal();
+  }
 }
 
 export default WebGLPointsLayerRenderer;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -408,6 +408,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.helper.enableAttributeArray(DefaultAttrib.OPACITY, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 6);
     this.helper.enableAttributeArray(DefaultAttrib.ROTATE_WITH_VIEW, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 7);
     this.helper.enableAttributeArray(DefaultAttrib.COLOR, 4, FLOAT, bytesPerFloat * stride, bytesPerFloat * 8);
+    this.helper.enableAttributeArray('a_index', 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 12);
 
     return true;
   }
@@ -568,6 +569,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.helper.enableAttributeArray(DefaultAttrib.OPACITY, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 6);
     this.helper.enableAttributeArray(DefaultAttrib.ROTATE_WITH_VIEW, 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 7);
     this.helper.enableAttributeArray(DefaultAttrib.COLOR, 4, FLOAT, bytesPerFloat * stride, bytesPerFloat * 8);
+    this.helper.enableAttributeArray('a_index', 1, FLOAT, bytesPerFloat * stride, bytesPerFloat * 12);
 
     const renderCount = this.indicesBuffer_.getSize();
     this.helper.drawElements(0, renderCount);

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -460,12 +460,10 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    * @param {import("../../PluggableMap.js").FrameState} frameState current frame state
    */
   renderHitDetection(frameState) {
-    // skip render entirely if vertices buffers for display & hit detection have different sizes
-    // this typically means both buffers are temporarily out of sync
-    // FIXME: adapt this to the new points renderer behaviour
-    // if (this.hitVerticesBuffer_.getSize() !== this.verticesBuffer_.getSize()) {
-    //   return;
-    // }
+    // skip render entirely if vertex buffers not ready/generated yet
+    if (!this.hitVerticesBuffer_.getSize()) {
+      return;
+    }
 
     this.hitRenderTarget_.setSize(frameState.size);
 

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -1,0 +1,56 @@
+/**
+ * Literal Style objects differ from standard styles in that they cannot
+ * be functions and are made up of simple objects instead of classes.
+ * @module ol/style/LiteralStyle
+ */
+
+/**
+ * Here are a few samples of literal style objects:
+ * ```js
+ * const style = {
+ *   symbol: {
+ *     symbolType: 'circle',
+ *     size: 8,
+ *     color: '#33AAFF',
+ *     opacity: 0.9
+ *   }
+ * }
+ * ```
+ *
+ * ```js
+ * const style = {
+ *   symbol: {
+ *     symbolType: 'image',
+ *     offset: [0, 12],
+ *     size: [4, 8],
+ *     src: '../static/exclamation-mark.png'
+ *   }
+ * }
+ * ```
+ *
+ * @typedef {Object} LiteralStyle
+ * @property {LiteralSymbolStyle} [symbol] Symbol representation.
+ */
+
+/**
+ * @enum {string}
+ */
+export const SymbolType = {
+  CIRCLE: 'circle',
+  SQUARE: 'square',
+  TRIANGLE: 'triangle',
+  IMAGE: 'image'
+};
+
+
+/**
+ * @typedef {Object} LiteralSymbolStyle
+ * @property {number|Array.<number, number>} size Size, mandatory.
+ * @property {SymbolType} symbolType Symbol type to use, either a regular shape or an image.
+ * @property {string} [src] Path to the image to be used for the symbol. Only required with `symbolType: 'image'`.
+ * @property {import("../color.js").Color|string} [color='#FFFFFF'] Color used for the representation (either fill, line or symbol).
+ * @property {number} [opacity=0] Opacity.
+ * @property {Array.<number, number>} [offset] Offset on X and Y axis for symbols. If not specified, the symbol will be centered.
+ * @property {Array.<number, number, number, number>} [textureCoord] Texture coordinates. If not specified, the whole texture will be used (range for 0 to 1 on both axes).
+ * @property {boolean} [rotateWithView=false] Specify whether the symbol must rotate with the view or stay upwards.
+ */

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -5,29 +5,6 @@
  */
 
 /**
- * Here are a few samples of literal style objects:
- * ```js
- * const style = {
- *   symbol: {
- *     symbolType: 'circle',
- *     size: 8,
- *     color: '#33AAFF',
- *     opacity: 0.9
- *   }
- * }
- * ```
- *
- * ```js
- * const style = {
- *   symbol: {
- *     symbolType: 'image',
- *     offset: [0, 12],
- *     size: [4, 8],
- *     src: '../static/exclamation-mark.png'
- *   }
- * }
- * ```
- *
  * @typedef {Object} LiteralStyle
  * @property {LiteralSymbolStyle} [symbol] Symbol representation.
  */
@@ -49,7 +26,7 @@ export const SymbolType = {
  * @property {SymbolType} symbolType Symbol type to use, either a regular shape or an image.
  * @property {string} [src] Path to the image to be used for the symbol. Only required with `symbolType: 'image'`.
  * @property {import("../color.js").Color|string} [color='#FFFFFF'] Color used for the representation (either fill, line or symbol).
- * @property {number} [opacity=0] Opacity.
+ * @property {number} [opacity=1] Opacity.
  * @property {Array.<number, number>} [offset] Offset on X and Y axis for symbols. If not specified, the symbol will be centered.
  * @property {Array.<number, number, number, number>} [textureCoord] Texture coordinates. If not specified, the whole texture will be used (range for 0 to 1 on both axes).
  * @property {boolean} [rotateWithView=false] Specify whether the symbol must rotate with the view or stay upwards.

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -14,7 +14,7 @@ import {
 } from '../transform.js';
 import {create, fromTransform} from '../vec/mat4.js';
 import WebGLPostProcessingPass from './PostProcessingPass.js';
-import {getContext, getSupportedExtensions} from '../webgl.js';
+import {FLOAT, getContext, getSupportedExtensions, UNSIGNED_BYTE, UNSIGNED_INT, UNSIGNED_SHORT} from '../webgl.js';
 import {includes} from '../array.js';
 import {assert} from '../asserts.js';
 
@@ -58,6 +58,28 @@ export const DefaultAttrib = {
   OFFSETS: 'a_offsets',
   COLOR: 'a_color'
 };
+
+/**
+ * Attribute types, either `UNSIGNED_BYTE`, `UNSIGNED_SHORT`, `UNSIGNED_INT` or `FLOAT`
+ * Note: an attribute stored in a `Float32Array` should be of type `FLOAT`.
+ * @enum {number}
+ */
+export const AttributeType = {
+  UNSIGNED_BYTE: UNSIGNED_BYTE,
+  UNSIGNED_SHORT: UNSIGNED_SHORT,
+  UNSIGNED_INT: UNSIGNED_INT,
+  FLOAT: FLOAT
+};
+
+/**
+ * Description of an attribute in a buffer
+ * @typedef {Object} AttributeDescription
+ * @property {string} name Attribute name to use in shaders
+ * @property {number} size Number of components per attributes
+ * @property {AttributeType} [type] Attribute type, i.e. number of bytes used to store the value. This is
+ * determined by the class of typed array which the buffer uses (eg. `Float32Array` for a `FLOAT` attribute).
+ * Default is `FLOAT`.
+ */
 
 /**
  * @typedef {number|Array<number>|HTMLCanvasElement|HTMLImageElement|ImageData|import("../transform").Transform} UniformLiteralValue
@@ -122,14 +144,14 @@ export const DefaultAttrib = {
  *   // for subsequent rendering calls
  *   const vertexShader = new WebGLVertex(VERTEX_SHADER);
  *   const fragmentShader = new WebGLFragment(FRAGMENT_SHADER);
- *   this.program = this.context.getProgram(fragmentShader, vertexShader);
- *   this.context.useProgram(this.program);
+ *   const program = this.context.getProgram(fragmentShader, vertexShader);
+ *   helper.useProgram(this.program);
  *   ```
  *
  *   Uniforms are defined using the `uniforms` option and can either be explicit values or callbacks taking the frame state as argument.
  *   You can also change their value along the way like so:
  *   ```js
- *   this.context.setUniformFloatValue('u_value', valueAsNumber);
+ *   helper.setUniformFloatValue('u_value', valueAsNumber);
  *   ```
  *
  * ### Defining post processing passes
@@ -162,32 +184,42 @@ export const DefaultAttrib = {
  *   Examples below:
  *   ```js
  *   // at initialization phase
- *   this.verticesBuffer = new WebGLArrayBuffer([], DYNAMIC_DRAW);
- *   this.indicesBuffer = new WebGLArrayBuffer([], DYNAMIC_DRAW);
+ *   const verticesBuffer = new WebGLArrayBuffer([], DYNAMIC_DRAW);
+ *   const indicesBuffer = new WebGLArrayBuffer([], DYNAMIC_DRAW);
  *
  *   // when array values have changed
- *   this.context.flushBufferData(ARRAY_BUFFER, this.verticesBuffer);
- *   this.context.flushBufferData(ELEMENT_ARRAY_BUFFER, this.indicesBuffer);
+ *   helper.flushBufferData(ARRAY_BUFFER, this.verticesBuffer);
+ *   helper.flushBufferData(ELEMENT_ARRAY_BUFFER, this.indicesBuffer);
  *
  *   // at rendering phase
- *   this.context.bindBuffer(ARRAY_BUFFER, this.verticesBuffer);
- *   this.context.bindBuffer(ELEMENT_ARRAY_BUFFER, this.indicesBuffer);
+ *   helper.bindBuffer(ARRAY_BUFFER, this.verticesBuffer);
+ *   helper.bindBuffer(ELEMENT_ARRAY_BUFFER, this.indicesBuffer);
  *   ```
  *
  * ### Specifying attributes
  *
  *   The GPU only receives the data as arrays of numbers. These numbers must be handled differently depending on what it describes (position, texture coordinate...).
- *   Attributes are used to specify these uses. Use {@link enableAttributeArray} and either
+ *   Attributes are used to specify these uses. Use {@link enableAttributeArray_} and either
  *   the default attribute names in {@link module:ol/webgl/Helper.DefaultAttrib} or custom ones.
  *
  *   Please note that you will have to specify the type and offset of the attributes in the data array. You can refer to the documentation of [WebGLRenderingContext.vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer) for more explanation.
  *   ```js
  *   // here we indicate that the data array has the following structure:
  *   // [posX, posY, offsetX, offsetY, texCoordU, texCoordV, posX, posY, ...]
- *   let bytesPerFloat = Float32Array.BYTES_PER_ELEMENT;
- *   this.context.enableAttributeArray(DefaultAttrib.POSITION, 2, FLOAT, bytesPerFloat * 6, 0);
- *   this.context.enableAttributeArray(DefaultAttrib.OFFSETS, 2, FLOAT, bytesPerFloat * 6, bytesPerFloat * 2);
- *   this.context.enableAttributeArray(DefaultAttrib.TEX_COORD, 2, FLOAT, bytesPerFloat * 6, bytesPerFloat * 4);
+ *   helper.enableAttributes([
+ *     {
+ *        name: 'a_position',
+ *        size: 2
+ *     },
+ *     {
+ *       name: 'a_offset',
+ *       size: 2
+ *     },
+ *     {
+ *       name: 'a_texCoord',
+ *       size: 2
+ *     }
+ *   ])
  *   ```
  *
  * ### Rendering primitives
@@ -195,13 +227,13 @@ export const DefaultAttrib = {
  *   Once all the steps above have been achieved, rendering primitives to the screen is done using {@link prepareDraw}, {@link drawElements} and {@link finalizeDraw}.
  *   ```js
  *   // frame preparation step
- *   this.context.prepareDraw(frameState);
+ *   helper.prepareDraw(frameState);
  *
  *   // call this for every data array that has to be rendered on screen
- *   this.context.drawElements(0, this.indicesBuffer.getArray().length);
+ *   helper.drawElements(0, this.indicesBuffer.getArray().length);
  *
  *   // finalize the rendering by applying post processes
- *   this.context.finalizeDraw(frameState);
+ *   helper.finalizeDraw(frameState);
  *   ```
  *
  * For an example usage of this class, refer to {@link module:ol/renderer/webgl/PointsLayer~WebGLPointsLayerRenderer}.
@@ -543,6 +575,7 @@ class WebGLHelper extends Disposable {
     let textureSlot = 0;
     this.uniforms_.forEach(function(uniform) {
       value = typeof uniform.value === 'function' ? uniform.value(frameState) : uniform.value;
+
       // apply value based on type
       if (value instanceof HTMLCanvasElement || value instanceof HTMLImageElement || value instanceof ImageData) {
         // create a texture & put data
@@ -734,15 +767,16 @@ class WebGLHelper extends Disposable {
   }
 
   /**
-   * Will set the currently bound buffer to an attribute of the shader program
+   * Will set the currently bound buffer to an attribute of the shader program. Used by `#enableAttributes`
+   * internally.
    * @param {string} attribName Attribute name
    * @param {number} size Number of components per attributes
    * @param {number} type UNSIGNED_INT, UNSIGNED_BYTE, UNSIGNED_SHORT or FLOAT
    * @param {number} stride Stride in bytes (0 means attribs are packed)
    * @param {number} offset Offset in bytes
-   * @api
+   * @private
    */
-  enableAttributeArray(attribName, size, type, stride, offset) {
+  enableAttributeArray_(attribName, size, type, stride, offset) {
     const location = this.getAttributeLocation(attribName);
     // the attribute has not been found in the shaders; do not enable it
     if (location < 0) {
@@ -751,6 +785,23 @@ class WebGLHelper extends Disposable {
     this.getGL().enableVertexAttribArray(location);
     this.getGL().vertexAttribPointer(location, size, type,
       false, stride, offset);
+  }
+
+  /**
+   * Will enable the following attributes to be read from the currently bound buffer,
+   * i.e. tell the GPU where to read the different attributes in the buffer. An error in the
+   * size/type/order of attributes will most likely break the rendering and throw a WebGL exception.
+   * @param {Array<AttributeDescription>} attributes Ordered list of attributes to read from the buffer
+   * @api
+   */
+  enableAttributes(attributes) {
+    const stride = computeAttributesStride(attributes);
+    let offset = 0;
+    for (let i = 0; i < attributes.length; i++) {
+      const attr = attributes[i];
+      this.enableAttributeArray_(attr.name, attr.size, attr.type || FLOAT, stride, offset);
+      offset += attr.size * getByteSizeFromType(attr.type);
+    }
   }
 
   /**
@@ -805,6 +856,36 @@ class WebGLHelper extends Disposable {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
     return texture;
+  }
+}
+
+/**
+ * Compute a stride based on a list of attributes
+ * @param {Array<AttributeDescription>} attributes Ordered list of attributes
+ * @returns {number} Stride, ie amount of values for each vertex in the vertex buffer
+ * @api
+ */
+export function computeAttributesStride(attributes) {
+  let stride = 0;
+  for (let i = 0; i < attributes.length; i++) {
+    const attr = attributes[i];
+    stride += attr.size * getByteSizeFromType(attr.type);
+  }
+  return stride;
+}
+
+/**
+ * Computes the size in byte of an attribute type.
+ * @param {AttributeType} type Attribute type
+ * @returns {number} The size in bytes
+ */
+function getByteSizeFromType(type) {
+  switch (type) {
+    case AttributeType.UNSIGNED_BYTE: return Uint8Array.BYTES_PER_ELEMENT;
+    case AttributeType.UNSIGNED_SHORT: return Uint16Array.BYTES_PER_ELEMENT;
+    case AttributeType.UNSIGNED_INT: return Uint32Array.BYTES_PER_ELEMENT;
+    case AttributeType.FLOAT:
+    default: return Float32Array.BYTES_PER_ELEMENT;
   }
 }
 

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -46,20 +46,6 @@ export const DefaultUniform = {
 };
 
 /**
- * Attribute names used in the default shaders: `POSITION`, `TEX_COORD`, `OPACITY`,
- * `ROTATE_WITH_VIEW`, `OFFSETS` and `COLOR`
- * @enum {string}
- */
-export const DefaultAttrib = {
-  POSITION: 'a_position',
-  TEX_COORD: 'a_texCoord',
-  OPACITY: 'a_opacity',
-  ROTATE_WITH_VIEW: 'a_rotateWithView',
-  OFFSETS: 'a_offsets',
-  COLOR: 'a_color'
-};
-
-/**
  * Attribute types, either `UNSIGNED_BYTE`, `UNSIGNED_SHORT`, `UNSIGNED_INT` or `FLOAT`
  * Note: an attribute stored in a `Float32Array` should be of type `FLOAT`.
  * @enum {number}
@@ -860,7 +846,7 @@ class WebGLHelper extends Disposable {
 }
 
 /**
- * Compute a stride based on a list of attributes
+ * Compute a stride in bytes based on a list of attributes
  * @param {Array<AttributeDescription>} attributes Ordered list of attributes
  * @returns {number} Stride, ie amount of values for each vertex in the vertex buffer
  * @api

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -1,5 +1,3 @@
-import {asArray} from '../color.js';
-
 /**
  * Utilities for generating shaders from literal style objects
  * @module ol/webgl/ShaderBuilder
@@ -16,6 +14,15 @@ export function formatNumber(v) {
 }
 
 /**
+ * Will return the number array as a float with a dot separator, concatenated with ', '.
+ * @param {Array<number>} array Numerical values array.
+ * @returns {string} The array as string, e. g.: `1.0, 2.0, 3.0`.
+ */
+export function formatArray(array) {
+  return array.map(formatNumber).join(', ');
+}
+
+/**
  * Will normalize and converts to string a color array compatible with GLSL.
  * @param {Array<number>} colorArray Color in [r, g, b, a] array form, with RGB components in the
  * 0..255 range and the alpha component in the 0..1 range. Note that if the A component is
@@ -29,54 +36,78 @@ export function formatColor(colorArray) {
 }
 
 /**
- * Generates a symbol vertex shader from a literal style,
+ * @typedef {Object} VaryingDescription
+ * @property {string} name Varying name, as will be declared in the header.
+ * @property {string} type Varying type, either `float`, `vec2`, `vec4`...
+ * @property {string} expression Expression which will be assigned to the varying in the vertex shader, and
+ * passed on to the fragment shader.
+ */
+
+/**
+ * @typedef {Object} ShaderParameters
+ * @property {Array<string>} [uniforms] Uniforms; these will be declared in the header (should include the type).
+ * @property {Array<string>} [attributes] Attributes; these will be declared in the header (should include the type).
+ * @property {Array<VaryingDescription>} [varyings] Varyings with a name, a type and an expression.
+ * @property {string} sizeExpression This will be assigned to a `vec2 size` variable.
+ * @property {string} offsetExpression This will be assigned to a `vec2 offset` variable.
+ * @property {string} colorExpression This will be the value assigned to gl_FragColor
+ * @property {string} texCoordExpression This will be the value assigned to the `vec4 v_texCoord` varying.
+ * @property {boolean} [rotateWithView=false] Whether symbols should rotate with view
+ */
+
+/**
+ * Generates a symbol vertex shader from a set of parameters,
  * intended to be used on point geometries.
  *
- * Expected the following attributes to be present in the attribute array:
+ * Three uniforms are hardcoded in all shaders: `u_projectionMatrix`, `u_offsetScaleMatrix` and
+ * `u_offsetRotateMatrix`.
+ *
+ * The following attributes are hardcoded and expected to be present in the vertex buffers:
  * `vec2 a_position`, `float a_index` (being the index of the vertex in the quad, 0 to 3).
  *
- * Transmits the following varyings to the fragment shader:
- * `vec2 v_texCoord`, `float v_opacity`, `vec4 v_color`
- *
- * @param {import('../style/LiteralStyle.js').LiteralSymbolStyle} parameters Parameters for the shader.
+ * @param {ShaderParameters} parameters Parameters for the shader.
  * @returns {string} The full shader as a string.
  */
 export function getSymbolVertexShader(parameters) {
   const offsetMatrix = parameters.rotateWithView ?
-    'mat4 offsetMatrix = u_offsetScaleMatrix * u_offsetRotateMatrix;' :
-    'mat4 offsetMatrix = u_offsetScaleMatrix;';
+    'u_offsetScaleMatrix * u_offsetRotateMatrix' :
+    'u_offsetScaleMatrix';
 
-  const offset = parameters.offset || [0, 0];
-  const size = Array.isArray(parameters.size) ? parameters.size : [parameters.size, parameters.size];
-  const texCoord = parameters.textureCoord || [0, 0, 1, 1];
-  const opacity = parameters.opacity !== undefined ? parameters.opacity : 1;
-  const color = parameters.color !== undefined ?
-    (typeof parameters.color === 'string' ? asArray(parameters.color) : parameters.color) :
-    [255, 255, 255, 1];
-
-  const f = formatNumber;
+  const uniforms = parameters.uniforms || [];
+  const attributes = parameters.attributes || [];
+  const varyings = parameters.varyings || [];
 
   const body = `precision mediump float;
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+${uniforms.map(function(uniform) {
+    return 'uniform ' + uniform + ';';
+  }).join('\n')}
 attribute vec2 a_position;
 attribute float a_index;
+${attributes.map(function(attribute) {
+    return 'attribute ' + attribute + ';';
+  }).join('\n')}
 varying vec2 v_texCoord;
-varying float v_opacity;
-varying vec4 v_color;
-
+${varyings.map(function(varying) {
+    return 'varying ' + varying.type + ' ' + varying.name + ';';
+  }).join('\n')}
 void main(void) {
-  ${offsetMatrix}
-  float offsetX = a_index == 0.0 || a_index == 3.0 ? ${f(offset[0] - size[0] / 2)} : ${f(offset[0] + size[0] / 2)};
-  float offsetY = a_index == 0.0 || a_index == 1.0 ? ${f(offset[1] - size[1] / 2)} : ${f(offset[1] + size[1] / 2)};
+  mat4 offsetMatrix = ${offsetMatrix};
+  vec2 size = ${parameters.sizeExpression};
+  vec2 offset = ${parameters.offsetExpression};
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? offset.x - size.x / 2.0 : offset.x + size.x / 2.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? offset.y - size.y / 2.0 : offset.y + size.y / 2.0;
   vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
-  float u = a_index == 0.0 || a_index == 3.0 ? ${f(texCoord[0])} : ${f(texCoord[2])};
-  float v = a_index == 0.0 || a_index == 1.0 ? ${f(texCoord[1])} : ${f(texCoord[3])};
+  vec4 texCoord = ${parameters.texCoordExpression};
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
   v_texCoord = vec2(u, v);
-  v_opacity = ${f(opacity)};
-  v_color = vec4(${formatColor(color)});
+${varyings.map(function(varying) {
+    return '  ' + varying.name + ' = ' + varying.expression + ';';
+  }).join('\n')}
 }`;
 
   return body;
@@ -86,24 +117,25 @@ void main(void) {
  * Generates a symbol fragment shader intended to be used on point geometries.
  *
  * Expected the following varyings to be transmitted by the vertex shader:
- * `vec2 v_texCoord`, `float v_opacity`, `vec4 v_color`
+ * `vec2 v_texCoord`
  *
+ * @param {ShaderParameters} parameters Parameters for the shader.
  * @returns {string} The full shader as a string.
  */
-export function getSymbolFragmentShader() {
-  const body = `precision mediump float;
-uniform sampler2D u_texture;
-varying vec2 v_texCoord;
-varying float v_opacity;
-varying vec4 v_color;
+export function getSymbolFragmentShader(parameters) {
+  const uniforms = parameters.uniforms || [];
+  const varyings = parameters.varyings || [];
 
+  const body = `precision mediump float;
+${uniforms.map(function(uniform) {
+    return 'uniform ' + uniform + ';';
+  }).join('\n')}
+varying vec2 v_texCoord;
+${varyings.map(function(varying) {
+    return 'varying ' + varying.type + ' ' + varying.name + ';';
+  }).join('\n')}
 void main(void) {
-  if (v_opacity == 0.0) {
-    discard;
-  }
-  vec4 textureColor = texture2D(u_texture, v_texCoord);
-  gl_FragColor = v_color * textureColor;
-  gl_FragColor.a *= v_opacity;
+  gl_FragColor = ${parameters.colorExpression};
   gl_FragColor.rgb *= gl_FragColor.a;
 }`;
 

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -1,0 +1,82 @@
+import {asArray} from '../color.js';
+
+/**
+ * Utilities for generating shaders from literal style objects
+ * @module ol/webgl/ShaderBuilder
+ */
+
+/**
+ * Will return the number as a float with a dit separator, which is required by GLSL.
+ * @param {number} v Numerical value.
+ * @returns {string} The value as string.
+ */
+export function formatNumber(v) {
+  const s = v.toString();
+  return s.indexOf('.') === -1 ? s + '.0' : s;
+}
+
+/**
+ * @typedef {Object} SymbolShaderParameters
+ * @property {number|Array.<number, number>} size Size.
+ * @property {boolean} [rotateWithView] Rotate with view.
+ * @property {Array.<number, number>} [offset] Offset.
+ * @property {Array.<number, number, number, number>} [textureCoord] Texture coordinates: u0, v0, u1, v1.
+ * @property {number} [opacity] Opacity.
+ * @property {import("../color.js").Color|string} [color] Color.
+ */
+
+/**
+ * Generates a symbol shader, i.e. a shader intended to be used on point geometries.
+ *
+ * Expected the following attributes to be present in the attribute array:
+ * `vec2 a_position`, `float a_index` (being the index of the vertex in the quad, 0 to 3).
+ *
+ * Transmits the following varyings to the fragment shader:
+ * `vec2 v_texCoord`, `float v_opacity`, `vec4 v_color`
+ *
+ * @param {SymbolShaderParameters} parameters Parameters for the shader.
+ * @returns {string} The full shader as a string.
+ */
+export function getSymbolVertexShader(parameters) {
+  const offsetMatrix = parameters.rotateWithView ?
+    'mat4 offsetMatrix = u_offsetScaleMatrix * u_offsetRotateMatrix;' :
+    'mat4 offsetMatrix = u_offsetScaleMatrix;';
+
+  const offset = parameters.offset || [0, 0];
+  const size = Array.isArray(parameters.size) ? parameters.size : [parameters.size, parameters.size];
+  const texCoord = parameters.textureCoord || [0, 0, 1, 1];
+  const opacity = parameters.opacity !== undefined ? parameters.opacity : 1;
+  const color = parameters.color !== undefined ?
+    (typeof parameters.color === 'string' ? asArray(parameters.color) : parameters.color) :
+    [255, 255, 255, 1];
+  function normalizeColor(c, i) {
+    return i < 3 ? c / 255 : c;
+  }
+
+  const f = formatNumber;
+
+  const body = `precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+attribute vec2 a_position;
+attribute float a_index;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  ${offsetMatrix}
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? ${f(offset[0] - size[0] / 2)} : ${f(offset[0] + size[0] / 2)};
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? ${f(offset[1] - size[1] / 2)} : ${f(offset[1] + size[1] / 2)};
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  float u = a_index == 0.0 || a_index == 3.0 ? ${f(texCoord[0])} : ${f(texCoord[2])};
+  float v = a_index == 0.0 || a_index == 1.0 ? ${f(texCoord[1])} : ${f(texCoord[3])};
+  v_texCoord = vec2(u, v);
+  v_opacity = ${f(opacity)};
+  v_color = vec4(${color.map(normalizeColor).map(f).join(', ')});
+}`;
+
+  return body;
+}

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -6,13 +6,26 @@ import {asArray} from '../color.js';
  */
 
 /**
- * Will return the number as a float with a dit separator, which is required by GLSL.
+ * Will return the number as a float with a dot separator, which is required by GLSL.
  * @param {number} v Numerical value.
  * @returns {string} The value as string.
  */
 export function formatNumber(v) {
   const s = v.toString();
   return s.indexOf('.') === -1 ? s + '.0' : s;
+}
+
+/**
+ * Will normalize and converts to string a color array compatible with GLSL.
+ * @param {Array<number>} colorArray Color in [r, g, b, a] array form, with RGB components in the
+ * 0..255 range and the alpha component in the 0..1 range. Note that if the A component is
+ * missing, only 3 values will be output.
+ * @returns {string} The color components concatenated in `1.0, 1.0, 1.0, 1.0` form.
+ */
+export function formatColor(colorArray) {
+  return colorArray.map(function (c, i) {
+    return i < 3 ? c / 255 : c;
+  }).map(formatNumber).join(', ');
 }
 
 /**
@@ -40,9 +53,6 @@ export function getSymbolVertexShader(parameters) {
   const color = parameters.color !== undefined ?
     (typeof parameters.color === 'string' ? asArray(parameters.color) : parameters.color) :
     [255, 255, 255, 1];
-  function normalizeColor(c, i) {
-    return i < 3 ? c / 255 : c;
-  }
 
   const f = formatNumber;
 
@@ -66,7 +76,7 @@ void main(void) {
   float v = a_index == 0.0 || a_index == 1.0 ? ${f(texCoord[1])} : ${f(texCoord[3])};
   v_texCoord = vec2(u, v);
   v_opacity = ${f(opacity)};
-  v_color = vec4(${color.map(normalizeColor).map(f).join(', ')});
+  v_color = vec4(${formatColor(color)});
 }`;
 
   return body;

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -26,7 +26,7 @@ export function formatNumber(v) {
  */
 
 /**
- * Generates a symbol shader, i.e. a shader intended to be used on point geometries.
+ * Generates a symbol vertex shader, i.e. a shader intended to be used on point geometries.
  *
  * Expected the following attributes to be present in the attribute array:
  * `vec2 a_position`, `float a_index` (being the index of the vertex in the quad, 0 to 3).
@@ -76,6 +76,34 @@ void main(void) {
   v_texCoord = vec2(u, v);
   v_opacity = ${f(opacity)};
   v_color = vec4(${color.map(normalizeColor).map(f).join(', ')});
+}`;
+
+  return body;
+}
+
+/**
+ * Generates a symbol fragment shader, i.e. a shader intended to be used on point geometries.
+ *
+ * Expected the following varyings to be transmitted by the vertex shader:
+ * `vec2 v_texCoord`, `float v_opacity`, `vec4 v_color`
+ *
+ * @returns {string} The full shader as a string.
+ */
+export function getSymbolFragmentShader() {
+  const body = `precision mediump float;
+uniform sampler2D u_texture;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  if (v_opacity == 0.0) {
+    discard;
+  }
+  vec4 textureColor = texture2D(u_texture, v_texCoord);
+  gl_FragColor = v_color * textureColor;
+  gl_FragColor.a *= v_opacity;
+  gl_FragColor.rgb *= gl_FragColor.a;
 }`;
 
   return body;

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -16,17 +16,8 @@ export function formatNumber(v) {
 }
 
 /**
- * @typedef {Object} SymbolShaderParameters
- * @property {number|Array.<number, number>} size Size.
- * @property {boolean} [rotateWithView] Rotate with view.
- * @property {Array.<number, number>} [offset] Offset.
- * @property {Array.<number, number, number, number>} [textureCoord] Texture coordinates: u0, v0, u1, v1.
- * @property {number} [opacity] Opacity.
- * @property {import("../color.js").Color|string} [color] Color.
- */
-
-/**
- * Generates a symbol vertex shader, i.e. a shader intended to be used on point geometries.
+ * Generates a symbol vertex shader from a literal style,
+ * intended to be used on point geometries.
  *
  * Expected the following attributes to be present in the attribute array:
  * `vec2 a_position`, `float a_index` (being the index of the vertex in the quad, 0 to 3).
@@ -34,7 +25,7 @@ export function formatNumber(v) {
  * Transmits the following varyings to the fragment shader:
  * `vec2 v_texCoord`, `float v_opacity`, `vec4 v_color`
  *
- * @param {SymbolShaderParameters} parameters Parameters for the shader.
+ * @param {import('../style/LiteralStyle.js').LiteralSymbolStyle} parameters Parameters for the shader.
  * @returns {string} The full shader as a string.
  */
 export function getSymbolVertexShader(parameters) {
@@ -82,7 +73,7 @@ void main(void) {
 }
 
 /**
- * Generates a symbol fragment shader, i.e. a shader intended to be used on point geometries.
+ * Generates a symbol fragment shader intended to be used on point geometries.
  *
  * Expected the following varyings to be transmitted by the vertex shader:
  * `vec2 v_texCoord`, `float v_opacity`, `vec4 v_color`

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -23,7 +23,7 @@ export function formatNumber(v) {
  * @returns {string} The color components concatenated in `1.0, 1.0, 1.0, 1.0` form.
  */
 export function formatColor(colorArray) {
-  return colorArray.map(function (c, i) {
+  return colorArray.map(function(c, i) {
     return i < 3 ? c / 255 : c;
   }).map(formatNumber).join(', ');
 }

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -14,7 +14,7 @@ const worker = self;
 worker.onmessage = event => {
   const received = event.data;
   if (received.type === WebGLWorkerMessageType.GENERATE_BUFFERS) {
-    // This is specific to point features
+    // This is specific to point features (x, y, index)
     const baseVertexAttrsCount = 3;
     const baseInstructionsCount = 2;
 

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -3,8 +3,6 @@
  * @module ol/worker/webgl
  */
 import {
-  POINT_INSTRUCTIONS_COUNT,
-  POINT_VERTEX_STRIDE,
   WebGLWorkerMessageType,
   writePointFeatureToBuffers
 } from '../renderer/webgl/Layer.js';
@@ -16,13 +14,17 @@ const worker = self;
 worker.onmessage = event => {
   const received = event.data;
   if (received.type === WebGLWorkerMessageType.GENERATE_BUFFERS) {
+    // This is specific to point features
+    const baseVertexAttrsCount = 3;
+    const baseInstructionsCount = 2;
+
+    const customAttrsCount = received.customAttributesCount;
+    const instructionsCount = baseInstructionsCount + customAttrsCount;
     const renderInstructions = new Float32Array(received.renderInstructions);
-    const customAttributesCount = received.customAttributesCount || 0;
-    const instructionsCount = POINT_INSTRUCTIONS_COUNT + customAttributesCount;
 
     const elementsCount = renderInstructions.length / instructionsCount;
     const indicesCount = elementsCount * 6;
-    const verticesCount = elementsCount * 4 * (POINT_VERTEX_STRIDE + customAttributesCount);
+    const verticesCount = elementsCount * 4 * (customAttrsCount + baseVertexAttrsCount);
     const indexBuffer = new Uint32Array(indicesCount);
     const vertexBuffer = new Float32Array(verticesCount);
 
@@ -33,8 +35,8 @@ worker.onmessage = event => {
         i,
         vertexBuffer,
         indexBuffer,
-        bufferPositions,
-        instructionsCount);
+        customAttrsCount,
+        bufferPositions);
     }
 
     /** @type {import('../renderer/webgl/Layer').WebGLWorkerGenerateBuffersMessage} */

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -1,8 +1,8 @@
 import WebGLLayerRenderer, {
   colorDecodeId,
   colorEncodeId,
-  getBlankImageData, POINT_INSTRUCTIONS_COUNT, POINT_VERTEX_STRIDE,
-  writePointFeatureInstructions, writePointFeatureToBuffers
+  getBlankImageData,
+  writePointFeatureToBuffers
 } from '../../../../../src/ol/renderer/webgl/Layer.js';
 import Layer from '../../../../../src/ol/layer/Layer.js';
 
@@ -32,60 +32,6 @@ describe('ol.renderer.webgl.Layer', function() {
 
   });
 
-  describe('writePointFeatureInstructions', function() {
-    let instructions;
-
-    beforeEach(function() {
-      instructions = new Float32Array(100);
-    });
-
-    it('writes instructions corresponding to the given parameters', function() {
-      const baseIndex = 17;
-      writePointFeatureInstructions(instructions, baseIndex,
-        1, 2, 3, 4, 5, 6,
-        7, 8, true, [10, 11, 12, 13]);
-      expect(instructions[baseIndex + 0]).to.eql(1);
-      expect(instructions[baseIndex + 1]).to.eql(2);
-      expect(instructions[baseIndex + 2]).to.eql(3);
-      expect(instructions[baseIndex + 3]).to.eql(4);
-      expect(instructions[baseIndex + 4]).to.eql(5);
-      expect(instructions[baseIndex + 5]).to.eql(6);
-      expect(instructions[baseIndex + 6]).to.eql(7);
-      expect(instructions[baseIndex + 7]).to.eql(8);
-      expect(instructions[baseIndex + 8]).to.eql(1);
-      expect(instructions[baseIndex + 9]).to.eql(10);
-      expect(instructions[baseIndex + 10]).to.eql(11);
-      expect(instructions[baseIndex + 11]).to.eql(12);
-      expect(instructions[baseIndex + 12]).to.eql(13);
-    });
-
-    it('correctly chains writes', function() {
-      let baseIndex = 0;
-      baseIndex = writePointFeatureInstructions(instructions, baseIndex,
-        1, 2, 3, 4, 5, 6,
-        7, 8, true, [10, 11, 12, 13]);
-      baseIndex = writePointFeatureInstructions(instructions, baseIndex,
-        1, 2, 3, 4, 5, 6,
-        7, 8, true, [10, 11, 12, 13]);
-      writePointFeatureInstructions(instructions, baseIndex,
-        1, 2, 3, 4, 5, 6,
-        7, 8, true, [10, 11, 12, 13]);
-      expect(instructions[baseIndex + 0]).to.eql(1);
-      expect(instructions[baseIndex + 1]).to.eql(2);
-      expect(instructions[baseIndex + 2]).to.eql(3);
-      expect(instructions[baseIndex + 3]).to.eql(4);
-      expect(instructions[baseIndex + 4]).to.eql(5);
-      expect(instructions[baseIndex + 5]).to.eql(6);
-      expect(instructions[baseIndex + 6]).to.eql(7);
-      expect(instructions[baseIndex + 7]).to.eql(8);
-      expect(instructions[baseIndex + 8]).to.eql(1);
-      expect(instructions[baseIndex + 9]).to.eql(10);
-      expect(instructions[baseIndex + 10]).to.eql(11);
-      expect(instructions[baseIndex + 11]).to.eql(12);
-      expect(instructions[baseIndex + 12]).to.eql(13);
-    });
-  });
-
   describe('writePointFeatureToBuffers', function() {
     let vertexBuffer, indexBuffer, instructions, elementIndex;
 
@@ -93,50 +39,29 @@ describe('ol.renderer.webgl.Layer', function() {
       vertexBuffer = new Float32Array(100);
       indexBuffer = new Uint32Array(100);
       instructions = new Float32Array(100);
-      elementIndex = 3;
 
-      writePointFeatureInstructions(instructions, elementIndex,
-        1, 2, 3, 4, 5, 6,
-        7, 8, true, [10, 11, 12, 13]);
+      instructions.set([0, 0, 0, 0, 10, 11]);
     });
 
     it('writes correctly to the buffers (without custom attributes)', function() {
-      const stride = POINT_VERTEX_STRIDE;
-      const positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer);
+      const stride = 3;
+      const positions = writePointFeatureToBuffers(instructions, 4, vertexBuffer, indexBuffer, 0);
 
-      expect(vertexBuffer[0]).to.eql(1);
-      expect(vertexBuffer[1]).to.eql(2);
-      expect(vertexBuffer[2]).to.eql(-3.5);
-      expect(vertexBuffer[3]).to.eql(-3.5);
-      expect(vertexBuffer[4]).to.eql(3);
-      expect(vertexBuffer[5]).to.eql(4);
-      expect(vertexBuffer[6]).to.eql(8);
-      expect(vertexBuffer[7]).to.eql(1);
-      expect(vertexBuffer[8]).to.eql(10);
-      expect(vertexBuffer[9]).to.eql(11);
-      expect(vertexBuffer[10]).to.eql(12);
-      expect(vertexBuffer[11]).to.eql(13);
+      expect(vertexBuffer[0]).to.eql(10);
+      expect(vertexBuffer[1]).to.eql(11);
+      expect(vertexBuffer[2]).to.eql(0);
 
-      expect(vertexBuffer[stride + 0]).to.eql(1);
-      expect(vertexBuffer[stride + 1]).to.eql(2);
-      expect(vertexBuffer[stride + 2]).to.eql(+3.5);
-      expect(vertexBuffer[stride + 3]).to.eql(-3.5);
-      expect(vertexBuffer[stride + 4]).to.eql(5);
-      expect(vertexBuffer[stride + 5]).to.eql(4);
+      expect(vertexBuffer[stride + 0]).to.eql(10);
+      expect(vertexBuffer[stride + 1]).to.eql(11);
+      expect(vertexBuffer[stride + 2]).to.eql(1);
 
-      expect(vertexBuffer[stride * 2 + 0]).to.eql(1);
-      expect(vertexBuffer[stride * 2 + 1]).to.eql(2);
-      expect(vertexBuffer[stride * 2 + 2]).to.eql(+3.5);
-      expect(vertexBuffer[stride * 2 + 3]).to.eql(+3.5);
-      expect(vertexBuffer[stride * 2 + 4]).to.eql(5);
-      expect(vertexBuffer[stride * 2 + 5]).to.eql(6);
+      expect(vertexBuffer[stride * 2 + 0]).to.eql(10);
+      expect(vertexBuffer[stride * 2 + 1]).to.eql(11);
+      expect(vertexBuffer[stride * 2 + 2]).to.eql(2);
 
-      expect(vertexBuffer[stride * 3 + 0]).to.eql(1);
-      expect(vertexBuffer[stride * 3 + 1]).to.eql(2);
-      expect(vertexBuffer[stride * 3 + 2]).to.eql(-3.5);
-      expect(vertexBuffer[stride * 3 + 3]).to.eql(+3.5);
-      expect(vertexBuffer[stride * 3 + 4]).to.eql(3);
-      expect(vertexBuffer[stride * 3 + 5]).to.eql(6);
+      expect(vertexBuffer[stride * 3 + 0]).to.eql(10);
+      expect(vertexBuffer[stride * 3 + 1]).to.eql(11);
+      expect(vertexBuffer[stride * 3 + 2]).to.eql(3);
 
       expect(indexBuffer[0]).to.eql(0);
       expect(indexBuffer[1]).to.eql(1);
@@ -149,43 +74,34 @@ describe('ol.renderer.webgl.Layer', function() {
       expect(positions.vertexPosition).to.eql(stride * 4);
     });
 
-    it('writes correctly to the buffers (with custom attributes)', function() {
-      instructions[elementIndex + POINT_INSTRUCTIONS_COUNT] = 101;
-      instructions[elementIndex + POINT_INSTRUCTIONS_COUNT + 1] = 102;
-      instructions[elementIndex + POINT_INSTRUCTIONS_COUNT + 2] = 103;
+    it('writes correctly to the buffers (with 2 custom attributes)', function() {
+      instructions.set([0, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13]);
+      const stride = 5;
+      const positions = writePointFeatureToBuffers(instructions, 8, vertexBuffer, indexBuffer, 2);
 
-      const stride = POINT_VERTEX_STRIDE + 3;
-      const positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer,
-        undefined, POINT_INSTRUCTIONS_COUNT + 3);
+      expect(vertexBuffer[0]).to.eql(10);
+      expect(vertexBuffer[1]).to.eql(11);
+      expect(vertexBuffer[2]).to.eql(0);
+      expect(vertexBuffer[3]).to.eql(12);
+      expect(vertexBuffer[4]).to.eql(13);
 
-      expect(vertexBuffer[0]).to.eql(1);
-      expect(vertexBuffer[1]).to.eql(2);
-      expect(vertexBuffer[2]).to.eql(-3.5);
-      expect(vertexBuffer[3]).to.eql(-3.5);
-      expect(vertexBuffer[4]).to.eql(3);
-      expect(vertexBuffer[5]).to.eql(4);
-      expect(vertexBuffer[6]).to.eql(8);
-      expect(vertexBuffer[7]).to.eql(1);
-      expect(vertexBuffer[8]).to.eql(10);
-      expect(vertexBuffer[9]).to.eql(11);
-      expect(vertexBuffer[10]).to.eql(12);
-      expect(vertexBuffer[11]).to.eql(13);
+      expect(vertexBuffer[stride + 0]).to.eql(10);
+      expect(vertexBuffer[stride + 1]).to.eql(11);
+      expect(vertexBuffer[stride + 2]).to.eql(1);
+      expect(vertexBuffer[stride + 3]).to.eql(12);
+      expect(vertexBuffer[stride + 4]).to.eql(13);
 
-      expect(vertexBuffer[12]).to.eql(101);
-      expect(vertexBuffer[13]).to.eql(102);
-      expect(vertexBuffer[14]).to.eql(103);
+      expect(vertexBuffer[stride * 2 + 0]).to.eql(10);
+      expect(vertexBuffer[stride * 2 + 1]).to.eql(11);
+      expect(vertexBuffer[stride * 2 + 2]).to.eql(2);
+      expect(vertexBuffer[stride * 2 + 3]).to.eql(12);
+      expect(vertexBuffer[stride * 2 + 4]).to.eql(13);
 
-      expect(vertexBuffer[stride + 12]).to.eql(101);
-      expect(vertexBuffer[stride + 13]).to.eql(102);
-      expect(vertexBuffer[stride + 14]).to.eql(103);
-
-      expect(vertexBuffer[stride * 2 + 12]).to.eql(101);
-      expect(vertexBuffer[stride * 2 + 13]).to.eql(102);
-      expect(vertexBuffer[stride * 2 + 14]).to.eql(103);
-
-      expect(vertexBuffer[stride * 3 + 12]).to.eql(101);
-      expect(vertexBuffer[stride * 3 + 13]).to.eql(102);
-      expect(vertexBuffer[stride * 3 + 14]).to.eql(103);
+      expect(vertexBuffer[stride * 3 + 0]).to.eql(10);
+      expect(vertexBuffer[stride * 3 + 1]).to.eql(11);
+      expect(vertexBuffer[stride * 3 + 2]).to.eql(3);
+      expect(vertexBuffer[stride * 3 + 3]).to.eql(12);
+      expect(vertexBuffer[stride * 3 + 4]).to.eql(13);
 
       expect(indexBuffer[0]).to.eql(0);
       expect(indexBuffer[1]).to.eql(1);
@@ -199,25 +115,23 @@ describe('ol.renderer.webgl.Layer', function() {
     });
 
     it('correctly chains buffer writes', function() {
-      const stride = POINT_VERTEX_STRIDE;
-      let positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer);
-      positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer, positions);
-      positions = writePointFeatureToBuffers(instructions, elementIndex, vertexBuffer, indexBuffer, positions);
+      instructions.set([10, 11, 20, 21, 30, 31]);
+      const stride = 3;
+      let positions = writePointFeatureToBuffers(instructions, 0, vertexBuffer, indexBuffer, 0);
+      positions = writePointFeatureToBuffers(instructions, 2, vertexBuffer, indexBuffer, 0, positions);
+      positions = writePointFeatureToBuffers(instructions, 4, vertexBuffer, indexBuffer, 0, positions);
 
-      expect(vertexBuffer[0]).to.eql(1);
-      expect(vertexBuffer[1]).to.eql(2);
-      expect(vertexBuffer[2]).to.eql(-3.5);
-      expect(vertexBuffer[3]).to.eql(-3.5);
+      expect(vertexBuffer[0]).to.eql(10);
+      expect(vertexBuffer[1]).to.eql(11);
+      expect(vertexBuffer[2]).to.eql(0);
 
-      expect(vertexBuffer[stride * 4 + 0]).to.eql(1);
-      expect(vertexBuffer[stride * 4 + 1]).to.eql(2);
-      expect(vertexBuffer[stride * 4 + 2]).to.eql(-3.5);
-      expect(vertexBuffer[stride * 4 + 3]).to.eql(-3.5);
+      expect(vertexBuffer[stride * 4 + 0]).to.eql(20);
+      expect(vertexBuffer[stride * 4 + 1]).to.eql(21);
+      expect(vertexBuffer[stride * 4 + 2]).to.eql(0);
 
-      expect(vertexBuffer[stride * 8 + 0]).to.eql(1);
-      expect(vertexBuffer[stride * 8 + 1]).to.eql(2);
-      expect(vertexBuffer[stride * 8 + 2]).to.eql(-3.5);
-      expect(vertexBuffer[stride * 8 + 3]).to.eql(-3.5);
+      expect(vertexBuffer[stride * 8 + 0]).to.eql(30);
+      expect(vertexBuffer[stride * 8 + 1]).to.eql(31);
+      expect(vertexBuffer[stride * 8 + 2]).to.eql(0);
 
       expect(indexBuffer[6 + 0]).to.eql(4);
       expect(indexBuffer[6 + 1]).to.eql(5);

--- a/test/spec/ol/renderer/webgl/layer.test.js
+++ b/test/spec/ol/renderer/webgl/layer.test.js
@@ -33,7 +33,7 @@ describe('ol.renderer.webgl.Layer', function() {
   });
 
   describe('writePointFeatureToBuffers', function() {
-    let vertexBuffer, indexBuffer, instructions, elementIndex;
+    let vertexBuffer, indexBuffer, instructions;
 
     beforeEach(function() {
       vertexBuffer = new Float32Array(100);

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -254,4 +254,20 @@ describe('ol.renderer.webgl.PointsLayer', function() {
     });
   });
 
+  describe('#disposeInternal', function() {
+    it('terminates the worker and calls dispose on the helper', function() {
+      const layer = new VectorLayer({
+        source: new VectorSource()
+      });
+      const renderer = new WebGLPointsLayerRenderer(layer, {
+      });
+
+      const spyHelper = sinon.spy(renderer.helper, 'disposeInternal');
+      const spyWorker = sinon.spy(renderer.worker_, 'terminate');
+      renderer.disposeInternal();
+      expect(spyHelper.called).to.be(true);
+      expect(spyWorker.called).to.be(true);
+    });
+  });
+
 });

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -5,8 +5,9 @@ import VectorSource from '../../../../../src/ol/source/Vector.js';
 import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
 import ViewHint from '../../../../../src/ol/ViewHint.js';
-import {POINT_VERTEX_STRIDE, WebGLWorkerMessageType} from '../../../../../src/ol/renderer/webgl/Layer.js';
-import {create as createTransform, compose as composeTransform} from '../../../../../src/ol/transform.js';
+import {WebGLWorkerMessageType} from '../../../../../src/ol/renderer/webgl/Layer.js';
+import {compose as composeTransform, create as createTransform} from '../../../../../src/ol/transform.js';
+import {getSymbolVertexShader} from '../../../../../src/ol/webgl/ShaderBuilder.js';
 
 const baseFrameState = {
   viewHints: [],
@@ -77,7 +78,7 @@ describe('ol.renderer.webgl.PointsLayer', function() {
       }));
       renderer.prepareFrame(frameState);
 
-      const attributePerVertex = POINT_VERTEX_STRIDE;
+      const attributePerVertex = 3;
 
       renderer.worker_.addEventListener('message', function(event) {
         if (event.data.type !== WebGLWorkerMessageType.GENERATE_BUFFERS) {
@@ -109,7 +110,7 @@ describe('ol.renderer.webgl.PointsLayer', function() {
         if (event.data.type !== WebGLWorkerMessageType.GENERATE_BUFFERS) {
           return;
         }
-        const attributePerVertex = 12;
+        const attributePerVertex = 3;
         expect(renderer.verticesBuffer_.getArray().length).to.eql(4 * attributePerVertex);
         expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
         done();
@@ -162,9 +163,9 @@ describe('ol.renderer.webgl.PointsLayer', function() {
         })
       });
       renderer = new WebGLPointsLayerRenderer(layer, {
-        sizeCallback: function() {
-          return 4;
-        }
+        vertexShader: getSymbolVertexShader({
+          size: 4
+        })
       });
     });
 

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -108,7 +108,9 @@ describe('ol.renderer.webgl.PointsLayer', function() {
       });
       renderer = new WebGLPointsLayerRenderer(layer, {
         vertexShader: simpleVertexShader,
-        fragmentShader: simpleFragmentShader
+        fragmentShader: simpleFragmentShader,
+        hitVertexShader: hitVertexShader,
+        hitFragmentShader: hitFragmentShader
       });
       frameState = Object.assign({
         size: [2, 2],

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,8 +1,9 @@
-import WebGLHelper, {AttributeType, computeAttributesStride} from '../../../../src/ol/webgl/Helper.js';
+import WebGLHelper from '../../../../src/ol/webgl/Helper.js';
 import {
   create as createTransform,
   rotate as rotateTransform,
-  scale as scaleTransform, translate as translateTransform
+  scale as scaleTransform,
+  translate as translateTransform
 } from '../../../../src/ol/transform.js';
 import {FLOAT} from '../../../../src/ol/webgl.js';
 

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -1,4 +1,9 @@
-import {getSymbolVertexShader, formatNumber, getSymbolFragmentShader} from '../../../../src/ol/webgl/ShaderBuilder.js';
+import {
+  getSymbolVertexShader,
+  formatNumber,
+  getSymbolFragmentShader,
+  formatColor, formatArray
+} from '../../../../src/ol/webgl/ShaderBuilder.js';
 
 describe('ol.webgl.ShaderBuilder', function() {
 
@@ -12,147 +17,180 @@ describe('ol.webgl.ShaderBuilder', function() {
     });
   });
 
+  describe('formatArray', function() {
+    it('outputs numbers with dot separators', function() {
+      expect(formatArray([1, 0, 3.45, 0.8888])).to.eql('1.0, 0.0, 3.45, 0.8888');
+    });
+  });
+
+  describe('formatColor', function() {
+    it('normalizes color and outputs numbers with dot separators', function() {
+      expect(formatColor([100, 0, 255, 1])).to.eql('0.39215686274509803, 0.0, 1.0, 1.0');
+    });
+  });
+
   describe('getSymbolVertexShader', function() {
-    it('generates a symbol vertex shader without using additional attributes', function() {
-      expect(getSymbolVertexShader(
-        {
-          rotateWithView: false,
-          color: '#5000ff',
-          opacity: 0.4,
-          offset: [5, -7],
-          size: 6,
-          textureCoord: [0, 0.5, 0.5, 1]
-        })).to.eql(`precision mediump float;
+    it('generates a symbol vertex shader (with varying)', function() {
+      const parameters = {
+        varyings: [{
+          name: 'v_opacity',
+          type: 'float',
+          expression: formatNumber(0.4)
+        }, {
+          name: 'v_test',
+          type: 'vec3',
+          expression: 'vec3(' + formatArray([1, 2, 3]) + ')'
+        }],
+        sizeExpression: 'vec2(' + formatNumber(6) + ')',
+        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
+        colorExpression: 'vec4(' + formatColor([80, 0, 255, 1]) + ')',
+        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')',
+        rotateWithView: false
+      };
+
+      expect(getSymbolVertexShader(parameters)).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+
 attribute vec2 a_position;
 attribute float a_index;
+
 varying vec2 v_texCoord;
 varying float v_opacity;
-varying vec4 v_color;
+varying vec3 v_test;
+void main(void) {
+  mat4 offsetMatrix = u_offsetScaleMatrix;
+  vec2 size = vec2(6.0);
+  vec2 offset = vec2(5.0, -7.0);
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? offset.x - size.x / 2.0 : offset.x + size.x / 2.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? offset.y - size.y / 2.0 : offset.y + size.y / 2.0;
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
+  v_texCoord = vec2(u, v);
+  v_opacity = 0.4;
+  v_test = vec3(1.0, 2.0, 3.0);
+}`);
+    });
+    it('generates a symbol vertex shader (with uniforms and attributes)', function() {
+      const parameters = {
+        uniforms: ['float u_myUniform'],
+        attributes: ['vec2 a_myAttr'],
+        sizeExpression: 'vec2(' + formatNumber(6) + ')',
+        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
+        colorExpression: 'vec4(' + formatColor([80, 0, 255, 1]) + ')',
+        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')'
+      };
+
+      expect(getSymbolVertexShader(parameters)).to.eql(`precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+uniform float u_myUniform;
+attribute vec2 a_position;
+attribute float a_index;
+attribute vec2 a_myAttr;
+varying vec2 v_texCoord;
 
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix;
-  float offsetX = a_index == 0.0 || a_index == 3.0 ? 2.0 : 8.0;
-  float offsetY = a_index == 0.0 || a_index == 1.0 ? -10.0 : -4.0;
+  vec2 size = vec2(6.0);
+  vec2 offset = vec2(5.0, -7.0);
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? offset.x - size.x / 2.0 : offset.x + size.x / 2.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? offset.y - size.y / 2.0 : offset.y + size.y / 2.0;
   vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
-  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 0.5;
-  float v = a_index == 0.0 || a_index == 1.0 ? 0.5 : 1.0;
+  vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
   v_texCoord = vec2(u, v);
-  v_opacity = 0.4;
-  v_color = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
-}`);
-    });
-    it('correctly handles size as an array', function() {
-      expect(getSymbolVertexShader(
-        {
-          rotateWithView: false,
-          color: '#5000ff',
-          opacity: 0.4,
-          offset: [5, -7],
-          size: [10, 12],
-          textureCoord: [0, 0.5, 0.5, 1]
-        })).to.eql(`precision mediump float;
-uniform mat4 u_projectionMatrix;
-uniform mat4 u_offsetScaleMatrix;
-uniform mat4 u_offsetRotateMatrix;
-attribute vec2 a_position;
-attribute float a_index;
-varying vec2 v_texCoord;
-varying float v_opacity;
-varying vec4 v_color;
 
-void main(void) {
-  mat4 offsetMatrix = u_offsetScaleMatrix;
-  float offsetX = a_index == 0.0 || a_index == 3.0 ? 0.0 : 10.0;
-  float offsetY = a_index == 0.0 || a_index == 1.0 ? -13.0 : -1.0;
-  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
-  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
-  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 0.5;
-  float v = a_index == 0.0 || a_index == 1.0 ? 0.5 : 1.0;
-  v_texCoord = vec2(u, v);
-  v_opacity = 0.4;
-  v_color = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
 }`);
     });
-    it('correctly handles rotate with view', function() {
-      expect(getSymbolVertexShader(
-        {
-          rotateWithView: true,
-          color: '#5000ff',
-          opacity: 0.4,
-          size: 6,
-          textureCoord: [0, 0.5, 0.5, 1]
-        })).to.eql(`precision mediump float;
+    it('generates a symbol vertex shader (with rotateWithView)', function() {
+      const parameters = {
+        sizeExpression: 'vec2(' + formatNumber(6) + ')',
+        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
+        colorExpression: 'vec4(' + formatColor([80, 0, 255, 1]) + ')',
+        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')',
+        rotateWithView: true
+      };
+
+      expect(getSymbolVertexShader(parameters)).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+
 attribute vec2 a_position;
 attribute float a_index;
+
 varying vec2 v_texCoord;
-varying float v_opacity;
-varying vec4 v_color;
 
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix * u_offsetRotateMatrix;
-  float offsetX = a_index == 0.0 || a_index == 3.0 ? -3.0 : 3.0;
-  float offsetY = a_index == 0.0 || a_index == 1.0 ? -3.0 : 3.0;
+  vec2 size = vec2(6.0);
+  vec2 offset = vec2(5.0, -7.0);
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? offset.x - size.x / 2.0 : offset.x + size.x / 2.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? offset.y - size.y / 2.0 : offset.y + size.y / 2.0;
   vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
-  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 0.5;
-  float v = a_index == 0.0 || a_index == 1.0 ? 0.5 : 1.0;
+  vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
   v_texCoord = vec2(u, v);
-  v_opacity = 0.4;
-  v_color = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
-}`);
-    });
-    it('correctly handles missing optional parameters', function() {
-      expect(getSymbolVertexShader(
-        {
-          rotateWithView: false,
-          size: 5
-        })).to.eql(`precision mediump float;
-uniform mat4 u_projectionMatrix;
-uniform mat4 u_offsetScaleMatrix;
-uniform mat4 u_offsetRotateMatrix;
-attribute vec2 a_position;
-attribute float a_index;
-varying vec2 v_texCoord;
-varying float v_opacity;
-varying vec4 v_color;
 
-void main(void) {
-  mat4 offsetMatrix = u_offsetScaleMatrix;
-  float offsetX = a_index == 0.0 || a_index == 3.0 ? -2.5 : 2.5;
-  float offsetY = a_index == 0.0 || a_index == 1.0 ? -2.5 : 2.5;
-  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
-  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
-  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
-  float v = a_index == 0.0 || a_index == 1.0 ? 0.0 : 1.0;
-  v_texCoord = vec2(u, v);
-  v_opacity = 1.0;
-  v_color = vec4(1.0, 1.0, 1.0, 1.0);
 }`);
     });
   });
 
   describe('getSymbolFragmentShader', function() {
-    it('generates a fixed shader', function() {
-      expect(getSymbolFragmentShader()).to.eql(`precision mediump float;
-uniform sampler2D u_texture;
+    it('generates a symbol fragment shader (with varying)', function() {
+      const parameters = {
+        varyings: [{
+          name: 'v_opacity',
+          type: 'float',
+          expression: formatNumber(0.4)
+        }, {
+          name: 'v_test',
+          type: 'vec3',
+          expression: 'vec3(' + formatArray([1, 2, 3]) + ')'
+        }],
+        sizeExpression: 'vec2(' + formatNumber(6) + ')',
+        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
+        colorExpression: 'vec4(' + formatColor([80, 0, 255]) + ', v_opacity)',
+        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')',
+        rotateWithView: false
+      };
+
+      expect(getSymbolFragmentShader(parameters)).to.eql(`precision mediump float;
+
 varying vec2 v_texCoord;
 varying float v_opacity;
-varying vec4 v_color;
+varying vec3 v_test;
+void main(void) {
+  gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, v_opacity);
+  gl_FragColor.rgb *= gl_FragColor.a;
+}`);
+    });
+    it('generates a symbol fragment shader (with uniforms)', function() {
+      const parameters = {
+        uniforms: ['float u_myUniform', 'vec2 u_myUniform2'],
+        sizeExpression: 'vec2(' + formatNumber(6) + ')',
+        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
+        colorExpression: 'vec4(' + formatColor([255, 255, 255, 1]) + ')',
+        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')'
+      };
+
+      expect(getSymbolFragmentShader(parameters)).to.eql(`precision mediump float;
+uniform float u_myUniform;
+uniform vec2 u_myUniform2;
+varying vec2 v_texCoord;
 
 void main(void) {
-  if (v_opacity == 0.0) {
-    discard;
-  }
-  vec4 textureColor = texture2D(u_texture, v_texCoord);
-  gl_FragColor = v_color * textureColor;
-  gl_FragColor.a *= v_opacity;
+  gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
 }`);
     });

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -1,4 +1,4 @@
-import {getSymbolVertexShader, formatNumber} from '../../../../src/ol/webgl/ShaderBuilder.js';
+import {getSymbolVertexShader, formatNumber, getSymbolFragmentShader} from '../../../../src/ol/webgl/ShaderBuilder.js';
 
 describe('ol.webgl.ShaderBuilder', function() {
 
@@ -134,6 +134,26 @@ void main(void) {
   v_texCoord = vec2(u, v);
   v_opacity = 1.0;
   v_color = vec4(1.0, 1.0, 1.0, 1.0);
+}`);
+    });
+  });
+
+  describe('getSymbolFragmentShader', function() {
+    it('generates a fixed shader', function() {
+      expect(getSymbolFragmentShader()).to.eql(`precision mediump float;
+uniform sampler2D u_texture;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  if (v_opacity == 0.0) {
+    discard;
+  }
+  vec4 textureColor = texture2D(u_texture, v_texCoord);
+  gl_FragColor = v_color * textureColor;
+  gl_FragColor.a *= v_opacity;
+  gl_FragColor.rgb *= gl_FragColor.a;
 }`);
     });
   });

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -1,0 +1,141 @@
+import {getSymbolVertexShader, formatNumber} from '../../../../src/ol/webgl/ShaderBuilder.js';
+
+describe('ol.webgl.ShaderBuilder', function() {
+
+  describe('formatNumber', function() {
+    it('does a simple transform when a fraction is present', function() {
+      expect(formatNumber(1.3456)).to.eql('1.3456');
+    });
+    it('adds a fraction separator when missing', function() {
+      expect(formatNumber(1)).to.eql('1.0');
+      expect(formatNumber(2.0)).to.eql('2.0');
+    });
+  });
+
+  describe('getSymbolVertexShader', function() {
+    it('generates a symbol vertex shader without using additional attributes', function() {
+      expect(getSymbolVertexShader(
+        {
+          rotateWithView: false,
+          color: '#5000ff',
+          opacity: 0.4,
+          offset: [5, -7],
+          size: 6,
+          textureCoord: [0, 0.5, 0.5, 1]
+        })).to.eql(`precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+attribute vec2 a_position;
+attribute float a_index;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  mat4 offsetMatrix = u_offsetScaleMatrix;
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? 2.0 : 8.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? -10.0 : -4.0;
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 0.5;
+  float v = a_index == 0.0 || a_index == 1.0 ? 0.5 : 1.0;
+  v_texCoord = vec2(u, v);
+  v_opacity = 0.4;
+  v_color = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
+}`);
+    });
+    it('correctly handles size as an array', function() {
+      expect(getSymbolVertexShader(
+        {
+          rotateWithView: false,
+          color: '#5000ff',
+          opacity: 0.4,
+          offset: [5, -7],
+          size: [10, 12],
+          textureCoord: [0, 0.5, 0.5, 1]
+        })).to.eql(`precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+attribute vec2 a_position;
+attribute float a_index;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  mat4 offsetMatrix = u_offsetScaleMatrix;
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? 0.0 : 10.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? -13.0 : -1.0;
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 0.5;
+  float v = a_index == 0.0 || a_index == 1.0 ? 0.5 : 1.0;
+  v_texCoord = vec2(u, v);
+  v_opacity = 0.4;
+  v_color = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
+}`);
+    });
+    it('correctly handles rotate with view', function() {
+      expect(getSymbolVertexShader(
+        {
+          rotateWithView: true,
+          color: '#5000ff',
+          opacity: 0.4,
+          size: 6,
+          textureCoord: [0, 0.5, 0.5, 1]
+        })).to.eql(`precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+attribute vec2 a_position;
+attribute float a_index;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  mat4 offsetMatrix = u_offsetScaleMatrix * u_offsetRotateMatrix;
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? -3.0 : 3.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? -3.0 : 3.0;
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 0.5;
+  float v = a_index == 0.0 || a_index == 1.0 ? 0.5 : 1.0;
+  v_texCoord = vec2(u, v);
+  v_opacity = 0.4;
+  v_color = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
+}`);
+    });
+    it('correctly handles missing optional parameters', function() {
+      expect(getSymbolVertexShader(
+        {
+          rotateWithView: false,
+          size: 5
+        })).to.eql(`precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+attribute vec2 a_position;
+attribute float a_index;
+varying vec2 v_texCoord;
+varying float v_opacity;
+varying vec4 v_color;
+
+void main(void) {
+  mat4 offsetMatrix = u_offsetScaleMatrix;
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? -2.5 : 2.5;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? -2.5 : 2.5;
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
+  float v = a_index == 0.0 || a_index == 1.0 ? 0.0 : 1.0;
+  v_texCoord = vec2(u, v);
+  v_opacity = 1.0;
+  v_color = vec4(1.0, 1.0, 1.0, 1.0);
+}`);
+    });
+  });
+
+});

--- a/test/spec/ol/worker/webgl.test.js
+++ b/test/spec/ol/worker/webgl.test.js
@@ -1,6 +1,5 @@
 import {create} from '../../../../src/ol/worker/webgl.js';
 import {
-  POINT_INSTRUCTIONS_COUNT,
   WebGLWorkerMessageType
 } from '../../../../src/ol/renderer/webgl/Layer.js';
 
@@ -22,7 +21,9 @@ describe('ol/worker/webgl', function() {
   describe('messaging', function() {
     describe('GENERATE_BUFFERS', function() {
       it('responds with buffer data', function(done) {
-        worker.addEventListener('error', done);
+        worker.addEventListener('error', function(error) {
+          expect().fail(error.message);
+        });
 
         worker.addEventListener('message', function(event) {
           expect(event.data.type).to.eql(WebGLWorkerMessageType.GENERATE_BUFFERS);
@@ -34,11 +35,12 @@ describe('ol/worker/webgl', function() {
           done();
         });
 
-        const instructions = new Float32Array(POINT_INSTRUCTIONS_COUNT);
+        const instructions = new Float32Array(10);
 
         const message = {
           type: WebGLWorkerMessageType.GENERATE_BUFFERS,
           renderInstructions: instructions,
+          customAttributesCount: 0,
           testInt: 101,
           testString: 'abcd'
         };


### PR DESCRIPTION
This is a work-in-progress.

A new  `WebGLPointsLayer` class have been added, which takes only a vector source and a literal style object:

```js
new WebGLPointsLayer({
    source: vectorSource,
    literalStyle: {
      symbol: {
        size: 4,
        color: '#3388FF',
        rotateWithView: false,
        offset: [0, 0],
        opacity: 1
      }
  }
  });
```

Also, the `WebGLPointsRenderer` have been reworked to now use pre-generated shaders and read attributes from the features themselves. This is how the renderer should be used now:

```js
new WebGLPointsLayerRenderer(layer, {
  attributes: [
    {
      name: 'size',
      callback: function(feature) {
        // compute something with the feature
      }
    },
    {
      name: 'weight',
      callback: function(feature) {
        // compute something with the feature
      }
    },
  ],
  vertexShader:
    // shader using attribute a_weight and a_size
  fragmentShader:
    // shader using varying v_weight and v_size
```

The renderer now uses much smaller vertex attribute buffers, and does not make assumption about these attributes (like opacity, color, size etc.). All the render parameters of the points should be handles by user defined attributes.

Things left to do:
- [x] fix hit detection
- [x] restore the possibility to use textures
- [ ] ~allow binding to feature attributes in the literal style format~
- [ ] ~offer predefined symbol shapes (circle, triangle, star...)~
