### PR TITLE
Avoid error from tsc

### DIFF
--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -32,10 +32,9 @@ export function VOID() {}
  * returned function is called twice in a row with the same arguments and the same
  * this object, it will return the value from the first call in the second call.
  *
+ * @param {function(...any): ReturnType} fn The function to memoize.
+ * @return {function(...any): ReturnType} The memoized function.
  * @template ReturnType
- * @template ThisType
- * @param {function(this:ThisType, ...any):ReturnType} fn The function to memoize.
- * @return {function(this:ThisType, ...any):ReturnType} The memoized function.
  */
 export function memoizeOne(fn) {
   let called = false;


### PR DESCRIPTION
Without this change, we get obscure failures from `tsc` like this:
```
/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:72973
                throw e;
                ^

TypeError: Cannot read property 'flags' of undefined
    at createSymbolWithType (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:36787:46)
    at getUnionSignatures (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:30929:53)
    at resolveUnionTypeMembers (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:31021:34)
    at resolveStructuredTypeMembers (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:31330:21)
    at getSignaturesOfStructuredType (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:31782:32)
    at getSignaturesOfType (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:31788:20)
    at resolveCallExpression (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:42223:34)
    at resolveSignature (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:42494:28)
    at getResolvedSignature (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:42514:26)
    at checkCallExpression (/home/runner/work/openlayers/openlayers/node_modules/typescript/lib/tsc.js:42585:29)
```

We should try to narrow this down and file an upstream issue.  But this temporarily gets things working again.

See https://github.com/openlayers/openlayers/runs/235397246 for an example failure.