### PR TITLE
fixed typescript issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10433,9 +10433,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://openlayers.org/",
   "scripts": {
     "lint": "eslint tasks test rendering src/ol examples config",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run typecheck",
     "test-rendering": "node rendering/test.js",
     "test": "npm run karma -- --single-run --log-level error && npm run test-rendering -- --force",
     "karma": "karma start test/karma.config.js",
@@ -95,7 +95,7 @@
     "shx": "^0.3.2",
     "sinon": "^7.3.2",
     "terser-webpack-plugin": "^2.0.1",
-    "typescript": "^3.4.5",
+    "typescript": "3.5.3",
     "url-polyfill": "^1.1.5",
     "walk": "^2.3.9",
     "webpack": "4.41.0",

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -472,6 +472,7 @@ class GMLBase extends XMLFeature {
   /**
    * @inheritDoc
    */
+  //@ts-ignore
   readGeometryFromNode(node, opt_options) {
     const geometry = this.readGeometryElement(node,
       [this.getReadOptions(node, opt_options ? opt_options : {})]);

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -52,6 +52,7 @@ const FEATURE_READER = {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const GPX_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'rte': makeArrayPusher(readRte),
@@ -64,6 +65,7 @@ const GPX_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'text': makeObjectPropertySetter(readString, 'linkText'),
@@ -75,6 +77,7 @@ const LINK_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const GPX_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'rte': makeChildAppender(writeRte),
@@ -228,6 +231,7 @@ class GPX extends XMLFeature {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const RTE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'name': makeObjectPropertySetter(readString),
@@ -246,6 +250,7 @@ const RTE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const RTEPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ele': makeObjectPropertySetter(readDecimal),
@@ -257,6 +262,7 @@ const RTEPT_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TRK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'name': makeObjectPropertySetter(readString),
@@ -275,6 +281,7 @@ const TRK_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TRKSEG_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'trkpt': parseTrkPt
@@ -285,6 +292,7 @@ const TRKSEG_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TRKPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ele': makeObjectPropertySetter(readDecimal),
@@ -296,6 +304,7 @@ const TRKPT_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const WPT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ele': makeObjectPropertySetter(readDecimal),
@@ -331,6 +340,7 @@ const LINK_SEQUENCE = ['text', 'type'];
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const LINK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'text': makeChildAppender(writeStringTextNode),
@@ -342,6 +352,7 @@ const LINK_SERIALIZERS = makeStructureNS(
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const RTE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'name', 'cmt', 'desc', 'src', 'link', 'number', 'type', 'rtept'
@@ -352,6 +363,7 @@ const RTE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const RTE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'name': makeChildAppender(writeStringTextNode),
@@ -369,6 +381,7 @@ const RTE_SERIALIZERS = makeStructureNS(
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const RTEPT_TYPE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'ele', 'time'
@@ -379,6 +392,7 @@ const RTEPT_TYPE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const TRK_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'name', 'cmt', 'desc', 'src', 'link', 'number', 'type', 'trkseg'
@@ -389,6 +403,7 @@ const TRK_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const TRK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'name': makeChildAppender(writeStringTextNode),
@@ -413,6 +428,7 @@ const TRKSEG_NODE_FACTORY = makeSimpleNodeFactory('trkpt');
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const TRKSEG_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'trkpt': makeChildAppender(writeWptType)
@@ -423,6 +439,7 @@ const TRKSEG_SERIALIZERS = makeStructureNS(
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const WPT_TYPE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'ele', 'time', 'magvar', 'geoidheight', 'name', 'cmt', 'desc', 'src',
@@ -435,6 +452,7 @@ const WPT_TYPE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const WPT_TYPE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ele': makeChildAppender(writeDecimalTextNode),

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -22,31 +22,6 @@ import {assert} from '../asserts.js';
  */
 
 /**
- * @typedef {Object} ImageInformationResponse1_0
- * @property {string} identifier
- * @property {number} width
- * @property {number} height
- * @property {Array<number>} [scale_factors] Resolution scaling factors.
- * @property {number} [tile_width]
- * @property {number} [tile_height]
- * @property {Array<string>} [formats] Supported image formats.
- * @property {string} [profile] Compliance level URI.
- */
-
-/**
- * @typedef {Object} ImageInformationResponse1_1
- * @property {string} "@id" The base URI of the image service.
- * @property {string} "@context" JSON-LD context URI.
- * @property {number} width Full image width.
- * @property {number} height Full image height.
- * @property {Array<number>} [scale_factors] Resolution scaling factors.
- * @property {number} [tile_width]
- * @property {number} [tile_height]
- * @property {Array<string>} [formats] Supported image formats.
- * @property {string} [profile] Compliance level URI.
- */
-
-/**
  * @typedef {Object} TileInfo
  * @property {Array<number>} scaleFactors Supported resolution scaling factors.
  * @property {number} width Tile width in pixels.
@@ -65,37 +40,8 @@ import {assert} from '../asserts.js';
  */
 
 /**
- * @typedef {Object} ImageInformationResponse2
- * @property {string} "@id" The base URI of the image service.
- * @property {string} "@context" JSON-LD context IRI
- * @property {number} width Full image width.
- * @property {number} height Full image height.
- * @property {Array<string|IiifProfile>} profile Additional informations about the image
- * service's capabilities.
- * @property {Array<Object<string, number>>} [sizes] Supported full image dimensions.
- * @property {Array<TileInfo>} [tiles] Supported tile sizes and resolution scaling factors.
- */
-
-/**
- * @typedef {Object} ImageInformationResponse3
- * @property {string} id The base URI of the image service.
- * @property {string} "@context" JSON-LD context IRI
- * @property {number} width Full image width.
- * @property {number} height Full image height.
- * @property {string} profile Compliance level, one of 'level0', 'level1' or 'level2'
- * @property {Array<Object<string, number>>} [sizes] Supported full image dimensions.
- * @property {Array<TileInfo>} [tiles] Supported tile sizes and resolution scaling factors.
- * @property {number} [maxArea] Maximum area (pixels) available for this image service.
- * @property {number} [maxHeight] Maximum height.
- * @property {number} [maxWidth] Maximum width.
- * @property {Array<string>} [extraQualities] IIIF image qualities supported by the
- * image service additional to the ones indicated by the compliance level.
- * @property {Array<string>} [extraFormats] Image formats supported by the
- * image service additional to the ones indicated by the compliance level.
- * @property {Array<string>} [extraFeatures] Additional supported features whose support
- * is not indicated by the compliance level.
- * @property {Array<string>} [preferredFormats] Image formats that should preferrably
- * be used.
+ * @typedef {Object<string,string|number|Array<number|string|IiifProfile>|Object<string, number>
+ *   |TileInfo>} ImageInformationResponse
  */
 
 /**
@@ -284,7 +230,7 @@ versionFunctions[Versions.VERSION3] = generateVersion3Options;
 class IIIFInfo {
 
   /**
-   * @param {string|ImageInformationResponse1_0|ImageInformationResponse1_1|ImageInformationResponse2|ImageInformationResponse3} imageInfo
+   * @param {string|ImageInformationResponse} imageInfo
    * Deserialized image information JSON response object or JSON response as string
    */
   constructor(imageInfo) {
@@ -292,7 +238,7 @@ class IIIFInfo {
   }
 
   /**
-   * @param {string|ImageInformationResponse1_0|ImageInformationResponse1_1|ImageInformationResponse2|ImageInformationResponse3} imageInfo
+   * @param {string|ImageInformationResponse} imageInfo
    * Deserialized image information JSON response object or JSON response as string
    * @api
    */

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -91,6 +91,7 @@ const ICON_ANCHOR_UNITS_MAP = {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PLACEMARK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ExtendedData': extendedDataParser,
@@ -128,6 +129,7 @@ const PLACEMARK_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const NETWORK_LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ExtendedData': extendedDataParser,
@@ -146,6 +148,7 @@ const NETWORK_LINK_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LINK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'href': makeObjectPropertySetter(readURI)
@@ -156,6 +159,7 @@ const LINK_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const REGION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LatLonAltBox': latLonAltBoxParser,
@@ -167,6 +171,7 @@ const REGION_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const KML_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'Document', 'Placemark'
@@ -177,6 +182,7 @@ const KML_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const KML_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Document': makeChildAppender(writeDocument),
@@ -471,6 +477,7 @@ class KML extends XMLFeature {
         'StyleMap': this.readSharedStyleMap_.bind(this)
       });
     /** @type {Array<Feature>} */
+    // @ts-ignore
     const features = pushParseAndPop([], parsersNS, node, objectStack, this);
     if (features) {
       return features;
@@ -1097,6 +1104,7 @@ function readScale(node) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const STYLE_MAP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Pair': pairDataParser
@@ -1118,6 +1126,7 @@ function readStyleMapValue(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const ICON_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Icon': makeObjectPropertySetter(readIcon),
@@ -1234,6 +1243,7 @@ function iconStyleParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LABEL_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'color': makeObjectPropertySetter(readColor),
@@ -1269,6 +1279,7 @@ function labelStyleParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LINE_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'color': makeObjectPropertySetter(readColor),
@@ -1305,6 +1316,7 @@ function lineStyleParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const POLY_STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'color': makeObjectPropertySetter(readColor),
@@ -1345,6 +1357,7 @@ function polyStyleParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const FLAT_LINEAR_RING_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'coordinates': makeReplacer(readFlatCoordinates)
@@ -1389,6 +1402,7 @@ function gxCoordParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const GX_MULTITRACK_GEOMETRY_PARSERS = makeStructureNS(
   GX_NAMESPACE_URIS, {
     'Track': makeArrayPusher(readGxTrack)
@@ -1414,6 +1428,7 @@ function readGxMultiTrack(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const GX_TRACK_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'when': whenParser
@@ -1450,6 +1465,7 @@ function readGxTrack(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const ICON_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'href': makeObjectPropertySetter(readURI)
@@ -1482,6 +1498,7 @@ function readIcon(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const GEOMETRY_FLAT_COORDINATES_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'coordinates': makeReplacer(readFlatCoordinates)
@@ -1503,6 +1520,7 @@ function readFlatCoordinatesFromNode(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const EXTRUDE_AND_ALTITUDE_MODE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'extrude': makeObjectPropertySetter(readBoolean),
@@ -1557,6 +1575,7 @@ function readLinearRing(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const MULTI_GEOMETRY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LineString': makeArrayPusher(readLineString),
@@ -1650,6 +1669,7 @@ function readPoint(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const FLAT_LINEAR_RINGS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'innerBoundaryIs': innerBoundaryIsParser,
@@ -1688,6 +1708,7 @@ function readPolygon(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'IconStyle': iconStyleParser,
@@ -1782,6 +1803,7 @@ function setCommonGeometryProperties(multiGeometry, geometries) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'displayName': makeObjectPropertySetter(readString),
@@ -1818,6 +1840,7 @@ function dataParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const EXTENDED_DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Data': dataParser,
@@ -1845,6 +1868,7 @@ function regionParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PAIR_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Style': makeObjectPropertySetter(readStyle),
@@ -1904,6 +1928,7 @@ function placemarkStyleMapParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const SCHEMA_DATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'SimpleData': simpleDataParser
@@ -1937,6 +1962,7 @@ function simpleDataParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LAT_LON_ALT_BOX_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'altitudeMode': makeObjectPropertySetter(readString),
@@ -1976,6 +2002,7 @@ function latLonAltBoxParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LOD_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'minLodPixels': makeObjectPropertySetter(readDecimal),
@@ -2006,6 +2033,7 @@ function lodParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LinearRing': makeReplacer(readFlatLinearRing)
@@ -2032,6 +2060,7 @@ function innerBoundaryIsParser(node, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const OUTER_BOUNDARY_IS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LinearRing': makeReplacer(readFlatLinearRing)
@@ -2138,6 +2167,7 @@ function writeCoordinatesTextNode(node, coordinates, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const EXTENDEDDATA_NODE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Data': makeChildAppender(writeDataNode),
@@ -2195,6 +2225,7 @@ function writeDataNodeValue(node, value) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const DOCUMENT_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Placemark': makeChildAppender(writePlacemark)
@@ -2258,6 +2289,7 @@ function writeExtendedData(node, namesAndValues, objectStack) {
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const ICON_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'href'
@@ -2271,6 +2303,7 @@ const ICON_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const ICON_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'href': makeChildAppender(writeStringTextNode)
@@ -2321,6 +2354,7 @@ function writeIcon(node, icon, objectStack) {
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const ICON_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'scale', 'heading', 'Icon', 'hotSpot'
@@ -2331,6 +2365,7 @@ const ICON_STYLE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const ICON_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Icon': makeChildAppender(writeIcon),
@@ -2347,7 +2382,7 @@ const ICON_STYLE_SERIALIZERS = makeStructureNS(
  */
 function writeIconStyle(node, style, objectStack) {
   const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
-  const properties = {};
+  const /** @type {Object<string, any>} */ properties = {};
   const src = style.getSrc();
   const size = style.getSize();
   const iconImageSize = style.getImageSize();
@@ -2401,6 +2436,7 @@ function writeIconStyle(node, style, objectStack) {
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const LABEL_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'color', 'scale'
@@ -2411,6 +2447,7 @@ const LABEL_STYLE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const LABEL_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'color': makeChildAppender(writeColorTextNode),
@@ -2447,6 +2484,7 @@ function writeLabelStyle(node, style, objectStack) {
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const LINE_STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'color', 'width'
@@ -2457,6 +2495,7 @@ const LINE_STYLE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const LINE_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'color': makeChildAppender(writeColorTextNode),
@@ -2551,6 +2590,7 @@ const POLYGON_NODE_FACTORY = makeSimpleNodeFactory('Polygon');
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const MULTI_GEOMETRY_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LineString': makeChildAppender(
@@ -2603,6 +2643,7 @@ function writeMultiGeometry(node, geometry, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const BOUNDARY_IS_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LinearRing': makeChildAppender(
@@ -2627,6 +2668,7 @@ function writeBoundaryIs(node, linearRing, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const PLACEMARK_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ExtendedData': makeChildAppender(writeExtendedData),
@@ -2650,6 +2692,7 @@ const PLACEMARK_SERIALIZERS = makeStructureNS(
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const PLACEMARK_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'name', 'open', 'visibility', 'address', 'phoneNumber', 'description',
@@ -2736,6 +2779,7 @@ function writePlacemark(node, feature, objectStack) {
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const PRIMITIVE_GEOMETRY_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'extrude', 'tessellate', 'altitudeMode', 'coordinates'
@@ -2746,6 +2790,7 @@ const PRIMITIVE_GEOMETRY_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const PRIMITIVE_GEOMETRY_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'extrude': makeChildAppender(writeBooleanTextNode),
@@ -2782,6 +2827,7 @@ function writePrimitiveGeometry(node, geometry, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const POLYGON_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'outerBoundaryIs': makeChildAppender(
@@ -2833,6 +2879,7 @@ function writePolygon(node, polygon, objectStack) {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const POLY_STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'color': makeChildAppender(writeColorTextNode)
@@ -2874,6 +2921,7 @@ function writeScaleTextNode(node, scale) {
  * @const
  * @type {Object<string, Array<string>>}
  */
+// @ts-ignore
 const STYLE_SEQUENCE = makeStructureNS(
   NAMESPACE_URIS, [
     'IconStyle', 'LabelStyle', 'LineStyle', 'PolyStyle'
@@ -2884,6 +2932,7 @@ const STYLE_SEQUENCE = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
  */
+// @ts-ignore
 const STYLE_SERIALIZERS = makeStructureNS(
   NAMESPACE_URIS, {
     'IconStyle': makeChildAppender(writeIconStyle),

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -26,6 +26,7 @@ const NAMESPACE_URIS = [null];
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const WAY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'nd': readNd,
@@ -37,6 +38,7 @@ const WAY_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'node': readNode,
@@ -108,6 +110,7 @@ class OSMXML extends XMLFeature {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const NODE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'tag': readTag

--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -18,6 +18,7 @@ const NAMESPACE_URIS = [null, 'http://www.opengis.net/ows/1.1'];
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ServiceIdentification': makeObjectPropertySetter(readServiceIdentification),
@@ -58,6 +59,7 @@ class OWS extends XML {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const ADDRESS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'DeliveryPoint': makeObjectPropertySetter(readString),
@@ -73,6 +75,7 @@ const ADDRESS_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const ALLOWED_VALUES_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Value': makeObjectPropertyPusher(readValue)
@@ -83,6 +86,7 @@ const ALLOWED_VALUES_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CONSTRAINT_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'AllowedValues': makeObjectPropertySetter(readAllowedValues)
@@ -93,6 +97,7 @@ const CONSTRAINT_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CONTACT_INFO_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Phone': makeObjectPropertySetter(readPhone),
@@ -104,6 +109,7 @@ const CONTACT_INFO_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const DCP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'HTTP': makeObjectPropertySetter(readHttp)
@@ -114,6 +120,7 @@ const DCP_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const HTTP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Get': makeObjectPropertyPusher(readGet),
@@ -125,6 +132,7 @@ const HTTP_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const OPERATION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'DCP': makeObjectPropertySetter(readDcp)
@@ -135,6 +143,7 @@ const OPERATION_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const OPERATIONS_METADATA_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Operation': readOperation
@@ -145,6 +154,7 @@ const OPERATIONS_METADATA_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PHONE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Voice': makeObjectPropertySetter(readString),
@@ -156,6 +166,7 @@ const PHONE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const REQUEST_METHOD_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Constraint': makeObjectPropertyPusher(readConstraint)
@@ -166,6 +177,7 @@ const REQUEST_METHOD_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const SERVICE_CONTACT_PARSERS =
     makeStructureNS(
       NAMESPACE_URIS, {
@@ -179,6 +191,7 @@ const SERVICE_CONTACT_PARSERS =
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const SERVICE_IDENTIFICATION_PARSERS =
     makeStructureNS(
       NAMESPACE_URIS, {
@@ -195,6 +208,7 @@ const SERVICE_IDENTIFICATION_PARSERS =
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const SERVICE_PROVIDER_PARSERS =
     makeStructureNS(
       NAMESPACE_URIS, {

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -22,6 +22,7 @@ const NAMESPACE_URIS = [
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Service': makeObjectPropertySetter(readService),
@@ -33,6 +34,7 @@ const PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CAPABILITY_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Request': makeObjectPropertySetter(readRequest),
@@ -86,6 +88,7 @@ class WMSCapabilities extends XML {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const SERVICE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Name': makeObjectPropertySetter(readString),
@@ -106,6 +109,7 @@ const SERVICE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CONTACT_INFORMATION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ContactPersonPrimary': makeObjectPropertySetter(readContactPersonPrimary),
@@ -121,6 +125,7 @@ const CONTACT_INFORMATION_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CONTACT_PERSON_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'ContactPerson': makeObjectPropertySetter(readString),
@@ -132,6 +137,7 @@ const CONTACT_PERSON_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CONTACT_ADDRESS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'AddressType': makeObjectPropertySetter(readString),
@@ -147,6 +153,7 @@ const CONTACT_ADDRESS_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const EXCEPTION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Format': makeArrayPusher(readString)
@@ -157,6 +164,7 @@ const EXCEPTION_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LAYER_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Name': makeObjectPropertySetter(readString),
@@ -184,6 +192,7 @@ const LAYER_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const ATTRIBUTION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Title': makeObjectPropertySetter(readString),
@@ -196,6 +205,7 @@ const ATTRIBUTION_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS =
     makeStructureNS(NAMESPACE_URIS, {
       'westBoundLongitude': makeObjectPropertySetter(readDecimal),
@@ -209,6 +219,7 @@ const EX_GEOGRAPHIC_BOUNDING_BOX_PARSERS =
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const REQUEST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'GetCapabilities': makeObjectPropertySetter(readOperationType),
@@ -221,6 +232,7 @@ const REQUEST_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const OPERATIONTYPE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Format': makeObjectPropertyPusher(readString),
@@ -232,6 +244,7 @@ const OPERATIONTYPE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const DCPTYPE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'HTTP': makeObjectPropertySetter(readHTTP)
@@ -242,6 +255,7 @@ const DCPTYPE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const HTTP_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Get': makeObjectPropertySetter(readFormatOnlineresource),
@@ -253,6 +267,7 @@ const HTTP_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Name': makeObjectPropertySetter(readString),
@@ -268,6 +283,7 @@ const STYLE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const FORMAT_ONLINERESOURCE_PARSERS =
     makeStructureNS(NAMESPACE_URIS, {
       'Format': makeObjectPropertySetter(readString),
@@ -279,6 +295,7 @@ const FORMAT_ONLINERESOURCE_PARSERS =
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const KEYWORDLIST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Keyword': makeArrayPusher(readString)

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -125,6 +125,7 @@ class WMSGetFeatureInfo extends XMLFeature {
           [context['featureNS'], null], parsers);
         layerElement.setAttribute('namespaceURI', this.featureNS_);
         const layerFeatures = pushParseAndPop(
+          // @ts-ignore
           [], parsersNS, layerElement, objectStack, this.gmlFormat_);
         if (layerFeatures) {
           extend(features, layerFeatures);

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -34,6 +34,7 @@ const OWS_NAMESPACE_URIS = [
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Contents': makeObjectPropertySetter(readContents)
@@ -89,6 +90,7 @@ class WMTSCapabilities extends XML {
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const CONTENTS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Layer': makeObjectPropertyPusher(readLayer),
@@ -100,6 +102,7 @@ const CONTENTS_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const LAYER_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Style': makeObjectPropertyPusher(readStyle),
@@ -119,6 +122,7 @@ const LAYER_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const STYLE_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'LegendURL': makeObjectPropertyPusher(readLegendUrl)
@@ -132,6 +136,7 @@ const STYLE_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TMS_LINKS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'TileMatrixSet': makeObjectPropertySetter(readString),
@@ -142,6 +147,7 @@ const TMS_LINKS_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TMS_LIMITS_LIST_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'TileMatrixLimits': makeArrayPusher(readTileMatrixLimits)
@@ -152,6 +158,7 @@ const TMS_LIMITS_LIST_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TMS_LIMITS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'TileMatrix': makeObjectPropertySetter(readString),
@@ -166,6 +173,7 @@ const TMS_LIMITS_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const DIMENSION_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'Default': makeObjectPropertySetter(readString),
@@ -179,6 +187,7 @@ const DIMENSION_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const WGS84_BBOX_READERS = makeStructureNS(
   OWS_NAMESPACE_URIS, {
     'LowerCorner': makeArrayPusher(readCoordinates),
@@ -190,6 +199,7 @@ const WGS84_BBOX_READERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TMS_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'WellKnownScaleSet': makeObjectPropertySetter(readString),
@@ -204,6 +214,7 @@ const TMS_PARSERS = makeStructureNS(
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
  */
+// @ts-ignore
 const TM_PARSERS = makeStructureNS(
   NAMESPACE_URIS, {
     'TopLeftCorner': makeObjectPropertySetter(readCoordinates),

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -61,8 +61,8 @@ class Geometry extends BaseObject {
      * Get a transformed and simplified version of the geometry.
      * @abstract
      * @param {number} squaredTolerance Squared tolerance.
-     * @param {import("../proj/Projection.js").default} sourceProjection The source projection.
-     * @param {import("../proj/Projection.js").default} destProjection The destination projection.
+     * @param {import("../proj/Projection.js").default} [sourceProjection] The source projection.
+     * @param {import("../proj/Projection.js").default} [destProjection] The destination projection.
      * @return {Geometry} Simplified geometry.
      */
     this.simplifyTransformed = memoizeOne(function(squaredTolerance, sourceProjection, destProjection) {

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -93,7 +93,7 @@ function renderCircleGeometry(builderGroup, geometry, style, feature) {
  * @param {import("../style/Style.js").default} style Style.
  * @param {number} squaredTolerance Squared tolerance.
  * @param {function(import("../events/Event.js").default): void} listener Listener function.
- * @param {import("../proj/Projection.js").default} projection The view projection.
+ * @param {import("../proj/Projection.js").default} [projection] The view projection.
  * @return {boolean} `true` if style is loading.
  * @template T
  */
@@ -124,7 +124,7 @@ export function renderFeature(replayGroup, feature, style, squaredTolerance, lis
  * @param {import("../Feature.js").FeatureLike} feature Feature.
  * @param {import("../style/Style.js").default} style Style.
  * @param {number} squaredTolerance Squared tolerance.
- * @param {import("../proj/Projection.js").default} projection The view projection.
+ * @param {import("../proj/Projection.js").default} [projection] The view projection.
  */
 function renderFeatureInternal(replayGroup, feature, style, squaredTolerance, projection) {
   const geometry = style.getGeometryFunction()(feature);

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -345,13 +345,12 @@ export const OBJECT_PROPERTY_NODE_FACTORY = makeSimpleNodeFactory();
  * Create an array of `values` to be used with {@link module:ol/xml~serialize} or
  * {@link module:ol/xml~pushSerializeAndPop}, where `orderedKeys` has to be provided as
  * `opt_key` argument.
- * @param {Object<string, V>} object Key-value pairs for the sequence. Keys can
+ * @param {Object<string, *>} object Key-value pairs for the sequence. Keys can
  *     be a subset of the `orderedKeys`.
  * @param {Array<string>} orderedKeys Keys in the order of the sequence.
- * @return {Array<V>} Values in the order of the sequence. The resulting array
+ * @return {Array<*>} Values in the order of the sequence. The resulting array
  *     has the same length as the `orderedKeys` array. Values that are not
  *     present in `object` will be `undefined` in the resulting array.
- * @template V
  */
 export function makeSequence(object, orderedKeys) {
   const length = orderedKeys.length;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": ["node"],                        /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true //,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -53,6 +53,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    //"skipDefaultLibCheck": true
   },
   "include": [
     "types/**/*.ts",


### PR DESCRIPTION
* Updated typescript to `3.5.3`
* Added `npm run typecheck` to the npm pretest script
* Added `//@ts-ignore` to cases of https://github.com/openlayers/openlayers/issues/8120#issuecomment-534430743
* Removed the extensive `ImageInformationResponse*` typedefs because typescript can not handle `@` at the start of a property name
* And fixed some more type realted issues