### PR TITLE
Adopt JSDoc annotations to allow '.d.ts' generation

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -6,7 +6,7 @@ import FormatType from './format/FormatType.js';
 
 /**
  *
- * @type {boolean} withCredentials Compare https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/
+ * @type {boolean}
  * @private
  */
 let withCredentials = false;

--- a/src/ol/render/canvas/LabelCache.js
+++ b/src/ol/render/canvas/LabelCache.js
@@ -8,7 +8,6 @@ import LRUCache from '../../structs/LRUCache.js';
 /**
  * @classdesc
  * Cache of pre-rendered labels.
- * @fires import("../events/Event.js").Event
  */
 class LabelCache extends LRUCache {
 

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -15,17 +15,17 @@ import TextPlacement from '../../style/TextPlacement.js';
  * @enum {number}
  */
 export const TEXT_ALIGN = {
-  left: 0,
-  end: 0,
-  center: 0.5,
-  right: 1,
-  start: 1,
-  top: 0,
-  middle: 0.5,
-  hanging: 0.2,
-  alphabetic: 0.8,
-  ideographic: 0.8,
-  bottom: 1
+  'left': 0,
+  'end': 0,
+  'center': 0.5,
+  'right': 1,
+  'start': 1,
+  'top': 0,
+  'middle': 0.5,
+  'hanging': 0.2,
+  'alphabetic': 0.8,
+  'ideographic': 0.8,
+  'bottom': 1
 };
 
 

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -14,18 +14,19 @@ import TextPlacement from '../../style/TextPlacement.js';
  * @const
  * @enum {number}
  */
-export const TEXT_ALIGN = {};
-TEXT_ALIGN['left'] = 0;
-TEXT_ALIGN['end'] = 0;
-TEXT_ALIGN['center'] = 0.5;
-TEXT_ALIGN['right'] = 1;
-TEXT_ALIGN['start'] = 1;
-TEXT_ALIGN['top'] = 0;
-TEXT_ALIGN['middle'] = 0.5;
-TEXT_ALIGN['hanging'] = 0.2;
-TEXT_ALIGN['alphabetic'] = 0.8;
-TEXT_ALIGN['ideographic'] = 0.8;
-TEXT_ALIGN['bottom'] = 1;
+export const TEXT_ALIGN = {
+  left: 0,
+  end: 0,
+  center: 0.5,
+  right: 1,
+  start: 1,
+  top: 0,
+  middle: 0.5,
+  hanging: 0.2,
+  alphabetic: 0.8,
+  ideographic: 0.8,
+  bottom: 1
+};
 
 
 class CanvasTextBuilder extends CanvasBuilder {


### PR DESCRIPTION
This introduces some smaller changes to the JSDoc annotations.
In order to auto-generate `.d.ts` files with [types-ol](https://github.com/hanreev/types-ol) from @hanreev as stated [here](https://github.com/openlayers/openlayers/issues/8120#issuecomment-534981112) some smaller changes to the docs are necessary.

This:
- removes a `@fires` annotation from `LabelCache.js`.
- refactors the `TEXT_ALIGN` enum in the `TextBuilder.js`
- fixes an invalid description of a `@type` anotation


