### PR TITLE
Return a new simplified geometry after modification

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -60,12 +60,13 @@ class Geometry extends BaseObject {
     /**
      * Get a transformed and simplified version of the geometry.
      * @abstract
+     * @param {number} revision The geometry revision.
      * @param {number} squaredTolerance Squared tolerance.
      * @param {import("../proj/Projection.js").default} sourceProjection The source projection.
      * @param {import("../proj/Projection.js").default} destProjection The destination projection.
      * @return {Geometry} Simplified geometry.
      */
-    this.simplifyTransformed = memoizeOne(function(squaredTolerance, sourceProjection, destProjection) {
+    this.simplifyTransformedInternal = memoizeOne(function(revision, squaredTolerance, sourceProjection, destProjection) {
       if (!sourceProjection || !destProjection) {
         return this.getSimplifiedGeometry(squaredTolerance);
       }
@@ -75,6 +76,18 @@ class Geometry extends BaseObject {
       return clone.getSimplifiedGeometry(squaredTolerance);
     });
 
+  }
+
+  /**
+   * Get a transformed and simplified version of the geometry.
+   * @abstract
+   * @param {number} squaredTolerance Squared tolerance.
+   * @param {import("../proj/Projection.js").default} sourceProjection The source projection.
+   * @param {import("../proj/Projection.js").default} destProjection The destination projection.
+   * @return {Geometry} Simplified geometry.
+   */
+  simplifyTransformed(squaredTolerance, sourceProjection, destProjection) {
+    return this.simplifyTransformedInternal(this.getRevision(), squaredTolerance, sourceProjection, destProjection);
   }
 
   /**

--- a/test/spec/ol/geom/point.test.js
+++ b/test/spec/ol/geom/point.test.js
@@ -1,4 +1,5 @@
 import Point from '../../../../src/ol/geom/Point.js';
+import {get as getProjection} from '../../../../src/ol/proj.js';
 
 
 describe('ol.geom.Point', function() {
@@ -150,6 +151,42 @@ describe('ol.geom.Point', function() {
       geom.scale(10, 15, [0, 0]);
       const coordinates = geom.getCoordinates();
       expect(coordinates).to.eql([10, 30]);
+    });
+
+  });
+
+  describe('#simplifyTransformed()', function() {
+
+    it('returns the same result if called twice with the same arguments', function() {
+      const geom = new Point([1, 2]);
+      const source = getProjection('EPSG:4326');
+      const dest = getProjection('EPSG:3857');
+      const squaredTolerance = 0.5;
+      const first = geom.simplifyTransformed(squaredTolerance, source, dest);
+      const second = geom.simplifyTransformed(squaredTolerance, source, dest);
+      expect(second).to.be(first);
+    });
+
+    it('returns a different result if called with a different tolerance', function() {
+      const geom = new Point([1, 2]);
+      const source = getProjection('EPSG:4326');
+      const dest = getProjection('EPSG:3857');
+      const squaredTolerance = 0.5;
+      const first = geom.simplifyTransformed(squaredTolerance, source, dest);
+      const second = geom.simplifyTransformed(squaredTolerance * 2, source, dest);
+      expect(second).not.to.be(first);
+    });
+
+    it('returns a different result if called after geometry modification', function() {
+      const geom = new Point([1, 2]);
+      const source = getProjection('EPSG:4326');
+      const dest = getProjection('EPSG:3857');
+      const squaredTolerance = 0.5;
+      const first = geom.simplifyTransformed(squaredTolerance, source, dest);
+
+      geom.setCoordinates([3, 4]);
+      const second = geom.simplifyTransformed(squaredTolerance * 2, source, dest);
+      expect(second).not.to.be(first);
     });
 
   });


### PR DESCRIPTION
This fixes a bug with the `geometry.simplifyTransformed()` method and adds regression tests.