### PR TITLE
Geometry editing with a user projection

### DIFF
--- a/examples/edit-geographic.html
+++ b/examples/edit-geographic.html
@@ -1,0 +1,11 @@
+---
+layout: example.html
+title: Geographic Editing
+shortdesc: Editing geometries with geographic coordinates.
+docs: >
+  Calling the <code>useGeographic</code> function in the <code>'ol/proj'</code> module
+  makes it so the map view uses geographic coordinates (even if the view projection is
+  not geographic).
+tags: "geographic"
+---
+<div id="map" class="map"></div>

--- a/examples/edit-geographic.html
+++ b/examples/edit-geographic.html
@@ -9,3 +9,7 @@ docs: >
 tags: "geographic"
 ---
 <div id="map" class="map"></div>
+<select id="mode">
+  <option value="modify">select a feature to modify</option>
+  <option value="draw">draw new features</option>
+</select>

--- a/examples/edit-geographic.js
+++ b/examples/edit-geographic.js
@@ -1,0 +1,37 @@
+import {Map, View} from '../src/ol/index.js';
+import GeoJSON from '../src/ol/format/GeoJSON.js';
+import {Modify, Select} from '../src/ol/interaction.js';
+import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
+import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import {useGeographic} from '../src/ol/proj.js';
+
+useGeographic();
+
+const vector = new VectorLayer({
+  source: new VectorSource({
+    url: 'data/geojson/countries.geojson',
+    format: new GeoJSON()
+  })
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [
+    new TileLayer({
+      source: new OSM()
+    }),
+    vector
+  ],
+  view: new View({
+    center: [0, 0],
+    zoom: 2
+  })
+});
+
+const select = new Select();
+map.addInteraction(select);
+
+const modify = new Modify({
+  features: select.getFeatures()
+});
+map.addInteraction(modify);

--- a/examples/edit-geographic.js
+++ b/examples/edit-geographic.js
@@ -1,17 +1,15 @@
 import {Map, View} from '../src/ol/index.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
-import {Modify, Select} from '../src/ol/interaction.js';
+import {Modify, Select, Draw} from '../src/ol/interaction.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
 import {useGeographic} from '../src/ol/proj.js';
 
 useGeographic();
 
-const vector = new VectorLayer({
-  source: new VectorSource({
-    url: 'data/geojson/countries.geojson',
-    format: new GeoJSON()
-  })
+const source = new VectorSource({
+  url: 'data/geojson/countries.geojson',
+  format: new GeoJSON()
 });
 
 const map = new Map({
@@ -20,7 +18,9 @@ const map = new Map({
     new TileLayer({
       source: new OSM()
     }),
-    vector
+    new VectorLayer({
+      source: source
+    })
   ],
   view: new View({
     center: [0, 0],
@@ -29,9 +29,35 @@ const map = new Map({
 });
 
 const select = new Select();
-map.addInteraction(select);
 
 const modify = new Modify({
   features: select.getFeatures()
 });
-map.addInteraction(modify);
+
+const draw = new Draw({
+  type: 'Polygon',
+  source: source
+});
+
+const mode = document.getElementById('mode');
+function onChange() {
+  switch (mode.value) {
+    case 'draw': {
+      map.removeInteraction(modify);
+      map.removeInteraction(select);
+      map.addInteraction(draw);
+      break;
+    }
+    case 'modify': {
+      map.removeInteraction(draw);
+      map.addInteraction(select);
+      map.addInteraction(modify);
+      break;
+    }
+    default: {
+      // pass
+    }
+  }
+}
+mode.addEventListener('change', onChange);
+onChange();

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -417,8 +417,7 @@ class Draw extends PointerInteraction {
         useSpatialIndex: false,
         wrapX: options.wrapX ? options.wrapX : false
       }),
-      style: options.style ? options.style :
-        getDefaultStyleFunction(),
+      style: options.style ? options.style : getDefaultStyleFunction(),
       updateWhileInteracting: true
     });
 
@@ -443,8 +442,7 @@ class Draw extends PointerInteraction {
     if (options.freehand) {
       this.freehandCondition_ = always;
     } else {
-      this.freehandCondition_ = options.freehandCondition ?
-        options.freehandCondition : shiftKeyOnly;
+      this.freehandCondition_ = options.freehandCondition ? options.freehandCondition : shiftKeyOnly;
     }
 
     this.addEventListener(getChangeEventType(InteractionProperty.ACTIVE), this.updateState_);
@@ -639,7 +637,7 @@ class Draw extends PointerInteraction {
         const map = event.map;
         for (let i = 0, ii = potentiallyFinishCoordinates.length; i < ii; i++) {
           const finishCoordinate = potentiallyFinishCoordinates[i];
-          const finishPixel = map.getPixelFromCoordinateInternal(finishCoordinate);
+          const finishPixel = map.getPixelFromCoordinate(finishCoordinate);
           const pixel = event.pixel;
           const dx = pixel[0] - finishPixel[0];
           const dy = pixel[1] - finishPixel[1];


### PR DESCRIPTION
This adds support for editing data when a user projection is set.

Here is the example that lets you select and modify existing features or draw new features: https://2184-4723248-gh.circle-artifacts.com/0/examples/edit-geographic.html

This should look just like a regular editing example.  The difference is that the features in the vector source are left in geographic coordinates.