### PR TITLE
Require type and listener for addEventListener/removeEventListener

### DIFF
--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -57,6 +57,9 @@ class Target extends Disposable {
    * @param {import("../events.js").ListenerFunction} listener Listener.
    */
   addEventListener(type, listener) {
+    if (!type || !listener) {
+      return;
+    }
     let listeners = this.listeners_[type];
     if (!listeners) {
       listeners = this.listeners_[type] = [];
@@ -146,6 +149,9 @@ class Target extends Disposable {
    * @param {import("../events.js").ListenerFunction} listener Listener.
    */
   removeEventListener(type, listener) {
+    if (!type || !listener) {
+      return;
+    }
     const listeners = this.listeners_[type];
     if (listeners) {
       const index = listeners.indexOf(listener);

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -64,6 +64,11 @@ describe('ol.events.EventTarget', function() {
       eventTarget.removeEventListener('foo', spy1, false);
       expect(eventTarget.listeners_['foo']).to.have.length(1);
     });
+    it.only('does nothing when called with undefined listener', function() {
+      eventTarget.addEventListener('foo', spy1);
+      eventTarget.removeEventListener('foo', undefined);
+      expect(eventTarget.listeners_['foo']).to.eql([spy1]);
+    });
   });
 
   describe('#dispatchEvent()', function() {


### PR DESCRIPTION
This pull request fixes another issue I found when upgrading an application: when `removeListener` is called with an `undefined` Listener, the last listener of the listeners array gets removed, instead of ignoring the call.