### PR TITLE
WebGL Points Layer: allow expressions in literal style

### DIFF
--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -3,13 +3,31 @@ layout: example.html
 title: WebGL points layer
 shortdesc: Using a WebGL-optimized layer to render a large quantities of points
 docs: >
-  <p>This example shows how to use a `WebGLPointsLayer` to show a large amount of points on the map.</p>
+  <p>This example shows how to use a <code>WebGLPointsLayer</code> to show a large amount of points on the map.</p>
+  <p>The layer is given a style in JSON format which allows a certain level of customization of the final reprensentation.</p>
+  <p>
+    The following operators can be used for numerical values:
+    <ul>
+      <li><code>["get", "attributeName"]</code> fetches a numeric attribute value for each feature</li>
+      <li><code>["+", value, value]</code> adds two values (which an either be numeric, or the result of another operator)</li>
+      <li><code>["*", value, value]</code> multiplies two values</li>
+      <li><code>["clamp", value, min, max]</code> outputs a value between <code>min</code> and <code>max</code></li>
+      <li><code>["stretch", value, low1, high1, low2, high2]</code> outputs a value which has been mapped from the
+        <code>low1..high1</code> range to the <code>low2..high2</code> range</li>
+    </ul>
+  </p>
 
 tags: "webgl, point, layer, feature"
 ---
 
 <div id="map" class="map"></div>
-<label>Current style used for the layer</label>
+<label>Choose a predefined style from the list below or edit it as JSON manually.</label><br>
+<select id="style-select">
+  <option>Predefined styles</option>
+  <option value="icons">Icons</option>
+  <option value="triangles">Triangles, color related to population</option>
+  <option value="circles">Circles, size related to population</option>
+</select>
 <textarea style="width: 100%; height: 20rem; font-family: monospace; font-size: small;" id="style-editor"></textarea>
 <small id="style-valid" style="display: none; color: forestgreen">
   ✓ style is valid

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -11,15 +11,42 @@ const vectorSource = new Vector({
   format: new GeoJSON()
 });
 
-let literalStyle = {
-  symbol: {
-    size: 4,
-    color: '#3388FF',
-    rotateWithView: false,
-    offset: [0, 0],
-    opacity: 1
+const predefinedStyles = {
+  'icons': {
+    symbol: {
+      symbolType: 'image',
+      src: 'data/icon.png',
+      size: [18, 28],
+      color: 'lightyellow',
+      rotateWithView: false,
+      offset: [0, 9]
+    }
+  },
+  'triangles': {
+    symbol: {
+      symbolType: 'triangle',
+      size: 18,
+      color: [
+        ['stretch', ['get', 'population'], 20000, 300000, 0.1, 1.0],
+        ['stretch', ['get', 'population'], 20000, 300000, 0.6, 0.3],
+        0.6,
+        1.0
+      ],
+      rotateWithView: true
+    }
+  },
+  'circles': {
+    symbol: {
+      symbolType: 'circle',
+      size: ['stretch', ['get', 'population'], 40000, 2000000, 8, 28],
+      color: '#006688',
+      rotateWithView: false,
+      offset: [0, 0],
+      opacity: ['stretch', ['get', 'population'], 40000, 2000000, 0.6, 0.92]
+    }
   }
 };
+let literalStyle = predefinedStyles['circles'];
 let pointsLayer;
 
 const map = new Map({
@@ -36,6 +63,7 @@ const map = new Map({
 });
 
 const editor = document.getElementById('style-editor');
+editor.value = JSON.stringify(literalStyle, null, 2);
 
 function refreshLayer() {
   if (pointsLayer) {
@@ -46,7 +74,6 @@ function refreshLayer() {
     style: literalStyle
   });
   map.addLayer(pointsLayer);
-  editor.value = JSON.stringify(literalStyle, null, ' ');
 }
 
 function setStyleStatus(valid) {
@@ -55,8 +82,13 @@ function setStyleStatus(valid) {
 }
 
 editor.addEventListener('input', function() {
+  const textStyle = editor.value;
+  if (JSON.stringify(JSON.parse(textStyle)) === JSON.stringify(literalStyle)) {
+    return;
+  }
+
   try {
-    literalStyle = JSON.parse(editor.value);
+    literalStyle = JSON.parse(textStyle);
     refreshLayer();
     setStyleStatus(true);
   } catch (e) {
@@ -64,3 +96,11 @@ editor.addEventListener('input', function() {
   }
 });
 refreshLayer();
+
+const select = document.getElementById('style-select');
+select.addEventListener('change', function() {
+  const style = select.value;
+  literalStyle = predefinedStyles[style];
+  editor.value = JSON.stringify(literalStyle, null, 2);
+  refreshLayer();
+});

--- a/rendering/cases/webgl-points/main.js
+++ b/rendering/cases/webgl-points/main.js
@@ -15,6 +15,7 @@ const vector = new WebGLPointsLayer({
   }),
   style: {
     symbol: {
+      symbolType: 'square',
       size: 4,
       color: 'white'
     }

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -201,8 +201,10 @@ export function parse(value, attributes, attributePrefix) {
       case 'stretch': return `(clamp(${p(v[1])}, ${p(v[2])}, ${p(v[3])}) * ((${p(v[5])} - ${p(v[4])}) / (${p(v[3])} - ${p(v[2])})) + ${p(v[4])})`;
       default: throw new Error('Unrecognized literal style expression: ' + JSON.stringify(value));
     }
-  } else {
+  } else if (typeof value === 'number') {
     return formatNumber(value);
+  } else {
+    throw new Error('Invalid value type in expression: ' + JSON.stringify(value));
   }
 }
 

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -57,6 +57,7 @@ attribute vec2 a_position;
 attribute float a_index;
 
 varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
 varying float v_opacity;
 varying vec3 v_test;
 void main(void) {
@@ -71,6 +72,9 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
   v_texCoord = vec2(u, v);
+  u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v_quadCoord = vec2(u, v);
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
@@ -94,6 +98,7 @@ attribute vec2 a_position;
 attribute float a_index;
 attribute vec2 a_myAttr;
 varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
 
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix;
@@ -107,6 +112,9 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
   v_texCoord = vec2(u, v);
+  u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v_quadCoord = vec2(u, v);
 
 }`);
     });
@@ -128,6 +136,7 @@ attribute vec2 a_position;
 attribute float a_index;
 
 varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
 
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix * u_offsetRotateMatrix;
@@ -141,6 +150,9 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
   v_texCoord = vec2(u, v);
+  u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v_quadCoord = vec2(u, v);
 
 }`);
     });
@@ -168,6 +180,7 @@ void main(void) {
       expect(getSymbolFragmentShader(parameters)).to.eql(`precision mediump float;
 
 varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
 varying float v_opacity;
 varying vec3 v_test;
 void main(void) {
@@ -188,6 +201,7 @@ void main(void) {
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
 
 void main(void) {
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
@@ -226,7 +240,7 @@ void main(void) {
   describe('parseSymbolStyle', function() {
     it('parses a style without expressions', function() {
       const result = parseSymbolStyle({
-        symbolType: 'circle',
+        symbolType: 'square',
         size: [4, 8],
         color: '#336699',
         rotateWithView: true
@@ -235,7 +249,7 @@ void main(void) {
         uniforms: [],
         attributes: [],
         varyings: [],
-        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 1.0)',
+        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 1.0 * 1.0)',
         sizeExpression: 'vec2(4.0, 8.0)',
         offsetExpression: 'vec2(0.0, 0.0)',
         texCoordExpression: 'vec4(0.0, 0.0, 1.0, 1.0)',
@@ -247,7 +261,7 @@ void main(void) {
 
     it('parses a style with expressions', function() {
       const result = parseSymbolStyle({
-        symbolType: 'circle',
+        symbolType: 'square',
         size: ['get', 'attr1'],
         color: [
           1.0, 0.0, 0.5, ['get', 'attr2']
@@ -259,11 +273,15 @@ void main(void) {
         uniforms: [],
         attributes: ['float a_attr1', 'float a_attr3', 'float a_attr2'],
         varyings: [{
+          name: 'v_attr1',
+          type: 'float',
+          expression: 'a_attr1'
+        }, {
           name: 'v_attr2',
           type: 'float',
           expression: 'a_attr2'
         }],
-        colorExpression: 'vec4(1.0, 0.0, 0.5, v_attr2) * vec4(1.0, 1.0, 1.0, 1.0)',
+        colorExpression: 'vec4(1.0, 0.0, 0.5, v_attr2) * vec4(1.0, 1.0, 1.0, 1.0 * 1.0)',
         sizeExpression: 'vec2(a_attr1, a_attr1)',
         offsetExpression: 'vec2(3.0, a_attr3)',
         texCoordExpression: 'vec4(0.5, 0.5, 0.5, 1.0)',
@@ -288,7 +306,7 @@ void main(void) {
         uniforms: ['sampler2D u_texture'],
         attributes: [],
         varyings: [],
-        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 0.5) * texture2D(u_texture, v_texCoord)',
+        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 0.5 * 1.0) * texture2D(u_texture, v_texCoord)',
         sizeExpression: 'vec2(6.0, 6.0)',
         offsetExpression: 'vec2(0.0, 0.0)',
         texCoordExpression: 'vec4(0.0, 0.0, 1.0, 1.0)',

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -2,7 +2,7 @@ import {
   getSymbolVertexShader,
   formatNumber,
   getSymbolFragmentShader,
-  formatColor, formatArray, parse
+  formatColor, formatArray, parse, parseSymbolStyle
 } from '../../../../src/ol/webgl/ShaderBuilder.js';
 
 describe('ol.webgl.ShaderBuilder', function() {
@@ -220,6 +220,82 @@ void main(void) {
       parseFn(['get', 'myAttr']);
       parseFn(['clamp', ['get', 'attr2'], ['get', 'attr2'], ['get', 'myAttr']]);
       expect(attributes).to.eql(['myAttr', 'attr2']);
+    });
+  });
+
+  describe('parseSymbolStyle', function() {
+    it('parses a style without expressions', function() {
+      const result = parseSymbolStyle({
+        symbolType: 'circle',
+        size: [4, 8],
+        color: '#336699',
+        rotateWithView: true
+      });
+      expect(result.params).to.eql({
+        uniforms: [],
+        attributes: [],
+        varyings: [],
+        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 1.0)',
+        sizeExpression: 'vec2(4.0, 8.0)',
+        offsetExpression: 'vec2(0.0, 0.0)',
+        texCoordExpression: 'vec4(0.0, 0.0, 1.0, 1.0)',
+        rotateWithView: true
+      });
+      expect(result.attributes).to.eql([]);
+      expect(result.uniforms).to.eql({});
+    });
+
+    it('parses a style with expressions', function() {
+      const result = parseSymbolStyle({
+        symbolType: 'circle',
+        size: ['get', 'attr1'],
+        color: [
+          1.0, 0.0, 0.5, ['get', 'attr2']
+        ],
+        textureCoord: [0.5, 0.5, 0.5, 1],
+        offset: [3, ['get', 'attr3']]
+      });
+      expect(result.params).to.eql({
+        uniforms: [],
+        attributes: ['float a_attr1', 'float a_attr3', 'float a_attr2'],
+        varyings: [{
+          name: 'v_attr2',
+          type: 'float',
+          expression: 'a_attr2'
+        }],
+        colorExpression: 'vec4(1.0, 0.0, 0.5, v_attr2) * vec4(1.0, 1.0, 1.0, 1.0)',
+        sizeExpression: 'vec2(a_attr1, a_attr1)',
+        offsetExpression: 'vec2(3.0, a_attr3)',
+        texCoordExpression: 'vec4(0.5, 0.5, 0.5, 1.0)',
+        rotateWithView: false
+      });
+      expect(result.attributes.length).to.eql(3);
+      expect(result.attributes[0].name).to.eql('attr1');
+      expect(result.attributes[1].name).to.eql('attr3');
+      expect(result.attributes[2].name).to.eql('attr2');
+      expect(result.uniforms).to.eql({});
+    });
+
+    it('parses a style with a uniform (texture)', function() {
+      const result = parseSymbolStyle({
+        symbolType: 'image',
+        src: '../data/image.png',
+        size: 6,
+        color: '#336699',
+        opacity: 0.5
+      });
+      expect(result.params).to.eql({
+        uniforms: ['sampler2D u_texture'],
+        attributes: [],
+        varyings: [],
+        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 0.5) * texture2D(u_texture, v_texCoord)',
+        sizeExpression: 'vec2(6.0, 6.0)',
+        offsetExpression: 'vec2(0.0, 0.0)',
+        texCoordExpression: 'vec4(0.0, 0.0, 1.0, 1.0)',
+        rotateWithView: false
+      });
+      expect(result.attributes).to.eql([]);
+      expect(result.uniforms).to.have.property('u_texture');
     });
   });
 


### PR DESCRIPTION
This PR expands on the `ShaderBuilder` utilities by allowing the use of expressions.

The following operators can be used:
 *  `['get', 'attributeName']` fetches a feature attribute
 * `['*', value1, value1]` multiplies value1 by value2
 * `['+', value1, value1]` adds value1 and value2
 * `['clamp', value1, value2, value3]` clamps value1 between values2 and value3
 * `['stretch', value1, value2, value3, value4, value5]` maps value1 from [value2, value3] range to [value4, value5] range, clamping values along the way

Values can either be literals (numbers) or another operator, as they will be evaluated recursively.

Also the `symbolType` property of the literal style can be used to render circles or triangles in addition to squares and icons.

The hosted example has been expanded with predefined styles: https://2161-4723248-gh.circle-artifacts.com/0/examples/webgl-points-layer.html

To sum things up, the general logic is:
* The `WebGLPointsLayer` class uses the `ShaderBuilder` utilities to generate fragment and vertex shaders based on a literal style
* The `WebGLPointsLayerRenderer` expects fragment and vertex shaders as strings, as well as a list of attributes and uniforms

It is still possible to use directly the renderer instead of the new layer type (this is still done in the other examples using WebGL).