### PR TITLE
updated jsdoc-plugin-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6454,9 +6454,9 @@
       }
     },
     "jsdoc-plugin-typescript": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.0.1.tgz",
-      "integrity": "sha512-2/Kr+Roo36G8Kci+UY1bM2XUDCxjHD1cVxBKHgzLTCfmapR2fjf+ijjnyrHO+lXc3sn9xXjeChy9pznue+qKKg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.0.2.tgz",
+      "integrity": "sha512-4/SveLQzTCkcQFfx9bDtVNRASmpv9E7iKncbSPkjnb+tm+9qHhCkF1Ewml3vBKZKU58LgW1zUsn4JYRlowP7NQ==",
       "dev": true
     },
     "jsesc": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "3.4.1",
     "jsdoc": "3.6.3",
-    "jsdoc-plugin-typescript": "^2.0.1",
+    "jsdoc-plugin-typescript": "^2.0.2",
     "karma": "^4.1.0",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage": "^2.0.1",

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -55,7 +55,7 @@ import Units from '../proj/Units.js';
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
  * Base class for feature formats.
- * {FeatureFormat} subclasses provide the ability to decode and encode
+ * {@link module:ol/format/Feature~FeatureFormat} subclasses provide the ability to decode and encode
  * {@link module:ol/Feature~Feature} objects from a variety of commonly used geospatial
  * file formats.  See the documentation for each format for more details.
  *

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -40,8 +40,8 @@ import {assert} from '../asserts.js';
  */
 
 /**
- * @typedef {Object<string,string|number|Array<number|string|IiifProfile>|Object<string, number>
- *   |TileInfo>} ImageInformationResponse
+ * @typedef {Object<string,string|number|Array<number|string|IiifProfile>|Object<string, number>|TileInfo>}
+ *    ImageInformationResponse
  */
 
 /**

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -2,8 +2,67 @@
  * @module ol/style/Style
  */
 
+import {assert} from '../asserts.js';
+import GeometryType from '../geom/GeometryType.js';
+import CircleStyle from './Circle.js';
+import Fill from './Fill.js';
+import Stroke from './Stroke.js';
+
+
 /**
- * Feature styles.
+ * A function that takes an {@link module:ol/Feature} and a `{number}`
+ * representing the view's resolution. The function should return a
+ * {@link module:ol/style/Style} or an array of them. This way e.g. a
+ * vector layer can be styled.
+ *
+ * @typedef {function(import("../Feature.js").FeatureLike, number):(Style|Array<Style>)} StyleFunction
+ */
+
+/**
+ * A {@link Style}, an array of {@link Style}, or a {@link StyleFunction}.
+ * @typedef {Style|Array<Style>|StyleFunction} StyleLike
+ */
+
+/**
+ * A function that takes an {@link module:ol/Feature} as argument and returns an
+ * {@link module:ol/geom/Geometry} that will be rendered and styled for the feature.
+ *
+ * @typedef {function(import("../Feature.js").FeatureLike):
+ *     (import("../geom/Geometry.js").default|import("../render/Feature.js").default|undefined)} GeometryFunction
+ */
+
+
+/**
+ * Custom renderer function. Takes two arguments:
+ *
+ * 1. The pixel coordinates of the geometry in GeoJSON notation.
+ * 2. The {@link module:ol/render~State} of the layer renderer.
+ *
+ * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>),import("../render.js").State): void}
+ * RenderFunction
+ */
+
+
+/**
+ * @typedef {Object} Options
+ * @property {string|import("../geom/Geometry.js").default|GeometryFunction} [geometry] Feature property or geometry
+ * or function returning a geometry to render for this style.
+ * @property {import("./Fill.js").default} [fill] Fill style.
+ * @property {import("./Image.js").default} [image] Image style.
+ * @property {RenderFunction} [renderer] Custom renderer. When configured, `fill`, `stroke` and `image` will be
+ * ignored, and the provided function will be called with each render frame for each geometry.
+ * @property {import("./Stroke.js").default} [stroke] Stroke style.
+ * @property {import("./Text.js").default} [text] Text style.
+ * @property {number} [zIndex] Z index.
+ */
+
+/**
+ * @classdesc
+ * Container for vector feature rendering styles. Any changes made to the style
+ * or its children through `set*()` methods will not take effect until the
+ * feature or layer that uses the style is re-rendered.
+ *
+ * ## Feature styles
  *
  * If no style is defined, the following default style is used:
  * ```js
@@ -85,66 +144,7 @@
  *          styles[GeometryType.POINT]
  *      );
  * ```
- */
-import {assert} from '../asserts.js';
-import GeometryType from '../geom/GeometryType.js';
-import CircleStyle from './Circle.js';
-import Fill from './Fill.js';
-import Stroke from './Stroke.js';
-
-
-/**
- * A function that takes an {@link module:ol/Feature} and a `{number}`
- * representing the view's resolution. The function should return a
- * {@link module:ol/style/Style} or an array of them. This way e.g. a
- * vector layer can be styled.
  *
- * @typedef {function(import("../Feature.js").FeatureLike, number):(Style|Array<Style>)} StyleFunction
- */
-
-/**
- * A {@link Style}, an array of {@link Style}, or a {@link StyleFunction}.
- * @typedef {Style|Array<Style>|StyleFunction} StyleLike
- */
-
-/**
- * A function that takes an {@link module:ol/Feature} as argument and returns an
- * {@link module:ol/geom/Geometry} that will be rendered and styled for the feature.
- *
- * @typedef {function(import("../Feature.js").FeatureLike):
- *     (import("../geom/Geometry.js").default|import("../render/Feature.js").default|undefined)} GeometryFunction
- */
-
-
-/**
- * Custom renderer function. Takes two arguments:
- *
- * 1. The pixel coordinates of the geometry in GeoJSON notation.
- * 2. The {@link module:ol/render~State} of the layer renderer.
- *
- * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>),import("../render.js").State): void}
- * RenderFunction
- */
-
-
-/**
- * @typedef {Object} Options
- * @property {string|import("../geom/Geometry.js").default|GeometryFunction} [geometry] Feature property or geometry
- * or function returning a geometry to render for this style.
- * @property {import("./Fill.js").default} [fill] Fill style.
- * @property {import("./Image.js").default} [image] Image style.
- * @property {RenderFunction} [renderer] Custom renderer. When configured, `fill`, `stroke` and `image` will be
- * ignored, and the provided function will be called with each render frame for each geometry.
- * @property {import("./Stroke.js").default} [stroke] Stroke style.
- * @property {import("./Text.js").default} [text] Text style.
- * @property {number} [zIndex] Z index.
- */
-
-/**
- * @classdesc
- * Container for vector feature rendering styles. Any changes made to the style
- * or its children through `set*()` methods will not take effect until the
- * feature or layer that uses the style is re-rendered.
  * @api
  */
 class Style {


### PR DESCRIPTION
See https://github.com/openlayers/jsdoc-plugin-typescript/pull/9

The following does not work anymore:
1. Local types in comments need to linked by {@link module:ol/local/module~Type}
2. No multiline types
