### PR TITLE
Bugfix for vector-tile-selection example

### DIFF
--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -53,6 +53,10 @@ map.on('click', function(event) {
     return;
   }
   const feature = features[0];
+  if (!feature) {
+    return;
+  }
+
   const fid = feature.get(idProp);
 
   if (selectElement.value === 'singleselect') {


### PR DESCRIPTION
This PR fixes a small bug when click outside of a feature in the `vector-tile-selection` example.
It checks if a feature exists before it accesses it `idProp`.
