### PR TITLE
Add a rule to disallow describe.only() and it.only() in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -858,12 +858,13 @@
       }
     },
     "@openlayers/eslint-plugin": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@openlayers/eslint-plugin/-/eslint-plugin-4.0.0-beta.2.tgz",
-      "integrity": "sha512-LgzFAdOXRxljCiBN8BQXt7SqVpb35vraXmVZJrLFzguiwQ0Shz5sgIwyn/n9rRUIZUAhlIc8ztelH22oLVkkeA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openlayers/eslint-plugin/-/eslint-plugin-4.0.0.tgz",
+      "integrity": "sha512-sht71mhj5XRrmeKJYGS4XeLgzV2UsT4rETbjzD/LEPEgKkmgjRdzj1F/qab1Pkfc1qHMFhgw556YmP9yo32H+Q==",
       "dev": true,
       "requires": {
-        "@openlayers/doctrine": "^2.2.0"
+        "@openlayers/doctrine": "^2.2.0",
+        "minimatch": "^3.0.4"
       }
     },
     "@openlayers/pepjs": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.4.0",
     "@babel/preset-env": "^7.4.4",
-    "@openlayers/eslint-plugin": "^4.0.0-beta.2",
+    "@openlayers/eslint-plugin": "^4.0.0",
     "@types/arcgis-rest-api": "^10.4.4",
     "@types/geojson": "^7946.0.7",
     "@types/pbf": "^3.0.1",
@@ -115,6 +115,12 @@
         "error",
         {
           "requireReturn": false
+        }
+      ],
+      "@openlayers/no-exclusive-tests": [
+        "error",
+        {
+          "include": "test/**/*.test.js"
         }
       ]
     }


### PR DESCRIPTION
This makes it so we can't push a commit with `describe.only()` or `it.only()` in one of the tests.

![image](https://user-images.githubusercontent.com/41094/65707812-8fdac300-e08d-11e9-85a5-9a5d1db0220f.png)
 