### PR TITLE
Cache starting coordinates and add mapBrowserEvent to translateEvent

### DIFF
--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -70,8 +70,10 @@ export class TranslateEvent extends Event {
    * @param {TranslateEventType} type Type.
    * @param {Collection<import("../Feature.js").default>} features The features translated.
    * @param {import("../coordinate.js").Coordinate} coordinate The event coordinate.
+   * @param {import("../coordinate.js").Coordinate} startCoordinate The original coordinates before.translation started
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    */
-  constructor(type, features,startCoordinate, coordinate,mapBrowserEvent) {
+  constructor(type, features, coordinate, startCoordinate, mapBrowserEvent) {
 
     super(type);
 
@@ -90,7 +92,7 @@ export class TranslateEvent extends Event {
      */
     this.coordinate = coordinate;
 
-		/**
+    /**
      * The coordinate of the start position before translation started.
      * @const
      * @type {import("../coordinate.js").Coordinate}
@@ -196,7 +198,7 @@ class Translate extends PointerInteraction {
   handleDownEvent(event) {
     this.lastFeature_ = this.featuresAtPixel_(event.pixel, event.map);
     if (!this.lastCoordinate_ && this.lastFeature_) {
-			this.startCoordinate_ =
+      this.startCoordinate_ =
       this.lastCoordinate_ = event.coordinate;
       this.handleMoveEvent(event);
 
@@ -204,8 +206,8 @@ class Translate extends PointerInteraction {
 
       this.dispatchEvent(
         new TranslateEvent(
-          TranslateEventType.TRANSLATESTART, features, this.startCoordinate_,
-          event.coordinate, event));
+          TranslateEventType.TRANSLATESTART, features,
+          event.coordinate, this.startCoordinate_, event));
       return true;
     }
     return false;
@@ -223,9 +225,9 @@ class Translate extends PointerInteraction {
 
       this.dispatchEvent(
         new TranslateEvent(
-          TranslateEventType.TRANSLATEEND, features,this.startCoordinate_,
-          event.coordinate, event));
-			// cleanup
+          TranslateEventType.TRANSLATEEND, features,
+          event.coordinate, this.startCoordinate_, event));
+      // cleanup
       this.startCoordinate_ = null;
       return true;
     }
@@ -252,8 +254,8 @@ class Translate extends PointerInteraction {
       this.lastCoordinate_ = newCoordinate;
       this.dispatchEvent(
         new TranslateEvent(
-          TranslateEventType.TRANSLATING, features,this.startCoordinate_,
-          newCoordinate,event));
+          TranslateEventType.TRANSLATING, features,
+          newCoordinate, this.startCoordinate_, event));
     }
   }
 

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -71,7 +71,7 @@ export class TranslateEvent extends Event {
    * @param {Collection<import("../Feature.js").default>} features The features translated.
    * @param {import("../coordinate.js").Coordinate} coordinate The event coordinate.
    */
-  constructor(type, features, coordinate) {
+  constructor(type, features,startCoordinate, coordinate,mapBrowserEvent) {
 
     super(type);
 
@@ -89,6 +89,21 @@ export class TranslateEvent extends Event {
      * @api
      */
     this.coordinate = coordinate;
+
+		/**
+     * The coordinate of the start position before translation started.
+     * @const
+     * @type {import("../coordinate.js").Coordinate}
+     * @api
+     */
+    this.startCoordinate = startCoordinate;
+
+    /**
+     * Associated {@link module:ol/MapBrowserEvent}.
+     * @type {import("../MapBrowserEvent.js").default}
+     * @api
+     */
+    this.mapBrowserEvent = mapBrowserEvent;
 
   }
 
@@ -117,6 +132,13 @@ class Translate extends PointerInteraction {
      * @private
      */
     this.lastCoordinate_ = null;
+
+    /**
+     * The start position before translation started.
+     * @type {import("../coordinate.js").Coordinate}
+     * @private
+     */
+    this.startCoordinate_ = null;
 
 
     /**
@@ -174,6 +196,7 @@ class Translate extends PointerInteraction {
   handleDownEvent(event) {
     this.lastFeature_ = this.featuresAtPixel_(event.pixel, event.map);
     if (!this.lastCoordinate_ && this.lastFeature_) {
+			this.startCoordinate_ =
       this.lastCoordinate_ = event.coordinate;
       this.handleMoveEvent(event);
 
@@ -181,8 +204,8 @@ class Translate extends PointerInteraction {
 
       this.dispatchEvent(
         new TranslateEvent(
-          TranslateEventType.TRANSLATESTART, features,
-          event.coordinate));
+          TranslateEventType.TRANSLATESTART, features, this.startCoordinate_,
+          event.coordinate, event));
       return true;
     }
     return false;
@@ -200,8 +223,10 @@ class Translate extends PointerInteraction {
 
       this.dispatchEvent(
         new TranslateEvent(
-          TranslateEventType.TRANSLATEEND, features,
-          event.coordinate));
+          TranslateEventType.TRANSLATEEND, features,this.startCoordinate_,
+          event.coordinate, event));
+			// cleanup
+      this.startCoordinate_ = null;
       return true;
     }
     return false;
@@ -227,8 +252,8 @@ class Translate extends PointerInteraction {
       this.lastCoordinate_ = newCoordinate;
       this.dispatchEvent(
         new TranslateEvent(
-          TranslateEventType.TRANSLATING, features,
-          newCoordinate));
+          TranslateEventType.TRANSLATING, features,this.startCoordinate_,
+          newCoordinate,event));
     }
   }
 


### PR DESCRIPTION
If the starting-coordinates in Translate and TranslateEvent are cached, they can easily be used to undo the translate.

I also added mapBrowserEvent just like it is done in (some) other interactions (ie. Select).

I have tested it in my own application. But I don't have the required test-environment (and I have no experience with that). But I hope it is ok. 😬 
