### PR TITLE
Do not remove listeners that do not exist

### DIFF
--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -149,20 +149,19 @@ class Target extends Disposable {
    * @param {import("../events.js").ListenerFunction} listener Listener.
    */
   removeEventListener(type, listener) {
-    if (!type || !listener) {
-      return;
-    }
     const listeners = this.listeners_[type];
     if (listeners) {
       const index = listeners.indexOf(listener);
-      if (type in this.pendingRemovals_) {
-        // make listener a no-op, and remove later in #dispatchEvent()
-        listeners[index] = VOID;
-        ++this.pendingRemovals_[type];
-      } else {
-        listeners.splice(index, 1);
-        if (listeners.length === 0) {
-          delete this.listeners_[type];
+      if (index !== -1) {
+        if (type in this.pendingRemovals_) {
+          // make listener a no-op, and remove later in #dispatchEvent()
+          listeners[index] = VOID;
+          ++this.pendingRemovals_[type];
+        } else {
+          listeners.splice(index, 1);
+          if (listeners.length === 0) {
+            delete this.listeners_[type];
+          }
         }
       }
     }

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -64,9 +64,12 @@ describe('ol.events.EventTarget', function() {
       eventTarget.removeEventListener('foo', spy1, false);
       expect(eventTarget.listeners_['foo']).to.have.length(1);
     });
-    it('does nothing when called with undefined listener', function() {
+    it('does not remove listeners when the specified listener is not found', function() {
       eventTarget.addEventListener('foo', spy1);
+      eventTarget.addEventListener('foo', spy2);
       eventTarget.removeEventListener('foo', undefined);
+      eventTarget.removeEventListener('foo', spy2);
+      eventTarget.removeEventListener('foo', spy2);
       expect(eventTarget.listeners_['foo']).to.eql([spy1]);
     });
   });


### PR DESCRIPTION
`Array.prototype.splice()` accepts a negative array index, so we need to safeguard against listeners  that are not found.

Thanks @RobertOrthofer for spotting this!