### PR TITLE
Support building the legacy build on windows

### DIFF
--- a/tasks/serialize-workers.js
+++ b/tasks/serialize-workers.js
@@ -14,7 +14,7 @@ async function build(input, {minify = true} = {}) {
         if (id !== input) {
           return null;
         }
-        return code.replace('export let create;\n', '');
+        return code.replace('export let create;', '');
       }
     },
     common(),


### PR DESCRIPTION
This should make it so people can build the legacy build on Windows.  Ideally, people that still use the legacy build use a hosted version of the legacy build instead of building it themself.  But it sounds like that isn't happening.

Fixes #9891.  See also #9672.