### PR TITLE
new SnapEvent and snapped boolean

### DIFF
--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -50,6 +50,13 @@ class MapBrowserEvent extends MapEvent {
      */
     this.dragging = opt_dragging !== undefined ? opt_dragging : false;
 
+    /**
+     * Indicates if a feature is currently snapped. Default is `false`.
+     *
+     * @type {boolean}
+     */
+    this.snapped_ = false;
+
   }
 
   /**
@@ -65,6 +72,18 @@ class MapBrowserEvent extends MapEvent {
   }
   set pixel(pixel) {
     this.pixel_ = pixel;
+  }
+
+  /**
+   * Indicates if a feature is currently snapped. Default is `false`.
+   * @type {boolean}
+   * @api
+   */
+  get snapped() {
+    return this.snapped_;
+  }
+  set snapped(snapped) {
+    this.snapped_ = snapped;
   }
 
   /**

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -2,6 +2,7 @@
  * @module ol/interaction/Snap
  */
 import {getUid} from '../util.js';
+import Collection from '../Collection.js';
 import CollectionEventType from '../CollectionEventType.js';
 import {distance as coordinateDistance, squaredDistance as squaredCoordinateDistance, closestOnCircle, closestOnSegment, squaredDistanceToSegment} from '../coordinate.js';
 import {listen, unlistenByKey} from '../events.js';
@@ -86,7 +87,7 @@ class SnapEvent extends Event {
   /**
    * @param {SnapEventType} type The event type.
    * @param {Result} result Snap result array.
-   * @param {Array<import("../Feature.js").default>} features Array with the snapped features.
+   * @param {Collection<import("../Feature.js").default>} features The snapped features.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Associated
    *     {@link module:ol/MapBrowserEvent}.
    */
@@ -101,8 +102,8 @@ class SnapEvent extends Event {
     this.result = result;
 
     /**
-     * Snapped features array.
-     * @type {Array<import("../Feature.js").default>}
+     * Snapped features collection.
+     * @type {Collection<import("../Feature.js").default>}
      * @api
      */
     this.features = features;
@@ -321,9 +322,10 @@ class Snap extends PointerInteraction {
       evt.pixel = result.vertexPixel;
 
       if (this.snapCondition_(evt)) {
+        const features = new Collection([evt.map.getFeaturesAtPixel(evt.pixel)]);
         this.dispatchEvent(
           new SnapEvent(SnapEventType.SNAP,
-            result, evt.map.getFeaturesAtPixel(evt.pixel), evt));
+            result, features, evt));
       }
     }
     return super.handleEvent(evt);

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -135,6 +135,7 @@ class SnapEvent extends Event {
  *       source: source
  *     });
  *
+ * @fires SnapEvent
  * @api
  */
 class Snap extends PointerInteraction {

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -54,6 +54,11 @@ const SnapEventType = {
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the pointer close enough to a segment or
  * vertex for snapping.
  * @property {import("../source/Vector.js").default} [source] Snap to features from this source. Either this option or features should be provided
+ * @property {import("../events/condition.js").Condition} [snapCondition] A function that
+ * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
+ * boolean to indicate whether that event should be handled. This is the event
+ * for the snapped features as a whole. By default, this is
+ * {@link module:ol/events/condition~singleClick}. Clicking on a snapped feature will trigger the SnapEvent
  */
 
 
@@ -78,7 +83,7 @@ function getFeatureFromEvent(evt) {
 class SnapEvent extends Event {
   /**
    * @param {SnapEventType} type The event type.
-   * @param {Array} result Snap result array.
+   * @param {Result} result Snap result array.
    * @param {Array<import("../Feature.js").default>} features Array with the snapped features.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Associated
    *     {@link module:ol/MapBrowserEvent}.
@@ -88,7 +93,7 @@ class SnapEvent extends Event {
 
     /**
      * Snapped result array.
-     * @type {Array}
+     * @type {Result}
      * @api
      */
     this.result = result;

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -322,7 +322,7 @@ class Snap extends PointerInteraction {
       evt.pixel = result.vertexPixel;
 
       if (this.snapCondition_(evt)) {
-        const features = new Collection([evt.map.getFeaturesAtPixel(evt.pixel)]);
+        const features = new Collection(evt.map.getFeaturesAtPixel(evt.pixel));
         this.dispatchEvent(
           new SnapEvent(SnapEventType.SNAP,
             result, features, evt));


### PR DESCRIPTION
With this code Snap will trigger a new SnapEvent. See issue #9958 
It uses a snapCondition like seen in Select. The condition defaults to singleClick.

When a feature is 'snapped' ánd the condition is met, then the SnapEvent is triggered from within the central handleEvent() function. This way it is not limited only to a mouseclick or -move etc.

Also a boolean 'snapped' is set in the MapBrowserEvent. 

### Question
The trigger does NOT handle the return from handleEvent(). I don't know if it should or not. 

**_Is handleEvent() ok like this ?_** :
```
  handleEvent(evt) {
    const result = this.snapTo(evt.pixel, evt.coordinate, evt.map);
    evt.snapped = result.snapped;
    if (result.snapped) {
      evt.coordinate = result.vertex.slice(0, 2);
      evt.pixel = result.vertexPixel;

      if (this.snapCondition_(evt)) {
        this.dispatchEvent(
          new SnapEvent(SnapEventType.SNAP,
            result, evt.map.getFeaturesAtPixel(evt.pixel), evt));
      }
    }
    return super.handleEvent(evt);
  }
```
**_or should it be 'return this.dispatchEvent_**' ? : 
```
       return this.dispatchEvent(
          new SnapEvent(SnapEventType.SNAP,
            result, evt.map.getFeaturesAtPixel(evt.pixel), evt));
```

PS.
(sorry for the extra edited lines because of spaces/tabs; I had a hard time to get my editor (netbeans on windows) to the requested format)