### PR TITLE
do not stale issues with `bug` or `pull request accepted` labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,8 @@ daysUntilClose: 7
 exemptLabels:
   - blocker
   - regression
+  - bug
+  - 'pull request accepted'
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
do not stale issues with `bug` labels to make it easier to find unfixed bugs, `pull request accepted` could help to find things to do for newcomers.
Both would be needed to be cleaned up occasionally, though.