### PR TITLE
Use expect().fail() instead of expect.fail()

### DIFF
--- a/test/spec/ol/feature.test.js
+++ b/test/spec/ol/feature.test.js
@@ -208,7 +208,7 @@ describe('ol.Feature', function() {
       expect(feature.getGeometry()).to.be(point2);
 
       feature.on('change', function() {
-        expect.fail();
+        expect().fail();
       });
       point.setCoordinates([0, 2]);
     });

--- a/test/spec/ol/net.test.js
+++ b/test/spec/ol/net.test.js
@@ -67,7 +67,7 @@ describe('ol.net', function() {
         };
       };
       function callback() {
-        expect.fail();
+        expect().fail();
       }
       function errback() {
         expect(window[key]).to.be(undefined);


### PR DESCRIPTION
According to [the docs](https://github.com/Automattic/expect.js), the way to fail is `expect().fail()`.