### PR TITLE
Ensure proper tile load sequence

### DIFF
--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -241,6 +241,9 @@ class Tile extends EventTarget {
    * @api
    */
   setState(state) {
+    if (this.state !== TileState.ERROR && this.state > state) {
+      throw new Error('Tile load sequence violation');
+    }
     this.state = state;
     this.changed();
   }

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -74,7 +74,8 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       source = new VectorTileSource({
         format: new MVT(),
         tileClass: TileClass,
-        tileGrid: createXYZ()
+        tileGrid: createXYZ(),
+        url: '{z}/{x}/{y}.pbf'
       });
       source.getSourceTiles = function() {
         return [new TileClass([0, 0, 0])];


### PR DESCRIPTION
This pull request adds a check to ol/Tile to make sure we are not violating the proper tile loading sequence.

This change also revealed an issue with tiles being changed even after they were destroyed. That is fixed as well.