### PR TITLE
Remove called assert extension

### DIFF
--- a/test/spec/ol/collection.test.js
+++ b/test/spec/ol/collection.test.js
@@ -95,7 +95,7 @@ describe('ol.collection', function() {
     describe('on an empty collection', function() {
       it('does not call the callback', function() {
         collection.forEach(cb);
-        expect(cb).to.not.be.called();
+        expect(cb.called).to.be(false);
       });
     });
     describe('on a non-empty collection', function() {
@@ -120,7 +120,7 @@ describe('ol.collection', function() {
       const cb = sinon.spy();
       listen(collection, CollectionEventType.REMOVE, cb);
       expect(collection.remove(1)).to.eql(1);
-      expect(cb).to.be.called();
+      expect(cb.called).to.be(true);
       expect(cb.lastCall.args[0].element).to.eql(1);
     });
     it('does not remove more than one matching element', function() {
@@ -216,21 +216,21 @@ describe('ol.collection', function() {
     describe('insertAt', function() {
       it('triggers change:length event', function() {
         collection.insertAt(2, 3);
-        expect(cb).to.be.called();
+        expect(cb.called).to.be(true);
       });
     });
 
     describe('removeAt', function() {
       it('triggers change:length event', function() {
         collection.removeAt(0);
-        expect(cb).to.be.called();
+        expect(cb.called).to.be(true);
       });
     });
 
     describe('setAt', function() {
       it('does not trigger change:length event', function() {
         collection.setAt(1, 1);
-        expect(cb).to.not.be.called();
+        expect(cb.called).to.be(false);
       });
     });
   });

--- a/test/spec/ol/expect.test.js
+++ b/test/spec/ol/expect.test.js
@@ -42,38 +42,6 @@ describe('expect.js', function() {
 
   });
 
-  describe('called', function() {
-
-    let telephone;
-    beforeEach(function() {
-      telephone = sinon.spy();
-    });
-
-    it('has caller ID', function() {
-      telephone();
-      expect(telephone).to.be.called();
-    });
-
-    it('also knows when it\'s speaking to the hand', function() {
-      (function() {})();
-      expect(telephone).not.to.be.called();
-    });
-
-    it('reminds you that you forgot', function() {
-      expect(function() {
-        expect(telephone).to.be.called();
-      }).to.throwException();
-    });
-
-    it('gets moody all too quickly', function() {
-      telephone();
-      expect(function() {
-        expect(telephone).not.to.be.called();
-      }).to.throwException();
-    });
-
-  });
-
   describe('Test equality of XML documents - xmleql', function() {
 
     it('Test XML document with single root, different prefix', function() {

--- a/test/spec/ol/image.test.js
+++ b/test/spec/ol/image.test.js
@@ -15,8 +15,8 @@ describe('HTML Image loading', function() {
     listenImage(img, handleLoad, handleError);
 
     setTimeout(function() {
-      expect(handleLoad).to.be.called();
-      expect(handleError).not.to.be.called();
+      expect(handleLoad.called).to.be(true);
+      expect(handleError.called).to.be(false);
       done();
     }, 200);
   });
@@ -26,8 +26,8 @@ describe('HTML Image loading', function() {
     img.src = 'spec/ol/data/dot.png';
 
     setTimeout(function() {
-      expect(handleLoad).to.be.called();
-      expect(handleError).not.to.be.called();
+      expect(handleLoad.called).to.be(true);
+      expect(handleError.called).to.be(false);
       done();
     }, 200);
   });
@@ -37,8 +37,8 @@ describe('HTML Image loading', function() {
     listenImage(img, handleLoad, handleError);
 
     setTimeout(function() {
-      expect(handleLoad).not.to.be.called();
-      expect(handleError).to.be.called();
+      expect(handleLoad.called).to.be(false);
+      expect(handleError.called).to.be(true);
       done();
     }, 200);
   });
@@ -48,8 +48,8 @@ describe('HTML Image loading', function() {
     listenImage(img, handleLoad, handleError)();
 
     setTimeout(function() {
-      expect(handleLoad).not.to.be.called();
-      expect(handleError).not.to.be.called();
+      expect(handleLoad.called).to.be(false);
+      expect(handleError.called).to.be(false);
       done();
     }, 200);
   });

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -216,8 +216,8 @@ describe('ol.interaction.Draw', function() {
       simulateEvent('pointermove', 10, 20);
       simulateEvent('pointerdown', 10, 20);
       simulateEvent('pointerup', 10, 20);
-      expect(ds).to.be.called();
-      expect(de).to.be.called();
+      expect(ds.called).to.be(true);
+      expect(de.called).to.be(true);
       simulateEvent('pointermove', 20, 20);
       expect(ds.callCount).to.be(1);
       expect(de.callCount).to.be(1);
@@ -478,9 +478,9 @@ describe('ol.interaction.Draw', function() {
       simulateEvent('pointerup', 30, 20);
       simulateEvent('pointermove', 10, 20);
 
-      expect(ds).to.be.called();
+      expect(ds.called).to.be(true);
       expect(ds.callCount).to.be(1);
-      expect(de).to.be.called();
+      expect(de.called).to.be(true);
       expect(de.callCount).to.be(1);
     });
 
@@ -801,9 +801,9 @@ describe('ol.interaction.Draw', function() {
       simulateEvent('pointerdown', 10, 20);
       simulateEvent('pointerup', 10, 20);
 
-      expect(ds).to.be.called();
+      expect(ds.called).to.be(true);
       expect(ds.callCount).to.be(1);
-      expect(de).to.be.called();
+      expect(de.called).to.be(true);
       expect(de.callCount).to.be(1);
     });
 
@@ -963,9 +963,9 @@ describe('ol.interaction.Draw', function() {
       simulateEvent('pointerdown', 30, 20);
       simulateEvent('pointerup', 30, 20);
 
-      expect(ds).to.be.called();
+      expect(ds.called).to.be(true);
       expect(ds.callCount).to.be(1);
-      expect(de).to.be.called();
+      expect(de.called).to.be(true);
       expect(de.callCount).to.be(1);
     });
 

--- a/test/spec/ol/object.test.js
+++ b/test/spec/ol/object.test.js
@@ -156,7 +156,7 @@ describe('ol.Object', function() {
 
     it('dispatches events to object', function() {
       o.set('k', 1);
-      expect(listener1).to.be.called();
+      expect(listener1.called).to.be(true);
 
       expect(o.getKeys()).to.eql(['k']);
     });
@@ -190,7 +190,7 @@ describe('ol.Object', function() {
     it('does not call the setter', function() {
       o.set('x', 1);
       expect(o.get('x')).to.eql(1);
-      expect(o.setX).to.not.be.called();
+      expect(o.setX.called).to.be(false);
 
       expect(o.getKeys()).to.eql(['x']);
     });
@@ -206,7 +206,7 @@ describe('ol.Object', function() {
 
     it('does not call the getter', function() {
       expect(o.get('x')).to.be(undefined);
-      expect(o.getX).to.not.be.called();
+      expect(o.getX.called).to.be(false);
     });
   });
 
@@ -231,8 +231,8 @@ describe('ol.Object', function() {
 
     it('dispatches the expected event', function() {
       o.set('K', 1);
-      expect(listener1).to.not.be.called();
-      expect(listener2).to.be.called();
+      expect(listener1.called).to.be(false);
+      expect(listener2.called).to.be(true);
 
       expect(o.getKeys()).to.eql(['K']);
     });

--- a/test/spec/ol/source/imagewms.test.js
+++ b/test/spec/ol/source/imagewms.test.js
@@ -211,7 +211,7 @@ describe('ol.source.ImageWMS', function() {
       const source = new ImageWMS(options);
       const image = source.getImage(extent, resolution, pixelRatio, projection);
       image.load();
-      expect(imageLoadFunction).to.be.called();
+      expect(imageLoadFunction.called).to.be(true);
       expect(imageLoadFunction.calledWith(image, image.src_)).to.be(true);
     });
 

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -34,7 +34,7 @@ describe('ol.source.Vector', function() {
       it('does not call the callback', function() {
         const f = sinon.spy();
         vectorSource.forEachFeatureInExtent(infiniteExtent, f);
-        expect(f).not.to.be.called();
+        expect(f.called).to.be(false);
       });
 
     });
@@ -71,7 +71,7 @@ describe('ol.source.Vector', function() {
         const listener = sinon.spy();
         listen(vectorSource, 'change', listener);
         vectorSource.addFeature(pointFeature);
-        expect(listener).to.be.called();
+        expect(listener.called).to.be(true);
       });
 
       it('adds same id features only once', function() {
@@ -249,9 +249,9 @@ describe('ol.source.Vector', function() {
         vectorSource.clear(true);
         expect(vectorSource.getFeatures()).to.eql([]);
         expect(vectorSource.isEmpty()).to.be(true);
-        expect(removeFeatureSpy).not.to.be.called();
+        expect(removeFeatureSpy.called).to.be(false);
         expect(removeFeatureSpy.callCount).to.be(0);
-        expect(clearSourceSpy).to.be.called();
+        expect(clearSourceSpy.called).to.be(true);
         expect(clearSourceSpy.callCount).to.be(1);
       });
 
@@ -263,9 +263,9 @@ describe('ol.source.Vector', function() {
         vectorSource.clear();
         expect(vectorSource.getFeatures()).to.eql([]);
         expect(vectorSource.isEmpty()).to.be(true);
-        expect(removeFeatureSpy).to.be.called();
+        expect(removeFeatureSpy.called).to.be(true);
         expect(removeFeatureSpy.callCount).to.be(features.length);
-        expect(clearSourceSpy).to.be.called();
+        expect(clearSourceSpy.called).to.be(true);
         expect(clearSourceSpy.callCount).to.be(1);
       });
 
@@ -323,14 +323,14 @@ describe('ol.source.Vector', function() {
         const listener = sinon.spy();
         listen(vectorSource, 'change', listener);
         vectorSource.removeFeature(features[0]);
-        expect(listener).to.be.called();
+        expect(listener.called).to.be(true);
       });
 
       it('fires a removefeature event', function() {
         const listener = sinon.spy();
         listen(vectorSource, 'removefeature', listener);
         vectorSource.removeFeature(features[0]);
-        expect(listener).to.be.called();
+        expect(listener.called).to.be(true);
       });
 
     });
@@ -416,7 +416,7 @@ describe('ol.source.Vector', function() {
       const listener = sinon.spy();
       listen(vectorSource, 'change', listener);
       feature.set('foo', 'bar');
-      expect(listener).to.be.called();
+      expect(listener.called).to.be(true);
     });
 
     it('fires a changefeature event when updating a feature', function() {
@@ -427,7 +427,7 @@ describe('ol.source.Vector', function() {
       });
       vectorSource.on('changefeature', listener);
       feature.setStyle(null);
-      expect(listener).to.be.called();
+      expect(listener.called).to.be(true);
     });
 
   });

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -88,23 +88,6 @@ import {equals} from '../src/ol/array.js';
   };
 
 
-  /**
-   * Assert that a sinon spy was called.
-   * @return {expect.Assertion} The assertion.
-   */
-  expect.Assertion.prototype.called = function() {
-    this.assert(
-      this.obj.called,
-      function() {
-        return 'expected ' + expect.stringify(this.obj) + ' to be called';
-      },
-      function() {
-        return 'expected ' + expect.stringify(this.obj) + ' not to be called';
-      });
-    return this;
-  };
-
-
   function getChildNodes(node, options) {
     // check whitespace
     if (options && options.includeWhiteSpace) {


### PR DESCRIPTION
As part of simplifying our test setup (and making it easier to swap out the parts), this removes the `called` extension to expect.js.