### PR TITLE
Ensure zoom level is not less than minimum integer zoom level for extent

### DIFF
--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -127,10 +127,14 @@ export function createSnapToPower(power, maxResolution, opt_minResolution, opt_s
           return getSmoothClampedResolution(resolution, cappedMaxRes, minResolution);
         }
 
-        const offset = -direction * (0.5 - 1e-9) + 0.5;
+        const tolerance = 1e-9;
+        const minZoomLevel = Math.ceil(
+          Math.log(maxResolution / cappedMaxRes) / Math.log(power) - tolerance);
+        const offset = -direction * (0.5 - tolerance) + 0.5;
         const capped = Math.min(cappedMaxRes, resolution);
-        const zoomLevel = Math.floor(
+        const cappedZoomLevel = Math.floor(
           Math.log(maxResolution / capped) / Math.log(power) + offset);
+        const zoomLevel = Math.max(minZoomLevel, cappedZoomLevel);
         const newResolution = maxResolution / Math.pow(power, zoomLevel);
         return clamp(newResolution, minResolution, cappedMaxRes);
       } else {

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -454,7 +454,7 @@ describe('ol.View', function() {
             maxResolution: maxResolution,
             constrainResolution: true
           });
-          expect(fn(defaultMaxRes, 0, size)).to.be(defaultMaxRes / 2);
+          expect(fn(defaultMaxRes, 0, size)).to.be(maxResolution / 4);
         });
 
         it('enabled, with constrainResolution', function() {


### PR DESCRIPTION
Fixes #10054

Ensure constrained zoom level is not less than minimum integer zoom level for extent
Correct the expected result in test