### PR TITLE
Use the same spelling used elsewhere

### DIFF
--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -390,7 +390,6 @@ describe('ol.interaction.Draw', function() {
       simulateEvent('pointerup', 60, 70);
 
       const features = source.getFeatures();
-      // expect(features).to.have.length(1);
       const geometry = features[0].getGeometry();
       expect(geometry).to.be.a(LineString);
       expect(geometry.getCoordinates()).to.eql(

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -708,7 +708,7 @@ describe('ol.interaction.Modify', function() {
       collection.remove(features[0]);
       expect(function() {
         simulateEvent('pointerup', -10, -10, null, 0);
-      }).to.not.throwError();
+      }).to.not.throwException();
     });
   });
 


### PR DESCRIPTION
There are 6 (+) ways to assert that a function does not throw with `expect.js`:

 * `expect(fn).not.to.throwException()`
 * `expect(fn).to.not.throwException()`
 * `expect(fn).not.throwException()`
 * `expect(fn).not.to.throwError()`
 * `expect(fn).to.not.throwError()`
 * `expect(fn).not.throwError()`

We only use the `throwError` spelling in one place, so this change gets rid of that.