### PR TITLE
fixed jsdoc type annotations

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -231,7 +231,7 @@ class Feature extends BaseObject {
    * styles. If it is `null` the feature has no style (a `null` style).
    * @param {import("./style/Style.js").StyleLike} style Style for this feature.
    * @api
-   * @fires module:ol/events/Event~Event#event:change
+   * @fires module:ol/events/Event~BaseEvent#event:change
    */
   setStyle(style) {
     this.style_ = style;
@@ -246,7 +246,7 @@ class Feature extends BaseObject {
    * {@link module:ol/source/Vector~VectorSource#getFeatureById} method.
    * @param {number|string|undefined} id The feature id.
    * @api
-   * @fires module:ol/events/Event~Event#event:change
+   * @fires module:ol/events/Event~BaseEvent#event:change
    */
   setId(id) {
     this.id_ = id;

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -81,7 +81,7 @@ class GeolocationError extends BaseEvent {
  *       window.console.log(geolocation.getPosition());
  *     });
  *
- * @fires module:ol/events/Event~Event#event:error
+ * @fires module:ol/events/Event~BaseEvent#event:error
  * @api
  */
 class Geolocation extends BaseObject {

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -13,7 +13,7 @@ import EventType from './events/EventType.js';
  * and unregistration. A generic `change` event is always available through
  * {@link module:ol/Observable~Observable#changed}.
  *
- * @fires import("./events/Event.js").Event
+ * @fires import("./events/Event.js").default
  * @api
  */
 class Observable extends EventTarget {

--- a/src/ol/events/EventType.js
+++ b/src/ol/events/EventType.js
@@ -9,14 +9,14 @@
 export default {
   /**
    * Generic change event. Triggered when the revision counter is increased.
-   * @event module:ol/events/Event~Event#change
+   * @event module:ol/events/Event~BaseEvent#change
    * @api
    */
   CHANGE: 'change',
 
   /**
    * Generic error event. Triggered when an error occurs.
-   * @event module:ol/events/Event~Event#error
+   * @event module:ol/events/Event~BaseEvent#error
    * @api
    */
   ERROR: 'error',

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -6,11 +6,6 @@ import CanvasImageLayerRenderer from '../renderer/canvas/ImageLayer.js';
 
 
 /**
- * @typedef {import("./BaseImage.js").Options} Options
- */
-
-
-/**
  * @classdesc
  * Server-rendered images that are available for arbitrary extents and
  * resolutions.
@@ -23,7 +18,7 @@ import CanvasImageLayerRenderer from '../renderer/canvas/ImageLayer.js';
 class ImageLayer extends BaseImageLayer {
 
   /**
-   * @param {Options=} opt_options Layer options.
+   * @param {import("./BaseImage.js").Options=} opt_options Layer options.
    */
   constructor(opt_options) {
     super(opt_options);

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -22,7 +22,7 @@ import EventType from '../events/EventType.js';
  * Object's properties (e.g. 'hasOwnProperty' is not allowed as a key). Expiring
  * items from the cache is the responsibility of the user.
  *
- * @fires import("../events/Event.js").Event
+ * @fires import("../events/Event.js").default
  * @template T
  */
 class LRUCache extends EventTarget {


### PR DESCRIPTION
Fixes `Event` type annotations to `BaseEvent` and removed an empty Option typedef for `ol/image/Layer` which caused the options to not be displayed inline in the docs.

Fixes #10044 