### PR TITLE
Remove offsets from mouse position calculation

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -217,7 +217,7 @@ class OverviewMap extends Control {
     const computeDesiredMousePosition = function(mousePosition) {
       return {
         clientX: mousePosition.clientX,
-        clientY: mousePosition.clientY 
+        clientY: mousePosition.clientY
       };
     };
 

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -216,8 +216,8 @@ class OverviewMap extends Control {
 
     const computeDesiredMousePosition = function(mousePosition) {
       return {
-        clientX: mousePosition.clientX - (overlayBox.offsetWidth / 2),
-        clientY: mousePosition.clientY + (overlayBox.offsetHeight / 2)
+        clientX: mousePosition.clientX,
+        clientY: mousePosition.clientY 
       };
     };
 


### PR DESCRIPTION
Fixes #10073

Remove unneeded offsets from mouse position calculation as box position was centered in #9919
