### PR TITLE
webgl points layer example fixes

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -241,10 +241,6 @@ Support for the `OES_element_index_uint` WebGL extension is mandatory for WebGL 
 
 Layer opacity must be a number.
 
-### 65
-
-A symbol literal representation must be defined on the style supplied to a `WebGLPointsLayer` instance.
-
 ### 66
 
 `forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled.

--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -29,10 +29,8 @@ experimental: true
   <option value="circles">Circles, size related to population</option>
 </select>
 <textarea style="width: 100%; height: 20rem; font-family: monospace; font-size: small;" id="style-editor"></textarea>
-<small id="style-valid" style="display: none; color: forestgreen">
-  ✓ style is valid
+<small>
+  <span id="style-valid" style="display: none; color: forestgreen">✓ style is valid</span>
+  <span id="style-invalid" style="display: none; color: grey">✗ <span>style not yet valid...</span></span>
+  &nbsp;
 </small>
-<small id="style-invalid" style="display: none; color: grey">
-  ✗ style not yet valid...
-</small>
-<small>&nbsp;</small>

--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -35,3 +35,4 @@ experimental: true
 <small id="style-invalid" style="display: none; color: grey">
   ✗ style not yet valid...
 </small>
+<small>&nbsp;</small>

--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -24,7 +24,6 @@ experimental: true
 <div id="map" class="map"></div>
 <label>Choose a predefined style from the list below or edit it as JSON manually.</label><br>
 <select id="style-select">
-  <option>Predefined styles</option>
   <option value="icons">Icons</option>
   <option value="triangles">Triangles, color related to population</option>
   <option value="circles">Circles, size related to population</option>

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -74,8 +74,8 @@ function refreshLayer() {
 }
 
 function setStyleStatus(valid) {
-  document.getElementById('style-valid').style.display = valid ? 'initial' : 'none';
-  document.getElementById('style-invalid').style.display = !valid ? 'initial' : 'none';
+  document.getElementById('style-valid').style.display = valid === true ? 'initial' : 'none';
+  document.getElementById('style-invalid').style.display = valid === false ? 'initial' : 'none';
 }
 
 const editor = document.getElementById('style-editor');
@@ -101,6 +101,7 @@ function onSelectChange() {
   literalStyle = predefinedStyles[style];
   editor.value = JSON.stringify(literalStyle, null, 2);
   refreshLayer();
+  setStyleStatus();
 }
 onSelectChange();
 select.addEventListener('change', onSelectChange);

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -46,8 +46,6 @@ const predefinedStyles = {
     }
   }
 };
-let literalStyle = predefinedStyles['circles'];
-let pointsLayer;
 
 const map = new Map({
   layers: [
@@ -62,9 +60,8 @@ const map = new Map({
   })
 });
 
-const editor = document.getElementById('style-editor');
-editor.value = JSON.stringify(literalStyle, null, 2);
-
+let literalStyle;
+let pointsLayer;
 function refreshLayer() {
   if (pointsLayer) {
     map.removeLayer(pointsLayer);
@@ -81,6 +78,7 @@ function setStyleStatus(valid) {
   document.getElementById('style-invalid').style.display = !valid ? 'initial' : 'none';
 }
 
+const editor = document.getElementById('style-editor');
 editor.addEventListener('input', function() {
   const textStyle = editor.value;
   if (JSON.stringify(JSON.parse(textStyle)) === JSON.stringify(literalStyle)) {
@@ -95,12 +93,14 @@ editor.addEventListener('input', function() {
     setStyleStatus(false);
   }
 });
-refreshLayer();
 
 const select = document.getElementById('style-select');
-select.addEventListener('change', function() {
+select.value = 'circles';
+function onSelectChange() {
   const style = select.value;
   literalStyle = predefinedStyles[style];
   editor.value = JSON.stringify(literalStyle, null, 2);
   refreshLayer();
-});
+}
+onSelectChange();
+select.addEventListener('change', onSelectChange);

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -103,10 +103,8 @@ select.value = 'circles';
 function onSelectChange() {
   const style = select.value;
   const newLiteralStyle = predefinedStyles[style];
-  if (refreshLayer(newLiteralStyle)) {
-    editor.value = JSON.stringify(newLiteralStyle, null, 2);
-  }
-  setStyleStatus();
+  setStyleStatus(refreshLayer(newLiteralStyle) ? undefined : false);
+  editor.value = JSON.stringify(newLiteralStyle, null, 2);
 }
 onSelectChange();
 select.addEventListener('change', onSelectChange);

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -81,13 +81,12 @@ function setStyleStatus(valid) {
 const editor = document.getElementById('style-editor');
 editor.addEventListener('input', function() {
   const textStyle = editor.value;
-  if (JSON.stringify(JSON.parse(textStyle)) === JSON.stringify(literalStyle)) {
-    return;
-  }
-
   try {
-    literalStyle = JSON.parse(textStyle);
-    refreshLayer();
+    const newLiteralStyle = JSON.parse(textStyle);
+    if (JSON.stringify(newLiteralStyle) !== JSON.stringify(literalStyle)) {
+      literalStyle = newLiteralStyle;
+      refreshLayer();
+    }
     setStyleStatus(true);
   } catch (e) {
     setStyleStatus(false);

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -74,10 +74,7 @@ class WebGLPointsLayer extends Layer {
      * @private
      * @type {import('../webgl/ShaderBuilder.js').StyleParseResult}
      */
-    this.parseResult_ = parseSymbolStyle(
-      /** @type {import('../style/LiteralStyle.js').LiteralStyle} */
-      (options.style).symbol
-    );
+    this.parseResult_ = parseSymbolStyle(options.style.symbol);
   }
 
   /**

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -4,7 +4,6 @@
 import {assign} from '../obj.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
 import {getSymbolFragmentShader, getSymbolVertexShader, parseSymbolStyle} from '../webgl/ShaderBuilder.js';
-import {assert} from '../asserts.js';
 import Layer from './Layer.js';
 
 
@@ -72,24 +71,24 @@ class WebGLPointsLayer extends Layer {
     super(baseOptions);
 
     /**
-     * @type {import('../style/LiteralStyle.js').LiteralStyle}
+     * @private
+     * @type {import('../webgl/ShaderBuilder.js').StyleParseResult}
      */
-    this.style = options.style;
-
-    assert(this.style.symbol !== undefined, 65);
+    this.parseResult_ = parseSymbolStyle(
+      /** @type {import('../style/LiteralStyle.js').LiteralStyle} */
+      (options.style).symbol
+    );
   }
 
   /**
    * @inheritDoc
    */
   createRenderer() {
-    const parseResult = parseSymbolStyle(this.style.symbol);
-
     return new WebGLPointsLayerRenderer(this, {
-      vertexShader: getSymbolVertexShader(parseResult.params),
-      fragmentShader: getSymbolFragmentShader(parseResult.params),
-      uniforms: parseResult.uniforms,
-      attributes: parseResult.attributes
+      vertexShader: getSymbolVertexShader(this.parseResult_.params),
+      fragmentShader: getSymbolFragmentShader(this.parseResult_.params),
+      uniforms: this.parseResult_.uniforms,
+      attributes: this.parseResult_.attributes
     });
   }
 }


### PR DESCRIPTION
This PR improves the webgl-points-layer example.
Bugs:
- Remove 'Predefined styles' option from input. When selected it displays undefined as style.
- Catch errors when input string cannot be parsed as JSON.
- Catch errors when input string is not a valid style.
- Do not remove current point layer if the new style is invalid.
- Show 'success' instead of 'invalid' message when the user reverts an invalid style to the previously selected one.

Improvements:
- Also pre-select the circles style in the select input.
- Add a dummy tag that reserves the height for the parsing status message.
- Hide this message when the style is changed via the select input.