### PR TITLE
Update mapbox-style example

### DIFF
--- a/examples/mapbox-style.html
+++ b/examples/mapbox-style.html
@@ -1,7 +1,10 @@
 ---
 layout: example-verbatim.html
 title: Vector tiles created from a Mapbox Style object
-shortdesc: Example of using ol-mapbox-style with tiles from tilehosting.com.
+shortdesc: Example of using ol-mapbox-style with tiles from maptiler.com.
+docs: >
+  Example of using `ol-mapbox-style` with tiles from maptiler.com.
+  **Note**: Make sure to get your own API key at https://www.maptiler.com/cloud/ when using this example. No map will be visible when the API key has expired.
 tags: "vector tiles, mapbox style, ol-mapbox-style, maptiler"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB


### PR DESCRIPTION
This PR updates the `mapbox-style` example to use the standard example layout (with visible code etc.) instead of the "verbatim" one and minor description fixes.