### PR TITLE
Cosmetic type fixes

### DIFF
--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -39,10 +39,10 @@ export function VOID() {}
 export function memoizeOne(fn) {
   let called = false;
 
-  /** @type ReturnType */
+  /** @type {ReturnType} */
   let lastResult;
 
-  /** @type Array<any> */
+  /** @type {Array<any>} */
   let lastArgs;
 
   let lastThis;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -401,7 +401,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       }
     }
 
-    /** @type import('./Layer').WebGLWorkerGenerateBuffersMessage */
+    /** @type {import('./Layer').WebGLWorkerGenerateBuffersMessage} */
     const message = {
       type: WebGLWorkerMessageType.GENERATE_BUFFERS,
       renderInstructions: this.renderInstructions_.buffer,
@@ -412,7 +412,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.worker_.postMessage(message, [this.renderInstructions_.buffer]);
     this.renderInstructions_ = null;
 
-    /** @type import('./Layer').WebGLWorkerGenerateBuffersMessage */
+    /** @type {import('./Layer').WebGLWorkerGenerateBuffersMessage} */
     if (this.hitDetectionEnabled_) {
       const hitMessage = {
         type: WebGLWorkerMessageType.GENERATE_BUFFERS,

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -25,7 +25,7 @@ import TileImage from './TileImage.js';
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {Array<number>} [resolutions] Supported resolutions as given in IIIF 'scaleFactors'
  * @property {import("../size.js").Size} size Size of the image [width, height].
- * @property {import("../size.js").Size[]} [sizes] Supported scaled image sizes.
+ * @property {Array<import("../size.js").Size>} [sizes] Supported scaled image sizes.
  * Content of the IIIF info.json 'sizes' property, but as array of Size objects.
  * @property {import("./State.js").default} [state] Source state.
  * @property {Array<string>} [supports=[]] Supported IIIF region and size calculation


### PR DESCRIPTION
Some cosmetic changes (using `{}` after `@type`, using `Array<>` instead of `[]`