### PR TITLE
Increase default attribution size

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -182,7 +182,7 @@
 .ol-attribution ul {
   margin: 0;
   padding: 0 .5em;
-  font-size: .7rem;
+  font-size: 1.1rem;
   line-height: 1.375em;
   color: #000;
   text-shadow: 0 0 2px #fff;


### PR DESCRIPTION
The current default of 0.7rem is anomalously tiny and unlikely to fulfil typical licence requirements (e.g. OpenStreetMap's requirement that attribution is "reasonably calculated to make any Person that... views... the Produced Work"). See https://www.cyclinguk.org/route/great-north-trail-full-route-cape-wrath for an example of this attribution in the wild: unreadably small on Safari, Chromium and Firefox (macOS).

Increasing to 80% of the lineheight, i.e. 1.1rem, takes up no more vertical screen space but makes the attribution readable.

Note that the OL attribution example at https://openlayers.org/en/latest/examples/attributions.html overrides the default attribution to have a height of 1rem.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
