### PR TITLE
Correct the defaulting of ol/source/VectorTile maxZoom

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -94,7 +94,7 @@ class VectorTile extends UrlTile {
 
     const tileGrid = options.tileGrid || createXYZ({
       extent: extent,
-      maxZoom: options.maxZoom || 22,
+      maxZoom: options.maxZoom !== undefined ? options.maxZoom : 22,
       minZoom: options.minZoom,
       tileSize: options.tileSize || 512
     });


### PR DESCRIPTION
Only default if undefined as `maxZoom: 0` should be valid as it is for all other tile sources
