### PR TITLE
No ERROR state for render tiles

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -12,7 +12,6 @@ import {createXYZ, extentFromProjection, createForProjection} from '../tilegrid.
 import {buffer as bufferExtent, getIntersection, intersects} from '../extent.js';
 import EventType from '../events/EventType.js';
 import {loadFeaturesXhr} from '../featureloader.js';
-import {isEmpty} from '../obj.js';
 import {equals} from '../array.js';
 
 /**
@@ -252,10 +251,11 @@ class VectorTile extends UrlTile {
                 } else if (state === TileState.ERROR) {
                   tile.errorSourceTileKeys[sourceTileKey] = true;
                 }
-                if (tile.loadingSourceTiles - Object.keys(tile.errorSourceTileKeys).length === 0) {
-                  tile.hifi = true;
+                const errorTileCount = Object.keys(tile.errorSourceTileKeys).length;
+                if (tile.loadingSourceTiles - errorTileCount === 0) {
+                  tile.hifi = errorTileCount === 0;
                   tile.sourceZ = sourceZ;
-                  tile.setState(isEmpty(tile.errorSourceTileKeys) ? TileState.LOADED : TileState.ERROR);
+                  tile.setState(TileState.LOADED);
                 }
               }
             };

--- a/test/spec/ol/vectorrendertile.test.js
+++ b/test/spec/ol/vectorrendertile.test.js
@@ -27,9 +27,11 @@ describe('ol.VectorRenderTile', function() {
     listen(tile, 'change', function(e) {
       ++calls;
       if (calls === 1) {
-        expect(tile.getState()).to.be(TileState.ERROR);
+        expect(tile.getState()).to.be(TileState.LOADED);
+        expect(tile.hifi).to.be(false);
         setTimeout(function() {
           sourceTile.setState(TileState.LOADED);
+          expect(tile.hifi).to.be(true);
         }, 0);
       } else if (calls === 2) {
         done();
@@ -37,7 +39,7 @@ describe('ol.VectorRenderTile', function() {
     });
   });
 
-  it('sets ERROR state when source tiles fail to load', function(done) {
+  it('sets LOADED state and hifi==false when source tiles fail to load', function(done) {
     const source = new VectorTileSource({
       format: new GeoJSON(),
       url: 'spec/ol/data/unavailable.json'
@@ -47,7 +49,8 @@ describe('ol.VectorRenderTile', function() {
     tile.load();
 
     listen(tile, 'change', function(e) {
-      expect(tile.getState()).to.be(TileState.ERROR);
+      expect(tile.getState()).to.be(TileState.LOADED);
+      expect(tile.hifi).to.be(false);
       done();
     });
   });


### PR DESCRIPTION
The standard vector tile loading process canl violate the tile loading sequence: when a render tile is covered by lower resolution source tiles, it gets the LOADED state. Now when target resolution source tiles are not available due to error, we previously set the state to ERROR. This is not allowed after a LOADED state has been set, because noone is listening for this change any more.

This pull request changes the logic so we now do not set the state to ERROR, but to LOADED, and leave the `hifi` attribute set to false, so we are still listening in case an errored source tile becomes available.

Fixes openlayers/ol-mapbox-style#234.
Fixes the vector tile issues described in #10033.