### PR TITLE
Document the OSM crossOrigin default

### DIFF
--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -21,7 +21,7 @@ export const ATTRIBUTION = '&#169; ' +
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Tile cache size. The default depends on the screen size. Will increase if too small.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {null|string} [crossOrigin='anonymous'] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {number} [maxZoom=19] Max zoom.


### PR DESCRIPTION
This might help someone using an alternative url in ol/source/OSM understand why they get a CORS error