### PR TITLE
Should be able to ovveride defaultvalue of style in selection.

### DIFF
--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -206,7 +206,7 @@ class Select extends Interaction {
      * @private
      * @type {import("../style/Style.js").default|Array.<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction|null}
      */
-    this.style_ = options.style ? options.style : getDefaultStyleFunction();
+    this.style_ = options.style !== undefined ? options.style : getDefaultStyleFunction();
 
     /**
      * An association between selected feature (key)

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -61,6 +61,7 @@ const SelectEventType = {
  * @property {import("../style/Style.js").StyleLike} [style]
  * Style for the selected features. By default the default edit style is used
  * (see {@link module:ol/style}).
+ * If set to `false` the selected feature's style will not change.
  * @property {import("../events/condition.js").Condition} [removeCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.


### PR DESCRIPTION
null or false should be able to prevent overriding the style.
As discussed here: https://github.com/openlayers/openlayers/issues/10131

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
