### PR TITLE
Fix tilechange events

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -167,10 +167,10 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../../proj/Projection").default} projection Projection.
    * @param {boolean} queue Queue tile for rendering.
-   * @return {boolean} Tile needs to be rendered.
+   * @return {boolean|undefined} Tile needs to be rendered.
    */
   prepareTile(tile, pixelRatio, projection, queue) {
-    let render = false;
+    let render;
     const tileUid = getUid(tile);
     const state = tile.getState();
     if (((state === TileState.LOADED && tile.hifi) ||


### PR DESCRIPTION
This pull request finally fixes the tile loading issues with vector tiles. The reason was the prepareTile function, which is used as a listener, and stops event propagation when it returns false.

Maybe we should change the behavior of our event system to not stop propagation when a listener returns false.

Fixes #10033