### PR TITLE
Webgl / Add support for filtering and color interpolation in style expressions

### DIFF
--- a/examples/filter-points-webgl.html
+++ b/examples/filter-points-webgl.html
@@ -3,14 +3,14 @@ layout: example.html
 title: Filtering features with WebGL
 shortdesc: Using WebGL to filter large quantities of features
 docs: >
-  This example shows how to use `ol/renderer/webgl/PointsLayer` to dynamically filter a large amount
+  This example shows how to use `ol/layer/WebGLPoints` with a literal style to dynamically filter a large amount
     of point geometries. The above map is based on a dataset from the NASA containing 45k recorded meteorite
     landing sites. Each meteorite is marked by a circle on the map (the bigger the circle, the heavier
     the object). A pulse effect has been added, which is slightly offset by the year of the impact.
 
-  Adjusting the sliders causes the objects outside of the date range to be filtered out of the map. This is done using
-    a custom fragment shader on the layer renderer, and by using the `v_opacity` attribute of the rendered objects
-    to store the year of impact.
+  Adjusting the sliders causes the objects outside of the date range to be filtered out of the map. This is done
+    by mutating the variables in the `style` object provided to the WebGL layer. Also note that the last snippet
+    of code is necessary to make sure the map refreshes itself every frame.
 
 tags: "webgl, icon, sprite, filter, feature"
 experimental: true

--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -3,162 +3,106 @@ import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import Feature from '../src/ol/Feature.js';
 import Point from '../src/ol/geom/Point.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
 import {Vector} from '../src/ol/source.js';
 import {fromLonLat} from '../src/ol/proj.js';
-import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
-import {clamp} from '../src/ol/math.js';
 import Stamen from '../src/ol/source/Stamen.js';
-import {formatColor} from '../src/ol/webgl/ShaderBuilder.js';
+import WebGLPointsLayer from '../src/ol/layer/WebGLPoints.js';
 
 const vectorSource = new Vector({
   attributions: 'NASA'
 });
 
-const oldColor = [180, 140, 140];
-const newColor = [255, 80, 80];
+const oldColor = 'rgba(242,56,22,0.61)';
+const newColor = '#ffe52c';
+const period = 12; // animation period in seconds
+const animRatio =
+  ['pow',
+    ['/',
+      ['mod',
+        ['+',
+          ['time'],
+          ['stretch', ['get', 'year'], 1850, 2020, 0, period]
+        ],
+        period
+      ],
+      period
+    ],
+    0.5
+  ];
 
-const startTime = Date.now() * 0.001;
+const style = {
+  variables: {
+    minYear: 1850,
+    maxYear: 2015
+  },
+  filter: ['between', ['get', 'year'], ['var', 'minYear'], ['var', 'maxYear']],
+  symbol: {
+    symbolType: 'circle',
+    size: ['*',
+      ['stretch', ['get', 'mass'], 0, 200000, 8, 26],
+      ['-', 1.5, ['*', animRatio, 0.5]]
+    ],
+    color: ['interpolate',
+      animRatio,
+      newColor, oldColor],
+    opacity: ['-', 1.0, ['*', animRatio, 0.75]]
+  }
+};
 
-// hanle input values & events
+// handle input values & events
 const minYearInput = document.getElementById('min-year');
 const maxYearInput = document.getElementById('max-year');
+
+function updateMinYear() {
+  style.variables.minYear = parseInt(minYearInput.value);
+  updateStatusText();
+}
+function updateMaxYear() {
+  style.variables.maxYear = parseInt(maxYearInput.value);
+  updateStatusText();
+}
 function updateStatusText() {
   const div = document.getElementById('status');
   div.querySelector('span.min-year').textContent = minYearInput.value;
   div.querySelector('span.max-year').textContent = maxYearInput.value;
 }
-minYearInput.addEventListener('input', updateStatusText);
-minYearInput.addEventListener('change', updateStatusText);
-maxYearInput.addEventListener('input', updateStatusText);
-maxYearInput.addEventListener('change', updateStatusText);
+
+minYearInput.addEventListener('input', updateMinYear);
+minYearInput.addEventListener('change', updateMinYear);
+maxYearInput.addEventListener('input', updateMaxYear);
+maxYearInput.addEventListener('change', updateMaxYear);
 updateStatusText();
 
-class WebglPointsLayer extends VectorLayer {
-  createRenderer() {
-    return new WebGLPointsLayerRenderer(this, {
-      attributes: [
-        {
-          name: 'size',
-          callback: function(feature) {
-            return 18 * clamp(feature.get('mass') / 200000, 0, 1) + 8;
-          }
-        },
-        {
-          name: 'year',
-          callback: function(feature) {
-            return feature.get('year');
-          }
-        }
-      ],
-      vertexShader: [
-        'precision mediump float;',
+// load data
+const client = new XMLHttpRequest();
+client.open('GET', 'data/csv/meteorite_landings.csv');
+client.onload = function() {
+  const csv = client.responseText;
+  const features = [];
 
-        'uniform mat4 u_projectionMatrix;',
-        'uniform mat4 u_offsetScaleMatrix;',
-        'uniform mat4 u_offsetRotateMatrix;',
-        'attribute vec2 a_position;',
-        'attribute float a_index;',
-        'attribute float a_size;',
-        'attribute float a_year;',
-        'varying vec2 v_texCoord;',
-        'varying float v_year;',
+  let prevIndex = csv.indexOf('\n') + 1; // scan past the header line
 
-        'void main(void) {',
-        '  mat4 offsetMatrix = u_offsetScaleMatrix;',
-        '  float offsetX = a_index == 0.0 || a_index == 3.0 ? -a_size / 2.0 : a_size / 2.0;',
-        '  float offsetY = a_index == 0.0 || a_index == 1.0 ? -a_size / 2.0 : a_size / 2.0;',
-        '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
-        '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
-        '  float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;',
-        '  float v = a_index == 0.0 || a_index == 1.0 ? 0.0 : 1.0;',
-        '  v_texCoord = vec2(u, v);',
-        '  v_year = a_year;',
-        '}'
-      ].join(' '),
-      fragmentShader: [
-        'precision mediump float;',
+  let curIndex;
+  while ((curIndex = csv.indexOf('\n', prevIndex)) != -1) {
+    const line = csv.substr(prevIndex, curIndex - prevIndex).split(',');
+    prevIndex = curIndex + 1;
 
-        'uniform float u_time;',
-        'uniform float u_minYear;',
-        'uniform float u_maxYear;',
-        'varying vec2 v_texCoord;',
-        'varying float v_year;',
-
-        'void main(void) {',
-
-        // filter out pixels if the year is outside of the given range
-        '  if (v_year < u_minYear || v_year > u_maxYear) {',
-        '    discard;',
-        '  }',
-
-        '  vec2 texCoord = v_texCoord * 2.0 - vec2(1.0, 1.0);',
-        '  float sqRadius = texCoord.x * texCoord.x + texCoord.y * texCoord.y;',
-        '  float value = 2.0 * (1.0 - sqRadius);',
-        '  float alpha = smoothstep(0.0, 1.0, value);',
-
-        // color is interpolated based on year
-        '  float ratio = clamp((v_year - 1800.0) / (2013.0 - 1800.0), 0.0, 1.1);',
-        '  vec3 color = mix(vec3(' + formatColor(oldColor) + '),',
-        '    vec3(' + formatColor(newColor) + '), ratio);',
-
-        '  float period = 8.0;',
-        '  color.g *= 2.0 * (1.0 - sqrt(mod(u_time + v_year * 0.025, period) / period));',
-
-        '  gl_FragColor = vec4(color, 1.0);',
-        '  gl_FragColor.a *= alpha;',
-        '  gl_FragColor.rgb *= gl_FragColor.a;',
-        '}'
-      ].join(' '),
-      uniforms: {
-        u_time: function() {
-          return Date.now() * 0.001 - startTime;
-        },
-        u_minYear: function() {
-          return parseInt(minYearInput.value);
-        },
-        u_maxYear: function() {
-          return parseInt(maxYearInput.value);
-        }
-      }
-    });
-  }
-}
-
-
-function loadData() {
-  const client = new XMLHttpRequest();
-  client.open('GET', 'data/csv/meteorite_landings.csv');
-  client.onload = function() {
-    const csv = client.responseText;
-    const features = [];
-
-    let prevIndex = csv.indexOf('\n') + 1; // scan past the header line
-
-    let curIndex;
-    while ((curIndex = csv.indexOf('\n', prevIndex)) != -1) {
-      const line = csv.substr(prevIndex, curIndex - prevIndex).split(',');
-      prevIndex = curIndex + 1;
-
-      const coords = fromLonLat([parseFloat(line[4]), parseFloat(line[3])]);
-      if (isNaN(coords[0]) || isNaN(coords[1])) {
-        // guard against bad data
-        continue;
-      }
-
-      features.push(new Feature({
-        mass: parseFloat(line[1]) || 0,
-        year: parseInt(line[2]) || 0,
-        geometry: new Point(coords)
-      }));
+    const coords = fromLonLat([parseFloat(line[4]), parseFloat(line[3])]);
+    if (isNaN(coords[0]) || isNaN(coords[1])) {
+      // guard against bad data
+      continue;
     }
 
-    vectorSource.addFeatures(features);
-  };
-  client.send();
-}
+    features.push(new Feature({
+      mass: parseFloat(line[1]) || 0,
+      year: parseInt(line[2]) || 0,
+      geometry: new Point(coords)
+    }));
+  }
 
-loadData();
+  vectorSource.addFeatures(features);
+};
+client.send();
 
 const map = new Map({
   layers: [
@@ -167,7 +111,8 @@ const map = new Map({
         layer: 'toner'
       })
     }),
-    new WebglPointsLayer({
+    new WebGLPointsLayer({
+      style: style,
       source: vectorSource
     })
   ],

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -27,10 +27,10 @@ const predefinedStyles = {
       symbolType: 'triangle',
       size: 18,
       color: [
-        ['stretch', ['get', 'population'], 20000, 300000, 0.1, 1.0],
-        ['stretch', ['get', 'population'], 20000, 300000, 0.6, 0.3],
-        0.6,
-        1.0
+        'interpolate',
+        ['stretch', ['get', 'population'], 20000, 300000, 0, 1],
+        '#5aca5b',
+        '#ff6a19'
       ],
       rotateWithView: true
     }

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -223,3 +223,14 @@ export function toString(color) {
   const a = color[3] === undefined ? 1 : color[3];
   return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
 }
+
+/**
+ * @param {string} s String.
+ * @return {boolean} Whether the string is actually a valid color
+ */
+export function isStringColor(s) {
+  if (NAMED_COLOR_RE_.test(s)) {
+    s = fromNamed(s);
+  }
+  return HEX_COLOR_RE_.test(s) || s.indexOf('rgba(') === 0 || s.indexOf('rgb(') === 0;
+}

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -3,7 +3,7 @@
  */
 import {assign} from '../obj.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
-import {getSymbolFragmentShader, getSymbolVertexShader, parseSymbolStyle} from '../webgl/ShaderBuilder.js';
+import {parseSymbolStyle} from '../webgl/ShaderBuilder.js';
 import Layer from './Layer.js';
 
 
@@ -82,8 +82,8 @@ class WebGLPointsLayer extends Layer {
    */
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
-      vertexShader: getSymbolVertexShader(this.parseResult_.params),
-      fragmentShader: getSymbolFragmentShader(this.parseResult_.params),
+      vertexShader: this.parseResult_.builder.getSymbolVertexShader(),
+      fragmentShader: this.parseResult_.builder.getSymbolFragmentShader(),
       uniforms: this.parseResult_.uniforms,
       attributes: this.parseResult_.attributes
     });

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -3,7 +3,7 @@
  */
 import {assign} from '../obj.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
-import {parseSymbolStyle} from '../webgl/ShaderBuilder.js';
+import {parseLiteralStyle} from '../webgl/ShaderBuilder.js';
 import Layer from './Layer.js';
 
 
@@ -74,7 +74,7 @@ class WebGLPointsLayer extends Layer {
      * @private
      * @type {import('../webgl/ShaderBuilder.js').StyleParseResult}
      */
-    this.parseResult_ = parseSymbolStyle(options.style.symbol);
+    this.parseResult_ = parseLiteralStyle(options.style);
   }
 
   /**

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -132,6 +132,10 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       options.vertexShader
     );
 
+    if (this.getShaderCompileErrors()) {
+      throw new Error(this.getShaderCompileErrors());
+    }
+
     /**
      * @type {boolean}
      * @private

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -17,11 +17,15 @@
  *   * `['time']` returns the time in seconds since the creation of the layer
  *
  * * Math operators:
- *   * `['*', value1, value1]` multiplies value1 by value2
- *   * `['+', value1, value1]` adds value1 and value2
- *   * `['clamp', value1, value2, value3]` clamps value1 between values2 and value3
- *   * `['stretch', value1, value2, value3, value4, value5]` maps value1 from [value2, value3] range to
- *     [value4, value5] range, clamping values along the way
+ *   * `['*', value1, value1]` multiplies `value1` by `value2`
+ *   * `['+', value1, value1]` adds `value1` and `value2`
+ *   * `['clamp', value, low, high]` clamps `value` between `low` and `high`
+ *   * `['stretch', value, low1, high1, low2, high2]` maps `value` from [`low1`, `high1`] range to
+ *     [`low2`, `high2`] range, clamping values along the way
+ *
+ * * Color operators:
+ *   * `['interpolate', ratio, color1, color2]` returns a color through interpolation between `color1` and
+ *     `color2` with the given `ratio`
  *
  * * Logical operators:
  *   * `['<', value1, value2]` returns `1` if `value1` is strictly lower than value 2, or `0` otherwise.
@@ -33,9 +37,13 @@
  *   * `['between', value1, value2, value3]` returns `1` if `value1` is contained between `value2` and `value3`
  *     (inclusively), or `0` otherwise.
  *
- * Values can either be literals (numbers) or another operator, as they will be evaluated recursively.
+ * Values can either be literals or another operator, as they will be evaluated recursively.
+ * Literal values can be of the following types:
+ * * `number`
+ * * `string`
+ * * {@link module:ol/color~Color}
  *
- * @typedef {Array<*>|number} ExpressionValue
+ * @typedef {Array<*>|import("../color.js").Color|string|number} ExpressionValue
  */
 
 /**

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -12,6 +12,9 @@
  *
  * * Reading operators:
  *   * `['get', 'attributeName']` fetches a feature attribute (it will be prefixed by `a_` in the shader)
+ *     Note: those will be taken from the attributes provided to the renderer
+ *   * `['var', 'varName']` fetches a value from the style variables, or 0 if undefined
+ *   * `['time']` returns the time in seconds since the creation of the layer
  *
  * * Math operators:
  *   * `['*', value1, value1]` multiplies value1 by value2
@@ -39,6 +42,8 @@
  * @typedef {Object} LiteralStyle
  * @property {ExpressionValue} [filter] Filter expression. If it resolves to a number strictly greater than 0, the
  * point will be displayed. If undefined, all points will show.
+ * @property {Object<string, number>} [variables] Style variables; each variable must hold a number.
+ * Note: **this object is meant to be mutated**: changes to the values will immediately be visible on the rendered features
  * @property {LiteralSymbolStyle} [symbol] Symbol representation.
  */
 

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -18,10 +18,14 @@
  *
  * * Math operators:
  *   * `['*', value1, value1]` multiplies `value1` by `value2`
+ *   * `['/', value1, value1]` divides `value1` by `value2`
  *   * `['+', value1, value1]` adds `value1` and `value2`
+ *   * `['-', value1, value1]` subtracts `value2` from `value1`
  *   * `['clamp', value, low, high]` clamps `value` between `low` and `high`
  *   * `['stretch', value, low1, high1, low2, high2]` maps `value` from [`low1`, `high1`] range to
  *     [`low2`, `high2`] range, clamping values along the way
+ *   * `['mod', value1, value1]` returns the result of `value1 % value2` (modulo)
+ *   * `['pow', value1, value1]` returns the value of `value1` raised to the `value2` power
  *
  * * Color operators:
  *   * `['interpolate', ratio, color1, color2]` returns a color through interpolation between `color1` and

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -5,7 +5,40 @@
  */
 
 /**
+ * Base type used for literal style parameters; can be a number literal or the output of an operator,
+ * which in turns takes {@link ExpressionValue} arguments.
+ *
+ * The following operators can be used:
+ *
+ * * Reading operators:
+ *   * `['get', 'attributeName']` fetches a feature attribute (it will be prefixed by `a_` in the shader)
+ *
+ * * Math operators:
+ *   * `['*', value1, value1]` multiplies value1 by value2
+ *   * `['+', value1, value1]` adds value1 and value2
+ *   * `['clamp', value1, value2, value3]` clamps value1 between values2 and value3
+ *   * `['stretch', value1, value2, value3, value4, value5]` maps value1 from [value2, value3] range to
+ *     [value4, value5] range, clamping values along the way
+ *
+ * * Logical operators:
+ *   * `['<', value1, value2]` returns `1` if `value1` is strictly lower than value 2, or `0` otherwise.
+ *   * `['<=', value1, value2]` returns `1` if `value1` is lower than or equals value 2, or `0` otherwise.
+ *   * `['>', value1, value2]` returns `1` if `value1` is strictly greater than value 2, or `0` otherwise.
+ *   * `['>=', value1, value2]` returns `1` if `value1` is greater than or equals value 2, or `0` otherwise.
+ *   * `['==', value1, value2]` returns `1` if `value1` equals value 2, or `0` otherwise.
+ *   * `['!', value1]` returns `0` if `value1` strictly greater than `0`, or `1` otherwise.
+ *   * `['between', value1, value2, value3]` returns `1` if `value1` is contained between `value2` and `value3`
+ *     (inclusively), or `0` otherwise.
+ *
+ * Values can either be literals (numbers) or another operator, as they will be evaluated recursively.
+ *
+ * @typedef {Array<*>|number} ExpressionValue
+ */
+
+/**
  * @typedef {Object} LiteralStyle
+ * @property {ExpressionValue} [filter] Filter expression. If it resolves to a number strictly greater than 0, the
+ * point will be displayed. If undefined, all points will show.
  * @property {LiteralSymbolStyle} [symbol] Symbol representation.
  */
 
@@ -22,12 +55,12 @@ export const SymbolType = {
 
 /**
  * @typedef {Object} LiteralSymbolStyle
- * @property {number|Array.<number, number>} size Size, mandatory.
+ * @property {ExpressionValue|Array<ExpressionValue, ExpressionValue>} size Size, mandatory.
  * @property {SymbolType} symbolType Symbol type to use, either a regular shape or an image.
  * @property {string} [src] Path to the image to be used for the symbol. Only required with `symbolType: 'image'`.
- * @property {import("../color.js").Color|string} [color='#FFFFFF'] Color used for the representation (either fill, line or symbol).
- * @property {number} [opacity=1] Opacity.
- * @property {Array.<number, number>} [offset] Offset on X and Y axis for symbols. If not specified, the symbol will be centered.
- * @property {Array.<number, number, number, number>} [textureCoord] Texture coordinates. If not specified, the whole texture will be used (range for 0 to 1 on both axes).
+ * @property {import("../color.js").Color|Array<ExpressionValue>|string} [color='#FFFFFF'] Color used for the representation (either fill, line or symbol).
+ * @property {ExpressionValue} [opacity=1] Opacity.
+ * @property {Array<ExpressionValue, ExpressionValue>} [offset] Offset on X and Y axis for symbols. If not specified, the symbol will be centered.
+ * @property {Array<ExpressionValue, ExpressionValue, ExpressionValue, ExpressionValue>} [textureCoord] Texture coordinates. If not specified, the whole texture will be used (range for 0 to 1 on both axes).
  * @property {boolean} [rotateWithView=false] Specify whether the symbol must rotate with the view or stay upwards.
  */

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -42,7 +42,8 @@ export const ShaderType = {
 export const DefaultUniform = {
   PROJECTION_MATRIX: 'u_projectionMatrix',
   OFFSET_SCALE_MATRIX: 'u_offsetScaleMatrix',
-  OFFSET_ROTATION_MATRIX: 'u_offsetRotateMatrix'
+  OFFSET_ROTATION_MATRIX: 'u_offsetRotateMatrix',
+  TIME: 'u_time'
 };
 
 /**
@@ -355,6 +356,12 @@ class WebGLHelper extends Disposable {
      * @private
      */
     this.shaderCompileErrors_ = null;
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.startTime_ = Date.now();
   }
 
   /**
@@ -548,6 +555,8 @@ class WebGLHelper extends Disposable {
 
     this.setUniformMatrixValue(DefaultUniform.OFFSET_SCALE_MATRIX, fromTransform(this.tmpMat4_, offsetScaleMatrix));
     this.setUniformMatrixValue(DefaultUniform.OFFSET_ROTATION_MATRIX, fromTransform(this.tmpMat4_, offsetRotateMatrix));
+
+    this.setUniformFloatValue(DefaultUniform.TIME, (Date.now() - this.startTime_) * 0.001);
   }
 
   /**

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -18,23 +18,32 @@ export function formatNumber(v) {
 /**
  * Will return the number array as a float with a dot separator, concatenated with ', '.
  * @param {Array<number>} array Numerical values array.
- * @returns {string} The array as string, e. g.: `1.0, 2.0, 3.0`.
+ * @returns {string} The array as a vector, e. g.: `vec3(1.0, 2.0, 3.0)`.
  */
 export function formatArray(array) {
-  return array.map(formatNumber).join(', ');
+  if (array.length < 2 || array.length > 4) {
+    throw new Error('`formatArray` can only output `vec2`, `vec3` or `vec4` arrays.');
+  }
+  return `vec${array.length}(${array.map(formatNumber).join(', ')})`;
 }
 
 /**
- * Will normalize and converts to string a color array compatible with GLSL.
+ * Will normalize and converts to string a `vec4` color array compatible with GLSL.
  * @param {string|import("../color.js").Color} color Color either in string format or [r, g, b, a] array format,
- * with RGB components in the 0..255 range and the alpha component in the 0..1 range. Note that if the A component is
- * missing, only 3 values will be output.
- * @returns {string} The color components concatenated in `1.0, 1.0, 1.0, 1.0` form.
+ * with RGB components in the 0..255 range and the alpha component in the 0..1 range.
+ * Note that the final array will always have 4 components.
+ * @returns {string} The color expressed in the `vec4(1.0, 1.0, 1.0, 1.0)` form.
  */
 export function formatColor(color) {
-  return asArray(color).map(function(c, i) {
-    return i < 3 ? c / 255 : c;
-  }).map(formatNumber).join(', ');
+  const array = asArray(color).slice();
+  if (array.length < 4) {
+    array.push(1);
+  }
+  return formatArray(
+    array.map(function(c, i) {
+      return i < 3 ? c / 255 : c;
+    })
+  );
 }
 
 /**

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -142,8 +142,6 @@ export function isValueTypeColor(value) {
  * @param {import("../style/LiteralStyle").ExpressionValue} value Either literal or an operator.
  */
 export function check(value) {
-  const v = value;
-
   // these will be used to validate types in the expressions
   function checkNumber(value) {
     if (!isValueTypeNumber(value)) {
@@ -171,7 +169,7 @@ export function check(value) {
     switch (value[0]) {
       case 'get':
       case 'var':
-        checkString(v[1]);
+        checkString(value[1]);
         break;
       case 'time':
         break;
@@ -181,44 +179,42 @@ export function check(value) {
       case '-':
       case 'mod':
       case 'pow':
-        checkNumber(v[1]);
-        checkNumber(v[2]);
+        checkNumber(value[1]);
+        checkNumber(value[2]);
         break;
       case 'clamp':
-        checkNumber(v[1]);
-        checkNumber(v[2]);
-        checkNumber(v[3]);
+        checkNumber(value[1]);
+        checkNumber(value[2]);
+        checkNumber(value[3]);
         break;
       case 'stretch':
-        checkNumber(v[1]);
-        checkNumber(v[2]);
-        checkNumber(v[3]);
-        checkNumber(v[4]);
-        checkNumber(v[5]);
+        checkNumber(value[1]);
+        checkNumber(value[2]);
+        checkNumber(value[3]);
+        checkNumber(value[4]);
+        checkNumber(value[5]);
         break;
       case '>':
       case '>=':
       case '<':
       case '<=':
       case '==':
-        checkNumber(v[1]);
-        checkNumber(v[2]);
+        checkNumber(value[1]);
+        checkNumber(value[2]);
         break;
       case '!':
-        checkNumber(v[1]);
+        checkNumber(value[1]);
         break;
       case 'between':
-        checkNumber(v[1]);
-        checkNumber(v[2]);
-        checkNumber(v[3]);
+        checkNumber(value[1]);
+        checkNumber(value[2]);
+        checkNumber(value[3]);
         break;
-
       case 'interpolate':
-        checkNumber(v[1]);
-        checkColor(v[2]);
-        checkColor(v[3]);
+        checkNumber(value[1]);
+        checkColor(value[2]);
+        checkColor(value[3]);
         break;
-
       default: throw new Error(`Unrecognized operator in style expression: ${JSON.stringify(value)}`);
     }
   }
@@ -253,7 +249,6 @@ export function check(value) {
 export function parse(value, attributes, attributePrefix, variables, typeHint) {
   check(value);
 
-  const v = value;
   function p(value) {
     return parse(value, attributes, attributePrefix, variables);
   }
@@ -262,19 +257,19 @@ export function parse(value, attributes, attributePrefix, variables, typeHint) {
   }
 
   // operator
-  if (Array.isArray(v) && typeof value[0] === 'string') {
-    switch (v[0]) {
+  if (Array.isArray(value) && typeof value[0] === 'string') {
+    switch (value[0]) {
       // reading operators
       case 'get':
-        if (attributes.indexOf(v[1]) === -1) {
-          attributes.push(v[1]);
+        if (attributes.indexOf(value[1]) === -1) {
+          attributes.push(value[1]);
         }
-        return attributePrefix + v[1];
+        return attributePrefix + value[1];
       case 'var':
-        if (variables.indexOf(v[1]) === -1) {
-          variables.push(v[1]);
+        if (variables.indexOf(value[1]) === -1) {
+          variables.push(value[1]);
         }
-        return `u_${v[1]}`;
+        return `u_${value[1]}`;
       case 'time':
         return 'u_time';
 
@@ -283,20 +278,20 @@ export function parse(value, attributes, attributePrefix, variables, typeHint) {
       case '/':
       case '+':
       case '-':
-        return `(${p(v[1])} ${v[0]} ${p(v[2])})`;
-      case 'clamp': return `clamp(${p(v[1])}, ${p(v[2])}, ${p(v[3])})`;
+        return `(${p(value[1])} ${value[0]} ${p(value[2])})`;
+      case 'clamp': return `clamp(${p(value[1])}, ${p(value[2])}, ${p(value[3])})`;
       case 'stretch':
-        const low1 = p(v[2]);
-        const high1 = p(v[3]);
-        const low2 = p(v[4]);
-        const high2 = p(v[5]);
-        return `((clamp(${p(v[1])}, ${low1}, ${high1}) - ${low1}) * ((${high2} - ${low2}) / (${high1} - ${low1})) + ${low2})`;
-      case 'mod': return `mod(${p(v[1])}, ${p(v[2])})`;
-      case 'pow': return `pow(${p(v[1])}, ${p(v[2])})`;
+        const low1 = p(value[2]);
+        const high1 = p(value[3]);
+        const low2 = p(value[4]);
+        const high2 = p(value[5]);
+        return `((clamp(${p(value[1])}, ${low1}, ${high1}) - ${low1}) * ((${high2} - ${low2}) / (${high1} - ${low1})) + ${low2})`;
+      case 'mod': return `mod(${p(value[1])}, ${p(value[2])})`;
+      case 'pow': return `pow(${p(value[1])}, ${p(value[2])})`;
 
       // color operators
       case 'interpolate':
-        return `mix(${pC(v[2])}, ${pC(v[3])}, ${p(v[1])})`;
+        return `mix(${pC(value[2])}, ${pC(value[3])}, ${p(value[1])})`;
 
       // logical operators
       case '>':
@@ -304,11 +299,11 @@ export function parse(value, attributes, attributePrefix, variables, typeHint) {
       case '<':
       case '<=':
       case '==':
-        return `(${p(v[1])} ${v[0]} ${p(v[2])} ? 1.0 : 0.0)`;
+        return `(${p(value[1])} ${value[0]} ${p(value[2])} ? 1.0 : 0.0)`;
       case '!':
-        return `(${p(v[1])} > 0.0 ? 0.0 : 1.0)`;
+        return `(${p(value[1])} > 0.0 ? 0.0 : 1.0)`;
       case 'between':
-        return `(${p(v[1])} >= ${p(v[2])} && ${p(v[1])} <= ${p(v[3])} ? 1.0 : 0.0)`;
+        return `(${p(value[1])} >= ${p(value[2])} && ${p(value[1])} <= ${p(value[3])} ? 1.0 : 0.0)`;
 
       default: throw new Error('Invalid style expression: ' + JSON.stringify(value));
     }

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -87,9 +87,13 @@ function getValueType(value) {
     case 'var':
     case 'time':
     case '*':
+    case '/':
     case '+':
+    case '-':
     case 'clamp':
     case 'stretch':
+    case 'mod':
+    case 'pow':
     case '>':
     case '>=':
     case '<':
@@ -172,7 +176,11 @@ export function check(value) {
       case 'time':
         break;
       case '*':
+      case '/':
       case '+':
+      case '-':
+      case 'mod':
+      case 'pow':
         checkNumber(v[1]);
         checkNumber(v[2]);
         break;
@@ -271,8 +279,11 @@ export function parse(value, attributes, attributePrefix, variables, typeHint) {
         return 'u_time';
 
       // math operators
-      case '*': return `(${p(v[1])} * ${p(v[2])})`;
-      case '+': return `(${p(v[1])} + ${p(v[2])})`;
+      case '*':
+      case '/':
+      case '+':
+      case '-':
+        return `(${p(v[1])} ${v[0]} ${p(v[2])})`;
       case 'clamp': return `clamp(${p(v[1])}, ${p(v[2])}, ${p(v[3])})`;
       case 'stretch':
         const low1 = p(v[2]);
@@ -280,6 +291,8 @@ export function parse(value, attributes, attributePrefix, variables, typeHint) {
         const low2 = p(v[4]);
         const high2 = p(v[5]);
         return `((clamp(${p(v[1])}, ${low1}, ${high1}) - ${low1}) * ((${high2} - ${low2}) / (${high1} - ${low1})) + ${low2})`;
+      case 'mod': return `mod(${p(v[1])}, ${p(v[2])})`;
+      case 'pow': return `pow(${p(v[1])}, ${p(v[2])})`;
 
       // color operators
       case 'interpolate':

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -163,6 +163,12 @@ export class ShaderBuilder {
     this.texCoordExpression = 'vec4(0.0, 0.0, 1.0, 1.0)';
 
     /**
+     * @type {string}
+     * @private
+     */
+    this.discardExpression = 'false';
+
+    /**
      * @type {boolean}
      * @private
      */
@@ -258,6 +264,20 @@ export class ShaderBuilder {
   }
 
   /**
+   * Sets an expression to determine whether a fragment (pixel) should be discarded,
+   * i.e. not drawn at all.
+   * This expression can use all the uniforms, varyings and attributes available
+   * in the fragment shader, and should evaluate to a `bool` value (it will be
+   * used in an `if` statement)
+   * @param {string} expression Fragment discard expression
+   * @return {ShaderBuilder} the builder object
+   */
+  setFragmentDiscardExpression(expression) {
+    this.texCoordExpression = expression;
+    return this;
+  }
+
+  /**
    * Sets whether the symbols should rotate with the view or stay aligned with the map.
    * Note: will only be used for point geometry shaders.
    * @param {boolean} rotateWithView Rotate with view
@@ -294,6 +314,13 @@ export class ShaderBuilder {
    */
   getTextureCoordinateExpression() {
     return this.texCoordExpression;
+  }
+
+  /**
+   * @returns {string} Previously set fragment discard expression
+   */
+  getFragmentDiscardExpression() {
+    return this.discardExpression;
   }
 
   /**
@@ -374,6 +401,7 @@ ${this.varyings.map(function(varying) {
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   }).join('\n')}
 void main(void) {
+  if (${this.discardExpression}) { discard; }
   gl_FragColor = ${this.colorExpression};
   gl_FragColor.rgb *= gl_FragColor.a;
 }`;

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -274,7 +274,12 @@ export function parse(value, attributes, attributePrefix, variables, typeHint) {
       case '*': return `(${p(v[1])} * ${p(v[2])})`;
       case '+': return `(${p(v[1])} + ${p(v[2])})`;
       case 'clamp': return `clamp(${p(v[1])}, ${p(v[2])}, ${p(v[3])})`;
-      case 'stretch': return `(clamp(${p(v[1])}, ${p(v[2])}, ${p(v[3])}) * ((${p(v[5])} - ${p(v[4])}) / (${p(v[3])} - ${p(v[2])})) + ${p(v[4])})`;
+      case 'stretch':
+        const low1 = p(v[2]);
+        const high1 = p(v[3]);
+        const low2 = p(v[4]);
+        const high2 = p(v[5]);
+        return `((clamp(${p(v[1])}, ${low1}, ${high1}) - ${low1}) * ((${high2} - ${low2}) / (${high1} - ${low1})) + ${low2})`;
 
       // color operators
       case 'interpolate':

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -26,13 +26,13 @@ export function formatArray(array) {
 
 /**
  * Will normalize and converts to string a color array compatible with GLSL.
- * @param {Array<number>} colorArray Color in [r, g, b, a] array form, with RGB components in the
- * 0..255 range and the alpha component in the 0..1 range. Note that if the A component is
+ * @param {string|import("../color.js").Color} color Color either in string format or [r, g, b, a] array format,
+ * with RGB components in the 0..255 range and the alpha component in the 0..1 range. Note that if the A component is
  * missing, only 3 values will be output.
  * @returns {string} The color components concatenated in `1.0, 1.0, 1.0, 1.0` form.
  */
-export function formatColor(colorArray) {
-  return colorArray.map(function(c, i) {
+export function formatColor(color) {
+  return asArray(color).map(function(c, i) {
     return i < 3 ? c / 255 : c;
   }).map(formatNumber).join(', ');
 }

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -66,6 +66,8 @@ export function parse(value, attributes, attributePrefix) {
           attributes.push(v[1]);
         }
         return attributePrefix + v[1];
+      case 'time':
+        return 'u_time';
 
       // math operators
       case '*': return `(${p(v[1])} * ${p(v[2])})`;
@@ -328,8 +330,8 @@ export class ShaderBuilder {
    * Generates a symbol vertex shader from the builder parameters,
    * intended to be used on point geometries.
    *
-   * Three uniforms are hardcoded in all shaders: `u_projectionMatrix`, `u_offsetScaleMatrix` and
-   * `u_offsetRotateMatrix`.
+   * Three uniforms are hardcoded in all shaders: `u_projectionMatrix`, `u_offsetScaleMatrix`,
+   * `u_offsetRotateMatrix`, `u_time`.
    *
    * The following attributes are hardcoded and expected to be present in the vertex buffers:
    * `vec2 a_position`, `float a_index` (being the index of the vertex in the quad, 0 to 3).
@@ -348,6 +350,7 @@ export class ShaderBuilder {
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+uniform float u_time;
 ${this.uniforms.map(function(uniform) {
     return 'uniform ' + uniform + ';';
   }).join('\n')}
@@ -393,6 +396,7 @@ ${this.varyings.map(function(varying) {
    */
   getSymbolFragmentShader() {
     return `precision mediump float;
+uniform float u_time;
 ${this.uniforms.map(function(uniform) {
     return 'uniform ' + uniform + ';';
   }).join('\n')}

--- a/test/spec/ol/color.test.js
+++ b/test/spec/ol/color.test.js
@@ -2,6 +2,7 @@ import {
   asArray,
   asString,
   fromString,
+  isStringColor,
   normalize,
   toString
 } from '../../../src/ol/color.js';
@@ -156,6 +157,20 @@ describe('ol.color', function() {
 
     it('sets default alpha value if undefined', function() {
       expect(toString([0, 0, 0])).to.be('rgba(0,0,0,1)');
+    });
+
+  });
+
+  describe('isValid()', function() {
+
+    it('correctly detects valid colors', function() {
+      expect(isStringColor('rgba(1,3,4,0.4)')).to.be(true);
+      expect(isStringColor('rgb(1,3,4)')).to.be(true);
+      expect(isStringColor('lightgreen')).to.be(true);
+      expect(isStringColor('yellow')).to.be(true);
+      expect(isStringColor('GREEN')).to.be(true);
+      expect(isStringColor('notacolor')).to.be(false);
+      expect(isStringColor('red_')).to.be(false);
     });
 
   });

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,4 +1,4 @@
-import WebGLHelper from '../../../../src/ol/webgl/Helper.js';
+import WebGLHelper, {DefaultUniform} from '../../../../src/ol/webgl/Helper.js';
 import {
   create as createTransform,
   rotate as rotateTransform,
@@ -11,9 +11,9 @@ import {FLOAT} from '../../../../src/ol/webgl.js';
 const VERTEX_SHADER = `
   precision mediump float;
   
-  uniform mat4 u_projectionMatrix;
   uniform mat4 u_offsetScaleMatrix;
   uniform mat4 u_offsetRotateMatrix;
+  uniform float u_time;
   
   attribute float a_test;
   uniform float u_test;
@@ -25,9 +25,9 @@ const VERTEX_SHADER = `
 const INVALID_VERTEX_SHADER = `
   precision mediump float;
   
-  uniform mat4 u_projectionMatrix;
   uniform mat4 u_offsetScaleMatrix;
   uniform mat4 u_offsetRotateMatrix;
+  uniform float u_time;
   
   bla
   uniform float u_test;
@@ -121,6 +121,12 @@ describe('ol.webgl.WebGLHelper', function() {
       it('has resized the canvas', function() {
         expect(h.getCanvas().width).to.eql(100);
         expect(h.getCanvas().height).to.eql(160);
+      });
+
+      it('has processed default uniforms', function() {
+        expect(h.uniformLocations_[DefaultUniform.OFFSET_ROTATION_MATRIX]).not.to.eql(undefined);
+        expect(h.uniformLocations_[DefaultUniform.OFFSET_SCALE_MATRIX]).not.to.eql(undefined);
+        expect(h.uniformLocations_[DefaultUniform.TIME]).not.to.eql(undefined);
       });
 
       it('has processed uniforms', function() {

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -25,18 +25,35 @@ describe('ol.webgl.ShaderBuilder', function() {
 
   describe('formatArray', function() {
     it('outputs numbers with dot separators', function() {
-      expect(formatArray([1, 0, 3.45, 0.8888])).to.eql('1.0, 0.0, 3.45, 0.8888');
+      expect(formatArray([1, 0, 3.45, 0.8888])).to.eql('vec4(1.0, 0.0, 3.45, 0.8888)');
+      expect(formatArray([3, 4])).to.eql('vec2(3.0, 4.0)');
+    });
+    it('throws on invalid lengths', function() {
+      let thrown = false;
+      try {
+        formatArray([3]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        formatArray([3, 2, 1, 0, -1]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
     });
   });
 
   describe('formatColor', function() {
     it('normalizes color and outputs numbers with dot separators', function() {
-      expect(formatColor([100, 0, 255, 1])).to.eql('0.39215686274509803, 0.0, 1.0, 1.0');
+      expect(formatColor([100, 0, 255])).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
+      expect(formatColor([100, 0, 255, 1])).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
     });
     it('handles colors in string format', function() {
-      expect(formatColor('red')).to.eql('1.0, 0.0, 0.0, 1.0');
-      expect(formatColor('rgb(100, 0, 255)')).to.eql('0.39215686274509803, 0.0, 1.0, 1.0');
-      expect(formatColor('rgba(100, 0, 255, 0.3)')).to.eql('0.39215686274509803, 0.0, 1.0, 0.3');
+      expect(formatColor('red')).to.eql('vec4(1.0, 0.0, 0.0, 1.0)');
+      expect(formatColor('#00ff99')).to.eql('vec4(0.0, 1.0, 0.6, 1.0)');
+      expect(formatColor('rgb(100, 0, 255)')).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
+      expect(formatColor('rgba(100, 0, 255, 0.3)')).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 0.3)');
     });
   });
 
@@ -84,11 +101,11 @@ describe('ol.webgl.ShaderBuilder', function() {
     it('generates a symbol vertex shader (with varying)', function() {
       const builder = new ShaderBuilder();
       builder.addVarying('v_opacity', 'float', formatNumber(0.4));
-      builder.addVarying('v_test', 'vec3', 'vec3(' + formatArray([1, 2, 3]) + ')');
-      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
-      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
-      builder.setColorExpression('vec4(' + formatColor([80, 0, 255, 1]) + ')');
-      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.addVarying('v_test', 'vec3', formatArray([1, 2, 3]));
+      builder.setSizeExpression(`vec2(${formatNumber(6)})`);
+      builder.setSymbolOffsetExpression(formatArray([5, -7]));
+      builder.setColorExpression(formatColor([80, 0, 255, 1]));
+      builder.setTextureCoordinateExpression(formatArray([0, 0.5, 0.5, 1]));
 
       expect(builder.getSymbolVertexShader()).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
@@ -126,10 +143,10 @@ void main(void) {
       const builder = new ShaderBuilder();
       builder.addUniform('float u_myUniform');
       builder.addAttribute('vec2 a_myAttr');
-      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
-      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
-      builder.setColorExpression('vec4(' + formatColor([80, 0, 255, 1]) + ')');
-      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.setSizeExpression(`vec2(${formatNumber(6)})`);
+      builder.setSymbolOffsetExpression(formatArray([5, -7]));
+      builder.setColorExpression(formatColor([80, 0, 255, 1]));
+      builder.setTextureCoordinateExpression(formatArray([0, 0.5, 0.5, 1]));
 
       expect(builder.getSymbolVertexShader()).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
@@ -163,10 +180,10 @@ void main(void) {
     });
     it('generates a symbol vertex shader (with rotateWithView)', function() {
       const builder = new ShaderBuilder();
-      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
-      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
-      builder.setColorExpression('vec4(' + formatColor([80, 0, 255, 1]) + ')');
-      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.setSizeExpression(`vec2(${formatNumber(6)})`);
+      builder.setSymbolOffsetExpression(formatArray([5, -7]));
+      builder.setColorExpression(formatColor([80, 0, 255, 1]));
+      builder.setTextureCoordinateExpression(formatArray([0, 0.5, 0.5, 1]));
       builder.setSymbolRotateWithView(true);
 
       expect(builder.getSymbolVertexShader()).to.eql(`precision mediump float;
@@ -205,11 +222,11 @@ void main(void) {
     it('generates a symbol fragment shader (with varying)', function() {
       const builder = new ShaderBuilder();
       builder.addVarying('v_opacity', 'float', formatNumber(0.4));
-      builder.addVarying('v_test', 'vec3', 'vec3(' + formatArray([1, 2, 3]) + ')');
-      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
-      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
-      builder.setColorExpression('vec4(' + formatColor([80, 0, 255]) + ', v_opacity)');
-      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.addVarying('v_test', 'vec3', formatArray([1, 2, 3]));
+      builder.setSizeExpression(`vec2(${formatNumber(6)})`);
+      builder.setSymbolOffsetExpression(formatArray([5, -7]));
+      builder.setColorExpression(formatColor([80, 0, 255]));
+      builder.setTextureCoordinateExpression(formatArray([0, 0.5, 0.5, 1]));
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
 uniform float u_time;
@@ -220,7 +237,7 @@ varying float v_opacity;
 varying vec3 v_test;
 void main(void) {
   if (false) { discard; }
-  gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, v_opacity);
+  gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
 }`);
     });
@@ -228,10 +245,10 @@ void main(void) {
       const builder = new ShaderBuilder();
       builder.addUniform('float u_myUniform');
       builder.addUniform('vec2 u_myUniform2');
-      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
-      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
-      builder.setColorExpression('vec4(' + formatColor([255, 255, 255, 1]) + ')');
-      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.setSizeExpression(`vec2(${formatNumber(6)})`);
+      builder.setSymbolOffsetExpression(formatArray([5, -7]));
+      builder.setColorExpression(formatColor([255, 255, 255, 1]));
+      builder.setTextureCoordinateExpression(formatArray([0, 0.5, 0.5, 1]));
       builder.setFragmentDiscardExpression('u_myUniform > 0.5');
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -29,6 +29,11 @@ describe('ol.webgl.ShaderBuilder', function() {
     it('normalizes color and outputs numbers with dot separators', function() {
       expect(formatColor([100, 0, 255, 1])).to.eql('0.39215686274509803, 0.0, 1.0, 1.0');
     });
+    it('handles colors in string format', function() {
+      expect(formatColor('red')).to.eql('1.0, 0.0, 0.0, 1.0');
+      expect(formatColor('rgb(100, 0, 255)')).to.eql('0.39215686274509803, 0.0, 1.0, 1.0');
+      expect(formatColor('rgba(100, 0, 255, 0.3)')).to.eql('0.39215686274509803, 0.0, 1.0, 0.3');
+    });
   });
 
   describe('getSymbolVertexShader', function() {

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -417,7 +417,7 @@ void main(void) {
         symbol: {
           symbolType: 'square',
           size: [4, 8],
-          color: '#336699',
+          color: '#ff0000',
           rotateWithView: true
         }
       });
@@ -425,7 +425,8 @@ void main(void) {
       expect(result.builder.uniforms).to.eql([]);
       expect(result.builder.attributes).to.eql([]);
       expect(result.builder.varyings).to.eql([]);
-      expect(result.builder.colorExpression).to.eql('vec4(0.2, 0.4, 0.6, 1.0 * 1.0 * 1.0)');
+      expect(result.builder.colorExpression).to.eql(
+        'vec4(vec4(1.0, 0.0, 0.0, 1.0).rgb, vec4(1.0, 0.0, 0.0, 1.0).a * 1.0 * 1.0)');
       expect(result.builder.sizeExpression).to.eql('vec2(4.0, 8.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
@@ -439,35 +440,29 @@ void main(void) {
         symbol: {
           symbolType: 'square',
           size: ['get', 'attr1'],
-          color: [
-            1.0, 0.0, 0.5, ['get', 'attr2']
-          ],
+          color: [255, 127.5, 63.75, 0.25],
           textureCoord: [0.5, 0.5, 0.5, 1],
           offset: [3, ['get', 'attr3']]
         }
       });
 
       expect(result.builder.uniforms).to.eql([]);
-      expect(result.builder.attributes).to.eql(['float a_attr1', 'float a_attr3', 'float a_attr2']);
+      expect(result.builder.attributes).to.eql(['float a_attr1', 'float a_attr3']);
       expect(result.builder.varyings).to.eql([{
         name: 'v_attr1',
         type: 'float',
         expression: 'a_attr1'
-      }, {
-        name: 'v_attr2',
-        type: 'float',
-        expression: 'a_attr2'
       }]);
       expect(result.builder.colorExpression).to.eql(
-        'vec4(1.0, 0.0, 0.5, v_attr2 * 1.0 * 1.0)');
+        'vec4(vec4(1.0, 0.5, 0.25, 0.25).rgb, vec4(1.0, 0.5, 0.25, 0.25).a * 1.0 * 1.0)'
+      );
       expect(result.builder.sizeExpression).to.eql('vec2(a_attr1, a_attr1)');
       expect(result.builder.offsetExpression).to.eql('vec2(3.0, a_attr3)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.5, 0.5, 0.5, 1.0)');
       expect(result.builder.rotateWithView).to.eql(false);
-      expect(result.attributes.length).to.eql(3);
+      expect(result.attributes.length).to.eql(2);
       expect(result.attributes[0].name).to.eql('attr1');
       expect(result.attributes[1].name).to.eql('attr3');
-      expect(result.attributes[2].name).to.eql('attr2');
       expect(result.uniforms).to.eql({});
     });
 
@@ -486,7 +481,8 @@ void main(void) {
       expect(result.builder.attributes).to.eql([]);
       expect(result.builder.varyings).to.eql([]);
       expect(result.builder.colorExpression).to.eql(
-        'vec4(0.2, 0.4, 0.6, 1.0 * 0.5 * 1.0) * texture2D(u_texture, v_texCoord)');
+        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0) * texture2D(u_texture, v_texCoord)'
+      );
       expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
@@ -516,9 +512,12 @@ void main(void) {
         type: 'float',
         expression: 'a_population'
       }]);
-      expect(result.builder.colorExpression).to.eql('vec4(0.2, 0.4, 0.6, 1.0 * 0.5 * 1.0)');
+      expect(result.builder.colorExpression).to.eql(
+        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0)'
+      );
       expect(result.builder.sizeExpression).to.eql(
-        'vec2((clamp(a_population, u_lower, u_higher) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0), (clamp(a_population, u_lower, u_higher) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))');
+        'vec2((clamp(a_population, u_lower, u_higher) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0), (clamp(a_population, u_lower, u_higher) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))'
+      );
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
       expect(result.builder.rotateWithView).to.eql(false);
@@ -544,7 +543,9 @@ void main(void) {
         type: 'float',
         expression: 'a_attr0'
       }]);
-      expect(result.builder.colorExpression).to.eql('vec4(0.2, 0.4, 0.6, 1.0 * 1.0 * 1.0)');
+      expect(result.builder.colorExpression).to.eql(
+        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 1.0 * 1.0)'
+      );
       expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
@@ -552,6 +553,28 @@ void main(void) {
       expect(result.builder.rotateWithView).to.eql(false);
       expect(result.attributes.length).to.eql(1);
       expect(result.attributes[0].name).to.eql('attr0');
+    });
+
+    it('parses a style with a color interpolation', function() {
+      const result = parseLiteralStyle({
+        symbol: {
+          symbolType: 'square',
+          size: 6,
+          color: ['interpolate', ['var', 'ratio'], [255, 255, 0], 'red']
+        }
+      });
+
+      expect(result.builder.attributes).to.eql([]);
+      expect(result.builder.varyings).to.eql([]);
+      expect(result.builder.colorExpression).to.eql(
+        'vec4(mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), u_ratio).rgb, mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), u_ratio).a * 1.0 * 1.0)'
+      );
+      expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
+      expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
+      expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
+      expect(result.builder.rotateWithView).to.eql(false);
+      expect(result.attributes).to.eql([]);
+      expect(result.uniforms).to.have.property('u_ratio');
     });
   });
 

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -45,6 +45,7 @@ describe('ol.webgl.ShaderBuilder', function() {
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+uniform float u_time;
 
 attribute vec2 a_position;
 attribute float a_index;
@@ -85,6 +86,7 @@ void main(void) {
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+uniform float u_time;
 uniform float u_myUniform;
 attribute vec2 a_position;
 attribute float a_index;
@@ -122,6 +124,7 @@ void main(void) {
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
+uniform float u_time;
 
 attribute vec2 a_position;
 attribute float a_index;
@@ -160,6 +163,7 @@ void main(void) {
       builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
+uniform float u_time;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
@@ -182,6 +186,7 @@ void main(void) {
       builder.setFragmentDiscardExpression('u_myUniform > 0.5');
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
+uniform float u_time;
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
@@ -209,6 +214,7 @@ void main(void) {
     it('parses expressions & literal values', function() {
       expect(parseFn(1)).to.eql('1.0');
       expect(parseFn(['get', 'myAttr'])).to.eql('a_myAttr');
+      expect(parseFn(['time'])).to.eql('u_time');
       expect(parseFn(['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
       expect(parseFn(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');
       expect(parseFn(['stretch', ['get', 'size'], 10, 100, 4, 8])).to.eql('(clamp(a_size, 10.0, 100.0) * ((8.0 - 4.0) / (100.0 - 10.0)) + 4.0)');

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -1,8 +1,10 @@
 import {
-  getSymbolVertexShader,
+  formatArray,
+  formatColor,
   formatNumber,
-  getSymbolFragmentShader,
-  formatColor, formatArray, parse, parseSymbolStyle
+  parse,
+  parseSymbolStyle,
+  ShaderBuilder
 } from '../../../../src/ol/webgl/ShaderBuilder.js';
 
 describe('ol.webgl.ShaderBuilder', function() {
@@ -31,24 +33,15 @@ describe('ol.webgl.ShaderBuilder', function() {
 
   describe('getSymbolVertexShader', function() {
     it('generates a symbol vertex shader (with varying)', function() {
-      const parameters = {
-        varyings: [{
-          name: 'v_opacity',
-          type: 'float',
-          expression: formatNumber(0.4)
-        }, {
-          name: 'v_test',
-          type: 'vec3',
-          expression: 'vec3(' + formatArray([1, 2, 3]) + ')'
-        }],
-        sizeExpression: 'vec2(' + formatNumber(6) + ')',
-        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
-        colorExpression: 'vec4(' + formatColor([80, 0, 255, 1]) + ')',
-        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')',
-        rotateWithView: false
-      };
+      const builder = new ShaderBuilder();
+      builder.addVarying('v_opacity', 'float', formatNumber(0.4));
+      builder.addVarying('v_test', 'vec3', 'vec3(' + formatArray([1, 2, 3]) + ')');
+      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
+      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
+      builder.setColorExpression('vec4(' + formatColor([80, 0, 255, 1]) + ')');
+      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
 
-      expect(getSymbolVertexShader(parameters)).to.eql(`precision mediump float;
+      expect(builder.getSymbolVertexShader()).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
@@ -80,16 +73,15 @@ void main(void) {
 }`);
     });
     it('generates a symbol vertex shader (with uniforms and attributes)', function() {
-      const parameters = {
-        uniforms: ['float u_myUniform'],
-        attributes: ['vec2 a_myAttr'],
-        sizeExpression: 'vec2(' + formatNumber(6) + ')',
-        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
-        colorExpression: 'vec4(' + formatColor([80, 0, 255, 1]) + ')',
-        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')'
-      };
+      const builder = new ShaderBuilder();
+      builder.addUniform('float u_myUniform');
+      builder.addAttribute('vec2 a_myAttr');
+      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
+      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
+      builder.setColorExpression('vec4(' + formatColor([80, 0, 255, 1]) + ')');
+      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
 
-      expect(getSymbolVertexShader(parameters)).to.eql(`precision mediump float;
+      expect(builder.getSymbolVertexShader()).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
@@ -119,15 +111,14 @@ void main(void) {
 }`);
     });
     it('generates a symbol vertex shader (with rotateWithView)', function() {
-      const parameters = {
-        sizeExpression: 'vec2(' + formatNumber(6) + ')',
-        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
-        colorExpression: 'vec4(' + formatColor([80, 0, 255, 1]) + ')',
-        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')',
-        rotateWithView: true
-      };
+      const builder = new ShaderBuilder();
+      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
+      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
+      builder.setColorExpression('vec4(' + formatColor([80, 0, 255, 1]) + ')');
+      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.setSymbolRotateWithView(true);
 
-      expect(getSymbolVertexShader(parameters)).to.eql(`precision mediump float;
+      expect(builder.getSymbolVertexShader()).to.eql(`precision mediump float;
 uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
@@ -160,24 +151,15 @@ void main(void) {
 
   describe('getSymbolFragmentShader', function() {
     it('generates a symbol fragment shader (with varying)', function() {
-      const parameters = {
-        varyings: [{
-          name: 'v_opacity',
-          type: 'float',
-          expression: formatNumber(0.4)
-        }, {
-          name: 'v_test',
-          type: 'vec3',
-          expression: 'vec3(' + formatArray([1, 2, 3]) + ')'
-        }],
-        sizeExpression: 'vec2(' + formatNumber(6) + ')',
-        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
-        colorExpression: 'vec4(' + formatColor([80, 0, 255]) + ', v_opacity)',
-        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')',
-        rotateWithView: false
-      };
+      const builder = new ShaderBuilder();
+      builder.addVarying('v_opacity', 'float', formatNumber(0.4));
+      builder.addVarying('v_test', 'vec3', 'vec3(' + formatArray([1, 2, 3]) + ')');
+      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
+      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
+      builder.setColorExpression('vec4(' + formatColor([80, 0, 255]) + ', v_opacity)');
+      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
 
-      expect(getSymbolFragmentShader(parameters)).to.eql(`precision mediump float;
+      expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
@@ -189,15 +171,15 @@ void main(void) {
 }`);
     });
     it('generates a symbol fragment shader (with uniforms)', function() {
-      const parameters = {
-        uniforms: ['float u_myUniform', 'vec2 u_myUniform2'],
-        sizeExpression: 'vec2(' + formatNumber(6) + ')',
-        offsetExpression: 'vec2(' + formatArray([5, -7]) + ')',
-        colorExpression: 'vec4(' + formatColor([255, 255, 255, 1]) + ')',
-        texCoordExpression: 'vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')'
-      };
+      const builder = new ShaderBuilder();
+      builder.addUniform('float u_myUniform');
+      builder.addUniform('vec2 u_myUniform2');
+      builder.setSizeExpression('vec2(' + formatNumber(6) + ')');
+      builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
+      builder.setColorExpression('vec4(' + formatColor([255, 255, 255, 1]) + ')');
+      builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
 
-      expect(getSymbolFragmentShader(parameters)).to.eql(`precision mediump float;
+      expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
@@ -245,16 +227,15 @@ void main(void) {
         color: '#336699',
         rotateWithView: true
       });
-      expect(result.params).to.eql({
-        uniforms: [],
-        attributes: [],
-        varyings: [],
-        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 1.0 * 1.0)',
-        sizeExpression: 'vec2(4.0, 8.0)',
-        offsetExpression: 'vec2(0.0, 0.0)',
-        texCoordExpression: 'vec4(0.0, 0.0, 1.0, 1.0)',
-        rotateWithView: true
-      });
+
+      expect(result.builder.uniforms).to.eql([]);
+      expect(result.builder.attributes).to.eql([]);
+      expect(result.builder.varyings).to.eql([]);
+      expect(result.builder.colorExpression).to.eql('vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 1.0 * 1.0)');
+      expect(result.builder.sizeExpression).to.eql('vec2(4.0, 8.0)');
+      expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
+      expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
+      expect(result.builder.rotateWithView).to.eql(true);
       expect(result.attributes).to.eql([]);
       expect(result.uniforms).to.eql({});
     });
@@ -269,24 +250,24 @@ void main(void) {
         textureCoord: [0.5, 0.5, 0.5, 1],
         offset: [3, ['get', 'attr3']]
       });
-      expect(result.params).to.eql({
-        uniforms: [],
-        attributes: ['float a_attr1', 'float a_attr3', 'float a_attr2'],
-        varyings: [{
-          name: 'v_attr1',
-          type: 'float',
-          expression: 'a_attr1'
-        }, {
-          name: 'v_attr2',
-          type: 'float',
-          expression: 'a_attr2'
-        }],
-        colorExpression: 'vec4(1.0, 0.0, 0.5, v_attr2) * vec4(1.0, 1.0, 1.0, 1.0 * 1.0)',
-        sizeExpression: 'vec2(a_attr1, a_attr1)',
-        offsetExpression: 'vec2(3.0, a_attr3)',
-        texCoordExpression: 'vec4(0.5, 0.5, 0.5, 1.0)',
-        rotateWithView: false
-      });
+
+      expect(result.builder.uniforms).to.eql([]);
+      expect(result.builder.attributes).to.eql(['float a_attr1', 'float a_attr3', 'float a_attr2']);
+      expect(result.builder.varyings).to.eql([{
+        name: 'v_attr1',
+        type: 'float',
+        expression: 'a_attr1'
+      }, {
+        name: 'v_attr2',
+        type: 'float',
+        expression: 'a_attr2'
+      }]);
+      expect(result.builder.colorExpression).to.eql(
+        'vec4(1.0, 0.0, 0.5, v_attr2) * vec4(1.0, 1.0, 1.0, 1.0 * 1.0)');
+      expect(result.builder.sizeExpression).to.eql('vec2(a_attr1, a_attr1)');
+      expect(result.builder.offsetExpression).to.eql('vec2(3.0, a_attr3)');
+      expect(result.builder.texCoordExpression).to.eql('vec4(0.5, 0.5, 0.5, 1.0)');
+      expect(result.builder.rotateWithView).to.eql(false);
       expect(result.attributes.length).to.eql(3);
       expect(result.attributes[0].name).to.eql('attr1');
       expect(result.attributes[1].name).to.eql('attr3');
@@ -302,16 +283,16 @@ void main(void) {
         color: '#336699',
         opacity: 0.5
       });
-      expect(result.params).to.eql({
-        uniforms: ['sampler2D u_texture'],
-        attributes: [],
-        varyings: [],
-        colorExpression: 'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 0.5 * 1.0) * texture2D(u_texture, v_texCoord)',
-        sizeExpression: 'vec2(6.0, 6.0)',
-        offsetExpression: 'vec2(0.0, 0.0)',
-        texCoordExpression: 'vec4(0.0, 0.0, 1.0, 1.0)',
-        rotateWithView: false
-      });
+
+      expect(result.builder.uniforms).to.eql(['sampler2D u_texture']);
+      expect(result.builder.attributes).to.eql([]);
+      expect(result.builder.varyings).to.eql([]);
+      expect(result.builder.colorExpression).to.eql(
+        'vec4(0.2, 0.4, 0.6, 1.0) * vec4(1.0, 1.0, 1.0, 0.5 * 1.0) * texture2D(u_texture, v_texCoord)');
+      expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
+      expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
+      expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
+      expect(result.builder.rotateWithView).to.eql(false);
       expect(result.attributes).to.eql([]);
       expect(result.uniforms).to.have.property('u_texture');
     });

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -166,6 +166,7 @@ varying vec2 v_quadCoord;
 varying float v_opacity;
 varying vec3 v_test;
 void main(void) {
+  if (false) { discard; }
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, v_opacity);
   gl_FragColor.rgb *= gl_FragColor.a;
 }`);
@@ -178,6 +179,7 @@ void main(void) {
       builder.setSymbolOffsetExpression('vec2(' + formatArray([5, -7]) + ')');
       builder.setColorExpression('vec4(' + formatColor([255, 255, 255, 1]) + ')');
       builder.setTextureCoordinateExpression('vec4(' + formatArray([0, 0.5, 0.5, 1]) + ')');
+      builder.setFragmentDiscardExpression('u_myUniform > 0.5');
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
 uniform float u_myUniform;
@@ -186,6 +188,7 @@ varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 
 void main(void) {
+  if (u_myUniform > 0.5) { discard; }
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
 }`);

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -279,8 +279,10 @@ void main(void) {
       check(['var', 'myValue']);
       check(['time']);
       check(['+', ['*', ['get', 'size'], 0.001], 12]);
+      check(['/', ['-', ['get', 'size'], 0.001], 12]);
       check(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20]);
       check(['stretch', ['get', 'size'], 10, 100, 4, 8]);
+      check(['mod', ['pow', ['get', 'size'], 0.5], 12]);
       check(['>', 10, ['get', 'attr4']]);
       check(['>=', 10, ['get', 'attr4']]);
       check(['<', 10, ['get', 'attr4']]);
@@ -381,8 +383,10 @@ void main(void) {
       expect(parseFn(['var', 'myValue'])).to.eql('u_myValue');
       expect(parseFn(['time'])).to.eql('u_time');
       expect(parseFn(['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
+      expect(parseFn(['/', ['-', ['get', 'size'], 20], 100])).to.eql('((a_size - 20.0) / 100.0)');
       expect(parseFn(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');
       expect(parseFn(['stretch', ['get', 'size'], 10, 100, 4, 8])).to.eql('((clamp(a_size, 10.0, 100.0) - 10.0) * ((8.0 - 4.0) / (100.0 - 10.0)) + 4.0)');
+      expect(parseFn(['pow', ['mod', ['time'], 10], 2])).to.eql('pow(mod(u_time, 10.0), 2.0)');
       expect(parseFn(['>', 10, ['get', 'attr4']])).to.eql('(10.0 > a_attr4 ? 1.0 : 0.0)');
       expect(parseFn(['>=', 10, ['get', 'attr4']])).to.eql('(10.0 >= a_attr4 ? 1.0 : 0.0)');
       expect(parseFn(['<', 10, ['get', 'attr4']])).to.eql('(10.0 < a_attr4 ? 1.0 : 0.0)');

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -2,6 +2,9 @@ import {
   formatArray,
   formatColor,
   formatNumber,
+  isValueTypeColor,
+  isValueTypeNumber,
+  isValueTypeString,
   parse,
   parseLiteralStyle,
   ShaderBuilder
@@ -33,6 +36,46 @@ describe('ol.webgl.ShaderBuilder', function() {
       expect(formatColor('red')).to.eql('1.0, 0.0, 0.0, 1.0');
       expect(formatColor('rgb(100, 0, 255)')).to.eql('0.39215686274509803, 0.0, 1.0, 1.0');
       expect(formatColor('rgba(100, 0, 255, 0.3)')).to.eql('0.39215686274509803, 0.0, 1.0, 0.3');
+    });
+  });
+
+  describe('value type checking', function() {
+    it('correctly recognizes a number value', function() {
+      expect(isValueTypeNumber(1234)).to.eql(true);
+      expect(isValueTypeNumber(['time'])).to.eql(true);
+      expect(isValueTypeNumber(['clamp', ['get', 'attr'], -1, 1])).to.eql(true);
+      expect(isValueTypeNumber(['interpolate', ['get', 'attr'], 'red', 'green'])).to.eql(false);
+      expect(isValueTypeNumber('yellow')).to.eql(false);
+      expect(isValueTypeNumber('#113366')).to.eql(false);
+      expect(isValueTypeNumber('rgba(252,171,48,0.62)')).to.eql(false);
+    });
+    it('correctly recognizes a color value', function() {
+      expect(isValueTypeColor(1234)).to.eql(false);
+      expect(isValueTypeColor(['time'])).to.eql(false);
+      expect(isValueTypeColor(['clamp', ['get', 'attr'], -1, 1])).to.eql(false);
+      expect(isValueTypeColor(['interpolate', ['get', 'attr'], 'red', 'green'])).to.eql(true);
+      expect(isValueTypeColor('yellow')).to.eql(true);
+      expect(isValueTypeColor('#113366')).to.eql(true);
+      expect(isValueTypeColor('rgba(252,171,48,0.62)')).to.eql(true);
+      expect(isValueTypeColor('abcd')).to.eql(false);
+    });
+    it('correctly recognizes a string value', function() {
+      expect(isValueTypeString(1234)).to.eql(false);
+      expect(isValueTypeString(['time'])).to.eql(false);
+      expect(isValueTypeString(['clamp', ['get', 'attr'], -1, 1])).to.eql(false);
+      expect(isValueTypeString(['interpolate', ['get', 'attr'], 'red', 'green'])).to.eql(false);
+      expect(isValueTypeString('yellow')).to.eql(true);
+      expect(isValueTypeString('#113366')).to.eql(true);
+      expect(isValueTypeString('rgba(252,171,48,0.62)')).to.eql(true);
+      expect(isValueTypeString('abcd')).to.eql(true);
+    });
+    it('throws on an unsupported type', function(done) {
+      try {
+        isValueTypeColor(true);
+      } catch (e) {
+        done();
+      }
+      done(true);
     });
   });
 

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -382,7 +382,7 @@ void main(void) {
       expect(parseFn(['time'])).to.eql('u_time');
       expect(parseFn(['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
       expect(parseFn(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');
-      expect(parseFn(['stretch', ['get', 'size'], 10, 100, 4, 8])).to.eql('(clamp(a_size, 10.0, 100.0) * ((8.0 - 4.0) / (100.0 - 10.0)) + 4.0)');
+      expect(parseFn(['stretch', ['get', 'size'], 10, 100, 4, 8])).to.eql('((clamp(a_size, 10.0, 100.0) - 10.0) * ((8.0 - 4.0) / (100.0 - 10.0)) + 4.0)');
       expect(parseFn(['>', 10, ['get', 'attr4']])).to.eql('(10.0 > a_attr4 ? 1.0 : 0.0)');
       expect(parseFn(['>=', 10, ['get', 'attr4']])).to.eql('(10.0 >= a_attr4 ? 1.0 : 0.0)');
       expect(parseFn(['<', 10, ['get', 'attr4']])).to.eql('(10.0 < a_attr4 ? 1.0 : 0.0)');
@@ -516,7 +516,7 @@ void main(void) {
         'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0)'
       );
       expect(result.builder.sizeExpression).to.eql(
-        'vec2((clamp(a_population, u_lower, u_higher) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0), (clamp(a_population, u_lower, u_higher) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))'
+        'vec2(((clamp(a_population, u_lower, u_higher) - u_lower) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0), ((clamp(a_population, u_lower, u_higher) - u_lower) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))'
       );
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -1,4 +1,5 @@
 import {
+  check,
   formatArray,
   formatColor,
   formatNumber,
@@ -246,6 +247,88 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
 }`);
     });
+  });
+
+  describe('check', function() {
+
+    it('does not throw on valid expressions', function(done) {
+      check(1);
+      check(['get', 'myAttr']);
+      check(['var', 'myValue']);
+      check(['time']);
+      check(['+', ['*', ['get', 'size'], 0.001], 12]);
+      check(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20]);
+      check(['stretch', ['get', 'size'], 10, 100, 4, 8]);
+      check(['>', 10, ['get', 'attr4']]);
+      check(['>=', 10, ['get', 'attr4']]);
+      check(['<', 10, ['get', 'attr4']]);
+      check(['<=', 10, ['get', 'attr4']]);
+      check(['==', 10, ['get', 'attr4']]);
+      check(['between', ['get', 'attr4'], -4.0, 5.0]);
+      check(['!', ['get', 'attr4']]);
+      done();
+    });
+
+    it('throws on unsupported types for operators', function() {
+      let thrown = false;
+      try {
+        check(['var', 1234]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        check(['<', 0, 'aa']);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        check(['+', true, ['get', 'attr']]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
+    it('throws with the wrong number of arguments', function() {
+      let thrown = false;
+      try {
+        check(['var', 1234, 456]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        check(['<', 4]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        check(['+']);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
+    it('throws on invalid expressions', function() {
+      let thrown = false;
+      try {
+        check(true);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        check([123, 456]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        check(null);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
   });
 
   describe('parse', function() {


### PR DESCRIPTION
This PR significantly reworks the `ol/style/LiteralStyle` and `ol/webgl/ShaderBuilder` modules to add the following:
* a `filter` expression can be specified in a literal style in order to exclude features from the render
* several logical operators have been added to support this: `>`, `>=`, `<`, `<=`, `between`
* the literal styles now handle different types instead of only numbers; for now this is only used for the `color` style property; all types will be checked when the style is parsed and exceptions will be thrown if there is a mismatch
* a new `interpolate` operator has been added, which takes in two color values and a numerical ratio
* several new math operators have been added: `/`, `-`, `mod`, `pow`
* a new `time` operator was added, which simply returns the time since layer creation in seconds
* the literal styles can also receive a `variables` object; each key in the object is a variable that can be referenced in the style expressions using the `var` operator; **this object is meant to be mutated** and all changes will be reflected in real time on the map

See the [reworked filter-points-webgl example](https://2445-4723248-gh.circle-artifacts.com/0/examples/filter-points-webgl.html) for a showcase of the added features.

Also the `ol/webgl/ShaderBuilder` module now has a `ShaderBuilder` class which actually implements a builder pattern and is used to generate shaders, hopefully making things easier to read & understand...