### PR TITLE
Add back html from select-features example

### DIFF
--- a/examples/select-features.html
+++ b/examples/select-features.html
@@ -1,0 +1,22 @@
+---
+layout: example.html
+title: Select Features
+shortdesc: Example of using the Select interaction.
+docs: >
+  Choose between <code>Single-click</code>, <code>Click</code>, <code>Hover</code> and <code>Alt+Click</code> as the event type for selection in the combobox below. When using <code>Single-click</code> or <code>Click</code> you can hold do <code>Shift</code> key to toggle the feature in the selection.</p>
+  <p>Note: when <code>Single-click</code> is used double-clicks won't select features. This in contrast to <code>Click</code>, where a double-click will both select the feature and zoom the map (because of the <code>DoubleClickZoom</code> interaction). Note that <code>Single-click</code> is less responsive than <code>Click</code> because of the delay it uses to detect double-clicks.</p>
+  <p>In this example, a listener is registered for the Select interaction's <code>select</code> event in order to update the selection status above.
+tags: "select, vector"
+---
+<div id="map" class="map"></div>
+<form class="form-inline">
+  <label>Action type &nbsp;</label>
+    <select id="type" class="form-control">
+      <option value="click" selected>Click</option>
+      <option value="singleclick">Single-click</option>
+      <option value="pointermove">Hover</option>
+      <option value="altclick">Alt+Click</option>
+      <option value="none">None</option>
+    </select>
+  <span id="status">&nbsp;0 selected features</span>
+</form>


### PR DESCRIPTION
The example was removed and added back in 38124d770b45803cb837b446fd78ec475e616ccc but the html file was missing
