### PR TITLE
Open default attributions links in a new tab or window

### DIFF
--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -44,7 +44,7 @@ export function quadKey(tileCoord) {
  * @type {string}
  */
 const TOS_ATTRIBUTION = '<a class="ol-attribution-bing-tos" ' +
-      'href="https://www.microsoft.com/maps/product/terms.html">' +
+      'href="https://www.microsoft.com/maps/product/terms.html" target="_blank">' +
       'Terms of Use</a>';
 
 

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -13,7 +13,7 @@ import XYZ from './XYZ.js';
  * @api
  */
 export const ATTRIBUTION = '&#169; ' +
-      '<a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
+      '<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> ' +
       'contributors.';
 
 

--- a/src/ol/source/Stamen.js
+++ b/src/ol/source/Stamen.js
@@ -11,8 +11,8 @@ import XYZ from './XYZ.js';
  * @type {Array<string>}
  */
 const ATTRIBUTIONS = [
-  'Map tiles by <a href="https://stamen.com/">Stamen Design</a>, ' +
-        'under <a href="https://creativecommons.org/licenses/by/3.0/">CC BY' +
+  'Map tiles by <a href="https://stamen.com/" target="_blank">Stamen Design</a>, ' +
+        'under <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY' +
         ' 3.0</a>.',
   OSM_ATTRIBUTION
 ];


### PR DESCRIPTION
Fixes #10167

Specify target="_blank" in default attributions links so they open in a new tab or window and the map is not closed when links are clicked