### PR TITLE
Remove description from type tag

### DIFF
--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -39,13 +39,13 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
 
     /**
      * @private
-     * @type {import("../../transform.js").Transform};
+     * @type {import("../../transform.js").Transform}
      */
     this.coordinateToVectorPixelTransform_ = create();
 
     /**
      * @private
-     * @type {import("../../transform.js").Transform};
+     * @type {import("../../transform.js").Transform}
      */
     this.renderedPixelToCoordinateTransform_ = null;
 


### PR DESCRIPTION
The `;` at the end of this `@type` annotation is being interpreted as a description (which is not allowed for this tag).