### PR TITLE
Avoid toggling when clicking the title

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -67,8 +67,8 @@ $(function () {
   });
 
   // Toggle when click an item element
-  $('.navigation').on('click', '.title', function (e) {
-    $(this).parent().find('.itemMembers').toggle();
+  $('.navigation').on('click', '.toggle', function (e) {
+    $(this).parent().parent().find('.itemMembers').toggle();
   });
 
   // Show an item related a current documentation automatically

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -15,9 +15,9 @@ function toShortName(name) {
         <li class="item" data-name="<?js= item.longname ?>" data-shortname="<?js= item.name.toLowerCase() ?>">
             <span class="title">
                 <?js if (item.type === 'module') { ?>
-                    <span class="glyphicon glyphicon-plus"></span> 
+                    <span class="glyphicon glyphicon-plus toggle"></span>
                 <?js } else if (item.type === 'class') { ?>
-                    <span class="glyphicon glyphicon-chevron-right"></span> 
+                    <span class="glyphicon glyphicon-chevron-right toggle"></span>
                 <?js } ?>
                 <?js= self.linkto(item.longname, item.prettyname) ?>
                 <?js if (item.type === 'namespace' &&


### PR DESCRIPTION
Minor change that makes it so the visibility of item members is only toggled when clicking on the "toggle" and not on the title itself.  The title links to a new page.  On a slower connection, it is weird to see the item toggle first and then navigate away.