### PR TITLE
add tags to example docs

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -113,7 +113,7 @@
           </h4>
           <p class="tags">
             {{#each tags}}
-              <a href="./index.html?q={{.}}"><span class="label label-primary">{{.}}</span></a>
+              <a href="./index.html?q={{.}}" class="label label-primary">{{.}}</a>
             {{/each}}
           </p>
           {{{ contents }}}

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -108,7 +108,14 @@
       <div class="row-fluid">
         <a class="codepen-button pull-right"><i class="fa fa-codepen"></i> Edit</a>
         <div class="span12">
-          <h4 id="title">{{ title }}</h4>
+          <h4 id="title">
+            {{ title }}
+          </h4>
+          <p class="tags">
+            {{#each tags}}
+              <a href="./index.html?q={{.}}"><span class="label label-primary">{{.}}</span></a>
+            {{/each}}
+          </p>
           {{{ contents }}}
         </div>
         <form method="POST" id="codepen-form" target="_blank" action="https://codesandbox.io/api/v1/sandboxes/define">

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -138,8 +138,12 @@ ExampleBuilder.prototype.apply = function(compiler) {
       .filter(chunk => chunk.names[0] !== this.common);
 
     const exampleData = [];
+    const uniqueTags = new Set();
     const promises = chunks.map(async chunk => {
       const [assets, data] = await this.render(compiler.context, chunk);
+
+      // collect tags for main page... TODO: implement index tag links
+      data.tags.forEach(tag => uniqueTags.add(tag));
 
       exampleData.push({
         link: data.filename,
@@ -158,7 +162,8 @@ ExampleBuilder.prototype.apply = function(compiler) {
 
     const info = {
       examples: exampleData,
-      index: createWordIndex(exampleData)
+      index: createWordIndex(exampleData),
+      tags: Array.from(uniqueTags)
     };
 
     const indexSource = `var info = ${JSON.stringify(info)}`;
@@ -181,6 +186,13 @@ ExampleBuilder.prototype.render = async function(dir, chunk) {
 
   data.olVersion = pkg.version;
   data.filename = htmlName;
+
+  // process tags
+  if (data.tags) {
+    data.tags = data.tags.replace(/[\s"]+/g, '').split(',');
+  } else {
+    data.tags = [];
+  }
 
   // add in script tag
   const jsName = `${name}.js`;


### PR DESCRIPTION
Part of https://github.com/openlayers/openlayers/issues/10022

Adds clickable tag links to the top of the example pages.

![openlayers](https://user-images.githubusercontent.com/5471079/67449986-a66b3000-f5e1-11e9-9945-83a7392a89ea.gif)

This also adds a unique collection of tags to the main index to eventually add a list of tags to the homepage. 