### PR TITLE
Treat hsl/hsla as named colors

### DIFF
--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -30,7 +30,7 @@ const HEX_COLOR_RE_ = /^#([a-f0-9]{3}|[a-f0-9]{4}(?:[a-f0-9]{2}){0,2})$/i;
  * @type {RegExp}
  * @private
  */
-const NAMED_COLOR_RE_ = /^([a-z]*)$/i;
+const NAMED_COLOR_RE_ = /^([a-z]*)$|^hsla?\(.*\)$/i;
 
 
 /**


### PR DESCRIPTION
Fixes #10185

hsl/hsla values produce an assertion error in fromStringInternal_  This is affecting the test for fill transparency introduced in #9395  The simplest solution is to treat them as named colors.