### PR TITLE
Webgl / add support for string and arrays in style expressions

### DIFF
--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -16,7 +16,7 @@ const oldColor = 'rgba(242,56,22,0.61)';
 const newColor = '#ffe52c';
 const period = 12; // animation period in seconds
 const animRatio =
-  ['pow',
+  ['^',
     ['/',
       ['mod',
         ['+',

--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -122,7 +122,8 @@ const map = new Map({
     }),
     new WebGLPointsLayer({
       style: style,
-      source: vectorSource
+      source: vectorSource,
+      disableHitDetection: true
     })
   ],
   target: document.getElementById('map'),

--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -44,7 +44,8 @@ const style = {
     ],
     color: ['interpolate',
       animRatio,
-      newColor, oldColor],
+      newColor, oldColor
+    ],
     opacity: ['-', 1.0, ['*', animRatio, 0.75]]
   }
 };

--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -21,7 +21,13 @@ const animRatio =
       ['mod',
         ['+',
           ['time'],
-          ['stretch', ['get', 'year'], 1850, 2020, 0, period]
+          [
+            'interpolate',
+            ['linear'],
+            ['get', 'year'],
+            1850, 0,
+            2015, period
+          ]
         ],
         period
       ],
@@ -39,12 +45,14 @@ const style = {
   symbol: {
     symbolType: 'circle',
     size: ['*',
-      ['stretch', ['get', 'mass'], 0, 200000, 8, 26],
-      ['-', 1.5, ['*', animRatio, 0.5]]
+      ['interpolate', ['linear'], ['get', 'mass'], 0, 8, 200000, 26],
+      ['-', 1.75, ['*', animRatio, 0.75]]
     ],
     color: ['interpolate',
+      ['linear'],
       animRatio,
-      newColor, oldColor
+      0, newColor,
+      1, oldColor
     ],
     opacity: ['-', 1.0, ['*', animRatio, 0.75]]
   }

--- a/examples/icon-sprite-webgl.html
+++ b/examples/icon-sprite-webgl.html
@@ -3,13 +3,13 @@ layout: example.html
 title: Icon Sprites with WebGL
 shortdesc: Rendering many icons with WebGL
 docs: >
-  This example shows how to use `ol/renderer/webgl/PointsLayer` to render
+  This example shows how to use `ol/layer/WebGLPoints` to render
     a very large amount of sprites. The above map is based on a dataset from the National UFO Reporting Center: each
     icon marks a UFO sighting according to its reported shape (disk, light, fireball...). The older the sighting, the redder
     the icon.
 
-  A very simple sprite atlas is used in the form of a PNG file containing all icons on a grid. Then, the `texCoordCallback`
-    option of the `ol/renderer/webgl/PointsLayer` constructor is used to specify which sprite to use according to the sighting shape.
+  A very simple sprite atlas is used in the form of a PNG file containing all icons on a grid. Then, the `style` object
+    given to the `ol/layer/WebGLPoints` constructor is used to specify which sprite to use according to the sighting shape.
 
   The dataset contains around 80k points and can be found here: https://www.kaggle.com/NUFORC/ufo-sightings
 tags: "webgl, icon, sprite, point, ufo"

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -4,11 +4,9 @@ import TileLayer from '../src/ol/layer/Tile.js';
 import TileJSON from '../src/ol/source/TileJSON.js';
 import Feature from '../src/ol/Feature.js';
 import Point from '../src/ol/geom/Point.js';
-import VectorLayer from '../src/ol/layer/Vector.js';
 import {Vector} from '../src/ol/source.js';
 import {fromLonLat} from '../src/ol/proj.js';
-import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
-import {colorToGlsl, numberToGlsl} from '../src/ol/style/expressions.js';
+import WebGLPointsLayer from '../src/ol/layer/WebGLPoints.js';
 
 const key = 'pk.eyJ1IjoidHNjaGF1YiIsImEiOiJjaW5zYW5lNHkxMTNmdWttM3JyOHZtMmNtIn0.CDIBD8H-G2Gf-cPkIuWtRg';
 
@@ -17,161 +15,40 @@ const vectorSource = new Vector({
   attributions: 'National UFO Reporting Center'
 });
 
-const texture = new Image();
-texture.src = 'data/ufo_shapes.png';
-
-// This describes the content of the associated sprite sheet
-// coords are u0, v0 for a given shape (all icons have a size of 0.25 x 0.5)
-const shapeTextureCoords = {
-  'light': [0, 0],
-  'sphere': [0.25, 0],
-  'circle': [0.25, 0],
-  'disc': [0.5, 0],
-  'oval': [0.5, 0],
-  'triangle': [0.75, 0],
-  'fireball': [0, 0.5],
-  'default': [0.75, 0.5]
-};
-
 const oldColor = [255, 160, 110];
 const newColor = [180, 255, 200];
 const size = 16;
 
-class WebglPointsLayer extends VectorLayer {
-  createRenderer() {
-    return new WebGLPointsLayerRenderer(this, {
-      attributes: [
-        {
-          name: 'year',
-          callback: function(feature) {
-            return feature.get('year');
-          }
-        },
-        {
-          name: 'texCoordU',
-          callback: function(feature) {
-            let coords = shapeTextureCoords[feature.get('shape')];
-            if (!coords) {
-              coords = shapeTextureCoords['default'];
-            }
-            return coords[0];
-          }
-        },
-        {
-          name: 'texCoordV',
-          callback: function(feature) {
-            let coords = shapeTextureCoords[feature.get('shape')];
-            if (!coords) {
-              coords = shapeTextureCoords['default'];
-            }
-            return coords[1];
-          }
-        }
-      ],
-      uniforms: {
-        u_texture: texture
-      },
-      vertexShader: [
-        'precision mediump float;',
-
-        'uniform mat4 u_projectionMatrix;',
-        'uniform mat4 u_offsetScaleMatrix;',
-        'uniform mat4 u_offsetRotateMatrix;',
-        'attribute vec2 a_position;',
-        'attribute float a_index;',
-        'attribute float a_year;',
-        'attribute float a_texCoordU;',
-        'attribute float a_texCoordV;',
-        'varying vec2 v_texCoord;',
-        'varying float v_year;',
-
-        'void main(void) {',
-        '  mat4 offsetMatrix = u_offsetScaleMatrix;',
-        '  float offsetX = a_index == 0.0 || a_index == 3.0 ? ',
-        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
-        '  float offsetY = a_index == 0.0 || a_index == 1.0 ? ',
-        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
-        '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
-        '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
-        '  float u = a_index == 0.0 || a_index == 3.0 ? a_texCoordU : a_texCoordU + 0.25;',
-        '  float v = a_index == 2.0 || a_index == 3.0 ? a_texCoordV : a_texCoordV + 0.5;',
-        '  v_texCoord = vec2(u, v);',
-        '  v_year = a_year;',
-        '}'
-      ].join(' '),
-      fragmentShader: [
-        'precision mediump float;',
-
-        'uniform float u_time;',
-        'uniform float u_minYear;',
-        'uniform float u_maxYear;',
-        'uniform sampler2D u_texture;',
-        'varying vec2 v_texCoord;',
-        'varying float v_year;',
-
-        'void main(void) {',
-        '  vec4 textureColor = texture2D(u_texture, v_texCoord);',
-        '  if (textureColor.a < 0.1) {',
-        '    discard;',
-        '  }',
-
-        // color is interpolated based on year
-        '  float ratio = clamp((v_year - 1950.0) / (2013.0 - 1950.0), 0.0, 1.1);',
-        '  vec3 color = mix(vec3(' + colorToGlsl(oldColor) + '),',
-        '    vec3(' + colorToGlsl(newColor) + '), ratio);',
-
-        '  gl_FragColor = vec4(color, 1.0) * textureColor;',
-        '  gl_FragColor.rgb *= gl_FragColor.a;',
-        '}'
-      ].join(' '),
-      hitVertexShader: [
-        'precision mediump float;',
-
-        'uniform mat4 u_projectionMatrix;',
-        'uniform mat4 u_offsetScaleMatrix;',
-        'uniform mat4 u_offsetRotateMatrix;',
-        'attribute vec2 a_position;',
-        'attribute float a_index;',
-        'attribute vec4 a_hitColor;',
-        'attribute float a_texCoordU;',
-        'attribute float a_texCoordV;',
-        'varying vec2 v_texCoord;',
-        'varying vec4 v_hitColor;',
-
-        'void main(void) {',
-        '  mat4 offsetMatrix = u_offsetScaleMatrix;',
-        '  float offsetX = a_index == 0.0 || a_index == 3.0 ? ',
-        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
-        '  float offsetY = a_index == 0.0 || a_index == 1.0 ? ',
-        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
-        '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
-        '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
-        '  float u = a_index == 0.0 || a_index == 3.0 ? a_texCoordU : a_texCoordU + 0.25;',
-        '  float v = a_index == 2.0 || a_index == 3.0 ? a_texCoordV : a_texCoordV + 0.5;',
-        '  v_texCoord = vec2(u, v);',
-        '  v_hitColor = a_hitColor;',
-        '}'
-      ].join(' '),
-      hitFragmentShader: [
-        'precision mediump float;',
-
-        'uniform sampler2D u_texture;',
-        'varying vec2 v_texCoord;',
-        'varying vec4 v_hitColor;',
-
-        'void main(void) {',
-        '  vec4 textureColor = texture2D(u_texture, v_texCoord);',
-        '  if (textureColor.a < 0.1) {',
-        '    discard;',
-        '  }',
-
-        '  gl_FragColor = v_hitColor;',
-        '}'
-      ].join(' ')
-    });
+const style = {
+  symbol: {
+    symbolType: 'image',
+    src: 'data/ufo_shapes.png',
+    size: size,
+    color: [
+      'interpolate',
+      ['stretch', ['get', 'year'], 1950, 2013, 0, 1],
+      oldColor,
+      newColor
+    ],
+    rotateWithView: false,
+    offset: [
+      0,
+      9
+    ],
+    textureCoord: [
+      'match',
+      ['get', 'shape'],
+      'light', [0, 0, 0.25, 0.5],
+      'sphere', [0.25, 0, 0.5, 0.5],
+      'circle', [0.25, 0, 0.5, 0.5],
+      'disc', [0.5, 0, 0.75, 0.5],
+      'oval', [0.5, 0, 0.75, 0.5],
+      'triangle', [0.75, 0, 1, 0.5],
+      'fireball', [0, 0.5, 0.25, 1],
+      [0.75, 0.5, 1, 1]
+    ]
   }
-}
-
+};
 
 function loadData() {
   const client = new XMLHttpRequest();
@@ -217,8 +94,9 @@ const map = new Map({
         crossOrigin: 'anonymous'
       })
     }),
-    new WebglPointsLayer({
-      source: vectorSource
+    new WebGLPointsLayer({
+      source: vectorSource,
+      style: style
     })
   ],
   target: document.getElementById('map'),
@@ -241,8 +119,4 @@ map.on('pointermove', function(evt) {
     const shape = feature.get('shape');
     info.innerText = 'On ' + datetime + ', lasted ' + duration + ' seconds and had a "' + shape + '" shape.';
   });
-});
-
-texture.addEventListener('load', function() {
-  map.render();
 });

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -26,9 +26,10 @@ const style = {
     size: size,
     color: [
       'interpolate',
-      ['stretch', ['get', 'year'], 1950, 2013, 0, 1],
-      oldColor,
-      newColor
+      ['linear'],
+      ['get', 'year'],
+      1950, oldColor,
+      2013, newColor
     ],
     rotateWithView: false,
     offset: [

--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -8,7 +8,7 @@ import VectorLayer from '../src/ol/layer/Vector.js';
 import {Vector} from '../src/ol/source.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import WebGLPointsLayerRenderer from '../src/ol/renderer/webgl/PointsLayer.js';
-import {formatColor, formatNumber} from '../src/ol/webgl/ShaderBuilder.js';
+import {colorToGlsl, numberToGlsl} from '../src/ol/style/expressions.js';
 
 const key = 'pk.eyJ1IjoidHNjaGF1YiIsImEiOiJjaW5zYW5lNHkxMTNmdWttM3JyOHZtMmNtIn0.CDIBD8H-G2Gf-cPkIuWtRg';
 
@@ -88,9 +88,9 @@ class WebglPointsLayer extends VectorLayer {
         'void main(void) {',
         '  mat4 offsetMatrix = u_offsetScaleMatrix;',
         '  float offsetX = a_index == 0.0 || a_index == 3.0 ? ',
-        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
         '  float offsetY = a_index == 0.0 || a_index == 1.0 ? ',
-        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
         '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
         '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
         '  float u = a_index == 0.0 || a_index == 3.0 ? a_texCoordU : a_texCoordU + 0.25;',
@@ -117,8 +117,8 @@ class WebglPointsLayer extends VectorLayer {
 
         // color is interpolated based on year
         '  float ratio = clamp((v_year - 1950.0) / (2013.0 - 1950.0), 0.0, 1.1);',
-        '  vec3 color = mix(vec3(' + formatColor(oldColor) + '),',
-        '    vec3(' + formatColor(newColor) + '), ratio);',
+        '  vec3 color = mix(vec3(' + colorToGlsl(oldColor) + '),',
+        '    vec3(' + colorToGlsl(newColor) + '), ratio);',
 
         '  gl_FragColor = vec4(color, 1.0) * textureColor;',
         '  gl_FragColor.rgb *= gl_FragColor.a;',
@@ -141,9 +141,9 @@ class WebglPointsLayer extends VectorLayer {
         'void main(void) {',
         '  mat4 offsetMatrix = u_offsetScaleMatrix;',
         '  float offsetX = a_index == 0.0 || a_index == 3.0 ? ',
-        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
         '  float offsetY = a_index == 0.0 || a_index == 1.0 ? ',
-        '    ' + formatNumber(-size / 2) + ' : ' + formatNumber(size / 2) + ';',
+        '    ' + numberToGlsl(-size / 2) + ' : ' + numberToGlsl(size / 2) + ';',
         '  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);',
         '  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;',
         '  float u = a_index == 0.0 || a_index == 3.0 ? a_texCoordU : a_texCoordU + 0.25;',

--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -26,7 +26,9 @@ experimental: true
 <select id="style-select">
   <option value="icons">Icons</option>
   <option value="triangles">Triangles, color related to population</option>
+  <option value="triangles-latitude">Triangles, color related to latitude</option>
   <option value="circles">Circles, size related to population</option>
+  <option value="circles-zoom">Circles, size related to zoom</option>
 </select>
 <textarea style="width: 100%; height: 20rem; font-family: monospace; font-size: small;" id="style-editor"></textarea>
 <small>

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -36,6 +36,29 @@ const predefinedStyles = {
       rotateWithView: true
     }
   },
+  'triangles-latitude': {
+    symbol: {
+      symbolType: 'triangle',
+      size: [
+        'interpolate',
+        ['linear'],
+        ['get', 'population'],
+        40000, 12,
+        2000000, 24
+      ],
+      color: [
+        'interpolate',
+        ['linear'],
+        ['get', 'latitude'],
+        -60, '#ff14c3',
+        -20, '#ff621d',
+        20, '#ffed02',
+        60, '#00ff67'
+      ],
+      offset: [0, 0],
+      opacity: 0.95
+    }
+  },
   'circles': {
     symbol: {
       symbolType: 'circle',
@@ -56,6 +79,21 @@ const predefinedStyles = {
         40000, 0.6,
         2000000, 0.92
       ]
+    }
+  },
+  'circles-zoom': {
+    symbol: {
+      symbolType: 'circle',
+      size: [
+        'interpolate',
+        ['exponential', 2.5],
+        ['zoom'],
+        2, 1,
+        14, 32
+      ],
+      color: '#240572',
+      offset: [0, 0],
+      opacity: 0.95
     }
   }
 };

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -28,9 +28,10 @@ const predefinedStyles = {
       size: 18,
       color: [
         'interpolate',
-        ['stretch', ['get', 'population'], 20000, 300000, 0, 1],
-        '#5aca5b',
-        '#ff6a19'
+        ['linear'],
+        ['get', 'population'],
+        20000, '#5aca5b',
+        300000, '#ff6a19'
       ],
       rotateWithView: true
     }
@@ -38,11 +39,23 @@ const predefinedStyles = {
   'circles': {
     symbol: {
       symbolType: 'circle',
-      size: ['stretch', ['get', 'population'], 40000, 2000000, 8, 28],
+      size: [
+        'interpolate',
+        ['linear'],
+        ['get', 'population'],
+        40000, 8,
+        2000000, 28
+      ],
       color: '#006688',
       rotateWithView: false,
       offset: [0, 0],
-      opacity: ['stretch', ['get', 'population'], 40000, 2000000, 0.6, 0.92]
+      opacity: [
+        'interpolate',
+        ['linear'],
+        ['get', 'population'],
+        40000, 0.6,
+        2000000, 0.92
+      ]
     }
   }
 };

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -117,7 +117,8 @@ function refreshLayer(newStyle) {
   const previousLayer = pointsLayer;
   pointsLayer = new WebGLPointsLayer({
     source: vectorSource,
-    style: newStyle
+    style: newStyle,
+    disableHitDetection: true
   });
   map.addLayer(pointsLayer);
 

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -84,6 +84,8 @@ class WebGLPointsLayer extends Layer {
     return new WebGLPointsLayerRenderer(this, {
       vertexShader: this.parseResult_.builder.getSymbolVertexShader(),
       fragmentShader: this.parseResult_.builder.getSymbolFragmentShader(),
+      hitVertexShader: this.parseResult_.builder.getSymbolVertexShader(true),
+      hitFragmentShader: this.parseResult_.builder.getSymbolFragmentShader(true),
       uniforms: this.parseResult_.uniforms,
       attributes: this.parseResult_.attributes
     });

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -24,6 +24,8 @@ import Layer from './Layer.js';
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
  * be visible.
  * @property {import("../source/Vector.js").default} [source] Source.
+ * @property {boolean} [disableHitDetection] Setting this to true will provide a slight performance boost, but will
+ * prevent all hit detection on the layer.
  */
 
 
@@ -75,6 +77,12 @@ class WebGLPointsLayer extends Layer {
      * @type {import('../webgl/ShaderBuilder.js').StyleParseResult}
      */
     this.parseResult_ = parseLiteralStyle(options.style);
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.hitDetectionDisabled_ = !!options.disableHitDetection;
   }
 
   /**
@@ -84,8 +92,10 @@ class WebGLPointsLayer extends Layer {
     return new WebGLPointsLayerRenderer(this, {
       vertexShader: this.parseResult_.builder.getSymbolVertexShader(),
       fragmentShader: this.parseResult_.builder.getSymbolFragmentShader(),
-      hitVertexShader: this.parseResult_.builder.getSymbolVertexShader(true),
-      hitFragmentShader: this.parseResult_.builder.getSymbolFragmentShader(true),
+      hitVertexShader: !this.hitDetectionDisabled_ &&
+        this.parseResult_.builder.getSymbolVertexShader(true),
+      hitFragmentShader: !this.hitDetectionDisabled_ &&
+        this.parseResult_.builder.getSymbolFragmentShader(true),
       uniforms: this.parseResult_.uniforms,
       attributes: this.parseResult_.attributes
     });

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -147,6 +147,10 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       options.hitVertexShader
     );
 
+    if (this.getShaderCompileErrors()) {
+      throw new Error(this.getShaderCompileErrors());
+    }
+
     const customAttributes = options.attributes ?
       options.attributes.map(function(attribute) {
         return {

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -5,49 +5,7 @@
  */
 
 /**
- * Base type used for literal style parameters; can be a number literal or the output of an operator,
- * which in turns takes {@link ExpressionValue} arguments.
- *
- * The following operators can be used:
- *
- * * Reading operators:
- *   * `['get', 'attributeName']` fetches a feature attribute (it will be prefixed by `a_` in the shader)
- *     Note: those will be taken from the attributes provided to the renderer
- *   * `['var', 'varName']` fetches a value from the style variables, or 0 if undefined
- *   * `['time']` returns the time in seconds since the creation of the layer
- *
- * * Math operators:
- *   * `['*', value1, value1]` multiplies `value1` by `value2`
- *   * `['/', value1, value1]` divides `value1` by `value2`
- *   * `['+', value1, value1]` adds `value1` and `value2`
- *   * `['-', value1, value1]` subtracts `value2` from `value1`
- *   * `['clamp', value, low, high]` clamps `value` between `low` and `high`
- *   * `['stretch', value, low1, high1, low2, high2]` maps `value` from [`low1`, `high1`] range to
- *     [`low2`, `high2`] range, clamping values along the way
- *   * `['mod', value1, value1]` returns the result of `value1 % value2` (modulo)
- *   * `['pow', value1, value1]` returns the value of `value1` raised to the `value2` power
- *
- * * Color operators:
- *   * `['interpolate', ratio, color1, color2]` returns a color through interpolation between `color1` and
- *     `color2` with the given `ratio`
- *
- * * Logical operators:
- *   * `['<', value1, value2]` returns `1` if `value1` is strictly lower than value 2, or `0` otherwise.
- *   * `['<=', value1, value2]` returns `1` if `value1` is lower than or equals value 2, or `0` otherwise.
- *   * `['>', value1, value2]` returns `1` if `value1` is strictly greater than value 2, or `0` otherwise.
- *   * `['>=', value1, value2]` returns `1` if `value1` is greater than or equals value 2, or `0` otherwise.
- *   * `['==', value1, value2]` returns `1` if `value1` equals value 2, or `0` otherwise.
- *   * `['!', value1]` returns `0` if `value1` strictly greater than `0`, or `1` otherwise.
- *   * `['between', value1, value2, value3]` returns `1` if `value1` is contained between `value2` and `value3`
- *     (inclusively), or `0` otherwise.
- *
- * Values can either be literals or another operator, as they will be evaluated recursively.
- * Literal values can be of the following types:
- * * `number`
- * * `string`
- * * {@link module:ol/color~Color}
- *
- * @typedef {Array<*>|import("../color.js").Color|string|number} ExpressionValue
+ * @typedef {import("./expressions.js").ExpressionValue} ExpressionValue
  */
 
 /**

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -252,6 +252,11 @@ function assertNumber(value) {
     throw new Error(`A numeric value was expected, got ${JSON.stringify(value)} instead`);
   }
 }
+function assertNumbers(arr) {
+  for (let i = 0; i < arr.length; i++) {
+    assertNumber(arr[i]);
+  }
+}
 function assertString(value) {
   if (!(getValueType(value) & ValueTypes.STRING)) {
     throw new Error(`A string value was expected, got ${JSON.stringify(value)} instead`);
@@ -350,8 +355,7 @@ Operators['*'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} * ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -361,8 +365,7 @@ Operators['/'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} / ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -372,8 +375,7 @@ Operators['+'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} + ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -383,8 +385,7 @@ Operators['-'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} - ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -394,9 +395,7 @@ Operators['clamp'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 3);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
-    assertNumber(args[2]);
+    assertNumbers(args);
     const min = expressionToGlsl(context, args[1]);
     const max = expressionToGlsl(context, args[2]);
     return `clamp(${expressionToGlsl(context, args[0])}, ${min}, ${max})`;
@@ -408,8 +407,7 @@ Operators['mod'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `mod(${expressionToGlsl(context, args[0])}, ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -419,8 +417,7 @@ Operators['^'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `pow(${expressionToGlsl(context, args[0])}, ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -430,8 +427,7 @@ Operators['>'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} > ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -441,8 +437,7 @@ Operators['>='] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} >= ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -452,8 +447,7 @@ Operators['<'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} < ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -463,8 +457,7 @@ Operators['<='] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} <= ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -474,8 +467,7 @@ Operators['=='] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 2);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
+    assertNumbers(args);
     return `(${expressionToGlsl(context, args[0])} == ${expressionToGlsl(context, args[1])})`;
   }
 };
@@ -495,9 +487,7 @@ Operators['between'] = {
   },
   toGlsl: function(context, args) {
     assertArgsCount(args, 3);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
-    assertNumber(args[2]);
+    assertNumbers(args);
     const min = expressionToGlsl(context, args[1]);
     const max = expressionToGlsl(context, args[2]);
     const value = expressionToGlsl(context, args[0]);
@@ -511,9 +501,7 @@ Operators['array'] = {
   toGlsl: function(context, args) {
     assertArgsMinCount(args, 2);
     assertArgsMaxCount(args, 4);
-    for (let i = 0; i < args.length; i++) {
-      assertNumber(args[i]);
-    }
+    assertNumbers(args);
     const parsedArgs = args.map(function(val) {
       return expressionToGlsl(context, val, ValueTypes.NUMBER);
     });
@@ -527,9 +515,7 @@ Operators['color'] = {
   toGlsl: function(context, args) {
     assertArgsMinCount(args, 3);
     assertArgsMaxCount(args, 4);
-    for (let i = 0; i < args.length; i++) {
-      assertNumber(args[i]);
-    }
+    assertNumbers(args);
     const array = /** @type {number[]} */(args);
     if (args.length === 3) {
       array.push(1);

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -115,7 +115,9 @@ export function getValueType(value) {
 /**
  * Context available during the parsing of an expression.
  * @typedef {Object} ParsingContext
- * @property {boolean} inFragmentShader If false, means the expression output should be made for a vertex shader
+ * @property {boolean} [inFragmentShader] If false, means the expression output should be made for a vertex shader
+ * @property {Array<string>} variables List of variables used in the expression; contains **unprefixed names**
+ * @property {Array<string>} attributes List of attributes used in the expression; contains **unprefixed names**
  */
 
 /**
@@ -239,10 +241,14 @@ export const Operators = {
       return ValueTypes.ANY;
     },
     toGlsl: function(context, args) {
-      const prefix = context.inFragmentShader ? 'v_' : 'a_';
       assertArgsCount(args, 1);
       assertString(args[0]);
-      return prefix + expressionToGlsl(context, args[0]);
+      const value = expressionToGlsl(context, args[0]);
+      if (context.attributes.indexOf(value) === -1) {
+        context.attributes.push(value);
+      }
+      const prefix = context.inFragmentShader ? 'v_' : 'a_';
+      return prefix + value;
     }
   },
   'var': {
@@ -252,7 +258,11 @@ export const Operators = {
     toGlsl: function(context, args) {
       assertArgsCount(args, 1);
       assertString(args[0]);
-      return `u_${expressionToGlsl(context, args[0])}`;
+      const value = expressionToGlsl(context, args[0]);
+      if (context.variables.indexOf(value) === -1) {
+        context.variables.push(value);
+      }
+      return `u_${value}`;
     }
   },
   'time': {

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -314,6 +314,24 @@ Operators['time'] = {
     return 'u_time';
   }
 };
+Operators['zoom'] = {
+  getReturnType: function(args) {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function(context, args) {
+    assertArgsCount(args, 0);
+    return 'u_zoom';
+  }
+};
+Operators['resolution'] = {
+  getReturnType: function(args) {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function(context, args) {
+    assertArgsCount(args, 0);
+    return 'u_resolution';
+  }
+};
 Operators['*'] = {
   getReturnType: function(args) {
     return ValueTypes.NUMBER;

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -192,7 +192,7 @@ export function stringToGlsl(context, string) {
  * will be read and modified during the parsing operation.
  * @param {ParsingContext} context Parsing context
  * @param {ExpressionValue} value Value
- * @param {ValueTypes} [typeHint] Hint for the expected final type
+ * @param {ValueTypes|number} [typeHint] Hint for the expected final type (can be several types combined)
  * @returns {string} GLSL-compatible output
  */
 export function expressionToGlsl(context, value, typeHint) {

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -4,7 +4,6 @@
  */
 
 import {asArray, isStringColor} from '../color.js';
-import {assign} from '../obj.js';
 
 /**
  * Base type used for literal style parameters; can be a number literal or the output of an operator,
@@ -246,11 +245,6 @@ function assertNumber(value) {
     throw new Error(`A numeric value was expected, got ${JSON.stringify(value)} instead`);
   }
 }
-function assertColor(value) {
-  if (!(getValueType(value) & ValueTypes.COLOR)) {
-    throw new Error(`A color value was expected, got ${JSON.stringify(value)} instead`);
-  }
-}
 function assertString(value) {
   if (!(getValueType(value) & ValueTypes.STRING)) {
     throw new Error(`A string value was expected, got ${JSON.stringify(value)} instead`);
@@ -376,24 +370,6 @@ Operators['clamp'] = {
     const min = expressionToGlsl(context, args[1]);
     const max = expressionToGlsl(context, args[2]);
     return `clamp(${expressionToGlsl(context, args[0])}, ${min}, ${max})`;
-  }
-};
-Operators['stretch'] = {
-  getReturnType: function(args) {
-    return ValueTypes.NUMBER;
-  },
-  toGlsl: function(context, args) {
-    assertArgsCount(args, 5);
-    assertNumber(args[0]);
-    assertNumber(args[1]);
-    assertNumber(args[2]);
-    assertNumber(args[3]);
-    assertNumber(args[4]);
-    const low1 = expressionToGlsl(context, args[1]);
-    const high1 = expressionToGlsl(context, args[2]);
-    const low2 = expressionToGlsl(context, args[3]);
-    const high2 = expressionToGlsl(context, args[4]);
-    return `((clamp(${expressionToGlsl(context, args[0])}, ${low1}, ${high1}) - ${low1}) * ((${high2} - ${low2}) / (${high1} - ${low1})) + ${low2})`;
   }
 };
 Operators['mod'] = {

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -1,0 +1,132 @@
+/**
+ * Operators and utilities used for style expressions
+ * @module ol/style/expressions
+ */
+
+import {isStringColor} from '../color.js';
+
+/**
+ * Base type used for literal style parameters; can be a number literal or the output of an operator,
+ * which in turns takes {@link ExpressionValue} arguments.
+ *
+ * The following operators can be used:
+ *
+ * * Reading operators:
+ *   * `['get', 'attributeName']` fetches a feature attribute (it will be prefixed by `a_` in the shader)
+ *     Note: those will be taken from the attributes provided to the renderer
+ *   * `['var', 'varName']` fetches a value from the style variables, or 0 if undefined
+ *   * `['time']` returns the time in seconds since the creation of the layer
+ *
+ * * Math operators:
+ *   * `['*', value1, value1]` multiplies `value1` by `value2`
+ *   * `['/', value1, value1]` divides `value1` by `value2`
+ *   * `['+', value1, value1]` adds `value1` and `value2`
+ *   * `['-', value1, value1]` subtracts `value2` from `value1`
+ *   * `['clamp', value, low, high]` clamps `value` between `low` and `high`
+ *   * `['stretch', value, low1, high1, low2, high2]` maps `value` from [`low1`, `high1`] range to
+ *     [`low2`, `high2`] range, clamping values along the way
+ *   * `['mod', value1, value1]` returns the result of `value1 % value2` (modulo)
+ *   * `['pow', value1, value1]` returns the value of `value1` raised to the `value2` power
+ *
+ * * Color operators:
+ *   * `['interpolate', ratio, color1, color2]` returns a color through interpolation between `color1` and
+ *     `color2` with the given `ratio`
+ *
+ * * Logical operators:
+ *   * `['<', value1, value2]` returns `1` if `value1` is strictly lower than value 2, or `0` otherwise.
+ *   * `['<=', value1, value2]` returns `1` if `value1` is lower than or equals value 2, or `0` otherwise.
+ *   * `['>', value1, value2]` returns `1` if `value1` is strictly greater than value 2, or `0` otherwise.
+ *   * `['>=', value1, value2]` returns `1` if `value1` is greater than or equals value 2, or `0` otherwise.
+ *   * `['==', value1, value2]` returns `1` if `value1` equals value 2, or `0` otherwise.
+ *   * `['!', value1]` returns `0` if `value1` strictly greater than `0`, or `1` otherwise.
+ *   * `['between', value1, value2, value3]` returns `1` if `value1` is contained between `value2` and `value3`
+ *     (inclusively), or `0` otherwise.
+ *   * `['match', input, match1, output1, ...matchN, outputN, fallback]` compares the `input` value against all
+ *     provided `matchX` values, returning the output associated with the first valid match. If no match is found,
+ *     returns the `fallback` value.
+ *     `input` and `matchX` values must all be of the same type, and can be `number` or `string`. `outputX` and
+ *     `fallback` values must be of the same type, and can be any kind.
+ *
+ * Values can either be literals or another operator, as they will be evaluated recursively.
+ * Literal values can be of the following types:
+ * * `number`
+ * * `string`
+ * * {@link module:ol/color~Color}
+ *
+ * @typedef {Array<*>|import("../color.js").Color|string|number|boolean} ExpressionValue
+ */
+
+/**
+ * Possible inferred types from a given value or expression.
+ * Note: these are binary flags.
+ * @enum {number}
+ */
+export const ValueTypes = {
+  NUMBER: 0b00001,
+  STRING: 0b00010,
+  COLOR: 0b00100,
+  BOOLEAN: 0b01000,
+  NUMBER_ARRAY: 0b10000,
+  ANY: 0b11111
+};
+
+/**
+ * Returns the possible types for a given value (each type being a binary flag)
+ * To test a value use e.g. `getValueType(v) & ValueTypes.BOOLEAN`
+ * @param {ExpressionValue} value Value
+ * @returns {ValueTypes|number} Type or types inferred from the value
+ */
+export function getValueType(value) {
+  if (typeof value === 'number') {
+    return ValueTypes.NUMBER;
+  }
+  if (typeof value === 'boolean') {
+    return ValueTypes.BOOLEAN;
+  }
+  if (typeof value === 'string') {
+    if (isStringColor(value)) {
+      return ValueTypes.COLOR | ValueTypes.STRING;
+    }
+    return ValueTypes.STRING;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`Unhandled value type: ${JSON.stringify(value)}`);
+  }
+  const onlyNumbers = value.every(function(v) {
+    return typeof v === 'number';
+  });
+  if (onlyNumbers) {
+    if (value.length === 3 || value.length === 4) {
+      return ValueTypes.COLOR | ValueTypes.NUMBER_ARRAY;
+    }
+    return ValueTypes.NUMBER_ARRAY;
+  }
+  if (typeof value[0] !== 'string') {
+    throw new Error(`Expected an expression operator but received: ${JSON.stringify(value)}`);
+  }
+  switch (value[0]) {
+    case 'get':
+    case 'var':
+    case 'time':
+    case '*':
+    case '/':
+    case '+':
+    case '-':
+    case 'clamp':
+    case 'stretch':
+    case 'mod':
+    case 'pow':
+    case '>':
+    case '>=':
+    case '<':
+    case '<=':
+    case '==':
+    case '!':
+    case 'between':
+      return ValueTypes.NUMBER;
+    case 'interpolate':
+      return ValueTypes.COLOR;
+    default:
+      throw new Error(`Unrecognized expression operator: ${JSON.stringify(value)}`);
+  }
+}

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -24,7 +24,7 @@ import {asArray, isStringColor} from '../color.js';
  *   * `['-', value1, value1]` subtracts `value2` from `value1`
  *   * `['clamp', value, low, high]` clamps `value` between `low` and `high`
  *   * `['mod', value1, value1]` returns the result of `value1 % value2` (modulo)
- *   * `['pow', value1, value1]` returns the value of `value1` raised to the `value2` power
+ *   * `['^', value1, value1]` returns the value of `value1` raised to the `value2` power
  *
  * * Transform operators:
  *   * `['match', input, match1, output1, ...matchN, outputN, fallback]` compares the `input` value against all
@@ -401,7 +401,7 @@ Operators['mod'] = {
     return `mod(${expressionToGlsl(context, args[0])}, ${expressionToGlsl(context, args[1])})`;
   }
 };
-Operators['pow'] = {
+Operators['^'] = {
   getReturnType: function(args) {
     return ValueTypes.NUMBER;
   },

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -43,7 +43,9 @@ export const DefaultUniform = {
   PROJECTION_MATRIX: 'u_projectionMatrix',
   OFFSET_SCALE_MATRIX: 'u_offsetScaleMatrix',
   OFFSET_ROTATION_MATRIX: 'u_offsetRotateMatrix',
-  TIME: 'u_time'
+  TIME: 'u_time',
+  ZOOM: 'u_zoom',
+  RESOLUTION: 'u_resolution'
 };
 
 /**
@@ -557,6 +559,8 @@ class WebGLHelper extends Disposable {
     this.setUniformMatrixValue(DefaultUniform.OFFSET_ROTATION_MATRIX, fromTransform(this.tmpMat4_, offsetRotateMatrix));
 
     this.setUniformFloatValue(DefaultUniform.TIME, (Date.now() - this.startTime_) * 0.001);
+    this.setUniformFloatValue(DefaultUniform.ZOOM, frameState.viewState.zoom);
+    this.setUniformFloatValue(DefaultUniform.RESOLUTION, frameState.viewState.resolution);
   }
 
   /**

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -274,6 +274,8 @@ uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 ${this.uniforms.map(function(uniform) {
     return 'uniform ' + uniform + ';';
   }).join('\n')}
@@ -335,6 +337,8 @@ ${varyings.map(function(varying) {
 
     return `precision mediump float;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 ${this.uniforms.map(function(uniform) {
     return 'uniform ' + uniform + ';';
   }).join('\n')}

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -138,7 +138,8 @@ describe('ol.style.expressions', function() {
       expect(getValueType(['==', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['between', ['get', 'attr4'], -4.0, 5.0])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['!', ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
-      expect(getValueType(['interpolate', ['get', 'attr4'], [255, 255, 255, 1], 'transparent'])).to.eql(ValueTypes.COLOR);
+      expect(getValueType(['array', ['get', 'attr4'], 1, 2, 3])).to.eql(ValueTypes.NUMBER_ARRAY);
+      expect(getValueType(['color', ['get', 'attr4'], 1, 2])).to.eql(ValueTypes.COLOR);
     });
 
   });
@@ -171,6 +172,8 @@ describe('ol.style.expressions', function() {
       expect(expressionToGlsl(context, ['==', 10, ['get', 'attr4']])).to.eql('(10.0 == a_attr4)');
       expect(expressionToGlsl(context, ['between', ['get', 'attr4'], -4.0, 5.0])).to.eql('(a_attr4 >= -4.0 && a_attr4 <= 5.0)');
       expect(expressionToGlsl(context, ['!', ['get', 'attr4']])).to.eql('(!a_attr4)');
+      expect(expressionToGlsl(context, ['array', ['get', 'attr4'], 1, 2, 3])).to.eql('vec4(a_attr4, 1.0, 2.0, 3.0)');
+      expect(expressionToGlsl(context, ['color', ['get', 'attr4'], 1, 2, 0.5])).to.eql('vec4(a_attr4 / 255.0, 1.0 / 255.0, 2.0 / 255.0, 0.5)');
     });
 
     it('correctly adapts output for fragment shaders', function() {
@@ -201,13 +204,35 @@ describe('ol.style.expressions', function() {
       } catch (e) {
         thrown = true;
       }
+      expect(thrown).to.be(true);
+
+      thrown = false;
       try {
         expressionToGlsl(context, ['<', 0, 'aa']);
       } catch (e) {
         thrown = true;
       }
+      expect(thrown).to.be(true);
+
+      thrown = false;
       try {
         expressionToGlsl(context, ['+', true, ['get', 'attr']]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['color', 1, 2, 'red']);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['array', 1, '2', 3]);
       } catch (e) {
         thrown = true;
       }
@@ -221,13 +246,35 @@ describe('ol.style.expressions', function() {
       } catch (e) {
         thrown = true;
       }
+      expect(thrown).to.be(true);
+
+      thrown = false;
       try {
         expressionToGlsl(context, ['<', 4]);
       } catch (e) {
         thrown = true;
       }
+      expect(thrown).to.be(true);
+
+      thrown = false;
       try {
         expressionToGlsl(context, ['+']);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['array', 1]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['color', 1, 2, 3, 4, 5]);
       } catch (e) {
         thrown = true;
       }
@@ -236,16 +283,6 @@ describe('ol.style.expressions', function() {
 
     it('throws on invalid expressions', function() {
       let thrown = false;
-      try {
-        expressionToGlsl(context, true);
-      } catch (e) {
-        thrown = true;
-      }
-      try {
-        expressionToGlsl(context, [123, 456]);
-      } catch (e) {
-        thrown = true;
-      }
       try {
         expressionToGlsl(context, null);
       } catch (e) {

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -122,6 +122,8 @@ describe('ol.style.expressions', function() {
       expect(getValueType(['get', 'myAttr'])).to.eql(ValueTypes.ANY);
       expect(getValueType(['var', 'myValue'])).to.eql(ValueTypes.ANY);
       expect(getValueType(['time'])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['zoom'])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['resolution'])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['+', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['-', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['/', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
@@ -156,6 +158,8 @@ describe('ol.style.expressions', function() {
       expect(expressionToGlsl(context, ['get', 'myAttr'])).to.eql('a_myAttr');
       expect(expressionToGlsl(context, ['var', 'myValue'])).to.eql('u_myValue');
       expect(expressionToGlsl(context, ['time'])).to.eql('u_time');
+      expect(expressionToGlsl(context, ['zoom'])).to.eql('u_zoom');
+      expect(expressionToGlsl(context, ['resolution'])).to.eql('u_resolution');
       expect(expressionToGlsl(context, ['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
       expect(expressionToGlsl(context, ['/', ['-', ['get', 'size'], 20], 100])).to.eql('((a_size - 20.0) / 100.0)');
       expect(expressionToGlsl(context, ['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -1,7 +1,57 @@
-import {getValueType, ValueTypes} from '../../../../src/ol/style/expressions.js';
+import {
+  arrayToGlsl, colorToGlsl,
+  expressionToGlsl,
+  getValueType,
+  numberToGlsl,
+  ValueTypes
+} from '../../../../src/ol/style/expressions.js';
 
 
 describe('ol.style.expressions', function() {
+
+  describe('numberToGlsl', function() {
+    it('does a simple transform when a fraction is present', function() {
+      expect(numberToGlsl(1.3456)).to.eql('1.3456');
+    });
+    it('adds a fraction separator when missing', function() {
+      expect(numberToGlsl(1)).to.eql('1.0');
+      expect(numberToGlsl(2.0)).to.eql('2.0');
+    });
+  });
+
+  describe('arrayToGlsl', function() {
+    it('outputs numbers with dot separators', function() {
+      expect(arrayToGlsl([1, 0, 3.45, 0.8888])).to.eql('vec4(1.0, 0.0, 3.45, 0.8888)');
+      expect(arrayToGlsl([3, 4])).to.eql('vec2(3.0, 4.0)');
+    });
+    it('throws on invalid lengths', function() {
+      let thrown = false;
+      try {
+        arrayToGlsl([3]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        arrayToGlsl([3, 2, 1, 0, -1]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+  });
+
+  describe('colorToGlsl', function() {
+    it('normalizes color and outputs numbers with dot separators', function() {
+      expect(colorToGlsl([100, 0, 255])).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
+      expect(colorToGlsl([100, 0, 255, 1])).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
+    });
+    it('handles colors in string format', function() {
+      expect(colorToGlsl('red')).to.eql('vec4(1.0, 0.0, 0.0, 1.0)');
+      expect(colorToGlsl('#00ff99')).to.eql('vec4(0.0, 1.0, 0.6, 1.0)');
+      expect(colorToGlsl('rgb(100, 0, 255)')).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
+      expect(colorToGlsl('rgba(100, 0, 255, 0.3)')).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 0.3)');
+    });
+  });
 
   describe('getValueType', function() {
 
@@ -56,6 +106,35 @@ describe('ol.style.expressions', function() {
       expect(getValueType(['between', ['get', 'attr4'], -4.0, 5.0])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['!', ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['interpolate', ['get', 'attr4'], [255, 255, 255, 1], 'transparent'])).to.eql(ValueTypes.COLOR);
+    });
+
+  });
+
+  describe('expressionToGlsl', function() {
+    let context;
+
+    beforeEach(function() {
+      context = {};
+    });
+
+    it('correctly converts expressions to GLSL', function() {
+      expect(expressionToGlsl(context, ['get', 'myAttr'])).to.eql('a_myAttr');
+      expect(expressionToGlsl(context, ['var', 'myValue'])).to.eql('u_myValue');
+      expect(expressionToGlsl(context, ['time'])).to.eql('u_time');
+      expect(expressionToGlsl(context, ['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
+      expect(expressionToGlsl(context, ['/', ['-', ['get', 'size'], 20], 100])).to.eql('((a_size - 20.0) / 100.0)');
+      expect(expressionToGlsl(context, ['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');
+      expect(expressionToGlsl(context, ['stretch', ['get', 'size'], 10, 100, 4, 8])).to.eql('((clamp(a_size, 10.0, 100.0) - 10.0) * ((8.0 - 4.0) / (100.0 - 10.0)) + 4.0)');
+      expect(expressionToGlsl(context, ['pow', ['mod', ['time'], 10], 2])).to.eql('pow(mod(u_time, 10.0), 2.0)');
+      expect(expressionToGlsl(context, ['>', 10, ['get', 'attr4']])).to.eql('(10.0 > a_attr4)');
+      expect(expressionToGlsl(context, ['>=', 10, ['get', 'attr4']])).to.eql('(10.0 >= a_attr4)');
+      expect(expressionToGlsl(context, ['<', 10, ['get', 'attr4']])).to.eql('(10.0 < a_attr4)');
+      expect(expressionToGlsl(context, ['<=', 10, ['get', 'attr4']])).to.eql('(10.0 <= a_attr4)');
+      expect(expressionToGlsl(context, ['==', 10, ['get', 'attr4']])).to.eql('(10.0 == a_attr4)');
+      expect(expressionToGlsl(context, ['between', ['get', 'attr4'], -4.0, 5.0])).to.eql('(a_attr4 >= -4.0 && a_attr4 <= 5.0)');
+      expect(expressionToGlsl(context, ['!', ['get', 'attr4']])).to.eql('(!a_attr4)');
+      expect(expressionToGlsl(context, ['interpolate', ['get', 'attr4'], [255, 255, 255, 1], 'transparent'])).to.eql(
+        'mix(vec4(1.0, 1.0, 1.0, 1.0), vec4(0.0, 0.0, 0.0, 0.0), a_attr4)');
     });
 
   });

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -1,0 +1,41 @@
+import {getValueType, ValueTypes} from '../../../../src/ol/style/expressions.js';
+
+
+describe('ol.style.expressions', function() {
+
+  describe('getValueType', function() {
+
+    it('correctly analyzes a literal value', function() {
+      expect(getValueType(1234)).to.eql(ValueTypes.NUMBER);
+      expect(getValueType([1, 2, 3, 4])).to.eql(ValueTypes.COLOR | ValueTypes.NUMBER_ARRAY);
+      expect(getValueType([1, 2, 3])).to.eql(ValueTypes.COLOR | ValueTypes.NUMBER_ARRAY);
+      expect(getValueType([1, 2])).to.eql(ValueTypes.NUMBER_ARRAY);
+      expect(getValueType([1, 2, 3, 4, 5])).to.eql(ValueTypes.NUMBER_ARRAY);
+      expect(getValueType('yellow')).to.eql(ValueTypes.COLOR | ValueTypes.STRING);
+      expect(getValueType('#113366')).to.eql(ValueTypes.COLOR | ValueTypes.STRING);
+      expect(getValueType('rgba(252,171,48,0.62)')).to.eql(ValueTypes.COLOR | ValueTypes.STRING);
+      expect(getValueType('abcd')).to.eql(ValueTypes.STRING);
+      expect(getValueType(true)).to.eql(ValueTypes.BOOLEAN);
+    });
+
+    it('throws on an unsupported type (object)', function(done) {
+      try {
+        getValueType(new Object());
+      } catch (e) {
+        done();
+      }
+      done(true);
+    });
+
+    it('throws on an unsupported type (mixed array)', function(done) {
+      try {
+        getValueType([1, true, 'aa']);
+      } catch (e) {
+        done();
+      }
+      done(true);
+    });
+
+  });
+
+});

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -114,7 +114,10 @@ describe('ol.style.expressions', function() {
     let context;
 
     beforeEach(function() {
-      context = {};
+      context = {
+        variables: [],
+        attributes: []
+      };
     });
 
     it('correctly converts expressions to GLSL', function() {
@@ -135,6 +138,21 @@ describe('ol.style.expressions', function() {
       expect(expressionToGlsl(context, ['!', ['get', 'attr4']])).to.eql('(!a_attr4)');
       expect(expressionToGlsl(context, ['interpolate', ['get', 'attr4'], [255, 255, 255, 1], 'transparent'])).to.eql(
         'mix(vec4(1.0, 1.0, 1.0, 1.0), vec4(0.0, 0.0, 0.0, 0.0), a_attr4)');
+    });
+
+    it('correctly adapts output for fragment shaders', function() {
+      context.inFragmentShader = true;
+      expect(expressionToGlsl(context, ['get', 'myAttr'])).to.eql('v_myAttr');
+    });
+
+    it('correctly adapts output for fragment shaders', function() {
+      expressionToGlsl(context, ['get', 'myAttr']);
+      expressionToGlsl(context, ['var', 'myVar']);
+      expressionToGlsl(context, ['clamp', ['get', 'attr2'], ['get', 'attr2'], ['get', 'myAttr']]);
+      expressionToGlsl(context, ['*', ['get', 'attr2'], ['var', 'myVar']]);
+      expressionToGlsl(context, ['*', ['get', 'attr3'], ['var', 'myVar2']]);
+      expect(context.attributes).to.eql(['myAttr', 'attr2', 'attr3']);
+      expect(context.variables).to.eql(['myVar', 'myVar2']);
     });
 
   });

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -36,6 +36,28 @@ describe('ol.style.expressions', function() {
       done(true);
     });
 
+    it('correctly analyzes operator return types', function() {
+      expect(getValueType(['get', 'myAttr'])).to.eql(ValueTypes.ANY);
+      expect(getValueType(['var', 'myValue'])).to.eql(ValueTypes.ANY);
+      expect(getValueType(['time'])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['+', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['-', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['/', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['*', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['stretch', ['get', 'size'], 10, 100, 4, 8])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['pow', 10, 2])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['mod', ['time'], 10])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['>', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['>=', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['<', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['<=', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['==', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['between', ['get', 'attr4'], -4.0, 5.0])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['!', ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['interpolate', ['get', 'attr4'], [255, 255, 255, 1], 'transparent'])).to.eql(ValueTypes.COLOR);
+    });
+
   });
 
 });

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -357,4 +357,43 @@ describe('ol.style.expressions', function() {
     });
 
   });
+
+  describe('complex expressions', function() {
+    let context;
+
+    beforeEach(function() {
+      context = {
+        variables: [],
+        attributes: [],
+        stringLiteralsMap: {}
+      };
+    });
+
+    it('correctly parses a combination of interpolate, match, color and number', function() {
+      const expression = ['interpolate',
+        ['pow',
+          ['/',
+            ['mod',
+              ['+',
+                ['time'],
+                ['stretch', ['get', 'year'], 1850, 2020, 0, 8]
+              ],
+              8
+            ],
+            8
+          ],
+          0.5
+        ],
+        'rgba(242,56,22,0.61)',
+        ['match',
+          ['get', 'year'],
+          2000, 'green',
+          '#ffe52c'
+        ]
+      ];
+      expect(expressionToGlsl(context, expression)).to.eql(
+        'mix(vec4(0.9490196078431372, 0.2196078431372549, 0.08627450980392157, 0.61), (a_year == 2000.0 ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : vec4(1.0, 0.8980392156862745, 0.17254901960784313, 1.0)), pow((mod((u_time + ((clamp(a_year, 1850.0, 2020.0) - 1850.0) * ((8.0 - 0.0) / (2020.0 - 1850.0)) + 0.0)), 8.0) / 8.0), 0.5))'
+      );
+    });
+  });
 });

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -155,6 +155,77 @@ describe('ol.style.expressions', function() {
       expect(context.variables).to.eql(['myVar', 'myVar2']);
     });
 
+    it('gives precedence to the string type unless asked otherwise', function() {
+      expect(expressionToGlsl(context, 'lightgreen')).to.eql('lightgreen');
+      expect(expressionToGlsl(context, 'lightgreen', ValueTypes.COLOR)).to.eql(
+        'vec4(0.5647058823529412, 0.9333333333333333, 0.5647058823529412, 1.0)');
+    });
+
+    it('throws on unsupported types for operators', function() {
+      let thrown = false;
+      try {
+        expressionToGlsl(context, ['var', 1234]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, ['<', 0, 'aa']);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, ['+', true, ['get', 'attr']]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, ['interpolate', ['get', 'attr4'], 1, '#3344FF']);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
+    it('throws with the wrong number of arguments', function() {
+      let thrown = false;
+      try {
+        expressionToGlsl(context, ['var', 1234, 456]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, ['<', 4]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, ['+']);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
+    it('throws on invalid expressions', function() {
+      let thrown = false;
+      try {
+        expressionToGlsl(context, true);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, [123, 456]);
+      } catch (e) {
+        thrown = true;
+      }
+      try {
+        expressionToGlsl(context, null);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
   });
 
 });

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -1,8 +1,8 @@
 import {
   arrayToGlsl, colorToGlsl,
   expressionToGlsl,
-  getValueType,
-  numberToGlsl,
+  getValueType, isTypeUnique,
+  numberToGlsl, stringToGlsl,
   ValueTypes
 } from '../../../../src/ol/style/expressions.js';
 
@@ -50,6 +50,38 @@ describe('ol.style.expressions', function() {
       expect(colorToGlsl('#00ff99')).to.eql('vec4(0.0, 1.0, 0.6, 1.0)');
       expect(colorToGlsl('rgb(100, 0, 255)')).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 1.0)');
       expect(colorToGlsl('rgba(100, 0, 255, 0.3)')).to.eql('vec4(0.39215686274509803, 0.0, 1.0, 0.3)');
+    });
+  });
+
+  describe('stringToGlsl', function() {
+    let context;
+    beforeEach(function() {
+      context = {
+        stringLiteralsMap: {}
+      };
+    });
+
+    it('maps input string to stable numbers', function() {
+      expect(stringToGlsl(context, 'abcd')).to.eql('0.0');
+      expect(stringToGlsl(context, 'defg')).to.eql('1.0');
+      expect(stringToGlsl(context, 'hijk')).to.eql('2.0');
+      expect(stringToGlsl(context, 'abcd')).to.eql('0.0');
+      expect(stringToGlsl(context, 'def')).to.eql('3.0');
+    });
+  });
+
+  describe('isTypeUnique', function() {
+    it('return true if only one value type', function() {
+      expect(isTypeUnique(ValueTypes.NUMBER)).to.eql(true);
+      expect(isTypeUnique(ValueTypes.STRING)).to.eql(true);
+      expect(isTypeUnique(ValueTypes.COLOR)).to.eql(true);
+    });
+    it('return false if several value types', function() {
+      expect(isTypeUnique(ValueTypes.NUMBER | ValueTypes.COLOR)).to.eql(false);
+      expect(isTypeUnique(ValueTypes.ANY)).to.eql(false);
+    });
+    it('return false if no value type', function() {
+      expect(isTypeUnique(ValueTypes.NUMBER & ValueTypes.COLOR)).to.eql(false);
     });
   });
 
@@ -116,7 +148,8 @@ describe('ol.style.expressions', function() {
     beforeEach(function() {
       context = {
         variables: [],
-        attributes: []
+        attributes: [],
+        stringLiteralsMap: {}
       };
     });
 
@@ -156,7 +189,7 @@ describe('ol.style.expressions', function() {
     });
 
     it('gives precedence to the string type unless asked otherwise', function() {
-      expect(expressionToGlsl(context, 'lightgreen')).to.eql('lightgreen');
+      expect(expressionToGlsl(context, 'lightgreen')).to.eql('0.0');
       expect(expressionToGlsl(context, 'lightgreen', ValueTypes.COLOR)).to.eql(
         'vec4(0.5647058823529412, 0.9333333333333333, 0.5647058823529412, 1.0)');
     });
@@ -225,7 +258,6 @@ describe('ol.style.expressions', function() {
       }
       expect(thrown).to.be(true);
     });
-
   });
 
 });

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -129,7 +129,7 @@ describe('ol.style.expressions', function() {
       expect(getValueType(['/', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['*', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql(ValueTypes.NUMBER);
-      expect(getValueType(['pow', 10, 2])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['^', 10, 2])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['mod', ['time'], 10])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['>', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['>=', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
@@ -163,7 +163,7 @@ describe('ol.style.expressions', function() {
       expect(expressionToGlsl(context, ['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
       expect(expressionToGlsl(context, ['/', ['-', ['get', 'size'], 20], 100])).to.eql('((a_size - 20.0) / 100.0)');
       expect(expressionToGlsl(context, ['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');
-      expect(expressionToGlsl(context, ['pow', ['mod', ['time'], 10], 2])).to.eql('pow(mod(u_time, 10.0), 2.0)');
+      expect(expressionToGlsl(context, ['^', ['mod', ['time'], 10], 2])).to.eql('pow(mod(u_time, 10.0), 2.0)');
       expect(expressionToGlsl(context, ['>', 10, ['get', 'attr4']])).to.eql('(10.0 > a_attr4)');
       expect(expressionToGlsl(context, ['>=', 10, ['get', 'attr4']])).to.eql('(10.0 >= a_attr4)');
       expect(expressionToGlsl(context, ['<', 10, ['get', 'attr4']])).to.eql('(10.0 < a_attr4)');
@@ -490,7 +490,7 @@ describe('ol.style.expressions', function() {
     it('correctly parses a combination of interpolate, match, color and number', function() {
       const expression = ['interpolate',
         ['linear'],
-        ['pow',
+        ['^',
           ['/',
             ['mod',
               ['+',

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -14,6 +14,8 @@ const VERTEX_SHADER = `
   uniform mat4 u_offsetScaleMatrix;
   uniform mat4 u_offsetRotateMatrix;
   uniform float u_time;
+  uniform float u_zoom;
+  uniform float u_resolution;
   
   attribute float a_test;
   uniform float u_test;
@@ -28,6 +30,8 @@ const INVALID_VERTEX_SHADER = `
   uniform mat4 u_offsetScaleMatrix;
   uniform mat4 u_offsetRotateMatrix;
   uniform float u_time;
+  uniform float u_zoom;
+  uniform float u_resolution;
   
   bla
   uniform float u_test;

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -18,6 +18,8 @@ uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 
 attribute vec2 a_position;
 attribute float a_index;
@@ -59,6 +61,8 @@ uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 uniform float u_myUniform;
 attribute vec2 a_position;
 attribute float a_index;
@@ -97,6 +101,8 @@ uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 
 attribute vec2 a_position;
 attribute float a_index;
@@ -130,6 +136,8 @@ uniform mat4 u_projectionMatrix;
 uniform mat4 u_offsetScaleMatrix;
 uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 
 attribute vec2 a_position;
 attribute float a_index;
@@ -169,6 +177,8 @@ void main(void) {
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
@@ -193,6 +203,8 @@ void main(void) {
 
       expect(builder.getSymbolFragmentShader()).to.eql(`precision mediump float;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
@@ -210,6 +222,8 @@ void main(void) {
 
       expect(builder.getSymbolFragmentShader(true)).to.eql(`precision mediump float;
 uniform float u_time;
+uniform float u_zoom;
+uniform float u_resolution;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -122,6 +122,39 @@ void main(void) {
 
 }`);
     });
+    it('generates a symbol vertex shader for hitDetection', function() {
+      const builder = new ShaderBuilder();
+
+      expect(builder.getSymbolVertexShader(true)).to.eql(`precision mediump float;
+uniform mat4 u_projectionMatrix;
+uniform mat4 u_offsetScaleMatrix;
+uniform mat4 u_offsetRotateMatrix;
+uniform float u_time;
+
+attribute vec2 a_position;
+attribute float a_index;
+attribute vec4 a_hitColor;
+varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
+void main(void) {
+  mat4 offsetMatrix = u_offsetScaleMatrix;
+  vec2 size = vec2(1.0);
+  vec2 offset = vec2(0.0);
+  float offsetX = a_index == 0.0 || a_index == 3.0 ? offset.x - size.x / 2.0 : offset.x + size.x / 2.0;
+  float offsetY = a_index == 0.0 || a_index == 1.0 ? offset.y - size.y / 2.0 : offset.y + size.y / 2.0;
+  vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
+  gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
+  vec4 texCoord = vec4(0.0, 0.0, 1.0, 1.0);
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
+  v_texCoord = vec2(u, v);
+  u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
+  v_quadCoord = vec2(u, v);
+  v_hitColor = a_hitColor;
+}`);
+    });
   });
 
   describe('getSymbolFragmentShader', function() {
@@ -145,6 +178,7 @@ void main(void) {
   if (false) { discard; }
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
+
 }`);
     });
     it('generates a symbol fragment shader (with uniforms)', function() {
@@ -168,6 +202,23 @@ void main(void) {
   if (u_myUniform > 0.5) { discard; }
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
+
+}`);
+    });
+    it('generates a symbol fragment shader for hit detection', function() {
+      const builder = new ShaderBuilder();
+
+      expect(builder.getSymbolFragmentShader(true)).to.eql(`precision mediump float;
+uniform float u_time;
+
+varying vec2 v_texCoord;
+varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
+void main(void) {
+  if (false) { discard; }
+  gl_FragColor = vec4(1.0);
+  gl_FragColor.rgb *= gl_FragColor.a;
+  if (gl_FragColor.a < 0.1) { discard; } gl_FragColor = v_hitColor;
 }`);
     });
   });

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -35,8 +35,8 @@ void main(void) {
   vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
   vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
@@ -75,8 +75,8 @@ void main(void) {
   vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
   vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
@@ -113,8 +113,8 @@ void main(void) {
   vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
   vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.q;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.p;
+  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
+  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
@@ -188,7 +188,7 @@ void main(void) {
       expect(result.builder.varyings).to.eql([]);
       expect(result.builder.colorExpression).to.eql(
         'vec4(vec4(1.0, 0.0, 0.0, 1.0).rgb, vec4(1.0, 0.0, 0.0, 1.0).a * 1.0 * 1.0)');
-      expect(result.builder.sizeExpression).to.eql('vec2(4.0, 8.0)');
+      expect(result.builder.sizeExpression).to.eql('vec2(vec2(4.0, 8.0))');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
       expect(result.builder.rotateWithView).to.eql(true);
@@ -203,7 +203,7 @@ void main(void) {
           size: ['get', 'attr1'],
           color: [255, 127.5, 63.75, 0.25],
           textureCoord: [0.5, 0.5, 0.5, 1],
-          offset: [3, ['get', 'attr3']]
+          offset: ['match', ['get', 'attr3'], 'red', [6, 0], 'green', [3, 0], [0, 0]]
         }
       });
 
@@ -217,8 +217,8 @@ void main(void) {
       expect(result.builder.colorExpression).to.eql(
         'vec4(vec4(1.0, 0.5, 0.25, 0.25).rgb, vec4(1.0, 0.5, 0.25, 0.25).a * 1.0 * 1.0)'
       );
-      expect(result.builder.sizeExpression).to.eql('vec2(a_attr1, a_attr1)');
-      expect(result.builder.offsetExpression).to.eql('vec2(3.0, a_attr3)');
+      expect(result.builder.sizeExpression).to.eql('vec2(a_attr1)');
+      expect(result.builder.offsetExpression).to.eql('(a_attr3 == 1.0 ? vec2(6.0, 0.0) : (a_attr3 == 0.0 ? vec2(3.0, 0.0) : vec2(0.0, 0.0)))');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.5, 0.5, 0.5, 1.0)');
       expect(result.builder.rotateWithView).to.eql(false);
       expect(result.attributes.length).to.eql(2);
@@ -244,7 +244,7 @@ void main(void) {
       expect(result.builder.colorExpression).to.eql(
         'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0) * texture2D(u_texture, v_texCoord)'
       );
-      expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
+      expect(result.builder.sizeExpression).to.eql('vec2(6.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
       expect(result.builder.rotateWithView).to.eql(false);
@@ -277,7 +277,7 @@ void main(void) {
         'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0)'
       );
       expect(result.builder.sizeExpression).to.eql(
-        'vec2(((clamp(a_population, u_lower, u_higher) - u_lower) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0), ((clamp(a_population, u_lower, u_higher) - u_lower) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))'
+        'vec2(((clamp(a_population, u_lower, u_higher) - u_lower) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))'
       );
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
@@ -307,10 +307,10 @@ void main(void) {
       expect(result.builder.colorExpression).to.eql(
         'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 1.0 * 1.0)'
       );
-      expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
+      expect(result.builder.sizeExpression).to.eql('vec2(6.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
-      expect(result.builder.discardExpression).to.eql('(v_attr0 >= 0.0 && v_attr0 <= 10.0)');
+      expect(result.builder.discardExpression).to.eql('!(v_attr0 >= 0.0 && v_attr0 <= 10.0)');
       expect(result.builder.rotateWithView).to.eql(false);
       expect(result.attributes.length).to.eql(1);
       expect(result.attributes[0].name).to.eql('attr0');
@@ -330,7 +330,7 @@ void main(void) {
       expect(result.builder.colorExpression).to.eql(
         'vec4(mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), u_ratio).rgb, mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), u_ratio).a * 1.0 * 1.0)'
       );
-      expect(result.builder.sizeExpression).to.eql('vec2(6.0, 6.0)');
+      expect(result.builder.sizeExpression).to.eql('vec2(6.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
       expect(result.builder.rotateWithView).to.eql(false);

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -311,7 +311,7 @@ void main(void) {
         },
         symbol: {
           symbolType: 'square',
-          size: ['stretch', ['get', 'population'], ['var', 'lower'], ['var', 'higher'], 4, 8],
+          size: ['interpolate', ['linear'], ['get', 'population'], ['var', 'lower'], 4, ['var', 'higher'], 8],
           color: '#336699',
           opacity: 0.5
         }
@@ -328,7 +328,7 @@ void main(void) {
         'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0)'
       );
       expect(result.builder.sizeExpression).to.eql(
-        'vec2(((clamp(a_population, u_lower, u_higher) - u_lower) * ((8.0 - 4.0) / (u_higher - u_lower)) + 4.0))'
+        'vec2(mix(4.0, 8.0, pow(clamp((a_population - u_lower) / (u_higher - u_lower), 0.0, 1.0), 1.0)))'
       );
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');
       expect(result.builder.texCoordExpression).to.eql('vec4(0.0, 0.0, 1.0, 1.0)');
@@ -372,14 +372,14 @@ void main(void) {
         symbol: {
           symbolType: 'square',
           size: 6,
-          color: ['interpolate', ['var', 'ratio'], [255, 255, 0], 'red']
+          color: ['interpolate', ['linear'], ['var', 'ratio'], 0, [255, 255, 0], 1, 'red']
         }
       });
 
       expect(result.builder.attributes).to.eql([]);
       expect(result.builder.varyings).to.eql([]);
       expect(result.builder.colorExpression).to.eql(
-        'vec4(mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), u_ratio).rgb, mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), u_ratio).a * 1.0 * 1.0)'
+        'vec4(mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), pow(clamp((u_ratio - 0.0) / (1.0 - 0.0), 0.0, 1.0), 1.0)).rgb, mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), pow(clamp((u_ratio - 0.0) / (1.0 - 0.0), 0.0, 1.0), 1.0)).a * 1.0 * 1.0)'
       );
       expect(result.builder.sizeExpression).to.eql('vec2(6.0)');
       expect(result.builder.offsetExpression).to.eql('vec2(0.0, 0.0)');


### PR DESCRIPTION
This PR is a followup of #10168 and again brings a lot of changes to the style expressions system:
* A new `ol/style/expressions` module has been created, which holds type definitions as well as type checking and conversion to GLSL logic for style expressions; I contemplated putting this in `ol/webgl/*` but eventually went with this as it holds all the expressions logic regardless of output

* Value types in style expressions are now handled by binary flags: `ValueTypes.NUMBER`, `ValueTypes.BOOLEAN`, `ValueTypes.COLOR` and `ValueTypes.STRING`; this means an operator can have a return type of `ValueTypes.NUMBER | ValueTypes.NUMBER_ARRAY`

* Style expression operators now all have their own declaration, composed of two methods:
  * `getReturnType` returns one or more value types and is used to recursively check types in style expressions
  * `toGlsl` takes in the parsing context and operator arguments, and outputs a GLSL-compatible string (by recursively parsing its arguments)
  Each operator can now have a different logic, take in variable amount of arguments, etc.
  The parsing context is used to store variables and attributes required by the expressions.

* Several new operators are added:
  * `match` compares an input to a list of matches and returns the associated output, with a fallback value (just like the [corresponding Mapbox style operator](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-match))
  * `interpolate` has been extended to work like the [corresponding Mapbox style operator](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate), and now allows interpolating through several stops with either a linear or exponential rate. Also handles numbers in addition to colors.
    Consequently, the `stretch` operator has been removed as it was essentially doing the same thing.
    Note: the implementation here is much simpler than in Mapbox-gl-js
  * `color` and `array` both take in number values and output their respective types
  * `zoom` and `resolution` simply return the current zoom and resolution values
  * `pow` has been renamed to `^` (again, matching the [Mapbox style spec](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-^))
  * the `get` operator can now handle string attributes; these get mapped to number values at parse time, so that they can be used in the vertex/fragment shaders; the string/number map is stored in the parsing context.

* The `ShaderBuilder` class is now able to output shaders fit for hit detection

* The `WebGLPointsLayer` class now takes an optional `disableHitDetection` flag which can save some performance when hit detection is not needed (hit detection is enabled by default).

As a result, the [icon-sprite-webgl](https://2485-4723248-gh.circle-artifacts.com/0/examples/icon-sprite-webgl.html) example was rewritten to use a literal style and not handcrafted shaders. Also the [webgl-points-layer](https://2485-4723248-gh.circle-artifacts.com/0/examples/webgl-points-layer.html) has been expanded with new sample styles! 

Thanks a lot for any review. With this in, I think we have a solid foundation for using style expressions.