### PR TITLE
WebGL renderer / use the specified loading strategy for the vector data

### DIFF
--- a/examples/heatmap-earthquakes.js
+++ b/examples/heatmap-earthquakes.js
@@ -16,16 +16,15 @@ const vector = new HeatmapLayer({
     })
   }),
   blur: parseInt(blur.value, 10),
-  radius: parseInt(radius.value, 10)
-});
-
-vector.getSource().on('addfeature', function(event) {
-  // 2012_Earthquakes_Mag5.kml stores the magnitude of each earthquake in a
-  // standards-violating <magnitude> tag in each Placemark.  We extract it from
-  // the Placemark's name instead.
-  const name = event.feature.get('name');
-  const magnitude = parseFloat(name.substr(2));
-  event.feature.set('weight', magnitude - 5);
+  radius: parseInt(radius.value, 10),
+  weight: function(feature) {
+    // 2012_Earthquakes_Mag5.kml stores the magnitude of each earthquake in a
+    // standards-violating <magnitude> tag in each Placemark.  We extract it from
+    // the Placemark's name instead.
+    const name = feature.get('name');
+    const magnitude = parseFloat(name.substr(2));
+    return magnitude - 5;
+  }
 });
 
 const raster = new TileLayer({
@@ -34,7 +33,7 @@ const raster = new TileLayer({
   })
 });
 
-const map = new Map({
+new Map({
   layers: [raster, vector],
   target: 'map',
   view: new View({

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -104,7 +104,8 @@ describe('ol.renderer.webgl.PointsLayer', function() {
 
     beforeEach(function() {
       layer = new VectorLayer({
-        source: new VectorSource()
+        source: new VectorSource(),
+        renderBuffer: 10
       });
       renderer = new WebGLPointsLayerRenderer(layer, {
         vertexShader: simpleVertexShader,
@@ -230,6 +231,35 @@ describe('ol.renderer.webgl.PointsLayer', function() {
       expect(spy.callCount).to.be(1);
 
       frameState.extent = [10, 20, 30, 40];
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(2);
+    });
+
+    it('triggers source loading when the extent changes', function() {
+      const spy = sinon.spy(layer.getSource(), 'loadFeatures');
+
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(1);
+
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(1);
+
+      frameState.extent = [10, 20, 30, 40];
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(2);
+      expect(spy.getCall(1).args[0]).to.eql([0, 10, 40, 50]); // renderBuffer is 10
+    });
+
+    it('triggers source loading when the source revision changes', function() {
+      const spy = sinon.spy(layer.getSource(), 'loadFeatures');
+
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(1);
+
+      renderer.prepareFrame(frameState);
+      expect(spy.callCount).to.be(1);
+
+      layer.getSource().changed();
       renderer.prepareFrame(frameState);
       expect(spy.callCount).to.be(2);
     });


### PR DESCRIPTION
Previously the WebGL points renderer would specify an infinite extent when loading features, bypassing the loading strategy and potentially crashing the browser. It now specifies the current view extent to `vectorSource.loadFeatures`.

Fixes #10173 

@mike-000 could you please take a look? thanks!