### PR TITLE
Carbon add on API docs

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -112,7 +112,7 @@ $(function () {
     var branchSearch = url.match(/\/([^\/]*)\/apidoc\//);
     var cookieText = 'dismissed=-' + latestVersion + '-';
     var dismissed = document.cookie.indexOf(cookieText) != -1;
-    if (!dismissed && /^v[0-9\.]*$/.test(branchSearch[1]) && currentVersion != latestVersion) {
+    if (branchSearch && !dismissed && /^v[0-9\.]*$/.test(branchSearch[1]) && currentVersion != latestVersion) {
       var link = url.replace(branchSearch[0], '/latest/apidoc/');
       fetch(link, {method: 'head'}).then(function(response) {
         var a = document.getElementById('latest-link');

--- a/config/jsdoc/api/template/static/styles/site.css
+++ b/config/jsdoc/api/template/static/styles/site.css
@@ -1,14 +1,18 @@
 /* Carbon adds (see https://sell.buysellads.com) */
 
+#ad {
+  margin-left: 1em;
+  float: right;
+  width: 330px;
+  min-height: 125px;
+}
+
 #carbonads {
   font-family: "Quattrocento Sans", "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Verdana, sans-serif;
 }
 
 #carbonads {
   display: flex;
-  max-width: 330px;
-  float: right;
-  margin-left: 1em;
 }
 
 #carbonads a {
@@ -58,8 +62,16 @@
   line-height: 1;
 }
 
+#carbonads a.carbon-poweredby {
+  color: #aaa;
+}
+
 /* Clear the float after the advertisement. */
 
 .container-overview {
+  clear: both;
+}
+
+pre.source {
   clear: both;
 }

--- a/config/jsdoc/api/template/static/styles/site.css
+++ b/config/jsdoc/api/template/static/styles/site.css
@@ -1,0 +1,65 @@
+/* Carbon adds (see https://sell.buysellads.com) */
+
+#carbonads {
+  font-family: "Quattrocento Sans", "Lucida Grande", "Lucida Sans Unicode", "Lucida Sans", Geneva, Verdana, sans-serif;
+}
+
+#carbonads {
+  display: flex;
+  max-width: 330px;
+  float: right;
+  margin-left: 1em;
+}
+
+#carbonads a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#carbonads a:hover {
+  color: inherit;
+}
+
+#carbonads span {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+#carbonads .carbon-wrap {
+  display: flex;
+}
+
+.carbon-img {
+  display: block;
+  margin: 0;
+  line-height: 1;
+}
+
+.carbon-img img {
+  display: block;
+}
+
+.carbon-text {
+  font-size: 13px;
+  padding: 10px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.carbon-poweredby {
+  display: block;
+  padding: 8px 10px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  font-weight: 600;
+  font-size: 9px;
+  line-height: 1;
+}
+
+/* Clear the float after the advertisement. */
+
+.container-overview {
+  clear: both;
+}

--- a/config/jsdoc/api/template/tmpl/container.tmpl
+++ b/config/jsdoc/api/template/tmpl/container.tmpl
@@ -41,7 +41,9 @@
         <pre class="prettyprint source"><code>import <?js= doc.name ?> from '<?js= importPath ?>';</code></pre>
       <?js } ?>
     <?js } ?>
-    <script async type="text/javascript" src="https://cdn.carbonads.com/carbon.js?serve=CE7DV53U&placement=openlayersorg" id="_carbonads_js"></script>
+    <div id="ad">
+        <script async type="text/javascript" src="https://cdn.carbonads.com/carbon.js?serve=CE7DV53U&placement=openlayersorg" id="_carbonads_js"></script>
+    </div>
     <?js if (doc.classdesc) { ?>
         <div class="class-description"><?js= doc.classdesc ?></div>
     <?js } ?>

--- a/config/jsdoc/api/template/tmpl/container.tmpl
+++ b/config/jsdoc/api/template/tmpl/container.tmpl
@@ -41,6 +41,7 @@
         <pre class="prettyprint source"><code>import <?js= doc.name ?> from '<?js= importPath ?>';</code></pre>
       <?js } ?>
     <?js } ?>
+    <script async type="text/javascript" src="https://cdn.carbonads.com/carbon.js?serve=CE7DV53U&placement=openlayersorg" id="_carbonads_js"></script>
     <?js if (doc.classdesc) { ?>
         <div class="class-description"><?js= doc.classdesc ?></div>
     <?js } ?>

--- a/config/jsdoc/api/template/tmpl/layout.tmpl
+++ b/config/jsdoc/api/template/tmpl/layout.tmpl
@@ -73,6 +73,7 @@ var version = obj.packageInfo.version;
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/bootstrap.min.css">
     <link type="text/css" rel="stylesheet" href="styles/jaguar.css">
+    <link type="text/css" rel="stylesheet" href="styles/site.css">
 </head>
 <body>
 


### PR DESCRIPTION
We've discussed trying out dev related advertising on the website as a way to contribute to project maintenance.  See [a writeup](https://medium.com/open-collective/using-ads-to-sustain-open-source-d048b75d4979) from Open Collective for more on the idea.

This change adds an ad to [API doc](https://2494-4723248-gh.circle-artifacts.com/0/apidoc/module-ol_layer_Vector-VectorLayer.html) pages that looks something like this:

![image](https://user-images.githubusercontent.com/41094/67623410-2b249c80-f7e2-11e9-85f1-27e8faefd980.png)
