### PR TITLE
Keep issues assigned to a milestone from going stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,8 @@ exemptLabels:
   - regression
   - bug
   - 'pull request accepted'
+# Issues assigned to a milestone will not go stale
+exemptMilestones: true
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This makes the stale bot ignore issues that have been assigned a milestone.