### PR TITLE
Add the default to the type column

### DIFF
--- a/config/jsdoc/api/template/tmpl/params.tmpl
+++ b/config/jsdoc/api/template/tmpl/params.tmpl
@@ -16,9 +16,8 @@
         }
     });
     
-    /* determine if we need extra columns, "attributes" and "default" */
+    /* determine if we need extra "attributes" column */
     params.hasAttributes = false;
-    params.hasDefault = false;
     params.hasName = false;
     
     var colspan = 2;
@@ -40,10 +39,6 @@
             params.hasName = true;
         }
         
-        if (typeof param.defaultvalue !== 'undefined') {
-            ++colspan;
-            params.hasDefault = true;
-        }
     });
 ?>
 
@@ -55,10 +50,6 @@
 		<?js } ?>
 		
 		<th>Type</th>
-		
-		<?js if (params.hasDefault) {?>
-		<th>Default</th>
-		<?js } ?>
 		
 		<th class="last">Description</th>
 	</tr>
@@ -80,18 +71,14 @@
             <td class="type">
             <?js if (param.type && param.type.names) {?>
                 <?js= self.partial('type.tmpl', param.type.names) ?>
+                <?js if (typeof param.defaultvalue !== 'undefined') { ?>
+                    (defaults to <?js= self.htmlsafe(param.defaultvalue) ?>)
+                <?js } ?>
             <?js } ?>
             </td>
-            
-            <?js if (params.hasDefault) {?>
-                <td class="default">
-                <?js if (typeof param.defaultvalue !== 'undefined') { ?>
-                    <?js= self.htmlsafe(param.defaultvalue) ?>
-                <?js } ?>
-                </td>
+
             <?js } ?>
-            <?js } ?>
-            
+
             <td<?js= (param.subparams ? ' colspan=' + colspan : ' ') ?> class="description last">
                 <?js if (param.stability) { ?>
                     <?js= self.partial('stability.tmpl', param) ?>


### PR DESCRIPTION
This removes the dedicated "default" column in the params table in favor of an inline default in the "type" column.

Before (with "default" column):

![image](https://user-images.githubusercontent.com/41094/67627283-35608e00-f816-11e9-882d-48030ae33416.png)

After (without "default" column):

![image](https://user-images.githubusercontent.com/41094/67627289-51642f80-f816-11e9-8b32-e50d1eb39c61.png)
