### PR TITLE
Add config file for dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+# See https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    version_requirement_updates: "increase_versions_if_necessary"


### PR DESCRIPTION
Adds a config file for dependabot, based on https://dependabot.com/docs/config-file/
The update strategy is now: _Increase the version requirement only when required by the new version_
