### PR TITLE
WebGL / Add 'case' operator for style expressions

### DIFF
--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -18,7 +18,7 @@ const period = 12; // animation period in seconds
 const animRatio =
   ['^',
     ['/',
-      ['mod',
+      ['%',
         ['+',
           ['time'],
           [

--- a/examples/icon-sprite-webgl.html
+++ b/examples/icon-sprite-webgl.html
@@ -20,3 +20,7 @@ cloak:
 ---
 <div id="map" class="map"></div>
 <div>Current sighting: <span id="info"></span></div>
+<div>
+  Filter by UFO shape:
+  <select id="shape-filter"></select>
+</div>

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -23,7 +23,7 @@ import {asArray, isStringColor} from '../color.js';
  *   * `['+', value1, value1]` adds `value1` and `value2`
  *   * `['-', value1, value1]` subtracts `value2` from `value1`
  *   * `['clamp', value, low, high]` clamps `value` between `low` and `high`
- *   * `['mod', value1, value1]` returns the result of `value1 % value2` (modulo)
+ *   * `['%', value1, value1]` returns the result of `value1 % value2` (modulo)
  *   * `['^', value1, value1]` returns the value of `value1` raised to the `value2` power
  *
  * * Transform operators:
@@ -412,7 +412,7 @@ Operators['clamp'] = {
     return `clamp(${expressionToGlsl(context, args[0])}, ${min}, ${max})`;
   }
 };
-Operators['mod'] = {
+Operators['%'] = {
   getReturnType: function(args) {
     return ValueTypes.NUMBER;
   },

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -294,6 +294,94 @@ describe('ol.style.expressions', function() {
     });
   });
 
+  describe('case operator', function() {
+    let context;
+
+    beforeEach(function () {
+      context = {
+        variables: [],
+        attributes: [],
+        stringLiteralsMap: {}
+      };
+    });
+
+    it('correctly guesses the output type', function() {
+      expect(getValueType(['case', true, 0, false, [3, 4, 5], 'green']))
+        .to.eql(ValueTypes.NONE);
+      expect(getValueType(['case', true, 0, false, 1, 2]))
+        .to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['case', true, [0, 0, 0], true, [1, 2, 3], ['get', 'attr'], [4, 5, 6, 7], [8, 9, 0]]))
+        .to.eql(ValueTypes.COLOR | ValueTypes.NUMBER_ARRAY);
+      expect(getValueType(['case', true, 'red', true, 'yellow', ['get', 'attr'], 'green', 'white']))
+        .to.eql(ValueTypes.COLOR | ValueTypes.STRING);
+      expect(getValueType(['case', true, [0, 0], false, [1, 1], [2, 2]]))
+        .to.eql(ValueTypes.NUMBER_ARRAY);
+    });
+
+    it('throws if no single output type could be inferred', function() {
+      let thrown = false;
+      try {
+        expressionToGlsl(context, ['case', false, 'red', true, 'yellow', 'green'], ValueTypes.COLOR);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(false);
+
+      try {
+        expressionToGlsl(context, ['case', true, 'red', true, 'yellow', 'green']);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['case', true, 'red', false, 'yellow', 'green'], ValueTypes.NUMBER);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['case', true, 'red', false, 'yellow', 'not_a_color'], ValueTypes.COLOR);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
+    it('throws if invalid argument count', function() {
+      let thrown = false;
+      try {
+        expressionToGlsl(context, ['case', true, 0, false, 1]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['case', true, 0]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      try {
+        expressionToGlsl(context, ['case', false]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+    });
+
+    it('correctly parses the expression (colors)', function() {
+      expect(expressionToGlsl(context, ['case', ['>', ['get', 'attr'], 3], 'red', ['>', ['get', 'attr'], 1], 'yellow', 'white'], ValueTypes.COLOR))
+        .to.eql('((a_attr > 3.0) ? vec4(1.0, 0.0, 0.0, 1.0) : ((a_attr > 1.0) ? vec4(1.0, 1.0, 0.0, 1.0) : vec4(1.0, 1.0, 1.0, 1.0)))');
+    });
+  });
+
   describe('match operator', function() {
     let context;
 

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -136,6 +136,7 @@ describe('ol.style.expressions', function() {
       expect(getValueType(['<', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['<=', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['==', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
+      expect(getValueType(['!=', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['between', ['get', 'attr4'], -4.0, 5.0])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['!', ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['array', ['get', 'attr4'], 1, 2, 3])).to.eql(ValueTypes.NUMBER_ARRAY);
@@ -170,6 +171,7 @@ describe('ol.style.expressions', function() {
       expect(expressionToGlsl(context, ['<', 10, ['get', 'attr4']])).to.eql('(10.0 < a_attr4)');
       expect(expressionToGlsl(context, ['<=', 10, ['get', 'attr4']])).to.eql('(10.0 <= a_attr4)');
       expect(expressionToGlsl(context, ['==', 10, ['get', 'attr4']])).to.eql('(10.0 == a_attr4)');
+      expect(expressionToGlsl(context, ['!=', 10, ['get', 'attr4']])).to.eql('(10.0 != a_attr4)');
       expect(expressionToGlsl(context, ['between', ['get', 'attr4'], -4.0, 5.0])).to.eql('(a_attr4 >= -4.0 && a_attr4 <= 5.0)');
       expect(expressionToGlsl(context, ['!', ['get', 'attr4']])).to.eql('(!a_attr4)');
       expect(expressionToGlsl(context, ['array', ['get', 'attr4'], 1, 2, 3])).to.eql('vec4(a_attr4, 1.0, 2.0, 3.0)');

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -130,7 +130,7 @@ describe('ol.style.expressions', function() {
       expect(getValueType(['*', ['get', 'size'], 12])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['^', 10, 2])).to.eql(ValueTypes.NUMBER);
-      expect(getValueType(['mod', ['time'], 10])).to.eql(ValueTypes.NUMBER);
+      expect(getValueType(['%', ['time'], 10])).to.eql(ValueTypes.NUMBER);
       expect(getValueType(['>', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['>=', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
       expect(getValueType(['<', 10, ['get', 'attr4']])).to.eql(ValueTypes.BOOLEAN);
@@ -165,7 +165,7 @@ describe('ol.style.expressions', function() {
       expect(expressionToGlsl(context, ['+', ['*', ['get', 'size'], 0.001], 12])).to.eql('((a_size * 0.001) + 12.0)');
       expect(expressionToGlsl(context, ['/', ['-', ['get', 'size'], 20], 100])).to.eql('((a_size - 20.0) / 100.0)');
       expect(expressionToGlsl(context, ['clamp', ['get', 'attr2'], ['get', 'attr3'], 20])).to.eql('clamp(a_attr2, a_attr3, 20.0)');
-      expect(expressionToGlsl(context, ['^', ['mod', ['time'], 10], 2])).to.eql('pow(mod(u_time, 10.0), 2.0)');
+      expect(expressionToGlsl(context, ['^', ['%', ['time'], 10], 2])).to.eql('pow(mod(u_time, 10.0), 2.0)');
       expect(expressionToGlsl(context, ['>', 10, ['get', 'attr4']])).to.eql('(10.0 > a_attr4)');
       expect(expressionToGlsl(context, ['>=', 10, ['get', 'attr4']])).to.eql('(10.0 >= a_attr4)');
       expect(expressionToGlsl(context, ['<', 10, ['get', 'attr4']])).to.eql('(10.0 < a_attr4)');
@@ -297,7 +297,7 @@ describe('ol.style.expressions', function() {
   describe('case operator', function() {
     let context;
 
-    beforeEach(function () {
+    beforeEach(function() {
       context = {
         variables: [],
         attributes: [],
@@ -619,7 +619,7 @@ describe('ol.style.expressions', function() {
         ['linear'],
         ['^',
           ['/',
-            ['mod',
+            ['%',
               ['+',
                 ['time'],
                 [

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -402,6 +402,56 @@ void main(void) {
       expect(result.attributes).to.eql([]);
       expect(result.uniforms).to.have.property('u_ratio');
     });
+
+    it('correctly adds string variables to the string literals mapping', function() {
+      const result = parseLiteralStyle({
+        variables: {
+          mySize: 'abcdef'
+        },
+        symbol: {
+          symbolType: 'square',
+          size: ['match', ['var', 'mySize'], 'abc', 10, 'def', 20, 30],
+          color: 'red'
+        }
+      });
+
+      expect(result.uniforms['u_mySize']()).to.be.greaterThan(0);
+    });
+
+    it('throws when a variable is requested but not present in the style', function(done) {
+      const result = parseLiteralStyle({
+        variables: {},
+        symbol: {
+          symbolType: 'square',
+          size: ['var', 'mySize'],
+          color: 'red'
+        }
+      });
+
+      try {
+        result.uniforms['u_mySize']();
+      } catch (e) {
+        done();
+      }
+      done(true);
+    });
+
+    it('throws when a variable is requested but the style does not have a variables dict', function(done) {
+      const result = parseLiteralStyle({
+        symbol: {
+          symbolType: 'square',
+          size: ['var', 'mySize'],
+          color: 'red'
+        }
+      });
+
+      try {
+        result.uniforms['u_mySize']();
+      } catch (e) {
+        done();
+      }
+      done(true);
+    });
   });
 
 });


### PR DESCRIPTION
This PR adds the `case` operator, allowing if/else control flow in expressions. The implementation should be compliant with [the Mapbox style spec](https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-case).

Also added the `!=` operator and renamed `mod` to `%` to be more in line with the afore-mentioned spec.

Finally, a few fixes were made to the existing operators and the `ShaderBuilder` class to allow filtering on string attributes. To showcase this, the icon-sprite-webgl example was modified to allow filtering UFO sightings based on shape.