### PR TITLE
ABORT reproj tiles properly

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -69,8 +69,6 @@ class ImageTile extends Tile {
     if (this.interimTile) {
       this.interimTile.dispose();
     }
-    this.state = TileState.ABORT;
-    this.changed();
     super.disposeInternal();
   }
 

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -150,6 +150,13 @@ class Tile extends EventTarget {
   }
 
   /**
+   * @inheritDoc
+   */
+  disposeInternal() {
+    this.setState(TileState.ABORT);
+  }
+
+  /**
    * @return {string} Key.
    */
   getKey() {

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -3,7 +3,6 @@
  */
 import {getUid} from './util.js';
 import Tile from './Tile.js';
-import TileState from './TileState.js';
 import {createCanvasContext2D} from './dom.js';
 import {unlistenByKey} from './events.js';
 
@@ -25,7 +24,7 @@ class VectorRenderTile extends Tile {
 
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {TileState} state State.
+   * @param {import("./TileState.js").default} state State.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
    * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
    * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function
@@ -128,7 +127,6 @@ class VectorRenderTile extends Tile {
         executorGroups[i].disposeInternal();
       }
     }
-    this.setState(TileState.ABORT);
     super.disposeInternal();
   }
 

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -74,14 +74,6 @@ class VectorTile extends Tile {
   }
 
   /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    this.setState(TileState.ABORT);
-    super.disposeInternal();
-  }
-
-  /**
    * Get the feature format assigned for reading this tile's features.
    * @return {import("./format/Feature.js").default} Feature format.
    * @api


### PR DESCRIPTION
When the tile cache gets ride of a tile, its state needs to be set to ABORT. This is missing in `reproj/Tile`. But instead of adding it there, I restructured things a bit to set the ABORT state in the base class instead, to make sure every tile class has this behavior.

In version 5, this tile life cycle issue (along with others that we fixed already) usually did not reveal itself, because we had an incredibly big tile cache default size there. In v6, with smaller tile caches, these issues became more apparent.

Fixes #10199.