### PR TITLE
Use render tiles instead of source tiles for hit detection

### DIFF
--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -7,18 +7,19 @@ import {Fill, Stroke, Style} from '../src/ol/style.js';
 
 // lookup for selection objects
 let selection = {};
-// feature property to act as identifier
-const idProp = 'iso_a3';
 
 const vtLayer = new VectorTileLayer({
   declutter: true,
   source: new VectorTileSource({
-    format: new MVT(),
+    maxZoom: 15,
+    format: new MVT({
+      idProperty: 'iso_a3'
+    }),
     url: 'https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/' +
       'ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf'
   }),
   style: function(feature) {
-    const selected = !!selection[feature.get(idProp)];
+    const selected = !!selection[feature.getId()];
     return new Style({
       stroke: new Stroke({
         color: selected ? 'rgba(200,20,20,0.8)' : 'gray',
@@ -56,7 +57,7 @@ map.on('click', function(event) {
     if (!feature) {
       return;
     }
-    const fid = feature.get(idProp);
+    const fid = feature.getId();
 
     if (selectElement.value === 'singleselect') {
       selection = {};

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -88,11 +88,6 @@ class Tile extends EventTarget {
     const options = opt_options ? opt_options : {};
 
     /**
-     * @type {ImageData}
-     */
-    this.hitDetectionImageData = null;
-
-    /**
      * @type {import("./tilecoord.js").TileCoord}
      */
     this.tileCoord = tileCoord;

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -62,6 +62,11 @@ class VectorRenderTile extends Tile {
     this.errorSourceTileKeys = {};
 
     /**
+     * @type {ImageData}
+     */
+    this.hitDetectionImageData = null;
+
+    /**
      * @private
      * @type {!Object<string, ReplayState>}
      */
@@ -73,9 +78,9 @@ class VectorRenderTile extends Tile {
     this.wantedResolution;
 
     /**
-     * @type {!function(import("./VectorRenderTile.js").default):Array<import("./VectorTile.js").default>}
+     * @type {!function():Array<import("./VectorTile.js").default>}
      */
-    this.getSourceTiles_ = getSourceTiles;
+    this.getSourceTiles = getSourceTiles.bind(this, this);
 
     /**
      * @type {!function(import("./VectorRenderTile.js").default):void}
@@ -186,7 +191,7 @@ class VectorRenderTile extends Tile {
    * @inheritDoc
    */
   load() {
-    this.getSourceTiles_(this);
+    this.getSourceTiles();
   }
 }
 

--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -62,7 +62,10 @@ export function createHitDetectionImageData(size, transforms, features, styleFun
       const image = originalStyle.getImage();
       if (image) {
         const imgSize = image.getImageSize();
-        const imgContext = createCanvasContext2D(imgSize[0], imgSize[1]);
+        const canvas = document.createElement('canvas');
+        canvas.width = imgSize[0];
+        canvas.height = imgSize[1];
+        const imgContext = canvas.getContext('2d', {alpha: false});
         imgContext.fillStyle = color;
         const img = imgContext.canvas;
         imgContext.fillRect(0, 0, img.width, img.height);
@@ -133,13 +136,10 @@ export function hitDetect(pixel, features, imageData) {
     const r = imageData.data[index];
     const g = imageData.data[index + 1];
     const b = imageData.data[index + 2];
-    const a = imageData.data[index + 3];
-    if (a === 255) {
-      const i = b + (256 * (g + (256 * r)));
-      const indexFactor = Math.ceil((256 * 256 * 256) / features.length);
-      if (i % indexFactor === 0) {
-        resultFeatures.push(features[i / indexFactor]);
-      }
+    const i = b + (256 * (g + (256 * r)));
+    const indexFactor = Math.ceil((256 * 256 * 256) / features.length);
+    if (i % indexFactor === 0) {
+      resultFeatures.push(features[i / indexFactor]);
     }
   }
   return resultFeatures;

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -430,10 +430,9 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       }
       const extent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
       const corner = getTopLeft(extent);
-      const renderScale = tileGrid.getResolution(tileCoord[0]) / resolution;
       const tilePixel = [
-        (coordinate[0] - corner[0]) / resolution / renderScale,
-        (corner[1] - coordinate[1]) / resolution / renderScale
+        (coordinate[0] - corner[0]) / resolution,
+        (corner[1] - coordinate[1]) / resolution
       ];
       const features = tile.getSourceTiles().reduce(function(accumulator, sourceTile) {
         return accumulator.concat(sourceTile.getFeatures());
@@ -444,12 +443,13 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
         const rotation = this.renderedRotation_;
         const transforms = [
           this.getRenderTransform(tileGrid.getTileCoordCenter(tile.wrappedTileCoord),
-            resolution * renderScale, 0, 0.5, size[0], size[1], 0)
+            resolution, 0, 0.5, size[0], size[1], 0)
         ];
         requestAnimationFrame(function() {
           tile.hitDetectionImageData = createHitDetectionImageData(tileSize, transforms,
             features, layer.getStyleFunction(),
-            tileGrid.getTileCoordExtent(tile.wrappedTileCoord), resolution, rotation);
+            tileGrid.getTileCoordExtent(tile.wrappedTileCoord),
+            tile.getReplayState(layer).renderedResolution, rotation);
           resolve(hitDetect(tilePixel, features, tile.hitDetectionImageData));
         });
       } else {


### PR DESCRIPTION
The way we currently do `getFeatures(pixel)` hit detection on vector source tiles returns inaccurate results when overzoomed, because the source tile resolution will be used. A better approach is to use vector render tiles (which also make sense because we need to *render* a hit canvas).