### PR TITLE
Fix layer zIndex test with falsy values

### DIFF
--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -108,11 +108,12 @@ class BaseLayer extends BaseObject {
       managed: opt_managed === undefined ? true : opt_managed,
       hasOverlay: false
     });
+    const zIndex = this.getZIndex();
     state.opacity = clamp(Math.round(this.getOpacity() * 100) / 100, 0, 1);
     state.sourceState = this.getSourceState();
     state.visible = this.getVisible();
     state.extent = this.getExtent();
-    state.zIndex = this.getZIndex() || (state.managed === false ? Infinity : 0);
+    state.zIndex = zIndex !== undefined ? zIndex : (state.managed === false ? Infinity : 0);
     state.maxResolution = this.getMaxResolution();
     state.minResolution = Math.max(this.getMinResolution(), 0);
     state.minZoom = this.getMinZoom();

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -592,7 +592,7 @@ describe('ol.layer.Layer', function() {
         const frameState = {
           layerStatesArray: []
         };
-        map.dispatchEvent(new RenderEvent('precompose', null, frameState, null, null));
+        map.dispatchEvent(new RenderEvent('precompose', null, frameState, null));
         expect(frameState.layerStatesArray.length).to.be(1);
         const layerState = frameState.layerStatesArray[0];
         expect(layerState.layer).to.equal(layer);
@@ -644,16 +644,14 @@ describe('ol.layer.Layer', function() {
       });
 
       it('has Infinity as zIndex when not configured otherwise', function() {
-        map.dispatchEvent(new RenderEvent('precompose', null,
-          frameState, null, null));
+        map.dispatchEvent(new RenderEvent('precompose', null, frameState, null));
         const layerState = frameState.layerStatesArray[0];
         expect(layerState.zIndex).to.be(Infinity);
       });
 
       it('respects the configured zIndex', function() {
         layer.setZIndex(42);
-        map.dispatchEvent(new RenderEvent('precompose', null,
-          frameState, null, null));
+        map.dispatchEvent(new RenderEvent('precompose', null, frameState, null));
         const layerState = frameState.layerStatesArray[0];
         expect(layerState.zIndex).to.be(42);
       });

--- a/test/spec/ol/layer/layer.test.js
+++ b/test/spec/ol/layer/layer.test.js
@@ -650,10 +650,12 @@ describe('ol.layer.Layer', function() {
       });
 
       it('respects the configured zIndex', function() {
-        layer.setZIndex(42);
-        map.dispatchEvent(new RenderEvent('precompose', null, frameState, null));
-        const layerState = frameState.layerStatesArray[0];
-        expect(layerState.zIndex).to.be(42);
+        [-5, 0, 42].forEach(index => {
+          layer.setZIndex(index);
+          map.dispatchEvent(new RenderEvent('precompose', null, frameState, null));
+          const layerState = frameState.layerStatesArray[0];
+          expect(layerState.zIndex).to.be(index);
+        });
       });
 
     });


### PR DESCRIPTION
A Z-index of `0` or `undefined` were treated the same. This issue only occurs with unmanged layers.

fixes #10234 
