### PR TITLE
Don't use instanceof HTMLElement in handleMapBrowserEvent

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -949,8 +949,8 @@ class PluggableMap extends BaseObject {
       // coordinates so interactions cannot be used.
       return;
     }
-    let target = mapBrowserEvent.originalEvent.target;
-    while (target instanceof HTMLElement) {
+    let target = /** @type {Node} */ (mapBrowserEvent.originalEvent.target);
+    while (target) {
       if (target.parentElement === this.overlayContainerStopEvent_) {
         return;
       }


### PR DESCRIPTION
Because not all elements in the DOM are instance of `HTMLElement`.
For example, SVGs created with `document.createElementNS` are instances of `Element`.

fixes #10091 