### PR TITLE
Allow View.adjust* methods to take a null opt_anchor

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1252,7 +1252,7 @@ class View extends BaseObject {
     const size = this.getSizeFromViewport_(this.getRotation());
     const newResolution = this.constraints_.resolution(this.targetResolution_ * ratio, 0, size, isMoving);
 
-    if (opt_anchor !== undefined) {
+    if (opt_anchor) {
       this.targetCenter_ = this.calculateCenterZoom(newResolution, opt_anchor);
     }
 
@@ -1292,7 +1292,7 @@ class View extends BaseObject {
   adjustRotationInternal(delta, opt_anchor) {
     const isMoving = this.getAnimating() || this.getInteracting();
     const newRotation = this.constraints_.rotation(this.targetRotation_ + delta, isMoving);
-    if (opt_anchor !== undefined) {
+    if (opt_anchor) {
       this.targetCenter_ = this.calculateCenterRotate(newRotation, opt_anchor);
     }
     this.targetRotation_ += delta;


### PR DESCRIPTION
The methods `View.adjustRotation`, `View.adjustZoom` and `View.adjustResolution` optionally take an `opt_anchor` parameter. When `opt_anchor` is `undefined`, the methods work properly. When it is `null`, they currently attempt to access the `null` value as though it is a `Coordinate` object, and throw:
```
TypeError: Cannot read property '0' of null
```

This change allows `opt_anchor` to safely be `null`.

Existing code paths already expect this to be supported. For example, when `MouseWheelZoom.useAnchor_` is `false`, then [`MouseWheelZoom.lastAnchor_` remains `null`](https://github.com/openlayers/openlayers/blob/77bc6897dd4f4dd47d7f6d4dc34fb9d4c5a34a29/src/ol/interaction/MouseWheelZoom.js#L166); thus, this `null` value [is passed to `View.adjustZoom` as `opt_anchor`](https://github.com/openlayers/openlayers/blob/77bc6897dd4f4dd47d7f6d4dc34fb9d4c5a34a29/src/ol/interaction/MouseWheelZoom.js#L209).

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
