### PR TITLE
Remove all the sketch features in abortDrawing

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -881,12 +881,10 @@ class Draw extends PointerInteraction {
   abortDrawing_() {
     this.finishCoordinate_ = null;
     const sketchFeature = this.sketchFeature_;
-    if (sketchFeature) {
-      this.sketchFeature_ = null;
-      this.sketchPoint_ = null;
-      this.sketchLine_ = null;
-      this.overlay_.getSource().clear(true);
-    }
+    this.sketchFeature_ = null;
+    this.sketchPoint_ = null;
+    this.sketchLine_ = null;
+    this.overlay_.getSource().clear(true);
     return sketchFeature;
   }
 

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -1080,6 +1080,24 @@ describe('ol.interaction.Draw', function() {
       });
     });
 
+    describe('#setMap(null) when no drawing is in progress', function() {
+      beforeEach(function() {
+        map.addInteraction(interaction);
+        simulateEvent('pointermove', 10, 20);
+        expect(interaction.sketchFeature_).to.be(null);
+        expect(interaction.sketchPoint_).not.to.be(null);
+      });
+      afterEach(function() {
+        map.removeInteraction(interaction);
+      });
+      it('clears the sketch features', function() {
+        interaction.setMap(null);
+        expect(interaction.sketchFeature_).to.be(null);
+        expect(interaction.sketchPoint_).to.be(null);
+        expect(interaction.sketchLine_).to.be(null);
+      });
+    });
+
     describe('#setMap(map)', function() {
       describe('#setMap(map) when interaction is active', function() {
         it('sets the map into the feature overlay', function() {


### PR DESCRIPTION
When a draw is aborted, the sketch features are removed only if a drawing is in progress, they should be always removed.

The issue can be reproduced here:
 * https://1pfhj.csb.app/ (source: https://codesandbox.io/s/draw-features-1pfhj)
 * move the cursor
 * press `l` to switch to the draw line interaction
 * move the cursor
 * press `p` to switch to the draw line interaction

the sketch point is not under the cursor but at the position before the cursor move