### PR TITLE
WebGL / do not throw error when shader compilation gives a warning

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -143,10 +143,6 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       options.vertexShader
     );
 
-    if (this.getShaderCompileErrors()) {
-      throw new Error(this.getShaderCompileErrors());
-    }
-
     /**
      * @type {boolean}
      * @private
@@ -157,10 +153,6 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       options.hitFragmentShader,
       options.hitVertexShader
     );
-
-    if (this.getShaderCompileErrors()) {
-      throw new Error(this.getShaderCompileErrors());
-    }
 
     const customAttributes = options.attributes ?
       options.attributes.map(function(attribute) {


### PR DESCRIPTION
Fixes #10258 

Firefox sometimes gives a warning on shader compilation, and there is no way around it to my knowledge. This happens on any kind of shader and does not impact the final result whatsoever.

As a result, we have to drop the logic of stopping execution if the shader compilation fails, and let the user call `getShaderCompileErrors` manually instead.