### PR TITLE
Rework to make Document and XMLSerializer lazy and injectable

### DIFF
--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -133,7 +133,7 @@ let domImplementation_ = undefined;
  * @api
  */
 export function registerDOMImplementation(domImplementation) {
-  domImplementation_ = document;
+  domImplementation_ = domImplementation;
 }
 
 let document_ = undefined;

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -123,31 +123,26 @@ export function replaceChildren(node, children) {
   }
 }
 
-let domImplementation_ = undefined;
+let document_ = undefined;
 
 /**
- * Register an external DOMImplementation. Can be used to supply a DOMImplementation
- * in non-browser environments.
+ * Register a Document to use when creating nodes for XML serializations. Can be used
+ * to inject a Document where there is no globally available implementation.
  *
- * @param {DOMImplementation} domImplementation A DOMImplementation.
+ * @param {Document} document A Document.
  * @api
  */
-export function registerDOMImplementation(domImplementation) {
-  domImplementation_ = domImplementation;
+export function registerDocument(document) {
+  document_ = document;
 }
-
-let document_ = undefined;
 
 /**
  * Get a document that should be used when creating nodes for XML serializations.
  * @return {Document} The document.
  */
 export function getDocument() {
-  if (document_ === undefined) {
-    if (!domImplementation_ && typeof document !== 'undefined') {
-      domImplementation_ = document.implementation;
-    }
-    document_ = domImplementation_.createDocument('', '', null);
+  if (document_ === undefined && typeof document !== 'undefined') {
+    document_ = document.implementation.createDocument('', '', null);
   }
   return document_;
 }

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -122,27 +122,3 @@ export function replaceChildren(node, children) {
     node.insertBefore(newChild, oldChild);
   }
 }
-
-let document_ = undefined;
-
-/**
- * Register a Document to use when creating nodes for XML serializations. Can be used
- * to inject a Document where there is no globally available implementation.
- *
- * @param {Document} document A Document.
- * @api
- */
-export function registerDocument(document) {
-  document_ = document;
-}
-
-/**
- * Get a document that should be used when creating nodes for XML serializations.
- * @return {Document} The document.
- */
-export function getDocument() {
-  if (document_ === undefined && typeof document !== 'undefined') {
-    document_ = document.implementation.createDocument('', '', null);
-  }
-  return document_;
-}

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -122,3 +122,32 @@ export function replaceChildren(node, children) {
     node.insertBefore(newChild, oldChild);
   }
 }
+
+let domImplementation_ = undefined;
+
+/**
+ * Register an external DOMImplementation. Can be used to supply a DOMImplementation
+ * in non-browser environments.
+ *
+ * @param {DOMImplementation} domImplementation A DOMImplementation.
+ * @api
+ */
+export function registerDOMImplementation(domImplementation) {
+  domImplementation_ = document;
+}
+
+let document_ = undefined;
+
+/**
+ * Get a document that should be used when creating nodes for XML serializations.
+ * @return {Document} The document.
+ */
+export function getDocument() {
+  if (document_ === undefined) {
+    if (!domImplementation_ && typeof document !== 'undefined') {
+      domImplementation_ = document.implementation;
+    }
+    document_ = domImplementation_.createDocument('', '', null);
+  }
+  return document_;
+}

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -5,7 +5,7 @@ import {abstract} from '../util.js';
 import {extend} from '../array.js';
 import FeatureFormat from '../format/Feature.js';
 import FormatType from '../format/FormatType.js';
-import {isDocument, parse} from '../xml.js';
+import {isDocument, parse, getXMLSerializer} from '../xml.js';
 
 /**
  * @classdesc
@@ -23,7 +23,7 @@ class XMLFeature extends FeatureFormat {
      * @type {XMLSerializer}
      * @private
      */
-    this.xmlSerializer_ = new XMLSerializer();
+    this.xmlSerializer_ = getXMLSerializer();
   }
 
   /**

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -1,7 +1,8 @@
 /**
  * @module ol/format/xsd
  */
-import {getAllTextContent, DOCUMENT} from '../xml.js';
+import {getDocument} from '../dom.js';
+import {getAllTextContent} from '../xml.js';
 import {padNumber} from '../string.js';
 
 
@@ -112,7 +113,7 @@ export function writeBooleanTextNode(node, bool) {
  * @param {string} string String.
  */
 export function writeCDATASection(node, string) {
-  node.appendChild(DOCUMENT.createCDATASection(string));
+  node.appendChild(getDocument().createCDATASection(string));
 }
 
 
@@ -128,7 +129,7 @@ export function writeDateTimeTextNode(node, dateTime) {
       padNumber(date.getUTCHours(), 2) + ':' +
       padNumber(date.getUTCMinutes(), 2) + ':' +
       padNumber(date.getUTCSeconds(), 2) + 'Z';
-  node.appendChild(DOCUMENT.createTextNode(string));
+  node.appendChild(getDocument().createTextNode(string));
 }
 
 
@@ -138,7 +139,7 @@ export function writeDateTimeTextNode(node, dateTime) {
  */
 export function writeDecimalTextNode(node, decimal) {
   const string = decimal.toPrecision();
-  node.appendChild(DOCUMENT.createTextNode(string));
+  node.appendChild(getDocument().createTextNode(string));
 }
 
 
@@ -148,7 +149,7 @@ export function writeDecimalTextNode(node, decimal) {
  */
 export function writeNonNegativeIntegerTextNode(node, nonNegativeInteger) {
   const string = nonNegativeInteger.toString();
-  node.appendChild(DOCUMENT.createTextNode(string));
+  node.appendChild(getDocument().createTextNode(string));
 }
 
 
@@ -157,5 +158,5 @@ export function writeNonNegativeIntegerTextNode(node, nonNegativeInteger) {
  * @param {string} string String.
  */
 export function writeStringTextNode(node, string) {
-  node.appendChild(DOCUMENT.createTextNode(string));
+  node.appendChild(getDocument().createTextNode(string));
 }

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -1,8 +1,7 @@
 /**
  * @module ol/format/xsd
  */
-import {getDocument} from '../dom.js';
-import {getAllTextContent} from '../xml.js';
+import {getAllTextContent, getDocument} from '../xml.js';
 import {padNumber} from '../string.js';
 
 

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -486,3 +486,27 @@ export function pushSerializeAndPop(object, serializersNS, nodeFactory, values, 
   serialize(serializersNS, nodeFactory, values, objectStack, opt_keys, opt_this);
   return /** @type {O|undefined} */ (objectStack.pop());
 }
+
+let xmlSerializer_ = undefined;
+
+/**
+ * Register a XMLSerializer. Can be used
+ * to inject a XMLSerializer where there is no globally available implementation.
+ *
+ * @param {XMLSerializer} xmlSerializer A XMLSerializer.
+ * @api
+ */
+export function registerXMLSerializer(xmlSerializer) {
+  xmlSerializer_ = xmlSerializer;
+}
+
+/**
+ * Get a document that should be used when creating nodes for XML serializations.
+ * @return {XMLSerializer} The XMLSerializer.
+ */
+export function getXMLSerializer() {
+  if (xmlSerializer_ === undefined && typeof XMLSerializer !== 'undefined') {
+    xmlSerializer_ = new XMLSerializer();
+  }
+  return xmlSerializer_;
+}

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -490,8 +490,8 @@ export function pushSerializeAndPop(object, serializersNS, nodeFactory, values, 
 let xmlSerializer_ = undefined;
 
 /**
- * Register a XMLSerializer. Can be used
- * to inject a XMLSerializer where there is no globally available implementation.
+ * Register a XMLSerializer. Can be used  to inject a XMLSerializer
+ * where there is no globally available implementation.
  *
  * @param {XMLSerializer} xmlSerializer A XMLSerializer.
  * @api
@@ -501,7 +501,6 @@ export function registerXMLSerializer(xmlSerializer) {
 }
 
 /**
- * Get a document that should be used when creating nodes for XML serializations.
  * @return {XMLSerializer} The XMLSerializer.
  */
 export function getXMLSerializer() {

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -2,6 +2,7 @@
  * @module ol/xml
  */
 import {extend} from './array.js';
+import {getDocument} from './dom.js';
 
 
 /**
@@ -24,15 +25,6 @@ import {extend} from './array.js';
 
 
 /**
- * This document should be used when creating nodes for XML serializations. This
- * document is also used by {@link module:ol/xml~createElementNS}
- * @const
- * @type {Document}
- */
-export const DOCUMENT = document.implementation.createDocument('', '', null);
-
-
-/**
  * @type {string}
  */
 export const XML_SCHEMA_INSTANCE_URI = 'http://www.w3.org/2001/XMLSchema-instance';
@@ -44,7 +36,7 @@ export const XML_SCHEMA_INSTANCE_URI = 'http://www.w3.org/2001/XMLSchema-instanc
  * @return {Element} Node.
  */
 export function createElementNS(namespaceURI, qualifiedName) {
-  return DOCUMENT.createElementNS(namespaceURI, qualifiedName);
+  return getDocument().createElementNS(namespaceURI, qualifiedName);
 }
 
 

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -2,7 +2,6 @@
  * @module ol/xml
  */
 import {extend} from './array.js';
-import {getDocument} from './dom.js';
 
 
 /**
@@ -508,4 +507,29 @@ export function getXMLSerializer() {
     xmlSerializer_ = new XMLSerializer();
   }
   return xmlSerializer_;
+}
+
+
+let document_ = undefined;
+
+/**
+ * Register a Document to use when creating nodes for XML serializations. Can be used
+ * to inject a Document where there is no globally available implementation.
+ *
+ * @param {Document} document A Document.
+ * @api
+ */
+export function registerDocument(document) {
+  document_ = document;
+}
+
+/**
+ * Get a document that should be used when creating nodes for XML serializations.
+ * @return {Document} The document.
+ */
+export function getDocument() {
+  if (document_ === undefined && typeof document !== 'undefined') {
+    document_ = document.implementation.createDocument('', '', null);
+  }
+  return document_;
 }


### PR DESCRIPTION
Intends to support registering external implementations for Document and XMLSerializer so that XML based formats can be used outside browser environments.

Related to https://github.com/openlayers/openlayers/issues/8846.