### PR TITLE
Fix longitudes that wrap around the IDL when converting from EPSG:3857 to EPSG:4326

### DIFF
--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -140,6 +140,14 @@ export function toEPSG4326(input, opt_output, opt_dimension) {
   }
   for (let i = 0; i < length; i += dimension) {
     output[i] = 180 * input[i] / HALF_SIZE;
+    // fix longitudes that wrap around the international date line.
+    output[i] %= 360;
+    if (output[i] < -180) {
+      output[i] += 360;
+    }
+    if (output[i] > 180) {
+      output[i] -= 360;
+    }
     output[i + 1] = 360 * Math.atan(
       Math.exp(input[i + 1] / RADIUS)) / Math.PI - 90;
   }


### PR DESCRIPTION
This adds a bit of logic to the `toEPSG4326()` function in `src/ol/proj/epsg3857.js` (for transforming coordinates from `EPSG:3857` to `EPSG:4326`), so that longitudes cannot be less than -180 or greater than +180. This issue occurs in various circumstances (described in #3899), including when drawing shapes after the map has been panned across the international date line.

See #3899 