### PR TITLE
Fix documentation of Stroke.lineDash default value

### DIFF
--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -10,7 +10,7 @@
  * Default null; if null, the Canvas/renderer default black will be used.
  * @property {CanvasLineCap} [lineCap='round'] Line cap style: `butt`, `round`, or `square`.
  * @property {CanvasLineJoin} [lineJoin='round'] Line join style: `bevel`, `round`, or `miter`.
- * @property {Array<number>} [lineDash] Line dash pattern. Default is `undefined` (no dash).
+ * @property {Array<number>} [lineDash] Line dash pattern. Default is `null` (no dash).
  * Please note that Internet Explorer 10 and lower do not support the `setLineDash` method on
  * the `CanvasRenderingContext2D` and therefore this option will have no visual effect in these browsers.
  * @property {number} [lineDashOffset=0] Line dash offset.


### PR DESCRIPTION
Documentation states that default value of lineDash is `undefined`, but it is `null` actually. This PR updates the documentation default value to the actual one.

fixes https://github.com/openlayers/openlayers/issues/10281
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
