### PR TITLE
Use the originalEvent in the targetNotEditable condition

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -207,12 +207,9 @@ export const shiftKeyOnly = function(mapBrowserEvent) {
  * @api
  */
 export const targetNotEditable = function(mapBrowserEvent) {
-  const target = mapBrowserEvent.target;
-  const tagName = /** @type {Element} */ (target).tagName;
-  return (
-    tagName !== 'INPUT' &&
-      tagName !== 'SELECT' &&
-      tagName !== 'TEXTAREA');
+  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (mapBrowserEvent.originalEvent);
+  const tagName = /** @type {Element} */ (originalEvent.target).tagName;
+  return tagName !== 'INPUT' && tagName !== 'SELECT' && tagName !== 'TEXTAREA';
 };
 
 

--- a/test/spec/ol/interaction/keyboardzoom.test.js
+++ b/test/spec/ol/interaction/keyboardzoom.test.js
@@ -43,6 +43,21 @@ describe('ol.interaction.KeyboardZoom', function() {
 
       view.animateInternal.restore();
     });
+
+    it('does nothing if the target is editable', function() {
+      const view = map.getView();
+      const spy = sinon.spy(view, 'animateInternal');
+      const event = new MapBrowserEvent('keydown', map, {
+        type: 'keydown',
+        target: document.createElement('input'),
+        preventDefault: Event.prototype.preventDefault
+      });
+
+      event.originalEvent.charCode = '+'.charCodeAt(0);
+      map.handleMapBrowserEvent(event);
+      expect(spy.called).to.be(false);
+    });
+
   });
 
 });


### PR DESCRIPTION
fixes #10270

The condition was using `mapBrowserEvent.target` but this is always the map instance.