### PR TITLE
Fix WMS GetLegendGraphic example codesandbox error

### DIFF
--- a/examples/wms-getlegendgraphic.html
+++ b/examples/wms-getlegendgraphic.html
@@ -12,4 +12,4 @@ tags: "GetLegendGraphic, getLegendUrl, WMS"
 ---
 <div id="map" class="map"></div>
 Legend:
-<div><img id="legend" src=""/></div>
+<div><img id="legend"/></div>


### PR DESCRIPTION
`src=""` is not needed in the html and causes an error when the example is opened in codesandbox
