### PR TITLE
Do not hit detect while tile is loading

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -364,7 +364,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
           tile = undefined;
         }
       }
-      if (!tile) {
+      if (!tile || tile.loadingSourceTiles > 0) {
         resolve([]);
         return;
       }


### PR DESCRIPTION
This pull request fixes an issue with `ol/layer/VectorTile`'s `getFeatures()` method: while source tiles for a tile are still loading, the source tile's `getFeatures()` method returns `null`, resulting in a `null` entry in the features array we use for hit detection. By resolving `ol/layer/VectorTile#getFeatures()` with an empty array when a tile has loading source tiles, we can avoid this issue.