### PR TITLE
Do not fail when hit detecting  features without style

### DIFF
--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -42,6 +42,9 @@ export function createHitDetectionImageData(size, transforms, features, styleFun
       continue;
     }
     let styles = featureStyleFunction(feature, resolution);
+    if (!styles) {
+      continue;
+    }
     if (!Array.isArray(styles)) {
       styles = [styles];
     }


### PR DESCRIPTION
`ol/layer/Vector#getFeatures()` currently fails when a style function returns undefined. Which is perfectly valid if a feature is not meant to be rendered.

This pull request fixes that.