### PR TITLE
Create hit detection data per layer and without requestAnimationFrame

### DIFF
--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -61,9 +61,9 @@ class VectorRenderTile extends Tile {
     this.errorSourceTileKeys = {};
 
     /**
-     * @type {ImageData}
+     * @type {Object<number, ImageData>}
      */
-    this.hitDetectionImageData = null;
+    this.hitDetectionImageData = {};
 
     /**
      * @private

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -232,49 +232,45 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
   getFeatures(pixel) {
     return new Promise(function(resolve, reject) {
       if (!this.hitDetectionImageData_ && !this.animatingOrInteracting_) {
-        requestAnimationFrame(function() {
-          const size = [this.context.canvas.width, this.context.canvas.height];
-          apply(this.pixelTransform, size);
-          const center = this.renderedCenter_;
-          const resolution = this.renderedResolution_;
-          const rotation = this.renderedRotation_;
-          const projection = this.renderedProjection_;
-          const extent = this.renderedExtent_;
-          const layer = this.getLayer();
-          const transforms = [];
-          const width = size[0] / 2;
-          const height = size[1] / 2;
-          transforms.push(this.getRenderTransform(center, resolution, rotation, 0.5, width, height, 0).slice());
-          const source = layer.getSource();
-          const projectionExtent = projection.getExtent();
-          if (source.getWrapX() && projection.canWrapX() && !containsExtent(projectionExtent, extent)) {
-            let startX = extent[0];
-            const worldWidth = getWidth(projectionExtent);
-            let world = 0;
-            let offsetX;
-            while (startX < projectionExtent[0]) {
-              --world;
-              offsetX = worldWidth * world;
-              transforms.push(this.getRenderTransform(center, resolution, rotation, 0.5, width, height, offsetX).slice());
-              startX += worldWidth;
-            }
-            world = 0;
-            startX = extent[2];
-            while (startX > projectionExtent[2]) {
-              ++world;
-              offsetX = worldWidth * world;
-              transforms.push(this.getRenderTransform(center, resolution, rotation, 0.5, width, height, offsetX).slice());
-              startX -= worldWidth;
-            }
+        const size = [this.context.canvas.width, this.context.canvas.height];
+        apply(this.pixelTransform, size);
+        const center = this.renderedCenter_;
+        const resolution = this.renderedResolution_;
+        const rotation = this.renderedRotation_;
+        const projection = this.renderedProjection_;
+        const extent = this.renderedExtent_;
+        const layer = this.getLayer();
+        const transforms = [];
+        const width = size[0] / 2;
+        const height = size[1] / 2;
+        transforms.push(this.getRenderTransform(center, resolution, rotation, 0.5, width, height, 0).slice());
+        const source = layer.getSource();
+        const projectionExtent = projection.getExtent();
+        if (source.getWrapX() && projection.canWrapX() && !containsExtent(projectionExtent, extent)) {
+          let startX = extent[0];
+          const worldWidth = getWidth(projectionExtent);
+          let world = 0;
+          let offsetX;
+          while (startX < projectionExtent[0]) {
+            --world;
+            offsetX = worldWidth * world;
+            transforms.push(this.getRenderTransform(center, resolution, rotation, 0.5, width, height, offsetX).slice());
+            startX += worldWidth;
           }
+          world = 0;
+          startX = extent[2];
+          while (startX > projectionExtent[2]) {
+            ++world;
+            offsetX = worldWidth * world;
+            transforms.push(this.getRenderTransform(center, resolution, rotation, 0.5, width, height, offsetX).slice());
+            startX -= worldWidth;
+          }
+        }
 
-          this.hitDetectionImageData_ = createHitDetectionImageData(size, transforms,
-            this.renderedFeatures_, layer.getStyleFunction(), extent, resolution, rotation);
-          resolve(hitDetect(pixel, this.renderedFeatures_, this.hitDetectionImageData_));
-        }.bind(this));
-      } else {
-        resolve(hitDetect(pixel, this.renderedFeatures_, this.hitDetectionImageData_));
+        this.hitDetectionImageData_ = createHitDetectionImageData(size, transforms,
+          this.renderedFeatures_, layer.getStyleFunction(), extent, resolution, rotation);
       }
+      resolve(hitDetect(pixel, this.renderedFeatures_, this.hitDetectionImageData_));
     }.bind(this));
   }
 

--- a/test/spec/ol/layer/vectortile.test.js
+++ b/test/spec/ol/layer/vectortile.test.js
@@ -125,7 +125,32 @@ describe('ol.layer.VectorTile', function() {
         layer.getFeatures(pixel).then(function(features) {
           expect(features[0].get('name')).to.be('feature1');
           done();
-        });
+        }).catch(done);
+      });
+    });
+
+    it('does not give false positives', function(done) {
+      map.once('rendercomplete', function() {
+        const pixel = map.getPixelFromCoordinate(fromLonLat([0, 0]));
+        layer.getFeatures(pixel).then(function(features) {
+          expect(features.length).to.be(0);
+          done();
+        }).catch(done);
+      });
+    });
+
+    it('stores separate hit detection data for each layer that uses the source', function(done) {
+      const layer2 = new VectorTileLayer({
+        source: layer.getSource()
+      });
+      map.addLayer(layer2);
+      map.once('rendercomplete', function() {
+        const pixel = map.getPixelFromCoordinate(fromLonLat([-36, 0]));
+        Promise.all([layer.getFeatures(pixel), layer2.getFeatures(pixel)]).then(function(result) {
+          const tile = layer.getSource().tileCache.get('0/0/0');
+          expect(Object.keys(tile.hitDetectionImageData).length).to.be(2);
+          done();
+        }).catch(done);
       });
     });
 


### PR DESCRIPTION
Calculating hit detection data in an animation frame properly would require more effort, to avoid creating it multiple time if multiple calls to `getFeatures()` were made before the animation frame. Looking at the performance profile, I decided to calculate it immediately, but only when we are not animating or interacting. For vector layers, this was the case already.

With vector tile layers, the previous code did extra work when a source was shared among multiple layers. By storing hit detection data on the render tile for each layer that uses the render tile (like we do for the executor groups), we can improve that.

Fixes #10250  