### PR TITLE
Fix feature lookup after removal of alpha

### DIFF
--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -33,10 +33,10 @@ export function createHitDetectionImageData(size, transforms, features, styleFun
   const renderer = new CanvasImmediateRenderer(context, 0.5, extent, null, rotation);
   const featureCount = features.length;
   // Stretch hit detection index to use the whole available color range
-  const indexFactor = Math.ceil((256 * 256 * 256) / featureCount);
+  const indexFactor = Math.ceil((256 * 256 * 256 - 1) / featureCount);
   const featuresByZIndex = {};
-  for (let i = 0; i < featureCount; ++i) {
-    const feature = features[i];
+  for (let i = 1; i <= featureCount; ++i) {
+    const feature = features[i - 1];
     const featureStyleFunction = feature.getStyleFunction() || styleFunction;
     if (!styleFunction) {
       continue;
@@ -141,9 +141,9 @@ export function hitDetect(pixel, features, imageData) {
     const g = imageData.data[index + 1];
     const b = imageData.data[index + 2];
     const i = b + (256 * (g + (256 * r)));
-    const indexFactor = Math.ceil((256 * 256 * 256) / features.length);
-    if (i % indexFactor === 0) {
-      resultFeatures.push(features[i / indexFactor]);
+    const indexFactor = Math.ceil((256 * 256 * 256 - 1) / features.length);
+    if (i && i % indexFactor === 0) {
+      resultFeatures.push(features[i / indexFactor - 1]);
     }
   }
   return resultFeatures;


### PR DESCRIPTION
This is another `Layer#getFeatures(pixel)` fix: After the removal of alpha (#10228), we cannot use the rgb value (0, 0, 0) for encoding features any more, because that is equal to having no feature at that pixel.