### PR TITLE
Ensure that OverviewMap respects the initial rotation of attached Maps

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -304,6 +304,8 @@ class OverviewMap extends Control {
    */
   bindView_(view) {
     view.addEventListener(getChangeEventType(ViewProperty.ROTATION), this.boundHandleRotationChanged_);
+    // Sync once with the new view
+    this.handleRotationChanged_();
   }
 
   /**

--- a/test/spec/ol/control/overviewmap.test.js
+++ b/test/spec/ol/control/overviewmap.test.js
@@ -35,7 +35,7 @@ describe('ol.control.OverviewMap', function() {
       const view = new View({
         center: [0, 0],
         zoom: 0,
-        rotation: 0
+        rotation: Math.PI / 2
       });
       map.setView(view);
 
@@ -44,7 +44,7 @@ describe('ol.control.OverviewMap', function() {
       });
       map.addControl(control);
       const ovView = control.ovmap_.getView();
-      expect(ovView.getRotation()).to.be(0);
+      expect(ovView.getRotation()).to.be(Math.PI / 2);
 
       view.setRotation(Math.PI / 4);
       expect(ovView.getRotation()).to.be(Math.PI / 4);
@@ -61,9 +61,11 @@ describe('ol.control.OverviewMap', function() {
       const view = new View({
         center: [0, 0],
         zoom: 0,
-        rotation: 0
+        rotation: Math.PI / 2
       });
       map.setView(view);
+      expect(ovView.getRotation()).to.be(Math.PI / 2);
+
       view.setRotation(Math.PI / 4);
       expect(ovView.getRotation()).to.be(Math.PI / 4);
     });


### PR DESCRIPTION
Without this fix, the updated tests here will fail.