### PR TITLE
Use a minimalist pointer events polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,11 +1333,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "@openlayers/pepjs": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@openlayers/pepjs/-/pepjs-0.5.3.tgz",
-      "integrity": "sha512-Bgvi5c14BS0FJWyYWWFstNEnXsB30nK8Jt8hkAAdqr7E0gDdBBWVDglF3Ub19wTxvgJ/CVHyTY6VuCtnyRzglg=="
-    },
     "@sinonjs/commons": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -3700,6 +3695,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "elm-pep": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/elm-pep/-/elm-pep-1.0.2.tgz",
+      "integrity": "sha512-+dIbw0659EIredBSGO7/vuQ/g3lJgy98ce7rkN9LvSSsyIPjTxfuBeAsxHDJGXuCrHXwji/Z4XRLghiAz1s4Uw=="
     },
     "emoji-regex": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/openlayers/openlayers/issues"
   },
   "dependencies": {
-    "@openlayers/pepjs": "^0.5.3",
+    "elm-pep": "^1.0.2",
     "pbf": "3.2.1",
     "pixelworks": "1.1.0",
     "rbush": "^3.0.1"

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -2,7 +2,7 @@
  * @module ol/MapBrowserEventHandler
  */
 
-import '@openlayers/pepjs';
+import 'elm-pep';
 import {DEVICE_PIXEL_RATIO} from './has.js';
 import MapBrowserEventType from './MapBrowserEventType.js';
 import MapBrowserPointerEvent from './MapBrowserPointerEvent.js';

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -1,12 +1,13 @@
 /**
  * @module ol/control/MousePosition
  */
+
+import 'elm-pep';
 import {listen} from '../events.js';
 import EventType from '../pointer/EventType.js';
 import {getChangeEventType} from '../Object.js';
 import Control from './Control.js';
 import {getTransformFromProjections, identityTransform, get as getProjection, getUserProjection} from '../proj.js';
-import '@openlayers/pepjs';
 
 
 /**

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -1,6 +1,8 @@
 /**
  * @module ol/control/ZoomSlider
  */
+
+import 'elm-pep';
 import Control from './Control.js';
 import {CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 import {easeOut} from '../easing.js';
@@ -9,7 +11,6 @@ import {stopPropagation} from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import {clamp} from '../math.js';
 import PointerEventType from '../pointer/EventType.js';
-import '@openlayers/pepjs';
 
 
 /**


### PR DESCRIPTION
I've been quite unhappy with size vs. quality of the PEP polyfill for pointer events. I wanted to create a minimal polyfill myself, but before I did I fortunately found the awesome [elm-pep](https://github.com/mpizenberg/elm-pep) polyfill, which does enough for OpenLayers to work properly on browsers that do not support pointer events (which are a diminishing fraction).

Another nice thing about this change is that builds are now 17kB smaller.