### PR TITLE
Set utfgrid tile as loaded after load instead of empty

### DIFF
--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -187,7 +187,7 @@ export class CustomTile extends Tile {
     this.keys_ = json['keys'];
     this.data_ = json['data'];
 
-    this.state = TileState.EMPTY;
+    this.state = TileState.LOADED;
     this.changed();
   }
 


### PR DESCRIPTION
This patch fixes #10346 

The state of an utfgrid tile, after being loaded, should be set to LOADED instead of EMPTY.  This makes sure that the tile may be re-used afterwards instead of being requested again when mouseovering the same place.