### PR TITLE
Include Transform typedef in API

### DIFF
--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -8,6 +8,7 @@ import {assert} from './asserts.js';
  * An array representing an affine 2d transformation for use with
  * {@link module:ol/transform} functions. The array has 6 elements.
  * @typedef {!Array<number>} Transform
+ * @api
  */
 
 


### PR DESCRIPTION
Fixes #10377

It should be in the API as it is referenced in https://openlayers.org/en/latest/apidoc/module-ol_render_Event-RenderEvent.html

