### PR TITLE
Import transpiled rbush

### DIFF
--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -19,7 +19,7 @@ import {
 import {createCanvasContext2D} from '../../dom.js';
 import {labelCache, defaultTextAlign, measureTextHeight, measureAndCacheTextWidth, measureTextWidths} from '../canvas.js';
 import Disposable from '../../Disposable.js';
-import RBush from 'rbush';
+import RBush from 'rbush/rbush.js';
 
 
 /**

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -2,7 +2,7 @@
  * @module ol/structs/RBush
  */
 import {getUid} from '../util.js';
-import RBush_ from 'rbush';
+import RBush_ from 'rbush/rbush.js';
 import {createOrUpdate, equals} from '../extent.js';
 import {isEmpty} from '../obj.js';
 


### PR DESCRIPTION
As described in #10379, import the transpiled version of the `rbush` package to avoid ES6 `class` statement in application bundles.

I don't think there are currently any tests that verify the contents of a bundle but I have checked that the existing RBush tests pass.