### PR TITLE
Use box-shadow css instead of filter

### DIFF
--- a/examples/popup.css
+++ b/examples/popup.css
@@ -1,8 +1,7 @@
 .ol-popup {
   position: absolute;
   background-color: white;
-  -webkit-filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
-  filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
   padding: 15px;
   border-radius: 10px;
   border: 1px solid #cccccc;


### PR DESCRIPTION
Fixes #10390.

I found this solution on https://stackoverflow.com/questions/56478925/safari-drop-shadow-filter-remains-visible-even-with-hidden-element.