### PR TITLE
getFeaturesInExtent function for ol/source/VectorTile

### DIFF
--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -105,7 +105,9 @@ class VectorTile extends Tile {
     if (this.state == TileState.IDLE) {
       this.setState(TileState.LOADING);
       this.tileLoadFunction_(this, this.url_);
-      this.loader_(this.extent, this.resolution, this.projection);
+      if (this.loader_) {
+        this.loader_(this.extent, this.resolution, this.projection);
+      }
     }
   }
 

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -52,6 +52,17 @@ import {listen, unlistenByKey} from '../events.js';
  *   });
  * }
  * ```
+ * If you do not need extent, resolution and projection to get the features for a tile (e.g.
+ * for GeoJSON tiles), your `tileLoadFunction` does not need a `setLoader()` call. Only make sure
+ * to call `setFeatures()` on the tile:
+ * ```js
+ * const format = new GeoJSON({featureProjection: map.getView().getProjection()});
+ * async function tileLoadFunction(tile, url) {
+ *   const response = await fetch(url);
+ *   const data = await response.json();
+ *   tile.setFeatures(format.readFeatures(data));
+ * }
+ * ```
  * @property {import("../Tile.js").UrlFunction} [tileUrlFunction] Optional function to get tile URL given a tile coordinate and the projection.
  * @property {string} [url] URL template. Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * A `{?-?}` template pattern, for example `subdomain{a-f}.domain.com`, may be
@@ -232,7 +243,7 @@ class VectorTile extends UrlTile {
               sourceTile.load();
             }
           }
-          covered = false;
+          covered = covered && sourceTile && sourceTile.getState() === TileState.LOADED;
           if (!sourceTile) {
             return;
           }


### PR DESCRIPTION
Many users want to get features or render features from a VectorTile source. Not that it is a very good idea in general, but there are valid rendering-centric use cases like e.g. for creating a dynamic legend that only shows entries for classes of features that are currently rendered.

In addition to adding a `getFeaturesInExtent()` function, this pull request also simplifies the API for the VectorTile source's `tileLoadFunction`: that function can now call `VectorTile#setFeatures()` synchronously, and does not need to call `VectorTile#setLoader()` any more. The need for this simplification came up when I wrote the tests for the `getFeaturesInExtent()` function.