### PR TITLE
Do not preventDefault on pointerdown

### DIFF
--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -146,9 +146,6 @@ class PointerInteraction extends Interaction {
     } else {
       if (mapBrowserEvent.type == MapBrowserEventType.POINTERDOWN) {
         const handled = this.handleDownEvent(mapBrowserEvent);
-        if (handled) {
-          mapBrowserEvent.preventDefault();
-        }
         this.handlingDownUpSequence = handled;
         stopEvent = this.stopDown(handled);
       } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERMOVE) {

--- a/test/spec/ol/interaction/pointer.test.js
+++ b/test/spec/ol/interaction/pointer.test.js
@@ -22,14 +22,14 @@ describe('ol.interaction.Pointer', function() {
       defaultPrevented = false;
     });
 
-    it('prevents default on handled down event', function() {
+    it('does not prevent default on handled down event', function() {
       const interaction = new PointerInteraction({
         handleDownEvent: function() {
           return true;
         }
       });
       interaction.handleEvent(event);
-      expect(defaultPrevented).to.be(true);
+      expect(defaultPrevented).to.be(false);
     });
 
     it('does not prevent default on unhandled down event', function() {


### PR DESCRIPTION
The `preventDefault()` call on `pointerdown` (introduced with #8465) is no longer necessary after the recent scroll behavior improvements (#10332).

Fixes #10232.