### PR TITLE
Use render feature compatible extent check

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -204,7 +204,7 @@ class VectorTile extends UrlTile {
             for (let j = 0, jj = tileFeatures.length; j < jj; ++j) {
               const candidate = tileFeatures[j];
               const geometry = candidate.getGeometry();
-              if (geometry.intersectsExtent(extent)) {
+              if (intersects(extent, geometry.getExtent())) {
                 features.push(candidate);
               }
             }


### PR DESCRIPTION
This pull request simply changes the way we compare the geometry extent against the queried extent. The previous version only worked for `ol/geom/Geometry` geometries, but not for `ol/render/Feature` geometries.