### PR TITLE
Control button span element pointer events

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -150,6 +150,9 @@
   border: none;
   padding: 0;
 }
+.ol-control button span {
+  pointer-events: none;
+}
 .ol-zoom-extent button {
   line-height: 1.4em;
 }


### PR DESCRIPTION
Fixes #10126

Prevent pointer events on span elements within control buttons as they propagate to the map

