### PR TITLE
Avoid accessing the DOM to read the viewport size too often

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/PluggableMap
  */
-import {getUid} from './util.js';
 import Collection from './Collection.js';
 import CollectionEventType from './CollectionEventType.js';
 import MapBrowserEvent from './MapBrowserEvent.js';
@@ -1102,7 +1101,8 @@ class PluggableMap extends BaseObject {
     }
     const view = this.getView();
     if (view) {
-      this.viewport_.setAttribute('data-view', getUid(view));
+      this.updateViewportSize_();
+
       this.viewPropertyListenerKey_ = listen(
         view, ObjectEventType.PROPERTYCHANGE,
         this.handleViewPropertyChanged_, this);
@@ -1359,6 +1359,27 @@ class PluggableMap extends BaseObject {
             parseFloat(computedStyle['paddingBottom']) -
             parseFloat(computedStyle['borderBottomWidth'])
       ]);
+    }
+
+    this.updateViewportSize_();
+  }
+
+  /**
+   * Recomputes the viewport size and save it on the view object (if any)
+   * @private
+   */
+  updateViewportSize_() {
+    const view = this.getView();
+    if (view) {
+      let size = undefined;
+      const computedStyle = getComputedStyle(this.viewport_);
+      if (computedStyle.width && computedStyle.height) {
+        size = [
+          parseInt(computedStyle.width, 10),
+          parseInt(computedStyle.height, 10)
+        ];
+      }
+      view.setViewportSize(size);
     }
   }
 }

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1461,28 +1461,37 @@ describe('ol.View', function() {
     });
   });
 
-  describe('#getSizeFromViewport_()', function() {
+  describe('#getViewportSize_()', function() {
     let map, target;
     beforeEach(function() {
       target = document.createElement('div');
       target.style.width = '200px';
       target.style.height = '150px';
+      document.body.appendChild(target);
       map = new Map({
         target: target
       });
-      document.body.appendChild(target);
     });
     afterEach(function() {
       map.setTarget(null);
       document.body.removeChild(target);
     });
-    it('calculates the size correctly', function() {
-      let size = map.getView().getSizeFromViewport_();
+    it('correctly initializes the viewport size', function() {
+      const size = map.getView().getViewportSize_();
       expect(size).to.eql([200, 150]);
-      size = map.getView().getSizeFromViewport_(Math.PI / 2);
+    });
+    it('correctly updates the viewport size', function() {
+      target.style.width = '300px';
+      target.style.height = '200px';
+      map.updateSize();
+      const size = map.getView().getViewportSize_();
+      expect(size).to.eql([300, 200]);
+    });
+    it('calculates the size correctly', function() {
+      let size = map.getView().getViewportSize_(Math.PI / 2);
       expect(size[0]).to.roughlyEqual(150, 1e-9);
       expect(size[1]).to.roughlyEqual(200, 1e-9);
-      size = map.getView().getSizeFromViewport_(Math.PI);
+      size = map.getView().getViewportSize_(Math.PI);
       expect(size[0]).to.roughlyEqual(200, 1e-9);
       expect(size[1]).to.roughlyEqual(150, 1e-9);
     });


### PR DESCRIPTION
Fixes #10431

This optimization prevents very frequent DOM access for view constraints computation. It should generally improve performance (`getComputedStyle` will trigger a layout reflow) although the gains were pretty subtle in my tests.