### PR TITLE
Add silent mode to update feature style

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -230,13 +230,16 @@ class Feature extends BaseObject {
    * of styles, or a function that takes a resolution and returns an array of
    * styles. If it is `null` the feature has no style (a `null` style).
    * @param {import("./style/Style.js").StyleLike} style Style for this feature.
+   * @param {boolean|false}  silent change style in silent mode, not fire changed event.
    * @api
    * @fires module:ol/events/Event~BaseEvent#event:change
    */
-  setStyle(style) {
+  setStyle(style,silent=false) {
     this.style_ = style;
     this.styleFunction_ = !style ? undefined : createStyleFunction(style);
-    this.changed();
+    if(!silent){
+      this.changed();
+    }
   }
 
   /**

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -234,10 +234,10 @@ class Feature extends BaseObject {
    * @api
    * @fires module:ol/events/Event~BaseEvent#event:change
    */
-  setStyle(style,silent=false) {
+  setStyle(style, silent = false) {
     this.style_ = style;
     this.styleFunction_ = !style ? undefined : createStyleFunction(style);
-    if(!silent){
+    if (!silent) {
       this.changed();
     }
   }


### PR DESCRIPTION
Add silent mode to update feature style;I have below scenario:
I need update thousands of points on the map every 10s, each feature have alone style, I create a new source then added those features, when update their style one by one ,each setStyle method cost 4 ms, totally 4s by 1000 feature,  caused by the "changed" event called too many times ; I need a silent mode, those style will apply when I add the new source to map layer.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
