### PR TITLE
Fix for undefined source in Vector layer

### DIFF
--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -11,16 +11,6 @@ import CanvasLayerRenderer from './Layer.js';
 import {defaultOrder as defaultRenderOrder, getTolerance as getRenderTolerance, getSquaredTolerance as getSquaredRenderTolerance, renderFeature} from '../vector.js';
 import {toString as transformToString, makeScale, makeInverse, apply} from '../../transform.js';
 import {createHitDetectionImageData, hitDetect} from '../../render/canvas/hitdetect.js';
-import VectorSource from '../../source/Vector.js';
-
-
-/**
- * @const
- * @type {VectorSource}
- * @private
- */
-const emptySource = new VectorSource();
-
 
 /**
  * @classdesc
@@ -338,7 +328,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    */
   prepareFrame(frameState) {
     const vectorLayer = this.getLayer();
-    const vectorSource = vectorLayer.getSource() || emptySource;
+    const vectorSource = vectorLayer.getSource();
+    if (!vectorSource) {
+      return false;
+    }
 
     const animating = frameState.viewHints[ViewHint.ANIMATING];
     const interacting = frameState.viewHints[ViewHint.INTERACTING];

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -11,6 +11,16 @@ import CanvasLayerRenderer from './Layer.js';
 import {defaultOrder as defaultRenderOrder, getTolerance as getRenderTolerance, getSquaredTolerance as getSquaredRenderTolerance, renderFeature} from '../vector.js';
 import {toString as transformToString, makeScale, makeInverse, apply} from '../../transform.js';
 import {createHitDetectionImageData, hitDetect} from '../../render/canvas/hitdetect.js';
+import VectorSource from '../../source/Vector.js';
+
+
+/**
+ * @const
+ * @type {VectorSource}
+ * @private
+ */
+const emptySource = new VectorSource();
+
 
 /**
  * @classdesc
@@ -328,7 +338,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    */
   prepareFrame(frameState) {
     const vectorLayer = this.getLayer();
-    const vectorSource = vectorLayer.getSource();
+    const vectorSource = vectorLayer.getSource() || emptySource;
 
     const animating = frameState.viewHints[ViewHint.ANIMATING];
     const interacting = frameState.viewHints[ViewHint.INTERACTING];


### PR DESCRIPTION
Fixes #10464

The documentation implies leaving a source undefined and setting it later is valid but that causes an error in OL6 for Vector layers.  For a vector layer a source left or set null or undefined is equivalent to an empty source so treat it as such to prevent errors in `prepareFrame`
