### PR TITLE
Fix for undefined source in Image layer

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -55,16 +55,20 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     }
 
     if (!hints[ViewHint.ANIMATING] && !hints[ViewHint.INTERACTING] && !isEmpty(renderedExtent)) {
-      let projection = viewState.projection;
-      if (!ENABLE_RASTER_REPROJECTION) {
-        const sourceProjection = imageSource.getProjection();
-        if (sourceProjection) {
-          projection = sourceProjection;
+      if (imageSource) {
+        let projection = viewState.projection;
+        if (!ENABLE_RASTER_REPROJECTION) {
+          const sourceProjection = imageSource.getProjection();
+          if (sourceProjection) {
+            projection = sourceProjection;
+          }
         }
-      }
-      const image = imageSource.getImage(renderedExtent, viewResolution, pixelRatio, projection);
-      if (image && this.loadImage(image)) {
-        this.image_ = image;
+        const image = imageSource.getImage(renderedExtent, viewResolution, pixelRatio, projection);
+        if (image && this.loadImage(image)) {
+          this.image_ = image;
+        }
+      } else {
+        this.image_ = null;
       }
     }
 


### PR DESCRIPTION
This fixes a similar issue to #10473 in Image layers.

Prevent error if layer does not have a source.  Also clear any existing image if the source is set to null or undefined by `setSource`.

Tile and VectorTile layers do not appear to be affected by this issue.