### PR TITLE
Do not abort and dispose of tiles

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -59,20 +59,6 @@ class ImageTile extends Tile {
   }
 
   /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    if (this.state == TileState.LOADING) {
-      this.unlistenImage_();
-      this.image_ = getBlankImage();
-    }
-    if (this.interimTile) {
-      this.interimTile.dispose();
-    }
-    super.disposeInternal();
-  }
-
-  /**
    * Get the HTML image element for this tile (may be a Canvas, Image, or Video).
    * @return {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement} Image.
    * @api

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -145,6 +145,12 @@ class Tile extends EventTarget {
   }
 
   /**
+   * Called by the tile cache when the tile is removed from the cache due to expiry
+   */
+  release() {
+  }
+
+  /**
    * @return {string} Key.
    */
   getKey() {

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -145,13 +145,6 @@ class Tile extends EventTarget {
   }
 
   /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    this.setState(TileState.ABORT);
-  }
-
-  /**
    * @return {string} Key.
    */
   getKey() {

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -15,7 +15,7 @@ class TileCache extends LRUCache {
       if (tile.getKey() in usedTiles) {
         break;
       } else {
-        this.pop();
+        this.pop().release();
       }
     }
   }
@@ -33,6 +33,7 @@ class TileCache extends LRUCache {
     this.forEach(function(tile) {
       if (tile.tileCoord[0] !== z) {
         this.remove(getKey(tile.tileCoord));
+        tile.release();
       }
     }.bind(this));
   }

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -7,15 +7,6 @@ import {fromKey, getKey} from './tilecoord.js';
 class TileCache extends LRUCache {
 
   /**
-   * @param {number=} opt_highWaterMark High water mark.
-   */
-  constructor(opt_highWaterMark) {
-
-    super(opt_highWaterMark);
-
-  }
-
-  /**
    * @param {!Object<string, import("./TileRange.js").default>} usedTiles Used tiles.
    */
   expireCache(usedTiles) {
@@ -24,7 +15,7 @@ class TileCache extends LRUCache {
       if (tile.getKey() in usedTiles) {
         break;
       } else {
-        this.pop().dispose();
+        this.pop();
       }
     }
   }
@@ -42,7 +33,6 @@ class TileCache extends LRUCache {
     this.forEach(function(tile) {
       if (tile.tileCoord[0] !== z) {
         this.remove(getKey(tile.tileCoord));
-        tile.dispose();
       }
     }.bind(this));
   }

--- a/src/ol/TileQueue.js
+++ b/src/ol/TileQueue.js
@@ -84,8 +84,7 @@ class TileQueue extends PriorityQueue {
   handleTileChange(event) {
     const tile = /** @type {import("./Tile.js").default} */ (event.target);
     const state = tile.getState();
-    if (tile.hifi && state === TileState.LOADED || state === TileState.ERROR ||
-        state === TileState.EMPTY || state === TileState.ABORT) {
+    if (tile.hifi && state === TileState.LOADED || state === TileState.ERROR || state === TileState.EMPTY) {
       tile.removeEventListener(EventType.CHANGE, this.boundHandleTileChange_);
       const tileKey = tile.getKey();
       if (tileKey in this.tilesLoadingKeys_) {
@@ -102,26 +101,18 @@ class TileQueue extends PriorityQueue {
    */
   loadMoreTiles(maxTotalLoading, maxNewLoads) {
     let newLoads = 0;
-    let abortedTiles = false;
     let state, tile, tileKey;
     while (this.tilesLoading_ < maxTotalLoading && newLoads < maxNewLoads &&
            this.getCount() > 0) {
       tile = /** @type {import("./Tile.js").default} */ (this.dequeue()[0]);
       tileKey = tile.getKey();
       state = tile.getState();
-      if (state === TileState.ABORT) {
-        abortedTiles = true;
-      } else if (state === TileState.IDLE && !(tileKey in this.tilesLoadingKeys_)) {
+      if (state === TileState.IDLE && !(tileKey in this.tilesLoadingKeys_)) {
         this.tilesLoadingKeys_[tileKey] = true;
         ++this.tilesLoading_;
         ++newLoads;
         tile.load();
       }
-    }
-    if (newLoads === 0 && abortedTiles) {
-      // Do not stop the render loop when all wanted tiles were aborted due to
-      // a small, saturated tile cache.
-      this.tileChangeCallback_();
     }
   }
 }

--- a/src/ol/TileState.js
+++ b/src/ol/TileState.js
@@ -14,6 +14,5 @@ export default {
    * @type {number}
    */
   ERROR: 3,
-  EMPTY: 4,
-  ABORT: 5
+  EMPTY: 4
 };

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -68,6 +68,11 @@ class VectorRenderTile extends Tile {
     this.replayState_ = {};
 
     /**
+     * @type {Array<import("./VectorTile.js").default>}
+     */
+    this.sourceTiles = null;
+
+    /**
      * @type {number}
      */
     this.wantedResolution;

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -127,12 +127,6 @@ class VectorRenderTile extends Tile {
       canvas.width = 0;
       canvas.height = 0;
     }
-    for (const key in this.executorGroups) {
-      const executorGroups = this.executorGroups[key];
-      for (let i = 0, ii = executorGroups.length; i < ii; ++i) {
-        executorGroups[i].disposeInternal();
-      }
-    }
     super.disposeInternal();
   }
 

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -26,7 +26,7 @@ class VectorRenderTile extends Tile {
    * @param {import("./TileState.js").default} state State.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
    * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function
-   * to get an source tiles for this tile.
+   * to get source tiles for this tile.
    */
   constructor(tileCoord, state, urlTileCoord, getSourceTiles) {
 
@@ -75,7 +75,7 @@ class VectorRenderTile extends Tile {
     /**
      * @type {!function():Array<import("./VectorTile.js").default>}
      */
-    this.getSourceTiles = getSourceTiles.bind(this, this);
+    this.getSourceTiles = getSourceTiles.bind(undefined, this);
 
     /**
      * z of the source tiles of the last getSourceTiles call.

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -4,7 +4,6 @@
 import {getUid} from './util.js';
 import Tile from './Tile.js';
 import {createCanvasContext2D} from './dom.js';
-import {unlistenByKey} from './events.js';
 
 
 /**
@@ -29,10 +28,8 @@ class VectorRenderTile extends Tile {
    * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
    * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function
    * to get an source tiles for this tile.
-   * @param {function(VectorRenderTile):void} removeSourceTiles Function to remove this tile from its
-   * source tiles's consumer count.
    */
-  constructor(tileCoord, state, urlTileCoord, sourceTileGrid, getSourceTiles, removeSourceTiles) {
+  constructor(tileCoord, state, urlTileCoord, sourceTileGrid, getSourceTiles) {
 
     super(tileCoord, state, {transition: 0});
 
@@ -82,20 +79,10 @@ class VectorRenderTile extends Tile {
     this.getSourceTiles = getSourceTiles.bind(this, this);
 
     /**
-     * @type {!function(import("./VectorRenderTile.js").default):void}
-     */
-    this.removeSourceTiles_ = removeSourceTiles;
-
-    /**
      * @private
      * @type {import("./tilegrid/TileGrid.js").default}
      */
     this.sourceTileGrid_ = sourceTileGrid;
-
-    /**
-     * @type {Array<import("./events.js").EventsKey>}
-     */
-    this.sourceTileListenerKeys = [];
 
     /**
      * z of the source tiles of the last getSourceTiles call.
@@ -113,21 +100,6 @@ class VectorRenderTile extends Tile {
      * @type {import("./tilecoord.js").TileCoord}
      */
     this.wrappedTileCoord = urlTileCoord;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    this.sourceTileListenerKeys.forEach(unlistenByKey);
-    this.sourceTileListenerKeys.length = 0;
-    this.removeSourceTiles_(this);
-    for (const key in this.context_) {
-      const canvas = this.context_[key].canvas;
-      canvas.width = 0;
-      canvas.height = 0;
-    }
-    super.disposeInternal();
   }
 
   /**

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -25,11 +25,10 @@ class VectorRenderTile extends Tile {
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("./TileState.js").default} state State.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
-   * @param {import("./tilegrid/TileGrid.js").default} sourceTileGrid Tile grid of the source.
    * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function
    * to get an source tiles for this tile.
    */
-  constructor(tileCoord, state, urlTileCoord, sourceTileGrid, getSourceTiles) {
+  constructor(tileCoord, state, urlTileCoord, getSourceTiles) {
 
     super(tileCoord, state, {transition: 0});
 
@@ -77,12 +76,6 @@ class VectorRenderTile extends Tile {
      * @type {!function():Array<import("./VectorTile.js").default>}
      */
     this.getSourceTiles = getSourceTiles.bind(this, this);
-
-    /**
-     * @private
-     * @type {import("./tilegrid/TileGrid.js").default}
-     */
-    this.sourceTileGrid_ = sourceTileGrid;
 
     /**
      * z of the source tiles of the last getSourceTiles call.

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -18,6 +18,10 @@ import {createCanvasContext2D} from './dom.js';
  * @property {number} renderedTileZ
  */
 
+/**
+ * @type {Array<HTMLCanvasElement>}
+ */
+const canvasPool = [];
 
 class VectorRenderTile extends Tile {
 
@@ -107,7 +111,7 @@ class VectorRenderTile extends Tile {
   getContext(layer) {
     const key = getUid(layer);
     if (!(key in this.context_)) {
-      this.context_[key] = createCanvasContext2D();
+      this.context_[key] = createCanvasContext2D(1, 1, canvasPool);
     }
     return this.context_[key];
   }
@@ -155,6 +159,16 @@ class VectorRenderTile extends Tile {
    */
   load() {
     this.getSourceTiles();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  release() {
+    for (const key in this.context_) {
+      canvasPool.push(this.context_[key].canvas);
+    }
+    super.release();
   }
 }
 

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -19,11 +19,6 @@ class VectorTile extends Tile {
     super(tileCoord, state, opt_options);
 
     /**
-     * @type {number}
-     */
-    this.consumers = 0;
-
-    /**
      * Extent of this tile; set by the source.
      * @type {import("./extent.js").Extent}
      */

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -7,10 +7,12 @@
  * Create an html canvas element and returns its 2d context.
  * @param {number=} opt_width Canvas width.
  * @param {number=} opt_height Canvas height.
+ * @param {Array<HTMLCanvasElement>=} opt_canvasPool Canvas pool to take existing canvas from.
  * @return {CanvasRenderingContext2D} The context.
  */
-export function createCanvasContext2D(opt_width, opt_height) {
-  const canvas = document.createElement('canvas');
+export function createCanvasContext2D(opt_width, opt_height, opt_canvasPool) {
+  const canvas = opt_canvasPool && opt_canvasPool.length ?
+    opt_canvasPool.shift() : document.createElement('canvas');
   if (opt_width) {
     canvas.width = opt_width;
   }

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -18,7 +18,6 @@ import {
 } from '../../transform.js';
 import {createCanvasContext2D} from '../../dom.js';
 import {labelCache, defaultTextAlign, measureTextHeight, measureAndCacheTextWidth, measureTextWidths} from '../canvas.js';
-import Disposable from '../../Disposable.js';
 import RBush from 'rbush/rbush.js';
 
 
@@ -52,7 +51,7 @@ const p3 = [];
 const p4 = [];
 
 
-class Executor extends Disposable {
+class Executor {
   /**
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
@@ -60,7 +59,6 @@ class Executor extends Disposable {
    * @param {SerializableInstructions} instructions The serializable instructions
    */
   constructor(resolution, pixelRatio, overlaps, instructions) {
-    super();
 
     /**
      * @protected
@@ -155,15 +153,6 @@ class Executor extends Disposable {
      */
     this.widths_ = {};
   }
-
-  /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    labelCache.release(this);
-    super.disposeInternal();
-  }
-
 
   /**
    * @param {string} text Text.

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -10,7 +10,6 @@ import {isEmpty} from '../../obj.js';
 import BuilderType from './BuilderType.js';
 import {create as createTransform, compose as composeTransform} from '../../transform.js';
 import Executor from './Executor.js';
-import Disposable from '../../Disposable.js';
 
 /**
  * @const
@@ -26,7 +25,7 @@ const ORDER = [
 ];
 
 
-class ExecutorGroup extends Disposable {
+class ExecutorGroup {
   /**
    * @param {import("../../extent.js").Extent} maxExtent Max extent for clipping. When a
    * `maxExtent` was set on the Buillder for this executor group, the same `maxExtent`
@@ -40,7 +39,6 @@ class ExecutorGroup extends Disposable {
    * @param {number=} opt_renderBuffer Optional rendering buffer.
    */
   constructor(maxExtent, resolution, pixelRatio, overlaps, allInstructions, opt_renderBuffer) {
-    super();
 
     /**
      * @private
@@ -128,24 +126,6 @@ class ExecutorGroup extends Disposable {
     }
   }
 
-  /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    for (const z in this.executorsByZIndex_) {
-      const executors = this.executorsByZIndex_[z];
-      for (const key in executors) {
-        executors[key].disposeInternal();
-      }
-    }
-    if (this.hitDetectionContext_) {
-      const canvas = this.hitDetectionContext_.canvas;
-      canvas.width = 0;
-      canvas.height = 0;
-    }
-
-    super.disposeInternal();
-  }
 
   /**
    * @param {Array<BuilderType>} executors Executors.

--- a/src/ol/render/canvas/LabelCache.js
+++ b/src/ol/render/canvas/LabelCache.js
@@ -1,4 +1,3 @@
-import {getUid} from '../../util.js';
 import LRUCache from '../../structs/LRUCache.js';
 
 /**
@@ -11,58 +10,10 @@ import LRUCache from '../../structs/LRUCache.js';
  */
 class LabelCache extends LRUCache {
 
-  /**
-   * @inheritDoc
-   */
-  constructor(opt_highWaterMark) {
-    super(opt_highWaterMark);
-    this.consumers = {};
-  }
-
-  clear() {
-    this.consumers = {};
-    super.clear();
-  }
-
-  /**
-   * @override
-   * @param {string} key Label key.
-   * @param {import("./Executor.js").default} consumer Label consumer.
-   * @return {HTMLCanvasElement} Label.
-   */
-  get(key, consumer) {
-    const canvas = super.get(key);
-    const consumerId = getUid(consumer);
-    if (!(consumerId in this.consumers)) {
-      this.consumers[consumerId] = {};
-    }
-    this.consumers[consumerId][key] = true;
-    return canvas;
-  }
-
-  prune() {
-    outer:
+  expireCache() {
     while (this.canExpireCache()) {
-      const key = this.peekLastKey();
-      for (const consumerId in this.consumers) {
-        if (key in this.consumers[consumerId]) {
-          break outer;
-        }
-      }
-      const canvas = this.pop();
-      canvas.width = 0;
-      canvas.height = 0;
-      for (const consumerId in this.consumers) {
-        delete this.consumers[consumerId][key];
-      }
+      this.pop();
     }
-  }
-
-  /**
-   * @param {import("./Executor.js").default} consumer Label consumer.
-   */
-  release(consumer) {
-    delete this.consumers[getUid(consumer)];
   }
 }
 

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -131,8 +131,6 @@ class CanvasTextBuilder extends CanvasBuilder {
      * @type {string}
      */
     this.strokeKey_ = '';
-
-    labelCache.prune();
   }
 
   /**
@@ -140,6 +138,7 @@ class CanvasTextBuilder extends CanvasBuilder {
    */
   finish() {
     const instructions = super.finish();
+    labelCache.expireCache();
     instructions.textStates = this.textStates;
     instructions.fillStates = this.fillStates;
     instructions.strokeStates = this.strokeStates;

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -362,7 +362,6 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     this.manageTilePyramid(frameState, tileSource, tileGrid, pixelRatio,
       projection, extent, z, tileLayer.getPreload());
-    this.updateCacheSize_(frameState, tileSource);
     this.scheduleExpireCache(frameState, tileSource);
 
     this.postRender(context, frameState);
@@ -472,27 +471,6 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       usedTiles[tileSourceKey] = {};
     }
     usedTiles[tileSourceKey][tile.getKey()] = true;
-  }
-
-  /**
-   * Check if the cache is big enough, and increase its size if necessary.
-   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
-   * @param {import("../../source/Tile.js").default} tileSource Tile source.
-   * @private
-   */
-  updateCacheSize_(frameState, tileSource) {
-    const tileSourceKey = getUid(tileSource);
-    let size = 0;
-    if (tileSourceKey in frameState.usedTiles) {
-      size += Object.keys(frameState.usedTiles[tileSourceKey]).length;
-    }
-    if (tileSourceKey in frameState.wantedTiles) {
-      size += Object.keys(frameState.wantedTiles[tileSourceKey]).length;
-    }
-    const tileCache = tileSource.tileCache;
-    if (tileCache.highWaterMark < size) {
-      tileCache.highWaterMark = size;
-    }
   }
 
   /**

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -384,9 +384,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       return true;
     }
 
-    if (this.replayGroup_) {
-      this.replayGroup_.dispose();
-    }
     this.replayGroup_ = null;
 
     this.dirty_ = false;

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -117,8 +117,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     let render;
     const tileUid = getUid(tile);
     const state = tile.getState();
-    if (((state === TileState.LOADED && tile.hifi) ||
-        state === TileState.ERROR || state === TileState.ABORT) &&
+    if (((state === TileState.LOADED && tile.hifi) || state === TileState.ERROR) &&
         tileUid in this.tileListenerKeys_) {
       unlistenByKey(this.tileListenerKeys_[tileUid]);
       delete this.tileListenerKeys_[tileUid];
@@ -468,9 +467,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const clipZs = [];
     for (let i = tiles.length - 1; i >= 0; --i) {
       const tile = /** @type {import("../../VectorRenderTile.js").default} */ (tiles[i]);
-      if (tile.getState() == TileState.ABORT) {
-        continue;
-      }
       const tileCoord = tile.tileCoord;
       const tileExtent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
       const worldOffset = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent)[0] - tileExtent[0];

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -218,12 +218,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
     const sourceTiles = source.getSourceTiles(pixelRatio, projection, tile);
     const layerUid = getUid(layer);
-    const executorGroups = tile.executorGroups[layerUid];
-    if (executorGroups) {
-      for (let i = 0, ii = executorGroups.length; i < ii; ++i) {
-        executorGroups[i].dispose();
-      }
-    }
     delete tile.hitDetectionImageData[layerUid];
     tile.executorGroups[layerUid] = [];
     for (let t = 0, tt = sourceTiles.length; t < tt; ++t) {

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -204,16 +204,6 @@ class ReprojTile extends Tile {
   }
 
   /**
-   * @inheritDoc
-   */
-  disposeInternal() {
-    if (this.state == TileState.LOADING) {
-      this.unlistenSources_();
-    }
-    super.disposeInternal();
-  }
-
-  /**
    * Get the HTML Canvas element for this tile.
    * @return {HTMLCanvasElement} Canvas.
    */

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -139,7 +139,7 @@ class UrlTile extends TileSource {
     } else if (uid in this.tileLoadingKeys_) {
       delete this.tileLoadingKeys_[uid];
       type = tileState == TileState.ERROR ? TileEventType.TILELOADERROR :
-        (tileState == TileState.LOADED || tileState == TileState.ABORT) ?
+        tileState == TileState.LOADED ?
           TileEventType.TILELOADEND : undefined;
     }
     if (type != undefined) {

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -407,7 +407,6 @@ class VectorTile extends UrlTile {
       tileCoord,
       empty ? TileState.EMPTY : TileState.IDLE,
       urlTileCoord,
-      this.tileGrid,
       this.getSourceTiles.bind(this, pixelRatio, projection));
 
     newTile.key = key;

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -146,12 +146,6 @@ class VectorTile extends UrlTile {
 
     /**
      * @private
-     * @type {Object<string, Array<import("../VectorTile.js").default>>}
-     */
-    this.sourceTilesByTileKey_ = {};
-
-    /**
-     * @private
      * @type {boolean}
      */
     this.overlaps_ = options.overlaps == undefined ? true : options.overlaps;
@@ -229,7 +223,6 @@ class VectorTile extends UrlTile {
   clear() {
     this.tileCache.clear();
     this.sourceTileCache.clear();
-    this.sourceTilesByTileKey_ = {};
   }
 
   /**
@@ -254,7 +247,7 @@ class VectorTile extends UrlTile {
     const sourceZ = sourceTileGrid.getZForResolution(resolution, 1);
     const minZoom = sourceTileGrid.getMinZoom();
 
-    const previousSourceTiles = this.sourceTilesByTileKey_[tile.getKey()];
+    const previousSourceTiles = tile.sourceTiles;
     let sourceTiles, covered, loadedZ;
     if (previousSourceTiles && previousSourceTiles.length > 0 && previousSourceTiles[0].tileCoord[0] === sourceZ) {
       sourceTiles = previousSourceTiles;
@@ -330,27 +323,11 @@ class VectorTile extends UrlTile {
       if (tile.getState() < TileState.LOADED) {
         tile.setState(TileState.LOADED);
       } else if (!previousSourceTiles || !equals(sourceTiles, previousSourceTiles)) {
-        this.removeSourceTiles(tile);
-        this.addSourceTiles(tile, sourceTiles);
+        tile.sourceTiles = sourceTiles;
       }
     }
     this.sourceTileCache.expireCache({});
     return sourceTiles;
-  }
-
-  /**
-   * @param {VectorRenderTile} tile Tile.
-   * @param {Array<import("../VectorTile").default>} sourceTiles Source tiles.
-   */
-  addSourceTiles(tile, sourceTiles) {
-    this.sourceTilesByTileKey_[tile.getKey()] = sourceTiles;
-  }
-
-  /**
-   * @param {VectorRenderTile} tile Tile.
-   */
-  removeSourceTiles(tile) {
-    delete this.sourceTilesByTileKey_[tile.getKey()];
   }
 
   /**

--- a/test/spec/ol/imagetile.test.js
+++ b/test/spec/ol/imagetile.test.js
@@ -83,21 +83,4 @@ describe('ol.ImageTile', function() {
 
   });
 
-  describe('dispose', function() {
-
-    it('sets image src to a blank image data uri', function() {
-      const tileCoord = [0, 0, 0];
-      const state = TileState.IDLE;
-      const src = 'spec/ol/data/osm-0-0-0.png';
-      const tileLoadFunction = defaultImageLoadFunction;
-      const tile = new ImageTile(tileCoord, state, src, null, tileLoadFunction);
-      tile.load();
-      expect(tile.getState()).to.be(TileState.LOADING);
-      tile.dispose();
-      expect(tile.getState()).to.be(TileState.ABORT);
-      expect(tile.getImage().src).to.be(ImageTile.blankImageUrl);
-    });
-
-  });
-
 });

--- a/test/spec/ol/render/canvas/labelcache.test.js
+++ b/test/spec/ol/render/canvas/labelcache.test.js
@@ -2,25 +2,11 @@ import LabelCache from '../../../../../src/ol/render/canvas/LabelCache.js';
 
 describe('ol.render.canvas.LabelCache', function() {
 
-  it('#prune()', function() {
+  it('#expireCache()', function() {
     const labelCache = new LabelCache(1);
     labelCache.set('key1', document.createElement('canvas'));
     labelCache.set('key2', document.createElement('canvas'));
-    labelCache.prune();
-    expect(labelCache.getCount()).to.be(1);
-  });
-
-  it('#prune() leaves used labels untouched until consumer is released', function() {
-    const labelCache = new LabelCache(1);
-    labelCache.set('key1', document.createElement('canvas'));
-    labelCache.set('key2', document.createElement('canvas'));
-    const consumer = {};
-    labelCache.get('key1', consumer);
-    labelCache.get('key2', consumer);
-    labelCache.prune();
-    expect(labelCache.getCount()).to.be(2);
-    labelCache.release(consumer);
-    labelCache.prune();
+    labelCache.expireCache();
     expect(labelCache.getCount()).to.be(1);
   });
 

--- a/test/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/tilelayer.test.js
@@ -78,15 +78,6 @@ describe('ol.renderer.canvas.TileLayer', function() {
       disposeMap(map);
     });
 
-    it('increases the cache size if necessary', function(done) {
-      const tileCache = layer.getSource().tileCache;
-      expect(tileCache.highWaterMark).to.be(1);
-      map.once('rendercomplete', function() {
-        expect(tileCache.highWaterMark).to.be(2);
-        done();
-      });
-    });
-
     it('respects the source\'s zDirection setting', function(done) {
       layer.getSource().zDirection = 1;
       map.getView().setZoom(5.8); // would lead to z6 tile request with the default zDirection

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -316,10 +316,10 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         tileGrid: createXYZ()
       });
       source.sourceTileCache.set('0/0/0.mvt', sourceTile);
-      source.sourceTilesByTileKey_[sourceTile.getKey()] = [sourceTile];
       executorGroup = {};
       source.getTile = function() {
         const tile = VectorTileSource.prototype.getTile.apply(source, arguments);
+        tile.sourceTiles = [sourceTile];
         tile.executorGroups[getUid(layer)] = [executorGroup];
         return tile;
       };

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -315,7 +315,7 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
         tileClass: TileClass,
         tileGrid: createXYZ()
       });
-      source.sourceTileByKey_[sourceTile.getKey()] = sourceTile;
+      source.sourceTileCache.set('0/0/0.mvt', sourceTile);
       source.sourceTilesByTileKey_[sourceTile.getKey()] = [sourceTile];
       executorGroup = {};
       source.getTile = function() {

--- a/test/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -255,11 +255,10 @@ describe('ol.renderer.canvas.VectorTileLayer', function() {
       sourceTile.getImage = function() {
         return document.createElement('canvas');
       };
-      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0], createXYZ(),
+      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0],
         function() {
           return sourceTile;
-        },
-        function() {});
+        });
       tile.transition_ = 0;
       tile.setState(TileState.LOADED);
       layer.getSource().getTile = function() {

--- a/test/spec/ol/source/tileimage.test.js
+++ b/test/spec/ol/source/tileimage.test.js
@@ -218,19 +218,6 @@ describe('ol.source.TileImage', function() {
       const tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
       tile.load();
     });
-
-    it('dispatches tileloadend events for aborted tiles', function() {
-      source.setTileLoadFunction(function() {});
-      const startSpy = sinon.spy();
-      source.on('tileloadstart', startSpy);
-      const endSpy = sinon.spy();
-      source.on('tileloadend', endSpy);
-      const tile = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));
-      tile.load();
-      tile.dispose();
-      expect(startSpy.callCount).to.be(1);
-      expect(endSpy.callCount).to.be(1);
-    });
   });
 
 });

--- a/test/spec/ol/tilecache.test.js
+++ b/test/spec/ol/tilecache.test.js
@@ -32,8 +32,6 @@ describe('ol.TileCache', function() {
         '2/1/0',
         '2/0/0'
       ]);
-
-      expect(tiles[0].dispose.calledOnce).to.be(true);
     });
   });
 });

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -89,20 +89,6 @@ describe('ol.TileQueue', function() {
 
     });
 
-    it('calls #tileChangeCallback_ when all wanted tiles are aborted', function() {
-      const tileChangeCallback = sinon.spy();
-      const queue = new TileQueue(noop, tileChangeCallback);
-      const numTiles = 20;
-      for (let i = 0; i < numTiles; ++i) {
-        const tile = createImageTile();
-        tile.state = TileState.ABORT;
-        queue.enqueue([tile]);
-      }
-      const maxLoading = numTiles / 2;
-      queue.loadMoreTiles(maxLoading, maxLoading);
-      expect(tileChangeCallback.callCount).to.be(1);
-    });
-
   });
 
   describe('heapify', function() {
@@ -144,7 +130,7 @@ describe('ol.TileQueue', function() {
   describe('tile change event', function() {
     const noop = function() {};
 
-    it('abort queued tiles', function() {
+    it('loaded tiles', function() {
       const tq = new TileQueue(noop, noop);
       const tile = createImageTile();
       expect(tile.hasListener('change')).to.be(false);
@@ -152,12 +138,11 @@ describe('ol.TileQueue', function() {
       tq.enqueue([tile]);
       expect(tile.hasListener('change')).to.be(true);
 
-      tile.dispose();
+      tile.setState(TileState.LOADED);
       expect(tile.hasListener('change')).to.be(false);
-      expect(tile.getState()).to.eql(5); // ABORT
     });
 
-    it('abort loading tiles', function() {
+    it('error tiles', function() {
       const tq = new TileQueue(noop, noop);
       const tile = createImageTile(noop);
 
@@ -166,10 +151,9 @@ describe('ol.TileQueue', function() {
       expect(tq.getTilesLoading()).to.eql(1);
       expect(tile.getState()).to.eql(1); // LOADING
 
-      tile.dispose();
+      tile.setState(TileState.ERROR);
       expect(tq.getTilesLoading()).to.eql(0);
       expect(tile.hasListener('change')).to.be(false);
-      expect(tile.getState()).to.eql(5); // ABORT
 
     });
 

--- a/test/spec/ol/vectorrendertile.test.js
+++ b/test/spec/ol/vectorrendertile.test.js
@@ -1,9 +1,8 @@
 import TileState from '../../../src/ol/TileState.js';
 import {defaultLoadFunction} from '../../../src/ol/source/VectorTile.js';
 import VectorTileSource from '../../../src/ol/source/VectorTile.js';
-import {listen, listenOnce, unlistenByKey} from '../../../src/ol/events.js';
+import {listen, unlistenByKey} from '../../../src/ol/events.js';
 import GeoJSON from '../../../src/ol/format/GeoJSON.js';
-import {createXYZ} from '../../../src/ol/tilegrid.js';
 import TileGrid from '../../../src/ol/tilegrid/TileGrid.js';
 import EventType from '../../../src/ol/events/EventType.js';
 
@@ -92,54 +91,6 @@ describe('ol.VectorRenderTile', function() {
         expect(sourceTiles[0].tileCoord).to.eql([0, 16, 9]);
         done();
       }
-    });
-  });
-
-  it('#dispose() while loading', function() {
-    const source = new VectorTileSource({
-      format: new GeoJSON(),
-      url: 'spec/ol/data/point.json',
-      tileGrid: createXYZ()
-    });
-    source.getTileGridForProjection = function() {
-      return createXYZ({tileSize: 512});
-    };
-    const tile = source.getTile(0, 0, 0, 1, source.getProjection());
-
-    tile.load();
-    expect(tile.getState()).to.be(TileState.LOADING);
-    tile.dispose();
-    expect(source.sourceTilesByTileKey_[tile.getKey()]).to.be(undefined);
-    expect(tile.getState()).to.be(TileState.ABORT);
-  });
-
-  it('#dispose() when source tiles are loaded', function(done) {
-    const source = new VectorTileSource({
-      format: new GeoJSON(),
-      url: 'spec/ol/data/point.json?{z}/{x}/{y}',
-      tileGrid: createXYZ()
-    });
-    source.getTileGridForProjection = function() {
-      return createXYZ({tileSize: 512});
-    };
-    const tile = source.getTile(0, 0, 0, 1, source.getProjection());
-
-    tile.load();
-    listenOnce(tile, 'change', function() {
-      expect(tile.getState()).to.be(TileState.LOADED);
-      expect(tile.loadingSourceTiles).to.be(0);
-      const sourceTiles = source.getSourceTiles(1, source.getProjection(), tile);
-      expect(sourceTiles.length).to.be(4);
-      for (let i = 0, ii = sourceTiles.length; i < ii; ++i) {
-        expect(sourceTiles[i].consumers).to.be(1);
-      }
-      tile.dispose();
-      expect(tile.getState()).to.be(TileState.ABORT);
-      for (let i = 0, ii = sourceTiles.length; i < ii; ++i) {
-        expect(sourceTiles[i].consumers).to.be(0);
-        expect(sourceTiles[i].getState()).to.be(TileState.ABORT);
-      }
-      done();
     });
   });
 


### PR DESCRIPTION
This pull request aims to remove the ABORT state of tiles, and favor garbage collection over cleanup through `disposeInternal()`.

This turns out to simplify the code in many places.

Fixes #10465.