### PR TITLE
Select style multiple select interactions removed

### DIFF
--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -169,6 +169,16 @@ class Select extends Interaction {
 
     /**
      * @private
+     */
+    this.boundAddFeature_ = this.addFeature_.bind(this);
+
+    /**
+     * @private
+     */
+    this.boundRemoveFeature_ = this.removeFeature_.bind(this);
+
+    /**
+     * @private
      * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : singleClick;
@@ -250,9 +260,8 @@ class Select extends Interaction {
      */
     this.featureLayerAssociation_ = {};
 
-    const features = this.getFeatures();
-    features.addEventListener(CollectionEventType.ADD, this.addFeature_.bind(this));
-    features.addEventListener(CollectionEventType.REMOVE, this.removeFeature_.bind(this));
+    this.features_.addEventListener(CollectionEventType.ADD, this.boundAddFeature_);
+    this.features_.addEventListener(CollectionEventType.REMOVE, this.boundRemoveFeature_);
   }
 
   /**
@@ -322,6 +331,10 @@ class Select extends Interaction {
     super.setMap(map);
     if (map && this.style_) {
       this.features_.forEach(this.applySelectedStyle_.bind(this));
+    }
+    if (!map) {
+      this.features_.removeEventListener(CollectionEventType.ADD, this.boundAddFeature_);
+      this.features_.removeEventListener(CollectionEventType.REMOVE, this.boundRemoveFeature_);
     }
   }
 

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -333,8 +333,7 @@ class Select extends Interaction {
       if (this.style_) {
         this.features_.forEach(this.applySelectedStyle_.bind(this));
       }
-    }
-    if (!map) {
+    } else {
       this.features_.removeEventListener(CollectionEventType.ADD, this.boundAddFeature_);
       this.features_.removeEventListener(CollectionEventType.REMOVE, this.boundRemoveFeature_);
     }

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -259,9 +259,6 @@ class Select extends Interaction {
      * @type {Object<string, import("../layer/Layer.js").default>}
      */
     this.featureLayerAssociation_ = {};
-
-    this.features_.addEventListener(CollectionEventType.ADD, this.boundAddFeature_);
-    this.features_.addEventListener(CollectionEventType.REMOVE, this.boundRemoveFeature_);
   }
 
   /**
@@ -329,8 +326,13 @@ class Select extends Interaction {
       this.features_.forEach(this.restorePreviousStyle_.bind(this));
     }
     super.setMap(map);
-    if (map && this.style_) {
-      this.features_.forEach(this.applySelectedStyle_.bind(this));
+    if (map) {
+      this.features_.addEventListener(CollectionEventType.ADD, this.boundAddFeature_);
+      this.features_.addEventListener(CollectionEventType.REMOVE, this.boundRemoveFeature_);
+
+      if (this.style_) {
+        this.features_.forEach(this.applySelectedStyle_.bind(this));
+      }
     }
     if (!map) {
       this.features_.removeEventListener(CollectionEventType.ADD, this.boundAddFeature_);

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -427,7 +427,7 @@ describe('ol.interaction.Select', function() {
     });
 
     // The base case
-    describe('with a single interaction added', function() {
+    xdescribe('with a single interaction added', function() {
       it('changes the selected feature once', function() {
         map.addInteraction(firstInteraction);
 
@@ -441,7 +441,7 @@ describe('ol.interaction.Select', function() {
     });
 
     // The "difficult" case. To prevent regression
-    xdescribe('with a replaced interaction', function() {
+    describe('with a replaced interaction', function() {
       it('changes the selected feature once', function() {
         map.addInteraction(firstInteraction);
         map.removeInteraction(firstInteraction);

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -408,7 +408,7 @@ describe('ol.interaction.Select', function() {
 
   });
 
-  xdescribe('clear event listeners on interaction removal', function() {
+  describe('clear event listeners on interaction removal', function() {
     let firstInteraction, secondInteraction, feature;
 
     beforeEach(function() {
@@ -441,7 +441,7 @@ describe('ol.interaction.Select', function() {
     });
 
     // The "difficult" case. To prevent regression
-    describe('with a replaced interaction', function() {
+    xdescribe('with a replaced interaction', function() {
       it('changes the selected feature once', function() {
         map.addInteraction(firstInteraction);
         map.removeInteraction(firstInteraction);

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -408,7 +408,7 @@ describe('ol.interaction.Select', function() {
 
   });
 
-  describe('clear event listeners on interaction removal', function() {
+  xdescribe('clear event listeners on interaction removal', function() {
     let firstInteraction, secondInteraction, feature;
 
     beforeEach(function() {

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -9,6 +9,7 @@ import Interaction from '../../../../src/ol/interaction/Interaction.js';
 import Select from '../../../../src/ol/interaction/Select.js';
 import VectorLayer from '../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
+import Style from '../../../../src/ol/style/Style.js';
 
 
 describe('ol.interaction.Select', function() {
@@ -405,5 +406,54 @@ describe('ol.interaction.Select', function() {
       });
     });
 
+  });
+
+  describe('clear event listeners on interaction removal', function() {
+    let firstInteraction, secondInteraction, feature;
+
+    beforeEach(function() {
+      feature = source.getFeatures()[3]; // top feature is selected
+
+      const style = new Style({});
+      const features = new Collection();
+
+      firstInteraction = new Select({ style, features });
+      secondInteraction = new Select({ style, features });
+    });
+
+    afterEach(function() {
+      map.removeInteraction(secondInteraction);
+      map.removeInteraction(firstInteraction);
+    });
+
+    // The base case
+    describe('with a single interaction added', function() {
+      it('changes the selected feature once', function() {
+        map.addInteraction(firstInteraction);
+
+        const listenerSpy = sinon.spy();
+        feature.on('change', listenerSpy);
+
+        simulateEvent('singleclick', 10, -20, false);
+
+        expect(listenerSpy.callCount).to.be(1);
+      });
+    });
+
+    // The "difficult" case. To prevent regression
+    describe('with a replaced interaction', function() {
+      it('changes the selected feature once', function() {
+        map.addInteraction(firstInteraction);
+        map.removeInteraction(firstInteraction);
+        map.addInteraction(secondInteraction);
+
+        const listenerSpy = sinon.spy();
+        feature.on('change', listenerSpy);
+
+        simulateEvent('singleclick', 10, -20, false);
+
+        expect(listenerSpy.callCount).to.be(1);
+      });
+    });
   });
 });

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -427,7 +427,7 @@ describe('ol.interaction.Select', function() {
     });
 
     // The base case
-    xdescribe('with a single interaction added', function() {
+    describe('with a single interaction added', function() {
       it('changes the selected feature once', function() {
         map.addInteraction(firstInteraction);
 

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -417,8 +417,8 @@ describe('ol.interaction.Select', function() {
       const style = new Style({});
       const features = new Collection();
 
-      firstInteraction = new Select({ style, features });
-      secondInteraction = new Select({ style, features });
+      firstInteraction = new Select({style, features});
+      secondInteraction = new Select({style, features});
     });
 
     afterEach(function() {


### PR DESCRIPTION
This fixes #10486 by removing the event listeners when an
interaction is removed from a map.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
