### PR TITLE
typo in view.fit

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1109,7 +1109,7 @@ class View extends BaseObject {
     } else {
       const userProjection = getUserProjection();
       if (userProjection) {
-        geometry = /** @type {import("./geom/SimpleGeometry.js").default} */ (geometry.clone().transform(userProjection, this.getProjection()));
+        geometry = /** @type {import("./geom/SimpleGeometry.js").default} */ (geometryOrExtent.clone().transform(userProjection, this.getProjection()));
       } else {
         geometry = geometryOrExtent;
       }


### PR DESCRIPTION
view.fit had a typo where the variable `geometry` was used instead of `geometryOrExtent`.