### PR TITLE
Do not stop events when dragging

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -933,11 +933,13 @@ class PluggableMap extends BaseObject {
       return;
     }
     let target = /** @type {Node} */ (mapBrowserEvent.originalEvent.target);
-    while (target) {
-      if (target.parentElement === this.overlayContainerStopEvent_) {
-        return;
+    if (!mapBrowserEvent.dragging) {
+      while (target && target !== this.viewport_) {
+        if (target.parentElement === this.overlayContainerStopEvent_) {
+          return;
+        }
+        target = target.parentElement;
       }
-      target = target.parentElement;
     }
     mapBrowserEvent.frameState = this.frameState_;
     const interactionsArray = this.getInteractions().getArray();


### PR DESCRIPTION
Instead of unconditionally stopping all events when the target or one of its parents is the stopevent container, we now do so only when we're not in a dragging sequence. In addition, we stop looking for parents when we've reached the viewport.

Fixes #10268.

