### PR TITLE
Fix for reset north when rotation is 360 degrees

### DIFF
--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -131,8 +131,9 @@ class Rotate extends Control {
       // upon it
       return;
     }
-    if (view.getRotation() !== undefined) {
-      if (this.duration_ > 0) {
+    const rotation = view.getRotation();
+    if (rotation !== undefined) {
+      if (this.duration_ > 0 && rotation % (2 * Math.PI) !== 0) {
         view.animate({
           rotation: 0,
           duration: this.duration_,


### PR DESCRIPTION
Fixes the Rotate control glitch observed in https://github.com/openlayers/openlayers/issues/10503#issuecomment-573031268
Animated reset doesn't work and isn't needed if rotation is 360 degrees (or a multiple of 360)
