### PR TITLE
Fix two missing apidoc links

### DIFF
--- a/src/ol/style/IconAnchorUnits.js
+++ b/src/ol/style/IconAnchorUnits.js
@@ -5,8 +5,15 @@
 /**
  * Icon anchor units. One of 'fraction', 'pixels'.
  * @enum {string}
+ * @api
  */
 export default {
+  /**
+   * Anchor is a fraction
+   */
   FRACTION: 'fraction',
+  /**
+   * Anchor is in pixels
+   */
   PIXELS: 'pixels'
 };

--- a/src/ol/style/IconOrigin.js
+++ b/src/ol/style/IconOrigin.js
@@ -5,10 +5,23 @@
 /**
  * Icon origin. One of 'bottom-left', 'bottom-right', 'top-left', 'top-right'.
  * @enum {string}
+ * @api
  */
 export default {
+  /**
+   * Origin is at bottom left
+   */
   BOTTOM_LEFT: 'bottom-left',
+  /**
+   * Origin is at bottom right
+   */
   BOTTOM_RIGHT: 'bottom-right',
+  /**
+   * Origin is at top left
+   */
   TOP_LEFT: 'top-left',
+  /**
+   * Origin is at top right
+   */
   TOP_RIGHT: 'top-right'
 };


### PR DESCRIPTION
Add IconAnchorUnits and IconOrigin to the api.

See #10460 