### PR TITLE
Fix the z-index of the Overlay-Container

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -253,7 +253,7 @@ class PluggableMap extends BaseObject {
      */
     this.overlayContainer_ = document.createElement('div');
     this.overlayContainer_.style.position = 'absolute';
-    this.overlayContainer_.style.zIndex = '0';
+    this.overlayContainer_.style.zIndex = 'auto';
     this.overlayContainer_.style.width = '100%';
     this.overlayContainer_.style.height = '100%';
     this.overlayContainer_.className = 'ol-overlaycontainer';
@@ -265,7 +265,7 @@ class PluggableMap extends BaseObject {
      */
     this.overlayContainerStopEvent_ = document.createElement('div');
     this.overlayContainerStopEvent_.style.position = 'absolute';
-    this.overlayContainerStopEvent_.style.zIndex = '0';
+    this.overlayContainerStopEvent_.style.zIndex = 'auto';
     this.overlayContainerStopEvent_.style.width = '100%';
     this.overlayContainerStopEvent_.style.height = '100%';
     this.overlayContainerStopEvent_.className = 'ol-overlaycontainer-stopevent';


### PR DESCRIPTION
Setting the z-index of 'ol-overlaycontainer-stopevent' to '0' makes the following use-case impossible:

 - I have a map in the background
 - I have some controls for user-interaction in front of the map
 - I want popups / overlays from the map to be in front of the controls

With z-index '0' on 'ol-overlaycontainer-stopevent', the popups / overlays are always behind the controls, even if I give them a higher z-index.
With z-index 'auto' on 'ol-overlaycontainer-stopevent', I can control the position of popups by setting their z-index to an appropriate value.

Before revision 898c349, the z-index was (implicitly) set to 'auto'. I expect the problem discribed above to be an unintended side-effect of that change.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
