### PR TITLE
Update MVT.js

### DIFF
--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -201,8 +201,8 @@ class MVT extends FeatureFormat {
         for (let i = 0, ii = ends.length; i < ii; ++i) {
           const end = ends[i];
           if (!linearRingIsClockwise(flatCoordinates, offset, end, 2)) {
-            endss.push(ends.slice(prevEndIndex, i));
-            prevEndIndex = i;
+            endss.push(ends.slice(prevEndIndex, i + 1));
+            prevEndIndex = i + 1;
           }
           offset = end;
         }


### PR DESCRIPTION
descriptions of slice method of Array: 
@param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'. 
initial value of prevEndIndex and i both are 0 so that slice(0, 0)  return a empty array. it lead to a new issue that when I load a multiplygon geometry, endss array's first item is [] but correct value should be the last coordinate index of first polygon of multiplygon. the description of issue: https://github.com/openlayers/openlayers/issues/10500

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
