### PR TITLE
@api tag must not have a value.

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -4,7 +4,7 @@
  */
 exports.defineTags = function(dictionary) {
   dictionary.defineTag('api', {
-    mustHaveValue: false,
+    mustNotHaveValue: true,
     canHaveType: false,
     canHaveName: false,
     onTagged: function(doclet, tag) {

--- a/config/jsdoc/api/plugins/inheritdoc.js
+++ b/config/jsdoc/api/plugins/inheritdoc.js
@@ -5,7 +5,7 @@
 
 exports.defineTags = function(dictionary) {
   dictionary.defineTag('inheritDoc', {
-    mustHaveValue: false,
+    mustNotHaveValue: true,
     canHaveType: false,
     canHaveName: false,
     onTagged: function(doclet, tag) {

--- a/config/jsdoc/info/virtual-plugin.js
+++ b/config/jsdoc/info/virtual-plugin.js
@@ -6,7 +6,7 @@ exports.defineTags = function(dictionary) {
 
   const classTag = dictionary.lookUp('class');
   dictionary.defineTag('interface', {
-    mustHaveValue: false,
+    mustNotHaveValue: true,
     onTagged: function(doclet, tag) {
       classTag.onTagged.apply(this, arguments);
       doclet.virtual = true;


### PR DESCRIPTION
To disallow any value for a tag the correct config is `mustNotHaveValue: true`.
https://jsdoc.app/about-plugins.html#the-dictionary

To check just add some text after one of these tags and run the 'apidoc' task.
It should generate a warning that text is not allowed after that tag:
```
WARNING: The @api tag does not permit a value; the value will be ignored. File: VectorTileLayer.js, line: 51
WARNING: The @api tag does not permit a value; the value will be ignored. File: VectorTileLayer.js, line: 56
```