### PR TITLE
Apidoc add experimental tag

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -20,7 +20,8 @@
     "config/jsdoc/api/plugins/inheritdoc",
     "config/jsdoc/api/plugins/events",
     "config/jsdoc/api/plugins/observable",
-    "config/jsdoc/api/plugins/api"
+    "config/jsdoc/api/plugins/api",
+    "config/jsdoc/api/plugins/experimental"
   ],
   "typescript": {
     "moduleRoot": "src"

--- a/config/jsdoc/api/plugins/experimental.js
+++ b/config/jsdoc/api/plugins/experimental.js
@@ -1,0 +1,28 @@
+const modules = {};
+
+exports.defineTags = function(dictionary) {
+  dictionary.defineTag('experimental', {
+    mustNotHaveValue: true,
+    canHaveType: false,
+    canHaveName: false,
+    onTagged: function(doclet, tag) {
+      doclet.experimental = true;
+      if (doclet.kind === 'module') {
+        modules[doclet.name] = true;
+      }
+    }
+  });
+};
+
+exports.handlers = {
+  newDoclet: function(e) {
+    const doclet = e.doclet;
+    if (doclet.kind == 'class') {
+      const match = doclet.longname.match(/^module:(.*)[~\.]/);
+      if (match && modules[match[1]]) {
+        doclet.experimental = true;
+      }
+    }
+  }
+};
+

--- a/config/jsdoc/api/template/tmpl/container.tmpl
+++ b/config/jsdoc/api/template/tmpl/container.tmpl
@@ -12,6 +12,18 @@
 <section class="content">
 
 <header>
+    <?js if (doc.experimental) { ?>
+        <div id="experimental-notice" class="alert alert-warning alert-dismissible" role="alert" style="display:block">
+            <button id="experimental-dismiss" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            This <?js= doc.kind ?> is experimental and subject to change between releases.
+        </div>
+        <script>
+            document.getElementById('experimental-dismiss').addEventListener('click', function() {
+                document.getElementById('experimental-notice').style.display = 'none';
+            });
+        </script>
+    <?js } ?>
+
     <h2><?js if (doc.ancestors && doc.ancestors.length) { ?>
         <span class="ancestors"><?js= doc.ancestors.join('') ?></span><?js } ?><?js= doc.name ?>
     <?js if (doc.variation) { ?>

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -1,5 +1,6 @@
 /**
  * @module ol/layer/WebGLPoints
+ * @experimental
  */
 import {assign} from '../obj.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
@@ -65,6 +66,7 @@ import Layer from './Layer.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @fires import("../render/Event.js").RenderEvent
+ * @api
  */
 class WebGLPointsLayer extends Layer {
   /**

--- a/src/ol/style/LiteralStyle.js
+++ b/src/ol/style/LiteralStyle.js
@@ -2,6 +2,7 @@
  * Literal Style objects differ from standard styles in that they cannot
  * be functions and are made up of simple objects instead of classes.
  * @module ol/style/LiteralStyle
+ * @experimental
  */
 
 /**
@@ -15,6 +16,7 @@
  * @property {Object<string, number>} [variables] Style variables; each variable must hold a number.
  * Note: **this object is meant to be mutated**: changes to the values will immediately be visible on the rendered features
  * @property {LiteralSymbolStyle} [symbol] Symbol representation.
+ * @api
  */
 
 /**

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -1,6 +1,7 @@
 /**
  * Operators and utilities used for style expressions
  * @module ol/style/expressions
+ * @experimental
  */
 
 import {asArray, isStringColor} from '../color.js';
@@ -71,6 +72,7 @@ import {asArray, isStringColor} from '../color.js';
  * * {@link module:ol/color~Color}
  *
  * @typedef {Array<*>|import("../color.js").Color|string|number|boolean} ExpressionValue
+ * @api
  */
 
 /**


### PR DESCRIPTION
This adds a 'experimental' notice to the api documentation similar to the one that is shown for examples using experimental features.
It is shown for module pages when the module is tagged with `@experimental` and also for class pages belonging to such a module.

Add the `ol/layer/WebGLPoints`, `ol/style/LiteralStyle.js` and `ol/style/expressions.js` as experimental api and thus fixes one dead link from the `WebGLPoints` module as seen in #10460