### PR TITLE
Only generate module apidoc pages when it contains api tags

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -119,7 +119,6 @@ exports.handlers = {
       api.push(doclet);
     }
     if (doclet.kind == 'class') {
-      modules[doclet.longname.split(/[~\.]/).shift()] = true;
       if (!(doclet.longname in classes)) {
         classes[doclet.longname] = doclet;
       } else if ('augments' in doclet) {


### PR DESCRIPTION
Some module apidoc pages are generated that should not be.
It should only add those modules from doclets that are marked stable, which is done in the block right before the removed line.
These are the pages that are no longer generated after this change:
> module-ol_Disposable.html
> module-ol_ImageBase.html
> module-ol_ImageCanvas.html
> module-ol_MapBrowserEventHandler.html
> module-ol_MapBrowserPointerEvent.html
> module-ol_TileCache.html
> module-ol_TileQueue.html
> module-ol_TileRange.html
> module-ol_VectorRenderTile.html
> module-ol_format_GMLBase.html
> module-ol_format_OWS.html
> module-ol_format_filter_And.html
> module-ol_format_filter_Comparison.html
> module-ol_format_filter_ComparisonBinary.html
> module-ol_format_filter_Filter.html
> module-ol_format_filter_LogicalNary.html
> module-ol_format_filter_Spatial.html
> module-ol_layer_WebGLPoints.html
> module-ol_proj_epsg3857.html
> module-ol_proj_epsg4326.html
> module-ol_render_Box.html
> module-ol_render_canvas_Builder.html
> module-ol_render_canvas_BuilderGroup.html
> module-ol_render_canvas_Executor.html
> module-ol_render_canvas_ExecutorGroup.html
> module-ol_render_canvas_ImageBuilder.html
> module-ol_render_canvas_LineStringBuilder.html
> module-ol_render_canvas_PolygonBuilder.html
> module-ol_render_canvas_TextBuilder.html
> module-ol_renderer_Layer.html
> module-ol_renderer_Map.html
> module-ol_renderer_canvas_Layer.html
> module-ol_reproj_Image.html
> module-ol_reproj_Tile.html
> module-ol_reproj_Triangulation.html
> module-ol_structs_LinkedList.html
> module-ol_structs_PriorityQueue.html
> module-ol_structs_RBush.html
> module-ol_style_IconImage.html
> module-ol_webgl_ShaderBuilder.html