### PR TITLE
Use correct extent for the vector image

### DIFF
--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -105,6 +105,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
       const context = vectorRenderer.context;
       const imageFrameState = /** @type {import("../../PluggableMap.js").FrameState} */ (assign({}, frameState, {
         declutterItems: [],
+        extent: renderedExtent,
         size: [width, height],
         viewState: /** @type {import("../../View.js").State} */ (assign({}, frameState.viewState, {
           rotation: 0


### PR DESCRIPTION
Currently the `imageRatio` for `ol/layer/VectorImage` is not respected. To fix this, we need to pass the correct extent to the image frame state.