### PR TITLE
Fix KML Polystyle outline 0 conflict with Linestyle for linestrings

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -2580,7 +2580,7 @@ function writeLineStyle(node, style, objectStack) {
   const /** @type {import("../xml.js").NodeStackItem} */ context = {node: node};
   const properties = {
     'color': style.getColor(),
-    'width': style.getWidth()
+    'width': Number(style.getWidth()) || 1
   };
   const parentNode = objectStack[objectStack.length - 1].node;
   const orderedKeys = LINE_STYLE_SEQUENCE[parentNode.namespaceURI];

--- a/test/spec/ol/format/kml.test.js
+++ b/test/spec/ol/format/kml.test.js
@@ -2167,6 +2167,11 @@ describe('ol.format.KML', function() {
         });
 
         it('disables the stroke when outline is \'0\'', function() {
+          const lineString = new LineString([[1, 2], [3, 4]]);
+          const polygon = new Polygon([[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]]);
+          const lineStringFeature = new Feature(lineString);
+          const polygonFeature = new Feature(polygon);
+          const collectionFeature = new Feature(new GeometryCollection([lineString, polygon]));
           const text =
               '<kml xmlns="http://earth.google.com/kml/2.2">' +
               '  <Placemark>' +
@@ -2190,20 +2195,53 @@ describe('ol.format.KML', function() {
           expect(styleFunction).not.to.be(undefined);
           const styleArray = styleFunction(f, 0);
           expect(styleArray).to.be.an(Array);
-          expect(styleArray).to.have.length(1);
+          expect(styleArray).to.have.length(2);
+
           const style = styleArray[0];
           expect(style).to.be.an(Style);
+          expect(style.getGeometryFunction()(lineStringFeature)).to.be(lineString);
+          expect(style.getGeometryFunction()(polygonFeature)).to.be(undefined);
+          const gc = style.getGeometryFunction()(collectionFeature);
+          expect(gc).to.be.an(GeometryCollection);
+          const gs = gc.getGeometries();
+          expect(gs).to.be.an(Array);
+          expect(gs).to.have.length(1);
+          expect(gs[0]).to.be.an(LineString);
+          expect(gs[0].getCoordinates()).to.eql(lineString.getCoordinates());
           const fillStyle = style.getFill();
           expect(fillStyle).to.be.an(Fill);
           expect(fillStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
           expect(style.getImage()).to.be(getDefaultImageStyle());
-          expect(style.getStroke()).to.be(null);
+          const strokeStyle = style.getStroke();
+          expect(strokeStyle).to.be.an(Stroke);
+          expect(strokeStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
+          expect(strokeStyle.getWidth()).to.be(9);
           expect(style.getText()).to.be(getDefaultTextStyle());
           expect(style.getZIndex()).to.be(undefined);
+
+          const style1 = styleArray[1];
+          expect(style1).to.be.an(Style);
+          expect(style1.getGeometryFunction()(lineStringFeature)).to.be(undefined);
+          expect(style1.getGeometryFunction()(polygonFeature)).to.be(polygon);
+          const gc1 = style1.getGeometryFunction()(collectionFeature);
+          expect(gc1).to.be.an(GeometryCollection);
+          const gs1 = gc1.getGeometries();
+          expect(gs1).to.be.an(Array);
+          expect(gs1).to.have.length(1);
+          expect(gs1[0]).to.be.an(Polygon);
+          expect(gs1[0].getCoordinates()).to.eql(polygon.getCoordinates());
+          expect(style1.getFill()).to.be(fillStyle);
+          expect(style1.getStroke()).to.be(null);
+          expect(style1.getZIndex()).to.be(undefined);
         });
 
         it('disables both fill and stroke when fill and outline are \'0\'',
           function() {
+            const lineString = new LineString([[1, 2], [3, 4]]);
+            const polygon = new Polygon([[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]]);
+            const lineStringFeature = new Feature(lineString);
+            const polygonFeature = new Feature(polygon);
+            const collectionFeature = new Feature(new GeometryCollection([lineString, polygon]));
             const text =
                   '<kml xmlns="http://earth.google.com/kml/2.2">' +
                   '  <Placemark>' +
@@ -2228,14 +2266,42 @@ describe('ol.format.KML', function() {
             expect(styleFunction).not.to.be(undefined);
             const styleArray = styleFunction(f, 0);
             expect(styleArray).to.be.an(Array);
-            expect(styleArray).to.have.length(1);
+            expect(styleArray).to.have.length(2);
+
             const style = styleArray[0];
             expect(style).to.be.an(Style);
+            expect(style.getGeometryFunction()(lineStringFeature)).to.be(lineString);
+            expect(style.getGeometryFunction()(polygonFeature)).to.be(undefined);
+            const gc = style.getGeometryFunction()(collectionFeature);
+            expect(gc).to.be.an(GeometryCollection);
+            const gs = gc.getGeometries();
+            expect(gs).to.be.an(Array);
+            expect(gs).to.have.length(1);
+            expect(gs[0]).to.be.an(LineString);
+            expect(gs[0].getCoordinates()).to.eql(lineString.getCoordinates());
             expect(style.getFill()).to.be(null);
             expect(style.getImage()).to.be(getDefaultImageStyle());
-            expect(style.getStroke()).to.be(null);
+            const strokeStyle = style.getStroke();
+            expect(strokeStyle).to.be.an(Stroke);
+            expect(strokeStyle.getColor()).to.eql([0x78, 0x56, 0x34, 0x12 / 255]);
+            expect(strokeStyle.getWidth()).to.be(9);
             expect(style.getText()).to.be(getDefaultTextStyle());
             expect(style.getZIndex()).to.be(undefined);
+
+            const style1 = styleArray[1];
+            expect(style1).to.be.an(Style);
+            expect(style1.getGeometryFunction()(lineStringFeature)).to.be(undefined);
+            expect(style1.getGeometryFunction()(polygonFeature)).to.be(polygon);
+            const gc1 = style1.getGeometryFunction()(collectionFeature);
+            expect(gc1).to.be.an(GeometryCollection);
+            const gs1 = gc1.getGeometries();
+            expect(gs1).to.be.an(Array);
+            expect(gs1).to.have.length(1);
+            expect(gs1[0]).to.be.an(Polygon);
+            expect(gs1[0].getCoordinates()).to.eql(polygon.getCoordinates());
+            expect(style1.getFill()).to.be(null);
+            expect(style1.getStroke()).to.be(null);
+            expect(style1.getZIndex()).to.be(undefined);
           });
 
         it('can create text style for named point placemarks (including html character codes)', function() {


### PR DESCRIPTION
Fixes #10571
Fixes #10538
Fixes #6028
Fixes #4466

Return separate style objects for polygon geometries (including multipolygon and polygons in geometry collections) and other geometries if Polystyle outline is defined as 0.

Update Polystyle outline 0 tests