### PR TITLE
Sort doc navigation properly and add missing modules

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -188,6 +188,12 @@ function attachModuleSymbols(doclets, modules) {
   });
 }
 
+function getPrettyName(longname) {
+  return longname
+    .split('~')[0]
+    .replace('module:', '');
+}
+
 /**
  * Create the navigation sidebar.
  * @param {object} members The members that will be used to create the sidebar.
@@ -206,10 +212,12 @@ function buildNav(members) {
   // merge namespaces and classes, then sort
   const merged = members.modules.concat(members.classes);
   merged.sort(function(a, b) {
-    if (a.longname > b.longname) {
+    const prettyNameA = getPrettyName(a.longname).toLowerCase();
+    const prettyNameB = getPrettyName(b.longname).toLowerCase();
+    if (prettyNameA > prettyNameB) {
       return 1;
     }
-    if (a.longname < b.longname) {
+    if (prettyNameA < prettyNameB) {
       return -1;
     }
     return 0;
@@ -221,9 +229,7 @@ function buildNav(members) {
       nav.push({
         type: 'class',
         longname: v.longname,
-        prettyname: v.longname
-          .split('~')[0]
-          .replace('module:', ''),
+        prettyname: getPrettyName(v.longname),
         name: v.name,
         module: find({
           kind: 'module',
@@ -269,13 +275,11 @@ function buildNav(members) {
         memberof: v.longname
       });
       // only add modules that have more to show than just a single class
-      if (classes.length !== 1 && (classes.length + members.length + methods.length + typedefs.length + events.length > 0)) {
+      if (!classes.length || classes.length - 1 + members.length + methods.length + typedefs.length + events.length > 0) {
         nav.push({
           type: 'module',
           longname: v.longname,
-          prettyname: v.longname
-            .split('~')[0]
-            .replace('module:', ''),
+          prettyname: getPrettyName(v.longname),
           name: v.name,
           members: members,
           methods: methods,

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -274,8 +274,9 @@ function buildNav(members) {
         kind: 'event',
         memberof: v.longname
       });
-      // only add modules that have more to show than just a single class
-      if (!classes.length || classes.length - 1 + members.length + methods.length + typedefs.length + events.length > 0) {
+      // only add modules that have more to show than just classes
+      const numItems = classes.length - 1 + members.length + methods.length + typedefs.length + events.length;
+      if (!classes.length || (numItems > 0 && numItems !== classes.length)) {
         nav.push({
           type: 'module',
           longname: v.longname,

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -325,7 +325,6 @@ class Attribution extends Control {
  * Update the attribution element.
  * @param {import("../MapEvent.js").default} mapEvent Map event.
  * @this {Attribution}
- * @api
  */
 export function render(mapEvent) {
   this.updateElement_(mapEvent.frameState);

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -79,9 +79,10 @@ class Control extends BaseObject {
     this.listenerKeys = [];
 
     /**
+     * @private
      * @type {function(import("../MapEvent.js").default): void}
      */
-    this.render = options.render ? options.render : VOID;
+    this.render_ = options.render ? options.render : VOID;
 
     if (options.target) {
       this.setTarget(options.target);
@@ -132,6 +133,16 @@ class Control extends BaseObject {
       }
       map.render();
     }
+  }
+
+  /**
+   * Update the projection. Rendering of the coordinates is done in
+   * `handleMouseMove` and `handleMouseUp`.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @api
+   */
+  render(mapEvent) {
+    this.render_.call(this, mapEvent);
   }
 
   /**

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -248,7 +248,6 @@ class MousePosition extends Control {
  * `handleMouseMove` and `handleMouseUp`.
  * @param {import("../MapEvent.js").default} mapEvent Map event.
  * @this {MousePosition}
- * @api
  */
 export function render(mapEvent) {
   const frameState = mapEvent.frameState;

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -603,7 +603,6 @@ class OverviewMap extends Control {
  * Update the overview map element.
  * @param {import("../MapEvent.js").default} mapEvent Map event.
  * @this {OverviewMap}
- * @api
  */
 export function render(mapEvent) {
   this.validateExtent_();

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -151,7 +151,6 @@ class Rotate extends Control {
  * Update the rotate control element.
  * @param {import("../MapEvent.js").default} mapEvent Map event.
  * @this {Rotate}
- * @api
  */
 export function render(mapEvent) {
   const frameState = mapEvent.frameState;

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -418,7 +418,6 @@ class ScaleLine extends Control {
  * Update the scale line element.
  * @param {import("../MapEvent.js").default} mapEvent Map event.
  * @this {ScaleLine}
- * @api
  */
 export function render(mapEvent) {
   const frameState = mapEvent.frameState;

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -339,7 +339,6 @@ class ZoomSlider extends Control {
  * Update the zoomslider element.
  * @param {import("../MapEvent.js").default} mapEvent Map event.
  * @this {ZoomSlider}
- * @api
  */
 export function render(mapEvent) {
   if (!mapEvent.frameState) {

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -70,14 +70,14 @@ describe('ol.control.ScaleLine', function() {
     describe('render', function() {
       it('defaults to `ol.control.ScaleLine.render`', function() {
         const ctrl = new ScaleLine();
-        expect(ctrl.render).to.be(render);
+        expect(ctrl.render_).to.be(render);
       });
       it('can be configured', function() {
         const myRender = function() {};
         const ctrl = new ScaleLine({
           render: myRender
         });
-        expect(ctrl.render).to.be(myRender);
+        expect(ctrl.render_).to.be(myRender);
       });
     });
 


### PR DESCRIPTION
This pull request improves the user experience when navigating the API doc, by applying a more natural sort order.

It also adds missing modules (e.g. for classes that also have static functions, e.g. `ol/geom/Polygon` to accommodate static functions like `fromExtent`.