### PR TITLE
Remove obsolete license notice

### DIFF
--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -1,11 +1,4 @@
 /**
- * @license
- * Latitude/longitude spherical geodesy formulae taken from
- * http://www.movable-type.co.uk/scripts/latlong.html
- * Licensed under CC-BY-3.0.
- */
-
-/**
  * @module ol/sphere
  */
 import {toRadians, toDegrees} from './math.js';


### PR DESCRIPTION
The removed license notice refers to code that has been entirely removed. So the license notice should be removed too.

Fixes #10589.