### PR TITLE
Mark GeometryLayout as public API

### DIFF
--- a/src/ol/geom/GeometryLayout.js
+++ b/src/ol/geom/GeometryLayout.js
@@ -7,6 +7,7 @@
  * or measure ('M') coordinate is available. Supported values are `'XY'`,
  * `'XYZ'`, `'XYM'`, `'XYZM'`.
  * @enum {string}
+ * @api
  */
 export default {
   XY: 'XY',


### PR DESCRIPTION
Missing `ol.geom.GeometryLayout` in full build at https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v6.1.1/build/ol.js

But it's listed as part of the API in the docs (assuming the docs show the public API?) https://openlayers.org/en/latest/apidoc/module-ol_geom_GeometryLayout.html
