### PR TITLE
Improve apidoc generation performance

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -21,14 +21,10 @@ exports.defineTags = function(dictionary) {
  * from the documentation.
  */
 
-const api = [];
+const api = {};
 const classes = {};
 const types = {};
 const modules = {};
-
-function hasApiMembers(doclet) {
-  return doclet.longname.split('#')[0] == this.longname;
-}
 
 function includeAugments(doclet) {
   // Make sure that `observables` and `fires` are taken from an already processed `class` doclet.
@@ -116,7 +112,7 @@ exports.handlers = {
     const doclet = e.doclet;
     if (doclet.stability) {
       modules[doclet.longname.split(/[~\.]/).shift()] = true;
-      api.push(doclet);
+      api[doclet.longname.split('#')[0]] = true;
     }
     if (doclet.kind == 'class') {
       if (!(doclet.longname in classes)) {
@@ -159,7 +155,7 @@ exports.handlers = {
       if (doclet.isEnum || doclet.kind == 'typedef') {
         continue;
       }
-      if (doclet.kind == 'class' && api.some(hasApiMembers, doclet)) {
+      if (doclet.kind == 'class' && doclet.longname in api) {
         // Mark undocumented classes with documented members as unexported.
         // This is used in ../template/tmpl/container.tmpl to hide the
         // constructor from the docs.

--- a/config/jsdoc/api/plugins/inheritdoc.js
+++ b/config/jsdoc/api/plugins/inheritdoc.js
@@ -42,62 +42,62 @@ exports.handlers = {
 
   parseComplete: function(e) {
     let ancestors, candidate, candidates, doclet, i, j, k, l, key;
-    let incompleteDoclet, stability, incomplete, incompletes;
+    let stability, incomplete, incompletes;
     const doclets = e.doclets;
     for (i = doclets.length - 1; i >= 0; --i) {
       doclet = doclets[i];
-      if (doclet.augments) {
-        ancestors = [].concat(doclet.augments);
-      }
       incompletes = incompleteByClass[doclet.longname];
-      if (ancestors && incompletes) {
-        // collect ancestors from the whole hierarchy
-        for (j = 0; j < ancestors.length; ++j) {
-          candidates = lookup[ancestors[j]];
-          if (candidates) {
-            for (k = candidates.length - 1; k >= 0; --k) {
-              candidate = candidates[k];
-              if (candidate.augments) {
-                ancestors = ancestors.concat(candidate.augments);
-              }
+      if (!doclet.augments || !incompletes) {
+        continue;
+      }
+      ancestors = doclet.augments.slice();
+      // collect ancestors from the whole hierarchy
+      for (j = 0; j < ancestors.length; ++j) {
+        candidates = lookup[ancestors[j]];
+        if (candidates) {
+          for (k = candidates.length - 1; k >= 0; --k) {
+            candidate = candidates[k];
+            if (candidate.augments) {
+              Array.prototype.push.apply(ancestors, candidate.augments);
             }
           }
         }
-        // walk through all inheritDoc members
-        for (j = incompletes.length - 1; j >= 0; --j) {
-          incomplete = incompletes[j];
-          candidates = lookup[doclet.longname + '#' + incomplete];
-          if (candidates) {
-            // get the incomplete doclet that needs to be augmented
-            for (k = candidates.length - 1; k >= 0; --k) {
-              incompleteDoclet = candidates[k];
-              if (incompleteDoclet.inheritdoc) {
-                break;
-              }
+      }
+      // walk through all inheritDoc members
+      let incompleteDoclet;
+      for (j = incompletes.length - 1; j >= 0; --j) {
+        incomplete = incompletes[j];
+        candidates = lookup[doclet.longname + '#' + incomplete];
+        if (candidates) {
+          // get the incomplete doclet that needs to be augmented
+          for (k = candidates.length - 1; k >= 0; --k) {
+            incompleteDoclet = candidates[k];
+            if (incompleteDoclet.inheritdoc) {
+              break;
             }
           }
-          // find the documented ancestor
-          for (k = ancestors.length - 1; k >= 0; --k) {
-            candidates = lookup[ancestors[k] + '#' + incomplete];
-            if (candidates) {
-              for (l = candidates.length - 1; l >= 0; --l) {
-                candidate = candidates[l];
-                if (candidate && !candidate.inheritdoc) {
-                  stability = candidate.stability || incompleteDoclet.stability;
-                  if (stability) {
-                    incompleteDoclet.stability = stability;
-                    for (key in candidate) {
-                      if (candidate.hasOwnProperty(key) &&
-                        keepKeys.indexOf(key) == -1) {
-                        incompleteDoclet[key] = candidate[key];
-                      }
+        }
+        // find the documented ancestor
+        for (k = ancestors.length - 1; k >= 0; --k) {
+          candidates = lookup[ancestors[k] + '#' + incomplete];
+          if (candidates) {
+            for (l = candidates.length - 1; l >= 0; --l) {
+              candidate = candidates[l];
+              if (candidate && !candidate.inheritdoc) {
+                stability = candidate.stability || incompleteDoclet.stability;
+                if (stability) {
+                  incompleteDoclet.stability = stability;
+                  for (key in candidate) {
+                    if (candidate.hasOwnProperty(key) &&
+                      keepKeys.indexOf(key) == -1) {
+                      incompleteDoclet[key] = candidate[key];
                     }
-                    // We have found a matching parent doc and applied it so we
-                    // don't want to ignore this doclet anymore.
-                    incompleteDoclet.ignore = false;
-                    // We found a match so we can stop break
-                    break;
                   }
+                  // We have found a matching parent doc and applied it so we
+                  // don't want to ignore this doclet anymore.
+                  incompleteDoclet.ignore = false;
+                  // We found a match so we can stop break
+                  break;
                 }
               }
             }

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -477,6 +477,7 @@ exports.publish = function(taffyData, opts, tutorials) {
   // index page displays information from package.json and lists files
   const files = find({kind: 'file'});
 
+  view.navigationHtml = helper.resolveLinks(view.partial('navigation.tmpl'));
   generate('Index',
     [{kind: 'mainpage', readme: opts.readme, longname: (opts.mainpagetitle) ? opts.mainpagetitle : 'Main Page'}].concat(files),
     indexUrl);

--- a/config/jsdoc/api/template/tmpl/layout.tmpl
+++ b/config/jsdoc/api/template/tmpl/layout.tmpl
@@ -92,7 +92,7 @@ var version = obj.packageInfo.version;
 </div>
 
 <div id="wrap" class="clearfix">
-    <?js= this.partial('navigation.tmpl', this) ?>
+    <?js= this.navigationHtml ?>
     <div class="main">
         <h1 class="page-title" data-filename="<?js= filename ?>"><?js= title ?></h1>
         <div id="latest-check" class="alert alert-warning alert-dismissible" role="alert" style="display:none">


### PR DESCRIPTION
This pull request improves the apidoc generation process.

- improves the overall speed of the apidoc generation by ~30% by caching the navigation html instead of generating it again for each page.
- Improves the caching of api members in api.js
- Fixes a minor bug in inheritdoc.js where two variables remain always set for the duration of the loop. Because of this the iteration was not skipped when a class has no ancestor.

The generated html pages are not changed (there is one empty line removed).