### PR TITLE
Improve new mousewheel zoom

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -96,7 +96,7 @@ class MouseWheelZoom extends Interaction {
      * interactions.
      * @type {number}
      */
-    this.eventGap_ = 400;
+    this.eventGap_ = 250;
 
     /**
      * @type {?}

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -44,13 +44,14 @@ function getViewportClampedResolution(resolution, maxExtent, viewportSize, showF
 function getSmoothClampedResolution(resolution, maxResolution, minResolution) {
   let result = Math.min(resolution, maxResolution);
   const ratio = 50;
+  const overZoomFactor = 1.15;
 
   result *= Math.log(1 + ratio * Math.max(0, resolution / maxResolution - 1)) / ratio + 1;
   if (minResolution) {
     result = Math.max(result, minResolution);
     result /= Math.log(1 + ratio * Math.max(0, minResolution / resolution - 1)) / ratio + 1;
   }
-  return clamp(result, minResolution / 2, maxResolution * 2);
+  return clamp(result, minResolution / overZoomFactor, maxResolution * overZoomFactor);
 }
 
 /**


### PR DESCRIPTION
Fixes #10638

This reduces the allowed amount of over-zoom allowed in the view
to provide faster feedback to the user that the limit is reached.

And it reduces the MouseWheelZoom's event gap to remove the small
pause after which the view snaps back to the constrained resolution.