### PR TITLE
deltaX and deltaY as strings

### DIFF
--- a/src/ol/geom/flat/transform.js
+++ b/src/ol/geom/flat/transform.js
@@ -108,8 +108,8 @@ export function translate(flatCoordinates, offset, end, stride, deltaX, deltaY, 
   const dest = opt_dest ? opt_dest : [];
   let i = 0;
   for (let j = offset; j < end; j += stride) {
-    dest[i++] = flatCoordinates[j] + deltaX;
-    dest[i++] = flatCoordinates[j + 1] + deltaY;
+    dest[i++] = flatCoordinates[j] + Number(deltaX);
+    dest[i++] = flatCoordinates[j + 1] + Number(deltaY);
     for (let k = j + 2; k < j + stride; ++k) {
       dest[i++] = flatCoordinates[k];
     }


### PR DESCRIPTION
The arguments deltaX and deltaY may be numbers represented as strings (for example, values from input forms), in that case, coordinates are summarised as strings and that's very bad.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
