### PR TITLE
Load polyfill before example specific scripts in examples template

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -67,9 +67,9 @@
     <link rel="stylesheet" href="./resources/prism/prism.css" type="text/css">
     <link rel="stylesheet" href="./css/ol.css" type="text/css">
     <link rel="stylesheet" href="./resources/layout.css" type="text/css">
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"></script>
     {{{ extraHead.local }}}
     {{{ css.tag }}}
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
     <title>{{ title }}</title>
   </head>


### PR DESCRIPTION
Fixes #10662

Load the polyfill script in the same order as in the displayed code as example specific scripts may also require the same polyfills for Internet Explorer
