### PR TITLE
Nicer mousewheel and trackpad zooming

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -794,6 +794,13 @@ class View extends BaseObject {
   }
 
   /**
+   * @return {boolean} Resolution constraint is set
+   */
+  getConstrainResolution() {
+    return this.options_.constrainResolution;
+  }
+
+  /**
    * @param {Array<number>=} opt_hints Destination array.
    * @return {Array<number>} Hint.
    */

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -217,9 +217,12 @@ class MouseWheelZoom extends Interaction {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {
+        if (view.getAnimating()) {
+          view.cancelAnimations();
+        }
         view.beginInteraction();
       }
-      this.trackpadTimeoutId_ = setTimeout(this.endInteraction_.bind(this), this.trackpadEventGap_);
+      this.trackpadTimeoutId_ = setTimeout(this.endInteraction_.bind(this), this.timeoutId_);
       view.adjustZoom(-delta / this.deltaPerZoom_, this.lastAnchor_);
       this.startTime_ = now;
       return false;

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -130,7 +130,7 @@ class MouseWheelZoom extends Interaction {
      * @private
      * @type {number}
      */
-    this.trackpadDeltaPerZoom_ = 300;
+    this.deltaPerZoom_ = 300;
 
   }
 
@@ -220,7 +220,7 @@ class MouseWheelZoom extends Interaction {
         view.beginInteraction();
       }
       this.trackpadTimeoutId_ = setTimeout(this.endInteraction_.bind(this), this.trackpadEventGap_);
-      view.adjustZoom(-delta / this.trackpadDeltaPerZoom_, this.lastAnchor_);
+      view.adjustZoom(-delta / this.deltaPerZoom_, this.lastAnchor_);
       this.startTime_ = now;
       return false;
     }
@@ -244,8 +244,15 @@ class MouseWheelZoom extends Interaction {
     if (view.getAnimating()) {
       view.cancelAnimations();
     }
-    const delta = clamp(this.totalDelta_, -this.maxDelta_, this.maxDelta_);
-    zoomByDelta(view, -delta, this.lastAnchor_, this.duration_);
+    let delta = -clamp(this.totalDelta_, -this.maxDelta_ * this.deltaPerZoom_, this.maxDelta_ * this.deltaPerZoom_) / this.deltaPerZoom_;
+    const currentZoom = view.getZoom();
+    const newZoom = view.getConstrainedZoom(currentZoom + delta);
+    if (currentZoom === newZoom) {
+      // view has a zoom constraint, zoom by 1
+      delta = delta ? delta > 0 ? 1 : -1 : 0;
+    }
+    zoomByDelta(view, delta, this.lastAnchor_, this.duration_);
+
     this.mode_ = undefined;
     this.totalDelta_ = 0;
     this.lastAnchor_ = null;

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -212,8 +212,8 @@ class MouseWheelZoom extends Interaction {
         Mode.WHEEL;
     }
 
-    if (this.mode_ === Mode.TRACKPAD) {
-      const view = map.getView();
+    const view = map.getView();
+    if (this.mode_ === Mode.TRACKPAD && !view.getConstrainResolution()) {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {
@@ -248,9 +248,7 @@ class MouseWheelZoom extends Interaction {
       view.cancelAnimations();
     }
     let delta = -clamp(this.totalDelta_, -this.maxDelta_ * this.deltaPerZoom_, this.maxDelta_ * this.deltaPerZoom_) / this.deltaPerZoom_;
-    const currentZoom = view.getZoom();
-    const newZoom = view.getConstrainedZoom(currentZoom + delta);
-    if (currentZoom === newZoom) {
+    if (view.getConstrainResolution()) {
       // view has a zoom constraint, zoom by 1
       delta = delta ? delta > 0 ? 1 : -1 : 0;
     }

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -121,7 +121,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
         const event = new MapBrowserEvent('wheel', map, {
           type: 'wheel',
           deltaMode: WheelEvent.DOM_DELTA_LINE,
-          deltaY: 3.714599609375,
+          deltaY: 20,
           target: map.getViewport(),
           preventDefault: Event.prototype.preventDefault
         });
@@ -140,7 +140,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
 
         const event = new MapBrowserEvent('wheel', map, {
           type: 'wheel',
-          deltaY: 120,
+          deltaY: 300,
           target: map.getViewport(),
           preventDefault: Event.prototype.preventDefault
         });

--- a/test/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/spec/ol/interaction/mousewheelzoom.test.js
@@ -3,7 +3,7 @@ import MapBrowserEvent from '../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../src/ol/View.js';
 import Event from '../../../../src/ol/events/Event.js';
 import {DEVICE_PIXEL_RATIO, FIREFOX} from '../../../../src/ol/has.js';
-import MouseWheelZoom from '../../../../src/ol/interaction/MouseWheelZoom.js';
+import MouseWheelZoom, {Mode} from '../../../../src/ol/interaction/MouseWheelZoom.js';
 
 
 describe('ol.interaction.MouseWheelZoom', function() {
@@ -32,13 +32,13 @@ describe('ol.interaction.MouseWheelZoom', function() {
   describe('timeout duration', function() {
     let clock;
     beforeEach(function() {
-      sinon.spy(interaction, 'endInteraction_');
+      sinon.spy(interaction, 'handleWheelZoom_');
       clock = sinon.useFakeTimers();
     });
 
     afterEach(function() {
       clock.restore();
-      interaction.endInteraction_.restore();
+      interaction.handleWheelZoom_.restore();
     });
 
     it('works with the default value', function(done) {
@@ -49,12 +49,12 @@ describe('ol.interaction.MouseWheelZoom', function() {
       });
 
       map.handleMapBrowserEvent(event);
-      clock.tick(100);
-      // default timeout is 400 ms, not called yet
-      expect(interaction.endInteraction_.called).to.be(false);
+      clock.tick(50);
+      // default timeout is 80 ms, not called yet
+      expect(interaction.handleWheelZoom_.called).to.be(false);
 
-      clock.tick(300);
-      expect(interaction.endInteraction_.called).to.be(true);
+      clock.tick(30);
+      expect(interaction.handleWheelZoom_.called).to.be(true);
 
       done();
     });
@@ -63,15 +63,10 @@ describe('ol.interaction.MouseWheelZoom', function() {
 
   describe('handleEvent()', function() {
 
-    let view;
-    beforeEach(function() {
-      view = map.getView();
-    });
-
     if (FIREFOX) {
       it('works on Firefox in DOM_DELTA_PIXEL mode (trackpad)', function(done) {
         map.once('postrender', function() {
-          expect(interaction.lastDelta_).to.be(1);
+          expect(interaction.mode_).to.be(Mode.TRACKPAD);
           done();
         });
         const event = new MapBrowserEvent('wheel', map, {
@@ -89,7 +84,7 @@ describe('ol.interaction.MouseWheelZoom', function() {
     if (!FIREFOX) {
       it('works in DOM_DELTA_PIXEL mode (trackpad)', function(done) {
         map.once('postrender', function() {
-          expect(interaction.lastDelta_).to.be(1);
+          expect(interaction.mode_).to.be(Mode.TRACKPAD);
           done();
         });
         const event = new MapBrowserEvent('wheel', map, {
@@ -104,61 +99,56 @@ describe('ol.interaction.MouseWheelZoom', function() {
       });
     }
 
-
-    it('works in DOM_DELTA_LINE mode (wheel)', function(done) {
-      map.once('postrender', function() {
-        expect(view.getResolution()).to.be(2);
-        expect(view.getCenter()).to.eql([0, 0]);
-        done();
+    describe('spying on view.animateInternal()', function() {
+      let view;
+      beforeEach(function() {
+        view = map.getView();
+        sinon.spy(view, 'animateInternal');
       });
 
-      const event = new MapBrowserEvent('wheel', map, {
-        type: 'wheel',
-        deltaMode: WheelEvent.DOM_DELTA_LINE,
-        deltaY: 7.5,
-        target: map.getViewport(),
-        preventDefault: Event.prototype.preventDefault
-      });
-      event.coordinate = [0, 0];
-
-      map.handleMapBrowserEvent(event);
-    });
-
-    it('works on all browsers (wheel)', function(done) {
-      map.once('postrender', function() {
-        expect(view.getResolution()).to.be(2);
-        expect(view.getCenter()).to.eql([0, 0]);
-        done();
+      afterEach(function() {
+        view.animateInternal.restore();
       });
 
-      const event = new MapBrowserEvent('wheel', map, {
-        type: 'wheel',
-        deltaY: 300, // trackpadDeltaPerZoom_
-        target: map.getViewport(),
-        preventDefault: Event.prototype.preventDefault
+      it('works in DOM_DELTA_LINE mode (wheel)', function(done) {
+        map.once('postrender', function() {
+          const call = view.animateInternal.getCall(0);
+          expect(call.args[0].resolution).to.be(2);
+          expect(call.args[0].anchor).to.eql([0, 0]);
+          done();
+        });
+
+        const event = new MapBrowserEvent('wheel', map, {
+          type: 'wheel',
+          deltaMode: WheelEvent.DOM_DELTA_LINE,
+          deltaY: 3.714599609375,
+          target: map.getViewport(),
+          preventDefault: Event.prototype.preventDefault
+        });
+        event.coordinate = [0, 0];
+
+        map.handleMapBrowserEvent(event);
       });
-      event.coordinate = [0, 0];
 
-      map.handleMapBrowserEvent(event);
-    });
+      it('works on all browsers (wheel)', function(done) {
+        map.once('postrender', function() {
+          const call = view.animateInternal.getCall(0);
+          expect(call.args[0].resolution).to.be(2);
+          expect(call.args[0].anchor).to.eql([0, 0]);
+          done();
+        });
 
-    it('works in DOM_DELTA_LINE mode (wheel)', function(done) {
-      map.once('postrender', function() {
-        expect(view.getResolution()).to.be(2);
-        expect(view.getCenter()).to.eql([0, 0]);
-        done();
+        const event = new MapBrowserEvent('wheel', map, {
+          type: 'wheel',
+          deltaY: 120,
+          target: map.getViewport(),
+          preventDefault: Event.prototype.preventDefault
+        });
+        event.coordinate = [0, 0];
+
+        map.handleMapBrowserEvent(event);
       });
 
-      const event = new MapBrowserEvent('wheel', map, {
-        type: 'wheel',
-        deltaMode: WheelEvent.DOM_DELTA_LINE,
-        deltaY: 7.5, // trackpadDeltaPerZoom_ / 40
-        target: map.getViewport(),
-        preventDefault: Event.prototype.preventDefault
-      });
-      event.coordinate = [0, 0];
-
-      map.handleMapBrowserEvent(event);
     });
 
   });


### PR DESCRIPTION
This pull request reverts the changes from #9565, and replaces them with a smaller change that gives the MouseWheelZoom interaction two different behaviors when using a mouse:
* When no zoom constraint is set on the view, one wheel tick will zoom the map only a fraction of a zoom level. The faster the wheel is moved, the more the movement of a single tick will be.
* When a zoom constaint is set on the view, the behavior is the same as it was before v6.2 - one tick zooms by 1 integer zoom.

For trackpad use, two improvements were made:
* The rebound behavior has been improved to feel more like the page scroll rebound behavior of browsers.
* When the view has a resolution constraint, the mousewheel behavior is used instead of trackpad mode.

Fixes #10659.
Fixes #10641.
Replaces and closes #10639.