### PR TITLE
Increase timeout in listenImage test

### DIFF
--- a/test/spec/ol/image.test.js
+++ b/test/spec/ol/image.test.js
@@ -40,7 +40,7 @@ describe('HTML Image loading', function() {
       expect(handleLoad.called).to.be(false);
       expect(handleError.called).to.be(true);
       done();
-    }, 200);
+    }, 500);
   });
 
   it('handles cancelation', function(done) {


### PR DESCRIPTION
Fixes failing test with Chrome 80 on Windows 10
