### PR TITLE
Publish type definition files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,30 +41,6 @@ See the following examples for more detail on bundling OpenLayers with your appl
  * Using [Parcel](https://github.com/openlayers/ol-parcel)
  * Using [Browserify](https://github.com/openlayers/ol-browserify)
 
-## IntelliSense support and type checking for VS Code
-
-The `ol` package contains a `src/` folder with JSDoc annotated sources. TypeScript can get type definitions from these sources with a `jsconfig.json` config file in the project root:
-```js
-{
-  "compilerOptions": {
-    "checkJs": true,
-    // Point to the JSDoc typed sources when using modules from the ol package
-    "baseUrl": "./",
-    "paths": {
-      "ol": ["node_modules/ol/src"],
-      "ol/*": ["node_modules/ol/src/*"]
-    }
-  },
-  "include": [
-    "**/*.js",
-    "node_modules/ol/**/*.js"
-  ]
-}
-```
-Project template with this configuration: https://gist.github.com/9a7253cb4712e8bf38d75d8ac898e36c.
-
-Note that the above only works when authoring in plain JavaScript. For similar configurations with a `tsconfig.json` in TypeScript projects, your mileage may vary.
-
 ## Supported Browsers
 
 OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, [polyfills](http://polyfill.io) for `requestAnimationFrame` and `Element.prototype.classList` are required, and using the KML format requires a polyfill for `URL`.

--- a/config/tsconfig-build.json
+++ b/config/tsconfig-build.json
@@ -7,8 +7,8 @@
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "../build/ol",                        /* Redirect output structure to the directory. */

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-index": "npm run build-package && node tasks/generate-index",
     "build-legacy": "shx rm -rf build && npm run build-index && webpack --config config/webpack-config-legacy-build.js && cleancss --source-map src/ol/ol.css -o build/legacy/ol.css",
     "copy-css": "shx cp src/ol/ol.css build/ol/ol.css",
-    "transpile": "shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build/ol/src && node tasks/serialize-workers && tsc --project config/tsconfig-build.json",
+    "transpile": "shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build/ol/src && node tasks/serialize-workers && npx --package typescript@3.8.1-rc tsc --project config/tsconfig-build.json",
     "typecheck": "tsc --pretty",
     "apidoc": "shx rm -rf build/apidoc && jsdoc -R config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -P package.json -d build/apidoc"
   },


### PR DESCRIPTION
Thanks to recent improvements of TypeScript, we can now use `tsc` to generate type definitions (`.d.ts` files) for OpenLayers.

With the changes in this pull request, `npm run build-package` will create `.d.ts` files. This means that once this pull request is merged, any future release will contain the definitions as part of the npm package.

One thing that @tschaub will like in particular: Thanks to the `"declarationMap": true` option in the TypeScript configuration `.d.ts.map` files will also be created. So clicking "Go to definition" in VS Code will take you to the source code in the `.js` file, and not the `.d.ts` file.

Because TypeScript v3.8.1-rc still lacks proper support for JavaScript enums (microsoft/TypeScript#33575), we cannot use that version for our type checks. But it does create proper type definitions, and for type checking w continue to use v3.5.3.

Fixes #8120
Replaces and closes #10061