### PR TITLE
Fix type and documentation of style function

### DIFF
--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -13,9 +13,10 @@ import Stroke from './Stroke.js';
  * A function that takes an {@link module:ol/Feature} and a `{number}`
  * representing the view's resolution. The function should return a
  * {@link module:ol/style/Style} or an array of them. This way e.g. a
- * vector layer can be styled.
+ * vector layer can be styled. If the function returns `undefined`, the
+ * feature will not be rendered.
  *
- * @typedef {function(import("../Feature.js").FeatureLike, number):(Style|Array<Style>)} StyleFunction
+ * @typedef {function(import("../Feature.js").FeatureLike, number):(Style|Array<Style>)|undefined} StyleFunction
  */
 
 /**


### PR DESCRIPTION
When a style function returns `undefined`, the feature will not be rendered. This has always been working, but never documented. So I updated the type and the documentation to reflect the implemented behavior.