### PR TITLE
Fix stylefunction return type

### DIFF
--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -16,7 +16,7 @@ import Stroke from './Stroke.js';
  * vector layer can be styled. If the function returns `undefined`, the
  * feature will not be rendered.
  *
- * @typedef {function(import("../Feature.js").FeatureLike, number):(Style|Array<Style>)|undefined} StyleFunction
+ * @typedef {function(import("../Feature.js").FeatureLike, number):(Style|Array<Style>|void)} StyleFunction
  */
 
 /**


### PR DESCRIPTION
Follow-up on #10709 : in the previous pull request, both the place for the additional return type and its actual type were wrong.