### PR TITLE
Fix disappearing graticule labels when rotation returns to 0

### DIFF
--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -611,7 +611,7 @@ class Graticule extends VectorLayer {
       for (index = 0, l = this.meridiansLabels_.length; index < l; ++index) {
         const lineString = this.meridians_[index];
         if (!rotation) {
-          textPoint = this.getMeridianPoint_(lineString, this.renderedExtent_, index);
+          textPoint = this.getMeridianPoint_(lineString, extent, index);
         } else {
           const clone = lineString.clone();
           clone.rotate(-rotation, rotationCenter);
@@ -628,7 +628,7 @@ class Graticule extends VectorLayer {
       for (index = 0, l = this.parallels_.length; index < l; ++index) {
         const lineString = this.parallels_[index];
         if (!rotation) {
-          textPoint = this.getParallelPoint_(lineString, this.renderedExtent_, index);
+          textPoint = this.getParallelPoint_(lineString, extent, index);
         } else {
           const clone = lineString.clone();
           clone.rotate(-rotation, rotationCenter);


### PR DESCRIPTION
Follow up to #10713

When the rotation snaps back to zero the renderedExtent hasn't yet been updated so all the labels disappear until there is an interaction.  Using the frameState extent directly fixes it.
