### PR TITLE
Apidoc better search

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -189,9 +189,15 @@ function attachModuleSymbols(doclets, modules) {
 }
 
 function getPrettyName(longname) {
-  return longname
-    .split('~')[0]
-    .replace('module:', '');
+  const fullname = longname.replace('module:', '');
+  const parts = fullname.split(/[~\.]/);
+  if (parts.length > 1) {
+    const pathParts = parts[0].split('/');
+    if (parts[parts.length - 1] === pathParts[pathParts.length - 1]) {
+      return parts[0];
+    }
+  }
+  return fullname;
 }
 
 /**

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -14,7 +14,6 @@ const path = require('jsdoc/lib/jsdoc/path');
 const taffy = require('taffydb').taffy;
 const handle = require('jsdoc/lib/jsdoc/util/error').handle;
 const helper = require('jsdoc/lib/jsdoc/util/templateHelper');
-const _ = require('underscore');
 const htmlsafe = helper.htmlsafe;
 const linkto = helper.linkto;
 const resolveAuthorLinks = helper.resolveAuthorLinks;
@@ -211,23 +210,9 @@ function getPrettyName(doclet) {
  */
 function buildNav(members) {
   const nav = [];
-  // merge namespaces and classes, then sort
-  const merged = members.modules.concat(members.classes);
-  merged.sort(function(a, b) {
-    const prettyNameA = getPrettyName(a).toLowerCase();
-    const prettyNameB = getPrettyName(b).toLowerCase();
-    if (prettyNameA > prettyNameB) {
-      return 1;
-    }
-    if (prettyNameA < prettyNameB) {
-      return -1;
-    }
-    return 0;
-  });
-
-  _.each(merged, function(v) {
+  members.classes.forEach(function(v) {
     // exclude interfaces from sidebar
-    if (v.interface !== true && v.kind === 'class') {
+    if (v.interface !== true) {
       nav.push({
         type: 'class',
         longname: v.longname,
@@ -255,43 +240,56 @@ function buildNav(members) {
           memberof: v.longname
         })
       });
-    } else if (v.kind == 'module') {
-      const classes = find({
-        kind: 'class',
-        memberof: v.longname
-      });
-      const members = find({
-        kind: 'member',
-        memberof: v.longname
-      });
-      const methods = find({
-        kind: 'function',
-        memberof: v.longname
-      });
-      const typedefs = find({
-        kind: 'typedef',
-        memberof: v.longname
-      });
-      const events = find({
-        kind: 'event',
-        memberof: v.longname
-      });
-      // Only add modules that contain more than just classes with their
-      // associated Options typedef
-      if (typedefs.length > classes.length || members.length + methods.length > 0) {
-        nav.push({
-          type: 'module',
-          longname: v.longname,
-          prettyname: getPrettyName(v),
-          name: v.name,
-          members: members,
-          methods: methods,
-          typedefs: typedefs,
-          fires: v.fires,
-          events: events
-        });
-      }
     }
+  });
+  members.modules.forEach(function(v) {
+    const classes = find({
+      kind: 'class',
+      memberof: v.longname
+    });
+    const members = find({
+      kind: 'member',
+      memberof: v.longname
+    });
+    const methods = find({
+      kind: 'function',
+      memberof: v.longname
+    });
+    const typedefs = find({
+      kind: 'typedef',
+      memberof: v.longname
+    });
+    const events = find({
+      kind: 'event',
+      memberof: v.longname
+    });
+    // Only add modules that contain more than just classes with their
+    // associated Options typedef
+    if (typedefs.length > classes.length || members.length + methods.length > 0) {
+      nav.push({
+        type: 'module',
+        longname: v.longname,
+        prettyname: getPrettyName(v),
+        name: v.name,
+        members: members,
+        methods: methods,
+        typedefs: typedefs,
+        fires: v.fires,
+        events: events
+      });
+    }
+  });
+
+  nav.sort(function(a, b) {
+    const prettyNameA = a.prettyname.toLowerCase();
+    const prettyNameB = b.prettyname.toLowerCase();
+    if (prettyNameA > prettyNameB) {
+      return 1;
+    }
+    if (prettyNameA < prettyNameB) {
+      return -1;
+    }
+    return 0;
   });
   return nav;
 }

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -188,14 +188,10 @@ function attachModuleSymbols(doclets, modules) {
   });
 }
 
-function getPrettyName(longname) {
-  const fullname = longname.replace('module:', '');
-  const parts = fullname.split(/[~\.]/);
-  if (parts.length > 1) {
-    const pathParts = parts[0].split('/');
-    if (parts[parts.length - 1] === pathParts[pathParts.length - 1]) {
-      return parts[0];
-    }
+function getPrettyName(doclet) {
+  const fullname = doclet.longname.replace('module:', '');
+  if (doclet.isDefaultExport) {
+    return fullname.split('~')[0];
   }
   return fullname;
 }
@@ -218,8 +214,8 @@ function buildNav(members) {
   // merge namespaces and classes, then sort
   const merged = members.modules.concat(members.classes);
   merged.sort(function(a, b) {
-    const prettyNameA = getPrettyName(a.longname).toLowerCase();
-    const prettyNameB = getPrettyName(b.longname).toLowerCase();
+    const prettyNameA = getPrettyName(a).toLowerCase();
+    const prettyNameB = getPrettyName(b).toLowerCase();
     if (prettyNameA > prettyNameB) {
       return 1;
     }
@@ -235,7 +231,7 @@ function buildNav(members) {
       nav.push({
         type: 'class',
         longname: v.longname,
-        prettyname: getPrettyName(v.longname),
+        prettyname: getPrettyName(v),
         name: v.name,
         module: find({
           kind: 'module',
@@ -286,7 +282,7 @@ function buildNav(members) {
         nav.push({
           type: 'module',
           longname: v.longname,
-          prettyname: getPrettyName(v.longname),
+          prettyname: getPrettyName(v),
           name: v.name,
           members: members,
           methods: methods,

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -29,7 +29,7 @@ $(function () {
   var getSearchWeight = function (searchTerm, $matchedItem) {
     let weight = 0;
     // We could get smarter on the weight here
-    if ($matchedItem.data('shortname') === searchTerm) {
+    if ($matchedItem.data('name') === searchTerm) {
       weight++;
     }
     return weight;
@@ -48,7 +48,7 @@ $(function () {
     .replace('module-', 'module:')
     .replace(/_/g, '/')
     .replace(/-/g, '~');
-  var $currentItem = $('.navigation .item[data-name*="' + longname.toLowerCase() + '"]:eq(0)');
+  var $currentItem = $('.navigation .item[data-longname="' + longname + '"]:eq(0)');
 
   if ($currentItem.length) {
     $currentItem

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -29,7 +29,7 @@ $(function () {
   var getSearchWeight = function (searchTerm, $matchedItem) {
     let weight = 0;
     // We could get smarter on the weight here
-    if ($matchedItem.data('shortname').toLowerCase() === searchTerm.toLowerCase()) {
+    if ($matchedItem.data('shortname') === searchTerm) {
       weight++;
     }
     return weight;
@@ -48,7 +48,7 @@ $(function () {
     .replace('module-', 'module:')
     .replace(/_/g, '/')
     .replace(/-/g, '~');
-  var $currentItem = $('.navigation .item[data-name*="' + longname + '"]:eq(0)');
+  var $currentItem = $('.navigation .item[data-name*="' + longname.toLowerCase() + '"]:eq(0)');
 
   if ($currentItem.length) {
     $currentItem
@@ -62,8 +62,9 @@ $(function () {
     var $el = $('.navigation');
 
     if (searchTerm.length > 1) {
+      searchTerm = searchTerm.toLowerCase();
       const regexp = constructRegex(searchTerm, function (searchTerm) {
-        return new RegExp(searchTerm, 'i');
+        return new RegExp(searchTerm);
       }, allowRegex);
       $el.find('li, .member-list').hide();
 

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -123,6 +123,9 @@ $(function () {
 
   // Search Items
   searchInput.addEventListener('input', queueSearch);
+  if (searchInput.value) {
+    doSearch(searchInput.value);
+  }
 
   // Toggle when click an item element
   $('.navigation').on('click', '.toggle', function (e) {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -12,7 +12,7 @@ $(function () {
     } catch (e) {
     }
     // In case of invalid regexp fall back to non-regexp, but still allow . to match /
-    return makeRe(searchTerm.replace(/\./g, '/').replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    return makeRe(searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\./g, '[./]'));
   }
 
   function getWeightFunction(searchTerm, allowRegex) {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -32,23 +32,20 @@ $(function () {
       if (beginOnly) {
         return re.baseName.test(name) ? 10000 : 0;
       }
-      let weight = 0;
+      // If everything else is equal, prefer shorter names, and prefer classes over modules
+      let weight = matchedItem.data('longname').length - name.length * 100;
       if (name.match(re.begin)) {
-        weight += 10000;
+        weight += 100000;
         if (re.baseName.test(name)) {
-          weight += 1000000;
+          weight += 10000000;
           if (re.fullName.test(name)) {
-            // Full match of the last part of the path is weighted even higher
-            weight += 10000000;
+            weight += 100000000;
             if (re.completeName.test(name)) {
-              // Complete match is weighted highest.
-              weight += 100000000;
+              weight += 1000000000;
             }
           }
         }
       }
-      // If everything else is equal, prefer shorter names.
-      weight -= name.length;
       return weight;
     }
   }

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -53,8 +53,7 @@ $(function () {
   }
 
   const search = (function () {
-    const $nav = $('.navigation');
-    const $navList = $nav.find('.navigation-list');
+    const $navList = $('.navigation-list');
     const navListNode = $navList.get(0);
     let $classItems;
     let $members;
@@ -74,7 +73,6 @@ $(function () {
     const $currentItem = $navList.find('.item[data-longname="' + longname + '"]:eq(0)');
     $currentItem.prependTo($navList);
     return {
-      $nav: $nav,
       $navList: $navList,
       $currentItem: $currentItem,
       lastSearchTerm: undefined,
@@ -93,13 +91,14 @@ $(function () {
         }
       },
       manualToggle: function ($node, show) {
+        $node.addClass('toggle-manual');
         $node.toggleClass('toggle-manual-hide', !show);
         $node.toggleClass('toggle-manual-show', show);
         manualToggles[$node.data('longname')] = $node;
       },
       clearManualToggles: function() {
         for (let clsName in manualToggles) {
-          manualToggles[clsName].removeClass('toggle-manual-show toggle-manual-hide');
+          manualToggles[clsName].removeClass('toggle-manual toggle-manual-show toggle-manual-hide');
         }
         manualToggles = {};
       },
@@ -240,7 +239,10 @@ $(function () {
   doSearch(searchInput.value);
 
   // Toggle when click an item element
-  search.$nav.on('click', '.toggle', function (e) {
+  search.$navList.on('click', '.toggle', function (e) {
+    if (event.target.tagName.toLowerCase() === 'a') {
+      return;
+    }
     const clsItem = $(this).closest('.item');
     let show;
     if (clsItem.hasClass('toggle-manual-show')) {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -210,25 +210,13 @@ $(function () {
   const searchInput = $('#search').get(0);
   // Skip searches when typing fast.
   let key;
-  let start;
-  const brandNode = document.querySelector('.brand');
   function queueSearch() {
     if (!key) {
-      start = Date.now();
       key = setTimeout(function () {
         key = undefined;
 
         const searchTerm = searchInput.value;
         doSearch(searchTerm);
-
-        const time = Date.now() - start
-        brandNode.innerHTML = time + ' ms';
-        const msg = [searchTerm + ':', time, 'ms'];
-        if (searchTerm.length >= minInputForSearch) {
-          msg.push(search.lastState);
-        }
-        console.log.apply(console, msg);
-        start = undefined;
       }, 0);
     }
   }

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -26,6 +26,22 @@ $(function () {
     return bW - aW;
   };
 
+  // Show an item related a current documentation automatically
+  const longname = $('.page-title').data('filename')
+    .replace(/\.[a-z]+$/, '')
+    .replace('module-', 'module:')
+    .replace(/_/g, '/')
+    .replace(/-/g, '~');
+  var $currentItem = $('.navigation .item[data-name*="' + longname + '"]:eq(0)');
+
+  if ($currentItem.length) {
+    $currentItem
+      .prependTo('.navigation .list')
+      .show()
+      .find('.member-list')
+      .show();
+  }
+
   // Search Items
   $('#search').on('keyup', function (e) {
     var value = $(this).val();
@@ -60,7 +76,9 @@ $(function () {
         .appendTo(".navigation ul.list"); // append again to the list
 
     } else {
-      $el.find('.item, .member-list').show();
+      $currentItem.prependTo('.navigation .list');
+      $currentItem.find('.member-list, li').show();
+      $el.find('.item').show();
     }
 
     $el.find('.list').scrollTop(0);
@@ -70,23 +88,6 @@ $(function () {
   $('.navigation').on('click', '.toggle', function (e) {
     $(this).parent().parent().find('.member-list').toggle();
   });
-
-  // Show an item related a current documentation automatically
-  var filename = $('.page-title').data('filename')
-    .replace(/\.[a-z]+$/, '')
-    .replace('module-', 'module:')
-    .replace(/_/g, '/')
-    .replace(/-/g, '~');
-  var $currentItem = $('.navigation .item[data-name*="' + filename + '"]:eq(0)');
-
-  if ($currentItem.length) {
-    $currentItem
-      .remove()
-      .prependTo('.navigation .list')
-      .show()
-      .find('.member-list')
-      .show();
-  }
 
   // Auto resizing on navigation
   var _onResize = function () {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -71,10 +71,12 @@ $(function () {
       .replace(/_/g, '/')
       .replace(/-/g, '~');
     const currentItem = navListNode.querySelector('.item[data-longname="' + longname + '"]');
-    $navList.prepend(currentItem);
+    if (currentItem) {
+      $navList.prepend(currentItem);
+    }
     return {
       $navList: $navList,
-      $currentItem: $(currentItem),
+      $currentItem: currentItem ? $(currentItem) : undefined,
       lastSearchTerm: undefined,
       lastState: {},
       getClassList: function () {
@@ -138,7 +140,7 @@ $(function () {
         // Restore the original, sorted order
         search.$navList.append(search.getClassList());
       }
-      if (state === 'search-empty') {
+      if (state === 'search-empty' && search.$currentItem) {
         search.manualToggle(search.$currentItem, true);
       }
     } else {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -32,18 +32,18 @@ $(function () {
       // We could get smarter on the weight here
       const name = matchedItem.dataset.name;
       if (beginOnly) {
-        return re.baseName.test(name) ? 10000 : 0;
+        return re.baseName.test(name) ? 100 : 1;
       }
       // If everything else is equal, prefer shorter names, and prefer classes over modules
-      let weight = matchedItem.dataset.longname.length - name.length * 100;
+      let weight = 10000 + matchedItem.dataset.longname.length - name.length * 100;
       if (name.match(re.begin)) {
-        weight += 100000;
+        weight += 10000;
         if (re.baseName.test(name)) {
-          weight += 10000000;
+          weight += 10000;
           if (re.fullName.test(name)) {
-            weight += 100000000;
+            weight += 10000;
             if (re.completeName.test(name)) {
-              weight += 1000000000;
+              weight += 10000;
             }
           }
         }
@@ -152,6 +152,19 @@ $(function () {
       const navList = search.$navList.get(0);
       const classes = [];
       const searchState = {};
+      search.getClassList().each(function (i, classEntry) {
+        const className = classEntry.dataset.longname;
+        if (!(className in searchState) && re.test(classEntry.dataset.name)) {
+          const cls = searchState[className] = {
+            item: classEntry,
+            // Do the weight thing
+            weight: getSearchWeight(classEntry, beginOnly) * 100000,
+            subItems: {}
+          };
+          classes.push(cls);
+          classEntry.classList.add('match');
+        }
+      });
       search.getMembers().each(function (i, li) {
         const name = li.dataset.name;
         if (re.test(name)) {
@@ -162,14 +175,13 @@ $(function () {
           if (!cls) {
             cls = searchState[className] = {
               item: classEntry,
-              // Do the weight thing
-              weight: getSearchWeight(classEntry, beginOnly) * 10000,
+              weight: 0,
               subItems: {}
             };
             classes.push(cls);
             classEntry.classList.add('match');
           }
-          cls.weight += getSearchWeight(li, true) + 1;
+          cls.weight += getSearchWeight(li, true);
           const memberType = itemMember.dataset.type;
           let members = cls.subItems[memberType];
           if (!members) {
@@ -181,19 +193,6 @@ $(function () {
           }
           members.subItems[name] = { item: li };
           li.classList.add('match');
-        }
-      });
-      search.getClassList().each(function (i, classEntry) {
-        const className = classEntry.dataset.longname;
-        if (!(className in searchState) && re.test(classEntry.dataset.name)) {
-          const cls = searchState[className] = {
-            item: classEntry,
-            // Do the weight thing
-            weight: getSearchWeight(classEntry, beginOnly) * 10000,
-            subItems: {}
-          };
-          classes.push(cls);
-          classEntry.classList.add('match');
         }
       });
       clearOldMatches(search.lastState, searchState);

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -85,11 +85,21 @@ $(function () {
   const searchInput = $('#search').get(0);
   // Skip searches when typing fast.
   let key;
+  let start;
+  const brandNode = document.querySelector('.brand');
   function queueSearch() {
     if (!key) {
+      start = Date.now();
       key = setTimeout(function () {
-        doSearch(searchInput.value);
         key = undefined;
+
+        const searchTerm = searchInput.value;
+        doSearch(searchTerm);
+
+        const time = Date.now() - start
+        brandNode.innerHTML = time + ' ms';
+        console.log(searchTerm + ':', time, 'ms');
+        start = undefined;
       }, 0);
     }
   }

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -137,22 +137,4 @@ $(function () {
       '<a href="' + link + textParts[1].replace('line ', '#L') + '">' +
       textParts[1] + '</a>';
   });
-
-  // Highlighting current anchor
-
-  var anchors = $('.anchor');
-  var _onHashChange = function () {
-    var activeHash = window.document.location.hash
-      .replace(/\./g, '\\.') // Escape dot in element id
-      .replace(/\~/g, '\\~'); // Escape tilde in element id
-
-    anchors.removeClass('highlighted');
-
-    if (activeHash.length > 0) {
-      anchors.filter(activeHash).addClass('highlighted');
-    }
-  };
-
-  $(window).on('hashchange', _onHashChange);
-  _onHashChange();
 });

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -3,16 +3,6 @@ $(function () {
   // Allow user configuration?
   const allowRegex = true;
 
-  // Search Items
-  $('#include_modules').change(function (e) {
-    console.log('change');
-    if ($(this).is(':checked')) {
-
-    } else {
-
-    }
-  });
-
   const reNotCache = {};
   function escapeRegexp(s, not) {
     if (not) {
@@ -39,8 +29,7 @@ $(function () {
   var getSearchWeight = function (searchTerm, $matchedItem) {
     let weight = 0;
     // We could get smarter on the weight here
-    if ($matchedItem.data('shortname')
-      && $matchedItem.data('shortname').toLowerCase() === searchTerm.toLowerCase()) {
+    if ($matchedItem.data('shortname').toLowerCase() === searchTerm.toLowerCase()) {
       weight++;
     }
     return weight;
@@ -82,19 +71,17 @@ $(function () {
         const $item = $(v);
         const name = $item.data('name');
 
-        if (name && regexp.test(name)) {
+        if (regexp.test(name)) {
           const $classEntry = $item.closest('.item');
           const $members = $item.closest('.member-list');
 
           // Do the weight thing
-          $classEntry.removeData('weight');
-          $classEntry.show();
           const weight = getSearchWeight(searchTerm, $classEntry);
           $classEntry.data('weight', weight);
 
+          $item.show();
           $members.show();
           $classEntry.show();
-          $item.show();
         }
       });
 

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -54,12 +54,13 @@ $(function () {
 
   const search = (function () {
     const $nav = $('.navigation');
-    const $navList = $nav.find('.list');
+    const $navList = $nav.find('.navigation-list');
+    const navListNode = $navList.get(0);
     let $classItems;
     let $members;
     let stateClass = (function () {
-      $nav.removeClass('search-started searching');
-      $nav.addClass('search-empty');
+      $navList.removeClass('search-started searching');
+      $navList.addClass('search-empty');
       return 'search-empty';
     })();
     let manualToggles = {};
@@ -72,7 +73,6 @@ $(function () {
       .replace(/-/g, '~');
     const $currentItem = $navList.find('.item[data-longname="' + longname + '"]:eq(0)');
     $currentItem.prependTo($navList);
-    $currentItem.addClass('item-current toggle-manual-show');
     return {
       $nav: $nav,
       $navList: $navList,
@@ -87,9 +87,8 @@ $(function () {
       },
       changeStateClass: function (newClass) {
         if (newClass !== stateClass) {
-          const navNode = $nav.get(0);
-          navNode.classList.remove(stateClass);
-          navNode.classList.add(newClass);
+          navListNode.classList.remove(stateClass);
+          navListNode.classList.add(newClass);
           stateClass = newClass;
         }
       },
@@ -238,9 +237,7 @@ $(function () {
 
   // Search Items
   searchInput.addEventListener('input', queueSearch);
-  if (searchInput.value) {
-    doSearch(searchInput.value);
-  }
+  doSearch(searchInput.value);
 
   // Toggle when click an item element
   search.$nav.on('click', '.toggle', function (e) {
@@ -264,7 +261,7 @@ $(function () {
     var height = $(window).height();
     var $el = $('.navigation');
 
-    $el.height(height).find('.list').height(height - 133);
+    $el.height(height).find('.navigation-list').height(height - 133);
   };
 
   $(window).on('resize', _onResize);

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -72,7 +72,7 @@ $(function () {
       .replace(/-/g, '~');
     const $currentItem = $navList.find('.item[data-longname="' + longname + '"]:eq(0)');
     $currentItem.prependTo($navList);
-    $currentItem.addClass('item-current');
+    $currentItem.addClass('item-current toggle-manual-show');
     return {
       $nav: $nav,
       $navList: $navList,
@@ -245,12 +245,18 @@ $(function () {
   // Toggle when click an item element
   search.$nav.on('click', '.toggle', function (e) {
     const clsItem = $(this).closest('.item');
-    let shown;
-    clsItem.find('.member-list').each(function (i, v) {
-      shown = $(v).is(':visible');
-      return !shown;
-    });
-    search.manualToggle(clsItem, !shown);
+    let show;
+    if (clsItem.hasClass('toggle-manual-show')) {
+      show = false;
+    } else if (clsItem.hasClass('toggle-manual-hide')) {
+      show = true;
+    } else {
+      clsItem.find('.member-list li').each(function (i, v) {
+        show = $(v).is(':hidden');
+        return !show;
+      });
+    }
+    search.manualToggle(clsItem, !!show);
   });
 
   // Auto resizing on navigation

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -70,11 +70,11 @@ $(function () {
       .replace('module-', 'module:')
       .replace(/_/g, '/')
       .replace(/-/g, '~');
-    const $currentItem = $navList.find('.item[data-longname="' + longname + '"]:eq(0)');
-    $currentItem.prependTo($navList);
+    const currentItem = navListNode.querySelector('.item[data-longname="' + longname + '"]');
+    $navList.prepend(currentItem);
     return {
       $navList: $navList,
-      $currentItem: $currentItem,
+      $currentItem: $(currentItem),
       lastSearchTerm: undefined,
       lastState: {},
       getClassList: function () {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -42,8 +42,7 @@ $(function () {
       .show();
   }
 
-  // Search Items
-  $('#search').on('keyup', function (e) {
+  function doSearch() {
     var value = $(this).val();
     var $el = $('.navigation');
 
@@ -82,7 +81,22 @@ $(function () {
     }
 
     $el.find('.list').scrollTop(0);
-  });
+  }
+
+  const searchInput = $('#search').get(0);
+  // Skip searches when typing fast.
+  let key;
+  function queueSearch() {
+    if (!key) {
+      key = setTimeout(function () {
+        doSearch.call(searchInput);
+        key = undefined;
+      }, 0);
+    }
+  }
+
+  // Search Items
+  searchInput.addEventListener('input', queueSearch);
 
   // Toggle when click an item element
   $('.navigation').on('click', '.toggle', function (e) {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -1,4 +1,8 @@
 $(function () {
+
+  // Allow user configuration?
+  const allowRegex = true;
+
   // Search Items
   $('#include_modules').change(function (e) {
     console.log('change');
@@ -8,6 +12,29 @@ $(function () {
 
     }
   });
+
+  const reNotCache = {};
+  function escapeRegexp(s, not) {
+    if (not) {
+      let re = reNotCache[not];
+      if (!re) {
+        const characters = '-\/\\^$*+?.()|[\]{}'.replace(new RegExp('[' + escapeRegexp(not) + ']', 'g'), '');
+        re = reNotCache[not] = new RegExp('[' + escapeRegexp(characters) + ']', 'g');
+      }
+      return s.replace(re, '\\$&');
+    }
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+
+  function constructRegex(searchTerm, makeRe, allowRegex) {
+    try {
+      if (allowRegex) {
+        return makeRe(searchTerm);
+      }
+    } catch (e) {
+    }
+    return makeRe(escapeRegexp(searchTerm, '.'));
+  }
 
   var getSearchWeight = function (searchTerm, $matchedItem) {
     let weight = 0;
@@ -46,7 +73,9 @@ $(function () {
     var $el = $('.navigation');
 
     if (searchTerm.length > 1) {
-      var regexp = new RegExp(searchTerm, 'i');
+      const regexp = constructRegex(searchTerm, function (searchTerm) {
+        return new RegExp(searchTerm, 'i');
+      }, allowRegex);
       $el.find('li, .member-list').hide();
 
       $el.find('li').each(function (i, v) {

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -1,4 +1,5 @@
 $(function () {
+  'use strict';
 
   // Allow user configuration?
   const allowRegex = true;

--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -42,12 +42,11 @@ $(function () {
       .show();
   }
 
-  function doSearch() {
-    var value = $(this).val();
+  function doSearch(searchTerm) {
     var $el = $('.navigation');
 
-    if (value && value.length > 1) {
-      var regexp = new RegExp(value, 'i');
+    if (searchTerm.length > 1) {
+      var regexp = new RegExp(searchTerm, 'i');
       $el.find('li, .member-list').hide();
 
       $el.find('li').each(function (i, v) {
@@ -61,7 +60,7 @@ $(function () {
           // Do the weight thing
           $classEntry.removeData('weight');
           $classEntry.show();
-          const weight = getSearchWeight(value, $classEntry);
+          const weight = getSearchWeight(searchTerm, $classEntry);
           $classEntry.data('weight', weight);
 
           $members.show();
@@ -89,7 +88,7 @@ $(function () {
   function queueSearch() {
     if (!key) {
       key = setTimeout(function () {
-        doSearch.call(searchInput);
+        doSearch(searchInput.value);
         key = undefined;
       }, 0);
     }

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -190,9 +190,51 @@ li {
   margin-top: 2px;
 }
 .navigation li.item .member-list {
-  display: none;
   padding-left: 8px;
 }
+
+/* search state */
+/* show all classes when search is empty */
+.navigation.search-empty li.item {
+  display: block;
+}
+/* hide all members by default when search is empty */
+.navigation.search-empty li.item .member-list {
+  display: none;
+}
+/* but show the members of the current pages module / class */
+.navigation.search-empty li.item.item-current .member-list {
+  display: block;
+}
+/* expand all members when one character is entered in the search field */
+.navigation.search-started li.item,
+.navigation.search-started .member-list,
+.navigation.search-started .member-list li {
+  display: block;
+}
+/* when more than one character is entered hide everything that is not a match */
+.navigation.searching li.item,
+.navigation.searching .member-list,
+.navigation.searching .member-list li {
+  display: none;
+}
+.navigation.searching li.item.match,
+.navigation.searching .member-list.match,
+.navigation.searching .member-list li.match {
+  display: block;
+}
+/* allow user to hide / show members */
+.navigation .item.toggle-manual-show .member-list,
+.navigation .item.toggle-manual-show li {
+  display: block!important;
+}
+.navigation .item.toggle-manual-hide .member-list,
+.navigation .item.toggle-manual-hide li,
+.navigation.searching .item.toggle-manual-show .member-list:not(.match),
+.navigation.searching .item.toggle-manual-show li:not(.match) {
+    display: none!important;
+}
+
 .main {
   padding: 20px 20px;
   margin-left: 250px;

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -124,7 +124,7 @@ li {
   color: #fff;
   border-color: #555;
 }
-.navigation .list {
+.navigation .navigation-list {
   padding: 10px 15px 0 15px;
   position: relative;
   overflow: auto;
@@ -195,37 +195,33 @@ li {
 
 /* search state */
 /* show all classes when search is empty */
-.navigation.search-empty li.item {
+.navigation-list.search-empty .item {
   display: block;
 }
 /* hide all members by default when search is empty */
-.navigation.search-empty li.item .member-list {
+.navigation-list.search-empty .item .member-list {
   display: none;
 }
-/* expand all members when one character is entered in the search field */
-.navigation.search-started li.item,
-.navigation.search-started .member-list,
-.navigation.search-started .member-list li {
+/* expand all members when input in search field available but too short to search */
+.navigation-list.search-started li,
+.navigation-list.search-started .member-list {
   display: block;
 }
-/* when more than one character is entered hide everything that is not a match */
-.navigation.searching li.item,
-.navigation.searching .member-list,
-.navigation.searching .member-list li {
+/* when searching hide everything that is not a match */
+.navigation-list.searching li,
+.navigation-list.searching .member-list {
   display: none;
 }
-.navigation.searching li.item.match,
-.navigation.searching .member-list.match,
-.navigation.searching .member-list li.match {
+.navigation-list.searching .match {
   display: block;
 }
 /* allow user to hide / show members */
-.navigation .item.toggle-manual-show .member-list,
-.navigation .item.toggle-manual-show li {
+.navigation-list .item.toggle-manual-show li,
+.navigation-list .item.toggle-manual-show .member-list {
   display: block!important;
 }
-.navigation:not(.searching) .item.toggle-manual-hide .member-list,
-.navigation:not(.searching) .item.toggle-manual-hide li {
+.navigation-list:not(.searching) .item.toggle-manual-hide li,
+.navigation-list:not(.searching) .item.toggle-manual-hide .member-list {
     display: none!important;
 }
 

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -202,10 +202,6 @@ li {
 .navigation.search-empty li.item .member-list {
   display: none;
 }
-/* but show the members of the current pages module / class */
-.navigation.search-empty li.item.item-current .member-list {
-  display: block;
-}
 /* expand all members when one character is entered in the search field */
 .navigation.search-started li.item,
 .navigation.search-started .member-list,
@@ -228,10 +224,8 @@ li {
 .navigation .item.toggle-manual-show li {
   display: block!important;
 }
-.navigation .item.toggle-manual-hide .member-list,
-.navigation .item.toggle-manual-hide li,
-.navigation.searching .item.toggle-manual-show .member-list:not(.match),
-.navigation.searching .item.toggle-manual-show li:not(.match) {
+.navigation:not(.searching) .item.toggle-manual-hide .member-list,
+.navigation:not(.searching) .item.toggle-manual-hide li {
     display: none!important;
 }
 

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -140,6 +140,19 @@ li {
   margin-right: 3px;
   flex-shrink: 0;
 }
+.navigation .item .glyphicon:before {
+  display: inline-block;
+}
+.navigation .item.toggle-manual .glyphicon:before {
+  transition: transform .1s;
+}
+.navigation .item-class.toggle-manual-show .glyphicon:before {
+  /* With 90deg the icon slightly slides left at transition end */
+  transform: rotate(89.9deg);
+}
+.navigation .item-module.toggle-manual-show .glyphicon:before {
+  transform: rotate(45deg);
+}
 
 .navigation li.perfect-match {
   border: 5px solid orange;

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -51,7 +51,8 @@ body {
   width: 0px;
   height: 0px;
 }
-.nameContainer .anchor.highlighted + h4 {
+/* Highlighting current anchor */
+.nameContainer .anchor:target + h4 {
   background-color: #faebcc;
 }
 a {

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -136,6 +136,11 @@ li {
   border-bottom: 1px solid #333;
 }
 
+.navigation .glyphicon {
+  margin-right: 3px;
+  flex-shrink: 0;
+}
+
 .navigation li.perfect-match {
   border: 5px solid orange;
 }
@@ -148,8 +153,8 @@ li {
 }
 .navigation li.item .title {
   cursor: pointer;
-  position: relative;
-  display: block;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 0.85em;
 }
 .navigation li.item .title a {

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -42,9 +42,9 @@ function listContent(item, title, listItemPrinter) {
     </div>
     <ul class="navigation-list search-empty"><?js
         this.nav.forEach(function (item) { ?>
-        <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.prettyname.toLowerCase() ?>">
-            <span class="title">
-                <span class="glyphicon <?js= getItemCssClass(item.type) ?> toggle"></span>
+        <li class="item item-<?js= item.type ?>" data-longname="<?js= item.longname ?>" data-name="<?js= item.prettyname.toLowerCase() ?>">
+            <span class="title toggle">
+                <span class="glyphicon <?js= getItemCssClass(item.type) ?>"></span>
                 <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~]/g, '\u200b$&')) ?></span>
             </span><?js
                 listContent(item, 'Members', printList);

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -15,11 +15,11 @@ function getItemCssClass(type) {
 }
 
 const printList = v => { ?>
-                    <li data-name="<?js= v.longname ?>"><?js
+                    <li data-name="<?js= v.longname.toLowerCase() ?>"><?js
 }
 const printListWithStability = v => {
     const cls = v.stability && v.stability !== 'stable' ? ' class="unstable"' : ''; ?>
-                    <li data-name="<?js= v.longname ?>"<?js= cls ?>><?js
+                    <li data-name="<?js= v.longname.toLowerCase() ?>"<?js= cls ?>><?js
 }
 
 function listContent(item, title, listItemPrinter) {
@@ -42,7 +42,7 @@ function listContent(item, title, listItemPrinter) {
     </div>
     <ul class="list"><?js
         this.nav.forEach(function (item) { ?>
-        <li class="item" data-name="<?js= item.longname ?>" data-shortname="<?js= item.name.toLowerCase() ?>">
+        <li class="item" data-name="<?js= item.longname.toLowerCase() ?>" data-shortname="<?js= item.name.toLowerCase() ?>">
             <span class="title">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?> toggle"></span>
                 <?js= self.linkto(item.longname, item.prettyname) ?>

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -25,7 +25,7 @@ const printListWithStability = v => {
 function listContent(item, title, listItemPrinter) {
     const type = title.toLowerCase();
     if (item[type] && item[type].length) { ?>
-            <div class="member-list">
+            <div class="member-list" data-type="<?js= type ?>">
                 <span class="subtitle"><?js= title ?></span>
                 <ul><?js
         item[type].forEach(function (v) {
@@ -36,13 +36,13 @@ function listContent(item, title, listItemPrinter) {
     }
 }
 ?>
-<div class="navigation">
+<div class="navigation search-empty">
     <div class="search">
         <input id="search" type="text" class="form-control input-sm" placeholder="Search Documentation">
     </div>
     <ul class="list"><?js
         this.nav.forEach(function (item) { ?>
-        <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.name.toLowerCase() ?>">
+        <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.prettyname.toLowerCase() ?>">
             <span class="title">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?> toggle"></span>
                 <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~]/g, '\u200b$&')) ?></span>

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -45,7 +45,7 @@ function listContent(item, title, listItemPrinter) {
         <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.name.toLowerCase() ?>">
             <span class="title">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?> toggle"></span>
-                <?js= self.linkto(item.longname, item.prettyname.replace(/[.~]/g, '\u200b$&')) ?>
+                <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~]/g, '\u200b$&')) ?></span>
             </span><?js
                 listContent(item, 'Members', printList);
                 listContent(item, 'Typedefs', printListWithStability);

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -15,11 +15,11 @@ function getItemCssClass(type) {
 }
 
 const printList = v => { ?>
-                    <li data-name="<?js= v.longname.toLowerCase() ?>"><?js
+                    <li data-name="<?js= toShortName(v.name).toLowerCase() ?>"><?js
 }
 const printListWithStability = v => {
     const cls = v.stability && v.stability !== 'stable' ? ' class="unstable"' : ''; ?>
-                    <li data-name="<?js= v.longname.toLowerCase() ?>"<?js= cls ?>><?js
+                    <li data-name="<?js= toShortName(v.name).toLowerCase() ?>"<?js= cls ?>><?js
 }
 
 function listContent(item, title, listItemPrinter) {
@@ -42,7 +42,7 @@ function listContent(item, title, listItemPrinter) {
     </div>
     <ul class="list"><?js
         this.nav.forEach(function (item) { ?>
-        <li class="item" data-name="<?js= item.longname.toLowerCase() ?>" data-shortname="<?js= item.name.toLowerCase() ?>">
+        <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.name.toLowerCase() ?>">
             <span class="title">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?> toggle"></span>
                 <?js= self.linkto(item.longname, item.prettyname) ?>

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -36,11 +36,11 @@ function listContent(item, title, listItemPrinter) {
     }
 }
 ?>
-<div class="navigation search-empty">
+<div class="navigation">
     <div class="search">
         <input id="search" type="text" class="form-control input-sm" placeholder="Search Documentation">
     </div>
-    <ul class="list"><?js
+    <ul class="navigation-list search-empty"><?js
         this.nav.forEach(function (item) { ?>
         <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.prettyname.toLowerCase() ?>">
             <span class="title">

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -45,7 +45,7 @@ function listContent(item, title, listItemPrinter) {
         <li class="item" data-longname="<?js= item.longname ?>" data-name="<?js= item.name.toLowerCase() ?>">
             <span class="title">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?> toggle"></span>
-                <?js= self.linkto(item.longname, item.prettyname) ?>
+                <?js= self.linkto(item.longname, item.prettyname.replace(/[.~]/g, '\u200b$&')) ?>
             </span><?js
                 listContent(item, 'Members', printList);
                 listContent(item, 'Typedefs', printListWithStability);


### PR DESCRIPTION
Searching feels rather slow, and the result relevance is not always great.
I set out to fix this.
There were  also a few bugs, that are fixed  with this:
- Clearing the input box after searching doesn't restore the original state instead there are the subtitles visible, and clicking the icon no longer expands members
- Entering an invalid regexp throws an exception
- When hovering a class entry the cursor changes to indicate it can be expanded, but actually only the glyph icon is clickable
- when searching for a class name all members are also matched, but not events because the search is done on the longname of each item / member, and events belong to different classes; searching for 'module' matches everything
- some entries are displayed with a wrong name e.g `ol/interaction/DragBox~DragBoxEvent` is also listed as `ol/interaction/DragBox`
- the keyup event used on the search input also captures keys like CTRL and arrow keys
- some events like e.g. boxdrag are not highlighted when clicked because a jquery error is thrown

Besides making searching faster and showing more relevant results I also did some small improvements (imho):
- If the search box is not empty on page load a search is started to show the corresponding results, Firefox leaves the input intact when reloading a page / going back to a previous page
- The prettyname includes the class name if it is different from the module name `ol/source/Vector~VectorSource` instead of only `ol/source/Vector`
- To better display the longer names a zero-width space is inserted before '~' and '.' in class and module names to allow word wrapping when needed
- The search is only done on the string that is displayed to the user - that's the prettyname for classes / modules and the name for members / events.
- The icon and class name are displayed in a two-column flexbox layout so wrapped lines are indented nicely
- When search results are displayed clicking a class toggles between the matched members and all members instead of collapsing all

Results are more relevant when
- any word of the path starts with the search term +
- the actual short class / module name starts with the search term ++
- the start *and* end of the name are both at word boundaries +++
- the whole name matches from start to finish ++++

additionally there is a small preference to
- shorter names
- classes over modules

The speed improvements are achieved by
- *not* using jquery with each item in the search loop 
- keeping track of the matched items from the previous search

Feel free to try it and leave a comment.