### PR TITLE
fix: handle layer clear event in case clear(true) called

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -290,7 +290,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.sourceListenKeys_ = [
       listen(source, VectorEventType.ADDFEATURE, this.handleSourceFeatureAdded_, this),
       listen(source, VectorEventType.CHANGEFEATURE, this.handleSourceFeatureChanged_, this),
-      listen(source, VectorEventType.REMOVEFEATURE, this.handleSourceFeatureDelete_, this)
+      listen(source, VectorEventType.REMOVEFEATURE, this.handleSourceFeatureDelete_, this),
+      listen(source, VectorEventType.CLEAR, this.handleSourceFeatureClear_, this)
     ];
     source.forEachFeature(function(feature) {
       this.featureCache_[getUid(feature)] = {
@@ -337,6 +338,14 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     const feature = event.feature;
     delete this.featureCache_[getUid(feature)];
     this.featureCount_--;
+  }
+
+  /**
+   * @private
+   */
+  handleSourceFeatureClear_() {
+    this.featureCache_ = {};
+    this.featureCount_ = 0;
   }
 
   /**


### PR DESCRIPTION
Should fix #10721 - tests pass.

Handle layer clear event in case clear(true) called as individual delete feature events aren't generated and the layer remains the same.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
