### PR TITLE
Improve the extent transforms used by Graticule and handle extents crossing the dateline

### DIFF
--- a/examples/sphere-mollweide.js
+++ b/examples/sphere-mollweide.js
@@ -17,8 +17,8 @@ register(proj4);
 // and a world extent. These are required for the Graticule.
 const sphereMollweideProjection = new Projection({
   code: 'ESRI:53009',
-  extent: [-9009954.605703328, -9009954.605703328,
-    9009954.605703328, 9009954.605703328],
+  extent: [-18019909.21177587, -9009954.605703328,
+    18019909.21177587, 9009954.605703328],
   worldExtent: [-179, -89.99, 179, 89.99]
 });
 
@@ -37,6 +37,6 @@ const map = new Map({
   view: new View({
     center: [0, 0],
     projection: sphereMollweideProjection,
-    zoom: 0
+    zoom: 1
   })
 });

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -778,18 +778,38 @@ export function intersectsSegment(extent, start, end) {
  * @param {import("./proj.js").TransformFunction} transformFn Transform function.
  * Called with `[minX, minY, maxX, maxY]` extent coordinates.
  * @param {Extent=} opt_extent Destination extent.
+ * @param {number=} opt_stops Number of stops per side used for the transform.
+ * By default only the corners are used.
  * @return {Extent} Extent.
  * @api
  */
-export function applyTransform(extent, transformFn, opt_extent) {
-  const coordinates = [
-    extent[0], extent[1],
-    extent[0], extent[3],
-    extent[2], extent[1],
-    extent[2], extent[3]
-  ];
+export function applyTransform(extent, transformFn, opt_extent, opt_stops) {
+  let coordinates = [];
+  if (opt_stops > 1) {
+    const width = extent[2] - extent[0];
+    const height = extent[3] - extent[1];
+    for (let i = 0; i < opt_stops; ++i) {
+      coordinates.push(
+        extent[0] + width * i / opt_stops, extent[1],
+        extent[2], extent[1] + height * i / opt_stops,
+        extent[2] - width * i / opt_stops, extent[3],
+        extent[0], extent[3] - height * i / opt_stops
+      );
+    }
+  } else {
+    coordinates = [
+      extent[0], extent[1],
+      extent[2], extent[1],
+      extent[2], extent[3],
+      extent[0], extent[3]
+    ];
+  }
   transformFn(coordinates, coordinates, 2);
-  const xs = [coordinates[0], coordinates[2], coordinates[4], coordinates[6]];
-  const ys = [coordinates[1], coordinates[3], coordinates[5], coordinates[7]];
+  const xs = [];
+  const ys = [];
+  for (let i = 0, l = coordinates.length; i < l; i += 2) {
+    xs.push(coordinates[i]);
+    ys.push(coordinates[i + 1]);
+  }
   return _boundingExtentXYs(xs, ys, opt_extent);
 }

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -144,7 +144,8 @@ const INTERVALS = [
 
 /**
  * @classdesc
- * Layer that renders a grid for a coordinate system.
+ * Layer that renders a grid for a coordinate system (currently only EPSG:4326 is supported).
+ * Note that the view projection must define both extent and worldExtent.
  *
  * @fires import("../render/Event.js").RenderEvent
  * @api
@@ -677,7 +678,7 @@ class Graticule extends VectorLayer {
       Math.min(extent[3], this.maxLatP_)
     ];
 
-    validExtent = transformExtent(validExtent, this.projection_, 'EPSG:4326');
+    validExtent = transformExtent(validExtent, this.projection_, 'EPSG:4326', 8);
     const maxLat = validExtent[3];
     const maxLon = validExtent[2];
     const minLat = validExtent[1];
@@ -896,7 +897,7 @@ class Graticule extends VectorLayer {
     const epsg4326Projection = getProjection('EPSG:4326');
 
     const worldExtent = projection.getWorldExtent();
-    const worldExtentP = transformExtent(worldExtent, epsg4326Projection, projection);
+    const worldExtentP = transformExtent(worldExtent, epsg4326Projection, projection, 8);
 
     this.maxLat_ = worldExtent[3];
     this.maxLon_ = worldExtent[2];

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -677,7 +677,7 @@ class Graticule extends VectorLayer {
       clamp(center[0], this.minLonP_, this.maxLonP_),
       clamp(center[1], this.minLatP_, this.maxLatP_)
     ];
-    
+
     const centerLonLat = this.toLonLatTransform_(validCenter);
     let centerLon = centerLonLat[0];
     let centerLat = centerLonLat[1];

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -679,8 +679,8 @@ class Graticule extends VectorLayer {
     ];
 
     const centerLonLat = this.toLonLatTransform_(validCenter);
-    let centerLon = centerLonLat[0];
-    let centerLat = centerLonLat[1];
+    let centerLon = clamp(centerLonLat[0], this.minLon_, this.maxLon_);
+    let centerLat = clamp(centerLonLat[1], this.minLat_, this.maxLat_);
     const maxLines = this.maxLines_;
     let cnt, idx, lat, lon;
 
@@ -693,10 +693,10 @@ class Graticule extends VectorLayer {
 
     validExtent = applyTransform(validExtent, this.toLonLatTransform_, undefined, 8);
 
-    const maxLat = Math.min(validExtent[3], this.maxLat_);
-    const maxLon = Math.min(validExtent[2], this.maxLon_);
-    const minLat = Math.max(validExtent[1], this.minLat_);
-    const minLon = Math.max(validExtent[0], this.minLon_);
+    const maxLat = clamp(validExtent[3], centerLat, this.maxLat_);
+    const maxLon = clamp(validExtent[2], centerLon, this.maxLon_);
+    const minLat = clamp(validExtent[1], this.minLat_, centerLat);
+    const minLon = clamp(validExtent[0], this.minLon_, centerLon);
 
     // Create meridians
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -476,12 +476,14 @@ export function transform(coordinate, source, destination) {
  * @param {import("./extent.js").Extent} extent The extent to transform.
  * @param {ProjectionLike} source Source projection-like.
  * @param {ProjectionLike} destination Destination projection-like.
+ * @param {number=} opt_stops Number of stops per side used for the transform.
+ * By default only the corners are used.
  * @return {import("./extent.js").Extent} The transformed extent.
  * @api
  */
-export function transformExtent(extent, source, destination) {
+export function transformExtent(extent, source, destination, opt_stops) {
   const transformFunc = getTransform(source, destination);
-  return applyTransform(extent, transformFunc);
+  return applyTransform(extent, transformFunc, undefined, opt_stops);
 }
 
 

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -1,5 +1,6 @@
 import * as _ol_extent_ from '../../../src/ol/extent.js';
 import {getTransform} from '../../../src/ol/proj.js';
+import {register} from '../../../src/ol/proj/proj4.js';
 
 
 describe('ol.extent', function() {
@@ -781,6 +782,38 @@ describe('ol.extent', function() {
       expect(destinationExtent[2]).to.be(15);
       expect(destinationExtent[1]).to.be(-60);
       expect(destinationExtent[3]).to.be(30);
+    });
+
+    it('can use the stops option', function() {
+      proj4.defs('EPSG:32632', '+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs');
+      register(proj4);
+      const transformFn = getTransform('EPSG:4326', 'EPSG:32632');
+      const sourceExtentN = [6, 0, 12, 84];
+      const destinationExtentN = _ol_extent_.applyTransform(
+        sourceExtentN, transformFn);
+      expect(destinationExtentN).not.to.be(undefined);
+      expect(destinationExtentN).not.to.be(null);
+      expect(destinationExtentN[0]).to.roughlyEqual(166021.44308053964, 1e-8);
+      expect(destinationExtentN[2]).to.roughlyEqual(0, 1e-8);
+      expect(destinationExtentN[1]).to.roughlyEqual(833978.5569194605, 1e-8);
+      expect(destinationExtentN[3]).to.roughlyEqual(9329005.182447437, 1e-8);
+      const sourceExtentNS = [6, -84, 12, 84];
+      const destinationExtentNS = _ol_extent_.applyTransform(
+        sourceExtentNS, transformFn);
+      expect(destinationExtentNS).not.to.be(undefined);
+      expect(destinationExtentNS).not.to.be(null);
+      expect(destinationExtentNS[0]).to.roughlyEqual(465005.34493886377, 1e-8);
+      expect(destinationExtentNS[2]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
+      expect(destinationExtentNS[1]).to.roughlyEqual(534994.6550611362, 1e-8);
+      expect(destinationExtentNS[3]).to.roughlyEqual(destinationExtentN[3], 1e-8);
+      const destinationExtentNS2 = _ol_extent_.applyTransform(
+        sourceExtentNS, transformFn, undefined, 2);
+      expect(destinationExtentNS2).not.to.be(undefined);
+      expect(destinationExtentNS2).not.to.be(null);
+      expect(destinationExtentNS2[0]).to.roughlyEqual(destinationExtentN[0], 1e-8);
+      expect(destinationExtentNS2[2]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
+      expect(destinationExtentNS2[1]).to.roughlyEqual(destinationExtentN[2], 1e-8);
+      expect(destinationExtentNS2[3]).to.roughlyEqual(destinationExtentN[3], 1e-8);
     });
 
   });

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -794,8 +794,8 @@ describe('ol.extent', function() {
       expect(destinationExtentN).not.to.be(undefined);
       expect(destinationExtentN).not.to.be(null);
       expect(destinationExtentN[0]).to.roughlyEqual(166021.44308053964, 1e-8);
-      expect(destinationExtentN[2]).to.roughlyEqual(0, 1e-8);
-      expect(destinationExtentN[1]).to.roughlyEqual(833978.5569194605, 1e-8);
+      expect(destinationExtentN[2]).to.roughlyEqual(833978.5569194605, 1e-8);
+      expect(destinationExtentN[1]).to.roughlyEqual(0, 1e-8);
       expect(destinationExtentN[3]).to.roughlyEqual(9329005.182447437, 1e-8);
       const sourceExtentNS = [6, -84, 12, 84];
       const destinationExtentNS = _ol_extent_.applyTransform(
@@ -803,16 +803,16 @@ describe('ol.extent', function() {
       expect(destinationExtentNS).not.to.be(undefined);
       expect(destinationExtentNS).not.to.be(null);
       expect(destinationExtentNS[0]).to.roughlyEqual(465005.34493886377, 1e-8);
-      expect(destinationExtentNS[2]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
-      expect(destinationExtentNS[1]).to.roughlyEqual(534994.6550611362, 1e-8);
+      expect(destinationExtentNS[2]).to.roughlyEqual(534994.6550611362, 1e-8);
+      expect(destinationExtentNS[1]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
       expect(destinationExtentNS[3]).to.roughlyEqual(destinationExtentN[3], 1e-8);
       const destinationExtentNS2 = _ol_extent_.applyTransform(
         sourceExtentNS, transformFn, undefined, 2);
       expect(destinationExtentNS2).not.to.be(undefined);
       expect(destinationExtentNS2).not.to.be(null);
       expect(destinationExtentNS2[0]).to.roughlyEqual(destinationExtentN[0], 1e-8);
-      expect(destinationExtentNS2[2]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
-      expect(destinationExtentNS2[1]).to.roughlyEqual(destinationExtentN[2], 1e-8);
+      expect(destinationExtentNS2[2]).to.roughlyEqual(destinationExtentN[2], 1e-8);
+      expect(destinationExtentNS2[1]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
       expect(destinationExtentNS2[3]).to.roughlyEqual(destinationExtentN[3], 1e-8);
     });
 


### PR DESCRIPTION
Fixes #10647
Fixes #10727

The default extent transform only works correctly if the maximum and minimum values are at the corners in both projections.  For large extents in some projections that is not the case.  This PR adds an option to consider extra stops along the edges (similar to the sides option in `ol/geom/Polygon.fromCircle`) to get a more realistic result.  This is then used to improve the output from the graticule.

Updates the Graticule to handle view projection extents which cross the dateline and enhance the validation for center and extents to avoid proj4 errors. The Graticule description is also updated with limitations as noted in https://github.com/openlayers/openlayers/issues/10696#issuecomment-590063086

Although not directly related to the problem the projection extent used in the Sphere Mollweide graticule example was incorrect and has been updated.

