### PR TITLE
Ensure the Modify Features Test example opens at correct zoom

### DIFF
--- a/examples/modify-test.js
+++ b/examples/modify-test.js
@@ -140,8 +140,7 @@ const geojsonObject = {
 };
 
 const source = new VectorSource({
-  features: (new GeoJSON()).readFeatures(geojsonObject),
-  wrapX: false
+  features: (new GeoJSON()).readFeatures(geojsonObject)
 });
 
 const layer = new VectorLayer({

--- a/examples/modify-test.js
+++ b/examples/modify-test.js
@@ -140,7 +140,8 @@ const geojsonObject = {
 };
 
 const source = new VectorSource({
-  features: (new GeoJSON()).readFeatures(geojsonObject)
+  features: (new GeoJSON()).readFeatures(geojsonObject),
+  wrapX: false
 });
 
 const layer = new VectorLayer({
@@ -232,6 +233,7 @@ const map = new Map({
   target: 'map',
   view: new View({
     center: [0, 1000000],
-    zoom: 2
+    zoom: 2,
+    multiWorld: true
   })
 });


### PR DESCRIPTION
The default projection isn't ideal for this example, but its side affects can be averted by setting `multiWorld: true` so the view opens at zoom 2 regardless of display width.
