### PR TITLE
Fix building apidoc on windows

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -115,7 +115,7 @@ exports.astNodeVisitor = {
   visitNode: function(node, e, parser, currentSourceName) {
     if (node.type === 'Identifier' && node.parent.type === 'ExportDefaultDeclaration') {
       const modulePath = path.relative(moduleRoot, currentSourceName).replace(/\.js$/, '');
-      defaultExports['module:' + modulePath + '~' + node.name] = true;
+      defaultExports['module:' + modulePath.replace(/\\/g, '/') + '~' + node.name] = true;
     }
   }
 };


### PR DESCRIPTION
The apidocs cannot be built on windows because the file path is not normalized to have `/` as path separator.

Sorry for that.