### PR TITLE
Fix "Cannot read property 'anchor' of undefined" in ol/View

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -609,10 +609,14 @@ class View extends BaseObject {
       if (series[0].callback) {
         animationCallback(series[0].callback, false);
       }
-      anchor = anchor ||
-        series.filter(function(animation) {
+      if (!anchor) {
+        const animations = series.filter(function(animation) {
           return !animation.complete;
-        })[0].anchor;
+        });
+        if (animations.length > 0) {
+          anchor = animations[0].anchor;
+        }
+      }
     }
     this.animations_.length = 0;
     this.cancelAnchor_ = anchor;

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -610,11 +610,12 @@ class View extends BaseObject {
         animationCallback(series[0].callback, false);
       }
       if (!anchor) {
-        const animations = series.filter(function(animation) {
-          return !animation.complete;
-        });
-        if (animations.length > 0) {
-          anchor = animations[0].anchor;
+        for (let j = 0, jj = series.length; j < jj; ++j) {
+          const animation = series[j];
+          if (!animation.complete) {
+            anchor = animation.anchor;
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes a timing issue in #10120 where all animations have completed when there is a cancellation (in this case caused by using setRotation to keep an EPSG:3857 view aligned to EPSG:27700 grid north if there is a significant change while panning) resulting in an error.  Using more robust code will fix it.

![image](https://user-images.githubusercontent.com/49240900/75590485-5875a580-5a75-11ea-9e27-5f3df108af6b.png)

