### PR TITLE
Allow using feature attributes for symbol rotation in WebGL layers

### DIFF
--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -427,6 +427,7 @@ export function parseLiteralStyle(style) {
   const parsedSize = expressionToGlsl(vertContext, size, ValueTypes.NUMBER_ARRAY | ValueTypes.NUMBER);
   const parsedOffset = expressionToGlsl(vertContext, offset, ValueTypes.NUMBER_ARRAY);
   const parsedTexCoord = expressionToGlsl(vertContext, texCoord, ValueTypes.NUMBER_ARRAY);
+  const parsedRotation = expressionToGlsl(vertContext, rotation, ValueTypes.NUMBER);
 
   /**
    * @type {import("../style/expressions.js").ParsingContext}
@@ -439,7 +440,6 @@ export function parseLiteralStyle(style) {
   };
   const parsedColor = expressionToGlsl(fragContext, color, ValueTypes.COLOR);
   const parsedOpacity = expressionToGlsl(fragContext, opacity, ValueTypes.NUMBER);
-  const parsedRotation = expressionToGlsl(fragContext, rotation, ValueTypes.NUMBER);
 
   let opacityFilter = '1.0';
   const visibleSize = `vec2(${expressionToGlsl(fragContext, size, ValueTypes.NUMBER_ARRAY | ValueTypes.NUMBER)}).x`;

--- a/test/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/spec/ol/webgl/shaderbuilder.test.js
@@ -511,6 +511,20 @@ void main(void) {
       expect(result.uniforms).to.have.property('u_ratio');
     });
 
+    it('parses a style with a rotation expression using an attribute', function() {
+      const result = parseLiteralStyle({
+        symbol: {
+          symbolType: 'square',
+          size: 6,
+          rotation: ['get', 'heading']
+        }
+      });
+
+      expect(result.builder.attributes).to.eql(['float a_heading']);
+      expect(result.builder.varyings).to.eql([]);
+      expect(result.builder.rotationExpression).to.eql('a_heading');
+    });
+
     it('correctly adds string variables to the string literals mapping', function() {
       const result = parseLiteralStyle({
         variables: {


### PR DESCRIPTION
Issue was reported [here](https://github.com/openlayers/openlayers/pull/10439#issuecomment-593476693).

Previously when using feature attributes in a rotation expression, the resulting rotation would always be zero.