### PR TITLE
Keep the render loop running during simulation

### DIFF
--- a/examples/geolocation-orientation.js
+++ b/examples/geolocation-orientation.js
@@ -147,6 +147,7 @@ function updateView() {
     view.setCenter(getCenterWithHeading(c, -c[2], view.getResolution()));
     view.setRotation(-c[2]);
     marker.setPosition(c);
+    map.render();
   }
 }
 


### PR DESCRIPTION
The new constraint system does not trigger a render when old and new view properties are the same. So we need to call `render()` on the map now to keep the simulation loop running.

Fixes #10760 