### PR TITLE
Improved projection extent in the "Reprojection with EPSG.io Search" example

### DIFF
--- a/examples/reprojection-by-code.html
+++ b/examples/reprojection-by-code.html
@@ -6,18 +6,22 @@ docs: >
   This example shows client-side raster reprojection capabilities from
   OSM (EPSG:3857) to arbitrary projection by searching
   in <a href="https://epsg.io/">EPSG.io</a> database.
-tags: "reprojection, projection, proj4js, epsg.io"
+tags: "reprojection, projection, proj4js, epsg.io, graticule"
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">
   <label for="epsg-query">Search projection:</label>
-  <input type="text" id="epsg-query" placeholder="4326, 27700, US National Atlas, Swiss, France, ..." class="form-control" size="50" />
+  <input type="text" id="epsg-query" placeholder="4326, 27700, 3031, US National Atlas, Swiss, France, ..." class="form-control" size="50" />
   <button id="epsg-search" class="btn">Search</button>
   <span id="epsg-result"></span>
   <div>
     <label for="render-edges">
       Render reprojection edges
       <input type="checkbox" id="render-edges">
+    </label>
+    <label for="show-graticule">
+      &nbsp;&nbsp;&nbsp;Show graticule
+      <input type="checkbox" id="show-graticule" />
     </label>
   </div>
 </form>

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -14,7 +14,7 @@ import proj4 from 'proj4';
 const graticule = new Graticule({
   // the style to use for the lines, optional.
   strokeStyle: new Stroke({
-    color: "rgba(255,120,0,0.9)",
+    color: 'rgba(255,120,0,0.9)',
     width: 2,
     lineDash: [0.5, 4]
   }),

--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -1,19 +1,34 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import {applyTransform} from '../src/ol/extent.js';
+import Graticule from '../src/ol/layer/Graticule.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import {get as getProjection, getTransform} from '../src/ol/proj.js';
 import {register} from '../src/ol/proj/proj4.js';
 import OSM from '../src/ol/source/OSM.js';
 import TileImage from '../src/ol/source/TileImage.js';
+import Stroke from '../src/ol/style/Stroke.js';
 import proj4 from 'proj4';
 
+
+const graticule = new Graticule({
+  // the style to use for the lines, optional.
+  strokeStyle: new Stroke({
+    color: "rgba(255,120,0,0.9)",
+    width: 2,
+    lineDash: [0.5, 4]
+  }),
+  showLabels: true,
+  visible: false,
+  wrapX: false
+});
 
 const map = new Map({
   layers: [
     new TileLayer({
       source: new OSM()
-    })
+    }),
+    graticule
   ],
   target: 'map',
   view: new View({
@@ -28,6 +43,7 @@ const queryInput = document.getElementById('epsg-query');
 const searchButton = document.getElementById('epsg-search');
 const resultSpan = document.getElementById('epsg-result');
 const renderEdgesCheckbox = document.getElementById('render-edges');
+const showGraticuleCheckbox = document.getElementById('show-graticule');
 
 function setProjection(code, name, proj4def, bbox) {
   if (code === null || name === null || proj4def === null || bbox === null) {
@@ -48,9 +64,15 @@ function setProjection(code, name, proj4def, bbox) {
   const newProj = getProjection(newProjCode);
   const fromLonLat = getTransform('EPSG:4326', newProj);
 
-  // very approximate calculation of projection extent
-  const extent = applyTransform(
-    [bbox[1], bbox[2], bbox[3], bbox[0]], fromLonLat);
+  let worldExtent = [bbox[1], bbox[2], bbox[3], bbox[0]];
+  newProj.setWorldExtent(worldExtent);
+
+  // approximate calculation of projection extent,
+  // checking if the world extent crosses the dateline
+  if (bbox[1] > bbox[3]) {
+    worldExtent = [bbox[1], bbox[2], bbox[3] + 360, bbox[0]];
+  }
+  const extent = applyTransform(worldExtent, fromLonLat, undefined, 8);
   newProj.setExtent(extent);
   const newView = new View({
     projection: newProj
@@ -98,7 +120,7 @@ searchButton.onclick = function(event) {
 
 
 /**
- * Handle change event.
+ * Handle checkbox change event.
  */
 renderEdgesCheckbox.onchange = function() {
   map.getLayers().forEach(function(layer) {
@@ -109,4 +131,11 @@ renderEdgesCheckbox.onchange = function() {
       }
     }
   });
+};
+
+/**
+ * Handle checkbox change event.
+ */
+showGraticuleCheckbox.onchange = function() {
+  graticule.setVisible(showGraticuleCheckbox.checked);
 };


### PR DESCRIPTION
The enhanced extent transforms introduced in #10723 allow the previously _"very approximate calculation of projection extent"_ (which for some polar projections resulted in extents with zero width or height) to be made more realistic.

Also after basing a test bed for the graticule updates on this example I think a graticule can help to illustrate a projection so I have added a "Show graticule" checkbox option in addition to the "Render edges" option.
