### PR TITLE
iOS 12 touchmove: Prevent touchmove event default when no preceding pointer event

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -277,7 +277,7 @@ class MapBrowserEventHandler extends EventTarget {
   handleTouchMove_(event) {
     // Due to https://github.com/mpizenberg/elm-pep/issues/2, `this.originalPointerMoveEvent_`
     // may not be initialized yet when we get here on a platform without native pointer events.
-    if (this.originalPointerMoveEvent_ && this.originalPointerMoveEvent_.defaultPrevented) {
+    if (!this.originalPointerMoveEvent_ || this.originalPointerMoveEvent_.defaultPrevented) {
       event.preventDefault();
     }
   }


### PR DESCRIPTION
Relates to https://github.com/openlayers/openlayers/issues/10747

And the previous PR: https://github.com/openlayers/openlayers/pull/10788

@ahocevar I'm not completely sure if it relates to https://github.com/mpizenberg/elm-pep/issues/2 . There does seem to be some delay before click events on the map are registered on iOS, but no double events. So maybe it's related to the initial tap not triggering `relayEvent_`.

Either way, this is an amended fix since I was able to test it more now. Turns out if you don't block the event in the first `handleTouchMove_` call, the initial zoom interaction on the map on iOS 12 can zoom the page, rather than the map. Effectively, this change adds one more preventDefault call in the beginning, and keeps the page from being zoomed instead of the map.

>Other than that, the call order of the two handlers is still wrong on the problematic platforms (`handleTouchMove_` uses the "prevented" status of the previous touch interaction), but it doesn't seem to cause big problems since the original pointer event is prevented rather unconditionally in most situations.