### PR TITLE
Apidoc add default-exported enums

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -113,9 +113,10 @@ const moduleRoot = path.join(process.cwd(), 'src');
 // Tag default exported Identifiers because their name should be the same as the module name.
 exports.astNodeVisitor = {
   visitNode: function(node, e, parser, currentSourceName) {
-    if (node.type === 'Identifier' && node.parent.type === 'ExportDefaultDeclaration') {
+    if (node.parent && node.parent.type === 'ExportDefaultDeclaration') {
       const modulePath = path.relative(moduleRoot, currentSourceName).replace(/\.js$/, '');
-      defaultExports['module:' + modulePath.replace(/\\/g, '/') + '~' + node.name] = true;
+      const exportName = 'module:' + modulePath.replace(/\\/g, '/') + (node.name ? '~' + node.name : '');
+      defaultExports[exportName] = true;
     }
   }
 };

--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -181,7 +181,7 @@ exports.handlers = {
         doclet._hideConstructor = true;
         includeAugments(doclet);
         sortOtherMembers(doclet);
-      } else if (!doclet._hideConstructor && !(doclet.kind == 'typedef' && doclet.longname in types)) {
+      } else if (!doclet._hideConstructor) {
         // Remove all other undocumented symbols
         doclet.undocumented = true;
       }

--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -157,6 +157,7 @@ exports.handlers = {
 
   parseComplete: function(e) {
     const doclets = e.doclets;
+    const byLongname = doclets.index.longname;
     for (let i = doclets.length - 1; i >= 0; --i) {
       const doclet = doclets[i];
       if (doclet.stability) {
@@ -181,7 +182,8 @@ exports.handlers = {
         doclet._hideConstructor = true;
         includeAugments(doclet);
         sortOtherMembers(doclet);
-      } else if (!doclet._hideConstructor) {
+      } else if (!doclet._hideConstructor
+          && !(doclet.longname in defaultExports && byLongname[doclet.longname].some(d => d.isEnum))) {
         // Remove all other undocumented symbols
         doclet.undocumented = true;
       }


### PR DESCRIPTION
This PR supersedes and closes #10512

This adds the apidoc pages for enums that are the default export of their module without any other documented members.

The following pages are now created:
>module-ol_CollectionEventType.html
module-ol_ImageState.html
module-ol_MapBrowserEventType.html
module-ol_MapEventType.html
module-ol_MapProperty.html
module-ol_ObjectEventType.html
module-ol_ViewHint.html
module-ol_ViewProperty.html
module-ol_events_EventType.html
module-ol_events_KeyCode.html
module-ol_extent_Corner.html
module-ol_extent_Relationship.html
module-ol_format_FormatType.html
module-ol_interaction_Property.html
module-ol_layer_Property.html
module-ol_layer_TileProperty.html
module-ol_pointer_EventType.html
module-ol_render_EventType.html
module-ol_render_canvas_BuilderType.html
module-ol_source_TileEventType.html
module-ol_source_VectorEventType.html
module-ol_style_IconAnchorUnits.html
module-ol_style_IconOrigin.html
module-ol_webgl_ContextEventType.html