### PR TITLE
Handle Graticule wrapX without calculating excess meridians

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -415,7 +415,7 @@ export function toStringXY(coordinate, opt_fractionDigits) {
  */
 export function wrapX(coordinate, projection) {
   const projectionExtent = projection.getExtent();
-  if (projection.canWrapX() && (coordinate[0] < projectionExtent[0] || coordinate[0] > projectionExtent[2])) {
+  if (projection.canWrapX() && (coordinate[0] < projectionExtent[0] || coordinate[0] >= projectionExtent[2])) {
     const worldWidth = getWidth(projectionExtent);
     const worldsAway = Math.floor((coordinate[0] - projectionExtent[0]) / worldWidth);
     coordinate[0] -= (worldsAway * worldWidth);

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -407,7 +407,8 @@ export function toStringXY(coordinate, opt_fractionDigits) {
 
 /**
  * Modifies the provided coordinate in-place to be within the real world
- * extent.
+ * extent. The lower projection extent boundary is inclusive, the upper one
+ * exclusive.
  *
  * @param {Coordinate} coordinate Coordinate.
  * @param {import("./proj/Projection.js").default} projection Projection

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -3,6 +3,7 @@
  */
 import {modulo} from './math.js';
 import {padNumber} from './string.js';
+import {getWidth} from './extent.js';
 
 
 /**
@@ -401,4 +402,23 @@ export function toStringHDMS(coordinate, opt_fractionDigits) {
  */
 export function toStringXY(coordinate, opt_fractionDigits) {
   return format(coordinate, '{x}, {y}', opt_fractionDigits);
+}
+
+
+/**
+ * Modifies the provided coordinate in-place to be within the real world
+ * extent.
+ *
+ * @param {Coordinate} coordinate Coordinate.
+ * @param {import("./proj/Projection.js").default} projection Projection
+ * @return {Coordinate} The coordinate within the real world extent.
+ */
+export function wrapX(coordinate, projection) {
+  const projectionExtent = projection.getExtent();
+  if (projection.canWrapX() && (coordinate[0] < projectionExtent[0] || coordinate[0] > projectionExtent[2])) {
+    const worldWidth = getWidth(projectionExtent);
+    const worldsAway = Math.floor((coordinate[0] - projectionExtent[0]) / worldWidth);
+    coordinate[0] -= (worldsAway * worldWidth);
+  }
+  return coordinate;
 }

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -813,3 +813,25 @@ export function applyTransform(extent, transformFn, opt_extent, opt_stops) {
   }
   return _boundingExtentXYs(xs, ys, opt_extent);
 }
+
+
+/**
+ * Modifies the provided extent in-place to be within the real world
+ * extent.
+ *
+ * @param {Extent} extent Extent.
+ * @param {import("./proj/Projection.js").default} projection Projection
+ * @return {Extent} The extent within the real world extent.
+ */
+export function wrapX(extent, projection) {
+  const projectionExtent = projection.getExtent();
+  const center = getCenter(extent);
+  if (projection.canWrapX() && (center[0] < projectionExtent[0] || center[0] > projectionExtent[2])) {
+    const worldWidth = getWidth(projectionExtent);
+    const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
+    const offset = (worldsAway * worldWidth);
+    extent[0] -= offset;
+    extent[2] -= offset;
+  }
+  return extent;
+}

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -295,6 +295,18 @@ export function equals(extent1, extent2) {
       extent1[1] == extent2[1] && extent1[3] == extent2[3];
 }
 
+/**
+ * Determine if two extents are approximately equivalent.
+ * @param {Extent} extent1 Extent 1.
+ * @param {Extent} extent2 Extent 2.
+ * @param {number} tolerance Tolerance in extent coordinate units.
+ * @return {boolean} The two extents differ by less than the tolerance.
+ */
+export function approximatelyEquals(extent1, extent2, tolerance) {
+  return Math.abs(extent1[0] - extent2[0]) < tolerance && Math.abs(extent1[2] - extent2[2]) < tolerance &&
+  Math.abs(extent1[1] - extent2[1]) < tolerance && Math.abs(extent1[3] - extent2[3]) < tolerance;
+}
+
 
 /**
  * Modify an extent to include another extent.

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -826,7 +826,7 @@ export function applyTransform(extent, transformFn, opt_extent, opt_stops) {
 export function wrapX(extent, projection) {
   const projectionExtent = projection.getExtent();
   const center = getCenter(extent);
-  if (projection.canWrapX() && (center[0] < projectionExtent[0] || center[0] > projectionExtent[2])) {
+  if (projection.canWrapX() && (center[0] < projectionExtent[0] || center[0] >= projectionExtent[2])) {
     const worldWidth = getWidth(projectionExtent);
     const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
     const offset = (worldsAway * worldWidth);

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -18,7 +18,7 @@ import {
   applyTransform,
   containsCoordinate,
   containsExtent,
-  equals,
+  approximatelyEquals,
   getCenter,
   getHeight,
   getIntersection,
@@ -481,17 +481,15 @@ class Graticule extends VectorLayer {
    */
   strategyFunction(extent, resolution) {
     // extents may be passed in different worlds, to avoid endless loop we use only one
-    const realExtent = extent.slice();
+    const realWorldExtent = extent.slice();
     if (this.projection_ && this.getSource().getWrapX()) {
-      wrapExtentX(realExtent, this.projection_);
+      wrapExtentX(realWorldExtent, this.projection_);
     }
-    realExtent[0] = Math.round(realExtent[0] * 1e8) / 1e8;
-    realExtent[2] = Math.round(realExtent[2] * 1e8) / 1e8;
-    if (this.loadedExtent_ && !equals(this.loadedExtent_, realExtent)) {
+    if (this.loadedExtent_ && !approximatelyEquals(this.loadedExtent_, realWorldExtent, resolution)) {
       // we should not keep track of loaded extents
       this.getSource().removeLoadedExtent(this.loadedExtent_);
     }
-    return [realExtent];
+    return [realWorldExtent];
   }
 
   /**
@@ -508,7 +506,7 @@ class Graticule extends VectorLayer {
     const layerExtent = this.getExtent() || [-Infinity, -Infinity, Infinity, Infinity];
     const renderExtent = getIntersection(layerExtent, extent);
 
-    if (this.renderedExtent_ && equals(this.renderedExtent_, renderExtent)) {
+    if (this.renderedExtent_ && approximatelyEquals(this.renderedExtent_, renderExtent, resolution)) {
       return;
     }
     this.renderedExtent_ = renderExtent;

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -481,13 +481,18 @@ class Graticule extends VectorLayer {
    */
   strategyFunction(extent, resolution) {
     // extents may be passed in different worlds, to avoid endless loop we use only one
-    const realWorldExtent = extent.slice();
+    let realWorldExtent = extent.slice();
     if (this.projection_ && this.getSource().getWrapX()) {
       wrapExtentX(realWorldExtent, this.projection_);
     }
-    if (this.loadedExtent_ && !approximatelyEquals(this.loadedExtent_, realWorldExtent, resolution)) {
-      // we should not keep track of loaded extents
-      this.getSource().removeLoadedExtent(this.loadedExtent_);
+    if (this.loadedExtent_) {
+      if (approximatelyEquals(this.loadedExtent_, realWorldExtent, resolution)) {
+        // make sure result is exactly equal to previous extent
+        realWorldExtent = this.loadedExtent_.slice();
+      } else {
+        // we should not keep track of loaded extents
+        this.getSource().removeLoadedExtent(this.loadedExtent_);
+      }
     }
     return [realWorldExtent];
   }

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -437,8 +437,7 @@ class Graticule extends VectorLayer {
         features: new Collection(),
         overlaps: false,
         useSpatialIndex: false,
-        wrapX: options.wrapX,
-        loadWrapX: false
+        wrapX: options.wrapX
       })
     );
 

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -18,6 +18,7 @@ import {
   applyTransform,
   containsCoordinate,
   containsExtent,
+  equals,
   approximatelyEquals,
   getCenter,
   getHeight,
@@ -511,7 +512,7 @@ class Graticule extends VectorLayer {
     const layerExtent = this.getExtent() || [-Infinity, -Infinity, Infinity, Infinity];
     const renderExtent = getIntersection(layerExtent, extent);
 
-    if (this.renderedExtent_ && approximatelyEquals(this.renderedExtent_, renderExtent, resolution)) {
+    if (this.renderedExtent_ && equals(this.renderedExtent_, renderExtent, resolution)) {
       return;
     }
     this.renderedExtent_ = renderExtent;

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -437,7 +437,8 @@ class Graticule extends VectorLayer {
         features: new Collection(),
         overlaps: false,
         useSpatialIndex: false,
-        wrapX: options.wrapX
+        wrapX: options.wrapX,
+        loadWrapX: false
       })
     );
 

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -512,7 +512,7 @@ class Graticule extends VectorLayer {
     const layerExtent = this.getExtent() || [-Infinity, -Infinity, Infinity, Infinity];
     const renderExtent = getIntersection(layerExtent, extent);
 
-    if (this.renderedExtent_ && equals(this.renderedExtent_, renderExtent, resolution)) {
+    if (this.renderedExtent_ && equals(this.renderedExtent_, renderExtent)) {
       return;
     }
     this.renderedExtent_ = renderExtent;

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -717,6 +717,22 @@ class Graticule extends VectorLayer {
       return;
     }
 
+    let wrapX = false;
+    const projectionExtent = this.projection_.getExtent();
+    const worldWidth = getWidth(projectionExtent);
+    if (this.getSource().getWrapX() && this.projection_.canWrapX() && !containsExtent(projectionExtent, extent)) {
+      if (getWidth(extent) >= worldWidth) {
+        extent[0] = projectionExtent[0];
+        extent[2] = projectionExtent[2];
+      } else {
+        const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
+        center[0] -= (worldsAway * worldWidth);
+        extent[0] -= (worldsAway * worldWidth);
+        extent[2] -= (worldsAway * worldWidth);
+        wrapX = true;
+      }
+    }
+
     // Constrain the center to fit into the extent available to the graticule
 
     const validCenterP = [
@@ -740,44 +756,56 @@ class Graticule extends VectorLayer {
 
     // Limit the extent to fit into the extent available to the graticule
 
-    const validExtentP = [
-      clamp(extent[0], this.minX_, this.maxX_),
-      clamp(extent[1], this.minY_, this.maxY_),
-      clamp(extent[2], this.minX_, this.maxX_),
-      clamp(extent[3], this.minY_, this.maxY_)
-    ];
+    let validExtentP = extent;
+    if (!wrapX) {
+      validExtentP = [
+        clamp(extent[0], this.minX_, this.maxX_),
+        clamp(extent[1], this.minY_, this.maxY_),
+        clamp(extent[2], this.minX_, this.maxX_),
+        clamp(extent[3], this.minY_, this.maxY_)
+      ];
+    }
 
     // Transform the extent to get the lon lat ranges for the edges of the extent
 
     const validExtent = applyTransform(validExtentP, this.toLonLatTransform_, undefined, 8);
 
-    // Check if extremities of the world extent lie inside the extent
-    // (for example the pole in a polar projection)
-    // and extend the extent as appropriate
+    let maxLat = validExtent[3];
+    let maxLon = validExtent[2];
+    let minLat = validExtent[1];
+    let minLon = validExtent[0];
 
-    if (containsCoordinate(validExtentP, this.bottomLeft_)) {
-      validExtent[0] = this.minLon_;
-      validExtent[1] = this.minLat_;
-    }
-    if (containsCoordinate(validExtentP, this.bottomRight_)) {
-      validExtent[2] = this.maxLon_;
-      validExtent[1] = this.minLat_;
-    }
-    if (containsCoordinate(validExtentP, this.topLeft_)) {
-      validExtent[0] = this.minLon_;
-      validExtent[3] = this.maxLat_;
-    }
-    if (containsCoordinate(validExtentP, this.topRight_)) {
-      validExtent[2] = this.maxLon_;
-      validExtent[3] = this.maxLat_;
-    }
+    if (!wrapX) {
 
-    // The transformed center may also extend the lon lat ranges used for rendering
+      // Check if extremities of the world extent lie inside the extent
+      // (for example the pole in a polar projection)
+      // and extend the extent as appropriate
 
-    const maxLat = clamp(validExtent[3], centerLat, this.maxLat_);
-    const maxLon = clamp(validExtent[2], centerLon, this.maxLon_);
-    const minLat = clamp(validExtent[1], this.minLat_, centerLat);
-    const minLon = clamp(validExtent[0], this.minLon_, centerLon);
+      if (containsCoordinate(validExtentP, this.bottomLeft_)) {
+        minLon = this.minLon_;
+        minLat = this.minLat_;
+      }
+      if (containsCoordinate(validExtentP, this.bottomRight_)) {
+        maxLon = this.maxLon_;
+        minLat = this.minLat_;
+      }
+      if (containsCoordinate(validExtentP, this.topLeft_)) {
+        minLon = this.minLon_;
+        maxLat = this.maxLat_;
+      }
+      if (containsCoordinate(validExtentP, this.topRight_)) {
+        maxLon = this.maxLon_;
+        maxLat = this.maxLat_;
+      }
+
+      // The transformed center may also extend the lon lat ranges used for rendering
+
+      maxLat = clamp(maxLat, centerLat, this.maxLat_);
+      maxLon = clamp(maxLon, centerLon, this.maxLon_);
+      minLat = clamp(minLat, this.minLat_, centerLat);
+      minLon = clamp(minLon, this.minLon_, centerLon);
+
+    }
 
     // Create meridians
 
@@ -787,17 +815,29 @@ class Graticule extends VectorLayer {
     idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, 0);
 
     cnt = 0;
-    while (lon != this.minLon_ && cnt++ < maxLines) {
-      lon = Math.max(lon - interval, this.minLon_);
-      idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
+    if (wrapX) {
+      while ((lon -= interval) >= minLon && cnt++ < maxLines) {
+        idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
+      }
+    } else {
+      while (lon != this.minLon_ && cnt++ < maxLines) {
+        lon = Math.max(lon - interval, this.minLon_);
+        idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
+      }
     }
 
     lon = clamp(centerLon, this.minLon_, this.maxLon_);
 
     cnt = 0;
-    while (lon != this.maxLon_ && cnt++ < maxLines) {
-      lon = Math.min(lon + interval, this.maxLon_);
-      idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
+    if (wrapX) {
+      while ((lon += interval) <= maxLon && cnt++ < maxLines) {
+        idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
+      }
+    } else {
+      while (lon != this.maxLon_ && cnt++ < maxLines) {
+        lon = Math.min(lon + interval, this.maxLon_);
+        idx = this.addMeridian_(lon, minLat, maxLat, squaredTolerance, extent, idx);
+      }
     }
 
     this.meridians_.length = idx;

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -25,8 +25,7 @@ import {
   getWidth,
   intersects,
   isEmpty,
-  buffer as bufferExtent,
-  wrapX
+  wrapX as wrapExtentX
 } from '../extent.js';
 import {clamp} from '../math.js';
 import Style from '../style/Style.js';
@@ -484,9 +483,11 @@ class Graticule extends VectorLayer {
     // extents may be passed in different worlds, to avoid endless loop we use only one
     const realExtent = extent.slice();
     if (this.projection_ && this.getSource().getWrapX()) {
-      wrapX(realExtent, this.projection_);
+      wrapExtentX(realExtent, this.projection_);
     }
-    if (this.loadedExtent_ && !containsExtent(bufferExtent(this.loadedExtent_, resolution / 2), realExtent)) {
+    realExtent[0] = Math.round(realExtent[0] * 1e8) / 1e8;
+    realExtent[2] = Math.round(realExtent[2] * 1e8) / 1e8;
+    if (this.loadedExtent_ && !equals(this.loadedExtent_, realExtent)) {
       // we should not keep track of loaded extents
       this.getSource().removeLoadedExtent(this.loadedExtent_);
     }

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -729,7 +729,7 @@ class Graticule extends VectorLayer {
         center[0] -= (worldsAway * worldWidth);
         extent[0] -= (worldsAway * worldWidth);
         extent[2] -= (worldsAway * worldWidth);
-        wrapX = true;
+        wrapX = !containsExtent(projectionExtent, extent);
       }
     }
 

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -725,11 +725,7 @@ class Graticule extends VectorLayer {
         extent[0] = projectionExtent[0];
         extent[2] = projectionExtent[2];
       } else {
-        const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
-        center[0] -= (worldsAway * worldWidth);
-        extent[0] -= (worldsAway * worldWidth);
-        extent[2] -= (worldsAway * worldWidth);
-        wrapX = !containsExtent(projectionExtent, extent);
+        wrapX = true;
       }
     }
 

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -9,6 +9,7 @@ import {inView} from '../layer/Layer.js';
 import {shared as iconImageCache} from '../style/IconImageCache.js';
 import {compose as composeTransform, makeInverse} from '../transform.js';
 import {renderDeclutterItems} from '../render.js';
+import {wrapX} from '../coordinate.js';
 
 /**
  * @abstract
@@ -102,19 +103,12 @@ class MapRenderer extends Disposable {
 
     const projection = viewState.projection;
 
-    let translatedCoordinate = coordinate;
+    const translatedCoordinate = wrapX(coordinate.slice(), projection);
     const offsets = [[0, 0]];
-    if (projection.canWrapX()) {
+    if (projection.canWrapX() && checkWrapped) {
       const projectionExtent = projection.getExtent();
       const worldWidth = getWidth(projectionExtent);
-      const x = coordinate[0];
-      if (x < projectionExtent[0] || x > projectionExtent[2]) {
-        const worldsAway = Math.ceil((projectionExtent[0] - x) / worldWidth);
-        translatedCoordinate = [x + worldWidth * worldsAway, coordinate[1]];
-      }
-      if (checkWrapped) {
-        offsets.push([-worldWidth, 0], [worldWidth, 0]);
-      }
+      offsets.push([-worldWidth, 0], [worldWidth, 0]);
     }
 
     const layerStates = frameState.layerStatesArray;

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -375,8 +375,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       const gutter = Math.max(getWidth(extent) / 2, worldWidth);
       extent[0] = projectionExtent[0] - gutter;
       extent[2] = projectionExtent[2] + gutter;
-      // Except for Graticule use this for loading features
-      if (typeof /** @type {?} */ (vectorLayer).getMeridians !== 'function') {
+      if (vectorSource.getLoadWrapX()) {
         loadExtent = extent;
       }
       const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -361,9 +361,8 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const center = viewState.center.slice();
     const extent = buffer(frameStateExtent,
       vectorLayerRenderBuffer * resolution);
-    const projectionExtent = viewState.projection.getExtent();
-
     let loadExtent = extent.slice();
+    const projectionExtent = viewState.projection.getExtent();
 
     if (vectorSource.getWrapX() && viewState.projection.canWrapX() &&
         !containsExtent(projectionExtent, frameState.extent)) {
@@ -376,12 +375,12 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       const gutter = Math.max(getWidth(extent) / 2, worldWidth);
       extent[0] = projectionExtent[0] - gutter;
       extent[2] = projectionExtent[2] + gutter;
+      // Except for Graticule use this for loading features
+      if (typeof /** @type {?} */ (vectorLayer).getMeridians !== 'function') {
+        loadExtent = extent;
+      }
       const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
       center[0] -= (worldsAway * worldWidth);
-    }
-
-    if (typeof /** @type {?} */ (vectorLayer).getMeridians !== 'function') {
-      loadExtent = extent;
     }
 
     if (!this.dirty_ &&

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -363,6 +363,8 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       vectorLayerRenderBuffer * resolution);
     const projectionExtent = viewState.projection.getExtent();
 
+    let loadExtent = extent.slice();
+
     if (vectorSource.getWrapX() && viewState.projection.canWrapX() &&
         !containsExtent(projectionExtent, frameState.extent)) {
       // For the replay group, we need an extent that intersects the real world
@@ -376,6 +378,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       extent[2] = projectionExtent[2] + gutter;
       const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
       center[0] -= (worldsAway * worldWidth);
+    }
+
+    if (typeof /** @type {?} */ (vectorLayer).getMeridians !== 'function') {
+      loadExtent = extent;
     }
 
     if (!this.dirty_ &&
@@ -398,10 +404,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const userProjection = getUserProjection();
     let userTransform;
     if (userProjection) {
-      vectorSource.loadFeatures(toUserExtent(extent, projection), resolution, userProjection);
+      vectorSource.loadFeatures(toUserExtent(loadExtent, projection), resolution, userProjection);
       userTransform = getTransformFromProjections(userProjection, projection);
     } else {
-      vectorSource.loadFeatures(extent, resolution, projection);
+      vectorSource.loadFeatures(loadExtent, resolution, projection);
     }
 
     const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -363,7 +363,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const extent = buffer(frameStateExtent,
       vectorLayerRenderBuffer * resolution);
     const loadExtents = [extent.slice()];
-    const projectionExtent = viewState.projection.getExtent();
+    const projectionExtent = projection.getExtent();
 
     if (vectorSource.getWrapX() && projection.canWrapX() &&
         !containsExtent(projectionExtent, frameState.extent)) {
@@ -378,7 +378,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       extent[2] = projectionExtent[2] + gutter;
       wrapCoordinateX(center, projection);
       const loadExtent = wrapExtentX(loadExtents[0], projection);
-      wrapExtentX(loadExtent, projection);
       // If the extent crosses the date line, we load data for both edges of the worlds
       if (loadExtent[0] < projectionExtent[0] && loadExtent[2] < projectionExtent[2]) {
         loadExtents.push([loadExtent[0] + worldWidth, loadExtent[1], loadExtent[2] + worldWidth, loadExtent[3]]);

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -361,7 +361,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const center = viewState.center.slice();
     const extent = buffer(frameStateExtent,
       vectorLayerRenderBuffer * resolution);
-    let loadExtent = extent.slice();
+    const loadExtent = extent.slice();
     const projectionExtent = viewState.projection.getExtent();
 
     if (vectorSource.getWrapX() && viewState.projection.canWrapX() &&
@@ -375,11 +375,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       const gutter = Math.max(getWidth(extent) / 2, worldWidth);
       extent[0] = projectionExtent[0] - gutter;
       extent[2] = projectionExtent[2] + gutter;
-      if (vectorSource.getLoadWrapX()) {
-        loadExtent = extent;
-      }
       const worldsAway = Math.floor((center[0] - projectionExtent[0]) / worldWidth);
       center[0] -= (worldsAway * worldWidth);
+      loadExtent[0] -= (worldsAway * worldWidth);
+      loadExtent[2] -= (worldsAway * worldWidth);
     }
 
     if (!this.dirty_ &&

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -6,7 +6,7 @@ import TileState from '../../TileState.js';
 import ViewHint from '../../ViewHint.js';
 import {listen, unlistenByKey} from '../../events.js';
 import EventType from '../../events/EventType.js';
-import {buffer, containsCoordinate, equals, getIntersection, intersects, containsExtent, getWidth, getTopLeft} from '../../extent.js';
+import {buffer, containsCoordinate, equals, getIntersection, intersects, containsExtent, getTopLeft} from '../../extent.js';
 import VectorTileRenderType from '../../layer/VectorTileRenderType.js';
 import ReplayType from '../../render/canvas/BuilderType.js';
 import CanvasBuilderGroup from '../../render/canvas/BuilderGroup.js';

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -25,6 +25,7 @@ import {
 import CanvasExecutorGroup, {replayDeclutter} from '../../render/canvas/ExecutorGroup.js';
 import {clear} from '../../obj.js';
 import {createHitDetectionImageData, hitDetect} from '../../render/canvas/hitdetect.js';
+import {wrapX} from '../../coordinate.js';
 
 
 /**
@@ -353,9 +354,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
           if (tile.getState() === TileState.LOADED && tile.hifi) {
             const extent = tileGrid.getTileCoordExtent(tile.tileCoord);
             if (source.getWrapX() && projection.canWrapX() && !containsExtent(projectionExtent, extent)) {
-              const worldWidth = getWidth(projectionExtent);
-              const worldsAway = Math.floor((coordinate[0] - projectionExtent[0]) / worldWidth);
-              coordinate[0] -= (worldsAway * worldWidth);
+              wrapX(coordinate, projection);
             }
             break;
           }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -146,10 +146,6 @@ export class VectorSourceEvent extends Event {
  * @property {boolean} [wrapX=true] Wrap the world horizontally. For vector editing across the
  * -180° and 180° meridians to work properly, this should be set to `false`. The
  * resulting geometry coordinates will then exceed the world bounds.
- * @property {boolean} [loadWrapX=true] Call the loader with one world width either side
- * of the projection extent when the world is wrapped horizontally. This allows features
- * to be loaded in a single request, but may be inefficient. If `false` only the viewport
- * extent is used and the loader must determine the appropriate real world requests.
  */
 
 
@@ -189,12 +185,6 @@ class VectorSource extends Source {
      * @type {import("../format/Feature.js").default|undefined}
      */
     this.format_ = options.format;
-
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this.loadWrapX_ = options.loadWrapX === undefined ? true : options.loadWrapX;
 
     /**
      * @private
@@ -808,14 +798,6 @@ class VectorSource extends Source {
    */
   getFormat() {
     return this.format_;
-  }
-
-
-  /**
-   * @return {boolean} The loadWrapX option used to construct the source.
-   */
-  getLoadWrapX() {
-    return this.loadWrapX_;
   }
 
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -146,6 +146,10 @@ export class VectorSourceEvent extends Event {
  * @property {boolean} [wrapX=true] Wrap the world horizontally. For vector editing across the
  * -180° and 180° meridians to work properly, this should be set to `false`. The
  * resulting geometry coordinates will then exceed the world bounds.
+ * @property {boolean} [loadWrapX=true] Call the loader with one world width either side
+ * of the projection extent when the world is wrapped horizontally. This allows features
+ * to be loaded in a single request, but may be inefficient. If `false` only the viewport
+ * extent is used and the loader must determine the appropriate real world requests.
  */
 
 
@@ -190,7 +194,13 @@ class VectorSource extends Source {
      * @private
      * @type {boolean}
      */
-    this.overlaps_ = options.overlaps == undefined ? true : options.overlaps;
+    this.loadWrapX_ = options.loadWrapX === undefined ? true : options.loadWrapX;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.overlaps_ = options.overlaps === undefined ? true : options.overlaps;
 
     /**
      * @private
@@ -798,6 +808,14 @@ class VectorSource extends Source {
    */
   getFormat() {
     return this.format_;
+  }
+
+
+  /**
+   * @return {boolean} The loadWrapX option used to construct the source.
+   */
+  getLoadWrapX() {
+    return this.loadWrapX_;
   }
 
 

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -1,5 +1,6 @@
-import {add as addCoordinate, scale as scaleCoordinate, rotate as rotateCoordinate, equals as coordinatesEqual, format as formatCoordinate, closestOnCircle, closestOnSegment, createStringXY, squaredDistanceToSegment, toStringXY, toStringHDMS} from '../../../src/ol/coordinate.js';
+import {add as addCoordinate, scale as scaleCoordinate, rotate as rotateCoordinate, equals as coordinatesEqual, format as formatCoordinate, closestOnCircle, closestOnSegment, createStringXY, squaredDistanceToSegment, toStringXY, toStringHDMS, wrapX} from '../../../src/ol/coordinate.js';
 import Circle from '../../../src/ol/geom/Circle.js';
+import {get} from '../../../src/ol/proj.js';
 
 
 describe('ol.coordinate', function() {
@@ -233,6 +234,31 @@ describe('ol.coordinate', function() {
       const expected = '7.85, 47.98';
       expect(got).to.be(expected);
     });
+  });
+
+  describe('wrapX()', function() {
+    const projection = get('EPSG:4326');
+
+    it('leaves real world coordinate untouched', function() {
+      expect(wrapX([16, 48], projection)).to.eql([16, 48]);
+    });
+
+    it('moves left world coordinate to real world', function() {
+      expect(wrapX([-344, 48], projection)).to.eql([16, 48]);
+    });
+
+    it('moves right world coordinate to real world', function() {
+      expect(wrapX([376, 48], projection)).to.eql([16, 48]);
+    });
+
+    it('moves far off left coordinate to real world', function() {
+      expect(wrapX([-1064, 48], projection)).to.eql([16, 48]);
+    });
+
+    it('moves far off right coordinate to real world', function() {
+      expect(wrapX([1096, 48], projection)).to.eql([16, 48]);
+    });
+
   });
 
 });

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -851,4 +851,13 @@ describe('ol.extent', function() {
 
   });
 
+  describe('approximatelyEquals', function() {
+    it('returns true when within tolerance', function() {
+      expect(_ol_extent_.approximatelyEquals([16, 48, 17, 49], [16.09, 48, 17, 49], 0.1)).to.be(true);
+    });
+    it('returns false when not within tolerance', function() {
+      expect(_ol_extent_.approximatelyEquals([16, 48, 17, 49], [16.11, 48, 17, 49], 0.1)).to.be(false);
+    });
+  });
+
 });

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -1,5 +1,5 @@
 import * as _ol_extent_ from '../../../src/ol/extent.js';
-import {getTransform} from '../../../src/ol/proj.js';
+import {getTransform, get} from '../../../src/ol/proj.js';
 import {register} from '../../../src/ol/proj/proj4.js';
 
 
@@ -814,6 +814,39 @@ describe('ol.extent', function() {
       expect(destinationExtentNS2[2]).to.roughlyEqual(destinationExtentN[2], 1e-8);
       expect(destinationExtentNS2[1]).to.roughlyEqual(-destinationExtentN[3], 1e-8);
       expect(destinationExtentNS2[3]).to.roughlyEqual(destinationExtentN[3], 1e-8);
+    });
+
+  });
+
+  describe('wrapX()', function() {
+    const projection = get('EPSG:4326');
+
+    it('leaves real world extent untouched', function() {
+      expect(_ol_extent_.wrapX([16, 48, 18, 49], projection)).to.eql([16, 48, 18, 49]);
+    });
+
+    it('moves left world extent to real world', function() {
+      expect(_ol_extent_.wrapX([-344, 48, -342, 49], projection)).to.eql([16, 48, 18, 49]);
+    });
+
+    it('moves right world extent to real world', function() {
+      expect(_ol_extent_.wrapX([376, 48, 378, 49], projection)).to.eql([16, 48, 18, 49]);
+    });
+
+    it('moves far off left extent to real world', function() {
+      expect(_ol_extent_.wrapX([-1064, 48, -1062, 49], projection)).to.eql([16, 48, 18, 49]);
+    });
+
+    it('moves far off right extent to real world', function() {
+      expect(_ol_extent_.wrapX([1096, 48, 1098, 49], projection)).to.eql([16, 48, 18, 49]);
+    });
+
+    it('leaves -180 crossing extent with real world center untouched', function() {
+      expect(_ol_extent_.wrapX([-184, 48, 16, 49], projection)).to.eql([-184, 48, 16, 49]);
+    });
+
+    it('moves +180 crossing extent with off-world center to the real world', function() {
+      expect(_ol_extent_.wrapX([300, 48, 376, 49], projection)).to.eql([-60, 48, 16, 49]);
     });
 
   });

--- a/test/spec/ol/extent.test.js
+++ b/test/spec/ol/extent.test.js
@@ -849,6 +849,12 @@ describe('ol.extent', function() {
       expect(_ol_extent_.wrapX([300, 48, 376, 49], projection)).to.eql([-60, 48, 16, 49]);
     });
 
+    it('produces the same real world extent for shifted extents with center at +/-180', function() {
+      expect(_ol_extent_.wrapX([360, -90, 720, 90], projection)).to.eql([-360, -90, 0, 90]);
+      expect(_ol_extent_.wrapX([0, -90, 360, 90], projection)).to.eql([-360, -90, 0, 90]);
+      expect(_ol_extent_.wrapX([-360, -90, 0, 90], projection)).to.eql([-360, -90, 0, 90]);
+    });
+
   });
 
   describe('approximatelyEquals', function() {

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -224,7 +224,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
     let frameState, projExtent, renderer, worldWidth, buffer, loadExtent;
     const loader = function(extent) {
       loadExtent = extent;
-    }
+    };
 
     beforeEach(function() {
       const layer = new VectorLayer({
@@ -335,7 +335,7 @@ describe('ol.renderer.canvas.VectorLayer', function() {
     let frameState, projExtent, renderer, worldWidth, buffer, loadExtent;
     const loader = function(extent) {
       loadExtent = extent;
-    }
+    };
 
     beforeEach(function() {
       const layer = new VectorLayer({

--- a/test/spec/ol/renderer/canvas/vectorlayer.test.js
+++ b/test/spec/ol/renderer/canvas/vectorlayer.test.js
@@ -1,7 +1,7 @@
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';
-import {buffer as bufferExtent, getWidth} from '../../../../../src/ol/extent.js';
+import {buffer as bufferExtent, getWidth, getCenter} from '../../../../../src/ol/extent.js';
 import Circle from '../../../../../src/ol/geom/Circle.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import {fromExtent} from '../../../../../src/ol/geom/Polygon.js';
@@ -243,7 +243,6 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       frameState = {
         viewHints: [],
         viewState: {
-          center: [0, 0],
           projection: projection,
           resolution: 1,
           rotation: 0
@@ -251,58 +250,72 @@ describe('ol.renderer.canvas.VectorLayer', function() {
       };
     });
 
+    function setExtent(extent) {
+      frameState.extent = extent;
+      frameState.viewState.center = getCenter(extent);
+    }
+
     it('sets correct extent for small viewport near dateline', function() {
 
-      frameState.extent =
-          [projExtent[0] - 10000, -10000, projExtent[0] + 10000, 10000];
+      setExtent([projExtent[0] - 10000, -10000, projExtent[0] + 10000, 10000]);
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroup_.maxExtent_).to.eql(bufferExtent([
         projExtent[0] - worldWidth + buffer,
         -10000, projExtent[2] + worldWidth - buffer, 10000
       ], buffer));
-      expect(loadExtent).to.eql(renderer.replayGroup_.maxExtent_);
+      expect(loadExtent).to.eql(bufferExtent(frameState.extent, buffer));
     });
 
     it('sets correct extent for viewport less than 1 world wide', function() {
 
-      frameState.extent =
-          [projExtent[0] - 10000, -10000, projExtent[1] - 10000, 10000];
+      setExtent([projExtent[0] - 10000, -10000, projExtent[2] - 10000, 10000]);
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroup_.maxExtent_).to.eql(bufferExtent([
         projExtent[0] - worldWidth + buffer,
         -10000, projExtent[2] + worldWidth - buffer, 10000
       ], buffer));
-      expect(loadExtent).to.eql(renderer.replayGroup_.maxExtent_);
+      expect(loadExtent).to.eql(bufferExtent(frameState.extent, buffer));
     });
 
     it('sets correct extent for viewport more than 1 world wide', function() {
 
-      frameState.extent =
-          [2 * projExtent[0] - 10000, -10000, 2 * projExtent[1] + 10000, 10000];
+      setExtent([2 * projExtent[0] + 10000, -10000, 2 * projExtent[2] - 10000, 10000]);
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroup_.maxExtent_).to.eql(bufferExtent([
         projExtent[0] - worldWidth + buffer,
         -10000, projExtent[2] + worldWidth - buffer, 10000
       ], buffer));
-      expect(loadExtent).to.eql(renderer.replayGroup_.maxExtent_);
+      expect(loadExtent).to.eql(bufferExtent(frameState.extent, buffer));
     });
 
-    it('sets correct extent for viewport more than 2 worlds wide', function() {
+    it('sets correct extent for viewport more than 2 worlds wide, one world away', function() {
 
-      frameState.extent = [
-        projExtent[0] - 2 * worldWidth - 10000,
-        -10000, projExtent[1] + 2 * worldWidth + 10000, 10000
-      ];
+      setExtent([projExtent[0] - 2 * worldWidth - 10000,
+        -10000, projExtent[0] + 2 * worldWidth + 10000, 10000
+      ]);
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroup_.maxExtent_).to.eql(bufferExtent([
         projExtent[0] - 2 * worldWidth - 10000,
         -10000, projExtent[2] + 2 * worldWidth + 10000, 10000
       ], buffer));
-      expect(loadExtent).to.eql(renderer.replayGroup_.maxExtent_);
+      const normalizedExtent = [projExtent[0] - 2 * worldWidth + worldWidth - 10000, -10000, projExtent[0] + 2 * worldWidth + worldWidth + 10000, 10000];
+      expect(loadExtent).to.eql(bufferExtent(normalizedExtent, buffer));
+    });
+
+    it('sets correct extent for small viewport near dateline, one world away', function() {
+
+      setExtent([-worldWidth - 10000, -10000, -worldWidth + 10000, 10000]);
+      renderer.prepareFrame(frameState);
+      expect(renderer.replayGroup_.maxExtent_).to.eql(bufferExtent([
+        projExtent[0] - worldWidth + buffer,
+        -10000, projExtent[2] + worldWidth - buffer, 10000
+      ], buffer));
+      const normalizedExtent = [-10000, -10000, 10000, 10000];
+      expect(loadExtent).to.eql(bufferExtent(normalizedExtent, buffer));
     });
 
     it('sets replayGroupChanged correctly', function() {
-      frameState.extent = [-10000, -10000, 10000, 10000];
+      setExtent([-10000, -10000, 10000, 10000]);
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroupChanged).to.be(true);
       renderer.prepareFrame(frameState);


### PR DESCRIPTION
Fixes #10799

When wrapped the renderer was calling the loader function with the full width of the projection resulting in the graticule attempting to calculate meridians for the whole world even when zoomed in on a small region.  This exceeded the `maxLines` limit and resulted in missing meridians, unnecessarily long parallels and poor performance.  It is fixed by the vector layer renderer always calling the loader with the frameState extent for Graticule layers and handling wrapping in the graticule.
