### PR TITLE
Add 'funding' field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
   "bugs": {
     "url": "https://github.com/openlayers/openlayers/issues"
   },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/openlayers"
+  },
   "dependencies": {
     "elm-pep": "^1.0.4",
     "pbf": "3.2.1",


### PR DESCRIPTION
This was introduced to `npm` recently and allows users of the ol package to e.g. type `npm fund ol` and our opencollective page opens in a browser. Just typing `npm fund` in a npm package will list the funding options of the dependencies of the current project.

See e.g. https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md , https://docs.npmjs.com/configuring-npm/package-json.html#funding or https://docs.npmjs.com/cli-commands/fund.html 

Please review.