### PR TITLE
Fix drawing svg icon with color option in ie11

### DIFF
--- a/examples/data/square.svg
+++ b/examples/data/square.svg
@@ -2,6 +2,6 @@
 
 <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
   <g>
-    <rect width="20" height="20" style="fill:#fff" />
+    <rect width="20" height="20" style="fill:#fff; stroke-width:4px; stroke:#000" />
   </g>
 </svg>

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -25,6 +25,7 @@ rome.setStyle(new Style({
   image: new Icon({
     color: '#8959A8',
     crossOrigin: 'anonymous',
+    imgSize: [20, 20],
     src: 'data/square.svg'
   })
 }));

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -217,10 +217,12 @@ class IconImage extends EventTarget {
     ctx.drawImage(this.image_, 0, 0);
 
     if (this.isTainted_(ctx)) {
-      // Internet explorer 11 marks canvas as tainted if the drawn image is a svg.
-      // This makes the getImageData function throw a SecurityError.
-      // The same effect can be achieved with the globalCompositionOperation but
-      // Internet Explorer 11 does not properly support the multiply operation.
+      // If reading from the canvas throws a SecurityError the same effect can be
+      // achieved with globalCompositeOperation.
+      // This could be used as the default, but it is not fully supported by all
+      // browsers. E. g. Internet Explorer 11 does not support the multiply
+      // operation and the resulting image shape will be completelly filled with
+      // the provided color.
       // So this is only used as a fallback. It is still better than having no icon
       // at all.
       const c = this.color_;


### PR DESCRIPTION
Fixes #9890 in case the svg icon is one single color.

Drawing a svg to canvas in Internet Explorer 11 always marks the canvas as tainted and then does not allow reading pixel data from it.
The same coloring effect can be achieved with globalCompositeOperation but that does neither works correctly in ie11, so I only implemented this as a fallback when there would be no icon at all otherwise. 

I updated the "icon color" example to work in ie11, then i added a black stroke around the square icon which does not work because ie11 does not implement all the blend modes.