### PR TITLE
Fix custom symbol example short description

### DIFF
--- a/examples/earthquake-custom-symbol.html
+++ b/examples/earthquake-custom-symbol.html
@@ -1,7 +1,7 @@
 ---
 layout: example.html
 title: Earthquakes with custom symbols
-shortdesc: Demonstrates the use of `toCanvas` to create custom icon symbols.
+shortdesc: Demonstrates the use of `toContext` to create custom icon symbols.
 docs: >
   This example parses a KML file and renders the features as a vector layer.  The layer is given a <code>style</code> that renders earthquake locations with a custom lightning symbol and a size relative to their magnitude.
 tags: "KML, vector, style, canvas, symbol"


### PR DESCRIPTION
`toCanvas` should be `toContext`
