### PR TITLE
API docs for enums

### DIFF
--- a/config/jsdoc/api/plugins/api.js
+++ b/config/jsdoc/api/plugins/api.js
@@ -73,9 +73,6 @@ function includeAugments(doclet) {
           });
         }
         cls._hideConstructor = true;
-        if (!cls.undocumented) {
-          cls._documented = true;
-        }
       }
     }
   }
@@ -182,13 +179,14 @@ exports.handlers = {
         doclet._hideConstructor = true;
         includeAugments(doclet);
         sortOtherMembers(doclet);
-      } else if (!doclet._hideConstructor
-          && !(doclet.longname in defaultExports && byLongname[doclet.longname].some(d => d.isEnum))) {
+      } else if (!doclet._hideConstructor) {
         // Remove all other undocumented symbols
         doclet.undocumented = true;
       }
-      if (doclet._documented) {
-        delete doclet.undocumented;
+      if (doclet.memberof && byLongname[doclet.memberof] &&
+          byLongname[doclet.memberof][0].isEnum &&
+          !byLongname[doclet.memberof][0].properties.some(p => p.stability)) {
+        byLongname[doclet.memberof][0].undocumented = true;
       }
     }
   },

--- a/config/jsdoc/api/template/tmpl/method.tmpl
+++ b/config/jsdoc/api/template/tmpl/method.tmpl
@@ -64,7 +64,7 @@ var self = this;
     <ul><?js fires.forEach(function(f) {
             var parts = f.split(/#?event:/);
             var type = parts.pop();
-            var eventClassName = parts[0];
+            var eventClass = self.find({longname: parts[0]})[0];
             parts = type.split(' ');
             type = parts.shift();
             var description = parts.length ? parts.join(' ') : '';
@@ -74,12 +74,9 @@ var self = this;
             }
         ?>
         <li class="<?js= (eventDoclet || data).stability !== 'stable' ? 'unstable' : '' ?>">
-            <code><?js= eventClassName ? self.linkto(f, type) : type ?></code>
-            <?js if (eventClassName) {
-              var eventClass = self.find({longname: eventClassName})[0];
-              if (eventClass) { ?>
-                (<?js= self.linkto(eventClass.longname) ?>)
-              <?js } ?>
+            <code><?js= eventClass ? self.linkto(f, type) : type ?></code>
+            <?js if (eventClass) { ?>
+              (<?js= self.linkto(eventClass.longname) ?>)
             <?js } ?>
             <?js= self.partial('stability.tmpl', eventDoclet || (data.stability ? data : {})) ?>
             <?js if (description) { ?> -

--- a/src/ol/style/IconAnchorUnits.js
+++ b/src/ol/style/IconAnchorUnits.js
@@ -5,15 +5,16 @@
 /**
  * Icon anchor units. One of 'fraction', 'pixels'.
  * @enum {string}
- * @api
  */
 export default {
   /**
    * Anchor is a fraction
+   * @api
    */
   FRACTION: 'fraction',
   /**
    * Anchor is in pixels
+   * @api
    */
   PIXELS: 'pixels'
 };

--- a/src/ol/style/IconAnchorUnits.js
+++ b/src/ol/style/IconAnchorUnits.js
@@ -5,8 +5,15 @@
 /**
  * Icon anchor units. One of 'fraction', 'pixels'.
  * @enum {string}
+ * @api
  */
 export default {
+  /**
+   * Anchor is a fraction
+   */
   FRACTION: 'fraction',
+  /**
+   * Anchor is in pixels
+   */
   PIXELS: 'pixels'
 };

--- a/src/ol/style/IconOrigin.js
+++ b/src/ol/style/IconOrigin.js
@@ -5,10 +5,23 @@
 /**
  * Icon origin. One of 'bottom-left', 'bottom-right', 'top-left', 'top-right'.
  * @enum {string}
+ * @api
  */
 export default {
+  /**
+   * Origin is at bottom left
+   */
   BOTTOM_LEFT: 'bottom-left',
+  /**
+   * Origin is at bottom right
+   */
   BOTTOM_RIGHT: 'bottom-right',
+  /**
+   * Origin is at top left
+   */
   TOP_LEFT: 'top-left',
+  /**
+   * Origin is at top right
+   */
   TOP_RIGHT: 'top-right'
 };

--- a/src/ol/style/IconOrigin.js
+++ b/src/ol/style/IconOrigin.js
@@ -5,23 +5,26 @@
 /**
  * Icon origin. One of 'bottom-left', 'bottom-right', 'top-left', 'top-right'.
  * @enum {string}
- * @api
  */
 export default {
   /**
    * Origin is at bottom left
+   * @api
    */
   BOTTOM_LEFT: 'bottom-left',
   /**
    * Origin is at bottom right
+   * @api
    */
   BOTTOM_RIGHT: 'bottom-right',
   /**
    * Origin is at top left
+   * @api
    */
   TOP_LEFT: 'top-left',
   /**
    * Origin is at top right
+   * @api
    */
   TOP_RIGHT: 'top-right'
 };


### PR DESCRIPTION
This pull request is mostly based on @MoonE's work in #10512. After seeing the results of #10802 and the review of #10805, I remembered how we decided to document enums a long time ago: only the values that are documented as options somewhere are marked as `@api`, but not the enums themselves. It also makes no sense to have enums in the docs that are only used internally.

With this change, consistency should be restored. 