### PR TITLE
Make OSM XML example work at dateline and replace Bing with MapTiler

### DIFF
--- a/examples/vector-osm.html
+++ b/examples/vector-osm.html
@@ -4,9 +4,9 @@ title: OSM XML
 shortdesc: Example of using the OSM XML source.
 docs: >
  OSM XML vector data is loaded dynamically from a the [Overpass API](http://overpass-api.de) using a bbox strategy. Note that panning and zooming will eventually lead to "Too many requests" errors from the Overpass API.
-tags: "vector, osmxml, loading, server, strategy, bbox"
+tags: "vector, osmxml, loading, server, strategy, bbox, maptiler"
 cloak:
-  - key: As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5
-    value: Your Bing Maps Key from http://www.bingmapsportal.com/ here
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>

--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -85,8 +85,8 @@ const vectorSource = new VectorSource({
       vectorSource.addFeatures(features);
     });
     const query = '(node(' +
-        epsg4326Extent[1] + ',' + epsg4326Extent[0] + ',' +
-        epsg4326Extent[3] + ',' + epsg4326Extent[2] +
+        epsg4326Extent[1] + ',' + Math.max(epsg4326Extent[0], -180) + ',' +
+        epsg4326Extent[3] + ',' + Math.min(epsg4326Extent[2], 180) +
         ');rel(bn)->.foo;way(bn);node(w)->.foo;rel(bw););out meta;';
     client.send(query);
   },
@@ -110,10 +110,15 @@ const vector = new VectorLayer({
   }
 });
 
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+const attributions = '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> ' +
+  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+
 const raster = new TileLayer({
-  source: new BingMaps({
-    imagerySet: 'Aerial',
-    key: 'As1HiMj1PvLPlqc_gtM7AqZfBL8ZL3VrjaS3zIb22Uvb9WKhuJObROC-qUpa81U5'
+  source: new XYZ({
+    attributions: attributions,
+    url: 'https://api.maptiler.com/tiles/satellite/{z}/{x}/{y}.jpg?key=' + key,
+    maxZoom: 20
   })
 });
 

--- a/examples/vector-osm.js
+++ b/examples/vector-osm.js
@@ -4,7 +4,7 @@ import OSMXML from '../src/ol/format/OSMXML.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {bbox as bboxStrategy} from '../src/ol/loadingstrategy.js';
 import {transformExtent} from '../src/ol/proj.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import XYZ from '../src/ol/source/XYZ.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 


### PR DESCRIPTION
I checked this example with the latest renderer updates and it now works at the dateline which would have previously been an excessive request although it was necessary to make sure the two small requests did not extend off the world beyond their own side of the line.  Also not obvious in the example area but very obvious in rural Fiji is the missing background layer which I have replaced with MapTiler.
