### PR TITLE
Perform auto-pan when adding an Overlay to a Map

### DIFF
--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -300,6 +300,7 @@ class Overlay extends BaseObject {
       } else {
         container.appendChild(this.element);
       }
+      this.performAutoPan();
     }
   }
 


### PR DESCRIPTION
 * Auto-pan settings currently only activate when the position of the
   Overlay is set and the Overlay is already on a Map.

 * The consequence of this is that creating an Overlay with position
   set and then adding to a Map results in no auto-pan being performed -
   it is necessary to first create the Overlay, then add to a Map and
   finally set the position in order for the Map to auto-pan.

 * This commit changes this behaviour so that the auto-pan settings are
   also considered when the map property of the Overlay is set and not
   only when the position property is set, leading to a more intuitive
   behaviour.

 * Fixes Issue #10843
