### PR TITLE
View / avoid solving constraints related to map size during animation

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -989,7 +989,7 @@ class PluggableMap extends BaseObject {
    * @private
    */
   handleSizeChanged_() {
-    if (this.getView()) {
+    if (this.getView() && !this.getView().getAnimating()) {
       this.getView().resolveConstraints(0);
     }
 

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -762,11 +762,14 @@ class View extends BaseObject {
    * Stores the viewport size on the view. The viewport size is not read every time from the DOM
    * to avoid performance hit and layout reflow.
    * This should be done on map size change.
+   * Note: the constraints are not resolved during an animation to avoid stopping it
    * @param {import("./size.js").Size=} opt_size Viewport size; if undefined, [100, 100] is assumed
    */
   setViewportSize(opt_size) {
     this.viewportSize_ = Array.isArray(opt_size) ? opt_size.slice() : [100, 100];
-    this.resolveConstraints(0);
+    if (!this.getAnimating()) {
+      this.resolveConstraints(0);
+    }
   }
 
   /**

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1090,6 +1090,54 @@ describe('ol.View', function() {
 
     });
 
+    it('completes even though Map#setSize is called', function(done) {
+
+      const view = new View({
+        center: [0, 0],
+        zoom: 0
+      });
+      const map = new Map({
+        view
+      });
+      map.setSize([110, 90]);
+
+      view.animate({
+        zoom: 1,
+        duration: 25
+      }, function() {
+        expect(view.getZoom()).to.be(1);
+        done();
+      });
+
+      setTimeout(function() {
+        map.setSize([100, 100]);
+      }, 10);
+
+    });
+
+    it('completes even though Map#updateSize is called', function(done) {
+
+      const view = new View({
+        center: [0, 0],
+        zoom: 0
+      });
+      const map = new Map({
+        view
+      });
+
+      view.animate({
+        zoom: 1,
+        duration: 25
+      }, function() {
+        expect(view.getZoom()).to.be(1);
+        done();
+      });
+
+      setTimeout(function() {
+        map.updateSize();
+      }, 10);
+
+    });
   });
 
   describe('#cancelAnimations()', function() {


### PR DESCRIPTION
Fixes #10313 

The view constraints are simply not solved if the map viewport size changes, or if `map.setSize` is used, during an animation.

The constraints are solved continuously during an animation anyway.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
