### PR TITLE
Do not append hit canvas to document body

### DIFF
--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -125,7 +125,6 @@ export function createHitDetectionImageData(size, transforms, features, styleFun
       }
     }
   }
-  document.body.appendChild(context.canvas);
   return context.getImageData(0, 0, canvas.width, canvas.height);
 }
 


### PR DESCRIPTION
Removes a line that was added for debugging and should not have been committed.