### PR TITLE
Apidoc - Fix toggle state when there are no hidden members

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -233,18 +233,8 @@ $(function () {
       return;
     }
     const clsItem = $(this).closest('.item');
-    let show;
-    if (clsItem.hasClass('toggle-manual-show')) {
-      show = false;
-    } else if (clsItem.hasClass('toggle-manual-hide')) {
-      show = true;
-    } else {
-      clsItem.find('.member-list li').each(function (i, v) {
-        show = $(v).is(':hidden');
-        return !show;
-      });
-    }
-    search.manualToggle(clsItem, !!show);
+    const show = !clsItem.hasClass('toggle-manual-show');
+    search.manualToggle(clsItem, show);
   });
 
   // Auto resizing on navigation


### PR DESCRIPTION
Trying to expand an element in the apidoc sidebar does not trigger an icon transition the first time if the clicked class/module has no hidden members.

Examples are `ol/webgl/Buffer`, or searching for 'stableSort' and then expaning the `ol/array` module