### PR TITLE
Move readFromDocument implementation to the base class

### DIFF
--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -34,19 +34,6 @@ class OWS extends XML {
   }
 
   /**
-   * @param {Document} doc Document.
-   * @return {Object} Object
-   */
-  readFromDocument(doc) {
-    for (let n = doc.firstChild; n; n = n.nextSibling) {
-      if (n.nodeType == Node.ELEMENT_NODE) {
-        return this.readFromNode(/** @type {Element} */ (n));
-      }
-    }
-    return null;
-  }
-
-  /**
    * @param {Element} node Node.
    * @return {Object} Object
    */

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -63,19 +63,6 @@ class WMSCapabilities extends XML {
   }
 
   /**
-   * @param {Document} doc Document.
-   * @return {Object} Object
-   */
-  readFromDocument(doc) {
-    for (let n = doc.firstChild; n; n = n.nextSibling) {
-      if (n.nodeType == Node.ELEMENT_NODE) {
-        return this.readFromNode(/** @type {Element} */ (n));
-      }
-    }
-    return null;
-  }
-
-  /**
    * @param {Element} node Node.
    * @return {Object} Object
    */

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -53,19 +53,6 @@ class WMTSCapabilities extends XML {
   }
 
   /**
-   * @param {Document} doc Document.
-   * @return {Object} Object
-   */
-  readFromDocument(doc) {
-    for (let n = doc.firstChild; n; n = n.nextSibling) {
-      if (n.nodeType == Node.ELEMENT_NODE) {
-        return this.readFromNode(/** @type {Element} */ (n));
-      }
-    }
-    return null;
-  }
-
-  /**
    * @param {Element} node Node.
    * @return {Object} Object
    */

--- a/src/ol/format/XML.js
+++ b/src/ol/format/XML.js
@@ -31,11 +31,17 @@ class XML {
   }
 
   /**
-   * @abstract
    * @param {Document} doc Document.
    * @return {Object} Object
    */
-  readFromDocument(doc) {}
+  readFromDocument(doc) {
+    for (let n = doc.firstChild; n; n = n.nextSibling) {
+      if (n.nodeType == Node.ELEMENT_NODE) {
+        return this.readFromNode(/** @type {Element} */ (n));
+      }
+    }
+    return null;
+  }
 
   /**
    * @abstract


### PR DESCRIPTION
All the child classes have the same code; move to the base class
