### PR TITLE
Use a new cache key in hopes of fixing test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          - v1-dependencies-
+          - v2-dependencies-{{ checksum "package-lock.json" }}
 
       - run:
           name: Install Dependencies
@@ -21,7 +20,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
+          key: v2-dependencies-{{ checksum "package-lock.json" }}
 
       - run:
           name: Run Tests


### PR DESCRIPTION
The next step in debugging our periodic rendering test failures is to use a new cache key.  This change also removes the less specific key, so we will no longer get [partial cache restores](https://circleci.com/docs/2.0/caching/#restoring-cache).  If we don't see test failures after this change, we may try adding `"v2-dependencies-"` as a key.
