### PR TITLE
Update TypeScript to v3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ See our [Open Collective](https://opencollective.com/openlayers/contribute/spons
 
 ## IntelliSense support and type checking for VS Code
 
-The ol package contains a src/ folder with JSDoc annotated sources. TypeScript can get type definitions from these sources with a `jsconfig.json` config file in the project root:
+The ol package contains a src/ folder with JSDoc annotated sources. TypeScript can get type definitions from these sources with a [`jsconfig.json`](https://gist.github.com/ahocevar/9a7253cb4712e8bf38d75d8ac898e36c#file-jsconfig-json) (when authoring in JavaScript) or [`tsconfig.json`](https://gist.github.com/ahocevar/ad7b52a2fa0f6c5495193cd695ab3780#file-tsconfig-json) (when authoring in TypeScript) config file in the project root:
+
+<details><summary>jsconfig.json</summary>
 
 ```json
 {
@@ -70,13 +72,39 @@ The ol package contains a src/ folder with JSDoc annotated sources. TypeScript c
   "include": [
     "**/*.js",
     "node_modules/ol/**/*.js"
-  ]
+  ],
+  "typeAcquisition": {
+    "exclude": ["ol"]
+  }
 }
 ```
 
-Project template with this configuration: https://gist.github.com/9a7253cb4712e8bf38d75d8ac898e36c.
+</details>
+<details><summary>tsconfig.json</summary>
 
-Note that the above only works when authoring in plain JavaScript. For similar configurations with a `tsconfig.json` in TypeScript projects, your mileage may vary. You may want to use a [third-party types package](https://github.com/hanreev/types-ol) in this case.
+```json
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "./",
+    "paths": {
+      "ol": ["node_modules/ol/src"],
+      "ol/*": ["node_modules/ol/src/*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "node_modules/ol/**/*"
+  ],
+  "typeAcquisition": {
+    "exclude": ["ol"]
+  }
+}
+```
+
+</details>
+
+TypeScript users may want to use a [third-party types package](https://github.com/hanreev/types-ol) instead.
 
 ## Supported Browsers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12105,9 +12105,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "shx": "^0.3.2",
     "sinon": "^9.0.0",
     "terser-webpack-plugin": "^2.0.1",
-    "typescript": "3.5.3",
+    "typescript": "^3.8.3",
     "url-polyfill": "^1.1.5",
     "walk": "^2.3.9",
     "webpack": "4.42.1",

--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -21,7 +21,7 @@ const Property = {
  */
 export class CollectionEvent extends Event {
   /**
-   * @param {CollectionEventType} type Type.
+   * @param {import("./CollectionEventType.js").default} type Type.
    * @param {*=} opt_element Element.
    * @param {number=} opt_index The index of the added or removed element.
    */

--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -68,7 +68,7 @@ class ImageWrapper extends ImageBase {
 
     /**
      * @protected
-     * @type {ImageState}
+     * @type {import("./ImageState.js").default}
      */
     this.state = ImageState.IDLE;
 

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -9,7 +9,7 @@ import {listenImage} from './Image.js';
 class ImageTile extends Tile {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {TileState} state State.
+   * @param {import("./TileState.js").default} state State.
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -21,7 +21,7 @@ import {outerHeight, outerWidth, removeChildren, removeNode} from './dom.js';
  * shifts the overlay down.
  * @property {import("./coordinate.js").Coordinate} [position] The overlay position
  * in map projection.
- * @property {OverlayPositioning} [positioning='top-left'] Defines how
+ * @property {import("./OverlayPositioning.js").default} [positioning='top-left'] Defines how
  * the overlay is actually positioned with respect to its `position` property.
  * Possible values are `'bottom-left'`, `'bottom-center'`, `'bottom-right'`,
  * `'center-left'`, `'center-center'`, `'center-right'`, `'top-left'`,
@@ -204,7 +204,7 @@ class Overlay extends BaseObject {
 
     this.setPositioning(
       options.positioning !== undefined
-        ? /** @type {OverlayPositioning} */ (options.positioning)
+        ? /** @type {import("./OverlayPositioning.js").default} */ (options.positioning)
         : OverlayPositioning.TOP_LEFT
     );
 
@@ -270,13 +270,13 @@ class Overlay extends BaseObject {
 
   /**
    * Get the current positioning of this overlay.
-   * @return {OverlayPositioning} How the overlay is positioned
+   * @return {import("./OverlayPositioning.js").default} How the overlay is positioned
    *     relative to its point on the map.
    * @observable
    * @api
    */
   getPositioning() {
-    return /** @type {OverlayPositioning} */ (this.get(Property.POSITIONING));
+    return /** @type {import("./OverlayPositioning.js").default} */ (this.get(Property.POSITIONING));
   }
 
   /**
@@ -481,7 +481,7 @@ class Overlay extends BaseObject {
 
   /**
    * Set the positioning for this overlay.
-   * @param {OverlayPositioning} positioning how the overlay is
+   * @param {import("./OverlayPositioning.js").default} positioning how the overlay is
    *     positioned relative to its point on the map.
    * @observable
    * @api

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -276,7 +276,9 @@ class Overlay extends BaseObject {
    * @api
    */
   getPositioning() {
-    return /** @type {import("./OverlayPositioning.js").default} */ (this.get(Property.POSITIONING));
+    return /** @type {import("./OverlayPositioning.js").default} */ (this.get(
+      Property.POSITIONING
+    ));
   }
 
   /**

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -75,7 +75,7 @@ import {easeIn} from './easing.js';
 class Tile extends EventTarget {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {TileState} state State.
+   * @param {import("./TileState.js").default} state State.
    * @param {Options=} opt_options Tile options.
    */
   constructor(tileCoord, state, opt_options) {
@@ -90,7 +90,7 @@ class Tile extends EventTarget {
 
     /**
      * @protected
-     * @type {TileState}
+     * @type {import("./TileState.js").default}
      */
     this.state = state;
 
@@ -227,7 +227,7 @@ class Tile extends EventTarget {
   }
 
   /**
-   * @return {TileState} State.
+   * @return {import("./TileState.js").default} State.
    */
   getState() {
     return this.state;
@@ -238,7 +238,7 @@ class Tile extends EventTarget {
    * it is important to set the state correctly to {@link module:ol/TileState~ERROR}
    * when the tile cannot be loaded. Otherwise the tile cannot be removed from
    * the tile queue and will block other requests.
-   * @param {TileState} state State.
+   * @param {import("./TileState.js").default} state State.
    * @api
    */
   setState(state) {

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -7,7 +7,7 @@ import TileState from './TileState.js';
 class VectorTile extends Tile {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {TileState} state State.
+   * @param {import("./TileState.js").default} state State.
    * @param {string} src Data source url.
    * @param {import("./format/Feature.js").default} format Feature format.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1481,7 +1481,7 @@ class View extends BaseObject {
   }
 
   /**
-   * @param {ViewHint} hint Hint.
+   * @param {import("./ViewHint.js").default} hint Hint.
    * @param {number} delta Delta.
    * @return {number} New value.
    */

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -49,7 +49,7 @@ class Attribution extends Control {
 
     super({
       element: document.createElement('div'),
-      render: options.render || render,
+      render: options.render,
       target: options.target,
     });
 
@@ -328,15 +328,15 @@ class Attribution extends Control {
   getCollapsed() {
     return this.collapsed_;
   }
-}
 
-/**
- * Update the attribution element.
- * @param {import("../MapEvent.js").default} mapEvent Map event.
- * @this {Attribution}
- */
-export function render(mapEvent) {
-  this.updateElement_(mapEvent.frameState);
+  /**
+   * Update the attribution element.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @override
+   */
+  render(mapEvent) {
+    this.updateElement_(mapEvent.frameState);
+  }
 }
 
 export default Attribution;

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -74,11 +74,9 @@ class Control extends BaseObject {
      */
     this.listenerKeys = [];
 
-    /**
-     * @private
-     * @type {function(import("../MapEvent.js").default): void}
-     */
-    this.render_ = options.render ? options.render : VOID;
+    if (options.render) {
+      this.render = options.render;
+    }
 
     if (options.target) {
       this.setTarget(options.target);
@@ -133,14 +131,11 @@ class Control extends BaseObject {
   }
 
   /**
-   * Update the projection. Rendering of the coordinates is done in
-   * `handleMouseMove` and `handleMouseUp`.
+   * Renders the control.
    * @param {import("../MapEvent.js").default} mapEvent Map event.
    * @api
    */
-  render(mapEvent) {
-    this.render_.call(this, mapEvent);
-  }
+  render(mapEvent) {}
 
   /**
    * This function is used to set a target element for the control. It has no

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -66,7 +66,7 @@ class MousePosition extends Control {
 
     super({
       element: element,
-      render: options.render || render,
+      render: options.render,
       target: options.target,
     });
 
@@ -251,22 +251,22 @@ class MousePosition extends Control {
       this.renderedHTML_ = html;
     }
   }
-}
 
-/**
- * Update the projection. Rendering of the coordinates is done in
- * `handleMouseMove` and `handleMouseUp`.
- * @param {import("../MapEvent.js").default} mapEvent Map event.
- * @this {MousePosition}
- */
-export function render(mapEvent) {
-  const frameState = mapEvent.frameState;
-  if (!frameState) {
-    this.mapProjection_ = null;
-  } else {
-    if (this.mapProjection_ != frameState.viewState.projection) {
-      this.mapProjection_ = frameState.viewState.projection;
-      this.transform_ = null;
+  /**
+   * Update the projection. Rendering of the coordinates is done in
+   * `handleMouseMove` and `handleMouseUp`.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @override
+   */
+  render(mapEvent) {
+    const frameState = mapEvent.frameState;
+    if (!frameState) {
+      this.mapProjection_ = null;
+    } else {
+      if (this.mapProjection_ != frameState.viewState.projection) {
+        this.mapProjection_ = frameState.viewState.projection;
+        this.transform_ = null;
+      }
     }
   }
 }

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -81,7 +81,7 @@ class OverviewMap extends Control {
 
     super({
       element: document.createElement('div'),
-      render: options.render || render,
+      render: options.render,
       target: options.target,
     });
 
@@ -644,16 +644,16 @@ class OverviewMap extends Control {
   getOverviewMap() {
     return this.ovmap_;
   }
-}
 
-/**
- * Update the overview map element.
- * @param {import("../MapEvent.js").default} mapEvent Map event.
- * @this {OverviewMap}
- */
-export function render(mapEvent) {
-  this.validateExtent_();
-  this.updateBox_();
+  /**
+   * Update the overview map element.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @override
+   */
+  render(mapEvent) {
+    this.validateExtent_();
+    this.updateBox_();
+  }
 }
 
 export default OverviewMap;

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -39,7 +39,7 @@ class Rotate extends Control {
 
     super({
       element: document.createElement('div'),
-      render: options.render || render,
+      render: options.render,
       target: options.target,
     });
 
@@ -145,32 +145,32 @@ class Rotate extends Control {
       }
     }
   }
-}
 
-/**
- * Update the rotate control element.
- * @param {import("../MapEvent.js").default} mapEvent Map event.
- * @this {Rotate}
- */
-export function render(mapEvent) {
-  const frameState = mapEvent.frameState;
-  if (!frameState) {
-    return;
-  }
-  const rotation = frameState.viewState.rotation;
-  if (rotation != this.rotation_) {
-    const transform = 'rotate(' + rotation + 'rad)';
-    if (this.autoHide_) {
-      const contains = this.element.classList.contains(CLASS_HIDDEN);
-      if (!contains && rotation === 0) {
-        this.element.classList.add(CLASS_HIDDEN);
-      } else if (contains && rotation !== 0) {
-        this.element.classList.remove(CLASS_HIDDEN);
-      }
+  /**
+   * Update the rotate control element.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @override
+   */
+  render(mapEvent) {
+    const frameState = mapEvent.frameState;
+    if (!frameState) {
+      return;
     }
-    this.label_.style.transform = transform;
+    const rotation = frameState.viewState.rotation;
+    if (rotation != this.rotation_) {
+      const transform = 'rotate(' + rotation + 'rad)';
+      if (this.autoHide_) {
+        const contains = this.element.classList.contains(CLASS_HIDDEN);
+        if (!contains && rotation === 0) {
+          this.element.classList.add(CLASS_HIDDEN);
+        } else if (contains && rotation !== 0) {
+          this.element.classList.remove(CLASS_HIDDEN);
+        }
+      }
+      this.label_.style.transform = transform;
+    }
+    this.rotation_ = rotation;
   }
-  this.rotation_ = rotation;
 }
 
 export default Rotate;

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -87,7 +87,7 @@ class ScaleLine extends Control {
 
     super({
       element: document.createElement('div'),
-      render: options.render || render,
+      render: options.render,
       target: options.target,
     });
 
@@ -471,21 +471,21 @@ class ScaleLine extends Control {
     const inchesPerMeter = 39.37;
     return parseFloat(resolution.toString()) * mpu * inchesPerMeter * dpi;
   }
-}
 
-/**
- * Update the scale line element.
- * @param {import("../MapEvent.js").default} mapEvent Map event.
- * @this {ScaleLine}
- */
-export function render(mapEvent) {
-  const frameState = mapEvent.frameState;
-  if (!frameState) {
-    this.viewState_ = null;
-  } else {
-    this.viewState_ = frameState.viewState;
+  /**
+   * Update the scale line element.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @override
+   */
+  render(mapEvent) {
+    const frameState = mapEvent.frameState;
+    if (!frameState) {
+      this.viewState_ = null;
+    } else {
+      this.viewState_ = frameState.viewState;
+    }
+    this.updateElement_();
   }
-  this.updateElement_();
 }
 
 export default ScaleLine;

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -47,7 +47,7 @@ const DEFAULT_DPI = 25.4 / 0.28;
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
  * @property {HTMLElement|string} [target] Specify a target if you want the control
  * to be rendered outside of the map's viewport.
- * @property {Units|string} [units='metric'] Units.
+ * @property {import("./ScaleLine.js").Units|string} [units='metric'] Units.
  * @property {boolean} [bar=false] Render scalebars instead of a line.
  * @property {number} [steps=4] Number of steps the scalebar should use. Use even numbers
  * for best results. Only applies when `bar` is `true`.
@@ -165,7 +165,7 @@ class ScaleLine extends Control {
 
   /**
    * Return the units to use in the scale line.
-   * @return {Units} The units
+   * @return {import("./ScaleLine.js").Units} The units
    * to use in the scale line.
    * @observable
    * @api
@@ -183,7 +183,7 @@ class ScaleLine extends Control {
 
   /**
    * Set the units to use in the scale line.
-   * @param {Units} units The units to use in the scale line.
+   * @param {import("./ScaleLine.js").Units} units The units to use in the scale line.
    * @observable
    * @api
    */

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -49,7 +49,7 @@ class ZoomSlider extends Control {
 
     super({
       element: document.createElement('div'),
-      render: options.render || render,
+      render: options.render,
     });
 
     /**
@@ -356,23 +356,23 @@ class ZoomSlider extends Control {
     const fn = this.getMap().getView().getValueForResolutionFunction();
     return clamp(1 - fn(res), 0, 1);
   }
-}
 
-/**
- * Update the zoomslider element.
- * @param {import("../MapEvent.js").default} mapEvent Map event.
- * @this {ZoomSlider}
- */
-export function render(mapEvent) {
-  if (!mapEvent.frameState) {
-    return;
+  /**
+   * Update the zoomslider element.
+   * @param {import("../MapEvent.js").default} mapEvent Map event.
+   * @override
+   */
+  render(mapEvent) {
+    if (!mapEvent.frameState) {
+      return;
+    }
+    if (!this.sliderInitialized_) {
+      this.initSlider_();
+    }
+    const res = mapEvent.frameState.viewState.resolution;
+    this.currentResolution_ = res;
+    this.setThumbPosition_(res);
   }
-  if (!this.sliderInitialized_) {
-    this.initSlider_();
-  }
-  const res = mapEvent.frameState.viewState.resolution;
-  this.currentResolution_ = res;
-  this.setThumbPosition_(res);
 }
 
 export default ZoomSlider;

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -160,7 +160,7 @@ export function containsXY(extent, x, y) {
  * Get the relationship between a coordinate and extent.
  * @param {Extent} extent The extent.
  * @param {import("./coordinate.js").Coordinate} coordinate The coordinate.
- * @return {Relationship} The relationship (bitwise compare with
+ * @return {import("./extent/Relationship.js").default} The relationship (bitwise compare with
  *     import("./extent/Relationship.js").Relationship).
  */
 export function coordinateRelationship(extent, coordinate) {
@@ -484,7 +484,7 @@ export function getCenter(extent) {
 /**
  * Get a corner coordinate of an extent.
  * @param {Extent} extent Extent.
- * @param {Corner} corner Corner.
+ * @param {import("./extent/Corner.js").default} corner Corner.
  * @return {import("./coordinate.js").Coordinate} Corner coordinate.
  */
 export function getCorner(extent, corner) {

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -73,10 +73,9 @@ class GML2 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>|undefined} Flat coordinates.
    */
-  readFlatCoordinates_(node, objectStack) {
+  readFlatCoordinates(node, objectStack) {
     const s = getAllTextContent(node, false).replace(/^\s*|\s*$/g, '');
     const context = /** @type {import("../xml.js").NodeStackItem} */ (objectStack[0]);
     const containerSrs = context['srsName'];
@@ -106,10 +105,9 @@ class GML2 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {import("../extent.js").Extent|undefined} Envelope.
    */
-  readBox_(node, objectStack) {
+  readBox(node, objectStack) {
     /** @type {Array<number>} */
     const flatCoordinates = pushParseAndPop(
       [null],
@@ -129,9 +127,8 @@ class GML2 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  innerBoundaryIsParser_(node, objectStack) {
+  innerBoundaryIsParser(node, objectStack) {
     /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(
       undefined,
@@ -151,9 +148,8 @@ class GML2 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  outerBoundaryIsParser_(node, objectStack) {
+  outerBoundaryIsParser(node, objectStack) {
     /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(
       undefined,
@@ -260,9 +256,8 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/LineString.js").default} geometry LineString geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeCurveOrLineString_(node, geometry, objectStack) {
+  writeCurveOrLineString(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const srsName = context['srsName'];
     if (node.nodeName !== 'LineStringSegment' && srsName) {
@@ -286,13 +281,12 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/LineString.js").default} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeLineStringOrCurveMember_(node, line, objectStack) {
+  writeLineStringOrCurveMember(node, line, objectStack) {
     const child = this.GEOMETRY_NODE_FACTORY_(line, objectStack);
     if (child) {
       node.appendChild(child);
-      this.writeCurveOrLineString_(child, line, objectStack);
+      this.writeCurveOrLineString(child, line, objectStack);
     }
   }
 
@@ -300,9 +294,8 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/MultiLineString.js").default} geometry MultiLineString geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeMultiCurveOrLineString_(node, geometry, objectStack) {
+  writeMultiCurveOrLineString(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -313,7 +306,7 @@ class GML2 extends GMLBase {
     const lines = geometry.getLineStrings();
     pushSerializeAndPop(
       {node: node, hasZ: hasZ, srsName: srsName, curve: curve},
-      this.LINESTRINGORCURVEMEMBER_SERIALIZERS_,
+      this.LINESTRINGORCURVEMEMBER_SERIALIZERS,
       this.MULTIGEOMETRY_MEMBER_NODE_FACTORY_,
       lines,
       objectStack,
@@ -349,7 +342,7 @@ class GML2 extends GMLBase {
     pushSerializeAndPop(
       /** @type {import("../xml.js").NodeStackItem} */
       (item),
-      this.GEOMETRY_SERIALIZERS_,
+      this.GEOMETRY_SERIALIZERS,
       this.GEOMETRY_NODE_FACTORY_,
       [value],
       objectStack,
@@ -402,16 +395,15 @@ class GML2 extends GMLBase {
   writeCurveSegments_(node, line, objectStack) {
     const child = createElementNS(node.namespaceURI, 'LineStringSegment');
     node.appendChild(child);
-    this.writeCurveOrLineString_(child, line, objectStack);
+    this.writeCurveOrLineString(child, line, objectStack);
   }
 
   /**
    * @param {Element} node Node.
    * @param {import("../geom/Polygon.js").default} geometry Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeSurfaceOrPolygon_(node, geometry, objectStack) {
+  writeSurfaceOrPolygon(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -422,7 +414,7 @@ class GML2 extends GMLBase {
       const rings = geometry.getLinearRings();
       pushSerializeAndPop(
         {node: node, hasZ: hasZ, srsName: srsName},
-        this.RING_SERIALIZERS_,
+        this.RING_SERIALIZERS,
         this.RING_NODE_FACTORY_,
         rings,
         objectStack,
@@ -465,19 +457,18 @@ class GML2 extends GMLBase {
   writeSurfacePatches_(node, polygon, objectStack) {
     const child = createElementNS(node.namespaceURI, 'PolygonPatch');
     node.appendChild(child);
-    this.writeSurfaceOrPolygon_(child, polygon, objectStack);
+    this.writeSurfaceOrPolygon(child, polygon, objectStack);
   }
 
   /**
    * @param {Node} node Node.
    * @param {import("../geom/LinearRing.js").default} ring LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeRing_(node, ring, objectStack) {
+  writeRing(node, ring, objectStack) {
     const linearRing = createElementNS(node.namespaceURI, 'LinearRing');
     node.appendChild(linearRing);
-    this.writeLinearRing_(linearRing, ring, objectStack);
+    this.writeLinearRing(linearRing, ring, objectStack);
   }
 
   /**
@@ -509,9 +500,8 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/Point.js").default} geometry Point geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writePoint_(node, geometry, objectStack) {
+  writePoint(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -529,9 +519,8 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/MultiPoint.js").default} geometry MultiPoint geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeMultiPoint_(node, geometry, objectStack) {
+  writeMultiPoint(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -541,7 +530,7 @@ class GML2 extends GMLBase {
     const points = geometry.getPoints();
     pushSerializeAndPop(
       {node: node, hasZ: hasZ, srsName: srsName},
-      this.POINTMEMBER_SERIALIZERS_,
+      this.POINTMEMBER_SERIALIZERS,
       makeSimpleNodeFactory('pointMember'),
       points,
       objectStack,
@@ -554,21 +543,19 @@ class GML2 extends GMLBase {
    * @param {Node} node Node.
    * @param {import("../geom/Point.js").default} point Point geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writePointMember_(node, point, objectStack) {
+  writePointMember(node, point, objectStack) {
     const child = createElementNS(node.namespaceURI, 'Point');
     node.appendChild(child);
-    this.writePoint_(child, point, objectStack);
+    this.writePoint(child, point, objectStack);
   }
 
   /**
    * @param {Element} node Node.
    * @param {import("../geom/LinearRing.js").default} geometry LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeLinearRing_(node, geometry, objectStack) {
+  writeLinearRing(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const srsName = context['srsName'];
     if (srsName) {
@@ -583,9 +570,8 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/MultiPolygon.js").default} geometry MultiPolygon geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeMultiSurfaceOrPolygon_(node, geometry, objectStack) {
+  writeMultiSurfaceOrPolygon(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -596,7 +582,7 @@ class GML2 extends GMLBase {
     const polygons = geometry.getPolygons();
     pushSerializeAndPop(
       {node: node, hasZ: hasZ, srsName: srsName, surface: surface},
-      this.SURFACEORPOLYGONMEMBER_SERIALIZERS_,
+      this.SURFACEORPOLYGONMEMBER_SERIALIZERS,
       this.MULTIGEOMETRY_MEMBER_NODE_FACTORY_,
       polygons,
       objectStack,
@@ -609,13 +595,12 @@ class GML2 extends GMLBase {
    * @param {Node} node Node.
    * @param {import("../geom/Polygon.js").default} polygon Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeSurfaceOrPolygonMember_(node, polygon, objectStack) {
+  writeSurfaceOrPolygonMember(node, polygon, objectStack) {
     const child = this.GEOMETRY_NODE_FACTORY_(polygon, objectStack);
     if (child) {
       node.appendChild(child);
-      this.writeSurfaceOrPolygon_(child, polygon, objectStack);
+      this.writeSurfaceOrPolygon(child, polygon, objectStack);
     }
   }
 
@@ -623,7 +608,6 @@ class GML2 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../extent.js").Extent} extent Extent.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
   writeEnvelope(node, extent, objectStack) {
     const context = objectStack[objectStack.length - 1];
@@ -636,7 +620,7 @@ class GML2 extends GMLBase {
     pushSerializeAndPop(
       /** @type {import("../xml.js").NodeStackItem} */
       ({node: node}),
-      this.ENVELOPE_SERIALIZERS_,
+      this.ENVELOPE_SERIALIZERS,
       OBJECT_PROPERTY_NODE_FACTORY,
       values,
       objectStack,
@@ -665,41 +649,37 @@ class GML2 extends GMLBase {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML2.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
   'http://www.opengis.net/gml': {
-    'coordinates': makeReplacer(GML2.prototype.readFlatCoordinates_),
+    'coordinates': makeReplacer(GML2.prototype.readFlatCoordinates),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML2.prototype.FLAT_LINEAR_RINGS_PARSERS = {
   'http://www.opengis.net/gml': {
-    'innerBoundaryIs': GML2.prototype.innerBoundaryIsParser_,
-    'outerBoundaryIs': GML2.prototype.outerBoundaryIsParser_,
+    'innerBoundaryIs': GML2.prototype.innerBoundaryIsParser,
+    'outerBoundaryIs': GML2.prototype.outerBoundaryIsParser,
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
 GML2.prototype.BOX_PARSERS_ = {
   'http://www.opengis.net/gml': {
-    'coordinates': makeArrayPusher(GML2.prototype.readFlatCoordinates_),
+    'coordinates': makeArrayPusher(GML2.prototype.readFlatCoordinates),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML2.prototype.GEOMETRY_PARSERS = {
   'http://www.opengis.net/gml': {
@@ -710,35 +690,32 @@ GML2.prototype.GEOMETRY_PARSERS = {
     'LinearRing': makeReplacer(GMLBase.prototype.readLinearRing),
     'Polygon': makeReplacer(GMLBase.prototype.readPolygon),
     'MultiPolygon': makeReplacer(GMLBase.prototype.readMultiPolygon),
-    'Box': makeReplacer(GML2.prototype.readBox_),
+    'Box': makeReplacer(GML2.prototype.readBox),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML2.prototype.GEOMETRY_SERIALIZERS_ = {
+GML2.prototype.GEOMETRY_SERIALIZERS = {
   'http://www.opengis.net/gml': {
-    'Curve': makeChildAppender(GML2.prototype.writeCurveOrLineString_),
-    'MultiCurve': makeChildAppender(
-      GML2.prototype.writeMultiCurveOrLineString_
-    ),
-    'Point': makeChildAppender(GML2.prototype.writePoint_),
-    'MultiPoint': makeChildAppender(GML2.prototype.writeMultiPoint_),
-    'LineString': makeChildAppender(GML2.prototype.writeCurveOrLineString_),
+    'Curve': makeChildAppender(GML2.prototype.writeCurveOrLineString),
+    'MultiCurve': makeChildAppender(GML2.prototype.writeMultiCurveOrLineString),
+    'Point': makeChildAppender(GML2.prototype.writePoint),
+    'MultiPoint': makeChildAppender(GML2.prototype.writeMultiPoint),
+    'LineString': makeChildAppender(GML2.prototype.writeCurveOrLineString),
     'MultiLineString': makeChildAppender(
-      GML2.prototype.writeMultiCurveOrLineString_
+      GML2.prototype.writeMultiCurveOrLineString
     ),
-    'LinearRing': makeChildAppender(GML2.prototype.writeLinearRing_),
-    'Polygon': makeChildAppender(GML2.prototype.writeSurfaceOrPolygon_),
+    'LinearRing': makeChildAppender(GML2.prototype.writeLinearRing),
+    'Polygon': makeChildAppender(GML2.prototype.writeSurfaceOrPolygon),
     'MultiPolygon': makeChildAppender(
-      GML2.prototype.writeMultiSurfaceOrPolygon_
+      GML2.prototype.writeMultiSurfaceOrPolygon
     ),
-    'Surface': makeChildAppender(GML2.prototype.writeSurfaceOrPolygon_),
+    'Surface': makeChildAppender(GML2.prototype.writeSurfaceOrPolygon),
     'MultiSurface': makeChildAppender(
-      GML2.prototype.writeMultiSurfaceOrPolygon_
+      GML2.prototype.writeMultiSurfaceOrPolygon
     ),
     'Envelope': makeChildAppender(GML2.prototype.writeEnvelope),
   },
@@ -746,61 +723,56 @@ GML2.prototype.GEOMETRY_SERIALIZERS_ = {
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML2.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
+GML2.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml': {
     'lineStringMember': makeChildAppender(
-      GML2.prototype.writeLineStringOrCurveMember_
+      GML2.prototype.writeLineStringOrCurveMember
     ),
     'curveMember': makeChildAppender(
-      GML2.prototype.writeLineStringOrCurveMember_
+      GML2.prototype.writeLineStringOrCurveMember
     ),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML2.prototype.RING_SERIALIZERS_ = {
+GML2.prototype.RING_SERIALIZERS = {
   'http://www.opengis.net/gml': {
-    'outerBoundaryIs': makeChildAppender(GML2.prototype.writeRing_),
-    'innerBoundaryIs': makeChildAppender(GML2.prototype.writeRing_),
+    'outerBoundaryIs': makeChildAppender(GML2.prototype.writeRing),
+    'innerBoundaryIs': makeChildAppender(GML2.prototype.writeRing),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML2.prototype.POINTMEMBER_SERIALIZERS_ = {
+GML2.prototype.POINTMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml': {
-    'pointMember': makeChildAppender(GML2.prototype.writePointMember_),
+    'pointMember': makeChildAppender(GML2.prototype.writePointMember),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML2.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
+GML2.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml': {
     'surfaceMember': makeChildAppender(
-      GML2.prototype.writeSurfaceOrPolygonMember_
+      GML2.prototype.writeSurfaceOrPolygonMember
     ),
     'polygonMember': makeChildAppender(
-      GML2.prototype.writeSurfaceOrPolygonMember_
+      GML2.prototype.writeSurfaceOrPolygonMember
     ),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML2.prototype.ENVELOPE_SERIALIZERS_ = {
+GML2.prototype.ENVELOPE_SERIALIZERS = {
   'http://www.opengis.net/gml': {
     'lowerCorner': makeChildAppender(writeStringTextNode),
     'upperCorner': makeChildAppender(writeStringTextNode),

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -113,14 +113,13 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {MultiLineString|undefined} MultiLineString.
    */
-  readMultiCurve_(node, objectStack) {
+  readMultiCurve(node, objectStack) {
     /** @type {Array<LineString>} */
     const lineStrings = pushParseAndPop(
       [],
-      this.MULTICURVE_PARSERS_,
+      this.MULTICURVE_PARSERS,
       node,
       objectStack,
       this
@@ -136,14 +135,13 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {MultiPolygon|undefined} MultiPolygon.
    */
-  readMultiSurface_(node, objectStack) {
+  readMultiSurface(node, objectStack) {
     /** @type {Array<Polygon>} */
     const polygons = pushParseAndPop(
       [],
-      this.MULTISURFACE_PARSERS_,
+      this.MULTISURFACE_PARSERS,
       node,
       objectStack,
       this
@@ -156,31 +154,28 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  curveMemberParser_(node, objectStack) {
-    parseNode(this.CURVEMEMBER_PARSERS_, node, objectStack, this);
+  curveMemberParser(node, objectStack) {
+    parseNode(this.CURVEMEMBER_PARSERS, node, objectStack, this);
   }
 
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  surfaceMemberParser_(node, objectStack) {
-    parseNode(this.SURFACEMEMBER_PARSERS_, node, objectStack, this);
+  surfaceMemberParser(node, objectStack) {
+    parseNode(this.SURFACEMEMBER_PARSERS, node, objectStack, this);
   }
 
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<(Array<number>)>|undefined} flat coordinates.
    */
-  readPatch_(node, objectStack) {
+  readPatch(node, objectStack) {
     return pushParseAndPop(
       [null],
-      this.PATCHES_PARSERS_,
+      this.PATCHES_PARSERS,
       node,
       objectStack,
       this
@@ -190,13 +185,12 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>|undefined} flat coordinates.
    */
-  readSegment_(node, objectStack) {
+  readSegment(node, objectStack) {
     return pushParseAndPop(
       [null],
-      this.SEGMENTS_PARSERS_,
+      this.SEGMENTS_PARSERS,
       node,
       objectStack,
       this
@@ -206,10 +200,9 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<(Array<number>)>|undefined} flat coordinates.
    */
-  readPolygonPatch_(node, objectStack) {
+  readPolygonPatch(node, objectStack) {
     return pushParseAndPop(
       [null],
       this.FLAT_LINEAR_RINGS_PARSERS,
@@ -222,10 +215,9 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>|undefined} flat coordinates.
    */
-  readLineStringSegment_(node, objectStack) {
+  readLineStringSegment(node, objectStack) {
     return pushParseAndPop(
       [null],
       this.GEOMETRY_FLAT_COORDINATES_PARSERS,
@@ -238,9 +230,8 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  interiorParser_(node, objectStack) {
+  interiorParser(node, objectStack) {
     /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(
       undefined,
@@ -260,9 +251,8 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  exteriorParser_(node, objectStack) {
+  exteriorParser(node, objectStack) {
     /** @type {Array<number>|undefined} */
     const flatLinearRing = pushParseAndPop(
       undefined,
@@ -282,14 +272,13 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Polygon|undefined} Polygon.
    */
-  readSurface_(node, objectStack) {
+  readSurface(node, objectStack) {
     /** @type {Array<Array<number>>} */
     const flatLinearRings = pushParseAndPop(
       [null],
-      this.SURFACE_PARSERS_,
+      this.SURFACE_PARSERS,
       node,
       objectStack,
       this
@@ -311,14 +300,13 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {LineString|undefined} LineString.
    */
-  readCurve_(node, objectStack) {
+  readCurve(node, objectStack) {
     /** @type {Array<number>} */
     const flatCoordinates = pushParseAndPop(
       [null],
-      this.CURVE_PARSERS_,
+      this.CURVE_PARSERS,
       node,
       objectStack,
       this
@@ -334,14 +322,13 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {import("../extent.js").Extent|undefined} Envelope.
    */
-  readEnvelope_(node, objectStack) {
+  readEnvelope(node, objectStack) {
     /** @type {Array<number>} */
     const flatCoordinates = pushParseAndPop(
       [null],
-      this.ENVELOPE_PARSERS_,
+      this.ENVELOPE_PARSERS,
       node,
       objectStack,
       this
@@ -357,10 +344,9 @@ class GML3 extends GMLBase {
   /**
    * @param {Node} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>|undefined} Flat coordinates.
    */
-  readFlatPos_(node, objectStack) {
+  readFlatPos(node, objectStack) {
     let s = getAllTextContent(node, false);
     const re = /^\s*([+\-]?\d*\.?\d+(?:[eE][+\-]?\d+)?)\s*/;
     /** @type {Array<number>} */
@@ -402,10 +388,9 @@ class GML3 extends GMLBase {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>|undefined} Flat coordinates.
    */
-  readFlatPosList_(node, objectStack) {
+  readFlatPosList(node, objectStack) {
     const s = getAllTextContent(node, false).replace(/^\s*|\s*$/g, '');
     const context = objectStack[0];
     const containerSrs = context['srsName'];
@@ -531,9 +516,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/Point.js").default} geometry Point geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writePoint_(node, geometry, objectStack) {
+  writePoint(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const srsName = context['srsName'];
     if (srsName) {
@@ -560,7 +544,7 @@ class GML3 extends GMLBase {
     pushSerializeAndPop(
       /** @type {import("../xml.js").NodeStackItem} */
       ({node: node}),
-      this.ENVELOPE_SERIALIZERS_,
+      this.ENVELOPE_SERIALIZERS,
       OBJECT_PROPERTY_NODE_FACTORY,
       values,
       objectStack,
@@ -573,9 +557,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/LinearRing.js").default} geometry LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeLinearRing_(node, geometry, objectStack) {
+  writeLinearRing(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const srsName = context['srsName'];
     if (srsName) {
@@ -610,9 +593,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {Polygon} geometry Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeSurfaceOrPolygon_(node, geometry, objectStack) {
+  writeSurfaceOrPolygon(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -623,7 +605,7 @@ class GML3 extends GMLBase {
       const rings = geometry.getLinearRings();
       pushSerializeAndPop(
         {node: node, hasZ: hasZ, srsName: srsName},
-        this.RING_SERIALIZERS_,
+        this.RING_SERIALIZERS,
         this.RING_NODE_FACTORY_,
         rings,
         objectStack,
@@ -641,9 +623,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {LineString} geometry LineString geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeCurveOrLineString_(node, geometry, objectStack) {
+  writeCurveOrLineString(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const srsName = context['srsName'];
     if (node.nodeName !== 'LineStringSegment' && srsName) {
@@ -667,9 +648,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {MultiPolygon} geometry MultiPolygon geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeMultiSurfaceOrPolygon_(node, geometry, objectStack) {
+  writeMultiSurfaceOrPolygon(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -680,7 +660,7 @@ class GML3 extends GMLBase {
     const polygons = geometry.getPolygons();
     pushSerializeAndPop(
       {node: node, hasZ: hasZ, srsName: srsName, surface: surface},
-      this.SURFACEORPOLYGONMEMBER_SERIALIZERS_,
+      this.SURFACEORPOLYGONMEMBER_SERIALIZERS,
       this.MULTIGEOMETRY_MEMBER_NODE_FACTORY_,
       polygons,
       objectStack,
@@ -693,9 +673,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {import("../geom/MultiPoint.js").default} geometry MultiPoint geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeMultiPoint_(node, geometry, objectStack) {
+  writeMultiPoint(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const srsName = context['srsName'];
     const hasZ = context['hasZ'];
@@ -705,7 +684,7 @@ class GML3 extends GMLBase {
     const points = geometry.getPoints();
     pushSerializeAndPop(
       {node: node, hasZ: hasZ, srsName: srsName},
-      this.POINTMEMBER_SERIALIZERS_,
+      this.POINTMEMBER_SERIALIZERS,
       makeSimpleNodeFactory('pointMember'),
       points,
       objectStack,
@@ -718,9 +697,8 @@ class GML3 extends GMLBase {
    * @param {Element} node Node.
    * @param {MultiLineString} geometry MultiLineString geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeMultiCurveOrLineString_(node, geometry, objectStack) {
+  writeMultiCurveOrLineString(node, geometry, objectStack) {
     const context = objectStack[objectStack.length - 1];
     const hasZ = context['hasZ'];
     const srsName = context['srsName'];
@@ -731,7 +709,7 @@ class GML3 extends GMLBase {
     const lines = geometry.getLineStrings();
     pushSerializeAndPop(
       {node: node, hasZ: hasZ, srsName: srsName, curve: curve},
-      this.LINESTRINGORCURVEMEMBER_SERIALIZERS_,
+      this.LINESTRINGORCURVEMEMBER_SERIALIZERS,
       this.MULTIGEOMETRY_MEMBER_NODE_FACTORY_,
       lines,
       objectStack,
@@ -744,25 +722,23 @@ class GML3 extends GMLBase {
    * @param {Node} node Node.
    * @param {import("../geom/LinearRing.js").default} ring LinearRing geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeRing_(node, ring, objectStack) {
+  writeRing(node, ring, objectStack) {
     const linearRing = createElementNS(node.namespaceURI, 'LinearRing');
     node.appendChild(linearRing);
-    this.writeLinearRing_(linearRing, ring, objectStack);
+    this.writeLinearRing(linearRing, ring, objectStack);
   }
 
   /**
    * @param {Node} node Node.
    * @param {Polygon} polygon Polygon geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeSurfaceOrPolygonMember_(node, polygon, objectStack) {
+  writeSurfaceOrPolygonMember(node, polygon, objectStack) {
     const child = this.GEOMETRY_NODE_FACTORY_(polygon, objectStack);
     if (child) {
       node.appendChild(child);
-      this.writeSurfaceOrPolygon_(child, polygon, objectStack);
+      this.writeSurfaceOrPolygon(child, polygon, objectStack);
     }
   }
 
@@ -770,25 +746,23 @@ class GML3 extends GMLBase {
    * @param {Node} node Node.
    * @param {import("../geom/Point.js").default} point Point geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writePointMember_(node, point, objectStack) {
+  writePointMember(node, point, objectStack) {
     const child = createElementNS(node.namespaceURI, 'Point');
     node.appendChild(child);
-    this.writePoint_(child, point, objectStack);
+    this.writePoint(child, point, objectStack);
   }
 
   /**
    * @param {Node} node Node.
    * @param {LineString} line LineString geometry.
    * @param {Array<*>} objectStack Node stack.
-   * @private
    */
-  writeLineStringOrCurveMember_(node, line, objectStack) {
+  writeLineStringOrCurveMember(node, line, objectStack) {
     const child = this.GEOMETRY_NODE_FACTORY_(line, objectStack);
     if (child) {
       node.appendChild(child);
-      this.writeCurveOrLineString_(child, line, objectStack);
+      this.writeCurveOrLineString(child, line, objectStack);
     }
   }
 
@@ -801,7 +775,7 @@ class GML3 extends GMLBase {
   writeSurfacePatches_(node, polygon, objectStack) {
     const child = createElementNS(node.namespaceURI, 'PolygonPatch');
     node.appendChild(child);
-    this.writeSurfaceOrPolygon_(child, polygon, objectStack);
+    this.writeSurfaceOrPolygon(child, polygon, objectStack);
   }
 
   /**
@@ -813,7 +787,7 @@ class GML3 extends GMLBase {
   writeCurveSegments_(node, line, objectStack) {
     const child = createElementNS(node.namespaceURI, 'LineStringSegment');
     node.appendChild(child);
-    this.writeCurveOrLineString_(child, line, objectStack);
+    this.writeCurveOrLineString(child, line, objectStack);
   }
 
   /**
@@ -843,7 +817,7 @@ class GML3 extends GMLBase {
     pushSerializeAndPop(
       /** @type {import("../xml.js").NodeStackItem} */
       (item),
-      this.GEOMETRY_SERIALIZERS_,
+      this.GEOMETRY_SERIALIZERS,
       this.GEOMETRY_NODE_FACTORY_,
       [value],
       objectStack,
@@ -1050,31 +1024,28 @@ class GML3 extends GMLBase {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
   'http://www.opengis.net/gml': {
-    'pos': makeReplacer(GML3.prototype.readFlatPos_),
-    'posList': makeReplacer(GML3.prototype.readFlatPosList_),
+    'pos': makeReplacer(GML3.prototype.readFlatPos),
+    'posList': makeReplacer(GML3.prototype.readFlatPosList),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML3.prototype.FLAT_LINEAR_RINGS_PARSERS = {
   'http://www.opengis.net/gml': {
-    'interior': GML3.prototype.interiorParser_,
-    'exterior': GML3.prototype.exteriorParser_,
+    'interior': GML3.prototype.interiorParser,
+    'exterior': GML3.prototype.exteriorParser,
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML3.prototype.GEOMETRY_PARSERS = {
   'http://www.opengis.net/gml': {
@@ -1085,115 +1056,106 @@ GML3.prototype.GEOMETRY_PARSERS = {
     'LinearRing': makeReplacer(GMLBase.prototype.readLinearRing),
     'Polygon': makeReplacer(GMLBase.prototype.readPolygon),
     'MultiPolygon': makeReplacer(GMLBase.prototype.readMultiPolygon),
-    'Surface': makeReplacer(GML3.prototype.readSurface_),
-    'MultiSurface': makeReplacer(GML3.prototype.readMultiSurface_),
-    'Curve': makeReplacer(GML3.prototype.readCurve_),
-    'MultiCurve': makeReplacer(GML3.prototype.readMultiCurve_),
-    'Envelope': makeReplacer(GML3.prototype.readEnvelope_),
+    'Surface': makeReplacer(GML3.prototype.readSurface),
+    'MultiSurface': makeReplacer(GML3.prototype.readMultiSurface),
+    'Curve': makeReplacer(GML3.prototype.readCurve),
+    'MultiCurve': makeReplacer(GML3.prototype.readMultiCurve),
+    'Envelope': makeReplacer(GML3.prototype.readEnvelope),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.MULTICURVE_PARSERS_ = {
+GML3.prototype.MULTICURVE_PARSERS = {
   'http://www.opengis.net/gml': {
-    'curveMember': makeArrayPusher(GML3.prototype.curveMemberParser_),
-    'curveMembers': makeArrayPusher(GML3.prototype.curveMemberParser_),
+    'curveMember': makeArrayPusher(GML3.prototype.curveMemberParser),
+    'curveMembers': makeArrayPusher(GML3.prototype.curveMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.MULTISURFACE_PARSERS_ = {
+GML3.prototype.MULTISURFACE_PARSERS = {
   'http://www.opengis.net/gml': {
-    'surfaceMember': makeArrayPusher(GML3.prototype.surfaceMemberParser_),
-    'surfaceMembers': makeArrayPusher(GML3.prototype.surfaceMemberParser_),
+    'surfaceMember': makeArrayPusher(GML3.prototype.surfaceMemberParser),
+    'surfaceMembers': makeArrayPusher(GML3.prototype.surfaceMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.CURVEMEMBER_PARSERS_ = {
+GML3.prototype.CURVEMEMBER_PARSERS = {
   'http://www.opengis.net/gml': {
     'LineString': makeArrayPusher(GMLBase.prototype.readLineString),
-    'Curve': makeArrayPusher(GML3.prototype.readCurve_),
+    'Curve': makeArrayPusher(GML3.prototype.readCurve),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.SURFACEMEMBER_PARSERS_ = {
+GML3.prototype.SURFACEMEMBER_PARSERS = {
   'http://www.opengis.net/gml': {
     'Polygon': makeArrayPusher(GMLBase.prototype.readPolygon),
-    'Surface': makeArrayPusher(GML3.prototype.readSurface_),
+    'Surface': makeArrayPusher(GML3.prototype.readSurface),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.SURFACE_PARSERS_ = {
+GML3.prototype.SURFACE_PARSERS = {
   'http://www.opengis.net/gml': {
-    'patches': makeReplacer(GML3.prototype.readPatch_),
+    'patches': makeReplacer(GML3.prototype.readPatch),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.CURVE_PARSERS_ = {
+GML3.prototype.CURVE_PARSERS = {
   'http://www.opengis.net/gml': {
-    'segments': makeReplacer(GML3.prototype.readSegment_),
+    'segments': makeReplacer(GML3.prototype.readSegment),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.ENVELOPE_PARSERS_ = {
+GML3.prototype.ENVELOPE_PARSERS = {
   'http://www.opengis.net/gml': {
-    'lowerCorner': makeArrayPusher(GML3.prototype.readFlatPosList_),
-    'upperCorner': makeArrayPusher(GML3.prototype.readFlatPosList_),
+    'lowerCorner': makeArrayPusher(GML3.prototype.readFlatPosList),
+    'upperCorner': makeArrayPusher(GML3.prototype.readFlatPosList),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.PATCHES_PARSERS_ = {
+GML3.prototype.PATCHES_PARSERS = {
   'http://www.opengis.net/gml': {
-    'PolygonPatch': makeReplacer(GML3.prototype.readPolygonPatch_),
+    'PolygonPatch': makeReplacer(GML3.prototype.readPolygonPatch),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML3.prototype.SEGMENTS_PARSERS_ = {
+GML3.prototype.SEGMENTS_PARSERS = {
   'http://www.opengis.net/gml': {
-    'LineStringSegment': makeReplacer(GML3.prototype.readLineStringSegment_),
+    'LineStringSegment': makeReplacer(GML3.prototype.readLineStringSegment),
   },
 };
 
@@ -1210,20 +1172,18 @@ GML3.prototype.writeFeatures;
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML3.prototype.RING_SERIALIZERS_ = {
+GML3.prototype.RING_SERIALIZERS = {
   'http://www.opengis.net/gml': {
-    'exterior': makeChildAppender(GML3.prototype.writeRing_),
-    'interior': makeChildAppender(GML3.prototype.writeRing_),
+    'exterior': makeChildAppender(GML3.prototype.writeRing),
+    'interior': makeChildAppender(GML3.prototype.writeRing),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML3.prototype.ENVELOPE_SERIALIZERS_ = {
+GML3.prototype.ENVELOPE_SERIALIZERS = {
   'http://www.opengis.net/gml': {
     'lowerCorner': makeChildAppender(writeStringTextNode),
     'upperCorner': makeChildAppender(writeStringTextNode),
@@ -1232,68 +1192,62 @@ GML3.prototype.ENVELOPE_SERIALIZERS_ = {
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML3.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
+GML3.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml': {
     'surfaceMember': makeChildAppender(
-      GML3.prototype.writeSurfaceOrPolygonMember_
+      GML3.prototype.writeSurfaceOrPolygonMember
     ),
     'polygonMember': makeChildAppender(
-      GML3.prototype.writeSurfaceOrPolygonMember_
+      GML3.prototype.writeSurfaceOrPolygonMember
     ),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML3.prototype.POINTMEMBER_SERIALIZERS_ = {
+GML3.prototype.POINTMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml': {
-    'pointMember': makeChildAppender(GML3.prototype.writePointMember_),
+    'pointMember': makeChildAppender(GML3.prototype.writePointMember),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML3.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
+GML3.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml': {
     'lineStringMember': makeChildAppender(
-      GML3.prototype.writeLineStringOrCurveMember_
+      GML3.prototype.writeLineStringOrCurveMember
     ),
     'curveMember': makeChildAppender(
-      GML3.prototype.writeLineStringOrCurveMember_
+      GML3.prototype.writeLineStringOrCurveMember
     ),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML3.prototype.GEOMETRY_SERIALIZERS_ = {
+GML3.prototype.GEOMETRY_SERIALIZERS = {
   'http://www.opengis.net/gml': {
-    'Curve': makeChildAppender(GML3.prototype.writeCurveOrLineString_),
-    'MultiCurve': makeChildAppender(
-      GML3.prototype.writeMultiCurveOrLineString_
-    ),
-    'Point': makeChildAppender(GML3.prototype.writePoint_),
-    'MultiPoint': makeChildAppender(GML3.prototype.writeMultiPoint_),
-    'LineString': makeChildAppender(GML3.prototype.writeCurveOrLineString_),
+    'Curve': makeChildAppender(GML3.prototype.writeCurveOrLineString),
+    'MultiCurve': makeChildAppender(GML3.prototype.writeMultiCurveOrLineString),
+    'Point': makeChildAppender(GML3.prototype.writePoint),
+    'MultiPoint': makeChildAppender(GML3.prototype.writeMultiPoint),
+    'LineString': makeChildAppender(GML3.prototype.writeCurveOrLineString),
     'MultiLineString': makeChildAppender(
-      GML3.prototype.writeMultiCurveOrLineString_
+      GML3.prototype.writeMultiCurveOrLineString
     ),
-    'LinearRing': makeChildAppender(GML3.prototype.writeLinearRing_),
-    'Polygon': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon_),
+    'LinearRing': makeChildAppender(GML3.prototype.writeLinearRing),
+    'Polygon': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon),
     'MultiPolygon': makeChildAppender(
-      GML3.prototype.writeMultiSurfaceOrPolygon_
+      GML3.prototype.writeMultiSurfaceOrPolygon
     ),
-    'Surface': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon_),
+    'Surface': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon),
     'MultiSurface': makeChildAppender(
-      GML3.prototype.writeMultiSurfaceOrPolygon_
+      GML3.prototype.writeMultiSurfaceOrPolygon
     ),
     'Envelope': makeChildAppender(GML3.prototype.writeEnvelope),
   },

--- a/src/ol/format/GML32.js
+++ b/src/ol/format/GML32.js
@@ -36,31 +36,28 @@ GML32.prototype.namespace = 'http://www.opengis.net/gml/3.2';
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML32.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'pos': makeReplacer(GML3.prototype.readFlatPos_),
-    'posList': makeReplacer(GML3.prototype.readFlatPosList_),
+    'pos': makeReplacer(GML3.prototype.readFlatPos),
+    'posList': makeReplacer(GML3.prototype.readFlatPosList),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML32.prototype.FLAT_LINEAR_RINGS_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'interior': GML3.prototype.interiorParser_,
-    'exterior': GML3.prototype.exteriorParser_,
+    'interior': GML3.prototype.interiorParser,
+    'exterior': GML3.prototype.exteriorParser,
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML32.prototype.GEOMETRY_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
@@ -71,142 +68,131 @@ GML32.prototype.GEOMETRY_PARSERS = {
     'LinearRing': makeReplacer(GMLBase.prototype.readLinearRing),
     'Polygon': makeReplacer(GMLBase.prototype.readPolygon),
     'MultiPolygon': makeReplacer(GMLBase.prototype.readMultiPolygon),
-    'Surface': makeReplacer(GML32.prototype.readSurface_),
-    'MultiSurface': makeReplacer(GML3.prototype.readMultiSurface_),
-    'Curve': makeReplacer(GML32.prototype.readCurve_),
-    'MultiCurve': makeReplacer(GML3.prototype.readMultiCurve_),
-    'Envelope': makeReplacer(GML32.prototype.readEnvelope_),
+    'Surface': makeReplacer(GML32.prototype.readSurface),
+    'MultiSurface': makeReplacer(GML3.prototype.readMultiSurface),
+    'Curve': makeReplacer(GML32.prototype.readCurve),
+    'MultiCurve': makeReplacer(GML3.prototype.readMultiCurve),
+    'Envelope': makeReplacer(GML32.prototype.readEnvelope),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.MULTICURVE_PARSERS_ = {
+GML32.prototype.MULTICURVE_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'curveMember': makeArrayPusher(GML3.prototype.curveMemberParser_),
-    'curveMembers': makeArrayPusher(GML3.prototype.curveMemberParser_),
+    'curveMember': makeArrayPusher(GML3.prototype.curveMemberParser),
+    'curveMembers': makeArrayPusher(GML3.prototype.curveMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.MULTISURFACE_PARSERS_ = {
+GML32.prototype.MULTISURFACE_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'surfaceMember': makeArrayPusher(GML3.prototype.surfaceMemberParser_),
-    'surfaceMembers': makeArrayPusher(GML3.prototype.surfaceMemberParser_),
+    'surfaceMember': makeArrayPusher(GML3.prototype.surfaceMemberParser),
+    'surfaceMembers': makeArrayPusher(GML3.prototype.surfaceMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.CURVEMEMBER_PARSERS_ = {
+GML32.prototype.CURVEMEMBER_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
     'LineString': makeArrayPusher(GMLBase.prototype.readLineString),
-    'Curve': makeArrayPusher(GML3.prototype.readCurve_),
+    'Curve': makeArrayPusher(GML3.prototype.readCurve),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.SURFACEMEMBER_PARSERS_ = {
+GML32.prototype.SURFACEMEMBER_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
     'Polygon': makeArrayPusher(GMLBase.prototype.readPolygon),
-    'Surface': makeArrayPusher(GML3.prototype.readSurface_),
+    'Surface': makeArrayPusher(GML3.prototype.readSurface),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.SURFACE_PARSERS_ = {
+GML32.prototype.SURFACE_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'patches': makeReplacer(GML3.prototype.readPatch_),
+    'patches': makeReplacer(GML3.prototype.readPatch),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.CURVE_PARSERS_ = {
+GML32.prototype.CURVE_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'segments': makeReplacer(GML3.prototype.readSegment_),
+    'segments': makeReplacer(GML3.prototype.readSegment),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.ENVELOPE_PARSERS_ = {
+GML32.prototype.ENVELOPE_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'lowerCorner': makeArrayPusher(GML3.prototype.readFlatPosList_),
-    'upperCorner': makeArrayPusher(GML3.prototype.readFlatPosList_),
+    'lowerCorner': makeArrayPusher(GML3.prototype.readFlatPosList),
+    'upperCorner': makeArrayPusher(GML3.prototype.readFlatPosList),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.PATCHES_PARSERS_ = {
+GML32.prototype.PATCHES_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'PolygonPatch': makeReplacer(GML3.prototype.readPolygonPatch_),
+    'PolygonPatch': makeReplacer(GML3.prototype.readPolygonPatch),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.SEGMENTS_PARSERS_ = {
+GML32.prototype.SEGMENTS_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'LineStringSegment': makeReplacer(GML3.prototype.readLineStringSegment_),
+    'LineStringSegment': makeReplacer(GML3.prototype.readLineStringSegment),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.MULTIPOINT_PARSERS_ = {
+GML32.prototype.MULTIPOINT_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'pointMember': makeArrayPusher(GMLBase.prototype.pointMemberParser_),
-    'pointMembers': makeArrayPusher(GMLBase.prototype.pointMemberParser_),
+    'pointMember': makeArrayPusher(GMLBase.prototype.pointMemberParser),
+    'pointMembers': makeArrayPusher(GMLBase.prototype.pointMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.MULTILINESTRING_PARSERS_ = {
+GML32.prototype.MULTILINESTRING_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
     'lineStringMember': makeArrayPusher(
-      GMLBase.prototype.lineStringMemberParser_
+      GMLBase.prototype.lineStringMemberParser
     ),
     'lineStringMembers': makeArrayPusher(
-      GMLBase.prototype.lineStringMemberParser_
+      GMLBase.prototype.lineStringMemberParser
     ),
   },
 };
@@ -214,32 +200,29 @@ GML32.prototype.MULTILINESTRING_PARSERS_ = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.MULTIPOLYGON_PARSERS_ = {
+GML32.prototype.MULTIPOLYGON_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'polygonMember': makeArrayPusher(GMLBase.prototype.polygonMemberParser_),
-    'polygonMembers': makeArrayPusher(GMLBase.prototype.polygonMemberParser_),
+    'polygonMember': makeArrayPusher(GMLBase.prototype.polygonMemberParser),
+    'polygonMembers': makeArrayPusher(GMLBase.prototype.polygonMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.POINTMEMBER_PARSERS_ = {
+GML32.prototype.POINTMEMBER_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'Point': makeArrayPusher(GMLBase.prototype.readFlatCoordinatesFromNode_),
+    'Point': makeArrayPusher(GMLBase.prototype.readFlatCoordinatesFromNode),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.LINESTRINGMEMBER_PARSERS_ = {
+GML32.prototype.LINESTRINGMEMBER_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
     'LineString': makeArrayPusher(GMLBase.prototype.readLineString),
   },
@@ -248,9 +231,8 @@ GML32.prototype.LINESTRINGMEMBER_PARSERS_ = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GML32.prototype.POLYGONMEMBER_PARSERS_ = {
+GML32.prototype.POLYGONMEMBER_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
     'Polygon': makeArrayPusher(GMLBase.prototype.readPolygon),
   },
@@ -259,30 +241,27 @@ GML32.prototype.POLYGONMEMBER_PARSERS_ = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GML32.prototype.RING_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
-    'LinearRing': makeReplacer(GMLBase.prototype.readFlatLinearRing_),
+    'LinearRing': makeReplacer(GMLBase.prototype.readFlatLinearRing),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML32.prototype.RING_SERIALIZERS_ = {
+GML32.prototype.RING_SERIALIZERS = {
   'http://www.opengis.net/gml/3.2': {
-    'exterior': makeChildAppender(GML3.prototype.writeRing_),
-    'interior': makeChildAppender(GML3.prototype.writeRing_),
+    'exterior': makeChildAppender(GML3.prototype.writeRing),
+    'interior': makeChildAppender(GML3.prototype.writeRing),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML32.prototype.ENVELOPE_SERIALIZERS_ = {
+GML32.prototype.ENVELOPE_SERIALIZERS = {
   'http://www.opengis.net/gml/3.2': {
     'lowerCorner': makeChildAppender(writeStringTextNode),
     'upperCorner': makeChildAppender(writeStringTextNode),
@@ -291,68 +270,62 @@ GML32.prototype.ENVELOPE_SERIALIZERS_ = {
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML32.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS_ = {
+GML32.prototype.SURFACEORPOLYGONMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml/3.2': {
     'surfaceMember': makeChildAppender(
-      GML3.prototype.writeSurfaceOrPolygonMember_
+      GML3.prototype.writeSurfaceOrPolygonMember
     ),
     'polygonMember': makeChildAppender(
-      GML3.prototype.writeSurfaceOrPolygonMember_
+      GML3.prototype.writeSurfaceOrPolygonMember
     ),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML32.prototype.POINTMEMBER_SERIALIZERS_ = {
+GML32.prototype.POINTMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml/3.2': {
-    'pointMember': makeChildAppender(GML3.prototype.writePointMember_),
+    'pointMember': makeChildAppender(GML3.prototype.writePointMember),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML32.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS_ = {
+GML32.prototype.LINESTRINGORCURVEMEMBER_SERIALIZERS = {
   'http://www.opengis.net/gml/3.2': {
     'lineStringMember': makeChildAppender(
-      GML3.prototype.writeLineStringOrCurveMember_
+      GML3.prototype.writeLineStringOrCurveMember
     ),
     'curveMember': makeChildAppender(
-      GML3.prototype.writeLineStringOrCurveMember_
+      GML3.prototype.writeLineStringOrCurveMember
     ),
   },
 };
 
 /**
  * @type {Object<string, Object<string, import("../xml.js").Serializer>>}
- * @private
  */
-GML32.prototype.GEOMETRY_SERIALIZERS_ = {
+GML32.prototype.GEOMETRY_SERIALIZERS = {
   'http://www.opengis.net/gml/3.2': {
-    'Curve': makeChildAppender(GML3.prototype.writeCurveOrLineString_),
-    'MultiCurve': makeChildAppender(
-      GML3.prototype.writeMultiCurveOrLineString_
-    ),
-    'Point': makeChildAppender(GML32.prototype.writePoint_),
-    'MultiPoint': makeChildAppender(GML3.prototype.writeMultiPoint_),
-    'LineString': makeChildAppender(GML3.prototype.writeCurveOrLineString_),
+    'Curve': makeChildAppender(GML3.prototype.writeCurveOrLineString),
+    'MultiCurve': makeChildAppender(GML3.prototype.writeMultiCurveOrLineString),
+    'Point': makeChildAppender(GML32.prototype.writePoint),
+    'MultiPoint': makeChildAppender(GML3.prototype.writeMultiPoint),
+    'LineString': makeChildAppender(GML3.prototype.writeCurveOrLineString),
     'MultiLineString': makeChildAppender(
-      GML3.prototype.writeMultiCurveOrLineString_
+      GML3.prototype.writeMultiCurveOrLineString
     ),
-    'LinearRing': makeChildAppender(GML3.prototype.writeLinearRing_),
-    'Polygon': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon_),
+    'LinearRing': makeChildAppender(GML3.prototype.writeLinearRing),
+    'Polygon': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon),
     'MultiPolygon': makeChildAppender(
-      GML3.prototype.writeMultiSurfaceOrPolygon_
+      GML3.prototype.writeMultiSurfaceOrPolygon
     ),
-    'Surface': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon_),
+    'Surface': makeChildAppender(GML3.prototype.writeSurfaceOrPolygon),
     'MultiSurface': makeChildAppender(
-      GML3.prototype.writeMultiSurfaceOrPolygon_
+      GML3.prototype.writeMultiSurfaceOrPolygon
     ),
     'Envelope': makeChildAppender(GML3.prototype.writeEnvelope),
   },

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -347,10 +347,7 @@ class GMLBase extends XMLFeature {
    * @return {Point|undefined} Point.
    */
   readPoint(node, objectStack) {
-    const flatCoordinates = this.readFlatCoordinatesFromNode_(
-      node,
-      objectStack
-    );
+    const flatCoordinates = this.readFlatCoordinatesFromNode(node, objectStack);
     if (flatCoordinates) {
       return new Point(flatCoordinates, GeometryLayout.XYZ);
     }
@@ -365,7 +362,7 @@ class GMLBase extends XMLFeature {
     /** @type {Array<Array<number>>} */
     const coordinates = pushParseAndPop(
       [],
-      this.MULTIPOINT_PARSERS_,
+      this.MULTIPOINT_PARSERS,
       node,
       objectStack,
       this
@@ -386,7 +383,7 @@ class GMLBase extends XMLFeature {
     /** @type {Array<LineString>} */
     const lineStrings = pushParseAndPop(
       [],
-      this.MULTILINESTRING_PARSERS_,
+      this.MULTILINESTRING_PARSERS,
       node,
       objectStack,
       this
@@ -405,7 +402,7 @@ class GMLBase extends XMLFeature {
     /** @type {Array<Polygon>} */
     const polygons = pushParseAndPop(
       [],
-      this.MULTIPOLYGON_PARSERS_,
+      this.MULTIPOLYGON_PARSERS,
       node,
       objectStack,
       this
@@ -418,28 +415,25 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  pointMemberParser_(node, objectStack) {
-    parseNode(this.POINTMEMBER_PARSERS_, node, objectStack, this);
+  pointMemberParser(node, objectStack) {
+    parseNode(this.POINTMEMBER_PARSERS, node, objectStack, this);
   }
 
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  lineStringMemberParser_(node, objectStack) {
-    parseNode(this.LINESTRINGMEMBER_PARSERS_, node, objectStack, this);
+  lineStringMemberParser(node, objectStack) {
+    parseNode(this.LINESTRINGMEMBER_PARSERS, node, objectStack, this);
   }
 
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    */
-  polygonMemberParser_(node, objectStack) {
-    parseNode(this.POLYGONMEMBER_PARSERS_, node, objectStack, this);
+  polygonMemberParser(node, objectStack) {
+    parseNode(this.POLYGONMEMBER_PARSERS, node, objectStack, this);
   }
 
   /**
@@ -448,10 +442,7 @@ class GMLBase extends XMLFeature {
    * @return {LineString|undefined} LineString.
    */
   readLineString(node, objectStack) {
-    const flatCoordinates = this.readFlatCoordinatesFromNode_(
-      node,
-      objectStack
-    );
+    const flatCoordinates = this.readFlatCoordinatesFromNode(node, objectStack);
     if (flatCoordinates) {
       const lineString = new LineString(flatCoordinates, GeometryLayout.XYZ);
       return lineString;
@@ -463,10 +454,9 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>|undefined} LinearRing flat coordinates.
    */
-  readFlatLinearRing_(node, objectStack) {
+  readFlatLinearRing(node, objectStack) {
     const ring = pushParseAndPop(
       null,
       this.GEOMETRY_FLAT_COORDINATES_PARSERS,
@@ -487,10 +477,7 @@ class GMLBase extends XMLFeature {
    * @return {LinearRing|undefined} LinearRing.
    */
   readLinearRing(node, objectStack) {
-    const flatCoordinates = this.readFlatCoordinatesFromNode_(
-      node,
-      objectStack
-    );
+    const flatCoordinates = this.readFlatCoordinatesFromNode(node, objectStack);
     if (flatCoordinates) {
       return new LinearRing(flatCoordinates, GeometryLayout.XYZ);
     }
@@ -527,10 +514,9 @@ class GMLBase extends XMLFeature {
   /**
    * @param {Element} node Node.
    * @param {Array<*>} objectStack Object stack.
-   * @private
    * @return {Array<number>} Flat coordinates.
    */
-  readFlatCoordinatesFromNode_(node, objectStack) {
+  readFlatCoordinatesFromNode(node, objectStack) {
     return pushParseAndPop(
       null,
       this.GEOMETRY_FLAT_COORDINATES_PARSERS,
@@ -589,7 +575,6 @@ GMLBase.prototype.namespace = GMLNS;
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GMLBase.prototype.FLAT_LINEAR_RINGS_PARSERS = {
   'http://www.opengis.net/gml': {},
@@ -598,7 +583,6 @@ GMLBase.prototype.FLAT_LINEAR_RINGS_PARSERS = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GMLBase.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
   'http://www.opengis.net/gml': {},
@@ -607,7 +591,6 @@ GMLBase.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GMLBase.prototype.GEOMETRY_PARSERS = {
   'http://www.opengis.net/gml': {},
@@ -616,27 +599,25 @@ GMLBase.prototype.GEOMETRY_PARSERS = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GMLBase.prototype.MULTIPOINT_PARSERS_ = {
+GMLBase.prototype.MULTIPOINT_PARSERS = {
   'http://www.opengis.net/gml': {
-    'pointMember': makeArrayPusher(GMLBase.prototype.pointMemberParser_),
-    'pointMembers': makeArrayPusher(GMLBase.prototype.pointMemberParser_),
+    'pointMember': makeArrayPusher(GMLBase.prototype.pointMemberParser),
+    'pointMembers': makeArrayPusher(GMLBase.prototype.pointMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
+GMLBase.prototype.MULTILINESTRING_PARSERS = {
   'http://www.opengis.net/gml': {
     'lineStringMember': makeArrayPusher(
-      GMLBase.prototype.lineStringMemberParser_
+      GMLBase.prototype.lineStringMemberParser
     ),
     'lineStringMembers': makeArrayPusher(
-      GMLBase.prototype.lineStringMemberParser_
+      GMLBase.prototype.lineStringMemberParser
     ),
   },
 };
@@ -644,32 +625,29 @@ GMLBase.prototype.MULTILINESTRING_PARSERS_ = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GMLBase.prototype.MULTIPOLYGON_PARSERS_ = {
+GMLBase.prototype.MULTIPOLYGON_PARSERS = {
   'http://www.opengis.net/gml': {
-    'polygonMember': makeArrayPusher(GMLBase.prototype.polygonMemberParser_),
-    'polygonMembers': makeArrayPusher(GMLBase.prototype.polygonMemberParser_),
+    'polygonMember': makeArrayPusher(GMLBase.prototype.polygonMemberParser),
+    'polygonMembers': makeArrayPusher(GMLBase.prototype.polygonMemberParser),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GMLBase.prototype.POINTMEMBER_PARSERS_ = {
+GMLBase.prototype.POINTMEMBER_PARSERS = {
   'http://www.opengis.net/gml': {
-    'Point': makeArrayPusher(GMLBase.prototype.readFlatCoordinatesFromNode_),
+    'Point': makeArrayPusher(GMLBase.prototype.readFlatCoordinatesFromNode),
   },
 };
 
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
+GMLBase.prototype.LINESTRINGMEMBER_PARSERS = {
   'http://www.opengis.net/gml': {
     'LineString': makeArrayPusher(GMLBase.prototype.readLineString),
   },
@@ -678,9 +656,8 @@ GMLBase.prototype.LINESTRINGMEMBER_PARSERS_ = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @private
  */
-GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
+GMLBase.prototype.POLYGONMEMBER_PARSERS = {
   'http://www.opengis.net/gml': {
     'Polygon': makeArrayPusher(GMLBase.prototype.readPolygon),
   },
@@ -689,11 +666,10 @@ GMLBase.prototype.POLYGONMEMBER_PARSERS_ = {
 /**
  * @const
  * @type {Object<string, Object<string, import("../xml.js").Parser>>}
- * @protected
  */
 GMLBase.prototype.RING_PARSERS = {
   'http://www.opengis.net/gml': {
-    'LinearRing': makeReplacer(GMLBase.prototype.readFlatLinearRing_),
+    'LinearRing': makeReplacer(GMLBase.prototype.readFlatLinearRing),
   },
 };
 

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -558,7 +558,7 @@ function appendCoordinate(flatCoordinates, layoutOptions, node, values) {
  * @param {LayoutOptions} layoutOptions Layout options.
  * @param {Array<number>} flatCoordinates Flat coordinates.
  * @param {Array<number>=} ends Ends.
- * @return {GeometryLayout} Layout.
+ * @return {import("../geom/GeometryLayout.js").default} Layout.
  */
 function applyLayoutOptions(layoutOptions, flatCoordinates, ends) {
   let layout = GeometryLayout.XY;

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -47,7 +47,7 @@ import {assert} from '../asserts.js';
  * Enum representing the major IIIF Image API versions
  * @enum {string}
  */
-const Versions = {
+export const Versions = {
   VERSION1: 'version1',
   VERSION2: 'version2',
   VERSION3: 'version3',
@@ -485,4 +485,3 @@ class IIIFInfo {
 }
 
 export default IIIFInfo;
-export {Versions};

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -57,10 +57,10 @@ import {transformGeometryWithOptions} from './Feature.js';
 /**
  * @typedef {Object} Vec2
  * @property {number} x
- * @property {IconAnchorUnits} xunits
+ * @property {import("../style/IconAnchorUnits").default} xunits
  * @property {number} y
- * @property {IconAnchorUnits} yunits
- * @property {IconOrigin} origin
+ * @property {import("../style/IconAnchorUnits").default} yunits
+ * @property {import("../style/IconOrigin.js").default} origin
  */
 
 /**
@@ -96,7 +96,7 @@ const SCHEMA_LOCATION =
   'https://developers.google.com/kml/schema/kml22gx.xsd';
 
 /**
- * @type {Object<string, IconAnchorUnits>}
+ * @type {Object<string, import("../style/IconAnchorUnits").default>}
  */
 const ICON_ANCHOR_UNITS_MAP = {
   'fraction': IconAnchorUnits.FRACTION,
@@ -212,12 +212,12 @@ export function getDefaultFillStyle() {
 let DEFAULT_IMAGE_STYLE_ANCHOR;
 
 /**
- * @type {IconAnchorUnits}
+ * @type {import("../style/IconAnchorUnits").default}
  */
 let DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS;
 
 /**
- * @type {IconAnchorUnits}
+ * @type {import("../style/IconAnchorUnits").default}
  */
 let DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS;
 

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -439,7 +439,6 @@ class KML extends XMLFeature {
       options.extractStyles !== undefined ? options.extractStyles : true;
 
     /**
-     * @private
      * @type {boolean}
      */
     this.writeStyles_ =
@@ -459,7 +458,6 @@ class KML extends XMLFeature {
       options.showPointNames !== undefined ? options.showPointNames : true;
 
     /**
-     * @private
      * @type {null|string}
      */
     this.crossOrigin_ =

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -421,10 +421,10 @@ function readRawFeature(pbf, layer, i) {
  * @param {number} type The raw feature's geometry type
  * @param {number} numEnds Number of ends of the flat coordinates of the
  * geometry.
- * @return {GeometryType} The geometry type.
+ * @return {import("../geom/GeometryType.js").default} The geometry type.
  */
 function getGeometryType(type, numEnds) {
-  /** @type {GeometryType} */
+  /** @type {import("../geom/GeometryType.js").default} */
   let geometryType;
   if (type === 1) {
     geometryType =

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -55,7 +55,7 @@ class Polyline extends TextFeature {
 
     /**
      * @private
-     * @type {GeometryLayout}
+     * @type {import("../geom/GeometryLayout").default}
      */
     this.geometryLayout_ = options.geometryLayout
       ? options.geometryLayout

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -16,7 +16,7 @@ import {transformGeometryWithOptions} from './Feature.js';
 
 /**
  * Geometry constructors
- * @enum {function (new:import("../geom/Geometry.js").default, Array, GeometryLayout)}
+ * @enum {function (new:import("../geom/Geometry.js").default, Array, import("../geom/GeometryLayout.js").default)}
  */
 const GeometryConstructor = {
   'POINT': Point,
@@ -241,7 +241,7 @@ class Parser {
     this.token_;
 
     /**
-     * @type {GeometryLayout}
+     * @type {import("../geom/GeometryLayout.js").default}
      * @private
      */
     this.layout_ = GeometryLayout.XY;
@@ -290,7 +290,7 @@ class Parser {
 
   /**
    * Try to parse the dimensional info.
-   * @return {GeometryLayout} The layout.
+   * @return {import("../geom/GeometryLayout.js").default} The layout.
    * @private
    */
   parseGeometryLayout_() {

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -25,7 +25,7 @@ class LineString extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -287,7 +287,7 @@ class LineString extends SimpleGeometry {
   /**
    * Set the coordinates of the linestring.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -22,7 +22,7 @@ class LinearRing extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -167,7 +167,7 @@ class LinearRing extends SimpleGeometry {
   /**
    * Set the coordinates of the linear ring.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -28,7 +28,7 @@ class MultiLineString extends SimpleGeometry {
    * @param {Array<Array<import("../coordinate.js").Coordinate>|LineString>|Array<number>} coordinates
    *     Coordinates or LineString geometries. (For internal use, flat coordinates in
    *     combination with `opt_layout` and `opt_ends` are also accepted.)
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @param {Array<number>=} opt_ends Flat coordinate ends for internal use.
    */
   constructor(coordinates, opt_layout, opt_ends) {

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -35,7 +35,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>|Polygon>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` and `opt_endss` are also accepted.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @param {Array<Array<number>>=} opt_endss Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
@@ -446,7 +446,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * Set the coordinates of the multipolygon.
    * @param {!Array<Array<Array<import("../coordinate.js").Coordinate>>>} coordinates Coordinates.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -35,7 +35,7 @@ class Polygon extends SimpleGeometry {
    *     an array of vertices' coordinates where the first coordinate and the last are
    *     equivalent. (For internal use, flat coordinates in combination with
    *     `opt_layout` and `opt_ends` are also accepted.)
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @param {Array<number>=} opt_ends Ends (for internal use with flat coordinates).
    */
   constructor(coordinates, opt_layout, opt_ends) {
@@ -385,7 +385,7 @@ class Polygon extends SimpleGeometry {
   /**
    * Set the coordinates of the polygon.
    * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -21,7 +21,7 @@ class SimpleGeometry extends Geometry {
 
     /**
      * @protected
-     * @type {GeometryLayout}
+     * @type {import("./GeometryLayout.js").default}
      */
     this.layout = GeometryLayout.XY;
 
@@ -90,7 +90,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * Return the {@link module:ol/geom/GeometryLayout layout} of the geometry.
-   * @return {GeometryLayout} Layout.
+   * @return {import("./GeometryLayout.js").default} Layout.
    * @api
    */
   getLayout() {
@@ -152,7 +152,7 @@ class SimpleGeometry extends Geometry {
   }
 
   /**
-   * @param {GeometryLayout} layout Layout.
+   * @param {import("./GeometryLayout.js").default} layout Layout.
    * @param {Array<number>} flatCoordinates Flat coordinates.
    */
   setFlatCoordinates(layout, flatCoordinates) {
@@ -164,14 +164,14 @@ class SimpleGeometry extends Geometry {
   /**
    * @abstract
    * @param {!Array<*>} coordinates Coordinates.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
    */
   setCoordinates(coordinates, opt_layout) {
     abstract();
   }
 
   /**
-   * @param {GeometryLayout|undefined} layout Layout.
+   * @param {import("./GeometryLayout.js").default|undefined} layout Layout.
    * @param {Array<*>} coordinates Coordinates.
    * @param {number} nesting Nesting.
    * @protected
@@ -300,7 +300,7 @@ class SimpleGeometry extends Geometry {
 
 /**
  * @param {number} stride Stride.
- * @return {GeometryLayout} layout Layout.
+ * @return {import("./GeometryLayout.js").default} layout Layout.
  */
 function getLayoutForStride(stride) {
   let layout;
@@ -311,11 +311,11 @@ function getLayoutForStride(stride) {
   } else if (stride == 4) {
     layout = GeometryLayout.XYZM;
   }
-  return /** @type {GeometryLayout} */ (layout);
+  return /** @type {import("./GeometryLayout.js").default} */ (layout);
 }
 
 /**
- * @param {GeometryLayout} layout Layout.
+ * @param {import("./GeometryLayout.js").default} layout Layout.
  * @return {number} Stride.
  */
 export function getStrideForLayout(layout) {

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -20,9 +20,7 @@ class DoubleClickZoom extends Interaction {
    * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
-    super({
-      handleEvent: handleEvent,
-    });
+    super();
 
     const options = opt_options ? opt_options : {};
 
@@ -38,28 +36,27 @@ class DoubleClickZoom extends Interaction {
      */
     this.duration_ = options.duration !== undefined ? options.duration : 250;
   }
-}
 
-/**
- * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
- * doubleclick) and eventually zooms the map.
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
- * @return {boolean} `false` to stop event propagation.
- * @this {DoubleClickZoom}
- */
-function handleEvent(mapBrowserEvent) {
-  let stopEvent = false;
-  if (mapBrowserEvent.type == MapBrowserEventType.DBLCLICK) {
-    const browserEvent = /** @type {MouseEvent} */ (mapBrowserEvent.originalEvent);
-    const map = mapBrowserEvent.map;
-    const anchor = mapBrowserEvent.coordinate;
-    const delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;
-    const view = map.getView();
-    zoomByDelta(view, delta, anchor, this.duration_);
-    mapBrowserEvent.preventDefault();
-    stopEvent = true;
+  /**
+   * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
+   * doubleclick) and eventually zooms the map.
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+   * @return {boolean} `false` to stop event propagation.
+   */
+  handleEvent(mapBrowserEvent) {
+    let stopEvent = false;
+    if (mapBrowserEvent.type == MapBrowserEventType.DBLCLICK) {
+      const browserEvent = /** @type {MouseEvent} */ (mapBrowserEvent.originalEvent);
+      const map = mapBrowserEvent.map;
+      const anchor = mapBrowserEvent.coordinate;
+      const delta = browserEvent.shiftKey ? -this.delta_ : this.delta_;
+      const view = map.getView();
+      zoomByDelta(view, delta, anchor, this.duration_);
+      mapBrowserEvent.preventDefault();
+      stopEvent = true;
+    }
+    return !stopEvent;
   }
-  return !stopEvent;
 }
 
 export default DoubleClickZoom;

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -172,10 +172,10 @@ class DragAndDrop extends Interaction {
     if (map) {
       const dropArea = this.target ? this.target : map.getViewport();
       this.dropListenKeys_ = [
-        listen(dropArea, EventType.DROP, handleDrop, this),
-        listen(dropArea, EventType.DRAGENTER, handleStop, this),
-        listen(dropArea, EventType.DRAGOVER, handleStop, this),
-        listen(dropArea, EventType.DROP, handleStop, this),
+        listen(dropArea, EventType.DROP, this.handleDrop, this),
+        listen(dropArea, EventType.DRAGENTER, this.handleStop, this),
+        listen(dropArea, EventType.DRAGOVER, this.handleStop, this),
+        listen(dropArea, EventType.DROP, this.handleStop, this),
       ];
     }
   }
@@ -234,32 +234,31 @@ class DragAndDrop extends Interaction {
       this.dropListenKeys_ = null;
     }
   }
-}
 
-/**
- * @param {DragEvent} event Event.
- * @this {DragAndDrop}
- */
-function handleDrop(event) {
-  const files = event.dataTransfer.files;
-  for (let i = 0, ii = files.length; i < ii; ++i) {
-    const file = files.item(i);
-    const reader = new FileReader();
-    reader.addEventListener(
-      EventType.LOAD,
-      this.handleResult_.bind(this, file)
-    );
-    reader.readAsText(file);
+  /**
+   * @param {DragEvent} event Event.
+   */
+  handleDrop(event) {
+    const files = event.dataTransfer.files;
+    for (let i = 0, ii = files.length; i < ii; ++i) {
+      const file = files.item(i);
+      const reader = new FileReader();
+      reader.addEventListener(
+        EventType.LOAD,
+        this.handleResult_.bind(this, file)
+      );
+      reader.readAsText(file);
+    }
   }
-}
 
-/**
- * @param {DragEvent} event Event.
- */
-function handleStop(event) {
-  event.stopPropagation();
-  event.preventDefault();
-  event.dataTransfer.dropEffect = 'copy';
+  /**
+   * @param {DragEvent} event Event.
+   */
+  handleStop(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  }
 }
 
 export default DragAndDrop;

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -5,7 +5,6 @@
 import Event from '../events/Event.js';
 import PointerInteraction from './Pointer.js';
 import RenderBox from '../render/Box.js';
-import {VOID} from '../functions.js';
 import {mouseActionButton} from '../events/condition.js';
 
 /**
@@ -120,12 +119,9 @@ class DragBox extends PointerInteraction {
      */
     this.minArea_ = options.minArea !== undefined ? options.minArea : 64;
 
-    /**
-     * Function to execute just before `onboxend` is fired
-     * @type {function(this:DragBox, import("../MapBrowserEvent.js").default): void}
-     * @private
-     */
-    this.onBoxEnd_ = options.onBoxEnd ? options.onBoxEnd : VOID;
+    if (options.onBoxEnd) {
+      this.onBoxEnd = options.onBoxEnd;
+    }
 
     /**
      * @type {import("../pixel.js").Pixel}
@@ -203,7 +199,7 @@ class DragBox extends PointerInteraction {
         mapBrowserEvent.pixel
       )
     ) {
-      this.onBoxEnd_(mapBrowserEvent);
+      this.onBoxEnd(mapBrowserEvent);
       this.dispatchEvent(
         new DragBoxEvent(
           DragBoxEventType.BOXEND,
@@ -237,6 +233,12 @@ class DragBox extends PointerInteraction {
       return false;
     }
   }
+
+  /**
+   * Function to execute just before `onboxend` is fired
+   * @param {import("../MapBrowserEvent.js").default} event Event.
+   */
+  onBoxEnd(event) {}
 }
 
 export default DragBox;

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -49,7 +49,6 @@ class DragZoom extends DragBox {
       condition: condition,
       className: options.className || 'ol-dragzoom',
       minArea: options.minArea,
-      onBoxEnd: onBoxEnd,
     });
 
     /**
@@ -64,40 +63,41 @@ class DragZoom extends DragBox {
      */
     this.out_ = options.out !== undefined ? options.out : false;
   }
-}
 
-/**
- * @this {DragZoom}
- */
-function onBoxEnd() {
-  const map = this.getMap();
-  const view = /** @type {!import("../View.js").default} */ (map.getView());
-  const size = /** @type {!import("../size.js").Size} */ (map.getSize());
-  let extent = this.getGeometry().getExtent();
+  /**
+   * Function to execute just before `onboxend` is fired
+   * @param {import("../MapBrowserEvent.js").default} event Event.
+   */
+  onBoxEnd(event) {
+    const map = this.getMap();
+    const view = /** @type {!import("../View.js").default} */ (map.getView());
+    const size = /** @type {!import("../size.js").Size} */ (map.getSize());
+    let extent = this.getGeometry().getExtent();
 
-  if (this.out_) {
-    const mapExtent = view.calculateExtentInternal(size);
-    const boxPixelExtent = createOrUpdateFromCoordinates([
-      map.getPixelFromCoordinateInternal(getBottomLeft(extent)),
-      map.getPixelFromCoordinateInternal(getTopRight(extent)),
-    ]);
-    const factor = view.getResolutionForExtentInternal(boxPixelExtent, size);
+    if (this.out_) {
+      const mapExtent = view.calculateExtentInternal(size);
+      const boxPixelExtent = createOrUpdateFromCoordinates([
+        map.getPixelFromCoordinateInternal(getBottomLeft(extent)),
+        map.getPixelFromCoordinateInternal(getTopRight(extent)),
+      ]);
+      const factor = view.getResolutionForExtentInternal(boxPixelExtent, size);
 
-    scaleFromCenter(mapExtent, 1 / factor);
-    extent = mapExtent;
+      scaleFromCenter(mapExtent, 1 / factor);
+      extent = mapExtent;
+    }
+
+    const resolution = view.getConstrainedResolution(
+      view.getResolutionForExtentInternal(extent, size)
+    );
+    const center = view.getConstrainedCenter(getCenter(extent), resolution);
+
+    view.animateInternal({
+      resolution: resolution,
+      center: center,
+      duration: this.duration_,
+      easing: easeOut,
+    });
   }
-
-  const resolution = view.getConstrainedResolution(
-    view.getResolutionForExtentInternal(extent, size)
-  );
-  const center = view.getConstrainedCenter(getCenter(extent), resolution);
-
-  view.animateInternal({
-    resolution: resolution,
-    center: center,
-    duration: this.duration_,
-    easing: easeOut,
-  });
 }
 
 export default DragZoom;

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -34,7 +34,7 @@ import {squaredDistance as squaredCoordinateDistance} from '../coordinate.js';
 
 /**
  * @typedef {Object} Options
- * @property {GeometryType} type Geometry type of
+ * @property {import("../geom/GeometryType.js").default} type Geometry type of
  * the geometries being drawn with this instance.
  * @property {number} [clickTolerance=6] The maximum distance in pixels between
  * "down" and "up" for a "up" event to be considered a "click" event and
@@ -244,10 +244,10 @@ class Draw extends PointerInteraction {
 
     /**
      * Geometry type.
-     * @type {GeometryType}
+     * @type {import("../geom/GeometryType.js").default}
      * @private
      */
-    this.type_ = /** @type {GeometryType} */ (options.type);
+    this.type_ = /** @type {import("../geom/GeometryType.js").default} */ (options.type);
 
     /**
      * Drawing mode (derived from geometry type.
@@ -1166,7 +1166,7 @@ export function createBox() {
 /**
  * Get the drawing mode.  The mode for mult-part geometries is the same as for
  * their single-part cousins.
- * @param {GeometryType} type Geometry type.
+ * @param {import("../geom/GeometryType.js").default} type Geometry type.
  * @return {Mode} Drawing mode.
  */
 function getMode(type) {

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -31,13 +31,13 @@ import {easeOut, linear} from '../easing.js';
  */
 class Interaction extends BaseObject {
   /**
-   * @param {InteractionOptions} options Options.
+   * @param {InteractionOptions=} opt_options Options.
    */
-  constructor(options) {
+  constructor(opt_options) {
     super();
 
-    if (options.handleEvent) {
-      this.handleEvent = options.handleEvent;
+    if (opt_options && opt_options.handleEvent) {
+      this.handleEvent = opt_options.handleEvent;
     }
 
     /**

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -37,9 +37,7 @@ class KeyboardPan extends Interaction {
    * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
-    super({
-      handleEvent: handleEvent,
-    });
+    super();
 
     const options = opt_options || {};
 
@@ -76,50 +74,50 @@ class KeyboardPan extends Interaction {
     this.pixelDelta_ =
       options.pixelDelta !== undefined ? options.pixelDelta : 128;
   }
-}
 
-/**
- * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
- * `KeyEvent`, and decides the direction to pan to (if an arrow key was
- * pressed).
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
- * @return {boolean} `false` to stop event propagation.
- * @this {KeyboardPan}
- */
-function handleEvent(mapBrowserEvent) {
-  let stopEvent = false;
-  if (mapBrowserEvent.type == EventType.KEYDOWN) {
-    const keyEvent = /** @type {KeyboardEvent} */ (mapBrowserEvent.originalEvent);
-    const keyCode = keyEvent.keyCode;
-    if (
-      this.condition_(mapBrowserEvent) &&
-      (keyCode == KeyCode.DOWN ||
-        keyCode == KeyCode.LEFT ||
-        keyCode == KeyCode.RIGHT ||
-        keyCode == KeyCode.UP)
-    ) {
-      const map = mapBrowserEvent.map;
-      const view = map.getView();
-      const mapUnitsDelta = view.getResolution() * this.pixelDelta_;
-      let deltaX = 0,
-        deltaY = 0;
-      if (keyCode == KeyCode.DOWN) {
-        deltaY = -mapUnitsDelta;
-      } else if (keyCode == KeyCode.LEFT) {
-        deltaX = -mapUnitsDelta;
-      } else if (keyCode == KeyCode.RIGHT) {
-        deltaX = mapUnitsDelta;
-      } else {
-        deltaY = mapUnitsDelta;
+  /**
+   * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
+   * `KeyEvent`, and decides the direction to pan to (if an arrow key was
+   * pressed).
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+   * @return {boolean} `false` to stop event propagation.
+   * @this {KeyboardPan}
+   */
+  handleEvent(mapBrowserEvent) {
+    let stopEvent = false;
+    if (mapBrowserEvent.type == EventType.KEYDOWN) {
+      const keyEvent = /** @type {KeyboardEvent} */ (mapBrowserEvent.originalEvent);
+      const keyCode = keyEvent.keyCode;
+      if (
+        this.condition_(mapBrowserEvent) &&
+        (keyCode == KeyCode.DOWN ||
+          keyCode == KeyCode.LEFT ||
+          keyCode == KeyCode.RIGHT ||
+          keyCode == KeyCode.UP)
+      ) {
+        const map = mapBrowserEvent.map;
+        const view = map.getView();
+        const mapUnitsDelta = view.getResolution() * this.pixelDelta_;
+        let deltaX = 0,
+          deltaY = 0;
+        if (keyCode == KeyCode.DOWN) {
+          deltaY = -mapUnitsDelta;
+        } else if (keyCode == KeyCode.LEFT) {
+          deltaX = -mapUnitsDelta;
+        } else if (keyCode == KeyCode.RIGHT) {
+          deltaX = mapUnitsDelta;
+        } else {
+          deltaY = mapUnitsDelta;
+        }
+        const delta = [deltaX, deltaY];
+        rotateCoordinate(delta, view.getRotation());
+        pan(view, delta, this.duration_);
+        mapBrowserEvent.preventDefault();
+        stopEvent = true;
       }
-      const delta = [deltaX, deltaY];
-      rotateCoordinate(delta, view.getRotation());
-      pan(view, delta, this.duration_);
-      mapBrowserEvent.preventDefault();
-      stopEvent = true;
     }
+    return !stopEvent;
   }
-  return !stopEvent;
 }
 
 export default KeyboardPan;

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -33,9 +33,7 @@ class KeyboardZoom extends Interaction {
    * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
-    super({
-      handleEvent: handleEvent,
-    });
+    super();
 
     const options = opt_options ? opt_options : {};
 
@@ -57,37 +55,38 @@ class KeyboardZoom extends Interaction {
      */
     this.duration_ = options.duration !== undefined ? options.duration : 100;
   }
-}
 
-/**
- * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
- * `KeyEvent`, and decides whether to zoom in or out (depending on whether the
- * key pressed was '+' or '-').
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
- * @return {boolean} `false` to stop event propagation.
- * @this {KeyboardZoom}
- */
-function handleEvent(mapBrowserEvent) {
-  let stopEvent = false;
-  if (
-    mapBrowserEvent.type == EventType.KEYDOWN ||
-    mapBrowserEvent.type == EventType.KEYPRESS
-  ) {
-    const keyEvent = /** @type {KeyboardEvent} */ (mapBrowserEvent.originalEvent);
-    const charCode = keyEvent.charCode;
+  /**
+   * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
+   * `KeyEvent`, and decides whether to zoom in or out (depending on whether the
+   * key pressed was '+' or '-').
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+   * @return {boolean} `false` to stop event propagation.
+   * @this {KeyboardZoom}
+   */
+  handleEvent(mapBrowserEvent) {
+    let stopEvent = false;
     if (
-      this.condition_(mapBrowserEvent) &&
-      (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0))
+      mapBrowserEvent.type == EventType.KEYDOWN ||
+      mapBrowserEvent.type == EventType.KEYPRESS
     ) {
-      const map = mapBrowserEvent.map;
-      const delta = charCode == '+'.charCodeAt(0) ? this.delta_ : -this.delta_;
-      const view = map.getView();
-      zoomByDelta(view, delta, undefined, this.duration_);
-      mapBrowserEvent.preventDefault();
-      stopEvent = true;
+      const keyEvent = /** @type {KeyboardEvent} */ (mapBrowserEvent.originalEvent);
+      const charCode = keyEvent.charCode;
+      if (
+        this.condition_(mapBrowserEvent) &&
+        (charCode == '+'.charCodeAt(0) || charCode == '-'.charCodeAt(0))
+      ) {
+        const map = mapBrowserEvent.map;
+        const delta =
+          charCode == '+'.charCodeAt(0) ? this.delta_ : -this.delta_;
+        const view = map.getView();
+        zoomByDelta(view, delta, undefined, this.duration_);
+        mapBrowserEvent.preventDefault();
+        stopEvent = true;
+      }
     }
+    return !stopEvent;
   }
-  return !stopEvent;
 }
 
 export default KeyboardZoom;

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -153,9 +153,7 @@ class Select extends Interaction {
    * @param {Options=} opt_options Options.
    */
   constructor(opt_options) {
-    super({
-      handleEvent: handleEvent,
-    });
+    super();
 
     const options = opt_options ? opt_options : {};
 
@@ -420,110 +418,110 @@ class Select extends Interaction {
   removeFeatureLayerAssociation_(feature) {
     delete this.featureLayerAssociation_[getUid(feature)];
   }
-}
 
-/**
- * Handles the {@link module:ol/MapBrowserEvent map browser event} and may change the
- * selected state of features.
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
- * @return {boolean} `false` to stop event propagation.
- * @this {Select}
- */
-function handleEvent(mapBrowserEvent) {
-  if (!this.condition_(mapBrowserEvent)) {
-    return true;
-  }
-  const add = this.addCondition_(mapBrowserEvent);
-  const remove = this.removeCondition_(mapBrowserEvent);
-  const toggle = this.toggleCondition_(mapBrowserEvent);
-  const set = !add && !remove && !toggle;
-  const map = mapBrowserEvent.map;
-  const features = this.getFeatures();
-  const deselected = [];
-  const selected = [];
-  if (set) {
-    // Replace the currently selected feature(s) with the feature(s) at the
-    // pixel, or clear the selected feature(s) if there is no feature at
-    // the pixel.
-    clear(this.featureLayerAssociation_);
-    map.forEachFeatureAtPixel(
-      mapBrowserEvent.pixel,
-      /**
-       * @param {import("../Feature.js").FeatureLike} feature Feature.
-       * @param {import("../layer/Layer.js").default} layer Layer.
-       * @return {boolean|undefined} Continue to iterate over the features.
-       */
-      function (feature, layer) {
-        if (this.filter_(feature, layer)) {
-          selected.push(feature);
-          this.addFeatureLayerAssociation_(feature, layer);
-          return !this.multi_;
-        }
-      }.bind(this),
-      {
-        layerFilter: this.layerFilter_,
-        hitTolerance: this.hitTolerance_,
-      }
-    );
-    for (let i = features.getLength() - 1; i >= 0; --i) {
-      const feature = features.item(i);
-      const index = selected.indexOf(feature);
-      if (index > -1) {
-        // feature is already selected
-        selected.splice(index, 1);
-      } else {
-        features.remove(feature);
-        deselected.push(feature);
-      }
+  /**
+   * Handles the {@link module:ol/MapBrowserEvent map browser event} and may change the
+   * selected state of features.
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+   * @return {boolean} `false` to stop event propagation.
+   * @this {Select}
+   */
+  handleEvent(mapBrowserEvent) {
+    if (!this.condition_(mapBrowserEvent)) {
+      return true;
     }
-    if (selected.length !== 0) {
-      features.extend(selected);
-    }
-  } else {
-    // Modify the currently selected feature(s).
-    map.forEachFeatureAtPixel(
-      mapBrowserEvent.pixel,
-      /**
-       * @param {import("../Feature.js").FeatureLike} feature Feature.
-       * @param {import("../layer/Layer.js").default} layer Layer.
-       * @return {boolean|undefined} Continue to iterate over the features.
-       */
-      function (feature, layer) {
-        if (this.filter_(feature, layer)) {
-          if ((add || toggle) && !includes(features.getArray(), feature)) {
+    const add = this.addCondition_(mapBrowserEvent);
+    const remove = this.removeCondition_(mapBrowserEvent);
+    const toggle = this.toggleCondition_(mapBrowserEvent);
+    const set = !add && !remove && !toggle;
+    const map = mapBrowserEvent.map;
+    const features = this.getFeatures();
+    const deselected = [];
+    const selected = [];
+    if (set) {
+      // Replace the currently selected feature(s) with the feature(s) at the
+      // pixel, or clear the selected feature(s) if there is no feature at
+      // the pixel.
+      clear(this.featureLayerAssociation_);
+      map.forEachFeatureAtPixel(
+        mapBrowserEvent.pixel,
+        /**
+         * @param {import("../Feature.js").FeatureLike} feature Feature.
+         * @param {import("../layer/Layer.js").default} layer Layer.
+         * @return {boolean|undefined} Continue to iterate over the features.
+         */
+        function (feature, layer) {
+          if (this.filter_(feature, layer)) {
             selected.push(feature);
             this.addFeatureLayerAssociation_(feature, layer);
-          } else if (
-            (remove || toggle) &&
-            includes(features.getArray(), feature)
-          ) {
-            deselected.push(feature);
-            this.removeFeatureLayerAssociation_(feature);
+            return !this.multi_;
           }
-          return !this.multi_;
+        }.bind(this),
+        {
+          layerFilter: this.layerFilter_,
+          hitTolerance: this.hitTolerance_,
         }
-      }.bind(this),
-      {
-        layerFilter: this.layerFilter_,
-        hitTolerance: this.hitTolerance_,
+      );
+      for (let i = features.getLength() - 1; i >= 0; --i) {
+        const feature = features.item(i);
+        const index = selected.indexOf(feature);
+        if (index > -1) {
+          // feature is already selected
+          selected.splice(index, 1);
+        } else {
+          features.remove(feature);
+          deselected.push(feature);
+        }
       }
-    );
-    for (let j = deselected.length - 1; j >= 0; --j) {
-      features.remove(deselected[j]);
+      if (selected.length !== 0) {
+        features.extend(selected);
+      }
+    } else {
+      // Modify the currently selected feature(s).
+      map.forEachFeatureAtPixel(
+        mapBrowserEvent.pixel,
+        /**
+         * @param {import("../Feature.js").FeatureLike} feature Feature.
+         * @param {import("../layer/Layer.js").default} layer Layer.
+         * @return {boolean|undefined} Continue to iterate over the features.
+         */
+        function (feature, layer) {
+          if (this.filter_(feature, layer)) {
+            if ((add || toggle) && !includes(features.getArray(), feature)) {
+              selected.push(feature);
+              this.addFeatureLayerAssociation_(feature, layer);
+            } else if (
+              (remove || toggle) &&
+              includes(features.getArray(), feature)
+            ) {
+              deselected.push(feature);
+              this.removeFeatureLayerAssociation_(feature);
+            }
+            return !this.multi_;
+          }
+        }.bind(this),
+        {
+          layerFilter: this.layerFilter_,
+          hitTolerance: this.hitTolerance_,
+        }
+      );
+      for (let j = deselected.length - 1; j >= 0; --j) {
+        features.remove(deselected[j]);
+      }
+      features.extend(selected);
     }
-    features.extend(selected);
+    if (selected.length > 0 || deselected.length > 0) {
+      this.dispatchEvent(
+        new SelectEvent(
+          SelectEventType.SELECT,
+          selected,
+          deselected,
+          mapBrowserEvent
+        )
+      );
+    }
+    return true;
   }
-  if (selected.length > 0 || deselected.length > 0) {
-    this.dispatchEvent(
-      new SelectEvent(
-        SelectEventType.SELECT,
-        selected,
-        deselected,
-        mapBrowserEvent
-      )
-    );
-  }
-  return true;
 }
 
 /**

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -25,7 +25,6 @@ class ImageLayer extends BaseImageLayer {
   /**
    * Create a renderer for this layer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
-   * @protected
    */
   createRenderer() {
     return new CanvasImageLayerRenderer(this);

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -46,7 +46,7 @@ import {listen, unlistenByKey} from '../events.js';
  * @typedef {Object} State
  * @property {import("./Layer.js").default} layer
  * @property {number} opacity Opacity, the value is rounded to two digits to appear after the decimal point.
- * @property {SourceState} sourceState
+ * @property {import("../source/State.js").default} sourceState
  * @property {boolean} visible
  * @property {boolean} managed
  * @property {import("../extent.js").Extent} [extent]

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -25,7 +25,6 @@ class VectorLayer extends BaseVectorLayer {
   /**
    * Create a renderer for this layer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
-   * @protected
    */
   createRenderer() {
     return new CanvasVectorLayerRenderer(this);

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -88,7 +88,6 @@ class VectorImageLayer extends BaseVectorLayer {
   /**
    * Create a renderer for this layer.
    * @return {import("../renderer/Layer.js").default} A layer renderer.
-   * @protected
    */
   createRenderer() {
     return new CanvasVectorImageLayerRenderer(this);

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -104,7 +104,7 @@ class VectorTileLayer extends BaseVectorLayer {
 
     /**
      * @private
-     * @type {VectorTileRenderType}
+     * @type {import("./VectorTileRenderType.js").default}
      */
     this.renderMode_ = renderMode;
 
@@ -144,7 +144,7 @@ class VectorTileLayer extends BaseVectorLayer {
   }
 
   /**
-   * @return {VectorTileRenderType} The render mode.
+   * @return {import("./VectorTileRenderType.js").default} The render mode.
    */
   getRenderMode() {
     return this.renderMode_;

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -113,7 +113,7 @@ class WebGLPointsLayer extends Layer {
    * Clean up.
    */
   disposeInternal() {
-    this.renderer_.dispose();
+    this.getRenderer().disposeInternal();
     super.disposeInternal();
   }
 }

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -181,7 +181,7 @@ export function get(projectionLike) {
  * @param {ProjectionLike} projection The projection.
  * @param {number} resolution Nominal resolution in projection units.
  * @param {import("./coordinate.js").Coordinate} point Point to find adjusted resolution at.
- * @param {Units=} opt_units Units to get the point resolution in.
+ * @param {import("./proj/Units.js").default=} opt_units Units to get the point resolution in.
  * Default is the projection's units.
  * @return {number} Point resolution.
  * @api

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -34,7 +34,7 @@ const tmpTransform = createTransform();
  */
 class RenderFeature {
   /**
-   * @param {GeometryType} type Geometry type.
+   * @param {import("../geom/GeometryType.js").default} type Geometry type.
    * @param {Array<number>} flatCoordinates Flat coordinates. These always need
    *     to be right-handed for polygons.
    * @param {Array<number>|Array<Array<number>>} ends Ends or Endss.
@@ -56,7 +56,7 @@ class RenderFeature {
 
     /**
      * @private
-     * @type {GeometryType}
+     * @type {import("../geom/GeometryType.js").default}
      */
     this.type_ = type;
 
@@ -267,7 +267,7 @@ class RenderFeature {
 
   /**
    * Get the type of this feature's geometry.
-   * @return {GeometryType} Geometry type.
+   * @return {import("../geom/GeometryType.js").default} Geometry type.
    * @api
    */
   getType() {

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -305,14 +305,14 @@ class RenderFeature {
       this.flatCoordinates_
     );
   }
+  /**
+   * @return {Array<number>|Array<Array<number>>} Ends or endss.
+   */
+  getEnds() {
+    return this.ends_;
+  }
 }
 
-/**
- * @return {Array<number>|Array<Array<number>>} Ends or endss.
- */
-RenderFeature.prototype.getEnds = function () {
-  return this.ends_;
-};
 RenderFeature.prototype.getEndss = RenderFeature.prototype.getEnds;
 
 /**

--- a/src/ol/render/canvas/Builder.js
+++ b/src/ol/render/canvas/Builder.js
@@ -370,7 +370,7 @@ class CanvasBuilder extends VectorContext {
     let begin = -1;
     for (i = 0; i < n; ++i) {
       instruction = hitDetectionInstructions[i];
-      type = /** @type {CanvasInstruction} */ (instruction[0]);
+      type = /** @type {import("./Instruction.js").default} */ (instruction[0]);
       if (type == CanvasInstruction.END_GEOMETRY) {
         begin = i;
       } else if (type == CanvasInstruction.BEGIN_GEOMETRY) {

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -669,7 +669,7 @@ class Executor {
     let x, y;
     while (i < ii) {
       const instruction = instructions[i];
-      const type = /** @type {CanvasInstruction} */ (instruction[0]);
+      const type = /** @type {import("./Instruction.js").default} */ (instruction[0]);
       switch (type) {
         case CanvasInstruction.BEGIN_GEOMETRY:
           feature = /** @type {import("../../Feature.js").FeatureLike} */ (instruction[1]);

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -16,7 +16,7 @@ import {transform2D} from '../../geom/flat/transform.js';
 
 /**
  * @const
- * @type {Array<BuilderType>}
+ * @type {Array<import("./BuilderType.js").default>}
  */
 const ORDER = [
   BuilderType.POLYGON,
@@ -36,7 +36,7 @@ class ExecutorGroup {
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {boolean} overlaps The executor group can have overlapping geometries.
-   * @param {!Object<string, !Object<BuilderType, import("./Builder.js").SerializableInstructions>>} allInstructions
+   * @param {!Object<string, !Object<import("./BuilderType.js").default, import("./Builder.js").SerializableInstructions>>} allInstructions
    * The serializable instructions.
    * @param {number=} opt_renderBuffer Optional rendering buffer.
    */
@@ -80,7 +80,7 @@ class ExecutorGroup {
 
     /**
      * @private
-     * @type {!Object<string, !Object<BuilderType, import("./Executor").default>>}
+     * @type {!Object<string, !Object<import("./BuilderType.js").default, import("./Executor").default>>}
      */
     this.executorsByZIndex_ = {};
 
@@ -116,7 +116,7 @@ class ExecutorGroup {
   /**
    * Create executors and populate them using the provided instructions.
    * @private
-   * @param {!Object<string, !Object<BuilderType, import("./Builder.js").SerializableInstructions>>} allInstructions The serializable instructions
+   * @param {!Object<string, !Object<import("./BuilderType.js").default, import("./Builder.js").SerializableInstructions>>} allInstructions The serializable instructions
    */
   createExecutors_(allInstructions) {
     for (const zIndex in allInstructions) {
@@ -139,7 +139,7 @@ class ExecutorGroup {
   }
 
   /**
-   * @param {Array<BuilderType>} executors Executors.
+   * @param {Array<import("./BuilderType.js").default>} executors Executors.
    * @return {boolean} Has executors of the provided types.
    */
   hasExecutors(executors) {
@@ -313,7 +313,7 @@ class ExecutorGroup {
    * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {boolean} snapToPixel Snap point symbols and test to integer pixel.
-   * @param {Array<BuilderType>=} opt_builderTypes Ordered replay types to replay.
+   * @param {Array<import("./BuilderType.js").default>=} opt_builderTypes Ordered replay types to replay.
    *     Default is {@link module:ol/render/replay~ORDER}
    * @param {Object<string, import("../canvas.js").DeclutterGroup>=} opt_declutterReplays Declutter replays.
    */

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -163,7 +163,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     const img = image.getImage();
 
     const transform = composeTransform(
-      this.tempTransform_,
+      this.tempTransform,
       width / 2,
       height / 2,
       scale,

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -44,10 +44,10 @@ class CanvasLayerRenderer extends LayerRenderer {
     /**
      * A temporary transform.  The values in this transform should only be used in a
      * function that sets the values.
-     * @private
+     * @protected
      * @type {import("../../transform.js").Transform}
      */
-    this.tempTransform_ = createTransform();
+    this.tempTransform = createTransform();
 
     /**
      * The transform for rendered pixels to viewport CSS pixels.  This transform must
@@ -66,7 +66,6 @@ class CanvasLayerRenderer extends LayerRenderer {
     this.inversePixelTransform = createTransform();
 
     /**
-     * @protected
      * @type {CanvasRenderingContext2D}
      */
     this.context = null;
@@ -255,7 +254,7 @@ class CanvasLayerRenderer extends LayerRenderer {
     const dx2 = -center[0] + offsetX;
     const dy2 = -center[1];
     return composeTransform(
-      this.tempTransform_,
+      this.tempTransform,
       dx1,
       dy1,
       sx,

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -290,7 +290,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     // set scale transform for calculating tile positions on the canvas
     composeTransform(
-      this.tempTransform_,
+      this.tempTransform,
       width / 2,
       height / 2,
       canvasScale,
@@ -346,7 +346,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         currentZ
       );
       const originTileExtent = tileGrid.getTileCoordExtent(originTileCoord);
-      const origin = applyTransform(this.tempTransform_, [
+      const origin = applyTransform(this.tempTransform, [
         (tilePixelRatio * (originTileExtent[0] - canvasExtent[0])) /
           tileResolution,
         (tilePixelRatio * (canvasExtent[3] - originTileExtent[3])) /

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -41,7 +41,7 @@ import {toSize} from '../size.js';
  * @property {number} [transition]
  * @property {string} [url] Base URL of the IIIF Image service.
  * This should be the same as the IIIF Image ID.
- * @property {Versions} [version=Versions.VERSION2] Service's IIIF Image API version.
+ * @property {import("../format/IIIFInfo.js").Versions} [version=Versions.VERSION2] Service's IIIF Image API version.
  * @property {number} [zDirection=0] Indicate which resolution should be used
  * by a renderer if the view resolution does not match any resolution of the tile source.
  * If 0, the nearest resolution will be used. If 1, the nearest lower resolution

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -29,7 +29,7 @@ import {get as getProjection} from '../proj.js';
  * @property {AttributionLike} [attributions]
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.
- * @property {SourceState} [state='ready']
+ * @property {import("./State.js").default} [state='ready']
  * @property {boolean} [wrapX=false]
  */
 
@@ -80,7 +80,7 @@ class Source extends BaseObject {
 
     /**
      * @private
-     * @type {SourceState}
+     * @type {import("./State.js").default}
      */
     this.state_ =
       options.state !== undefined ? options.state : SourceState.READY;
@@ -126,7 +126,7 @@ class Source extends BaseObject {
 
   /**
    * Get the state of the source, see {@link module:ol/source/State~State} for possible states.
-   * @return {SourceState} State.
+   * @return {import("./State.js").default} State.
    * @api
    */
   getState() {
@@ -162,7 +162,7 @@ class Source extends BaseObject {
 
   /**
    * Set the state of the source.
-   * @param {SourceState} state State.
+   * @param {import("./State.js").default} state State.
    * @protected
    */
   setState(state) {

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -97,7 +97,6 @@ class TileWMS extends TileImage {
       tileClass: options.tileClass,
       tileGrid: options.tileGrid,
       tileLoadFunction: options.tileLoadFunction,
-      tileUrlFunction: tileUrlFunction,
       url: options.url,
       urls: options.urls,
       wrapX: options.wrapX !== undefined ? options.wrapX : true,
@@ -409,60 +408,60 @@ class TileWMS extends TileImage {
     const version = this.params_['VERSION'] || DEFAULT_WMS_VERSION;
     this.v13_ = compareVersions(version, '1.3') >= 0;
   }
-}
 
-/**
- * @param {import("../tilecoord.js").TileCoord} tileCoord The tile coordinate
- * @param {number} pixelRatio The pixel ratio
- * @param {import("../proj/Projection.js").default} projection The projection
- * @return {string|undefined} The tile URL
- * @this {TileWMS}
- */
-function tileUrlFunction(tileCoord, pixelRatio, projection) {
-  let tileGrid = this.getTileGrid();
-  if (!tileGrid) {
-    tileGrid = this.getTileGridForProjection(projection);
+  /**
+   * @param {import("../tilecoord.js").TileCoord} tileCoord The tile coordinate
+   * @param {number} pixelRatio The pixel ratio
+   * @param {import("../proj/Projection.js").default} projection The projection
+   * @return {string|undefined} The tile URL
+   * @override
+   */
+  tileUrlFunction(tileCoord, pixelRatio, projection) {
+    let tileGrid = this.getTileGrid();
+    if (!tileGrid) {
+      tileGrid = this.getTileGridForProjection(projection);
+    }
+
+    if (tileGrid.getResolutions().length <= tileCoord[0]) {
+      return undefined;
+    }
+
+    if (pixelRatio != 1 && (!this.hidpi_ || this.serverType_ === undefined)) {
+      pixelRatio = 1;
+    }
+
+    const tileResolution = tileGrid.getResolution(tileCoord[0]);
+    let tileExtent = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent_);
+    let tileSize = toSize(tileGrid.getTileSize(tileCoord[0]), this.tmpSize);
+
+    const gutter = this.gutter_;
+    if (gutter !== 0) {
+      tileSize = bufferSize(tileSize, gutter, this.tmpSize);
+      tileExtent = buffer(tileExtent, tileResolution * gutter, tileExtent);
+    }
+
+    if (pixelRatio != 1) {
+      tileSize = scaleSize(tileSize, pixelRatio, this.tmpSize);
+    }
+
+    const baseParams = {
+      'SERVICE': 'WMS',
+      'VERSION': DEFAULT_WMS_VERSION,
+      'REQUEST': 'GetMap',
+      'FORMAT': 'image/png',
+      'TRANSPARENT': true,
+    };
+    assign(baseParams, this.params_);
+
+    return this.getRequestUrl_(
+      tileCoord,
+      tileSize,
+      tileExtent,
+      pixelRatio,
+      projection,
+      baseParams
+    );
   }
-
-  if (tileGrid.getResolutions().length <= tileCoord[0]) {
-    return undefined;
-  }
-
-  if (pixelRatio != 1 && (!this.hidpi_ || this.serverType_ === undefined)) {
-    pixelRatio = 1;
-  }
-
-  const tileResolution = tileGrid.getResolution(tileCoord[0]);
-  let tileExtent = tileGrid.getTileCoordExtent(tileCoord, this.tmpExtent_);
-  let tileSize = toSize(tileGrid.getTileSize(tileCoord[0]), this.tmpSize);
-
-  const gutter = this.gutter_;
-  if (gutter !== 0) {
-    tileSize = bufferSize(tileSize, gutter, this.tmpSize);
-    tileExtent = buffer(tileExtent, tileResolution * gutter, tileExtent);
-  }
-
-  if (pixelRatio != 1) {
-    tileSize = scaleSize(tileSize, pixelRatio, this.tmpSize);
-  }
-
-  const baseParams = {
-    'SERVICE': 'WMS',
-    'VERSION': DEFAULT_WMS_VERSION,
-    'REQUEST': 'GetMap',
-    'FORMAT': 'image/png',
-    'TRANSPARENT': true,
-  };
-  assign(baseParams, this.params_);
-
-  return this.getRequestUrl_(
-    tileCoord,
-    tileSize,
-    tileExtent,
-    pixelRatio,
-    projection,
-    baseParams
-  );
 }
 
 export default TileWMS;

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -26,7 +26,7 @@ import {jsonp as requestJSONP} from '../net.js';
 export class CustomTile extends Tile {
   /**
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {TileState} state State.
+   * @param {import("../TileState.js").default} state State.
    * @param {string} src Image source URI.
    * @param {import("../extent.js").Extent} extent Extent of the tile.
    * @param {boolean} preemptive Load the tile when visible (before it's needed).

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -4,11 +4,7 @@
 import TileEventType from './TileEventType.js';
 import TileSource, {TileSourceEvent} from './Tile.js';
 import TileState from '../TileState.js';
-import {
-  createFromTemplates,
-  expandUrl,
-  nullTileUrlFunction,
-} from '../tileurlfunction.js';
+import {createFromTemplates, expandUrl} from '../tileurlfunction.js';
 import {getKeyZXY} from '../tilecoord.js';
 import {getUid} from '../util.js';
 
@@ -62,7 +58,8 @@ class UrlTile extends TileSource {
      * @private
      * @type {boolean}
      */
-    this.generateTileUrlFunction_ = !options.tileUrlFunction;
+    this.generateTileUrlFunction_ =
+      this.tileUrlFunction === UrlTile.prototype.tileUrlFunction;
 
     /**
      * @protected
@@ -70,13 +67,9 @@ class UrlTile extends TileSource {
      */
     this.tileLoadFunction = options.tileLoadFunction;
 
-    /**
-     * @protected
-     * @type {import("../Tile.js").UrlFunction}
-     */
-    this.tileUrlFunction = options.tileUrlFunction
-      ? options.tileUrlFunction.bind(this)
-      : nullTileUrlFunction;
+    if (options.tileUrlFunction) {
+      this.tileUrlFunction = options.tileUrlFunction.bind(this);
+    }
 
     /**
      * @protected
@@ -204,6 +197,16 @@ class UrlTile extends TileSource {
     } else {
       this.setKey(key);
     }
+  }
+
+  /**
+   * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
+   * @param {number} pixelRatio Pixel ratio.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @return {string|undefined} Tile URL.
+   */
+  tileUrlFunction(tileCoord, pixelRatio, projection) {
+    return undefined;
   }
 
   /**

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -25,7 +25,7 @@ export class CustomTile extends ImageTile {
   /**
    * @param {import("../size.js").Size} tileSize Full tile size.
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {TileState} state State.
+   * @param {import("../TileState.js").default} state State.
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
    * @param {import("../Tile.js").LoadFunction} tileLoadFunction Tile load function.

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -57,7 +57,7 @@ export function wrapX(tileGrid, tileCoord, projection) {
  *     DEFAULT_MAX_ZOOM).
  * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {Corner=} opt_corner Extent corner (default is `'top-left'`).
+ * @param {import("./extent/Corner.js").default=} opt_corner Extent corner (default is `'top-left'`).
  * @return {!TileGrid} TileGrid instance.
  */
 export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
@@ -153,7 +153,7 @@ function resolutionsFromExtent(
  *     DEFAULT_MAX_ZOOM).
  * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {Corner=} opt_corner Extent corner (default is `'top-left'`).
+ * @param {import("./extent/Corner.js").default=} opt_corner Extent corner (default is `'top-left'`).
  * @return {!TileGrid} TileGrid instance.
  */
 export function createForProjection(

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -1,6 +1,6 @@
 import Map from '../../../../src/ol/Map.js';
 import Projection from '../../../../src/ol/proj/Projection.js';
-import ScaleLine, {render} from '../../../../src/ol/control/ScaleLine.js';
+import ScaleLine from '../../../../src/ol/control/ScaleLine.js';
 import View from '../../../../src/ol/View.js';
 import proj4 from 'proj4';
 import {
@@ -82,14 +82,14 @@ describe('ol.control.ScaleLine', function () {
     describe('render', function () {
       it('defaults to `ol.control.ScaleLine.render`', function () {
         const ctrl = new ScaleLine();
-        expect(ctrl.render_).to.be(render);
+        expect(ctrl.render).to.be(ScaleLine.prototype.render);
       });
       it('can be configured', function () {
         const myRender = function () {};
         const ctrl = new ScaleLine({
           render: myRender,
         });
-        expect(ctrl.render_).to.be(myRender);
+        expect(ctrl.render).to.be(myRender);
       });
     });
   });

--- a/test/spec/ol/interaction/dragzoom.test.js
+++ b/test/spec/ol/interaction/dragzoom.test.js
@@ -70,7 +70,7 @@ describe('ol.interaction.DragZoom', function () {
       box.geometry_ = polygonFromExtent(extent);
       interaction.box_ = box;
 
-      interaction.onBoxEnd_();
+      interaction.onBoxEnd();
       setTimeout(function () {
         const view = map.getView();
         const center = view.getCenterInternal();
@@ -93,7 +93,7 @@ describe('ol.interaction.DragZoom', function () {
 
       map.getView().setResolution(0.25);
       setTimeout(function () {
-        interaction.onBoxEnd_();
+        interaction.onBoxEnd();
         setTimeout(function () {
           const view = map.getView();
           const resolution = view.getResolution();


### PR DESCRIPTION
This pull request makes several fixes related to types, which allows us to upgrade to the latest TypeScript version.

Most issues were around private/protected/public scope problems. I resolved some of them by refactoring the way we pass functions to the contstructor (e.g. `tileUrlFunction`). Now we simply rely on inheritance for that. A broader field of problems were the XML formats. Due to the way these allow matching and mixing properties and functions from other formats, I had to remove private/protected restrictions from these properties and functions.

This pull request also contains one commit that works around microsoft/TypeScript#33575, b0f20d6 to make `npm run typecheck` pass. We might be able to revert that commit when the TypeScript issue is fixed. Also, until that TypeScript issue is fixed, enum types in applications still do not work correctly.

When these changes are in, TypeScript projects can also benefit from the types that are directly derived from the sources in the package's `src/` folder.