### PR TITLE
Fix calling Overlay.panIntoView with no options

### DIFF
--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -408,7 +408,7 @@ class Overlay extends BaseObject {
   /**
    * Pan the map so that the overlay is entirely visible in the current viewport
    * (if necessary).
-   * @param {PanIntoViewOptions|undefined} opt_panIntoViewOptions Options for the pan action
+   * @param {PanIntoViewOptions=} opt_panIntoViewOptions Options for the pan action
    * @api
    */
   panIntoView(opt_panIntoViewOptions) {

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -408,10 +408,10 @@ class Overlay extends BaseObject {
   /**
    * Pan the map so that the overlay is entirely visible in the current viewport
    * (if necessary).
-   * @param {PanIntoViewOptions|undefined} panIntoViewOptions Options for the pan action
+   * @param {PanIntoViewOptions|undefined} opt_panIntoViewOptions Options for the pan action
    * @api
    */
-  panIntoView(panIntoViewOptions) {
+  panIntoView(opt_panIntoViewOptions) {
     const map = this.getMap();
 
     if (!map || !map.getTargetElement() || !this.get(Property.POSITION)) {
@@ -424,6 +424,8 @@ class Overlay extends BaseObject {
       outerWidth(element),
       outerHeight(element),
     ]);
+
+    const panIntoViewOptions = opt_panIntoViewOptions || {};
 
     const myMargin =
       panIntoViewOptions.margin === undefined ? 20 : panIntoViewOptions.margin;


### PR DESCRIPTION
 * API-doc said undefined is OK, code assumed an object

 * Fixes a bug introduced in #10800 (mea culpa!)