### PR TITLE
Use the tile coordinate as a tile pseudo URL in geojson-vt example

### DIFF
--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -82,6 +82,16 @@ fetch(url)
         }),
       }),
       tileUrlFunction: function (tileCoord) {
+        // Use the tile coordinate as a pseudo URL for caching purposes
+        return JSON.stringify(tileCoord);
+      },
+    });
+    // For tile loading obtain the GeoJSON for the tile coordinate
+    // before calling the default tileLoadFunction
+    const defaultTileLoadFunction = vectorSource.getTileLoadFunction();
+    vectorSource.setTileLoadFunction(
+      function (tile, url) {
+        const tileCoord = JSON.parse(url);
         const data = tileIndex.getTile(
           tileCoord[0],
           tileCoord[1],
@@ -94,9 +104,12 @@ fetch(url)
           },
           replacer
         );
-        return 'data:application/json;charset=UTF-8,' + geojson;
-      },
-    });
+        defaultTileLoadFunction(
+          tile,
+          'data:application/json;charset=UTF-8,' + geojson
+        );
+      }
+    );
     const vectorLayer = new VectorTileLayer({
       source: vectorSource,
     });

--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -89,27 +89,21 @@ fetch(url)
     // For tile loading obtain the GeoJSON for the tile coordinate
     // before calling the default tileLoadFunction
     const defaultTileLoadFunction = vectorSource.getTileLoadFunction();
-    vectorSource.setTileLoadFunction(
-      function (tile, url) {
-        const tileCoord = JSON.parse(url);
-        const data = tileIndex.getTile(
-          tileCoord[0],
-          tileCoord[1],
-          tileCoord[2]
-        );
-        const geojson = JSON.stringify(
-          {
-            type: 'FeatureCollection',
-            features: data ? data.features : [],
-          },
-          replacer
-        );
-        defaultTileLoadFunction(
-          tile,
-          'data:application/json;charset=UTF-8,' + geojson
-        );
-      }
-    );
+    vectorSource.setTileLoadFunction(function (tile, url) {
+      const tileCoord = JSON.parse(url);
+      const·data·=·tileIndex.getTile(tileCoord[0],·tileCoord[1],·tileCoord[2]);
+      const geojson = JSON.stringify(
+        {
+          type: 'FeatureCollection',
+          features: data ? data.features : [],
+        },
+        replacer
+      );
+      defaultTileLoadFunction(
+        tile,
+        'data:application/json;charset=UTF-8,' + geojson
+      );
+    });
     const vectorLayer = new VectorTileLayer({
       source: vectorSource,
     });

--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -91,7 +91,7 @@ fetch(url)
     const defaultTileLoadFunction = vectorSource.getTileLoadFunction();
     vectorSource.setTileLoadFunction(function (tile, url) {
       const tileCoord = JSON.parse(url);
-      const·data·=·tileIndex.getTile(tileCoord[0],·tileCoord[1],·tileCoord[2]);
+      const data = tileIndex.getTile(tileCoord[0], tileCoord[1], tileCoord[2]);
       const geojson = JSON.stringify(
         {
           type: 'FeatureCollection',

--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -87,7 +87,11 @@ fetch(url)
       },
       tileLoadFunction: function (tile, url) {
         const tileCoord = JSON.parse(url);
-        const data = tileIndex.getTile(tileCoord[0], tileCoord[1], tileCoord[2]);
+        const data = tileIndex.getTile(
+          tileCoord[0],
+          tileCoord[1],
+          tileCoord[2]
+        );
         const geojson = JSON.stringify(
           {
             type: 'FeatureCollection',
@@ -97,7 +101,7 @@ fetch(url)
         );
         const features = format.readFeatures(geojson, {
           extent: vectorSource.getTileGrid().getTileCoordExtent(tileCoord),
-          featureProjection: map.getView().getProjection()
+          featureProjection: map.getView().getProjection(),
         });
         tile.setFeatures(features);
       },


### PR DESCRIPTION
Fixes #10933

The issue with solid fill seen in #10933 can also be seen although less obvious in the semi-opaque default fill in the live example.

Using the unique tile coordinate as a tile pseudo URL instead of a GeoJSON data URL which may not be unique prevents problems with tile caching,  The construction of the GeoJSON is instead done in a custom tileLoadFunction.
