### PR TITLE
Losen listener type

### DIFF
--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -49,7 +49,7 @@ class Observable extends EventTarget {
   /**
    * Listen for a certain type of event.
    * @param {string|Array<string>} type The event type or array of event types.
-   * @param {import("./events.js").ListenerFunction} listener The listener function.
+   * @param {function(?): ?} listener The listener function.
    * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Unique key for the listener. If
    *     called with an array of event types as the first argument, the return
    *     will be an array of keys.


### PR DESCRIPTION
This change makes the use of the `Observable#on` method easier in type checked environments. Because `Event` and `ol/events/Event` do not overlap, typecasts are needed in applications.

This change fixes that, by using the same listener type for `on` that is already used for `once` and `un`.

A future improvement would be to define [overload types](https://github.com/Microsoft/TypeScript/issues/25590#issuecomment-561493756) of `on`, `once` and `un` for every `Observable` subclass, but that would require to expose event type enums (currently the `type` is a `{string}`). That change, in turn, would also require modifications to our docs genaration customizations for events. So that would be a huge effort, that maybe our TypeScript users want to take on.