### PR TITLE
Always prevent default after handleDragEvent

### DIFF
--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -138,6 +138,8 @@ class PointerInteraction extends Interaction {
     if (this.handlingDownUpSequence) {
       if (mapBrowserEvent.type == MapBrowserEventType.POINTERDRAG) {
         this.handleDragEvent(mapBrowserEvent);
+        // prevent page scrolling during dragging
+        mapBrowserEvent.preventDefault();
       } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERUP) {
         const handledUp = this.handleUpEvent(mapBrowserEvent);
         this.handlingDownUpSequence =

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -262,8 +262,7 @@ class Translate extends PointerInteraction {
       });
 
       this.lastCoordinate_ = newCoordinate;
-      // Prevent page scrolling during drag
-      event.preventDefault();
+
       this.dispatchEvent(
         new TranslateEvent(
           TranslateEventType.TRANSLATING,


### PR DESCRIPTION
Fixes #10940.

To avoid having to `preventDefault()` when dragging in every interaction that involves a drag sequence, we can do that in one place in the `Pointer` event base class.