### PR TITLE
Add constrainResolution option

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -229,8 +229,7 @@ class MouseWheelZoom extends Interaction {
     if (
       this.mode_ === Mode.TRACKPAD &&
       !(view.getConstrainResolution() || this.constrainResolution_)
-     )
-    {
+    ) {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -223,7 +223,8 @@ class MouseWheelZoom extends Interaction {
     }
 
     const view = map.getView();
-    if (this.mode_ === Mode.TRACKPAD && !(view.getConstrainResolution() || this.constrainResolution_)) {
+    if (this.mode_ === Mode.TRACKPAD &&
+        !(view.getConstrainResolution() || this.constrainResolution_)) {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -226,8 +226,10 @@ class MouseWheelZoom extends Interaction {
     }
 
     const view = map.getView();
-    if (this.mode_ === Mode.TRACKPAD &&
-      !(view.getConstrainResolution() || this.constrainResolution_))
+    if (
+      this.mode_ === Mode.TRACKPAD &&
+      !(view.getConstrainResolution() || this.constrainResolution_)
+     )
     {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -91,7 +91,10 @@ class MouseWheelZoom extends Interaction {
      * @private
      * @type {boolean}
      */
-    this.constrainResolution_ = options.constrainResolution !== undefined ? options.constrainResolution : false;
+    this.constrainResolution_ =
+      options.constrainResolution !== undefined
+        ? options.constrainResolution
+        : false;
     
     /**
      * @private
@@ -224,7 +227,7 @@ class MouseWheelZoom extends Interaction {
 
     const view = map.getView();
     if (this.mode_ === Mode.TRACKPAD &&
-        !(view.getConstrainResolution() || this.constrainResolution_)) {
+      !(view.getConstrainResolution() || this.constrainResolution_)) {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -95,7 +95,7 @@ class MouseWheelZoom extends Interaction {
       options.constrainResolution !== undefined
         ? options.constrainResolution
         : false;
-    
+
     /**
      * @private
      * @type {import("../events/condition.js").Condition}
@@ -227,7 +227,8 @@ class MouseWheelZoom extends Interaction {
 
     const view = map.getView();
     if (this.mode_ === Mode.TRACKPAD &&
-      !(view.getConstrainResolution() || this.constrainResolution_)) {
+      !(view.getConstrainResolution() || this.constrainResolution_))
+    {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -29,6 +29,9 @@ export const Mode = {
  * @property {boolean} [useAnchor=true] Enable zooming using the mouse's
  * location as the anchor. When set to `false`, zooming in and out will zoom to
  * the center of the screen instead of zooming on the mouse's location.
+ * @property {boolean} [constrainResolution=false] If true, the mouse wheel zoom
+ * event will always animate to the closest zoom level after an interaction;
+ * false means intermediary zoom levels are allowed.
  */
 
 /**
@@ -84,6 +87,12 @@ class MouseWheelZoom extends Interaction {
     this.useAnchor_ =
       options.useAnchor !== undefined ? options.useAnchor : true;
 
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.constrainResolution_ = options.constrainResolution !== undefined ? options.constrainResolution : false;
+    
     /**
      * @private
      * @type {import("../events/condition.js").Condition}
@@ -214,7 +223,7 @@ class MouseWheelZoom extends Interaction {
     }
 
     const view = map.getView();
-    if (this.mode_ === Mode.TRACKPAD && !view.getConstrainResolution()) {
+    if (this.mode_ === Mode.TRACKPAD && !(view.getConstrainResolution() || this.constrainResolution_)) {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {
@@ -260,7 +269,7 @@ class MouseWheelZoom extends Interaction {
         -this.maxDelta_ * this.deltaPerZoom_,
         this.maxDelta_ * this.deltaPerZoom_
       ) / this.deltaPerZoom_;
-    if (view.getConstrainResolution()) {
+    if (view.getConstrainResolution() || this.constrainResolution_) {
       // view has a zoom constraint, zoom by 1
       delta = delta ? (delta > 0 ? 1 : -1) : 0;
     }


### PR DESCRIPTION
Sometimes we may have the functionality to set scale/resolution provided by a user and it can be any number (so constrainResolution in View class is not useful), but we would like to have constrainResolution in mouse wheel zoom event.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
