### PR TITLE
Wrap transforms between global projections defined using proj4

### DIFF
--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -1179,25 +1179,34 @@ class Graticule extends VectorLayer {
       this.toLonLatTransform_ = toLonLatTransform;
     } else {
       const split = this.minLon_ + this.maxLon_ / 2;
-      this.maxLon_ += 360;
-      this.toLonLatTransform_ = function (
-        coordinates,
-        opt_output,
-        opt_dimension
-      ) {
-        const dimension = opt_dimension || 2;
-        const lonLatCoordinates = toLonLatTransform(
+      if (projection.canWrapX()) {
+        if (split > 0) {
+          this.minLon_ -= 360;
+        } else {
+          this.maxLon_ += 360;
+        }
+        this.toLonLatTransform_ = toLonLatTransform;
+      } else {
+        this.maxLon_ += 360;
+        this.toLonLatTransform_ = function (
           coordinates,
           opt_output,
-          dimension
-        );
-        for (let i = 0, l = lonLatCoordinates.length; i < l; i += dimension) {
-          if (lonLatCoordinates[i] < split) {
-            lonLatCoordinates[i] += 360;
+          opt_dimension
+        ) {
+          const dimension = opt_dimension || 2;
+          const lonLatCoordinates = toLonLatTransform(
+            coordinates,
+            opt_output,
+            dimension
+          );
+          for (let i = 0, l = lonLatCoordinates.length; i < l; i += dimension) {
+            if (lonLatCoordinates[i] < split) {
+              lonLatCoordinates[i] += 360;
+            }
           }
-        }
-        return lonLatCoordinates;
-      };
+          return lonLatCoordinates;
+        };
+      }
     }
 
     // Transform the extent to get the limits of the view projection extent

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -503,11 +503,14 @@ describe('ol.proj', function () {
       const transformNoWrap = getTransform(merc, 'EPSG:4326', false);
       for (let x = -210; x <= 570; x += 30) {
         const point = transform([x, 0], 'EPSG:4326', merc);
-        expect(point[0]).to.roughlyEqual(((x - 150) * half) / 180, 5e-2);
+        const p0 = ((x - 150) * half) / 180;
+        expect(point[0]).to.roughlyEqual(p0, 5e-2);
         lonLat = transform(point, merc, 'EPSG:4326');
         expect(lonLat[0]).to.roughlyEqual(x, 5e-7);
         expect(lonLat[1]).to.roughlyEqual(0, 1e-9);
-        lonLat = transformNoWrap(point);
+        lonLat = transform([p0, 0], merc, 'EPSG:4326');
+        expect(lonLat[0]).to.roughlyEqual(x, 5e-7);
+        lonLat = transformNoWrap([p0, 0]);
         const lon = ((x + 540) % 360) - 180;
         expect(lonLat[0]).to.roughlyEqual(lon, 5e-7);
       }

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -512,7 +512,12 @@ describe('ol.proj', function () {
         expect(lonLat[0]).to.roughlyEqual(x, 5e-7);
         lonLat = transformNoWrap([p0, 0]);
         const lon = ((x + 540) % 360) - 180;
-        expect(lonLat[0]).to.roughlyEqual(lon, 5e-7);
+        if (Math.abs(lon) == 180) {
+          // with no wrap 180 degrees could be returned as + or -
+          expect(Math.abs(lonLat[0])).to.roughlyEqual(Math.abs(lon), 5e-7);
+        } else {
+          expect(lonLat[0]).to.roughlyEqual(lon, 5e-7);
+        }
       }
     });
 


### PR DESCRIPTION
Fixes #10928

If both projections are set to allow wrapX return an updated transform to handle that similar to the predefined projections, and which is used by default.  `getTransform` has an optional `wrapX` parameter which if false sets the transform to merely normalise the source coordinates before transforming - this might be useful when loading data into a single world of a destination projection where the world is offset from the data source world (a potential follow up might a `readWrapX()` method for formats which support `readProjection()` so features on a wrapping source load into its normal world).

`ol/layer/Graticule` is updated to handle offset projections which were previously assumed to be always non-wrapping.
