### PR TITLE
Do not render tile when there is nothing to render

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -608,6 +608,10 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       const tile = /** @type {import("../../VectorRenderTile.js").default} */ (tiles[
         i
       ]);
+      const executorGroups = tile.executorGroups[getUid(layer)];
+      if (!executorGroups) {
+        continue;
+      }
       const tileCoord = tile.tileCoord;
       const tileExtent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
       const worldOffset =
@@ -629,7 +633,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
           worldOffset
         )
       );
-      const executorGroups = tile.executorGroups[getUid(layer)];
       let clipped = false;
       for (let t = 0, tt = executorGroups.length; t < tt; ++t) {
         const executorGroup = executorGroups[t];


### PR DESCRIPTION
When a VectorTile source is used by more than one layer, an executor group may not exist for a layer that has just been switched from `visible: false` to `visible: true`. That is because the `wantedTiles` frame state is keyed by source, not by layer, and vector tiles have an executor group per layer.

This pull request avoids `cannot read length of undefined` errors when trying to render a tile that has no executor group for the current layer.