### PR TITLE
Apply projection.getMetersPerUnit() to calculated WMTS resolution

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -451,7 +451,8 @@ export function optionsFromCapabilities(wmtsCap, config) {
   const wrapX = false;
 
   const matrix0 = matrixSetObj.TileMatrix[0];
-  const resolution = (matrix0.ScaleDenominator * 0.00028) / projection.getMetersPerUnit(); // WMTS 1.0.0: standardized rendering pixel size
+  const resolution =
+    (matrix0.ScaleDenominator * 0.00028) / projection.getMetersPerUnit(); // WMTS 1.0.0: standardized rendering pixel size
   const origin =
     projection === getProjection('EPSG:4326')
       ? [matrix0.TopLeftCorner[1], matrix0.TopLeftCorner[0]]

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -451,7 +451,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   const wrapX = false;
 
   const matrix0 = matrixSetObj.TileMatrix[0];
-  const resolution = matrix0.ScaleDenominator * 0.00028; // WMTS 1.0.0: standardized rendering pixel size
+  const resolution = (matrix0.ScaleDenominator * 0.00028) / projection.getMetersPerUnit(); // WMTS 1.0.0: standardized rendering pixel size
   const origin =
     projection === getProjection('EPSG:4326')
       ? [matrix0.TopLeftCorner[1], matrix0.TopLeftCorner[0]]

--- a/test/spec/ol/format/wmts/capabilities_wgs84.xml
+++ b/test/spec/ol/format/wmts/capabilities_wgs84.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
+    <ows:ServiceIdentification>
+        <ows:Title>Sample WMTS</ows:Title>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+        <ows:Fees>None</ows:Fees>
+        <ows:AccessConstraints>none</ows:AccessConstraints>
+    </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName></ows:ProviderName>
+        <ows:ProviderSite/>
+        <ows:ServiceContact>
+            <ows:IndividualName></ows:IndividualName>
+            <ows:ContactInfo>
+                <ows:Address>
+                    <ows:City></ows:City>
+                    <ows:Country></ows:Country>
+                    <ows:ElectronicMailAddress></ows:ElectronicMailAddress>
+                </ows:Address>
+            </ows:ContactInfo>
+        </ows:ServiceContact>
+    </ows:ServiceProvider>
+    <Contents>
+        <Layer>
+            <ows:Title>Baselayer</ows:Title>
+            <ows:Abstract>Baselayer</ows:Abstract>
+            <ows:Identifier>baselayer</ows:Identifier>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+                <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::4326">
+                <ows:LowerCorner>-90.0 -180.0</ows:LowerCorner>
+                <ows:UpperCorner>90.0 180.0</ows:UpperCorner>
+            </ows:BoundingBox>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>               
+            <TileMatrixSetLink>
+                <TileMatrixSet>inspire_quad</TileMatrixSet>
+                <TileMatrixSetLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>0</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>1</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>2</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>1</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>2</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>4</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>2</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>4</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>8</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>3</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>8</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>16</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>4</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>16</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>32</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>5</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>32</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>64</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>6</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>64</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>128</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>7</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>128</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>256</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>8</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>256</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>512</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>9</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>512</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>1024</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>10</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>1024</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>2048</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>11</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>2048</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>4096</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>12</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>4096</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>8192</MaxTileCol>
+                    </TileMatrixLimits>
+                </TileMatrixSetLimits>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
+        </Layer>
+        <TileMatrixSet>
+            <ows:Title>InspireCRS84Quad</ows:Title>
+            <ows:Identifier>inspire_quad</ows:Identifier>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::4326</ows:SupportedCRS>
+            <TileMatrix>
+                <ows:Identifier>0</ows:Identifier>
+                <ScaleDenominator>279541132.014357</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2</MatrixWidth>
+                <MatrixHeight>1</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier>
+                <ScaleDenominator>1.3977056600717938E8</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4</MatrixWidth>
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>2</ows:Identifier>
+                <ScaleDenominator>6.988528300358969E7</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8</MatrixWidth>
+                <MatrixHeight>4</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>3</ows:Identifier>
+                <ScaleDenominator>3.4942641501794845E7</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16</MatrixWidth>
+                <MatrixHeight>8</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>4</ows:Identifier>
+                <ScaleDenominator>1.7471320750897422E7</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32</MatrixWidth>
+                <MatrixHeight>16</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>5</ows:Identifier>
+                <ScaleDenominator>8735660.375448711</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>64</MatrixWidth>
+                <MatrixHeight>32</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>6</ows:Identifier>
+                <ScaleDenominator>4367830.187724356</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>128</MatrixWidth>
+                <MatrixHeight>64</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>7</ows:Identifier>
+                <ScaleDenominator>2183915.093862178</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>256</MatrixWidth>
+                <MatrixHeight>128</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>8</ows:Identifier>
+                <ScaleDenominator>1091957.546931089</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>512</MatrixWidth>
+                <MatrixHeight>256</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>9</ows:Identifier>
+                <ScaleDenominator>545978.7734655445</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>1024</MatrixWidth>
+                <MatrixHeight>512</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>10</ows:Identifier>
+                <ScaleDenominator>272989.3867327722</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>2048</MatrixWidth>
+                <MatrixHeight>1024</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>11</ows:Identifier>
+                <ScaleDenominator>136494.6933663861</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>4096</MatrixWidth>
+                <MatrixHeight>2048</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>12</ows:Identifier>
+                <ScaleDenominator>68247.34668319306</ScaleDenominator>
+                <TopLeftCorner>90.0 -180.0</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8192</MatrixWidth>
+                <MatrixHeight>4096</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>       
+    </Contents>
+    <ServiceMetadataURL xlink:href="https://example.com/wmts/1.0.0/WMTSCapabilities.xml"/>
+</Capabilities>

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -349,6 +349,61 @@ describe('ol.source.WMTS', function () {
       );
     });
   });
+  
+  describe('when creating options from wgs84 capabilities', function () {
+    const parser = new WMTSCapabilities();
+    let capabilities, content;
+    before(function (done) {
+      afterLoadText('spec/ol/format/wmts/capabilities_wgs84.xml', function (xml) {
+        try {
+          content = xml;
+          capabilities = parser.read(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+    
+    
+    it('returns correct bounding box', function () {
+        const options = optionsFromCapabilities(capabilities, {
+          layer: 'baselayer',
+          matrixSet: 'inspire_quad',
+          requestEncoding: 'REST',
+        });
+
+        expect(options.urls).to.be.an('array');
+        expect(options.urls).to.have.length(1);
+        expect(options.urls[0]).to.be.eql(
+          'https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png'
+        );
+
+        expect(options.layer).to.be.eql('baselayer');
+
+        expect(options.matrixSet).to.be.eql('inspire_quad');
+
+        expect(options.format).to.be.eql('image/png');
+
+        expect(options.projection).to.be.a(Projection);
+        expect(options.projection).to.be.eql(getProjection('EPSG:4326'));
+
+        expect(options.requestEncoding).to.be.eql('REST');
+
+        expect(options.tileGrid).to.be.a(WMTSTileGrid);
+        expect(options.style).to.be.eql('default');
+
+        const extent = options.tileGrid.getExtent();
+
+        // compare with delta, due to rounding not the exact bounding box is returned...
+        const expectDelta = (value, expected) => expect(Math.abs(value - expected)).to.below(1e-10);
+        
+        expectDelta(extent[0], -180);
+        expectDelta(extent[1], -90);
+        expectDelta(extent[2], 180);
+        expectDelta(extent[3], 90);        
+      });	
+  });
 
   describe('#setUrls()', function () {
     it('sets the URL for the source', function () {
@@ -478,5 +533,6 @@ describe('ol.source.WMTS', function () {
       const requestEncoding = source.getRequestEncoding();
       expect(requestEncoding).to.be.eql('REST');
     });
-  });
+  }); 
+ 
 });

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -349,14 +349,15 @@ describe('ol.source.WMTS', function () {
       );
     });
   });
-  
+
   describe('when creating options from wgs84 capabilities', function () {
     const parser = new WMTSCapabilities();
-    let capabilities, content;
+    let capabilities;
     before(function (done) {
-      afterLoadText('spec/ol/format/wmts/capabilities_wgs84.xml', function (xml) {
+      afterLoadText('spec/ol/format/wmts/capabilities_wgs84.xml', function (
+        xml
+      ) {
         try {
-          content = xml;
           capabilities = parser.read(xml);
         } catch (e) {
           done(e);
@@ -364,45 +365,45 @@ describe('ol.source.WMTS', function () {
         done();
       });
     });
-    
-    
+
     it('returns correct bounding box', function () {
-        const options = optionsFromCapabilities(capabilities, {
-          layer: 'baselayer',
-          matrixSet: 'inspire_quad',
-          requestEncoding: 'REST',
-        });
+      const options = optionsFromCapabilities(capabilities, {
+        layer: 'baselayer',
+        matrixSet: 'inspire_quad',
+        requestEncoding: 'REST',
+      });
 
-        expect(options.urls).to.be.an('array');
-        expect(options.urls).to.have.length(1);
-        expect(options.urls[0]).to.be.eql(
-          'https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png'
-        );
+      expect(options.urls).to.be.an('array');
+      expect(options.urls).to.have.length(1);
+      expect(options.urls[0]).to.be.eql(
+        'https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png'
+      );
 
-        expect(options.layer).to.be.eql('baselayer');
+      expect(options.layer).to.be.eql('baselayer');
 
-        expect(options.matrixSet).to.be.eql('inspire_quad');
+      expect(options.matrixSet).to.be.eql('inspire_quad');
 
-        expect(options.format).to.be.eql('image/png');
+      expect(options.format).to.be.eql('image/png');
 
-        expect(options.projection).to.be.a(Projection);
-        expect(options.projection).to.be.eql(getProjection('EPSG:4326'));
+      expect(options.projection).to.be.a(Projection);
+      expect(options.projection).to.be.eql(getProjection('EPSG:4326'));
 
-        expect(options.requestEncoding).to.be.eql('REST');
+      expect(options.requestEncoding).to.be.eql('REST');
 
-        expect(options.tileGrid).to.be.a(WMTSTileGrid);
-        expect(options.style).to.be.eql('default');
+      expect(options.tileGrid).to.be.a(WMTSTileGrid);
+      expect(options.style).to.be.eql('default');
 
-        const extent = options.tileGrid.getExtent();
+      const extent = options.tileGrid.getExtent();
 
-        // compare with delta, due to rounding not the exact bounding box is returned...
-        const expectDelta = (value, expected) => expect(Math.abs(value - expected)).to.below(1e-10);
-        
-        expectDelta(extent[0], -180);
-        expectDelta(extent[1], -90);
-        expectDelta(extent[2], 180);
-        expectDelta(extent[3], 90);        
-      });	
+      // compare with delta, due to rounding not the exact bounding box is returned...
+      const expectDelta = (value, expected) =>
+        expect(Math.abs(value - expected)).to.below(1e-10);
+
+      expectDelta(extent[0], -180);
+      expectDelta(extent[1], -90);
+      expectDelta(extent[2], 180);
+      expectDelta(extent[3], 90);
+    });
   });
 
   describe('#setUrls()', function () {
@@ -533,6 +534,5 @@ describe('ol.source.WMTS', function () {
       const requestEncoding = source.getRequestEncoding();
       expect(requestEncoding).to.be.eql('REST');
     });
-  }); 
- 
+  });
 });


### PR DESCRIPTION
Fixes #10974

- Applied projection.getMetersPerUnit() to calculated WMTS resolution
- Added a testcase with a WGS84 WMTS capabilities document. 