### PR TITLE
Only render vector tile when there are executor groups

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -210,9 +210,10 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   isDrawableTile(tile) {
     const layer = this.getLayer();
     return (
-      (super.isDrawableTile(tile) &&
-        layer.getRenderMode() === VectorTileRenderType.VECTOR) ||
-      tile.hasContext(layer)
+      super.isDrawableTile(tile) &&
+      (layer.getRenderMode() === VectorTileRenderType.VECTOR
+        ? getUid(layer) in tile.executorGroups
+        : tile.hasContext(layer))
     );
   }
 


### PR DESCRIPTION
This pull request prevents errors when there is no executor group for a tile. This can happen when a vector tile layer is configured with `renderMode: vector` and the source is being used by more than one layer.