### PR TITLE
Calculate WMTS TileGrid extent using TileMatrixSetLimit when available

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -449,14 +449,14 @@ export function optionsFromCapabilities(wmtsCap, config) {
   }
 
   const wrapX = false;
+  const switchOriginXY = projection.getAxisOrientation().substr(0, 2) == 'ne';
 
   const matrix0 = matrixSetObj.TileMatrix[0];
   const resolution =
     (matrix0.ScaleDenominator * 0.00028) / projection.getMetersPerUnit(); // WMTS 1.0.0: standardized rendering pixel size
-  const origin =
-    projection === getProjection('EPSG:4326')
-      ? [matrix0.TopLeftCorner[1], matrix0.TopLeftCorner[0]]
-      : matrix0.TopLeftCorner;
+  const origin = switchOriginXY
+    ? [matrix0.TopLeftCorner[1], matrix0.TopLeftCorner[0]]
+    : matrix0.TopLeftCorner;
   const tileSpanX = matrix0.TileWidth * resolution;
   const tileSpanY = matrix0.TileHeight * resolution;
 

--- a/test/spec/ol/format/wmts/capabilities_wgs84.xml
+++ b/test/spec/ol/format/wmts/capabilities_wgs84.xml
@@ -40,101 +40,122 @@
             <Format>image/png</Format>               
             <TileMatrixSetLink>
                 <TileMatrixSet>inspire_quad</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
+        </Layer>
+        <Layer>
+            <ows:Title>Mean depth full coverage with land coverage</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:Identifier>mean_atlas_land</ows:Identifier>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>-36.0 15.0</ows:LowerCorner>
+                <ows:UpperCorner>43.0 90.0</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::4326">
+                <ows:LowerCorner>14.999942759061003 -36.0</ows:LowerCorner>
+                <ows:UpperCorner>90.0 42.999938986416</ows:UpperCorner>
+            </ows:BoundingBox>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>inspire_quad</TileMatrixSet>
                 <TileMatrixSetLimits>
                     <TileMatrixLimits>
                         <TileMatrix>0</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>1</MaxTileRow>
+                        <MaxTileRow>0</MaxTileRow>
                         <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>2</MaxTileCol>
+                        <MaxTileCol>1</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>1</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>2</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>4</MaxTileCol>
+                        <MaxTileRow>0</MaxTileRow>
+                        <MinTileCol>1</MinTileCol>
+                        <MaxTileCol>2</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>2</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>4</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>8</MaxTileCol>
+                        <MaxTileRow>1</MaxTileRow>
+                        <MinTileCol>3</MinTileCol>
+                        <MaxTileCol>4</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>3</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>8</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>16</MaxTileCol>
+                        <MaxTileRow>3</MaxTileRow>
+                        <MinTileCol>6</MinTileCol>
+                        <MaxTileCol>9</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>4</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>16</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>32</MaxTileCol>
+                        <MaxTileRow>6</MaxTileRow>
+                        <MinTileCol>12</MinTileCol>
+                        <MaxTileCol>19</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>5</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>32</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>64</MaxTileCol>
+                        <MaxTileRow>13</MaxTileRow>
+                        <MinTileCol>25</MinTileCol>
+                        <MaxTileCol>39</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>6</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>64</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>128</MaxTileCol>
+                        <MaxTileRow>26</MaxTileRow>
+                        <MinTileCol>51</MinTileCol>
+                        <MaxTileCol>79</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>7</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>128</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>256</MaxTileCol>
+                        <MaxTileRow>53</MaxTileRow>
+                        <MinTileCol>102</MinTileCol>
+                        <MaxTileCol>158</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>8</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>256</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>512</MaxTileCol>
+                        <MaxTileRow>106</MaxTileRow>
+                        <MinTileCol>204</MinTileCol>
+                        <MaxTileCol>317</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>9</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>512</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>1024</MaxTileCol>
+                        <MaxTileRow>213</MaxTileRow>
+                        <MinTileCol>409</MinTileCol>
+                        <MaxTileCol>634</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>10</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>1024</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>2048</MaxTileCol>
+                        <MaxTileRow>426</MaxTileRow>
+                        <MinTileCol>819</MinTileCol>
+                        <MaxTileCol>1268</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>11</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>2048</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>4096</MaxTileCol>
+                        <MaxTileRow>853</MaxTileRow>
+                        <MinTileCol>1638</MinTileCol>
+                        <MaxTileCol>2537</MaxTileCol>
                     </TileMatrixLimits>
                     <TileMatrixLimits>
                         <TileMatrix>12</TileMatrix>
                         <MinTileRow>0</MinTileRow>
-                        <MaxTileRow>4096</MaxTileRow>
-                        <MinTileCol>0</MinTileCol>
-                        <MaxTileCol>8192</MaxTileCol>
+                        <MaxTileRow>1706</MaxTileRow>
+                        <MinTileCol>3276</MinTileCol>
+                        <MaxTileCol>5074</MaxTileCol>
                     </TileMatrixLimits>
                 </TileMatrixSetLimits>
             </TileMatrixSetLink>
-            <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
+            <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/mean_atlas_land/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
         </Layer>
         <TileMatrixSet>
             <ows:Title>InspireCRS84Quad</ows:Title>

--- a/test/spec/ol/format/wmts/capabilities_with_tilematrixsetlink.xml
+++ b/test/spec/ol/format/wmts/capabilities_with_tilematrixsetlink.xml
@@ -39,9 +39,123 @@
             </Style>
             <Format>image/png</Format>               
             <TileMatrixSetLink>
-                <TileMatrixSet>inspire_quad</TileMatrixSet>     
+                <TileMatrixSet>inspire_quad</TileMatrixSet>
             </TileMatrixSetLink>
             <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/baselayer/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
+        </Layer>
+        <Layer>
+            <ows:Title>Mean depth full coverage with land coverage</ows:Title>
+            <ows:Abstract></ows:Abstract>
+            <ows:Identifier>mean_atlas_land</ows:Identifier>
+            <ows:WGS84BoundingBox>
+                <ows:LowerCorner>-36.0 15.0</ows:LowerCorner>
+                <ows:UpperCorner>43.0 90.0</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::4326">
+                <ows:LowerCorner>14.999942759061003 -36.0</ows:LowerCorner>
+                <ows:UpperCorner>90.0 42.999938986416</ows:UpperCorner>
+            </ows:BoundingBox>
+            <Style>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>inspire_quad</TileMatrixSet>
+                <TileMatrixSetLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>0</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>0</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>1</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>1</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>0</MaxTileRow>
+                        <MinTileCol>1</MinTileCol>
+                        <MaxTileCol>2</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>2</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>1</MaxTileRow>
+                        <MinTileCol>3</MinTileCol>
+                        <MaxTileCol>4</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>3</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>3</MaxTileRow>
+                        <MinTileCol>6</MinTileCol>
+                        <MaxTileCol>9</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>4</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>6</MaxTileRow>
+                        <MinTileCol>12</MinTileCol>
+                        <MaxTileCol>19</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>5</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>13</MaxTileRow>
+                        <MinTileCol>25</MinTileCol>
+                        <MaxTileCol>39</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>6</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>26</MaxTileRow>
+                        <MinTileCol>51</MinTileCol>
+                        <MaxTileCol>79</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>7</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>53</MaxTileRow>
+                        <MinTileCol>102</MinTileCol>
+                        <MaxTileCol>158</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>8</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>106</MaxTileRow>
+                        <MinTileCol>204</MinTileCol>
+                        <MaxTileCol>317</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>9</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>213</MaxTileRow>
+                        <MinTileCol>409</MinTileCol>
+                        <MaxTileCol>634</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>10</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>426</MaxTileRow>
+                        <MinTileCol>819</MinTileCol>
+                        <MaxTileCol>1268</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>11</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>853</MaxTileRow>
+                        <MinTileCol>1638</MinTileCol>
+                        <MaxTileCol>2537</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>12</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>1706</MaxTileRow>
+                        <MinTileCol>3276</MinTileCol>
+                        <MaxTileCol>5074</MaxTileCol>
+                    </TileMatrixLimits>
+                </TileMatrixSetLimits>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://example.com/wmts/mean_atlas_land/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
         </Layer>
         <TileMatrixSet>
             <ows:Title>InspireCRS84Quad</ows:Title>

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -404,6 +404,51 @@ describe('ol.source.WMTS', function () {
       expectDelta(extent[2], 180);
       expectDelta(extent[3], 90);
     });
+
+    it('returns correct bounding box for a layer restricted by TileMatrixSetLink', function () {
+      const options = optionsFromCapabilities(capabilities, {
+        layer: 'mean_atlas_land',
+        matrixSet: 'inspire_quad',
+        requestEncoding: 'REST',
+      });
+
+      expect(options.urls).to.be.an('array');
+      expect(options.urls).to.have.length(1);
+      expect(options.urls[0]).to.be.eql(
+        'https://example.com/wmts/mean_atlas_land/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png'
+      );
+
+      expect(options.layer).to.be.eql('mean_atlas_land');
+
+      expect(options.matrixSet).to.be.eql('inspire_quad');
+
+      expect(options.format).to.be.eql('image/png');
+
+      expect(options.projection).to.be.a(Projection);
+      expect(options.projection).to.be.eql(getProjection('EPSG:4326'));
+
+      expect(options.requestEncoding).to.be.eql('REST');
+
+      expect(options.tileGrid).to.be.a(WMTSTileGrid);
+      expect(options.style).to.be.eql('default');
+
+      const extent = options.tileGrid.getExtent();
+
+      // calculate with of one tile, this will be used as tolerance for result extent
+      const tile_width =
+        ((68247.34668319306 * 0.00028) /
+          getProjection('EPSG:4326').getMetersPerUnit()) *
+        256;
+
+      // compare with delta, due to rounding not the exact bounding box is returned...
+      const expectDelta = (value, expected) =>
+        expect(Math.abs(value - expected)).to.below(tile_width + 1e-10);
+
+      expectDelta(extent[0], -36);
+      expectDelta(extent[1], 15);
+      expectDelta(extent[2], 43);
+      expectDelta(extent[3], 90);
+    });
   });
 
   describe('#setUrls()', function () {

--- a/test/spec/ol/source/wmts.test.js
+++ b/test/spec/ol/source/wmts.test.js
@@ -404,8 +404,26 @@ describe('ol.source.WMTS', function () {
       expectDelta(extent[2], 180);
       expectDelta(extent[3], 90);
     });
+  });
 
-    it('returns correct bounding box for a layer restricted by TileMatrixSetLink', function () {
+  describe('when creating options from capabilities with TileMatrixSetLink', function () {
+    const parser = new WMTSCapabilities();
+    let capabilities;
+    before(function (done) {
+      afterLoadText(
+        'spec/ol/format/wmts/capabilities_with_tilematrixsetlink.xml',
+        function (xml) {
+          try {
+            capabilities = parser.read(xml);
+          } catch (e) {
+            done(e);
+          }
+          done();
+        }
+      );
+    });
+
+    it('returns correct bounding box for a layer', function () {
       const options = optionsFromCapabilities(capabilities, {
         layer: 'mean_atlas_land',
         matrixSet: 'inspire_quad',


### PR DESCRIPTION
Fixes #10979 

I've changed the extent calculation to use the TileMatrixSetLimit of the WMTS Capabilities when available. The most detailed level is used to get the closest possible representation of the extent. 
Extent calculation is unchanged when no TileMatrixSetLimit is defined.

Also, i fixed a potential issue where the switching of XY was only applied for EPSG:4326. Instead, now   ```projection.getAxisOrientation().substr(0, 2) == 'ne' ``` is used, as there are more NE coordinate systems (for example LAEA Lambert / EPSG:3035)

The changed case is covered by a test.  

<sup><sup>(Hopefully the lint won't be upset with me this time 😊, thanks for the pointer in my previous PR 👍, I had some failing tests locally though regarding scale lines. Hopefully this is a local glitch in my development environment )</sup></sup>
