### PR TITLE
Correct bold font tag closure in example description

### DIFF
--- a/examples/disable-image-smoothing.html
+++ b/examples/disable-image-smoothing.html
@@ -6,7 +6,7 @@ docs: >
   Example of disabling image smoothing when using raster DEM (digital elevation model) data.
   The <code>imageSmoothing: false</code> setting is used to disable canvas image smoothing during
   reprojection and rendering. Elevation data is
-  calculated from the pixel value returned by <b>forEachLayerAtPixel<b>. For comparison a second map
+  calculated from the pixel value returned by <b>forEachLayerAtPixel</b>. For comparison a second map
   with smoothing enabled returns inaccuate elevations which are very noticeable close to 3107 meters
   due to how elevation is calculated from the pixel value.
 tags: "disable image smoothing, xyz, maptiler, reprojection"


### PR DESCRIPTION
Avoids bold font persisting through the description due to incorrect tag closure