### PR TITLE
Use brokenDiagonalRendering reprojection processing if image smoothing is disabled

### DIFF
--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/reproj
  */
-import {assign} from './obj.js';
+import {assign, isEmpty} from './obj.js';
 import {
   containsCoordinate,
   createEmpty,
@@ -330,7 +330,7 @@ export function render(
     context.save();
     context.beginPath();
 
-    if (isBrokenDiagonalRendering()) {
+    if (isBrokenDiagonalRendering() || !isEmpty(opt_contextOptions)) {
       // Make sure that everything is on pixel boundaries
       const u0r = pixelRound(u0);
       const v0r = pixelRound(v0);

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -1,7 +1,8 @@
 /**
  * @module ol/reproj
  */
-import {assign, isEmpty} from './obj.js';
+import {IMAGE_SMOOTHING_DISABLED} from './source/common.js';
+import {assign} from './obj.js';
 import {
   containsCoordinate,
   createEmpty,
@@ -330,7 +331,7 @@ export function render(
     context.save();
     context.beginPath();
 
-    if (isBrokenDiagonalRendering() || !isEmpty(opt_contextOptions)) {
+    if (isBrokenDiagonalRendering() || opt_contextOptions === IMAGE_SMOOTHING_DISABLED) {
       // Make sure that everything is on pixel boundaries
       const u0r = pixelRound(u0);
       const v0r = pixelRound(v0);

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -331,7 +331,10 @@ export function render(
     context.save();
     context.beginPath();
 
-    if (isBrokenDiagonalRendering() || opt_contextOptions === IMAGE_SMOOTHING_DISABLED) {
+    if (
+      isBrokenDiagonalRendering() ||
+      opt_contextOptions === IMAGE_SMOOTHING_DISABLED
+    ) {
       // Make sure that everything is on pixel boundaries
       const u0r = pixelRound(u0);
       const v0r = pixelRound(v0);

--- a/src/ol/source/common.js
+++ b/src/ol/source/common.js
@@ -13,9 +13,10 @@ export const DEFAULT_WMS_VERSION = '1.3.0';
  * Context options to disable image smoothing.
  * @type {Object}
  */
-export const IMAGE_SMOOTHING_DISABLED = FIREFOX || SAFARI || WEBKIT
-  ? {imageSmoothingEnabled: false}
-  : {
-    imageSmoothingEnabled: false,
-    msImageSmoothingEnabled: false,
-  };
+export const IMAGE_SMOOTHING_DISABLED =
+  FIREFOX || SAFARI || WEBKIT
+    ? {imageSmoothingEnabled: false}
+    : {
+        imageSmoothingEnabled: false,
+        msImageSmoothingEnabled: false,
+      };

--- a/src/ol/source/common.js
+++ b/src/ol/source/common.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/source/common
  */
-import {FIREFOX, SAFARI, WEBKIT} from '../has.js';
 
 /**
  * Default WMS version.
@@ -13,10 +12,7 @@ export const DEFAULT_WMS_VERSION = '1.3.0';
  * Context options to disable image smoothing.
  * @type {Object}
  */
-export const IMAGE_SMOOTHING_DISABLED =
-  FIREFOX || SAFARI || WEBKIT
-    ? {imageSmoothingEnabled: false}
-    : {
-        imageSmoothingEnabled: false,
-        msImageSmoothingEnabled: false,
-      };
+export const IMAGE_SMOOTHING_DISABLED = {
+  imageSmoothingEnabled: false,
+  msImageSmoothingEnabled: false,
+};

--- a/src/ol/source/common.js
+++ b/src/ol/source/common.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/source/common
  */
+import {FIREFOX, SAFARI, WEBKIT} from '../has.js';
 
 /**
  * Default WMS version.
@@ -12,7 +13,9 @@ export const DEFAULT_WMS_VERSION = '1.3.0';
  * Context options to disable image smoothing.
  * @type {Object}
  */
-export const IMAGE_SMOOTHING_DISABLED = {
-  imageSmoothingEnabled: false,
-  msImageSmoothingEnabled: false,
-};
+export const IMAGE_SMOOTHING_DISABLED = FIREFOX || SAFARI || WEBKIT
+  ? {imageSmoothingEnabled: false}
+  : {
+    imageSmoothingEnabled: false,
+    msImageSmoothingEnabled: false,
+  };


### PR DESCRIPTION
Apply the brokenDiagonalRendering reprojection processing if image smoothing is disabled to avoid the color distortion along reprojection edges which happens with both `source-over` and `lighter` globalCompositeOperation settings.

The distortion can be seen when highlighted by an ol/source/Raster showing odd and even values
![image](https://user-images.githubusercontent.com/49240900/80709114-aeea7900-8ae4-11ea-944a-7b2f366a8ecb.png)
