### PR TITLE
Add log2 function to ol/math

### DIFF
--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -41,6 +41,31 @@ export const cosh = (function () {
 })();
 
 /**
+ * Return the base 2 logarithm of a given number. The method will use the
+ * native `Math.log2` function if it is available, otherwise the base 2
+ * logarithm will be calculated via the reference implementation of the
+ * Mozilla developer network.
+ *
+ * @param {number} x X.
+ * @return {number} Base 2 logarithm of x.
+ */
+export const log2 = (function () {
+  // Wrapped in a iife, to save the overhead of checking for the native
+  // implementation on every invocation.
+  let log2;
+  if ('log2' in Math) {
+    // The environment supports the native Math.log2 function, use it…
+    log2 = Math.log2;
+  } else {
+    // … else, use the reference implementation of MDN:
+    log2 = function (x) {
+      return Math.log(x) * Math.LOG2E;
+    };
+  }
+  return log2;
+})();
+
+/**
  * Returns the square of the closest distance between the point (x, y) and the
  * line segment (x1, y1) to (x2, y2).
  * @param {number} x X.

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -14,7 +14,7 @@ import {
   intersects,
 } from '../extent.js';
 import {getTransform} from '../proj.js';
-import {modulo} from '../math.js';
+import {log2, modulo} from '../math.js';
 
 /**
  * Single triangle; consists of 3 source points and 3 target points.
@@ -169,7 +169,7 @@ class Triangulation {
         ? Math.max(
             0,
             Math.ceil(
-              Math.log2(
+              log2(
                 getArea(targetExtent) /
                   (opt_destinationResolution *
                     opt_destinationResolution *

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -75,7 +75,7 @@ describe('ol.math.log2', function () {
   });
 
   it('returns the correct value at -1', function () {
-    expect(log2(-1)).to.eql(NaN);
+    expect(log2(-1).toString()).to.eql('NaN');
   });
 });
 

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -2,6 +2,7 @@ import {
   clamp,
   cosh,
   lerp,
+  log2,
   modulo,
   solveLinearSystem,
   toDegrees,
@@ -49,6 +50,32 @@ describe('ol.math.cosh', function () {
 
   it('returns the correct value at Infinity', function () {
     expect(cosh(Infinity)).to.eql(Infinity);
+  });
+});
+
+describe('ol.math.log2', function () {
+  it('returns the correct value at Infinity', function () {
+    expect(log2(Infinity)).to.eql(Infinity);
+  });
+
+  it('returns the correct value at 3', function () {
+    expect(log2(3)).to.roughlyEqual(1.584962500721156, 1e-9);
+  });
+
+  it('returns the correct value at 2', function () {
+    expect(log2(2)).to.eql(1);
+  });
+
+  it('returns the correct value at 1', function () {
+    expect(log2(1)).to.eql(0);
+  });
+
+  it('returns the correct value at 0', function () {
+    expect(log2(0)).to.eql(-Infinity);
+  });
+
+  it('returns the correct value at -1', function () {
+    expect(log2(0)).to.eql(NaN);
   });
 });
 

--- a/test/spec/ol/math.test.js
+++ b/test/spec/ol/math.test.js
@@ -75,7 +75,7 @@ describe('ol.math.log2', function () {
   });
 
   it('returns the correct value at -1', function () {
-    expect(log2(0)).to.eql(NaN);
+    expect(log2(-1)).to.eql(NaN);
   });
 });
 


### PR DESCRIPTION
Fixes #10988

Add and test log2 function to replace Math.log2
Replace Math.log2 in ol/reproj/Triangulation.js with the new function
