### PR TITLE
Include context options in tile cache key

### DIFF
--- a/examples/disable-image-smoothing.js
+++ b/examples/disable-image-smoothing.js
@@ -35,7 +35,7 @@ const enabledLayer = new TileLayer({
   source: new XYZ({
     attributions: attributions,
     url:
-      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key;
+      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
     maxZoom: 10,
     crossOrigin: '',
   }),

--- a/examples/disable-image-smoothing.js
+++ b/examples/disable-image-smoothing.js
@@ -35,9 +35,7 @@ const enabledLayer = new TileLayer({
   source: new XYZ({
     attributions: attributions,
     url:
-      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' +
-      key +
-      '&map=2', // dummy parameter added to avoid shared cache
+      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key;
     maxZoom: 10,
     crossOrigin: '',
   }),

--- a/examples/disable-image-smoothing.js
+++ b/examples/disable-image-smoothing.js
@@ -35,7 +35,8 @@ const enabledLayer = new TileLayer({
   source: new XYZ({
     attributions: attributions,
     url:
-      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
+      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key +
+      '&map=2', // dummy parameter added to avoid shared cache
     maxZoom: 10,
     crossOrigin: '',
   }),

--- a/examples/disable-image-smoothing.js
+++ b/examples/disable-image-smoothing.js
@@ -35,7 +35,8 @@ const enabledLayer = new TileLayer({
   source: new XYZ({
     attributions: attributions,
     url:
-      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key +
+      'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' +
+      key +
       '&map=2', // dummy parameter added to avoid shared cache
     maxZoom: 10,
     crossOrigin: '',

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -207,6 +207,18 @@ class TileImage extends UrlTile {
   getGutter() {
     return 0;
   }
+  
+  /**
+   * Return the key to be used for all tiles in the source.
+   * @return {string} The key for all tiles.
+   * @protected
+   */
+  getKey() {
+    return super.getKey() +
+      (this.contextOptions_
+        ? '\n' + JSON.stringify(this.contextOptions_)
+        : '');
+  }
 
   /**
    * @param {import("../proj/Projection.js").default} projection Projection.
@@ -328,11 +340,7 @@ class TileImage extends UrlTile {
       const cache = this.getTileCacheForProjection(projection);
       const tileCoord = [z, x, y];
       let tile;
-      const tileCoordKey =
-        getKey(tileCoord) +
-        (this.contextOptions_
-          ? '\n' + JSON.stringify(this.contextOptions_)
-          : '');
+      const tileCoordKey = getKey(tileCoord);
       if (cache.containsKey(tileCoordKey)) {
         tile = cache.get(tileCoordKey);
       }

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -207,17 +207,17 @@ class TileImage extends UrlTile {
   getGutter() {
     return 0;
   }
-  
+
   /**
    * Return the key to be used for all tiles in the source.
    * @return {string} The key for all tiles.
    * @protected
    */
   getKey() {
-    return super.getKey() +
-      (this.contextOptions_
-        ? '\n' + JSON.stringify(this.contextOptions_)
-        : '');
+    return (
+      super.getKey() +
+      (this.contextOptions_ ? '\n' + JSON.stringify(this.contextOptions_) : '')
+    );
   }
 
   /**

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -332,7 +332,8 @@ class TileImage extends UrlTile {
       if (cache.containsKey(tileCoordKey)) {
         tile = cache.get(tileCoordKey);
       }
-      const key = this.getKey();
+      const key = this.getKey() +
+        (this.contextOptions_ ? '\n' + JSON.stringify(this.contextOptions_) : '');
       if (tile && tile.key == key) {
         return tile;
       } else {

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -328,15 +328,15 @@ class TileImage extends UrlTile {
       const cache = this.getTileCacheForProjection(projection);
       const tileCoord = [z, x, y];
       let tile;
-      const tileCoordKey = getKey(tileCoord);
-      if (cache.containsKey(tileCoordKey)) {
-        tile = cache.get(tileCoordKey);
-      }
-      const key =
-        this.getKey() +
+      const tileCoordKey =
+        getKey(tileCoord) +
         (this.contextOptions_
           ? '\n' + JSON.stringify(this.contextOptions_)
           : '');
+      if (cache.containsKey(tileCoordKey)) {
+        tile = cache.get(tileCoordKey);
+      }
+      const key = this.getKey();
       if (tile && tile.key == key) {
         return tile;
       } else {

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -332,8 +332,11 @@ class TileImage extends UrlTile {
       if (cache.containsKey(tileCoordKey)) {
         tile = cache.get(tileCoordKey);
       }
-      const key = this.getKey() +
-        (this.contextOptions_ ? '\n' + JSON.stringify(this.contextOptions_) : '');
+      const key =
+        this.getKey() +
+        (this.contextOptions_
+          ? '\n' + JSON.stringify(this.contextOptions_)
+          : '');
       if (tile && tile.key == key) {
         return tile;
       } else {


### PR DESCRIPTION
Fixes #10984

It seems two sources using the same URL but different options (e..g. smoothing, cross origin) might be sharing the same internal cache (although that affect should have been seen in all browsers) so a follow up investigation the internal cache can be duplicated if necessary without the performance overhead of overriding browser cache.  The original Chrome issue now appears to be a browser cache problem and is possibly related to hardware acceleration.
