### PR TITLE
Update shelljs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10696,9 +10696,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",


### PR DESCRIPTION
This bumps up the version of shelljs used by shx to avoid warnings like this in Node 14:
```
(Use `node --trace-warnings ...` to show where the warning was created)
(node:16838) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'echo' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'tempdir' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'pwd' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'exec' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'ls' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'find' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'grep' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'head' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'ln' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'mkdir' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'rm' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'mv' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'sed' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'set' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'sort' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'tail' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'test' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'to' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'toEnd' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'touch' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'uniq' of module exports inside circular dependency
(node:16838) Warning: Accessing non-existent property 'which' of module exports inside circular dependency
```

See shelljs/shelljs#991.
