### PR TITLE
Add cache key option to sources which allow tileUrlFunction

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -30,6 +30,7 @@ import {toSize} from '../size.js';
  * @property {number} [cacheSize=128] Cache size.
  * @property {import("../extent.js").Extent} [extent]
  * @property {import("../format/Feature.js").default} [format] Feature format for tiles. Used and required by the default.
+ * @property {string} [key] Optional tile key for proper cache fetching
  * @property {boolean} [overlaps=true] This source may have overlapping geometries. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
@@ -125,6 +126,7 @@ class VectorTile extends UrlTile {
       attributions: options.attributions,
       attributionsCollapsible: options.attributionsCollapsible,
       cacheSize: options.cacheSize,
+      key: options.key,
       opaque: false,
       projection: projection,
       state: options.state,

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -44,6 +44,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
+ * @property {string} [key] Optional tile key for proper cache fetching
  * @property {number} [zDirection=0] Indicate which resolution should be used
  * by a renderer if the view resolution does not match any resolution of the tile source.
  * If 0, the nearest resolution will be used. If 1, the nearest lower resolution
@@ -104,6 +105,7 @@ class XYZ extends TileImage {
       urls: options.urls,
       wrapX: options.wrapX !== undefined ? options.wrapX : true,
       transition: options.transition,
+      key: options.key,
       attributionsCollapsible: options.attributionsCollapsible,
       zDirection: options.zDirection,
     });


### PR DESCRIPTION
Like `ol/source/TileImage` both `ol/soure/XYZ` and `ol/source/VectorTile` allow a `tileUrlFunction` to be specified instead of `url` or `urls`, but they had no option to be specify a cache `key` which therefore always defaulted to an empty string