### PR TITLE
Add MapBrowserPointerEvent to apidoc

### DIFF
--- a/src/ol/MapBrowserPointerEvent.js
+++ b/src/ol/MapBrowserPointerEvent.js
@@ -3,6 +3,10 @@
  */
 import MapBrowserEvent from './MapBrowserEvent.js';
 
+/**
+ * @classdesc
+ * @api
+ */
 class MapBrowserPointerEvent extends MapBrowserEvent {
   /**
    * @param {string} type Event type.


### PR DESCRIPTION
This adds a page for the `ol/MapBrowserPointerEvent` class which is linked to from a few different pages as detailed in #10460.
