### PR TITLE
Fix custom controls with user-provided element

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -48,10 +48,10 @@ class Attribution extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       render: options.render,
       target: options.target,
     });
-    this.createElement();
 
     /**
      * @private

--- a/src/ol/control/Control.js
+++ b/src/ol/control/Control.js
@@ -50,11 +50,16 @@ class Control extends BaseObject {
   constructor(options) {
     super();
 
+    const element = options.element;
+    if (element && !options.target && !element.style.pointerEvents) {
+      element.style.pointerEvents = 'auto';
+    }
+
     /**
      * @protected
      * @type {HTMLElement}
      */
-    this.element = options.element ? options.element : null;
+    this.element = element ? element : null;
 
     /**
      * @private
@@ -81,17 +86,6 @@ class Control extends BaseObject {
     if (options.target) {
       this.setTarget(options.target);
     }
-  }
-
-  /**
-   * Creates the element for this control and sets it on the instance.
-   * @return {HTMLDivElement} Element for this control.
-   */
-  createElement() {
-    const element = document.createElement('div');
-    element.style.pointerEvents = 'auto';
-    this.element = element;
-    return element;
   }
 
   /**

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -72,9 +72,9 @@ class FullScreen extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       target: options.target,
     });
-    this.createElement();
 
     /**
      * @private

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -60,14 +60,15 @@ class MousePosition extends Control {
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
 
+    const element = document.createElement('div');
+    element.className =
+      options.className !== undefined ? options.className : 'ol-mouse-position';
+
     super({
+      element: element,
       render: options.render,
       target: options.target,
     });
-
-    const element = this.createElement();
-    element.className =
-      options.className !== undefined ? options.className : 'ol-mouse-position';
 
     this.addEventListener(
       getChangeEventType(PROJECTION),

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -80,10 +80,10 @@ class OverviewMap extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       render: options.render,
       target: options.target,
     });
-    this.createElement();
 
     /**
      * @private

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -38,10 +38,10 @@ class Rotate extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       render: options.render,
       target: options.target,
     });
-    this.createElement();
 
     const className =
       options.className !== undefined ? options.className : 'ol-rotate';

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -86,10 +86,10 @@ class ScaleLine extends Control {
         : 'ol-scale-line';
 
     super({
+      element: document.createElement('div'),
       render: options.render,
       target: options.target,
     });
-    this.createElement();
 
     /**
      * @private

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -37,9 +37,9 @@ class Zoom extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       target: options.target,
     });
-    this.createElement();
 
     const className =
       options.className !== undefined ? options.className : 'ol-zoom';

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -48,9 +48,9 @@ class ZoomSlider extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       render: options.render,
     });
-    this.createElement();
 
     /**
      * @type {!Array.<import("../events.js").EventsKey>}

--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -33,9 +33,9 @@ class ZoomToExtent extends Control {
     const options = opt_options ? opt_options : {};
 
     super({
+      element: document.createElement('div'),
       target: options.target,
     });
-    this.createElement();
 
     /**
      * @type {?import("../extent.js").Extent}

--- a/test/spec/ol/control/control.test.js
+++ b/test/spec/ol/control/control.test.js
@@ -27,6 +27,30 @@ describe('ol.control.Control', function () {
   });
 });
 
+describe('element', function () {
+  it('sets `pointer-events: auto` for default target', function () {
+    const control = new Control({
+      element: document.createElement('div'),
+    });
+    expect(control.element.style.pointerEvents).to.be('auto');
+  });
+  it('does not set `pointer-events: auto` for custom target', function () {
+    const control = new Control({
+      element: document.createElement('div'),
+      target: document.createElement('div'),
+    });
+    expect(control.element.style.pointerEvents).to.be('');
+  });
+  it('does not override `pointer-events` style', function () {
+    const element = document.createElement('div');
+    element.style.pointerEvents = 'none';
+    const control = new Control({
+      element: element,
+    });
+    expect(control.element.style.pointerEvents).to.be('none');
+  });
+});
+
 describe("ol.control.Control's target", function () {
   describe('target as string or element', function () {
     it('transforms target from string to element', function () {


### PR DESCRIPTION
#10936 broke the [Custom Controls example](https://623-4974939-gh.circle-artifacts.com/0/examples/custom-controls.html): clicking the custom 'N' button does not do anything.

This pull request fixes that by setting the appropriate `pointer-events: auto` style even on a user-provided element, if no other `pointer-events` style is set and no custom `target` is specified.