### PR TITLE
Install headless Chrome dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,16 @@ jobs:
           - v2-dependencies-{{ checksum "package-lock.json" }}
 
       - run:
+          name: Install Headless Chrome Dependencies
+          command: |
+            sudo apt-get install -yq \
+            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
+            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+      - run:
           name: Install Dependencies
           command: npm install
 


### PR DESCRIPTION
The latest advice from CircleCI on trying to fix the issue launching headless Chrome is to add the dependencies used by the [threetreeslight/puppeteer orb](https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer) (see the [troubleshooting doc](https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-on-circleci)).

If this doesn't improve the situation, it might be worth revisiting the decision to run in headless mode in CI (see 8c89e17618e1b0486e7297fb52e35e0eec74dc0e and be17bfe85af859a506862f66cf641873299d0029).  If we do need to run in "headfull" mode, we could also try switching to GitHub actions and using something like [puppeteer-headful](https://github.com/marketplace/actions/puppeteer-headful).
