### PR TITLE
Run tests as a GitHub CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:current-browsers
+      - image: circleci/node:current
 
     working_directory: ~/repo
 
@@ -14,16 +14,6 @@ jobs:
           - v2-dependencies-{{ checksum "package-lock.json" }}
 
       - run:
-          name: Install Headless Chrome Dependencies
-          command: |
-            sudo apt-get install -yq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
-      - run:
           name: Install Dependencies
           command: npm install
 
@@ -31,21 +21,6 @@ jobs:
           paths:
             - node_modules
           key: v2-dependencies-{{ checksum "package-lock.json" }}
-
-      - run:
-          name: Run Tests
-          command: npm test
-
-      - store_artifacts:
-          path: /home/circleci/.npm/_logs
-
-      - store_artifacts:
-          path: coverage/
-          destination: coverage
-
-      - store_artifacts:
-          path: rendering/cases/
-          destination: rendering
 
       - run:
           name: Build Examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,10 @@ jobs:
 
       - name: Run Tests
         run: npm test
+
+      - name: Store Rendering Test Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: rendering-tests
+          path: rendering/cases/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  CI: true
+
+jobs:
+  run:
+    name: Node ${{ matrix.node }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        node:
+          - 14
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+
+      - name: Set Node.js Version
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Tests
+        run: npm test

--- a/rendering/cases/layer-vectortile-rendermode-vector/main.js
+++ b/rendering/cases/layer-vectortile-rendermode-vector/main.js
@@ -27,5 +27,5 @@ new Map({
 
 render({
   message: 'Vector tile layer renders with vector render mode',
-  tolerance: 0.01,
+  tolerance: 0.02,
 });

--- a/rendering/cases/layer-vectortile-rotate-vector/main.js
+++ b/rendering/cases/layer-vectortile-rotate-vector/main.js
@@ -48,4 +48,7 @@ new Map({
   }),
 });
 
-render({message: 'Vector tile layer rotates with vector layer on top'});
+render({
+  message: 'Vector tile layer rotates with vector layer on top',
+  tolerance: 0.01,
+});

--- a/rendering/cases/layer-vectortile-rotate/main.js
+++ b/rendering/cases/layer-vectortile-rotate/main.js
@@ -24,4 +24,4 @@ const map = new Map({
 });
 
 map.getView().setRotation(Math.PI / 4);
-render({message: 'Vector tile layer rotates'});
+render({message: 'Vector tile layer rotates', tolerance: 0.01});

--- a/rendering/cases/layer-vectortile-simple/main.js
+++ b/rendering/cases/layer-vectortile-simple/main.js
@@ -25,5 +25,5 @@ new Map({
 
 render({
   message: 'Vector tile layer renders',
-  tolerance: 0.01,
+  tolerance: 0.02,
 });

--- a/rendering/cases/multiple-layers/main.js
+++ b/rendering/cases/multiple-layers/main.js
@@ -46,4 +46,4 @@ const unmanaged = new VectorLayer({
 });
 unmanaged.setMap(map);
 
-render();
+render({tolerance: 0.01});

--- a/rendering/test.js
+++ b/rendering/test.js
@@ -381,7 +381,7 @@ if (require.main === module) {
     .option('headless', {
       describe: 'Launch Puppeteer in headless mode',
       type: 'boolean',
-      default: false,
+      default: !!process.env.CI,
     })
     .option('puppeteer-args', {
       describe: 'Additional args for Puppeteer',

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = function (karma) {
   karma.set({
-    browsers: ['Chrome'],
+    browsers: [process.env.CI ? 'ChromeHeadless' : 'Chrome'],
     browserDisconnectTolerance: 2,
     frameworks: ['mocha'],
     client: {


### PR DESCRIPTION
This moves tests from CircleCI to GitLab CI.  Examples and API docs are still built on CircleCI because we can easily view those artifacts.  It looks like artifacts uploaded from a GitLab CI workflow can only be downloaded as a zip archive.

I'm encouraged that tests seem to be [passing reliably](https://github.com/openlayers/openlayers/actions?query=branch%3Atest-action) (after adjusting rendering tolerances).