### PR TITLE
Clear event listeners when disposing a raster source.

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -797,6 +797,7 @@ class RasterSource extends ImageSource {
     if (this.processor_) {
       this.processor_.dispose();
     }
+    super.disposeInternal();
   }
 }
 


### PR DESCRIPTION
This was an oversight in #11047.
