### PR TITLE
Build examples and API docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build-package": "npm run transpile && npm run copy-css && node tasks/prepare-package && shx cp README.md build/ol",
     "build-index": "npm run build-package && node tasks/generate-index",
     "build-legacy": "shx rm -rf build && npm run build-index && webpack --config config/webpack-config-legacy-build.js && cleancss --source-map src/ol/ol.css -o build/legacy/ol.css",
+    "build-site": "npm run build-examples && npm run apidoc && mkdir build/site && cp site/index.html build/site && mv build/apidoc build/site/apidoc && mv build/examples build/site/examples",
     "copy-css": "shx cp src/ol/ol.css build/ol/ol.css",
     "transpile": "shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build/ol/src && node tasks/serialize-workers && tsc --project config/tsconfig-build.json",
     "typecheck": "tsc --pretty",

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>OpenLayers</title>
+    <link href='https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
+    <link href='https://openlayers.org/assets/theme/site.css' rel='stylesheet' type='text/css'>
+  </head>
+  <body>
+    <ul>
+      <li><a href="./apidoc/">API Docs</a></li>
+      <li><a href="./examples/">Examples</a></li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
This adds a `build-site` script to the `package.json`.  Initially, this is just a way to [preview examples and API docs](https://deploy-preview-11053--ol-site.netlify.app/) for pull requests as an alternative to using CircleCI for the same.  I think we can extend this into a replacement for the openlayers.github.io repository.  I think this initial step is useful even if we don't have a complete plan for migrating the rest of the site yet.