### PR TITLE
Fix outside window dragging

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1030,14 +1030,17 @@ class PluggableMap extends BaseObject {
               originalEvent.clientY
             );
       if (
-        this.overlayContainerStopEvent_.contains(target) ||
-        !(document.body.contains(target) || rootNode.contains(target))
+        // Do not abort when the pointer is outside the shadow root
+        originalEvent.target !== document.documentElement &&
+        // Abort when target is on overlayContainerStopEvent
+        (this.overlayContainerStopEvent_.contains(target) ||
+          // Abort if the event target is a child of the container that doesn't allow
+          // event propagation or is no longer in the page. It's possible for the target to no longer
+          // be in the page if it has been removed in an event listener, this might happen in a Control
+          // that recreates it's content based on user interaction either manually or via a render
+          // in something like https://reactjs.org/
+          !(document.body.contains(target) || rootNode.contains(target)))
       ) {
-        // Abort if the event target is a child of the container that doesn't allow
-        // event propagation or is no longer in the page. It's possible for the target to no longer
-        // be in the page if it has been removed in an event listener, this might happen in a Control
-        // that recreates it's content based on user interaction either manually or via a render
-        // in something like https://reactjs.org/
         return;
       }
     }

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1031,7 +1031,7 @@ class PluggableMap extends BaseObject {
             );
       if (
         this.overlayContainerStopEvent_.contains(target) ||
-        !(document.body.contains(target) || this.viewport_.contains(target))
+        !(document.body.contains(target) || rootNode.contains(target))
       ) {
         // Abort if the event target is a child of the container that doesn't allow
         // event propagation or is no longer in the page. It's possible for the target to no longer


### PR DESCRIPTION
Fixes #11081.

Before #11024, which introduced the #11081 regression, we checked for
```js
this.viewport_.getRootNode().contains(target)
```

In #11024, this was changed to

```js
this.viewport_.contains(target)
```

This is obviously not the same, and the reason for the problem. Now that we have a `rootNode` calculated already, the fix is easy.