### PR TITLE
No search autocomplete

### DIFF
--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -52,7 +52,7 @@ function listContent(item, title, listItemPrinter) {
 ?>
 <div class="navigation">
     <div class="search">
-        <input id="search" type="text" class="form-control input-sm" placeholder="Search Documentation">
+        <input id="search" type="text" autocomplete="off" class="form-control input-sm" placeholder="Search Documentation">
     </div>
     <ul class="navigation-list search-empty"><?js
         this.nav.forEach(function (item) { ?>

--- a/examples/index.html
+++ b/examples/index.html
@@ -202,7 +202,7 @@
         <div class="display-table pull-left">
           <a class="navbar-brand" href="./"><img class="header-logo" src="./resources/logo-70x70.png">&nbsp;OpenLayers</a>
           <form class="navbar-form" role="search">
-            <input name="q" type="text" id="keywords" class="search-query" placeholder="Search" autofocus>
+            <input name="q" type="text" id="keywords" class="search-query" placeholder="Search" autocomplete="off" autofocus>
             <span id="count"></span>
           </form>
         </div>


### PR DESCRIPTION
When searching the API or examples index, the browser's input field autocomplete can make typing keywords an annoying experience. This pull request turns the browser autocomplete off for these input fields.