### PR TITLE
Use drag-pan default condition with onFocusOnly

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -14,6 +14,29 @@ import {assert} from '../asserts.js';
  */
 
 /**
+ * Creates a condition function that is only fulfilled when a chain of conditions pass.
+ * @param {...Condition} var_args Conditions to check.
+ * @return {Condition} Condition function that checks a chain of conditions.
+ */
+export function chain(var_args) {
+  const conditions = arguments;
+  /**
+   * @param {import("../MapBrowserEvent.js").default} event Event.
+   * @return {boolean} All conditions passed.
+   */
+  return function (event) {
+    let pass = true;
+    for (let i = 0, ii = conditions.length; i < ii; ++i) {
+      pass = pass && conditions[i](event);
+      if (!pass) {
+        break;
+      }
+    }
+    return pass;
+  };
+}
+
+/**
  * Return `true` if only the alt-key is pressed, `false` otherwise (e.g. when
  * additionally the shift-key is pressed).
  *

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -14,11 +14,11 @@ import {assert} from '../asserts.js';
  */
 
 /**
- * Creates a condition function that is only fulfilled when a chain of conditions pass.
+ * Creates a condition function that passes when all provided conditions pass.
  * @param {...Condition} var_args Conditions to check.
- * @return {Condition} Condition function that checks a chain of conditions.
+ * @return {Condition} Condition function.
  */
-export function chain(var_args) {
+export function all(var_args) {
   const conditions = arguments;
   /**
    * @param {import("../MapBrowserEvent.js").default} event Event.

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -3,7 +3,9 @@
  */
 import Collection from './Collection.js';
 import DoubleClickZoom from './interaction/DoubleClickZoom.js';
-import DragPan from './interaction/DragPan.js';
+import DragPan, {
+  defaultCondition as dragPanDefaultCondition,
+} from './interaction/DragPan.js';
 import DragRotate from './interaction/DragRotate.js';
 import DragZoom from './interaction/DragZoom.js';
 import KeyboardPan from './interaction/KeyboardPan.js';
@@ -112,7 +114,11 @@ export function defaults(opt_options) {
   if (dragPan) {
     interactions.push(
       new DragPan({
-        condition: options.onFocusOnly ? focusWithTabindex : undefined,
+        condition: options.onFocusOnly
+          ? function (event) {
+              return focusWithTabindex(event) && dragPanDefaultCondition(event);
+            }
+          : undefined,
         kinetic: kinetic,
       })
     );

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -3,9 +3,7 @@
  */
 import Collection from './Collection.js';
 import DoubleClickZoom from './interaction/DoubleClickZoom.js';
-import DragPan, {
-  defaultCondition as dragPanDefaultCondition,
-} from './interaction/DragPan.js';
+import DragPan from './interaction/DragPan.js';
 import DragRotate from './interaction/DragRotate.js';
 import DragZoom from './interaction/DragZoom.js';
 import KeyboardPan from './interaction/KeyboardPan.js';
@@ -14,7 +12,6 @@ import Kinetic from './Kinetic.js';
 import MouseWheelZoom from './interaction/MouseWheelZoom.js';
 import PinchRotate from './interaction/PinchRotate.js';
 import PinchZoom from './interaction/PinchZoom.js';
-import {focusWithTabindex} from './events/condition.js';
 
 export {default as DoubleClickZoom} from './interaction/DoubleClickZoom.js';
 export {default as DragAndDrop} from './interaction/DragAndDrop.js';
@@ -114,11 +111,7 @@ export function defaults(opt_options) {
   if (dragPan) {
     interactions.push(
       new DragPan({
-        condition: options.onFocusOnly
-          ? function (event) {
-              return focusWithTabindex(event) && dragPanDefaultCondition(event);
-            }
-          : undefined,
+        onFocusOnly: options.onFocusOnly,
         kinetic: kinetic,
       })
     );
@@ -155,7 +148,7 @@ export function defaults(opt_options) {
   if (mouseWheelZoom) {
     interactions.push(
       new MouseWheelZoom({
-        condition: options.onFocusOnly ? focusWithTabindex : undefined,
+        onFocusOnly: options.onFocusOnly,
         duration: options.zoomDuration,
       })
     );

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -6,7 +6,7 @@ import PointerInteraction, {
 } from './Pointer.js';
 import {FALSE} from '../functions.js';
 import {
-  chain,
+  all,
   focusWithTabindex,
   noModifierKeys,
   primaryAction,
@@ -66,14 +66,14 @@ class DragPan extends PointerInteraction {
 
     const condition = options.condition
       ? options.condition
-      : chain(noModifierKeys, primaryAction);
+      : all(noModifierKeys, primaryAction);
 
     /**
      * @private
      * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.onFocusOnly
-      ? chain(focusWithTabindex, condition)
+      ? all(focusWithTabindex, condition)
       : condition;
 
     /**

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -179,7 +179,7 @@ class DragPan extends PointerInteraction {
  * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Browser event.
  * @return {boolean} Combined condition result.
  */
-function defaultCondition(mapBrowserEvent) {
+export function defaultCondition(mapBrowserEvent) {
   return noModifierKeys(mapBrowserEvent) && primaryAction(mapBrowserEvent);
 }
 

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -5,8 +5,13 @@ import PointerInteraction, {
   centroid as centroidFromPointers,
 } from './Pointer.js';
 import {FALSE} from '../functions.js';
+import {
+  chain,
+  focusWithTabindex,
+  noModifierKeys,
+  primaryAction,
+} from '../events/condition.js';
 import {easeOut} from '../easing.js';
-import {noModifierKeys, primaryAction} from '../events/condition.js';
 import {
   rotate as rotateCoordinate,
   scale as scaleCoordinate,
@@ -17,8 +22,8 @@ import {
  * @property {import("../events/condition.js").Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
  * Default is {@link module:ol/events/condition~noModifierKeys} and {@link module:ol/events/condition~primaryAction}.
- * In addition, if there is a `tabindex` attribute on the map element,
- * {@link module:ol/events/condition~focus} will also be applied.
+ * @property {boolean} [onFocusOnly=false] When the map's target has a `tabindex` attribute set,
+ * the interaction will only handle events when the map has the focus.
  * @property {import("../Kinetic.js").default} [kinetic] Kinetic inertia to apply to the pan.
  */
 
@@ -59,11 +64,17 @@ class DragPan extends PointerInteraction {
      */
     this.panning_ = false;
 
+    const condition = options.condition
+      ? options.condition
+      : chain(noModifierKeys, primaryAction);
+
     /**
      * @private
      * @type {import("../events/condition.js").Condition}
      */
-    this.condition_ = options.condition ? options.condition : defaultCondition;
+    this.condition_ = options.onFocusOnly
+      ? chain(focusWithTabindex, condition)
+      : condition;
 
     /**
      * @private
@@ -173,14 +184,6 @@ class DragPan extends PointerInteraction {
       return false;
     }
   }
-}
-
-/**
- * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Browser event.
- * @return {boolean} Combined condition result.
- */
-export function defaultCondition(mapBrowserEvent) {
-  return noModifierKeys(mapBrowserEvent) && primaryAction(mapBrowserEvent);
 }
 
 export default DragPan;

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -4,7 +4,7 @@
 import EventType from '../events/EventType.js';
 import Interaction, {zoomByDelta} from './Interaction.js';
 import {DEVICE_PIXEL_RATIO, FIREFOX} from '../has.js';
-import {always} from '../events/condition.js';
+import {always, chain, focusWithTabindex} from '../events/condition.js';
 import {clamp} from '../math.js';
 
 /**
@@ -21,8 +21,8 @@ export const Mode = {
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
  * {@link module:ol/events/condition~always}.
- * In addition, if there is a `tabindex` attribute on the map element,
- * {@link module:ol/events/condition~focus} will also be applied.
+ * @property {boolean} [onFocusOnly=false] When the map's target has a `tabindex` attribute set,
+ * the interaction will only handle events when the map has the focus.
  * @property {number} [maxDelta=1] Maximum mouse wheel delta.
  * @property {number} [duration=250] Animation duration in milliseconds.
  * @property {number} [timeout=80] Mouse wheel timeout duration in milliseconds.
@@ -96,11 +96,15 @@ class MouseWheelZoom extends Interaction {
         ? options.constrainResolution
         : false;
 
+    const condition = options.condition ? options.condition : always;
+
     /**
      * @private
      * @type {import("../events/condition.js").Condition}
      */
-    this.condition_ = options.condition ? options.condition : always;
+    this.condition_ = options.onFocusOnly
+      ? chain(focusWithTabindex, condition)
+      : condition;
 
     /**
      * @private

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -4,7 +4,7 @@
 import EventType from '../events/EventType.js';
 import Interaction, {zoomByDelta} from './Interaction.js';
 import {DEVICE_PIXEL_RATIO, FIREFOX} from '../has.js';
-import {always, chain, focusWithTabindex} from '../events/condition.js';
+import {all, always, focusWithTabindex} from '../events/condition.js';
 import {clamp} from '../math.js';
 
 /**
@@ -103,7 +103,7 @@ class MouseWheelZoom extends Interaction {
      * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.onFocusOnly
-      ? chain(focusWithTabindex, condition)
+      ? all(focusWithTabindex, condition)
       : condition;
 
     /**

--- a/test/spec/ol/map.test.js
+++ b/test/spec/ol/map.test.js
@@ -1,5 +1,7 @@
 import DoubleClickZoom from '../../../src/ol/interaction/DoubleClickZoom.js';
-import DragPan from '../../../src/ol/interaction/DragPan.js';
+import DragPan, {
+  defaultCondition,
+} from '../../../src/ol/interaction/DragPan.js';
 import Feature from '../../../src/ol/Feature.js';
 import GeoJSON from '../../../src/ol/format/GeoJSON.js';
 import ImageLayer from '../../../src/ol/layer/Image.js';
@@ -743,13 +745,13 @@ describe('ol.Map', function () {
         const interactions = defaultInteractions(options);
         expect(interactions.getLength()).to.eql(1);
         expect(interactions.item(0)).to.be.a(DragPan);
-        expect(interactions.item(0).condition_).to.not.be(focusWithTabindex);
+        expect(interactions.item(0).condition_).to.be(defaultCondition);
       });
-      it('uses the focus condition when onFocusOnly option is set', function () {
+      it('does not use the default condition when onFocusOnly option is set', function () {
         options.onFocusOnly = true;
         options.dragPan = true;
         const interactions = defaultInteractions(options);
-        expect(interactions.item(0).condition_).to.be(focusWithTabindex);
+        expect(interactions.item(0).condition_).to.not.be(defaultCondition);
       });
     });
 


### PR DESCRIPTION
Fixes #11162.

I think the most convenient way to conditionally apply different conditions is to have a `chain(...conditions)` function. This pull request introduces such a function internally, and it also adds `onFocusOnly` options to the `DragPan` and `MousewheelZoom` interactions. This should make it easier for users to configure these interactions properly, in cases like the one described in #11102.