### PR TITLE
Allow using un() for events registered with once()

### DIFF
--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -78,16 +78,18 @@ class Observable extends EventTarget {
    * @api
    */
   once(type, listener) {
+    let key;
     if (Array.isArray(type)) {
       const len = type.length;
-      const keys = new Array(len);
+      key = new Array(len);
       for (let i = 0; i < len; ++i) {
-        keys[i] = listenOnce(this, type[i], listener);
+        key[i] = listenOnce(this, type[i], listener);
       }
-      return keys;
     } else {
-      return listenOnce(this, /** @type {string} */ (type), listener);
+      key = listenOnce(this, /** @type {string} */ (type), listener);
     }
+    /** @type {Object} */ (listener).ol_key = key;
+    return key;
   }
 
   /**
@@ -97,7 +99,10 @@ class Observable extends EventTarget {
    * @api
    */
   un(type, listener) {
-    if (Array.isArray(type)) {
+    const key = /** @type {Object} */ (listener).ol_key;
+    if (key) {
+      unByKey(key);
+    } else if (Array.isArray(type)) {
       for (let i = 0, ii = type.length; i < ii; ++i) {
         this.removeEventListener(type[i], listener);
       }

--- a/test/spec/ol/observable.test.js
+++ b/test/spec/ol/observable.test.js
@@ -97,6 +97,13 @@ describe('ol.Observable', function () {
 
       expect(typeof key).to.be('object');
     });
+
+    it('can be unregistered with un()', function () {
+      observable.once('foo', listener);
+      observable.un('foo', listener);
+      observable.dispatchEvent('foo');
+      expect(listener.callCount).to.be(0);
+    });
   });
 
   describe('#un()', function () {


### PR DESCRIPTION
Fixes #11147.