### PR TITLE
Remove elm-pep dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ TypeScript users may want to use a [third-party types package](https://github.co
 
 ## Supported Browsers
 
-OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, [polyfills](http://polyfill.io) for `requestAnimationFrame` and `Element.prototype.classList` are required, and using the KML format requires a polyfill for `URL`.
+OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/). This includes Chrome, Firefox, Safari and Edge.
+
+For older browsers and platforms (Internet Explorer, Android 4.x, iOS v12 and older, Safari v12 and older), polyfills may be needed for the following browser features:
+
+* [`requestAnimationFrame`](https://caniuse.com/#feat=requestanimationframe): Available from [polyfill.io](https://polyfill.io/).
+* [`element.prototype.classList` (`add`/`remove`)](https://caniuse.com/#feat=classlist): Available from [polyfill.io](https://polyfill.io/).
+* [`URL` API](https://caniuse.com/#feat=url): Available from [polyfill.io](https://polyfill.io/).
+* [Pointer events](https://caniuse.com/#feat=pointer): Use [elm-pep](https://npmjs.com/package/elm-pep) (lightweight) or [@openlayers/pepjs](https://npmjs.com/package/pepjs) (for really, really old browsers).
 
 ## Documentation
 

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,11 @@
 ## Upgrade notes
 
+### v6.4.0
+
+#### Pointer events polyfill removed
+
+Now that all major browsers support Pointer events natively, we removed the [elm-pep](https://npmjs.com/package/elm-pep) dependency. If you are targeting older browsers that do not have Pointer events, you now need to include the polyfill in your application.
+
 ### v6.3.2
 
 #### Backwards incompatible changes

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -68,6 +68,7 @@
     <link rel="stylesheet" href="./css/ol.css" type="text/css">
     <link rel="stylesheet" href="./resources/layout.css" type="text/css">
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"></script>
+    <script src="https://unpkg.com/elm-pep"></script>
     {{{ extraHead.local }}}
     {{{ css.tag }}}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
@@ -147,7 +148,9 @@
   &lt;head&gt;
     &lt;title&gt;{{ title }}&lt;/title&gt;
     &lt;!-- The line below is only needed for old environments like Internet Explorer and Android 4.x --&gt;
-    &lt;script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"&gt;&lt;/script&gt;{{#if extraHead.remote}}
+    &lt;script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL"&gt;&lt;/script&gt;
+    &lt;!-- Pointer events polyfill for old browsers, seehttps://caniuse.com/#feat=pointer --&gt;
+    &lt;script src="https://unpkg.com/elm-pep"&gt;&lt;/script&gt;{{#if extraHead.remote}}
 {{ indent extraHead.remote spaces=4 }}{{/if}}
     &lt;style&gt;
       .map {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5081,11 +5081,6 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
-    "elm-pep": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/elm-pep/-/elm-pep-1.0.6.tgz",
-      "integrity": "sha512-1DJ6ReFk8+GtgoqRiEhBo28K69Rxe9Bfc7h16+1VMQT2KlCuPBYj5W33OYa2AZpqkuqCBLhcNzO10zxJVakapA=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "url": "https://opencollective.com/openlayers"
   },
   "dependencies": {
-    "elm-pep": "^1.0.4",
     "ol-mapbox-style": "^6.1.1",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -2,7 +2,6 @@
  * @module ol/MapBrowserEventHandler
  */
 
-import 'elm-pep';
 import EventTarget from './events/Target.js';
 import EventType from './events/EventType.js';
 import MapBrowserEvent from './MapBrowserEvent.js';

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -2,7 +2,6 @@
  * @module ol/control/MousePosition
  */
 
-import 'elm-pep';
 import Control from './Control.js';
 import EventType from '../pointer/EventType.js';
 import {getChangeEventType} from '../Object.js';

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -2,7 +2,6 @@
  * @module ol/control/ZoomSlider
  */
 
-import 'elm-pep';
 import Control from './Control.js';
 import EventType from '../events/EventType.js';
 import PointerEventType from '../pointer/EventType.js';


### PR DESCRIPTION
This pull request removes the elm-pep dependency, assuming that most users will not need a pointer events polyfill any more. Of course it is still possible to add a pointer events polyfill on the application level, if support for old browsers is desired.

Fixes #11138