### PR TITLE
ol/geom/LineString#getCoordinateAt() to return Z and M values if available

### DIFF
--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -211,7 +211,8 @@ class LineString extends SimpleGeometry {
       this.flatCoordinates.length,
       this.stride,
       fraction,
-      opt_dest
+      opt_dest,
+      this.stride
     );
   }
 

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -11,6 +11,7 @@ import {lerp} from '../../math.js';
  * @param {number} stride Stride.
  * @param {number} fraction Fraction.
  * @param {Array<number>=} opt_dest Destination.
+ * @param {number=} opt_dimension Destination dimension (default is `2`)
  * @return {Array<number>} Destination.
  */
 export function interpolatePoint(
@@ -19,21 +20,16 @@ export function interpolatePoint(
   end,
   stride,
   fraction,
-  opt_dest
+  opt_dest,
+  opt_dimension
 ) {
-  let pointX = NaN;
-  let pointY = NaN;
+  let o, t;
   const n = (end - offset) / stride;
   if (n === 1) {
-    pointX = flatCoordinates[offset];
-    pointY = flatCoordinates[offset + 1];
-  } else if (n == 2) {
-    pointX =
-      (1 - fraction) * flatCoordinates[offset] +
-      fraction * flatCoordinates[offset + stride];
-    pointY =
-      (1 - fraction) * flatCoordinates[offset + 1] +
-      fraction * flatCoordinates[offset + stride + 1];
+    o = offset;
+  } else if (n === 2) {
+    o = offset;
+    t = fraction;
   } else if (n !== 0) {
     let x1 = flatCoordinates[offset];
     let y1 = flatCoordinates[offset + 1];
@@ -50,24 +46,25 @@ export function interpolatePoint(
     const target = fraction * length;
     const index = binarySearch(cumulativeLengths, target);
     if (index < 0) {
-      const t =
+      t =
         (target - cumulativeLengths[-index - 2]) /
         (cumulativeLengths[-index - 1] - cumulativeLengths[-index - 2]);
-      const o = offset + (-index - 2) * stride;
-      pointX = lerp(flatCoordinates[o], flatCoordinates[o + stride], t);
-      pointY = lerp(flatCoordinates[o + 1], flatCoordinates[o + stride + 1], t);
+      o = offset + (-index - 2) * stride;
     } else {
-      pointX = flatCoordinates[offset + index * stride];
-      pointY = flatCoordinates[offset + index * stride + 1];
+      o = offset + index * stride;
     }
   }
-  if (opt_dest) {
-    opt_dest[0] = pointX;
-    opt_dest[1] = pointY;
-    return opt_dest;
-  } else {
-    return [pointX, pointY];
+  const dimension = opt_dimension > 1 ? opt_dimension : 2;
+  const dest = opt_dest ? opt_dest : new Array(dimension);
+  for (let i = 0; i < dimension; ++i) {
+    dest[i] =
+      o === undefined
+        ? NaN
+        : t === undefined
+        ? flatCoordinates[o + i]
+        : lerp(flatCoordinates[o + i], flatCoordinates[o + stride + i], t);
   }
+  return dest;
 }
 
 /**

--- a/test/spec/ol/geom/linestring.test.js
+++ b/test/spec/ol/geom/linestring.test.js
@@ -427,6 +427,12 @@ describe('ol.geom.LineString', function () {
       );
     });
 
+    describe('#getCoordinateAt', function () {
+      it('returns the expected value', function () {
+        expect(lineString.getCoordinateAt(0.5)).to.eql([2.5, 3.5, 4.5]);
+      });
+    });
+
     describe('#getCoordinateAtM', function () {
       it('returns the expected value', function () {
         expect(lineString.getCoordinateAtM(2, false)).to.be(null);
@@ -461,6 +467,12 @@ describe('ol.geom.LineString', function () {
         [18, -18, 36, 18],
         [22, -22, 44, 22],
       ]);
+    });
+
+    describe('#getCoordinateAt', function () {
+      it('returns the expected value', function () {
+        expect(lineString.getCoordinateAt(0.5)).to.eql([11, -11, 22, 11]);
+      });
     });
 
     describe('#getCoordinateAtM', function () {


### PR DESCRIPTION
Fixes #11177

Add option for `ol/geom/flat/interpolate#interpolatePoint` to interpolate all dimensions in the stride to make `getCoordinateAt()` consistent with other API methods.  Keep the default behaviour of `interpolatePoint` as returning 2 dimensions for compatibility with internal methods such as `getFlatMidpoints`.
