### PR TITLE
getExtent() to return getEmpty() if geometry is unprojectable

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -8,7 +8,12 @@ import {
   compose as composeTransform,
   create as createTransform,
 } from '../transform.js';
-import {createEmpty, getHeight, returnOrUpdate} from '../extent.js';
+import {
+  containsExtent,
+  createEmpty,
+  getHeight,
+  returnOrUpdate,
+} from '../extent.js';
 import {get as getProjection, getTransform} from '../proj.js';
 import {memoizeOne} from '../functions.js';
 import {transform2D} from './flat/transform.js';
@@ -170,6 +175,11 @@ class Geometry extends BaseObject {
   getExtent(opt_extent) {
     if (this.extentRevision_ != this.getRevision()) {
       this.extent_ = this.computeExtent(this.extent_);
+      if (
+        !containsExtent([-Infinity, -Infinity, Infinity, Infinity], this.extent_)
+      ) {
+        this.extent_ = createEmpty();
+      }
       this.extentRevision_ = this.getRevision();
     }
     return returnOrUpdate(this.extent_, opt_extent);

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -176,7 +176,10 @@ class Geometry extends BaseObject {
     if (this.extentRevision_ != this.getRevision()) {
       this.extent_ = this.computeExtent(this.extent_);
       if (
-        !containsExtent([-Infinity, -Infinity, Infinity, Infinity], this.extent_)
+        !containsExtent(
+          [-Infinity, -Infinity, Infinity, Infinity],
+          this.extent_
+        )
       ) {
         this.extent_ = createEmpty();
       }

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -9,8 +9,8 @@ import {
   create as createTransform,
 } from '../transform.js';
 import {
-  containsExtent,
   createEmpty,
+  createOrUpdateEmpty,
   getHeight,
   returnOrUpdate,
 } from '../extent.js';
@@ -174,14 +174,9 @@ class Geometry extends BaseObject {
    */
   getExtent(opt_extent) {
     if (this.extentRevision_ != this.getRevision()) {
-      this.extent_ = this.computeExtent(this.extent_);
-      if (
-        !containsExtent(
-          [-Infinity, -Infinity, Infinity, Infinity],
-          this.extent_
-        )
-      ) {
-        this.extent_ = createEmpty();
+      const extent = this.computeExtent(this.extent_);
+      if (isNaN(extent[0]) || isNaN(extent[1])) {
+        createOrUpdateEmpty(extent);
       }
       this.extentRevision_ = this.getRevision();
     }


### PR DESCRIPTION
Fixes #11175

Return getEmpty() if unprojectable geometry coordinates have been correctly transformed to NaN to prevent the entire source extent being "tainted" and to allow projectable features to be rendered.

