### PR TITLE
getFeatures() uses wrong transforms after resetting rotation

### DIFF
--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -150,6 +150,21 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
         function () {
           if (image.getState() === ImageState.LOADED) {
             this.image_ = image;
+            const imageResolution = image.getResolution();
+            const imagePixelRatio = image.getPixelRatio();
+            const renderedResolution =
+              (imageResolution * pixelRatio) / imagePixelRatio;
+            this.renderedResolution = renderedResolution;
+            this.coordinateToVectorPixelTransform_ = compose(
+              this.coordinateToVectorPixelTransform_,
+              width / 2,
+              height / 2,
+              1 / renderedResolution,
+              -1 / renderedResolution,
+              0,
+              -viewState.center[0],
+              -viewState.center[1]
+            );
           }
         }.bind(this)
       );
@@ -157,23 +172,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
     }
 
     if (this.image_) {
-      const image = this.image_;
-      const imageResolution = image.getResolution();
-      const imagePixelRatio = image.getPixelRatio();
-      const renderedResolution =
-        (imageResolution * pixelRatio) / imagePixelRatio;
-      this.renderedResolution = renderedResolution;
       this.renderedPixelToCoordinateTransform_ = frameState.pixelToCoordinateTransform.slice();
-      this.coordinateToVectorPixelTransform_ = compose(
-        this.coordinateToVectorPixelTransform_,
-        width / 2,
-        height / 2,
-        1 / renderedResolution,
-        -1 / renderedResolution,
-        0,
-        -viewState.center[0],
-        -viewState.center[1]
-      );
     }
 
     return !!this.image_;

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -318,6 +318,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       container.style.opacity = opacity === 1 ? '' : String(opacity);
     }
 
+    if (this.renderedRotation_ !== viewState.rotation) {
+      this.renderedRotation_ = viewState.rotation;
+      this.hitDetectionImageData_ = null;
+    }
     return this.container;
   }
 
@@ -660,7 +664,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     this.renderedRevision_ = vectorLayerRevision;
     this.renderedRenderOrder_ = vectorLayerRenderOrder;
     this.renderedExtent_ = extent;
-    this.renderedRotation_ = viewState.rotation;
     this.renderedCenter_ = center;
     this.renderedProjection_ = projection;
     this.replayGroup_ = executorGroup;


### PR DESCRIPTION
This pull request moves transform calculations and code that clears existing hit images to the correct places to make sure the correct transforms are used.

The issue can be seen in the https://openlayers.org/en/main/examples/hitdetect-vector.html example: when rotating the map (not too much - less than 45 degrees), a new canvas will be created to accommodate the bigger image needed for the rotated extent. So a new hit image will be created. But when resetting the rotation, that canvas will still be used because because it fits the non-rotated extent. From this moment on the hit image is wrong until the map is panned or zoomed.