### PR TITLE
Make proj4 transforms behave like built-in transforms

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -410,17 +410,22 @@ export function toStringXY(coordinate, opt_fractionDigits) {
  * @return {Coordinate} The coordinate within the real world extent.
  */
 export function wrapX(coordinate, projection) {
-  const projectionExtent = projection.getExtent();
-  if (
-    projection.canWrapX() &&
-    (coordinate[0] < projectionExtent[0] ||
-      coordinate[0] >= projectionExtent[2])
-  ) {
-    const worldWidth = getWidth(projectionExtent);
-    const worldsAway = Math.floor(
-      (coordinate[0] - projectionExtent[0]) / worldWidth
-    );
-    coordinate[0] -= worldsAway * worldWidth;
+  const worldsAway = getWorldsAway(coordinate, projection);
+  if (worldsAway) {
+    coordinate[0] -= worldsAway * getWidth(projection.getExtent());
   }
   return coordinate;
+}
+
+export function getWorldsAway(coordinate, projection) {
+  const projectionExtent = projection.getExtent();
+  let worldsAway = 0;
+  if (
+    projection.canWrapX() &&
+    (coordinate[0] < projectionExtent[0] || coordinate[0] > projectionExtent[2])
+  ) {
+    const worldWidth = getWidth(projectionExtent);
+    worldsAway = Math.floor((coordinate[0] - projectionExtent[0]) / worldWidth);
+  }
+  return worldsAway;
 }

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -406,26 +406,35 @@ export function toStringXY(coordinate, opt_fractionDigits) {
  * exclusive.
  *
  * @param {Coordinate} coordinate Coordinate.
- * @param {import("./proj/Projection.js").default} projection Projection
+ * @param {import("./proj/Projection.js").default} projection Projection.
  * @return {Coordinate} The coordinate within the real world extent.
  */
 export function wrapX(coordinate, projection) {
-  const worldsAway = getWorldsAway(coordinate, projection);
+  const worldWidth = getWidth(projection.getExtent());
+  const worldsAway = getWorldsAway(coordinate, projection, worldWidth);
   if (worldsAway) {
-    coordinate[0] -= worldsAway * getWidth(projection.getExtent());
+    coordinate[0] -= worldsAway * worldWidth;
   }
   return coordinate;
 }
-
-export function getWorldsAway(coordinate, projection) {
+/**
+ * @param {Coordinate} coordinate Coordinate.
+ * @param {import("./proj/Projection.js").default} projection Projection.
+ * @param {number=} opt_sourceExtentWidth Width of the source extent.
+ * @return {number} Offset in world widths.
+ */
+export function getWorldsAway(coordinate, projection, opt_sourceExtentWidth) {
   const projectionExtent = projection.getExtent();
   let worldsAway = 0;
   if (
     projection.canWrapX() &&
     (coordinate[0] < projectionExtent[0] || coordinate[0] > projectionExtent[2])
   ) {
-    const worldWidth = getWidth(projectionExtent);
-    worldsAway = Math.floor((coordinate[0] - projectionExtent[0]) / worldWidth);
+    const sourceExtentWidth =
+      opt_sourceExtentWidth || getWidth(projectionExtent);
+    worldsAway = Math.floor(
+      (coordinate[0] - projectionExtent[0]) / sourceExtentWidth
+    );
   }
   return worldsAway;
 }

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -71,7 +71,14 @@ import {
   clear as clearTransformFuncs,
   get as getTransformFunc,
 } from './proj/transforms.js';
-import {applyTransform, getWidth} from './extent.js';
+import {
+  applyTransform,
+  getBottomLeft,
+  getBottomRight,
+  getTopLeft,
+  getTopRight,
+  getWidth,
+} from './extent.js';
 import {clamp, modulo} from './math.js';
 import {getDistance} from './sphere.js';
 import {getWorldsAway} from './coordinate.js';
@@ -659,21 +666,19 @@ export function createSafeCoordinateTransform(
     if (!isFinite(transformed[0]) || !isFinite(transformed[1])) {
       // Try to recover from out-of-bounds transform
       if (destExtent) {
-        const corner1 = inverse(destExtent.slice(0, 2));
-        const corner2 = inverse(destExtent.slice(2, 4));
-        const x1 = corner1[0];
-        const x2 = corner2[0];
-        const y1 = corner1[1];
-        const y2 = corner2[1];
-        if (isFinite(x1) && isFinite(x2)) {
-          x = clamp(
-            x == undefined ? coord[1] : x,
-            Math.min(x1, x2),
-            Math.max(x1, x2)
-          );
+        const corner1 = inverse(getBottomLeft(destExtent));
+        const corner2 = inverse(getBottomRight(destExtent));
+        const corner3 = inverse(getTopLeft(destExtent));
+        const corner4 = inverse(getTopRight(destExtent));
+        const minX = Math.min(corner1[0], corner2[0], corner3[0], corner4[0]);
+        const maxX = Math.max(corner1[0], corner2[0], corner3[0], corner4[0]);
+        const minY = Math.min(corner1[1], corner2[1], corner3[1], corner4[1]);
+        const maxY = Math.max(corner1[1], corner2[1], corner3[1], corner4[1]);
+        if (isFinite(minX) && isFinite(maxX)) {
+          x = clamp(x == undefined ? coord[1] : x, minX, maxX);
         }
-        if (isFinite(y1) && isFinite(y2)) {
-          y = clamp(coord[1], Math.min(y1, y2), Math.max(y1, y2));
+        if (isFinite(minY) && isFinite(maxY)) {
+          y = clamp(coord[1], minY, maxY);
         }
         transformed = forward([x, y]);
       }

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -659,12 +659,23 @@ export function createSafeCoordinateTransform(
     if (!isFinite(transformed[0]) || !isFinite(transformed[1])) {
       // Try to recover from out-of-bounds transform
       if (destExtent) {
-        const y1 = inverse(destExtent.slice(0, 2))[1];
-        const y2 = inverse(destExtent.slice(2, 4))[1];
+        const corner1 = inverse(destExtent.slice(0, 2));
+        const corner2 = inverse(destExtent.slice(2, 4));
+        const x1 = corner1[0];
+        const x2 = corner2[0];
+        const y1 = corner1[1];
+        const y2 = corner2[1];
+        if (isFinite(x1) && isFinite(x2)) {
+          x = clamp(
+            x == undefined ? coord[1] : x,
+            Math.min(x1, x2),
+            Math.max(x1, x2)
+          );
+        }
         if (isFinite(y1) && isFinite(y2)) {
           y = clamp(coord[1], Math.min(y1, y2), Math.max(y1, y2));
-          transformed = forward([x === undefined ? coord[0] : x, y]);
         }
+        transformed = forward([x, y]);
       }
     }
     if (worldsAway && destProj.canWrapX()) {

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -649,7 +649,7 @@ export function createSafeCoordinateTransform(
       const sourceExtent = sourceProj.getExtent();
       const sourceExtentWidth = getWidth(sourceExtent);
       worldsAway = getWorldsAway(coord, sourceProj, sourceExtentWidth);
-      if (worldsAway && sourceExtent) {
+      if (worldsAway) {
         // Move x to the real world
         x = coord[0] - worldsAway * sourceExtentWidth;
       }

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -6,6 +6,7 @@ import {
   addCoordinateTransforms,
   addEquivalentProjections,
   addProjection,
+  createSafeCoordinateTransform,
   get,
 } from '../proj.js';
 import {assign} from '../obj.js';
@@ -60,8 +61,18 @@ export function register(proj4) {
           addCoordinateTransforms(
             proj1,
             proj2,
-            transform.forward,
-            transform.inverse
+            createSafeCoordinateTransform(
+              proj1,
+              proj2,
+              transform.forward,
+              transform.inverse
+            ),
+            createSafeCoordinateTransform(
+              proj2,
+              proj1,
+              transform.inverse,
+              transform.forward
+            )
           );
         }
       }

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -560,6 +560,25 @@ describe('ol.proj', function () {
       });
       expect(getProjection('EPSG:4326')).to.equal(epsg4326);
     });
+
+    it('uses safe transform functions', function () {
+      register(proj4);
+      const wgs84 = getProjection('WGS84');
+      const epsg4326 = getProjection('EPSG:4326');
+      wgs84.setExtent(epsg4326.getExtent());
+      wgs84.setGlobal(true);
+      const google = getProjection('GOOGLE');
+      const epsg3857 = getProjection('EPSG:3857');
+      google.setExtent(epsg3857.getExtent());
+      google.setGlobal(true);
+      const coord = [-190, 90];
+      const transformed = transform(coord, wgs84, google);
+      expect(transformed).to.eql(transform(coord, epsg4326, epsg3857));
+      const got = transform(transformed, google, wgs84);
+      const expected = transform(transformed, epsg3857, epsg4326);
+      expect(got[0]).to.roughlyEqual(expected[0], 1e-9);
+      expect(got[1]).to.roughlyEqual(expected[1], 1e-9);
+    });
   });
 
   describe('ol.proj.getTransformFromProjections()', function () {


### PR DESCRIPTION
This pull request adds a `createSafeCoordinateTransform()` function, which shims a transform function so it supports wrapping x coordinates and clamping input coordinates to the destination projection's validity extent. That way, transform functions e.g. from proj4 behave the same way as the built-in transform functions between EPSG:4326 and EPSG:3857.

The added tests make use of the fact that proj4 does not overwrite existing projections (EPSG:4326 and EPSG:3857), but registers projections for codes that are not registered yet (WGS84 and GOOGLE). So we can compare the proj4 transforms with the built-in transforms.

Replaces and closes #10958
Fixes #10928