### PR TITLE
Use 'source-over' to render reprojection edges

### DIFF
--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -398,6 +398,7 @@ export function render(
   if (opt_renderEdges) {
     context.save();
 
+    context.globalCompositeOperation = 'source-over';
     context.strokeStyle = 'black';
     context.lineWidth = 1;
 


### PR DESCRIPTION
Reprojection edges are only visible in the development examples https://openlayers.org/en/main/examples/reprojection.html and https://openlayers.org/en/main/examples/reprojection-by-code.html where there are no tiles, or there is partial transparency as in the United States overlay.  This is a consequence of the globalCompositeOperation having been set to 'lighter'.
