### PR TITLE
Add missing SimpleGeometry export

### DIFF
--- a/src/ol/geom.js
+++ b/src/ol/geom.js
@@ -5,10 +5,11 @@
 export {default as Circle} from './geom/Circle.js';
 export {default as Geometry} from './geom/Geometry.js';
 export {default as GeometryCollection} from './geom/GeometryCollection.js';
+export {default as LinearRing} from './geom/LinearRing.js';
 export {default as LineString} from './geom/LineString.js';
 export {default as MultiLineString} from './geom/MultiLineString.js';
 export {default as MultiPoint} from './geom/MultiPoint.js';
 export {default as MultiPolygon} from './geom/MultiPolygon.js';
 export {default as Point} from './geom/Point.js';
 export {default as Polygon} from './geom/Polygon.js';
-export {default as LinearRing} from './geom/LinearRing.js';
+export {default as SimpleGeometry} from './geom/SimpleGeometry.js';


### PR DESCRIPTION
Add SimpleGeometry as a named export from ol/geom.
Sort exports alphabetically.

closes #11233
