### PR TITLE
Replace ol tag with openlayers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "map",
     "mapping",
-    "ol"
+    "openlayers"
   ],
   "private": true,
   "homepage": "https://openlayers.org/",


### PR DESCRIPTION
Since the package name is ol, it makes no sense to add an `ol` tag in package.json. Instead, an `openlayers` tag could be useful, because that is what I would guess most users search for.