### PR TITLE
Allow line breaks before slashes in apidoc navigation

### DIFF
--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -59,7 +59,7 @@ function listContent(item, title, listItemPrinter) {
         <li class="item item-<?js= item.type ?>" data-longname="<?js= item.longname ?>" data-name="<?js= item.prettyname.toLowerCase() ?>">
             <span class="title toggle">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?>"></span>
-                <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~]/g, '\u200b$&')) ?></span>
+                <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~/]/g, '\u200b$&')) ?></span>
             </span><?js
                 listContent(item, 'Members', printListItem);
                 listContent(item, 'Typedefs', printListItemWithStability);

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -59,7 +59,7 @@ function listContent(item, title, listItemPrinter) {
         <li class="item item-<?js= item.type ?>" data-longname="<?js= item.longname ?>" data-name="<?js= item.prettyname.toLowerCase() ?>">
             <span class="title toggle">
                 <span class="glyphicon <?js= getItemCssClass(item.type) ?>"></span>
-                <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~/]/g, '\u200b$&')) ?></span>
+                <span><?js= self.linkto(item.longname, item.prettyname.replace(/[.~\/]/g, '\u200b$&')) ?></span>
             </span><?js
                 listContent(item, 'Members', printListItem);
                 listContent(item, 'Typedefs', printListItemWithStability);


### PR DESCRIPTION
Firefox allows line breaks before slashes but chrome needs a little extra help.
This gets rid of the horizontal scrollbar in the apidoc navigation in chrome.