### PR TITLE
Drag and Drop to update source and fire event only if features added

### DIFF
--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -149,7 +149,9 @@ class DragAndDrop extends Interaction {
       if (features && features.length > 0) {
         if (this.source_) {
           this.source_.clear();
-          this.source_.addFeatures(/** @type {Array<import("../Feature.js").default>} */ (features));
+          this.source_.addFeatures(
+            /** @type {Array<import("../Feature.js").default>} */ (features)
+          );
         }
         this.dispatchEvent(
           new DragAndDropEvent(

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -218,9 +218,10 @@ class DragAndDrop extends Interaction {
    */
   tryReadFeatures_(format, text, options) {
     try {
-      return
-      /** @type {Array<import("../Feature.js").default>} */
-      (format.readFeatures(text, options));
+      return (
+        /** @type {Array<import("../Feature.js").default>} */
+        (format.readFeatures(text, options))
+      );
     } catch (e) {
       return null;
     }

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -149,13 +149,13 @@ class DragAndDrop extends Interaction {
       if (features && features.length > 0) {
         if (this.source_) {
           this.source_.clear();
-          this.source_.addFeatures(features);
+          this.source_.addFeatures(/** @type {Array<import("../Feature.js").default>} */ (features));
         }
         this.dispatchEvent(
           new DragAndDropEvent(
             DragAndDropEventType.ADD_FEATURES,
             file,
-            features,
+            /** @type {Array<import("../Feature.js").default>} */ (features),
             projection
           )
         );

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -147,21 +147,21 @@ class DragAndDrop extends Interaction {
         featureProjection: projection,
       });
       if (features && features.length > 0) {
+        if (this.source_) {
+          this.source_.clear();
+          this.source_.addFeatures(features);
+        }
+        this.dispatchEvent(
+          new DragAndDropEvent(
+            DragAndDropEventType.ADD_FEATURES,
+            file,
+            features,
+            projection
+          )
+        );
         break;
       }
     }
-    if (this.source_) {
-      this.source_.clear();
-      this.source_.addFeatures(features);
-    }
-    this.dispatchEvent(
-      new DragAndDropEvent(
-        DragAndDropEventType.ADD_FEATURES,
-        file,
-        features,
-        projection
-      )
-    );
   }
 
   /**

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -140,24 +140,21 @@ class DragAndDrop extends Interaction {
     }
 
     const formatConstructors = this.formatConstructors_;
-    let features = [];
     for (let i = 0, ii = formatConstructors.length; i < ii; ++i) {
       const format = new formatConstructors[i]();
-      features = this.tryReadFeatures_(format, result, {
+      const features = this.tryReadFeatures_(format, result, {
         featureProjection: projection,
       });
       if (features && features.length > 0) {
         if (this.source_) {
           this.source_.clear();
-          this.source_.addFeatures(
-            /** @type {Array<import("../Feature.js").default>} */ (features)
-          );
+          this.source_.addFeatures(features);
         }
         this.dispatchEvent(
           new DragAndDropEvent(
             DragAndDropEventType.ADD_FEATURES,
             file,
-            /** @type {Array<import("../Feature.js").default>} */ (features),
+            features,
             projection
           )
         );
@@ -217,11 +214,13 @@ class DragAndDrop extends Interaction {
    * @param {string} text Text.
    * @param {import("../format/Feature.js").ReadOptions} options Read options.
    * @private
-   * @return {Array<import("../Feature.js").FeatureLike>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    */
   tryReadFeatures_(format, text, options) {
     try {
-      return format.readFeatures(text, options);
+      return
+      /** @type {Array<import("../Feature.js").default>} */
+      (format.readFeatures(text, options));
     } catch (e) {
       return null;
     }


### PR DESCRIPTION
Fixes #11299

Do not update the source or fire the addfeatures event if dropping out of the formatConstructors loop without features being parsed.
