### PR TITLE
PluggableMap: avoid crash when multiple interactions are removed

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1045,8 +1045,8 @@ class PluggableMap extends BaseObject {
       }
     }
     mapBrowserEvent.frameState = this.frameState_;
-    const interactionsArray = this.getInteractions().getArray();
     if (this.dispatchEvent(mapBrowserEvent) !== false) {
+      const interactionsArray = this.getInteractions().getArray().slice();
       for (let i = interactionsArray.length - 1; i >= 0; i--) {
         const interaction = interactionsArray[i];
         if (!interaction.getActive()) {


### PR DESCRIPTION
As shown in [this codepen](https://codesandbox.io/s/draw-and-modify-features-wzi0k?file=/draw-removal-ol-issue.js) it is possible to cause a crash when handling a map browser event. The way to achieve this error is to remove multiple interactions are part of one of the map browser event handlers. Due to the way the for loop is structure, we changes in the `interactionsArray` can cause inconsistencies.

In my case I ran into this issue when using a draw event -- when the draw was completed the interaction would remove itself and a snap interaction from the map. As the draw was the last interaction in the `interactionsArray` its `drawend` handler was called first by PluggableMap, then my event handler removed 2 interactions, the `handleMapBrowserEvent` continue to the index that had the snap provider which caused `interaction = undefined` and the following error to occur.

```
PluggableMap.js:353 Uncaught TypeError: Cannot read property 'getActive' of undefined
    at Map.PluggableMap.handleMapBrowserEvent (PluggableMap.js:353)
    at MapBrowserEventHandler.Target.dispatchEvent (Target.js:71)
    at MapBrowserEventHandler.handlePointerUp_ (MapBrowserEventHandler.js:88)
```

Can you provide pointers of where the unit test for this should be added?

An alternative fix which may be cleaner may be to `slice` the `interactionsArray` prior to looping over it in order to guarantee the collection doesn't change during the event handler.