### PR TITLE
Do not extract comments to avoid asset name conflicts

### DIFF
--- a/examples/webpack/config.js
+++ b/examples/webpack/config.js
@@ -48,6 +48,7 @@ module.exports = {
         sourceMap: true,
         // Do not minify examples that inject code into workers
         exclude: [/(color-manipulation|region-growing|raster)\.js/],
+        extractComments: false,
       }),
     ],
     runtimeChunk: {


### PR DESCRIPTION
Our examples builds are currently failing because of the latest terser-webpack-plugin update.

> ERROR in The comment file "ec58c6a50cf37d55ddc6.worker.js.LICENSE.txt" conflicts with an existing asset, this may lead to code corruption, please use a different name

By configuring terser-webpack-plugin to not extract license comments to a separate file, we avoid the issue.