### PR TITLE
Use bootstrap 4.5.0 in all examples

### DIFF
--- a/examples/geographic.html
+++ b/examples/geographic.html
@@ -9,9 +9,9 @@ docs: >
 tags: "geographic"
 experimental: true
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js
 ---
 <div id="map" class="map"><div id="popup"></div></div>
 <div id="info"></div>

--- a/examples/geographic.js
+++ b/examples/geographic.js
@@ -74,7 +74,7 @@ map.on('click', function (event) {
     });
     $(element).popover('show');
   } else {
-    $(element).popover('destroy');
+    $(element).popover('dispose');
   }
 });
 

--- a/examples/icon-scale.html
+++ b/examples/icon-scale.html
@@ -3,14 +3,14 @@ layout: example.html
 title: Icon Scale
 shortdesc: Example of scaling icons and labels.
 docs: >
-  Icons and labels can be scaled in both dimensions if required. A negative value will flip the image 
+  Icons and labels can be scaled in both dimensions if required. A negative value will flip the image
   or text around its anchor point (reversed text is <b>not</b> suitable for line placement). A newline
   character inserted in label text is interpreted in a <b>vector layer</b>, but will not be shown in
   a <b>vector context</b>.
 tags: "vector, style, icon, label, scale"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js
 ---
 <div id="map" class="map"><div id="popup"></div></div>

--- a/examples/icon-scale.js
+++ b/examples/icon-scale.js
@@ -107,7 +107,7 @@ map.on('click', function (evt) {
   const feature = map.forEachFeatureAtPixel(evt.pixel, function (feature) {
     return feature;
   });
-  $(element).popover('destroy');
+  $(element).popover('dispose');
   if (feature) {
     const coordinates = feature.getGeometry().getCoordinates();
     popup.setPosition(coordinates);
@@ -124,7 +124,7 @@ map.on('click', function (evt) {
 // change mouse cursor when over marker
 map.on('pointermove', function (e) {
   if (e.dragging) {
-    $(element).popover('destroy');
+    $(element).popover('dispose');
     return;
   }
   const pixel = map.getEventPixel(e.originalEvent);

--- a/examples/icon.html
+++ b/examples/icon.html
@@ -6,8 +6,8 @@ docs: >
   Example using an icon to symbolize a point.
 tags: "vector, style, icon, marker, popup"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js
 ---
 <div id="map" class="map"><div id="popup"></div></div>

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -75,14 +75,14 @@ map.on('click', function (evt) {
     });
     $(element).popover('show');
   } else {
-    $(element).popover('destroy');
+    $(element).popover('dispose');
   }
 });
 
 // change mouse cursor when over marker
 map.on('pointermove', function (e) {
   if (e.dragging) {
-    $(element).popover('destroy');
+    $(element).popover('dispose');
     return;
   }
   const pixel = map.getEventPixel(e.originalEvent);

--- a/examples/kml-earthquakes.html
+++ b/examples/kml-earthquakes.html
@@ -6,8 +6,8 @@ docs: >
   This example parses a KML file and renders the features as a vector layer.  The layer is given a <code>style</code> that renders earthquake locations with a size relative to their magnitude.
 tags: "KML, vector, style, tooltip"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js
 ---
 <div id="map" class="map"><div id="info"></div></div>

--- a/examples/kml-timezones.html
+++ b/examples/kml-timezones.html
@@ -7,8 +7,8 @@ docs: >
   yellow with an opacity calculated based on the current offset to local noon.
 tags: "KML, vector, style"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css
-  - https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css
+  - https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js
 ---
 <div id="map" class="map"><div id="info"></div></div>


### PR DESCRIPTION
Some of the examples still used the old bootstrap / jquery versions. 
This caused an error with the call to destroy and the background went pitch black when clicking on the new tag count buttons.