### PR TITLE
Examples fix / improvement

### DIFF
--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -73,11 +73,7 @@ const displayFeatureInfo = function (pixel) {
     return feature;
   });
   if (feature) {
-    info
-      .tooltip('hide')
-      .attr('data-original-title', feature.get('name'))
-      .tooltip('fixTitle')
-      .tooltip('show');
+    info.attr('data-original-title', feature.get('name')).tooltip('show');
   } else {
     info.tooltip('hide');
   }

--- a/examples/layer-group.html
+++ b/examples/layer-group.html
@@ -6,7 +6,7 @@ docs: >
   Example of a map with layer group.
 tags: "tilejson, input, bind, group, layergroup"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
 cloak:
   - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2pzbmg0Nmk5MGF5NzQzbzRnbDNoeHJrbiJ9.7_-_gL8ur7ZtEiNwRfCy7Q
     value: Your Mapbox access token from https://mapbox.com/ here

--- a/examples/topolis.html
+++ b/examples/topolis.html
@@ -8,7 +8,7 @@ docs: >
 tags: "draw, edit, vector, topology, topolis"
 resources:
   - https://unpkg.com/topolis@0.2.5/dist/topolis.js
-  - https://code.jquery.com/jquery-3.1.1.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.3/toastr.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.3/toastr.min.css
 ---

--- a/examples/vector-esri-edit.html
+++ b/examples/vector-esri-edit.html
@@ -6,7 +6,7 @@ docs: >
   This example loads features from ArcGIS REST Feature Service and allows to add new features or update existing features.
 tags: "vector, esri, ArcGIS, REST, Feature, Service, loading, server, edit, updateFeature, addFeature"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/vector-esri.html
+++ b/examples/vector-esri.html
@@ -6,7 +6,7 @@ docs: >
   This example loads new features from ArcGIS REST Feature Service when the view extent changes.
 tags: "vector, esri, ArcGIS, REST, Feature, Service, loading, server"
 resources:
-  - https://code.jquery.com/jquery-2.2.3.min.js
+  - https://code.jquery.com/jquery-3.5.1.min.js
 ---
 <div id="map" class="map"></div>
 <div id="info">&nbsp;</div>


### PR DESCRIPTION
- Use the same jquery version (3.5.1) in all examples.
- Don't add bootstrap js twice
- Remove unused extraResources in build process
- fix tooltip in kml-earthquake example