### PR TITLE
Fix text instruction flat coordinates when stride is not 2

### DIFF
--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -174,7 +174,7 @@ class CanvasTextBuilder extends CanvasBuilder {
     const geometryType = geometry.getType();
     let flatCoordinates = null;
     let end = 2;
-    let stride = 2;
+    let stride = geometry.getStride();
     let i, ii;
 
     if (textState.placement === TextPlacement.LINE) {
@@ -183,7 +183,6 @@ class CanvasTextBuilder extends CanvasBuilder {
       }
       let ends;
       flatCoordinates = geometry.getFlatCoordinates();
-      stride = geometry.getStride();
       if (geometryType == GeometryType.LINE_STRING) {
         ends = [flatCoordinates.length];
       } else if (geometryType == GeometryType.MULTI_LINE_STRING) {
@@ -250,6 +249,7 @@ class CanvasTextBuilder extends CanvasBuilder {
           break;
         case GeometryType.MULTI_LINE_STRING:
           flatCoordinates = /** @type {import("../../geom/MultiLineString.js").default} */ (geometry).getFlatMidpoints();
+          stride = 2;
           end = flatCoordinates.length;
           break;
         case GeometryType.POLYGON:
@@ -268,6 +268,7 @@ class CanvasTextBuilder extends CanvasBuilder {
             }
             flatCoordinates.push(interiorPoints[i], interiorPoints[i + 1]);
           }
+          stride = 2;
           end = flatCoordinates.length;
           if (end == 0) {
             return;

--- a/test/spec/ol/render/canvas/textbuilder.test.js
+++ b/test/spec/ol/render/canvas/textbuilder.test.js
@@ -1,6 +1,11 @@
+import Circle from '../../../../../src/ol/geom/Circle.js';
 import Executor from '../../../../../src/ol/render/canvas/Executor.js';
 import Feature from '../../../../../src/ol/Feature.js';
+import LineString from '../../../../../src/ol/geom/LineString.js';
+import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
+import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import Text from '../../../../../src/ol/style/Text.js';
 import TextBuilder from '../../../../../src/ol/render/canvas/TextBuilder.js';
@@ -43,6 +48,202 @@ function executeInstructions(
 }
 
 describe('ol.render.canvas.TextBuilder', function () {
+  it('builds correct coordinates array with a stride of 2 for geometries with 2 dimensions', function () {
+    const builder = createBuilder();
+    const features = [
+      new Feature(new Point([0, 0])),
+      new Feature(new Point([1, 1])),
+      new Feature(
+        new MultiLineString([
+          new LineString([
+            [1, 1],
+            [3, 3],
+          ]),
+          new LineString([
+            [2, 2],
+            [4, 4],
+          ]),
+        ])
+      ),
+      new Feature(
+        new LineString([
+          [3, 3],
+          [5, 5],
+        ])
+      ),
+      new Feature(new Circle([5, 5, 7], 4)),
+      new Feature(
+        new MultiPoint([
+          [6, 6],
+          [7, 7],
+        ])
+      ),
+      new Feature(
+        new Polygon([
+          [
+            [7, 7],
+            [7, 9],
+            [9, 9],
+            [9, 7],
+            [7, 7],
+          ],
+        ])
+      ),
+      new Feature(
+        new MultiPolygon([
+          new Polygon([
+            [
+              [8, 8],
+              [8, 10],
+              [10, 10],
+              [10, 8],
+              [8, 8],
+            ],
+          ]),
+          new Polygon([
+            [
+              [9, 9],
+              [9, 11],
+              [11, 11],
+              [11, 9],
+              [9, 9],
+            ],
+          ]),
+        ])
+      ),
+    ];
+    builder.setTextStyle(
+      new Text({
+        text: 'Text',
+      })
+    );
+    features.forEach(function (feature) {
+      builder.drawText(feature.getGeometry(), feature);
+    });
+    expect(builder.coordinates).to.eql([
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+      4,
+      4,
+      5,
+      5,
+      6,
+      6,
+      7,
+      7,
+      8,
+      8,
+      9,
+      9,
+      10,
+      10,
+    ]);
+  });
+
+  it('builds correct coordinates array with a stride of 2 for geometries with 3 dimensions', function () {
+    const builder = createBuilder();
+    const features = [
+      new Feature(new Point([0, 0, 1])),
+      new Feature(new Point([1, 1, 2])),
+      new Feature(
+        new MultiLineString([
+          new LineString([
+            [1, 1, 1],
+            [3, 3, 2],
+          ]),
+          new LineString([
+            [2, 2, 3],
+            [4, 4, 4],
+          ]),
+        ])
+      ),
+      new Feature(
+        new LineString([
+          [3, 3, 5],
+          [5, 5, 6],
+        ])
+      ),
+      new Feature(new Circle([5, 5, 7], 4)),
+      new Feature(
+        new MultiPoint([
+          [6, 6, 8],
+          [7, 7, 9],
+        ])
+      ),
+      new Feature(
+        new Polygon([
+          [
+            [7, 7, 1],
+            [7, 9, 2],
+            [9, 9, 3],
+            [9, 7, 4],
+            [7, 7, 5],
+          ],
+        ])
+      ),
+      new Feature(
+        new MultiPolygon([
+          new Polygon([
+            [
+              [8, 8, 1],
+              [8, 10, 2],
+              [10, 10, 3],
+              [10, 8, 4],
+              [8, 8, 1],
+            ],
+          ]),
+          new Polygon([
+            [
+              [9, 9, 5],
+              [9, 11, 6],
+              [11, 11, 7],
+              [11, 9, 8],
+              [9, 9, 5],
+            ],
+          ]),
+        ])
+      ),
+    ];
+    builder.setTextStyle(
+      new Text({
+        text: 'Text',
+      })
+    );
+    features.forEach(function (feature) {
+      builder.drawText(feature.getGeometry(), feature);
+    });
+    expect(builder.coordinates).to.eql([
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+      4,
+      4,
+      5,
+      5,
+      6,
+      6,
+      7,
+      7,
+      8,
+      8,
+      9,
+      9,
+      10,
+      10,
+    ]);
+  });
+
   it('renders polygon labels only when they fit', function () {
     let builder = createBuilder();
     const geometry = new Polygon([


### PR DESCRIPTION
Fixes #11347 

Text instructions (i.e. labels) for features with 3 or more dimensions caused the whole feature to disappear when interacting with the map. This pull request fixes that.