### PR TITLE
Add all layers to layer export

### DIFF
--- a/src/ol/layer.js
+++ b/src/ol/layer.js
@@ -2,11 +2,14 @@
  * @module ol/layer
  */
 
+export {default as Graticule} from './layer/Graticule.js';
 export {default as Group} from './layer/Group.js';
 export {default as Heatmap} from './layer/Heatmap.js';
 export {default as Image} from './layer/Image.js';
 export {default as Layer} from './layer/Layer.js';
+export {default as MapboxVector} from './layer/MapboxVector.js';
 export {default as Tile} from './layer/Tile.js';
 export {default as Vector} from './layer/Vector.js';
 export {default as VectorImage} from './layer/VectorImage.js';
 export {default as VectorTile} from './layer/VectorTile.js';
+export {default as WebGLPoints} from './layer/WebGLPoints.js';


### PR DESCRIPTION
Three of the layer types are not listed in `ol/layer` module. I guess they just were forgotten?