### PR TITLE
check projection can wrap before getting width

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -410,10 +410,12 @@ export function toStringXY(coordinate, opt_fractionDigits) {
  * @return {Coordinate} The coordinate within the real world extent.
  */
 export function wrapX(coordinate, projection) {
-  const worldWidth = getWidth(projection.getExtent());
-  const worldsAway = getWorldsAway(coordinate, projection, worldWidth);
-  if (worldsAway) {
-    coordinate[0] -= worldsAway * worldWidth;
+  if (projection.canWrapX()) {
+    const worldWidth = getWidth(projection.getExtent());
+    const worldsAway = getWorldsAway(coordinate, projection, worldWidth);
+    if (worldsAway) {
+      coordinate[0] -= worldsAway * worldWidth;
+    }
   }
   return coordinate;
 }

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -1,4 +1,5 @@
 import Circle from '../../../src/ol/geom/Circle.js';
+import Projection from '../../../src/ol/proj/Projection.js';
 import {
   add as addCoordinate,
   closestOnCircle,
@@ -270,6 +271,15 @@ describe('ol.coordinate', function () {
 
     it('moves far off right coordinate to real world', function () {
       expect(wrapX([1096, 48], projection)).to.eql([16, 48]);
+    });
+    
+    const swiss = new Projection({
+      code: 'EPSG:21781',
+      units: 'm',
+    });
+    
+    it('leaves non-global projection coordinates untouched', function () {
+      expect(wrapX([1096, 48], swiss)).to.eql([1096, 48]);
     });
   });
 });

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -272,9 +272,9 @@ describe('ol.coordinate', function () {
     it('moves far off right coordinate to real world', function () {
       expect(wrapX([1096, 48], projection)).to.eql([16, 48]);
     });
-    
+
     const swiss = new Projection({code: 'EPSG:21781', units: 'm'});
-    
+
     it('leaves non-global projection coordinates untouched', function () {
       expect(wrapX([1096, 48], swiss)).to.eql([1096, 48]);
     });

--- a/test/spec/ol/coordinate.test.js
+++ b/test/spec/ol/coordinate.test.js
@@ -273,10 +273,7 @@ describe('ol.coordinate', function () {
       expect(wrapX([1096, 48], projection)).to.eql([16, 48]);
     });
     
-    const swiss = new Projection({
-      code: 'EPSG:21781',
-      units: 'm',
-    });
+    const swiss = new Projection({code: 'EPSG:21781', units: 'm'});
     
     it('leaves non-global projection coordinates untouched', function () {
       expect(wrapX([1096, 48], swiss)).to.eql([1096, 48]);

--- a/test/spec/ol/renderer/map.test.js
+++ b/test/spec/ol/renderer/map.test.js
@@ -1,6 +1,12 @@
 import Disposable from '../../../../src/ol/Disposable.js';
+import Feature from '../../../../src/ol/Feature.js';
 import Map from '../../../../src/ol/Map.js';
 import MapRenderer from '../../../../src/ol/renderer/Map.js';
+import VectorLayer from '../../../../src/ol/layer/Vector.js';
+import VectorSource from '../../../../src/ol/source/Vector.js';
+import View from '../../../../src/ol/View.js';
+import {Point} from '../../../../src/ol/geom.js';
+import {Projection} from '../../../../src/ol/proj.js';
 
 describe('ol.renderer.Map', function () {
   describe('constructor', function () {
@@ -11,6 +17,48 @@ describe('ol.renderer.Map', function () {
       expect(renderer).to.be.a(Disposable);
       renderer.dispose();
       map.dispose();
+    });
+  });
+
+  describe('#forEachFeatureAtCoordinate', function () {
+    let map;
+    beforeEach(function () {
+      const target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      const projection = new Projection({
+        code: 'EPSG:21781',
+        units: 'm',
+      });
+      map = new Map({
+        target: target,
+        layers: [
+          new VectorLayer({
+            source: new VectorSource({
+              projection: projection,
+              features: [new Feature(new Point([660000, 190000]))],
+            }),
+          }),
+        ],
+        view: new View({
+          projection: projection,
+          center: [660000, 190000],
+          zoom: 9,
+        }),
+      });
+      map.renderSync();
+    });
+
+    afterEach(function () {
+      const target = map.getTargetElement();
+      map.setTarget(null);
+      document.body.removeChild(target);
+    });
+
+    it('works with custom projection', function () {
+      const features = map.getFeaturesAtPixel([50, 50]);
+      expect(features.length).to.be(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #11356

This ensures the projection has an extent and also avoids unnecessary calculation of width