### PR TITLE
Add nominalScale option to ScaleBar

### DIFF
--- a/examples/scale-line.html
+++ b/examples/scale-line.html
@@ -30,3 +30,7 @@ tags: "scale-line, openstreetmap"
 <div id="showScaleTextDiv" style="display:none">
   <input type="checkbox" id="showScaleText" checked>Show scale text
 </div>
+
+<div id="nominalScaleDiv" style="display:none">
+  <input type="checkbox" id="nominalScale">Nominal scale
+</div>

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -9,10 +9,13 @@ const typeSelect = document.getElementById('type');
 const stepsSelect = document.getElementById('steps');
 const scaleTextCheckbox = document.getElementById('showScaleText');
 const showScaleTextDiv = document.getElementById('showScaleTextDiv');
+const nominalScaleCheckbox = document.getElementById('nominalScale');
+const nominalScaleDiv = document.getElementById('nominalScaleDiv');
 
 let scaleType = 'scaleline';
 let scaleBarSteps = 4;
 let scaleBarText = true;
+let nominalScale = false;
 let control;
 
 function scaleControl() {
@@ -27,6 +30,7 @@ function scaleControl() {
     bar: true,
     steps: scaleBarSteps,
     text: scaleBarText,
+    nominalScale: nominalScale,
     minWidth: 140,
   });
   return control;
@@ -53,14 +57,14 @@ function onChangeType() {
   if (typeSelect.value === 'scalebar') {
     stepsSelect.style.display = 'inline';
     showScaleTextDiv.style.display = 'inline';
-    map.removeControl(control);
-    map.addControl(scaleControl());
+    nominalScaleDiv.style.display = scaleBarText ? 'inline' : 'none';
   } else {
     stepsSelect.style.display = 'none';
     showScaleTextDiv.style.display = 'none';
-    map.removeControl(control);
-    map.addControl(scaleControl());
+    nominalScaleDiv.style.display = 'none';
   }
+  map.removeControl(control);
+  map.addControl(scaleControl());
 }
 function onChangeSteps() {
   scaleBarSteps = parseInt(stepsSelect.value, 10);
@@ -69,6 +73,12 @@ function onChangeSteps() {
 }
 function onChangeScaleText() {
   scaleBarText = scaleTextCheckbox.checked;
+  nominalScaleDiv.style.display = scaleBarText ? 'inline' : 'none';
+  map.removeControl(control);
+  map.addControl(scaleControl());
+}
+function onChangeNominalScale() {
+  nominalScale = nominalScaleCheckbox.checked;
   map.removeControl(control);
   map.addControl(scaleControl());
 }
@@ -76,3 +86,4 @@ unitsSelect.addEventListener('change', onChange);
 typeSelect.addEventListener('change', onChangeType);
 stepsSelect.addEventListener('change', onChangeSteps);
 scaleTextCheckbox.addEventListener('change', onChangeScaleText);
+nominalScaleCheckbox.addEventListener('change', onChangeNominalScale);

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -53,6 +53,8 @@ const DEFAULT_DPI = 25.4 / 0.28;
  * for best results. Only applies when `bar` is `true`.
  * @property {boolean} [text=false] Render the text scale above of the scalebar. Only applies
  * when `bar` is `true`.
+ * @property {boolean} [nominalScale=false] Displays the text scale based on nominal units unadjusted
+ * for the point resolution of the view. Only applies when `bar` and `text` are `true`.
  * @property {number|undefined} [dpi=undefined] dpi of output device such as printer. Only applies
  * when `bar` is `true`. If undefined the OGC default screen pixel size of 0.28mm will be assumed.
  */
@@ -155,6 +157,12 @@ class ScaleLine extends Control {
      * @type {boolean}
      */
     this.scaleBarText_ = options.text || false;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.nominalScale_ = options.nominalScale || false;
 
     /**
      * @private
@@ -461,14 +469,17 @@ class ScaleLine extends Control {
    * @return {number} The appropriate scale.
    */
   getScaleForResolution() {
-    const resolution = getPointResolution(
-      this.viewState_.projection,
-      this.viewState_.resolution,
-      this.viewState_.center
-    );
+    let resolution = this.viewState_.resolution;
+    if (!this.nominalScale_) {
+      resolution = getPointResolution(
+        this.viewState_.projection,
+        resolution,
+        this.viewState_.center
+      );
+    }
     const dpi = this.dpi_ || DEFAULT_DPI;
     const mpu = this.viewState_.projection.getMetersPerUnit();
-    const inchesPerMeter = 39.37;
+    const inchesPerMeter = 1000 / 25.4;
     return parseFloat(resolution.toString()) * mpu * inchesPerMeter * dpi;
   }
 

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -596,4 +596,77 @@ describe('ol.control.ScaleLine', function () {
       }
     });
   });
+
+  describe('scalebar text', function () {
+    it('it corresponds to the resolution', function () {
+      const ctrl = new ScaleLine({
+        bar: true,
+        text: true,
+      });
+      ctrl.setMap(map);
+      map.setView(
+        new View({
+          center: [0, 0],
+          zoom: 2,
+          multiWorld: true,
+        })
+      );
+      map.renderSync();
+      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      expect(element).to.not.be(null);
+      expect(element).to.be.a(HTMLDivElement);
+      const text = element.innerText;
+      expect(text.slice(0, 4)).to.be('1 : ');
+      expect(text.replace(/^1|\D/g, '')).to.eql(
+        Math.round(map.getView().getResolution() / 0.00028)
+      );
+    });
+    it('it changes with latitude', function () {
+      const ctrl = new ScaleLine({
+        bar: true,
+        text: true,
+      });
+      ctrl.setMap(map);
+      map.setView(
+        new View({
+          center: fromLonLat([0, 60]),
+          zoom: 2,
+          multiWorld: true,
+        })
+      );
+      map.renderSync();
+      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      expect(element).to.not.be(null);
+      expect(element).to.be.a(HTMLDivElement);
+      const text = element.innerText;
+      expect(text.slice(0, 4)).to.be('1 : ');
+      expect(text.replace(/^1|\D/g, '')).to.eql(
+        Math.round((map.getView().getResolution() * 0.5) / 0.00028)
+      );
+    });
+    it('it does not change with latitude if nomimalScale is specified', function () {
+      const ctrl = new ScaleLine({
+        bar: true,
+        text: true,
+        nominalScale: true,
+      });
+      ctrl.setMap(map);
+      map.setView(
+        new View({
+          center: fromLonLat([0, 60]),
+          zoom: 2,
+          multiWorld: true,
+        })
+      );
+      map.renderSync();
+      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      expect(element).to.not.be(null);
+      expect(element).to.be.a(HTMLDivElement);
+      const text = element.innerText;
+      expect(text.slice(0, 4)).to.be('1 : ');
+      expect(text.replace(/^1|\D/g, '')).to.eql(
+        Math.round(map.getView().getResolution() / 0.00028)
+      );
+    });
+  });
 });


### PR DESCRIPTION
Fixes #11349 

Adds a nominalScale boolean option to the ScaleLine control to allow the scale text above the scalebar to be based on nominal projection units without adjustment for point resolution.