### PR TITLE
Fix wrap x for custom projections without extent defined

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -410,8 +410,9 @@ export function toStringXY(coordinate, opt_fractionDigits) {
  * @return {Coordinate} The coordinate within the real world extent.
  */
 export function wrapX(coordinate, projection) {
-  if (projection.canWrapX()) {
-    const worldWidth = getWidth(projection.getExtent());
+  const extent = projection.getExtent();
+  if (projection.canWrapX() && extent !== null) {
+    const worldWidth = getWidth(extent);
     const worldsAway = getWorldsAway(coordinate, projection, worldWidth);
     if (worldsAway) {
       coordinate[0] -= worldsAway * worldWidth;

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -410,10 +410,12 @@ export function toStringXY(coordinate, opt_fractionDigits) {
  * @return {Coordinate} The coordinate within the real world extent.
  */
 export function wrapX(coordinate, projection) {
-  const worldWidth = getWidth(projection.getExtent());
-  const worldsAway = getWorldsAway(coordinate, projection, worldWidth);
-  if (worldsAway) {
-    coordinate[0] -= worldsAway * worldWidth;
+  if (projection.canWrapX()) {
+    const worldWidth = getWidth(projection.getExtent());
+    const worldsAway = getWorldsAway(coordinate, projection, worldWidth);
+    if (worldsAway) {
+      coordinate[0] -= worldsAway * worldWidth;
+    }
   }
   return coordinate;
 }


### PR DESCRIPTION
Version 6.4.0 changed the way `wrapX` works, it stopped checking if given projection can be wrapped and extent exists. This PR restores it, returns unchanged coordinate if doesn't.

BTW. should this function mutate original array?