### PR TITLE
Use https for mapbox tiles

### DIFF
--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -139,7 +139,7 @@ const map = new Map({
     new TileLayer({
       source: new TileJSON({
         url:
-          'https://a.tiles.mapbox.com/v4/aj.1x1-degrees.json?access_token=' +
+          'https://a.tiles.mapbox.com/v4/aj.1x1-degrees.json?secure&access_token=' +
           key,
       }),
     }),

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -91,7 +91,7 @@ const vectorLayer = new VectorLayer({
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json',
+    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
     crossOrigin: '',
   }),
 });

--- a/examples/icon-scale.js
+++ b/examples/icon-scale.js
@@ -12,7 +12,7 @@ import {getVectorContext} from '../src/ol/render.js';
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json',
+    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
     crossOrigin: '',
   }),
 });

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -36,7 +36,7 @@ const vectorLayer = new VectorLayer({
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json',
+    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
     crossOrigin: '',
   }),
 });

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -7,7 +7,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new TileJSON({
-        url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json',
+        url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
         crossOrigin: 'anonymous',
       }),
     }),


### PR DESCRIPTION
Browsers are going to block non-secure content on https pages at some point in the future.

Is there a reason why some examples use v3 api and some v4? 
And why does the v3 api not need access tokens?