### PR TITLE
Reference persistence in forEachSegment can confuse consumers

### DIFF
--- a/src/ol/geom/flat/segments.js
+++ b/src/ol/geom/flat/segments.js
@@ -22,7 +22,7 @@ export function forEach(flatCoordinates, offset, end, stride, callback) {
   for (; offset + stride < end; offset += stride) {
     point2[0] = flatCoordinates[offset + stride];
     point2[1] = flatCoordinates[offset + stride + 1];
-    ret = callback(point1, point2);
+    ret = callback([...point1], [...point2]);
     if (ret) {
       return ret;
     }

--- a/test/spec/ol/geom/flat/segments.test.js
+++ b/test/spec/ol/geom/flat/segments.test.js
@@ -13,22 +13,22 @@ describe('ol.geom.flat.segments', function () {
       it('executes the callback for each segment', function () {
         const args = [];
         const spy = sinon.spy(function (point1, point2) {
-          args.push([point1[0], point1[1], point2[0], point2[1]]);
+          args.push([point1, point2]);
         });
         const ret = forEachSegment(flatCoordinates, offset, end, stride, spy);
         expect(spy.callCount).to.be(3);
-        expect(args[0][0]).to.be(0);
-        expect(args[0][1]).to.be(0);
-        expect(args[0][2]).to.be(1);
-        expect(args[0][3]).to.be(1);
-        expect(args[1][0]).to.be(1);
-        expect(args[1][1]).to.be(1);
-        expect(args[1][2]).to.be(2);
-        expect(args[1][3]).to.be(2);
-        expect(args[2][0]).to.be(2);
-        expect(args[2][1]).to.be(2);
-        expect(args[2][2]).to.be(3);
-        expect(args[2][3]).to.be(3);
+        expect(args[0][0][0]).to.be(0);
+        expect(args[0][0][1]).to.be(0);
+        expect(args[0][1][0]).to.be(1);
+        expect(args[0][1][1]).to.be(1);
+        expect(args[1][0][0]).to.be(1);
+        expect(args[1][0][1]).to.be(1);
+        expect(args[1][1][0]).to.be(2);
+        expect(args[1][1][1]).to.be(2);
+        expect(args[2][0][0]).to.be(2);
+        expect(args[2][0][1]).to.be(2);
+        expect(args[2][1][0]).to.be(3);
+        expect(args[2][1][1]).to.be(3);
         expect(ret).to.be(false);
       });
     });


### PR DESCRIPTION
Calling the forEachSegment callback with the same array over and over with only with its elements reassigned new values led to some tricky bugs to track.  By copying into new arrays in the callback call, we dodge having the same array reference presented to the callback on every iteration, so it can do what it likes with what is passed.

Here I have made the absolute minimum change to the segment.js file, and modified a test to be functionally identical, but reveal the tricky effect if the patch is not applied.

