### PR TITLE
Simplify scale calculation used for WMS getLegendUrl()

### DIFF
--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -247,9 +247,8 @@ class ImageWMS extends ImageSource {
       const mpu = this.getProjection()
         ? this.getProjection().getMetersPerUnit()
         : 1;
-      const dpi = 25.4 / 0.28;
-      const inchesPerMeter = 39.37;
-      baseParams['SCALE'] = resolution * mpu * inchesPerMeter * dpi;
+      const pixelSize = 0.00028;
+      baseParams['SCALE'] = (resolution * mpu) / pixelSize;
     }
 
     assign(baseParams, params);

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -263,9 +263,8 @@ class TileWMS extends TileImage {
       const mpu = this.getProjection()
         ? this.getProjection().getMetersPerUnit()
         : 1;
-      const dpi = 25.4 / 0.28;
-      const inchesPerMeter = 39.37;
-      baseParams['SCALE'] = resolution * mpu * inchesPerMeter * dpi;
+      const pixelSize = 0.00028;
+      baseParams['SCALE'] = (resolution * mpu) / pixelSize;
     }
 
     assign(baseParams, params);

--- a/test/spec/ol/source/imagewms.test.js
+++ b/test/spec/ol/source/imagewms.test.js
@@ -369,7 +369,7 @@ describe('ol.source.ImageWMS', function () {
       expect(queryData.get('REQUEST')).to.be('GetLegendGraphic');
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('VERSION')).to.be('1.3.0');
-      expect(queryData.get('SCALE')).to.be('357.14214285714274');
+      expect(queryData.get('SCALE')).to.be('357.14285714285717');
     });
 
     it('does not include SCALE if no resolution was provided', function () {
@@ -405,7 +405,7 @@ describe('ol.source.ImageWMS', function () {
       expect(queryData.get('REQUEST')).to.be('GetLegendGraphic');
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('VERSION')).to.be('1.3.0');
-      expect(queryData.get('SCALE')).to.be('357.14214285714274');
+      expect(queryData.get('SCALE')).to.be('357.14285714285717');
       expect(queryData.get('STYLE')).to.be('STYLE_VALUE');
       expect(queryData.get('FEATURETYPE')).to.be('FEATURETYPE_VALUE');
       expect(queryData.get('RULE')).to.be('RULE_VALUE');

--- a/test/spec/ol/source/tilewms.test.js
+++ b/test/spec/ol/source/tilewms.test.js
@@ -329,7 +329,7 @@ describe('ol.source.TileWMS', function () {
       expect(queryData.get('REQUEST')).to.be('GetLegendGraphic');
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('VERSION')).to.be('1.3.0');
-      expect(queryData.get('SCALE')).to.be('357.14214285714274');
+      expect(queryData.get('SCALE')).to.be('357.14285714285717');
     });
 
     it('does not include SCALE if no resolution was provided', function () {
@@ -365,7 +365,7 @@ describe('ol.source.TileWMS', function () {
       expect(queryData.get('REQUEST')).to.be('GetLegendGraphic');
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('VERSION')).to.be('1.3.0');
-      expect(queryData.get('SCALE')).to.be('357.14214285714274');
+      expect(queryData.get('SCALE')).to.be('357.14285714285717');
       expect(queryData.get('STYLE')).to.be('STYLE_VALUE');
       expect(queryData.get('FEATURETYPE')).to.be('FEATURETYPE_VALUE');
       expect(queryData.get('RULE')).to.be('RULE_VALUE');


### PR DESCRIPTION
Not only is converting from meters to inches and back to meters inefficient but as noted in https://github.com/openlayers/openlayers/issues/11349#issuecomment-668024841 using the international conversion forward and the old US conversion back is introducing a small error (if US units are being used for the projection the difference between US and imperial/international is already taken into account in the mpu).
