### PR TITLE
Correct inchesPerMeter and add tests for ScaleBar text

### DIFF
--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -468,7 +468,7 @@ class ScaleLine extends Control {
     );
     const dpi = this.dpi_ || DEFAULT_DPI;
     const mpu = this.viewState_.projection.getMetersPerUnit();
-    const inchesPerMeter = 39.37;
+    const inchesPerMeter = 1000 / 25.4;
     return parseFloat(resolution.toString()) * mpu * inchesPerMeter * dpi;
   }
 

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -617,9 +617,7 @@ describe('ol.control.ScaleLine', function () {
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;
       expect(text.slice(0, 4)).to.be('1 : ');
-      expect(text.replace(/^1|\D/g, '')).to.eql(
-        Math.round(map.getView().getResolution() / 0.00028)
-      );
+      expect(text.replace(/^1|\D/g, '')).to.eql(139770566);
     });
     it('it changes with latitude', function () {
       const ctrl = new ScaleLine({
@@ -640,9 +638,7 @@ describe('ol.control.ScaleLine', function () {
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;
       expect(text.slice(0, 4)).to.be('1 : ');
-      expect(text.replace(/^1|\D/g, '')).to.eql(
-        Math.round((map.getView().getResolution() * 0.5) / 0.00028)
-      );
+      expect(text.replace(/^1|\D/g, '')).to.eql(69885283);
     });
   });
 });

--- a/test/spec/ol/control/scaleline.test.js
+++ b/test/spec/ol/control/scaleline.test.js
@@ -596,4 +596,53 @@ describe('ol.control.ScaleLine', function () {
       }
     });
   });
+
+  describe('scalebar text', function () {
+    it('it corresponds to the resolution', function () {
+      const ctrl = new ScaleLine({
+        bar: true,
+        text: true,
+      });
+      ctrl.setMap(map);
+      map.setView(
+        new View({
+          center: [0, 0],
+          zoom: 2,
+          multiWorld: true,
+        })
+      );
+      map.renderSync();
+      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      expect(element).to.not.be(null);
+      expect(element).to.be.a(HTMLDivElement);
+      const text = element.innerText;
+      expect(text.slice(0, 4)).to.be('1 : ');
+      expect(text.replace(/^1|\D/g, '')).to.eql(
+        Math.round(map.getView().getResolution() / 0.00028)
+      );
+    });
+    it('it changes with latitude', function () {
+      const ctrl = new ScaleLine({
+        bar: true,
+        text: true,
+      });
+      ctrl.setMap(map);
+      map.setView(
+        new View({
+          center: fromLonLat([0, 60]),
+          zoom: 2,
+          multiWorld: true,
+        })
+      );
+      map.renderSync();
+      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      expect(element).to.not.be(null);
+      expect(element).to.be.a(HTMLDivElement);
+      const text = element.innerText;
+      expect(text.slice(0, 4)).to.be('1 : ');
+      expect(text.replace(/^1|\D/g, '')).to.eql(
+        Math.round((map.getView().getResolution() * 0.5) / 0.00028)
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR contains a fix and tests from #11361 which were not specific to the nominalScale proposal.  The issue with using an imprecise inches per meter value can also be seen in the Print to scale example if 1:500000 is selected (the text in the pdf is 1:499999)

If #11361 is not merged this replaces #11361
