### PR TITLE
Add security scan

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,4 @@
+name: "OpenLayers CodeQL Config"
+
+paths:
+  - src

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,40 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'  # At 00:00 on Sunday
+
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # Must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head of the pull request.
+          # Only include this option if you are running this workflow on pull requests.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event then checkout
+      # the head of the pull request instead of the merge commit.
+      # Only include this step if you are running this workflow on pull requests.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: javascript
+          config-file: ./.github/codeql/config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This adds a workflow that runs a [CodeQL action](https://github.com/github/codeql-action).

I'm curious to see if this results in a lot of false positives.  If it doesn't, we could make it a required check.

**Update**: I've signed up for the [security scanning beta](https://github.com/features/security/advanced-security/signup?account=openlayers).  It looks like this is a prerequisite for running the codeql action (the action is currently failing with `repository not enabled for code scanning`).

See #11399. 