### PR TITLE
Support deprecated coordinates element for GML3+ formats

### DIFF
--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/format/GML3
  */
+import GML2 from './GML2.js';
 import GMLBase, {GMLNS} from './GMLBase.js';
 import GeometryLayout from '../geom/GeometryLayout.js';
 import LineString from '../geom/LineString.js';
@@ -1032,6 +1033,7 @@ GML3.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
   'http://www.opengis.net/gml': {
     'pos': makeReplacer(GML3.prototype.readFlatPos),
     'posList': makeReplacer(GML3.prototype.readFlatPosList),
+    'coordinates': makeReplacer(GML2.prototype.readFlatCoordinates),
   },
 };
 

--- a/src/ol/format/GML32.js
+++ b/src/ol/format/GML32.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/format/GML32
  */
+import GML2 from './GML2.js';
 import GML3 from './GML3.js';
 import GMLBase from './GMLBase.js';
 import {makeArrayPusher, makeChildAppender, makeReplacer} from '../xml.js';
@@ -41,6 +42,7 @@ GML32.prototype.GEOMETRY_FLAT_COORDINATES_PARSERS = {
   'http://www.opengis.net/gml/3.2': {
     'pos': makeReplacer(GML3.prototype.readFlatPos),
     'posList': makeReplacer(GML3.prototype.readFlatPosList),
+    'coordinates': makeReplacer(GML2.prototype.readFlatCoordinates),
   },
 };
 


### PR DESCRIPTION
Intends to resolve https://github.com/openlayers/openlayers/issues/11409.