### PR TITLE
Fix sort order of examples search results

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -72,7 +72,7 @@
     // sort examples, first by number of words matched, then
     // by word frequency
     examples.sort(function (a, b) {
-      return a.score - b.score || a.words - b.words;
+      return b.score - a.score || b.words - a.words;
     });
     return examples;
   }


### PR DESCRIPTION
Currently the search results on the examples index page are sorted from worst to best match. Example: Go to https://openlayers.org/en/latest/examples/ and enter "wmts hidpi" as search term. You'll see that the wmts-hidpi example is shown last.

This pull request reverses the search result sort order.