### PR TITLE
Checks before calling handleEvent on interactions

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1026,7 +1026,11 @@ class PluggableMap extends BaseObject {
       const interactionsArray = this.getInteractions().getArray().slice();
       for (let i = interactionsArray.length - 1; i >= 0; i--) {
         const interaction = interactionsArray[i];
-        if (!interaction.getActive()) {
+        if (
+          interaction.getMap() !== this ||
+          !interaction.getActive() ||
+          !this.getTargetElement()
+        ) {
           continue;
         }
         const cont = interaction.handleEvent(mapBrowserEvent);


### PR DESCRIPTION
This pull request avoids that interactions handle events when the map has no target or the interaction has been removed from the map.

#11305 introduced a regression which causes `handleEvent` to be called on interactions that have been removed from the map. This pull request fixes that.

Also fixes #11445.