### PR TITLE
Allow returning null from canvasFunction

### DIFF
--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -21,7 +21,7 @@ import {
  * references the {@link module:ol/source/ImageCanvas}.
  *
  * @typedef {function(this:import("../ImageCanvas.js").default, import("../extent.js").Extent, number,
- *     number, import("../size.js").Size, import("../proj/Projection.js").default): HTMLCanvasElement} FunctionType
+ *     number, import("../size.js").Size, import("../proj/Projection.js").default): HTMLCanvasElement|null} FunctionType
  */
 
 /**


### PR DESCRIPTION
The code handles the case where canvasFunction is null which should be reflected in the type annotations.

If this change is approved then I can also make a PR for the DefinitelyTyped types: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ol/source/ImageCanvas.d.ts#L21

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
