### PR TITLE
VectorTile source projection has to match the view projection

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -252,4 +252,4 @@ A layer can only be added to the map once. Use either `layer.setMap()` or `map.a
 
 ### 68
 
-A VectorTile source can only be rendered if it has a projection compatible with the view projection.
+Data from this source can only be rendered if it has a projection compatible with the view projection.

--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -249,3 +249,7 @@ This is done by providing adequate shaders using the `hitVertexShader` and `hitF
 ### 67
 
 A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both.
+
+### 68
+
+A VectorTile source can only be rendered if it has a projection compatible with the view projection.

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -20,6 +20,7 @@ import {
   scale as scaleTransform,
   translate as translateTransform,
 } from '../../transform.js';
+import {assert} from '../../asserts.js';
 import {
   buffer,
   containsCoordinate,
@@ -34,6 +35,7 @@ import {
   createHitDetectionImageData,
   hitDetect,
 } from '../../render/canvas/hitdetect.js';
+import {equivalent} from '../../proj.js';
 import {
   getSquaredTolerance as getSquaredRenderTolerance,
   renderFeature,
@@ -230,7 +232,15 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @return {boolean} Layer is ready to be rendered.
    */
   prepareFrame(frameState) {
-    const layerRevision = this.getLayer().getRevision();
+    const layer = this.getLayer();
+    assert(
+      equivalent(
+        layer.getSource().getProjection(),
+        frameState.viewState.projection
+      ),
+      68 // A VectorTile source can only be rendered if it has a projection compatible with the view projection.
+    );
+    const layerRevision = layer.getRevision();
     if (this.renderedLayerRevision_ != layerRevision) {
       this.renderedTiles.length = 0;
     }

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -20,7 +20,6 @@ import {
   scale as scaleTransform,
   translate as translateTransform,
 } from '../../transform.js';
-import {assert} from '../../asserts.js';
 import {
   buffer,
   containsCoordinate,
@@ -35,7 +34,6 @@ import {
   createHitDetectionImageData,
   hitDetect,
 } from '../../render/canvas/hitdetect.js';
-import {equivalent} from '../../proj.js';
 import {
   getSquaredTolerance as getSquaredRenderTolerance,
   renderFeature,
@@ -232,15 +230,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @return {boolean} Layer is ready to be rendered.
    */
   prepareFrame(frameState) {
-    const layer = this.getLayer();
-    assert(
-      equivalent(
-        layer.getSource().getProjection(),
-        frameState.viewState.projection
-      ),
-      68 // A VectorTile source can only be rendered if it has a projection compatible with the view projection.
-    );
-    const layerRevision = layer.getRevision();
+    const layerRevision = this.getLayer().getRevision();
     if (this.renderedLayerRevision_ != layerRevision) {
       this.renderedTiles.length = 0;
     }

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -6,6 +6,7 @@ import Source from './Source.js';
 import TileCache from '../TileCache.js';
 import TileState from '../TileState.js';
 import {abstract} from '../util.js';
+import {assert} from '../asserts.js';
 import {equivalent} from '../proj.js';
 import {getKeyZXY, withinExtentAndZ} from '../tilecoord.js';
 import {
@@ -250,12 +251,11 @@ class TileSource extends Source {
    * @protected
    */
   getTileCacheForProjection(projection) {
-    const thisProj = this.getProjection();
-    if (thisProj && !equivalent(thisProj, projection)) {
-      return null;
-    } else {
-      return this.tileCache;
-    }
+    assert(
+      equivalent(this.getProjection(), projection),
+      68 // A VectorTile source can only be rendered if it has a projection compatible with the view projection.
+    );
+    return this.tileCache;
   }
 
   /**


### PR DESCRIPTION
A pull request to make debugging of misconfigured vector tile sources easier.

Fixes #11429.