### PR TITLE
Feature: added preRender and postRender methods to WebGLLayerRenderer…

### DIFF
--- a/src/ol/render/Event.js
+++ b/src/ol/render/Event.js
@@ -17,7 +17,7 @@ class RenderEvent extends Event {
 
     /**
      * Transform from CSS pixels (relative to the top-left corner of the map viewport)
-     * to rendered pixels on this event's `context`.
+     * to rendered pixels on this event's `context`. Only available when a Canvas renderer is used, null otherwise.
      * @type {import("../transform.js").Transform|undefined}
      * @api
      */

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -2,6 +2,8 @@
  * @module ol/renderer/webgl/Layer
  */
 import LayerRenderer from '../Layer.js';
+import RenderEvent from '../../render/Event.js';
+import RenderEventType from '../../render/EventType.js';
 import WebGLHelper from '../../webgl/Helper.js';
 
 /**
@@ -80,6 +82,36 @@ class WebGLLayerRenderer extends LayerRenderer {
    */
   getShaderCompileErrors() {
     return this.helper.getShaderCompileErrors();
+  }
+
+  /**
+   * @param {import("../../render/EventType.js").default} type Event type.
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @private
+   */
+  dispatchRenderEvent_(type, frameState) {
+    const layer = this.getLayer();
+    if (layer.hasListener(type)) {
+      // RenderEvent does not get a context or an inversePixelTransform, because WebGL allows much less direct editing than Canvas2d does.
+      const event = new RenderEvent(type, null, frameState, null);
+      layer.dispatchEvent(event);
+    }
+  }
+
+  /**
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @protected
+   */
+  preRender(frameState) {
+    this.dispatchRenderEvent_(RenderEventType.PRERENDER, frameState);
+  }
+
+  /**
+   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
+   * @protected
+   */
+  postRender(frameState) {
+    this.dispatchRenderEvent_(RenderEventType.POSTRENDER, frameState);
   }
 }
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -409,6 +409,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    * @return {HTMLElement} The rendered element.
    */
   renderFrame(frameState) {
+    this.preRender(frameState);
+
     const renderCount = this.indicesBuffer_.getSize();
     this.helper.drawElements(0, renderCount);
     this.helper.finalizeDraw(frameState);
@@ -424,6 +426,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       this.renderHitDetection(frameState);
       this.hitRenderTarget_.clearCachedData();
     }
+
+    this.postRender(frameState);
 
     return canvas;
   }

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -4,6 +4,7 @@ import Point from '../../../../../src/ol/geom/Point.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
 import ViewHint from '../../../../../src/ol/ViewHint.js';
+import WebGLPointsLayer from '../../../../../src/ol/layer/WebGLPoints.js';
 import WebGLPointsLayerRenderer from '../../../../../src/ol/renderer/webgl/PointsLayer.js';
 import {WebGLWorkerMessageType} from '../../../../../src/ol/renderer/webgl/Layer.js';
 import {
@@ -614,8 +615,13 @@ describe('ol.renderer.webgl.PointsLayer', function () {
         }),
       });
 
-      layer = new VectorLayer({
+      layer = new WebGLPointsLayer({
         source,
+        style: {
+          symbol: {
+            symbolType: 'square',
+          },
+        },
       });
 
       renderer = new WebGLPointsLayerRenderer(layer, {

--- a/test/spec/ol/renderer/webgl/pointslayer.test.js
+++ b/test/spec/ol/renderer/webgl/pointslayer.test.js
@@ -1,4 +1,5 @@
 import Feature from '../../../../../src/ol/Feature.js';
+import GeoJSON from '../../../../../src/ol/format/GeoJSON.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
@@ -590,6 +591,83 @@ describe('ol.renderer.webgl.PointsLayer', function () {
       expect(getCache(features[0], renderer).properties['added']).to.be(
         features[0].get('added')
       );
+    });
+  });
+
+  describe('fires events', () => {
+    let layer, source, renderer, frameState;
+
+    beforeEach(function () {
+      source = new VectorSource({
+        features: new GeoJSON().readFeatures({
+          'type': 'FeatureCollection',
+          'features': [
+            {
+              'type': 'Feature',
+              'properties': {},
+              'geometry': {
+                'type': 'Point',
+                'coordinates': [13, 52],
+              },
+            },
+          ],
+        }),
+      });
+
+      layer = new VectorLayer({
+        source,
+      });
+
+      renderer = new WebGLPointsLayerRenderer(layer, {
+        vertexShader: simpleVertexShader,
+        fragmentShader: simpleFragmentShader,
+      });
+
+      frameState = {
+        viewHints: [],
+        viewState: {
+          projection: getProjection('EPSG:4326'),
+          resolution: 0.010986328125,
+          rotation: 0,
+          center: [15, 52],
+          zoom: 7,
+        },
+        extent: [
+          11.1932373046875,
+          46.429931640625,
+          18.8067626953125,
+          57.570068359375,
+        ],
+        size: [693, 1014],
+        layerIndex: 0,
+        layerStatesArray: [
+          {
+            layer: layer,
+            opacity: 1,
+            visible: true,
+            zIndex: 0,
+          },
+        ],
+      };
+    });
+
+    it('fires prerender and postrender events', function (done) {
+      let prerenderNotified = false;
+      let postrenderNotified = false;
+
+      layer.once('prerender', (evt) => {
+        prerenderNotified = true;
+      });
+
+      layer.once('postrender', (evt) => {
+        postrenderNotified = true;
+        expect(prerenderNotified).to.be(true);
+        expect(postrenderNotified).to.be(true);
+        done();
+      });
+
+      renderer.prepareFrame(frameState);
+      renderer.renderFrame(frameState);
     });
   });
 });


### PR DESCRIPTION
…. Calling them from WebGLPointsLayerRenderer. This way users can get notified of `prerender` and `postrender` events

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

This PR handles [issue 11463](https://github.com/openlayers/openlayers/issues/11463).

### Description

Currently, Heatmaps don't fire  `prerender` or `postrender` events. This is because a.t.m. only `CanvasLayerRenderer` implements the `preRender` and `postRender`  methods. 

Here's a minimum working example: note how only the OSM's render-events are being logged:

```js
const layers = [
    new TileLayer({
        source: new OSM(),
    }),
    new Heatmap({
        source: new VectorSource({
            features: new GeoJSON().readFeatures({
                "type": "FeatureCollection",
                "features": [{
                    "type": "Feature",
                    "properties": {},
                    "geometry": {
                      "type": "Point",
                      "coordinates": [13.38134765625, 52.50953477032727]
                    }
                }]
              })
        })
    })
];

const view = new View({
    center: [15, 52],
    zoom: 7,
    projection: 'EPSG:4326'
});


const map = new Map({
    layers, view, target
});


for (const layer of layers) {
    layer.on('postrender', (event) => {
        console.log(event);
    });
}
```

### Solution

We basically just copy-pasted the source code of `CanvasLayerRenderer`'s `preRender` and `postRender`  methods into `WebGLLayerRenderer`. We then only had to call `preRender` and `postRender` from `WebGLPointsLayerRenderer` inside of `renderFrame`. 

A notable change: `RenderEvent`s usually provide the user with a `context` and an `inversePixelTransform`. After [a little discussion](https://github.com/openlayers/openlayers/issues/11463#issuecomment-679876602), it was decided that those two attributes are less useful in a WebGL context and can therefore be set to `null`.

### Ceterum censeo ...
As always, I am grateful for all constructive criticism and thanks to all for the great work :)