### PR TITLE
Adding original properties to cloned geometry

### DIFF
--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -189,6 +189,18 @@ class BaseObject extends Observable {
   }
 
   /**
+   * Apply any properties from another object without triggering events.
+   * @param {BaseObject} source The source object.
+   * @protected
+   */
+  applyProperties(source) {
+    if (!source.values_) {
+      return;
+    }
+    assign(this.values_ || (this.values_ = {}), source.values_);
+  }
+
+  /**
    * Unsets a property.
    * @param {string} key Key name.
    * @param {boolean=} opt_silent Unset without triggering an event.

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -37,7 +37,13 @@ class Circle extends SimpleGeometry {
    * @api
    */
   clone() {
-    return new Circle(this.flatCoordinates.slice(), undefined, this.layout);
+    const circle = new Circle(
+      this.flatCoordinates.slice(),
+      undefined,
+      this.layout
+    );
+    circle.importPropertiesFrom(this);
+    return circle;
   }
 
   /**

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -42,7 +42,7 @@ class Circle extends SimpleGeometry {
       undefined,
       this.layout
     );
-    circle.importPropertiesFrom(this);
+    circle.applyProperties(this);
     return circle;
   }
 

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -110,6 +110,17 @@ class Geometry extends BaseObject {
   }
 
   /**
+   * Import properties from another geometry.
+   * @param {Geometry} geometry Source geometry.
+   * @protected
+   */
+  importPropertiesFrom(geometry) {
+    if (geometry.hasProperties()) {
+      this.setProperties(geometry.getProperties(), true);
+    }
+  }
+
+  /**
    * @abstract
    * @param {number} x X.
    * @param {number} y Y.

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -110,17 +110,6 @@ class Geometry extends BaseObject {
   }
 
   /**
-   * Import properties from another geometry.
-   * @param {Geometry} geometry Source geometry.
-   * @protected
-   */
-  importPropertiesFrom(geometry) {
-    if (geometry.hasProperties()) {
-      this.setProperties(geometry.getProperties(), true);
-    }
-  }
-
-  /**
    * @abstract
    * @param {number} x X.
    * @param {number} y Y.

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -69,6 +69,7 @@ class GeometryCollection extends Geometry {
   clone() {
     const geometryCollection = new GeometryCollection(null);
     geometryCollection.setGeometries(this.geometries_);
+    geometryCollection.importPropertiesFrom(this);
     return geometryCollection;
   }
 

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -69,7 +69,7 @@ class GeometryCollection extends Geometry {
   clone() {
     const geometryCollection = new GeometryCollection(null);
     geometryCollection.setGeometries(this.geometries_);
-    geometryCollection.importPropertiesFrom(this);
+    geometryCollection.applyProperties(this);
     return geometryCollection;
   }
 

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -87,7 +87,12 @@ class LineString extends SimpleGeometry {
    * @api
    */
   clone() {
-    return new LineString(this.flatCoordinates.slice(), this.layout);
+    const lineString = new LineString(
+      this.flatCoordinates.slice(),
+      this.layout
+    );
+    lineString.importPropertiesFrom(this);
+    return lineString;
   }
 
   /**

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -91,7 +91,7 @@ class LineString extends SimpleGeometry {
       this.flatCoordinates.slice(),
       this.layout
     );
-    lineString.importPropertiesFrom(this);
+    lineString.applyProperties(this);
     return lineString;
   }
 

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -107,7 +107,7 @@ class MultiLineString extends SimpleGeometry {
       this.layout,
       this.ends_.slice()
     );
-    multiLineString.importPropertiesFrom(this);
+    multiLineString.applyProperties(this);
     return multiLineString;
   }
 

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -102,11 +102,13 @@ class MultiLineString extends SimpleGeometry {
    * @api
    */
   clone() {
-    return new MultiLineString(
+    const multiLineString = new MultiLineString(
       this.flatCoordinates.slice(),
       this.layout,
       this.ends_.slice()
     );
+    multiLineString.importPropertiesFrom(this);
+    return multiLineString;
   }
 
   /**

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -61,6 +61,7 @@ class MultiPoint extends SimpleGeometry {
       this.flatCoordinates.slice(),
       this.layout
     );
+    multiPoint.importPropertiesFrom(this);
     return multiPoint;
   }
 

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -61,7 +61,7 @@ class MultiPoint extends SimpleGeometry {
       this.flatCoordinates.slice(),
       this.layout
     );
-    multiPoint.importPropertiesFrom(this);
+    multiPoint.applyProperties(this);
     return multiPoint;
   }
 

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -155,11 +155,14 @@ class MultiPolygon extends SimpleGeometry {
       newEndss[i] = this.endss_[i].slice();
     }
 
-    return new MultiPolygon(
+    const multiPolygon = new MultiPolygon(
       this.flatCoordinates.slice(),
       this.layout,
       newEndss
     );
+    multiPolygon.importPropertiesFrom(this);
+
+    return multiPolygon;
   }
 
   /**

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -160,7 +160,7 @@ class MultiPolygon extends SimpleGeometry {
       this.layout,
       newEndss
     );
-    multiPolygon.importPropertiesFrom(this);
+    multiPolygon.applyProperties(this);
 
     return multiPolygon;
   }

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -30,6 +30,7 @@ class Point extends SimpleGeometry {
    */
   clone() {
     const point = new Point(this.flatCoordinates.slice(), this.layout);
+    point.importPropertiesFrom(this);
     return point;
   }
 

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -30,7 +30,7 @@ class Point extends SimpleGeometry {
    */
   clone() {
     const point = new Point(this.flatCoordinates.slice(), this.layout);
-    point.importPropertiesFrom(this);
+    point.applyProperties(this);
     return point;
   }
 

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -123,7 +123,7 @@ class Polygon extends SimpleGeometry {
       this.layout,
       this.ends_.slice()
     );
-    polygon.importPropertiesFrom(this);
+    polygon.applyProperties(this);
     return polygon;
   }
 

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -118,11 +118,13 @@ class Polygon extends SimpleGeometry {
    * @api
    */
   clone() {
-    return new Polygon(
+    const polygon = new Polygon(
       this.flatCoordinates.slice(),
       this.layout,
       this.ends_.slice()
     );
+    polygon.importPropertiesFrom(this);
+    return polygon;
   }
 
   /**

--- a/test/spec/ol/geom/circle.test.js
+++ b/test/spec/ol/geom/circle.test.js
@@ -9,11 +9,14 @@ describe('ol.geom.Circle', function () {
 
     describe('#clone', function () {
       it('returns a clone', function () {
+        circle.setProperties({foo: 'bar', baz: null});
+
         const clone = circle.clone();
         expect(clone).to.be.an(Circle);
         expect(clone.getCenter()).to.eql(circle.getCenter());
         expect(clone.getCenter()).not.to.be(circle.getCenter());
         expect(clone.getRadius()).to.be(circle.getRadius());
+        expect(clone.getProperties()).to.eql({foo: 'bar', baz: null});
       });
     });
 

--- a/test/spec/ol/geom/geometrycollection.test.js
+++ b/test/spec/ol/geom/geometrycollection.test.js
@@ -97,6 +97,7 @@ describe('ol.geom.GeometryCollection', function () {
       ]);
       const poly = new Polygon([outer, inner1, inner2]);
       const multi = new GeometryCollection([point, line, poly]);
+      multi.setProperties({foo: 'bar', baz: null});
       const clone = multi.clone();
       expect(clone).to.not.be(multi);
       const geometries = clone.getGeometries();
@@ -106,6 +107,7 @@ describe('ol.geom.GeometryCollection', function () {
         [30, 40],
       ]);
       expect(geometries[2].getCoordinates()).to.eql([outer, inner1, inner2]);
+      expect(clone.getProperties()).to.eql({foo: 'bar', baz: null});
     });
 
     it('does a deep clone', function () {

--- a/test/spec/ol/geom/multipolygon.test.js
+++ b/test/spec/ol/geom/multipolygon.test.js
@@ -276,8 +276,11 @@ describe('ol.geom.MultiPolygon', function () {
 
     describe('#clone()', function () {
       it('has the expected endss_', function () {
+        multiPolygon.setProperties({foo: 'bar', baz: null});
+
         const clone = multiPolygon.clone();
         expect(multiPolygon.endss_).to.eql(clone.endss_);
+        expect(clone.getProperties()).to.eql({foo: 'bar', baz: null});
       });
     });
 


### PR DESCRIPTION
This PR fix #11071 issue. If the original geometry has additional properties, they are copied to the cloned geometry.