### PR TITLE
"Layer Z-Index" example bugfix

### DIFF
--- a/examples/layer-z-index.js
+++ b/examples/layer-z-index.js
@@ -56,7 +56,7 @@ function createLayer(coordinates, style, zIndex) {
   return vectorLayer;
 }
 
-const layer0 = createLayer([40, 40], styles['star'], 0);
+const layer0 = createLayer([40, 40], styles['star']);
 const layer1 = createLayer([0, 0], styles['square'], 1);
 const layer2 = createLayer([0, 40], styles['triangle'], 0);
 


### PR DESCRIPTION
This PR fix #11100 issue. The code did not match the description. The star layer was assigned a z-index.