### PR TITLE
Empty this.canvas_ for all pixel ratios when render() is called

### DIFF
--- a/rendering/cases/circle-style/main.js
+++ b/rendering/cases/circle-style/main.js
@@ -52,7 +52,7 @@ const style = new Style({
 });
 
 new Map({
-  pixelRatio: 1,
+  pixelRatio: 2,
   layers: [
     new VectorLayer({
       source: vectorSource,

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -404,6 +404,7 @@ class RegularShape extends ImageStyle {
 
     this.draw_(renderOptions, context, 0, 0, 1);
 
+    this.canvas_ = {};
     this.canvas_[1] = context.canvas;
 
     // canvas.width and height are rounded to the closest integer


### PR DESCRIPTION
Fixes #11497

Empty this.canvas_ for all pixel ratios when render() is called
Use pixelRatio 2 in rendering test