### PR TITLE
Fix issue with WMS Capabilities containing a single layer

### DIFF
--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -407,7 +407,13 @@ function readException(node, objectStack) {
  * @return {Object|undefined} Layer object.
  */
 function readCapabilityLayer(node, objectStack) {
-  return pushParseAndPop({}, LAYER_PARSERS, node, objectStack);
+  const layerObject = pushParseAndPop({}, LAYER_PARSERS, node, objectStack);
+
+  if (layerObject.Layer === undefined) {
+    return Object.assign(layerObject, readLayer(node, objectStack));
+  }
+
+  return layerObject;
 }
 
 /**

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -409,7 +409,7 @@ function readException(node, objectStack) {
 function readCapabilityLayer(node, objectStack) {
   const layerObject = pushParseAndPop({}, LAYER_PARSERS, node, objectStack);
 
-  if (layerObject.Layer === undefined) {
+  if (layerObject['Layer'] === undefined) {
     return Object.assign(layerObject, readLayer(node, objectStack));
   }
 

--- a/test/spec/ol/format/wms/singlelayer.xml
+++ b/test/spec/ol/format/wms/singlelayer.xml
@@ -1,0 +1,146 @@
+<?xml version='1.0' encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd">
+<Service>
+  <Name>WMS</Name>
+  <Title>Acme Corp. Map Server</Title>
+  <Abstract>Map Server maintained by Acme Corporation.  Contact: webmaster@wmt.acme.com.  High-quality maps showing roadrunner nests and possible ambush locations.</Abstract>
+
+  <KeywordList>
+    <Keyword>bird</Keyword>
+    <Keyword>roadrunner</Keyword>
+    <Keyword>ambush</Keyword>
+  </KeywordList>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple"
+   xlink:href="http://hostname/" />
+
+
+  <ContactInformation>
+    <ContactPersonPrimary>
+      <ContactPerson>Jeff Smith</ContactPerson>
+      <ContactOrganization>NASA</ContactOrganization>
+    </ContactPersonPrimary>
+    <ContactPosition>Computer Scientist</ContactPosition>
+
+    <ContactAddress>
+      <AddressType>postal</AddressType>
+      <Address>NASA Goddard Space Flight Center</Address>
+      <City>Greenbelt</City>
+      <StateOrProvince>MD</StateOrProvince>
+      <PostCode>20771</PostCode>
+
+      <Country>USA</Country>
+    </ContactAddress>
+    <ContactVoiceTelephone>+1 301 555-1212</ContactVoiceTelephone>
+    <ContactElectronicMailAddress>user@host.com</ContactElectronicMailAddress>
+  </ContactInformation>
+
+  <Fees>none</Fees>
+
+  <AccessConstraints>none</AccessConstraints>
+  <LayerLimit>16</LayerLimit>
+  <MaxWidth>2048</MaxWidth>
+  <MaxHeight>2048</MaxHeight>
+</Service>
+<Capability>
+  <Request>
+    <GetCapabilities>
+
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+             xlink:type="simple"
+             xlink:href="http://hostname/path?" />
+          </Get>
+          <Post>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+             xlink:type="simple"
+             xlink:href="http://hostname/path?" />
+
+          </Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/gif</Format>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+
+      <DCPType>
+        <HTTP>
+          <Get>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+             xlink:type="simple"
+             xlink:href="http://hostname/path?" />
+          </Get>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+
+    <GetFeatureInfo>
+      <Format>text/xml</Format>
+      <Format>text/plain</Format>
+      <Format>text/html</Format>
+      <DCPType>
+        <HTTP>
+          <Get>
+
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+             xlink:type="simple"
+             xlink:href="http://hostname/path?" />
+          </Get>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+  </Request>
+  <Exception>
+    <Format>XML</Format>
+
+    <Format>INIMAGE</Format>
+    <Format>BLANK</Format>
+  </Exception>
+  <Layer queryable="1">
+    <Name>ROADS_1M</Name>
+    <Title>Roads at 1:1M scale</Title>
+    <Abstract>Roads at a scale of 1 to 1 million.</Abstract>
+
+    <KeywordList>
+      <Keyword>road</Keyword>
+      <Keyword>transportation</Keyword>
+      <Keyword>atlas</Keyword>
+    </KeywordList>
+    <Identifier authority="DIF_ID">123456</Identifier>
+    <MetadataURL type="FGDC:1998">
+
+            <Format>text/plain</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+              xlink:type="simple"
+              xlink:href="http://www.university.edu/metadata/roads.txt" />
+          </MetadataURL>
+    <MetadataURL type="ISO19115:2003">
+            <Format>text/xml</Format>
+            <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+            xlink:type="simple"
+            xlink:href="http://www.university.edu/metadata/roads.xml" />
+          </MetadataURL>
+
+    <Style>
+      <Name>ATLAS</Name>
+      <Title>Road atlas style</Title>
+      <Abstract>Roads are shown in a style like that used in a commercial road atlas.</Abstract>
+    <LegendURL width="72" height="72">
+      <Format>image/gif</Format>
+      <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+        xlink:type="simple"
+        xlink:href="http://www.university.edu/legends/atlas.gif" />
+
+    </LegendURL>
+    </Style>
+  </Layer>
+
+</Capability>
+</WMS_Capabilities>

--- a/test/spec/ol/format/wmscapabilities.test.js
+++ b/test/spec/ol/format/wmscapabilities.test.js
@@ -160,3 +160,40 @@ describe('ol.format.WMSCapabilities', function () {
     });
   });
 });
+
+describe('ol.format.WMSCapabilities', function () {
+  describe('when parsing singlelayer.xml', function () {
+    const parser = new WMSCapabilities();
+    let capabilities;
+    before(function (done) {
+      afterLoadText('spec/ol/format/wms/singlelayer.xml', function (xml) {
+        try {
+          capabilities = parser.read(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('can read version', function () {
+      expect(capabilities.version).to.eql('1.3.0');
+    });
+
+    it('can read Service section', function () {
+      // FIXME not all fields are tested
+      const service = capabilities.Service;
+
+      expect(service.Name).to.eql('WMS');
+      expect(service.Title).to.eql('Acme Corp. Map Server');
+    });
+
+    it('can read Capability.Layer', function () {
+      const layer = capabilities.Capability.Layer;
+
+      expect(layer.Title).to.eql('Roads at 1:1M scale');
+      expect(layer.Name).to.be('ROADS_1M');
+      expect(layer.queryable).to.be(true);
+    });
+  });
+});


### PR DESCRIPTION
There is an issue when parsing WMS Capabilities : the options on the layer (`queryable`, ...) are not read correctly.
This pull requests fixes that issue (and add a test for this specific case).

This is my first contribution to OpenLayers source code, let me know if I should improve something.

Fix #9205
Close https://github.com/geo6/mapper/issues/27