### PR TITLE
Add urn:x-ogc:def:crs:EPSG:6.6:4326 as WGS84 proj identifier

### DIFF
--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -64,8 +64,6 @@ export const PROJECTIONS = [
   new EPSG3857Projection('EPSG:102100'),
   new EPSG3857Projection('EPSG:102113'),
   new EPSG3857Projection('EPSG:900913'),
-  new EPSG3857Projection('urn:ogc:def:crs:EPSG:6.18:3:3857'),
-  new EPSG3857Projection('urn:ogc:def:crs:EPSG::3857'),
   new EPSG3857Projection('http://www.opengis.net/gml/srs/epsg.xml#3857'),
 ];
 

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -67,4 +67,5 @@ export const PROJECTIONS = [
   new EPSG4326Projection('urn:ogc:def:crs:OGC:2:84'),
   new EPSG4326Projection('http://www.opengis.net/gml/srs/epsg.xml#4326', 'neu'),
   new EPSG4326Projection('urn:x-ogc:def:crs:EPSG:4326', 'neu'),
+  new EPSG4326Projection('urn:x-ogc:def:crs:EPSG:6.6:4326', 'neu'),
 ];

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -61,11 +61,7 @@ class EPSG4326Projection extends Projection {
 export const PROJECTIONS = [
   new EPSG4326Projection('CRS:84'),
   new EPSG4326Projection('EPSG:4326', 'neu'),
-  new EPSG4326Projection('urn:ogc:def:crs:EPSG::4326', 'neu'),
-  new EPSG4326Projection('urn:ogc:def:crs:EPSG:6.6:4326', 'neu'),
   new EPSG4326Projection('urn:ogc:def:crs:OGC:1.3:CRS84'),
   new EPSG4326Projection('urn:ogc:def:crs:OGC:2:84'),
   new EPSG4326Projection('http://www.opengis.net/gml/srs/epsg.xml#4326', 'neu'),
-  new EPSG4326Projection('urn:x-ogc:def:crs:EPSG:4326', 'neu'),
-  new EPSG4326Projection('urn:x-ogc:def:crs:EPSG:6.6:4326', 'neu'),
 ];

--- a/src/ol/proj/projections.js
+++ b/src/ol/proj/projections.js
@@ -20,7 +20,11 @@ export function clear() {
  * @return {import("./Projection.js").default} The projection (if cached).
  */
 export function get(code) {
-  return cache[code] || null;
+  return (
+    cache[code] ||
+    cache[code.replace(/urn:(x-)?ogc:def:crs:EPSG:(.*:)?(\w+)$/, 'EPSG:$3')] ||
+    null
+  );
 }
 
 /**

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -369,10 +369,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
           return el['Identifier'] == elt['TileMatrixSet'];
         });
         const supportedCRS = tileMatrixSet['SupportedCRS'];
-        const proj1 =
-          getProjection(
-            supportedCRS.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')
-          ) || getProjection(supportedCRS);
+        const proj1 = getProjection(supportedCRS);
         const proj2 = getProjection(config['projection']);
         if (proj1 && proj2) {
           return equivalent(proj1, proj2);
@@ -434,10 +431,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   let projection;
   const code = matrixSetObj['SupportedCRS'];
   if (code) {
-    projection =
-      getProjection(
-        code.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')
-      ) || getProjection(code);
+    projection = getProjection(code);
   }
   if ('projection' in config) {
     const projConfig = getProjection(config['projection']);

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -124,10 +124,7 @@ export function createFromCapabilitiesMatrixSet(
   const tileHeightPropName = 'TileHeight';
 
   const code = matrixSet[supportedCRSPropName];
-  const projection =
-    getProjection(
-      code.replace(/urn:ogc:def:crs:(\w+):(.*:)?(\w+)$/, '$1:$3')
-    ) || getProjection(code);
+  const projection = getProjection(code);
   const metersPerUnit = projection.getMetersPerUnit();
   // swap origin x and y coordinates if axis orientation is lat/long
   const switchOriginXY = projection.getAxisOrientation().substr(0, 2) == 'ne';

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -215,12 +215,13 @@ describe('ol.proj', function () {
     });
 
     it(
-      'gives that CRS:84, urn:ogc:def:crs:EPSG:6.6:4326, EPSG:4326 are ' +
-        'equivalent',
+      'gives that CRS:84, urn:ogc:def:crs:EPSG:6.6:4326, EPSG:4326, ' +
+        'urn:x-ogc:def:crs:EPSG:6.6:4326 are equivalent',
       function () {
         _testAllEquivalent([
           'CRS:84',
           'urn:ogc:def:crs:EPSG:6.6:4326',
+          'urn:x-ogc:def:crs:EPSG:6.6:4326',
           'EPSG:4326',
         ]);
       }


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/11508

Add `urn:x-ogc:def:crs:EPSG:6.6:4326` as an equivalent identifier for WGS84 projection.