### PR TITLE
Do not use fractional pixel ratio for rendering vector tiles

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -796,7 +796,9 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const context = tile.getContext(layer);
 
     // Increase tile size when overzooming for low pixel ratio, to avoid blurry tiles
-    pixelRatio = Math.max(pixelRatio, renderPixelRatio / pixelRatio);
+    pixelRatio = Math.round(
+      Math.max(pixelRatio, renderPixelRatio / pixelRatio)
+    );
     const size = source.getTilePixelSize(z, pixelRatio, projection);
     context.canvas.width = size[0];
     context.canvas.height = size[1];


### PR DESCRIPTION
Fixes #11505.

Previously, for device pixel ratios < 2, the render pixel ratio of vector tiles was dynamically adjusted with fractional pixel ratios to avoid blurry tiles. Now we round the pixel ratio to enforce integer pixel ratios. The reason is that fractional pixel ratios result in non-integer tile border pixels, which can cause rendering artifacts at tile borders.