### PR TITLE
Avoid unnecessary transform in the MVT format

### DIFF
--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -194,7 +194,7 @@ class MVT extends FeatureFormat {
         values,
         id
       );
-      feature.transform(options.dataProjection, options.featureProjection);
+      feature.transform(options.dataProjection);
     } else {
       let geom;
       if (geometryType == GeometryType.POLYGON) {

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -276,34 +276,34 @@ class RenderFeature {
 
   /**
    * Transform geometry coordinates from tile pixel space to projected.
-   * The SRS of the source and destination are expected to be the same.
    *
-   * @param {import("../proj.js").ProjectionLike} source The current projection
-   * @param {import("../proj.js").ProjectionLike} destination The desired projection.
+   * @param {import("../proj.js").ProjectionLike} projection The data projection
    */
-  transform(source, destination) {
-    source = getProjection(source);
-    const pixelExtent = source.getExtent();
-    const projectedExtent = source.getWorldExtent();
-    const scale = getHeight(projectedExtent) / getHeight(pixelExtent);
-    composeTransform(
-      tmpTransform,
-      projectedExtent[0],
-      projectedExtent[3],
-      scale,
-      -scale,
-      0,
-      0,
-      0
-    );
-    transform2D(
-      this.flatCoordinates_,
-      0,
-      this.flatCoordinates_.length,
-      2,
-      tmpTransform,
-      this.flatCoordinates_
-    );
+  transform(projection) {
+    projection = getProjection(projection);
+    const pixelExtent = projection.getExtent();
+    const projectedExtent = projection.getWorldExtent();
+    if (pixelExtent && projectedExtent) {
+      const scale = getHeight(projectedExtent) / getHeight(pixelExtent);
+      composeTransform(
+        tmpTransform,
+        projectedExtent[0],
+        projectedExtent[3],
+        scale,
+        -scale,
+        0,
+        0,
+        0
+      );
+      transform2D(
+        this.flatCoordinates_,
+        0,
+        this.flatCoordinates_.length,
+        2,
+        tmpTransform,
+        this.flatCoordinates_
+      );
+    }
   }
   /**
    * @return {Array<number>|Array<Array<number>>} Ends or endss.

--- a/test/spec/ol/format/mvt.test.js
+++ b/test/spec/ol/format/mvt.test.js
@@ -65,6 +65,15 @@ where('ArrayBuffer.isView').describe('ol.format.MVT', function () {
       expect(geometry.getCoordinates()[1][0]).to.eql([4160, 3489]);
     });
 
+    it('avoids unnecessary reprojections of the ol.render.Feature', function () {
+      const format = new MVT({
+        layers: ['poi_label'],
+      });
+      const geometry = format.readFeatures(data)[0].getGeometry();
+      expect(geometry.getType()).to.be('Point');
+      expect(geometry.getFlatCoordinates()).to.eql([-1210, 2681]);
+    });
+
     it('parses id property', function () {
       // ol.Feature
       let format = new MVT({


### PR DESCRIPTION
When reading features using `ol.render.Feature` a mandatory geometry transform was applied.
The reprojection now only occurs when an `option.featureProjection` is defined.

With this change it is now easy again to use the MVT format as a standalone way to read features in the native tile projection.
Since there is no reprojection, there is no need either to define an extent and a world extent, for that use-case.

@ahocevar, I require this change to implement an experimental MapBoxVectorTile imagery provider for Cesium, in the OL-Cesium project.