### PR TITLE
wmts matrixset null pointer fix and improved handling of Identifier

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -465,10 +465,12 @@ export function optionsFromCapabilities(wmtsCap, config) {
   //in case of matrix limits, use matrix limits to calculate extent
   if (matrixLimits) {
     selectedMatrixLimit = matrixLimits[matrixLimits.length - 1];
-    matrix = find(
+    const m = find(
       matrixSetObj.TileMatrix,
-      (value) => value.Identifier === selectedMatrixLimit.TileMatrix
+      (tileMatrixValue) => tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix || matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix
     );
+    if (m)
+      matrix = m;
   }
 
   const resolution =

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -467,7 +467,9 @@ export function optionsFromCapabilities(wmtsCap, config) {
     selectedMatrixLimit = matrixLimits[matrixLimits.length - 1];
     const m = find(
       matrixSetObj.TileMatrix,
-      (tileMatrixValue) => tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix || matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix
+      (tileMatrixValue) =>
+        tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix ||
+        matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix
     );
     if (m) {
       matrix = m;

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -469,8 +469,9 @@ export function optionsFromCapabilities(wmtsCap, config) {
       matrixSetObj.TileMatrix,
       (tileMatrixValue) => tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix || matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix
     );
-    if (m)
+    if (m) {
       matrix = m;
+    }
   }
 
   const resolution =

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -469,8 +469,8 @@ export function optionsFromCapabilities(wmtsCap, config) {
       matrixSetObj.TileMatrix,
       (tileMatrixValue) =>
         tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix ||
-        matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier ===
-        selectedMatrixLimit.TileMatrix
+        matrixSetObj.Identifier + ':' + tileMatrixValue.Identifier ===
+          selectedMatrixLimit.TileMatrix
     );
     if (m) {
       matrix = m;

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -469,7 +469,8 @@ export function optionsFromCapabilities(wmtsCap, config) {
       matrixSetObj.TileMatrix,
       (tileMatrixValue) =>
         tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix ||
-        matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix
+        matrixSetObj.Identifier + ":" + tileMatrixValue.Identifier ===
+        selectedMatrixLimit.TileMatrix
     );
     if (m) {
       matrix = m;


### PR DESCRIPTION
Nullpointer bug was introduced in 6.4.0 when fixing issue #10981. Commit #9cab1215c08aaf813ab9ee3be1116ef074aca1ea.

Fix nullpointer error when a matrixSet is not found in the matrixsetobj when matrix limits exist.
Also check for matrix match by prepending matrixSetObj.Identifier to support more wmts services.
