### PR TITLE
Bind tileUrlFunction before returning it from getTileUrlFunction

### DIFF
--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -68,7 +68,7 @@ class UrlTile extends TileSource {
     this.tileLoadFunction = options.tileLoadFunction;
 
     if (options.tileUrlFunction) {
-      this.tileUrlFunction = options.tileUrlFunction.bind(this);
+      this.tileUrlFunction = options.tileUrlFunction;
     }
 
     /**
@@ -105,7 +105,9 @@ class UrlTile extends TileSource {
    * @api
    */
   getTileUrlFunction() {
-    return this.tileUrlFunction;
+    return Object.getPrototypeOf(this).tileUrlFunction === this.tileUrlFunction
+      ? this.tileUrlFunction.bind(this)
+      : this.tileUrlFunction;
   }
 
   /**

--- a/test/spec/ol/source/tilewms.test.js
+++ b/test/spec/ol/source/tilewms.test.js
@@ -159,6 +159,15 @@ describe('ol.source.TileWMS', function () {
   });
 
   describe('#tileUrlFunction', function () {
+    it('can be used when obtained through #getTileUrlFunction', function () {
+      options.extent = [-80, -40, -50, -10];
+      const source = new TileWMS(options);
+      const tileCoord = [3, 2, 2];
+      expect(function () {
+        source.getTileUrlFunction()(tileCoord, 1, getProjection('EPSG:4326'));
+      }).to.not.throwException();
+    });
+
     it('returns a tile if it is contained within layers extent', function () {
       options.extent = [-80, -40, -50, -10];
       const source = new TileWMS(options);


### PR DESCRIPTION
When the `tileUrlFunction` is the one of the prototype, it may only work when bound to the instance because it may reference `this`. This pull request makes sure we return a bound function in such cases.

In the future, a sensible breaking change would be to remove `getTileUrlFunction()` and provide an API method `getTileUrl(tileCoord)` instead.

Fixes #11547.