### PR TITLE
Only use elementFromPoint with ShadowRoot

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1000,12 +1000,12 @@ class PluggableMap extends BaseObject {
         ? this.viewport_.getRootNode()
         : document;
       const target =
-        rootNode === document
-          ? /** @type {Node} */ (originalEvent.target)
-          : /** @type {ShadowRoot} */ (rootNode).elementFromPoint(
+        'host' in rootNode // ShadowRoot
+          ? /** @type {ShadowRoot} */ (rootNode).elementFromPoint(
               originalEvent.clientX,
               originalEvent.clientY
-            );
+            )
+          : /** @type {Node} */ (originalEvent.target);
       if (
         // Abort if the target is a child of the container for elements whose events are not meant
         // to be handled by map interactions.


### PR DESCRIPTION
By changing the logic to get the event target when handling map browser events, we can avoid the case where we work with a `Node` instead of the expected `Document` or a `ShadowRoot`.

Fixes #11541.