### PR TITLE
Fix Vector Clipping Layer geojson url so it is imported into codesandbox

### DIFF
--- a/examples/layer-clipping-vector.js
+++ b/examples/layer-clipping-vector.js
@@ -22,7 +22,7 @@ const base = new TileLayer({
 const clipLayer = new VectorLayer({
   style: null,
   source: new VectorSource({
-    url: './data/geojson/switzerland.geojson',
+    url: 'data/geojson/switzerland.geojson',
     format: new GeoJSON(),
   }),
 });


### PR DESCRIPTION
Fixes the Vector Clipping Layer example which does not work in codesandbox when edit is clicked as an unneeded `./` in the geojson url prevents it being treated as a resource.