### PR TITLE
Fix raster source crash bug when using multiple threads

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -283,7 +283,7 @@ export class Processor extends Disposable {
           const offset = i * segmentLength;
           const slices = [];
           for (let j = 0, jj = buffers.length; j < jj; ++j) {
-            slices.push(buffers[i].slice(offset, offset + segmentLength));
+            slices.push(buffers[j].slice(offset, offset + segmentLength));
           }
           this._workers[i].postMessage(
             {

--- a/test/spec/ol/source/raster.test.js
+++ b/test/spec/ol/source/raster.test.js
@@ -594,6 +594,23 @@ where('Uint8ClampedArray').describe('Processor', function () {
         done();
       }, 1000);
     });
+
+    it('can run on multiple threads', function (done) {
+      const processor = new Processor({
+        threads: 2,
+        operation: identity,
+      });
+
+      const input = newImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1);
+      processor.process([input], {}, function (err) {
+        if (err) {
+          done(err);
+        }
+      });
+
+      processor.dispose();
+      setTimeout(done, 20);
+    });
   });
 
   describe('#process() - faux worker', function () {


### PR DESCRIPTION
This PR fixes #11178 by correcting the assignment of buffer slices to workers. Previously, if a raster source was processed by multiple threads, this would instead result in an error message. This is caused by the use of a presumably incorrect loop variable, which will crash the application if the number of threads exceeds the number of buffers.