### PR TITLE
Determine orientation by actual text start and end x

### DIFF
--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -918,7 +918,9 @@ class Executor {
                   part = parts[c]; // x, y, anchorX, rotation, chunk
                   chars = /** @type {string} */ (part[4]);
                   label = this.createLabel(chars, textKey, '', strokeKey);
-                  anchorX = /** @type {number} */ (part[2]) + strokeWidth;
+                  anchorX =
+                    /** @type {number} */ (part[2]) +
+                    (textScale[0] < 0 ? -strokeWidth : strokeWidth);
                   anchorY =
                     baseline * label.height +
                     ((0.5 - baseline) * 2 * strokeWidth * textScale[1]) /

--- a/test/spec/ol/geom/flat/textpath.test.js
+++ b/test/spec/ol/geom/flat/textpath.test.js
@@ -28,7 +28,7 @@ describe('ol.geom.flat.drawTextOnPath', function () {
       '',
       {}
     );
-    expect(instructions).to.eql([[40, 0, 5, 0, 'foo']]);
+    expect(instructions).to.eql([[50, 0, 15, 0, 'foo']]);
   });
 
   it('left-aligns text on a horizontal line', function () {
@@ -45,7 +45,7 @@ describe('ol.geom.flat.drawTextOnPath', function () {
       '',
       {}
     );
-    expect(instructions).to.eql([[5, 0, 5, 0, 'foo']]);
+    expect(instructions).to.eql([[15, 0, 15, 0, 'foo']]);
   });
 
   it('right-aligns text on a horizontal line', function () {
@@ -63,7 +63,7 @@ describe('ol.geom.flat.drawTextOnPath', function () {
       '',
       {}
     );
-    expect(instructions).to.eql([[75, 0, 5, 0, 'foo']]);
+    expect(instructions).to.eql([[85, 0, 15, 0, 'foo']]);
   });
 
   it('draws text on a vertical line', function () {
@@ -82,7 +82,7 @@ describe('ol.geom.flat.drawTextOnPath', function () {
       {}
     );
     const a = (90 * Math.PI) / 180;
-    expect(instructions).to.eql([[0, 40, 5, a, 'foo']]);
+    expect(instructions).to.eql([[0, 50, 15, a, 'foo']]);
   });
 
   it('draws text on a diagonal line', function () {
@@ -138,19 +138,19 @@ describe('ol.geom.flat.drawTextOnPath', function () {
       '',
       {}
     );
-    expect(instructions[0]).to.eql([-20, 0, 5, 0, 'foo-foo-foo-foo']);
+    expect(instructions[0]).to.eql([50, 0, 75, 0, 'foo-foo-foo-foo']);
     expect(instructions.length).to.be(1);
   });
 
   it('renders angled text', function () {
     const length = lineStringLength(angled, 0, angled.length, 2);
-    const startM = length / 2 - 15;
+    const startM = length / 2 - 20;
     const instructions = drawTextOnPath(
       angled,
       0,
       angled.length,
       2,
-      'foo',
+      'fooo',
       startM,
       Infinity,
       1,
@@ -159,11 +159,9 @@ describe('ol.geom.flat.drawTextOnPath', function () {
       {}
     );
     expect(instructions[0][3]).to.eql((45 * Math.PI) / 180);
-    expect(instructions[0][4]).to.be('f');
-    expect(instructions[1][3]).to.eql((45 * Math.PI) / 180);
-    expect(instructions[1][4]).to.be('o');
-    expect(instructions[2][3]).to.eql((-45 * Math.PI) / 180);
-    expect(instructions[2][4]).to.be('o');
+    expect(instructions[0][4]).to.be('fo');
+    expect(instructions[1][3]).to.eql((-45 * Math.PI) / 180);
+    expect(instructions[1][4]).to.be('oo');
   });
 
   it('respects maxAngle', function () {


### PR DESCRIPTION
Fixes #11584 
Instead of using the first and last x coordinate of the entire line it interpolates the x for the exact begin and end of the text.
Characters on the same line segment are drawn with one instruction, see the `it('renders angled text', function () {` test for an example.

Todo:
- ~Text rendering along a path is broken with a negative x scale, not related to this change though~ no change with this PR
- ~I do not yet understand in which case the rotation is set, please tell me if you know~