### PR TITLE
Make permalink example less complex

### DIFF
--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -13,7 +13,7 @@ if (window.location.hash !== '') {
   const hash = window.location.hash.replace('#map=', '');
   const parts = hash.split('/');
   if (parts.length === 4) {
-    zoom = parseInt(parts[0], 10);
+    zoom = parseFloat(parts[0]);
     center = [parseFloat(parts[1]), parseFloat(parts[2])];
     rotation = parseFloat(parts[3]);
   }

--- a/examples/permalink.js
+++ b/examples/permalink.js
@@ -45,11 +45,11 @@ const updatePermalink = function () {
   const center = view.getCenter();
   const hash =
     '#map=' +
-    view.getZoom() +
+    view.getZoom().toFixed(2) +
     '/' +
-    Math.round(center[0] * 100) / 100 +
+    center[0].toFixed(2) +
     '/' +
-    Math.round(center[1] * 100) / 100 +
+    center[1].toFixed(2) +
     '/' +
     view.getRotation();
   const state = {


### PR DESCRIPTION
https://openlayers.org/en/latest/examples/permalink.html used hard to understand math to do some number formatting, I switched it to .toFixed() instead. It might be a minor thing for experienced JS developers but had me confused for a moment and feels totally unnecessary.

I also took the chance to fix fractional zooming not being stored as such.