### PR TITLE
Remove context references when releasing tiles

### DIFF
--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -164,6 +164,7 @@ class VectorRenderTile extends Tile {
   release() {
     for (const key in this.context_) {
       canvasPool.push(this.context_[key].canvas);
+      delete this.context_[key];
     }
     super.release();
   }


### PR DESCRIPTION
Vector tile layers sometimes show incorrect tiles. This can be seen with all vector tile examples (e.g. https://openlayers.org/en/latest/examples/mapbox-style.html) when navigating around in the map.

The reason for this behavior is that references to the tile canvases are not removed when a tile is released from the cache. As a consequence, when another tile gets that canvas from the canvas pool, both tiles can update the same tile canvas.

This pull request fixes that.