### PR TITLE
Modify interaction insert only one vertex

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1070,6 +1070,7 @@ class Modify extends PointerInteraction {
       if (dist <= this.pixelTolerance_) {
         /** @type {Object<string, boolean>} */
         const vertexSegments = {};
+        vertexSegments[getUid(closestSegment)] = true;
 
         if (
           node.geometry.getType() === GeometryType.CIRCLE &&
@@ -1091,14 +1092,18 @@ class Modify extends PointerInteraction {
                 : closestSegment[0];
           }
           this.createOrUpdateVertexFeature_(vertex);
+          const geometries = {};
+          geometries[getUid(node.geometry)] = true;
           for (let i = 1, ii = nodes.length; i < ii; ++i) {
             const segment = nodes[i].segment;
             if (
-              (coordinatesEqual(closestSegment[0], segment[0]) &&
+              ((coordinatesEqual(closestSegment[0], segment[0]) &&
                 coordinatesEqual(closestSegment[1], segment[1])) ||
-              (coordinatesEqual(closestSegment[0], segment[1]) &&
-                coordinatesEqual(closestSegment[1], segment[0]))
+                (coordinatesEqual(closestSegment[0], segment[1]) &&
+                  coordinatesEqual(closestSegment[1], segment[0]))) &&
+              !(getUid(nodes[i].geometry) in geometries)
             ) {
+              geometries[getUid(nodes[i].geometry)] = true;
               vertexSegments[getUid(segment)] = true;
             } else {
               break;
@@ -1106,7 +1111,6 @@ class Modify extends PointerInteraction {
           }
         }
 
-        vertexSegments[getUid(closestSegment)] = true;
         this.vertexSegments_ = vertexSegments;
         return;
       }

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -960,7 +960,7 @@ class Modify extends PointerInteraction {
           !componentSegments[uid][1] &&
           this.insertVertexCondition_(evt)
         ) {
-          insertVertices.push([segmentDataMatch, vertex]);
+          insertVertices.push(segmentDataMatch);
         }
       }
 
@@ -969,7 +969,7 @@ class Modify extends PointerInteraction {
       }
 
       for (let j = insertVertices.length - 1; j >= 0; --j) {
-        this.insertVertex_.apply(this, insertVertices[j]);
+        this.insertVertex_(insertVertices[j], vertex);
       }
     }
     return !!this.vertexFeature_;

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -398,6 +398,33 @@ describe('ol.interaction.Modify', function () {
     });
   });
 
+  describe('vertex insertion', function () {
+    it('only inserts one vertex per geometry', function () {
+      const lineFeature = new Feature({
+        geometry: new LineString([
+          [-10, -10],
+          [10, 10],
+          [-10, -10],
+          [10, 10],
+        ]),
+      });
+      features.length = 0;
+      features.push(lineFeature);
+
+      const modify = new Modify({
+        features: new Collection(features),
+      });
+      map.addInteraction(modify);
+
+      // Click on line
+      simulateEvent('pointermove', 0, 0, null, 0);
+      simulateEvent('pointerdown', 0, 0, null, 0);
+      simulateEvent('pointerup', 0, 0, null, 0);
+
+      expect(lineFeature.getGeometry().getCoordinates().length).to.equal(5);
+    });
+  });
+
   describe('circle modification', function () {
     it('changes the circle radius and center', function () {
       const circleFeature = new Feature(new Circle([10, 10], 20));


### PR DESCRIPTION
Modify interaction now only inserts one vertex if there are multiple overlapping segments of the same feature.
See the second point in #11608