### PR TITLE
Add charset to the examples html below the map

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -189,6 +189,7 @@
         <pre><code id="example-html-source" class="language-markup">&lt;!DOCTYPE html&gt;
 &lt;html lang="en"&gt;
   &lt;head&gt;
+    &lt;meta charset="UTF-8"&gt;
     &lt;title&gt;{{ title }}&lt;/title&gt;
     &lt;!-- Pointer events polyfill for old browsers, see https://caniuse.com/#feat=pointer --&gt;
     &lt;script src="https://unpkg.com/elm-pep"&gt;&lt;/script&gt;{{#if extraHead.remote}}


### PR DESCRIPTION
The vector-labels example uses the wrong encoding when opened with codesandbox. The '°' does not show correctly.
