### PR TITLE
Ensure a unique tile key for each tile coordinate

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -39,6 +39,8 @@ class ImageTile extends Tile {
      */
     this.src_ = src;
 
+    this.key = src;
+
     /**
      * @private
      * @type {HTMLImageElement|HTMLCanvasElement}
@@ -68,13 +70,6 @@ class ImageTile extends Tile {
    */
   getImage() {
     return this.image_;
-  }
-
-  /**
-   * @return {string} Key.
-   */
-  getKey() {
-    return this.src_;
   }
 
   /**

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -63,6 +63,8 @@ class VectorTile extends Tile {
      * @type {string}
      */
     this.url_ = src;
+
+    this.key = src;
   }
 
   /**
@@ -81,13 +83,6 @@ class VectorTile extends Tile {
    */
   getFeatures() {
     return this.features_;
-  }
-
-  /**
-   * @return {string} Key.
-   */
-  getKey() {
-    return this.url_;
   }
 
   /**

--- a/test/spec/ol/source/vectortile.test.js
+++ b/test/spec/ol/source/vectortile.test.js
@@ -393,7 +393,7 @@ describe('ol.source.VectorTile', function () {
           );
           if (sourceTiles) {
             expect(sourceTiles[0].getKey()).to.be(
-              'spec/ol/data/14-8938-5680.vector.pbf?new'
+              'spec/ol/data/14-8938-5680.vector.pbf?new/14,8938,5680'
             );
             unByKey(key);
             done();


### PR DESCRIPTION
Instead of providing a `getKey()` method for each subclass of `ol/Tile`, we can use the one from `ol/Tile` if we set the `key` on the instance.

In particular, this pull request fixes issues with custom `tileLoadFunction`s in applications, in which case there is no need to configure the tile source with a unique `url` for each tile coordinate. The `ol/Tile` `getKey()` function ensures that the tile coordinate is part of the key, to make it unique. The unique key is needed for the tile queue.

Fixes #11626