### PR TITLE
Dwithin filter

### DIFF
--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -1104,11 +1104,8 @@ function writeDuringFilter(node, filter, objectStack) {
   const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const context = parent['context'];
   const version = context['version'];
-  const ns = FESNS[version];
-  const valueReference = createElementNS(ns, 'ValueReference');
-  writeStringTextNode(valueReference, filter.propertyName);
-  node.appendChild(valueReference);
 
+  writePropertyName(version, node, filter.propertyName);
   const timePeriod = createElementNS(GMLNS, 'TimePeriod');
 
   node.appendChild(timePeriod);
@@ -1176,12 +1173,11 @@ function writeComparisonFilter(node, filter, objectStack) {
   const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const context = parent['context'];
   const version = context['version'];
-  const ns = OGCNS[context['version']];
   if (filter.matchCase !== undefined) {
     node.setAttribute('matchCase', filter.matchCase.toString());
   }
   writePropertyName(version, node, filter.propertyName);
-  writeOgcLiteral(ns, node, '' + filter.expression);
+  writeLiteral(version, node, '' + filter.expression);
 }
 
 /**
@@ -1205,17 +1201,17 @@ function writeIsBetweenFilter(node, filter, objectStack) {
   const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const context = parent['context'];
   const version = context['version'];
-  const ns = OGCNS[context['version']];
+  const ns = getFilterNS(version);
 
   writePropertyName(version, node, filter.propertyName);
 
   const lowerBoundary = createElementNS(ns, 'LowerBoundary');
   node.appendChild(lowerBoundary);
-  writeOgcLiteral(ns, lowerBoundary, '' + filter.lowerBoundary);
+  writeLiteral(version, lowerBoundary, '' + filter.lowerBoundary);
 
   const upperBoundary = createElementNS(ns, 'UpperBoundary');
   node.appendChild(upperBoundary);
-  writeOgcLiteral(ns, upperBoundary, '' + filter.upperBoundary);
+  writeLiteral(version, upperBoundary, '' + filter.upperBoundary);
 }
 
 /**
@@ -1227,7 +1223,6 @@ function writeIsLikeFilter(node, filter, objectStack) {
   const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const context = parent['context'];
   const version = context['version'];
-  const ns = OGCNS[version];
   node.setAttribute('wildCard', filter.wildCard);
   node.setAttribute('singleChar', filter.singleChar);
   node.setAttribute('escapeChar', filter.escapeChar);
@@ -1235,7 +1230,7 @@ function writeIsLikeFilter(node, filter, objectStack) {
     node.setAttribute('matchCase', filter.matchCase.toString());
   }
   writePropertyName(version, node, filter.propertyName);
-  writeOgcLiteral(ns, node, '' + filter.pattern);
+  writeLiteral(version, node, '' + filter.pattern);
 }
 
 /**
@@ -1244,7 +1239,7 @@ function writeIsLikeFilter(node, filter, objectStack) {
  * @param {Node} node Node.
  * @param {string} value Value.
  */
-function writeOgcExpression(ns, tagName, node, value) {
+function writeExpression(ns, tagName, node, value) {
   const property = createElementNS(ns, tagName);
   writeStringTextNode(property, value);
   node.appendChild(property);
@@ -1255,30 +1250,21 @@ function writeOgcExpression(ns, tagName, node, value) {
  * @param {Node} node Node.
  * @param {string} value PropertyName value.
  */
+function writeLiteral(version, node, value) {
+  writeExpression(getFilterNS(version), 'Literal', node, value);
+}
+
+/**
+ * @param {string} version Version.
+ * @param {Node} node Node.
+ * @param {string} value PropertyName value.
+ */
 function writePropertyName(version, node, value) {
   if (version === '2.0.0') {
-    writeFesValueReference(FESNS[version], node, value);
+    writeExpression(FESNS[version], 'ValueReference', node, value);
   } else {
-    writeOgcExpression(OGCNS[version], 'PropertyName', node, value);
+    writeExpression(OGCNS[version], 'PropertyName', node, value);
   }
-}
-
-/**
- * @param {string} ns Namespace.
- * @param {Node} node Node.
- * @param {string} value PropertyName value.
- */
-function writeFesValueReference(ns, node, value) {
-  writeOgcExpression(ns, 'ValueReference', node, value);
-}
-
-/**
- * @param {string} ns Namespace.
- * @param {Node} node Node.
- * @param {string} value PropertyName value.
- */
-function writeOgcLiteral(ns, node, value) {
-  writeOgcExpression(ns, 'Literal', node, value);
 }
 
 /**

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -1087,7 +1087,11 @@ function writeDWithinFilter(node, filter, objectStack) {
   writeSpatialFilter(node, filter, objectStack);
   const distance = createElementNS(getFilterNS(version), 'Distance');
   writeStringTextNode(distance, filter.distance.toString());
-  distance.setAttribute('uom', filter.unit);
+  if (version === '2.0.0') {
+    distance.setAttribute('uom', filter.unit);
+  } else {
+    distance.setAttribute('units', filter.unit);
+  }
   node.appendChild(distance);
 }
 

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -1105,7 +1105,7 @@ function writeDuringFilter(node, filter, objectStack) {
   const context = parent['context'];
   const version = context['version'];
 
-  writePropertyName(version, node, filter.propertyName);
+  writeExpression(FESNS[version], 'ValueReference', node, filter.propertyName);
   const timePeriod = createElementNS(GMLNS, 'TimePeriod');
 
   node.appendChild(timePeriod);

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -925,9 +925,9 @@ const GETFEATURE_SERIALIZERS = {
     'Or': makeChildAppender(writeLogicalFilter),
     'Not': makeChildAppender(writeNotFilter),
     'BBOX': makeChildAppender(writeBboxFilter),
-    'Contains': makeChildAppender(writeContainsFilter),
-    'Intersects': makeChildAppender(writeIntersectsFilter),
-    'Within': makeChildAppender(writeWithinFilter),
+    'Contains': makeChildAppender(writeSpatialFilter),
+    'Intersects': makeChildAppender(writeSpatialFilter),
+    'Within': makeChildAppender(writeSpatialFilter),
     'DWithin': makeChildAppender(writeDWithinFilter),
     'PropertyIsEqualTo': makeChildAppender(writeComparisonFilter),
     'PropertyIsNotEqualTo': makeChildAppender(writeComparisonFilter),
@@ -945,11 +945,11 @@ const GETFEATURE_SERIALIZERS = {
     'Or': makeChildAppender(writeLogicalFilter),
     'Not': makeChildAppender(writeNotFilter),
     'BBOX': makeChildAppender(writeBboxFilter),
-    'Contains': makeChildAppender(writeContainsFilter),
-    'Disjoint': makeChildAppender(writeDisjointFilter),
-    'Intersects': makeChildAppender(writeIntersectsFilter),
+    'Contains': makeChildAppender(writeSpatialFilter),
+    'Disjoint': makeChildAppender(writeSpatialFilter),
+    'Intersects': makeChildAppender(writeSpatialFilter),
     'ResourceId': makeChildAppender(writeResourceIdFilter),
-    'Within': makeChildAppender(writeWithinFilter),
+    'Within': makeChildAppender(writeSpatialFilter),
     'DWithin': makeChildAppender(writeDWithinFilter),
     'PropertyIsEqualTo': makeChildAppender(writeComparisonFilter),
     'PropertyIsNotEqualTo': makeChildAppender(writeComparisonFilter),
@@ -1051,54 +1051,6 @@ function writeBboxFilter(node, filter, objectStack) {
 }
 
 /**
- * @param {Node} node Node.
- * @param {import("./filter/Contains.js").default} filter Filter.
- * @param {Array<*>} objectStack Node stack.
- */
-function writeContainsFilter(node, filter, objectStack) {
-  const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
-  const context = parent['context'];
-  const version = context['version'];
-  parent['srsName'] = filter.srsName;
-  const format = GML_FORMATS[version];
-
-  writePropertyName(version, node, filter.geometryName);
-  format.prototype.writeGeometryElement(node, filter.geometry, objectStack);
-}
-
-/**
- * @param {Node} node Node.
- * @param {import("./filter/Intersects.js").default} filter Filter.
- * @param {Array<*>} objectStack Node stack.
- */
-function writeIntersectsFilter(node, filter, objectStack) {
-  const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
-  const context = parent['context'];
-  const version = context['version'];
-  parent['srsName'] = filter.srsName;
-  const format = GML_FORMATS[version];
-
-  writePropertyName(version, node, filter.geometryName);
-  format.prototype.writeGeometryElement(node, filter.geometry, objectStack);
-}
-
-/**
- * @param {Node} node Node.
- * @param {import("./filter/Disjoint.js").default} filter Filter.
- * @param {Array<*>} objectStack Node stack.
- */
-function writeDisjointFilter(node, filter, objectStack) {
-  const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
-  const context = parent['context'];
-  const version = context['version'];
-  parent['srsName'] = filter.srsName;
-  const format = GML_FORMATS[version];
-
-  writePropertyName(version, node, filter.geometryName);
-  format.prototype.writeGeometryElement(node, filter.geometry, objectStack);
-}
-
-/**
  * @param {Element} node Element.
  * @param {import("./filter/ResourceId.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
@@ -1109,10 +1061,10 @@ function writeResourceIdFilter(node, filter, objectStack) {
 
 /**
  * @param {Node} node Node.
- * @param {import("./filter/Within.js").default} filter Filter.
+ * @param {import("./filter/Spatial.js").default} filter Filter.
  * @param {Array<*>} objectStack Node stack.
  */
-function writeWithinFilter(node, filter, objectStack) {
+function writeSpatialFilter(node, filter, objectStack) {
   const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const context = parent['context'];
   const version = context['version'];
@@ -1132,12 +1084,7 @@ function writeDWithinFilter(node, filter, objectStack) {
   const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   const context = parent['context'];
   const version = context['version'];
-  context['srsName'] = filter.srsName;
-  const format = GML_FORMATS[version];
-
-  writePropertyName(version, node, filter.geometryName);
-  format.prototype.writeGeometryElement(node, filter.geometry, objectStack);
-
+  writeSpatialFilter(node, filter, objectStack);
   const distance = createElementNS(getFilterNS(version), 'Distance');
   writeStringTextNode(distance, filter.distance.toString());
   distance.setAttribute('uom', filter.unit);

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -928,6 +928,7 @@ const GETFEATURE_SERIALIZERS = {
     'Contains': makeChildAppender(writeContainsFilter),
     'Intersects': makeChildAppender(writeIntersectsFilter),
     'Within': makeChildAppender(writeWithinFilter),
+    'DWithin': makeChildAppender(writeDWithinFilter),
     'PropertyIsEqualTo': makeChildAppender(writeComparisonFilter),
     'PropertyIsNotEqualTo': makeChildAppender(writeComparisonFilter),
     'PropertyIsLessThan': makeChildAppender(writeComparisonFilter),
@@ -949,6 +950,7 @@ const GETFEATURE_SERIALIZERS = {
     'Intersects': makeChildAppender(writeIntersectsFilter),
     'ResourceId': makeChildAppender(writeResourceIdFilter),
     'Within': makeChildAppender(writeWithinFilter),
+    'DWithin': makeChildAppender(writeDWithinFilter),
     'PropertyIsEqualTo': makeChildAppender(writeComparisonFilter),
     'PropertyIsNotEqualTo': makeChildAppender(writeComparisonFilter),
     'PropertyIsLessThan': makeChildAppender(writeComparisonFilter),
@@ -1119,6 +1121,27 @@ function writeWithinFilter(node, filter, objectStack) {
 
   writePropertyName(version, node, filter.geometryName);
   format.prototype.writeGeometryElement(node, filter.geometry, objectStack);
+}
+
+/**
+ * @param {Node} node Node.
+ * @param {import("./filter/DWithin.js").default} filter Filter.
+ * @param {Array<*>} objectStack Node stack.
+ */
+function writeDWithinFilter(node, filter, objectStack) {
+  const parent = /** @type {Object} */ (objectStack[objectStack.length - 1]);
+  const context = parent['context'];
+  const version = context['version'];
+  context['srsName'] = filter.srsName;
+  const format = GML_FORMATS[version];
+
+  writePropertyName(version, node, filter.geometryName);
+  format.prototype.writeGeometryElement(node, filter.geometry, objectStack);
+
+  const distance = createElementNS(getFilterNS(version), 'Distance');
+  writeStringTextNode(distance, filter.distance.toString());
+  distance.setAttribute('uom', filter.unit);
+  node.appendChild(distance);
 }
 
 /**

--- a/src/ol/format/filter.js
+++ b/src/ol/format/filter.js
@@ -4,6 +4,7 @@
 import And from './filter/And.js';
 import Bbox from './filter/Bbox.js';
 import Contains from './filter/Contains.js';
+import DWithin from './filter/DWithin.js';
 import Disjoint from './filter/Disjoint.js';
 import During from './filter/During.js';
 import EqualTo from './filter/EqualTo.js';
@@ -129,6 +130,23 @@ export function disjoint(geometryName, geometry, opt_srsName) {
  */
 export function within(geometryName, geometry, opt_srsName) {
   return new Within(geometryName, geometry, opt_srsName);
+}
+
+/**
+ * Create a `<DWithin>` operator to test whether a geometry-valued property
+ * is within a distance to a given geometry.
+ *
+ * @param {!string} geometryName Geometry name to use.
+ * @param {!import("../geom/Geometry.js").default} geometry Geometry.
+ * @param {!number} distance Distance.
+ * @param {!string} unit Unit.
+ * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ *    set on geometries when this is not provided.
+ * @returns {!DWithin} `<DWithin>` operator.
+ * @api
+ */
+export function dwithin(geometryName, geometry, distance, unit, opt_srsName) {
+  return new DWithin(geometryName, geometry, distance, unit, opt_srsName);
 }
 
 /**

--- a/src/ol/format/filter/DWithin.js
+++ b/src/ol/format/filter/DWithin.js
@@ -1,0 +1,38 @@
+/**
+ * @module ol/format/filter/DWithin
+ */
+import Spatial from './Spatial.js';
+
+/**
+ * @classdesc
+ * Represents a `<DWithin>` operator to test whether a geometry-valued property
+ * is within a distance to a given geometry.
+ * @api
+ */
+class DWithin extends Spatial {
+  /**
+   * @param {!string} geometryName Geometry name to use.
+   * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
+   * @param {!number} distance Distance.
+   * @param {!string} unit Unit.
+   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   *    set on geometries when this is not provided.
+   */
+  constructor(geometryName, geometry, distance, unit, opt_srsName) {
+    super('DWithin', geometryName, geometry, opt_srsName);
+
+    /**
+     * @public
+     * @type {!number}
+     */
+    this.distance = distance;
+
+    /**
+     * @public
+     * @type {!string}
+     */
+    this.unit = unit;
+  }
+}
+
+export default DWithin;

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -687,7 +687,7 @@ describe('ol.format.WFS', function () {
       expect(serialized.firstElementChild).to.xmleql(parse(text));
     });
 
-    it('creates a dwithin filter for WFS 1.x', function () {
+    it('creates a dwithin filter', function () {
       const text =
         '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
         '    typeName="area" srsName="EPSG:4326" ' +
@@ -729,55 +729,13 @@ describe('ol.format.WFS', function () {
       expect(serialized.firstElementChild).to.xmleql(parse(text));
     });
 
-    it('creates a dwithin filter for WFS 2.0', function () {
-      const text =
-        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
-        '    typeNames="area" srsName="EPSG:4326" ' +
-        '    xmlns:topp="http://www.openplans.org/topp">' +
-        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
-        '    <fes:DWithin>' +
-        '      <fes:ValueReference>the_geom</fes:ValueReference>' +
-        '      <gml:Polygon xmlns:gml="http://www.opengis.net/gml/3.2">' +
-        '        <gml:exterior>' +
-        '          <gml:LinearRing>' +
-        '            <gml:posList srsDimension="2">' +
-        '              10 20 10 25 15 25 15 20 10 20' +
-        '            </gml:posList>' +
-        '          </gml:LinearRing>' +
-        '        </gml:exterior>' +
-        '      </gml:Polygon>' +
-        '      <fes:Distance uom="m">10</fes:Distance>' +
-        '    </fes:DWithin>' +
-        '  </fes:Filter>' +
-        '</wfs:Query>';
-      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
-        srsName: 'EPSG:4326',
-        featureTypes: ['area'],
-        filter: dwithinFilter(
-          'the_geom',
-          new Polygon([
-            [
-              [10, 20],
-              [10, 25],
-              [15, 25],
-              [15, 20],
-              [10, 20],
-            ],
-          ]),
-          10,
-          'm'
-        ),
-      });
-      expect(serialized.firstElementChild).to.xmleql(parse(text));
-    });
-
     it('creates During property filter', function () {
       const text =
         '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
         '    typeName="states" srsName="EPSG:4326">' +
         '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
         '    <ogc:During>' +
-        '      <fes:ValueReference xmlns:fes="http://www.opengis.net/fes">date_prop</fes:ValueReference>' +
+        '      <ogc:PropertyName>date_prop</ogc:PropertyName>' +
         '      <gml:TimePeriod xmlns:gml="http://www.opengis.net/gml">' +
         '        <gml:begin>' +
         '          <gml:TimeInstant>' +
@@ -1679,6 +1637,177 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         });
         expect(serialized).to.xmleql(parse(text));
       });
+    });
+
+    it('creates a dwithin filter', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    typeNames="area" srsName="EPSG:4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '    <fes:DWithin>' +
+        '      <fes:ValueReference>the_geom</fes:ValueReference>' +
+        '      <gml:Polygon xmlns:gml="http://www.opengis.net/gml/3.2">' +
+        '        <gml:exterior>' +
+        '          <gml:LinearRing>' +
+        '            <gml:posList srsDimension="2">' +
+        '              10 20 10 25 15 25 15 20 10 20' +
+        '            </gml:posList>' +
+        '          </gml:LinearRing>' +
+        '        </gml:exterior>' +
+        '      </gml:Polygon>' +
+        '      <fes:Distance uom="m">10</fes:Distance>' +
+        '    </fes:DWithin>' +
+        '  </fes:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
+        srsName: 'EPSG:4326',
+        featureTypes: ['area'],
+        filter: dwithinFilter(
+          'the_geom',
+          new Polygon([
+            [
+              [10, 20],
+              [10, 25],
+              [15, 25],
+              [15, 20],
+              [10, 20],
+            ],
+          ]),
+          10,
+          'm'
+        ),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
+    it('creates isLike property filter', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    typeNames="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '    <fes:PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+        '      <fes:ValueReference>name</fes:ValueReference>' +
+        '      <fes:Literal>New*</fes:Literal>' +
+        '    </fes:PropertyIsLike>' +
+        '  </fes:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: likeFilter('name', 'New*'),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
+    it('creates isBetween property filter', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    typeNames="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '    <fes:PropertyIsBetween>' +
+        '      <fes:ValueReference>area</fes:ValueReference>' +
+        '      <fes:LowerBoundary><fes:Literal>100</fes:Literal></fes:LowerBoundary>' +
+        '      <fes:UpperBoundary><fes:Literal>1000</fes:Literal></fes:UpperBoundary>' +
+        '    </fes:PropertyIsBetween>' +
+        '  </fes:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: betweenFilter('area', 100, 1000),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
+    it('creates greater/less than property filters', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    typeNames="topp:states" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '    <fes:Or>' +
+        '      <fes:And>' +
+        '        <fes:PropertyIsGreaterThan>' +
+        '          <fes:ValueReference>area</fes:ValueReference>' +
+        '          <fes:Literal>100</fes:Literal>' +
+        '        </fes:PropertyIsGreaterThan>' +
+        '        <fes:PropertyIsGreaterThanOrEqualTo>' +
+        '          <fes:ValueReference>pop</fes:ValueReference>' +
+        '          <fes:Literal>20000</fes:Literal>' +
+        '        </fes:PropertyIsGreaterThanOrEqualTo>' +
+        '      </fes:And>' +
+        '      <fes:And>' +
+        '        <fes:PropertyIsLessThan>' +
+        '          <fes:ValueReference>area</fes:ValueReference>' +
+        '          <fes:Literal>100</fes:Literal>' +
+        '        </fes:PropertyIsLessThan>' +
+        '        <fes:PropertyIsLessThanOrEqualTo>' +
+        '          <fes:ValueReference>pop</fes:ValueReference>' +
+        '          <fes:Literal>20000</fes:Literal>' +
+        '        </fes:PropertyIsLessThanOrEqualTo>' +
+        '      </fes:And>' +
+        '    </fes:Or>' +
+        '  </fes:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: ['states'],
+        filter: orFilter(
+          andFilter(
+            greaterThanFilter('area', 100),
+            greaterThanOrEqualToFilter('pop', 20000)
+          ),
+          andFilter(
+            lessThanFilter('area', 100),
+            lessThanOrEqualToFilter('pop', 20000)
+          )
+        ),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
+    it('creates During property filter', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    typeNames="states" srsName="EPSG:4326">' +
+        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '    <fes:During>' +
+        '      <fes:ValueReference>date_prop</fes:ValueReference>' +
+        '      <gml:TimePeriod xmlns:gml="http://www.opengis.net/gml">' +
+        '        <gml:begin>' +
+        '          <gml:TimeInstant>' +
+        '            <gml:timePosition>2010-01-20T00:00:00Z</gml:timePosition>' +
+        '          </gml:TimeInstant>' +
+        '        </gml:begin>' +
+        '        <gml:end>' +
+        '          <gml:TimeInstant>' +
+        '            <gml:timePosition>2012-12-31T00:00:00Z</gml:timePosition>' +
+        '          </gml:TimeInstant>' +
+        '        </gml:end>' +
+        '      </gml:TimePeriod>' +
+        '    </fes:During>' +
+        '  </fes:Filter>' +
+        '</wfs:Query>';
+
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
+        srsName: 'EPSG:4326',
+        featureTypes: ['states'],
+        filter: duringFilter(
+          'date_prop',
+          '2010-01-20T00:00:00Z',
+          '2012-12-31T00:00:00Z'
+        ),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
     });
   });
 });

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -735,7 +735,7 @@ describe('ol.format.WFS', function () {
         '    typeName="states" srsName="EPSG:4326">' +
         '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
         '    <ogc:During>' +
-        '      <ogc:PropertyName>date_prop</ogc:PropertyName>' +
+        '      <fes:ValueReference xmlns:fes="http://www.opengis.net/fes">date_prop</fes:ValueReference>' +
         '      <gml:TimePeriod xmlns:gml="http://www.opengis.net/gml">' +
         '        <gml:begin>' +
         '          <gml:TimeInstant>' +

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -19,6 +19,7 @@ import {
   contains as containsFilter,
   disjoint as disjointFilter,
   during as duringFilter,
+  dwithin as dwithinFilter,
   equalTo as equalToFilter,
   greaterThan as greaterThanFilter,
   greaterThanOrEqualTo as greaterThanOrEqualToFilter,
@@ -681,6 +682,48 @@ describe('ol.format.WFS', function () {
               [10, 20],
             ],
           ])
+        ),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
+    it('creates a dwithin filter', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+        '    typeName="area" srsName="EPSG:4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+        '    <ogc:DWithin>' +
+        '      <ogc:PropertyName>the_geom</ogc:PropertyName>' +
+        '      <gml:Polygon xmlns:gml="http://www.opengis.net/gml">' +
+        '        <gml:exterior>' +
+        '          <gml:LinearRing>' +
+        '            <gml:posList srsDimension="2">' +
+        '              10 20 10 25 15 25 15 20 10 20' +
+        '            </gml:posList>' +
+        '          </gml:LinearRing>' +
+        '        </gml:exterior>' +
+        '      </gml:Polygon>' +
+        '      <ogc:Distance uom="m">10</ogc:Distance>' +
+        '    </ogc:DWithin>' +
+        '  </ogc:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS().writeGetFeature({
+        srsName: 'EPSG:4326',
+        featureTypes: ['area'],
+        filter: dwithinFilter(
+          'the_geom',
+          new Polygon([
+            [
+              [10, 20],
+              [10, 25],
+              [15, 25],
+              [15, 20],
+              [10, 20],
+            ],
+          ]),
+          10,
+          'm'
         ),
       });
       expect(serialized.firstElementChild).to.xmleql(parse(text));

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -687,7 +687,7 @@ describe('ol.format.WFS', function () {
       expect(serialized.firstElementChild).to.xmleql(parse(text));
     });
 
-    it('creates a dwithin filter', function () {
+    it('creates a dwithin filter for WFS 1.x', function () {
       const text =
         '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
         '    typeName="area" srsName="EPSG:4326" ' +
@@ -704,11 +704,53 @@ describe('ol.format.WFS', function () {
         '          </gml:LinearRing>' +
         '        </gml:exterior>' +
         '      </gml:Polygon>' +
-        '      <ogc:Distance uom="m">10</ogc:Distance>' +
+        '      <ogc:Distance units="m">10</ogc:Distance>' +
         '    </ogc:DWithin>' +
         '  </ogc:Filter>' +
         '</wfs:Query>';
       const serialized = new WFS().writeGetFeature({
+        srsName: 'EPSG:4326',
+        featureTypes: ['area'],
+        filter: dwithinFilter(
+          'the_geom',
+          new Polygon([
+            [
+              [10, 20],
+              [10, 25],
+              [15, 25],
+              [15, 20],
+              [10, 20],
+            ],
+          ]),
+          10,
+          'm'
+        ),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
+    it('creates a dwithin filter for WFS 2.0', function () {
+      const text =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    typeNames="area" srsName="EPSG:4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '    <fes:DWithin>' +
+        '      <fes:ValueReference>the_geom</fes:ValueReference>' +
+        '      <gml:Polygon xmlns:gml="http://www.opengis.net/gml/3.2">' +
+        '        <gml:exterior>' +
+        '          <gml:LinearRing>' +
+        '            <gml:posList srsDimension="2">' +
+        '              10 20 10 25 15 25 15 20 10 20' +
+        '            </gml:posList>' +
+        '          </gml:LinearRing>' +
+        '        </gml:exterior>' +
+        '      </gml:Polygon>' +
+        '      <fes:Distance uom="m">10</fes:Distance>' +
+        '    </fes:DWithin>' +
+        '  </fes:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
         srsName: 'EPSG:4326',
         featureTypes: ['area'],
         filter: dwithinFilter(


### PR DESCRIPTION
- added support for distance within filter
- fixed wrong filter encoding namespace handling for WFS 2.0 requests.


this was also requested some years ago:  https://github.com/openlayers/openlayers/issues/5458

I also removed some duplicated code and combined the writeContainsFilter, writeDisjointFilter, writeIntersectsFilter and writeWithinFilter functions in a new writeSpatialFilter function. 

```
<fes:Filter
   xmlns:fes="http://www.opengis.net/fes/2.0"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.opengis.net/fes/2.0
   http://schemas.opengis.net/filter/2.0/filterAll.xsd
   http://www.opengis.net/gml/3.2
   http://schemas.opengis.net/gml/3.2.1/gml.xsd">
   <fes:DWithin>
      <fes:ValueReference>geometry</fes:ValueReference>
      <gml:Point gml:id="P1" srsName="http://www.opengis.net/def/crs/epsg/0/4326">
         <gml:pos>43.716589 -79.340686</gml:pos>
      </gml:Point>
      <fes:Distance uom="m">10</fes:Distance>
   </fes:DWithin>
</fes:Filter>
```

