### PR TITLE
Deal with undefined units from proj4 longlat projections

### DIFF
--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -2,6 +2,7 @@
  * @module ol/proj/proj4
  */
 import Projection from './Projection.js';
+import Units from './Units.js';
 import {
   addCoordinateTransforms,
   addEquivalentProjections,
@@ -31,12 +32,16 @@ export function register(proj4) {
     const code = projCodes[i];
     if (!get(code)) {
       const def = proj4.defs(code);
+      let units = def.units;
+      if (!units && def.projName === 'longlat') {
+        units = Units.DEGREES;
+      }
       addProjection(
         new Projection({
           code: code,
           axisOrientation: def.axis,
           metersPerUnit: def.to_meter,
-          units: def.units,
+          units,
         })
       );
     }

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -1,4 +1,5 @@
 import Projection from '../../../src/ol/proj/Projection.js';
+import Units from '../../../src/ol/proj/Units.js';
 import {HALF_SIZE} from '../../../src/ol/proj/epsg3857.js';
 import {
   METERS_PER_UNIT,
@@ -446,6 +447,20 @@ describe('ol.proj', function () {
       expect(proj.getMetersPerUnit()).to.eql(1200 / 3937);
 
       delete proj4.defs['EPSG:3739'];
+    });
+
+    it('creates ol.proj.Projection instance from EPSG:4258', function () {
+      proj4.defs(
+        'EPSG:4258',
+        '+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs'
+      );
+      register(proj4);
+      const proj = getProjection('EPSG:4258');
+      expect(proj.getCode()).to.eql('EPSG:4258');
+      expect(proj.getUnits()).to.eql('degrees');
+      expect(proj.getMetersPerUnit()).to.eql(METERS_PER_UNIT[Units.DEGREES]);
+
+      delete proj4.defs['EPSG:4258'];
     });
 
     it('allows Proj4js projections to be used transparently', function () {


### PR DESCRIPTION
According to the [documentation](https://github.com/openlayers/openlayers/blob/d4acf2ce10e71ea1066e63f5357a3a0e8538b073/src/ol/proj/Projection.js#L9-L10), `ol/Projection` does not need to be instantiated with `units` when the projection code is registered from proj4. But that is not correct: When a projection was defined with a proj string, the units can be missing, so OpenLayers cannot guess them.

As far as I can tell, proj4 does not have a default for the `+units` parameter, but I think it is safe to assume degrees when the `+proj` is `longlat`.

This pull request makes the necessary changes to set the units to degrees in this case.

Fixes #11632.