### PR TITLE
Make webpack dev server run with current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "npm run test-spec && npm run test-rendering -- --force",
     "karma": "karma start test/karma.config.js",
     "start": "npm run serve-examples",
-    "serve-examples": "webpack-dev-server --config examples/webpack/config.js --mode development --watch",
+    "serve-examples": "webpack serve --config examples/webpack/config.js --mode development --watch",
     "build-examples": "webpack --config examples/webpack/config.js --mode production",
     "build-package": "npm run transpile && npm run copy-css && node tasks/prepare-package && shx cp README.md build/ol",
     "build-index": "npm run build-package && node tasks/generate-index",


### PR DESCRIPTION
webpack-dev-server seems to be no longer available.
https://github.com/webpack/webpack-dev-server/issues/2029#issuecomment-585207461