### PR TITLE
Draw pointer improvements

### DIFF
--- a/examples/draw-features.html
+++ b/examples/draw-features.html
@@ -19,5 +19,5 @@ tags: "draw, edit, freehand, vector"
     <option value="Circle">Circle</option>
     <option value="None">None</option>
   </select>
-  <input class="form-control mr-2 mb-2 mt-2" type="button" value="Undo" id="undo"></input>
+  <input class="form-control mr-2 mb-2 mt-2" type="button" value="Undo" id="undo">
 </form>

--- a/examples/draw-features.html
+++ b/examples/draw-features.html
@@ -6,17 +6,18 @@ docs: >
   Example of using the Draw interaction. Select a geometry type from the
   dropdown above to start drawing. To finish drawing, click the last
   point. To activate freehand drawing for lines, polygons, and circles, hold
-  the `Shift` key.
+  the `Shift` key. To remove the last point of a line or polygon, press "Undo".
 tags: "draw, edit, freehand, vector"
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">
-  <label for="type">Geometry type &nbsp;</label>
-  <select id="type">
+  <label for="type">Geometry type: &nbsp;</label>
+  <select class="form-control mr-2 mb-2 mt-2" id="type">
     <option value="Point">Point</option>
     <option value="LineString">LineString</option>
     <option value="Polygon">Polygon</option>
     <option value="Circle">Circle</option>
     <option value="None">None</option>
   </select>
+  <input class="form-control mr-2 mb-2 mt-2" type="button" value="Undo" id="undo"></input>
 </form>

--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -45,4 +45,8 @@ typeSelect.onchange = function () {
   addInteraction();
 };
 
+document.getElementById('undo').addEventListener('click', function () {
+  draw.removeLastPoint();
+});
+
 addInteraction();

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -535,7 +535,7 @@ class Draw extends PointerInteraction {
       event.type === MapBrowserEventType.POINTERDOWN
     ) {
       pass = false;
-    } else if (move) {
+    } else if (move && this.getPointerCount() === 1) {
       pass = event.type === MapBrowserEventType.POINTERMOVE;
       if (pass && this.freehand_) {
         this.handlePointerMove_(event);
@@ -603,34 +603,37 @@ class Draw extends PointerInteraction {
   handleUpEvent(event) {
     let pass = true;
 
-    if (this.downTimeout_) {
-      clearTimeout(this.downTimeout_);
-      this.downTimeout_ = undefined;
-    }
-
-    this.handlePointerMove_(event);
-
-    const circleMode = this.mode_ === Mode.CIRCLE;
-
-    if (this.shouldHandle_) {
-      if (!this.finishCoordinate_) {
-        this.startDrawing_(event);
-        if (this.mode_ === Mode.POINT) {
-          this.finishDrawing();
-        }
-      } else if (this.freehand_ || circleMode) {
-        this.finishDrawing();
-      } else if (this.atFinish_(event)) {
-        if (this.finishCondition_(event)) {
-          this.finishDrawing();
-        }
-      } else {
-        this.addToDrawing_(event.coordinate);
+    if (this.getPointerCount() === 0) {
+      if (this.downTimeout_) {
+        clearTimeout(this.downTimeout_);
+        this.downTimeout_ = undefined;
       }
-      pass = false;
-    } else if (this.freehand_) {
-      this.abortDrawing();
+
+      this.handlePointerMove_(event);
+
+      const circleMode = this.mode_ === Mode.CIRCLE;
+
+      if (this.shouldHandle_) {
+        if (!this.finishCoordinate_) {
+          this.startDrawing_(event);
+          if (this.mode_ === Mode.POINT) {
+            this.finishDrawing();
+          }
+        } else if (this.freehand_ || circleMode) {
+          this.finishDrawing();
+        } else if (this.atFinish_(event)) {
+          if (this.finishCondition_(event)) {
+            this.finishDrawing();
+          }
+        } else {
+          this.addToDrawing_(event.coordinate);
+        }
+        pass = false;
+      } else if (this.freehand_) {
+        this.abortDrawing();
+      }
     }
+
     if (!pass && this.stopClick_) {
       event.stopPropagation();
     }


### PR DESCRIPTION
This pull request makes a few improvements to the draw interaction on touch devices:

* Fixes visual feedback when `removeLastPoint()` is called for undoing vertex additions for lines or polygons
* Makes sure that events are only considered draw actions when a single pointer is detected. This avoids interference of the Draw interaction with pinch-zooming.

Fixes #11675