### PR TITLE
Treat svg as binary resource

### DIFF
--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -9,7 +9,7 @@
 
   function fetchResource(resource) {
     return new Promise(function (resolve, reject) {
-      const isImage = /\.(png|jpe?g|gif|tiff)$/.test(resource);
+      const isImage = /\.(png|jpe?g|gif|tiff|svg)$/.test(resource);
       if (isImage) {
         resolve ({
           isBinary: true,


### PR DESCRIPTION
The large svg in the SVG Layer example, when embedded as text, is causing an error when attempting to open the example in CodeSandbox.  It (and any other svg data) can however be successfully imported into CodeSandbox in the same way as binary image files.
