### PR TITLE
Clamp EPSG:3857 y to lowest/highest possible value instead of validity extent

### DIFF
--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -36,7 +36,7 @@ export const WORLD_EXTENT = [-180, -85, 180, 85];
  * @const
  * @type {number}
  */
-export const MAX_SAFE_Y = RADIUS * Math.log(Math.tan((Math.PI * 180) / 360));
+export const MAX_SAFE_Y = RADIUS * Math.log(Math.tan(Math.PI / 2));
 
 /**
  * @classdesc

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -32,6 +32,13 @@ export const EXTENT = [-HALF_SIZE, -HALF_SIZE, HALF_SIZE, HALF_SIZE];
 export const WORLD_EXTENT = [-180, -85, 180, 85];
 
 /**
+ * Maximum safe value in y direction
+ * @const
+ * @type {number}
+ */
+export const MAX_SAFE_Y = RADIUS * Math.log(Math.tan((Math.PI * 180) / 360));
+
+/**
  * @classdesc
  * Projection object for web/spherical Mercator (EPSG:3857).
  */
@@ -87,14 +94,13 @@ export function fromEPSG4326(input, opt_output, opt_dimension) {
       output = new Array(length);
     }
   }
-  const halfSize = HALF_SIZE;
   for (let i = 0; i < length; i += dimension) {
-    output[i] = (halfSize * input[i]) / 180;
+    output[i] = (HALF_SIZE * input[i]) / 180;
     let y = RADIUS * Math.log(Math.tan((Math.PI * (+input[i + 1] + 90)) / 360));
-    if (y > halfSize) {
-      y = halfSize;
-    } else if (y < -halfSize) {
-      y = -halfSize;
+    if (y > MAX_SAFE_Y) {
+      y = MAX_SAFE_Y;
+    } else if (y < -MAX_SAFE_Y) {
+      y = -MAX_SAFE_Y;
     }
     output[i + 1] = y;
   }

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -1,4 +1,8 @@
-import {HALF_SIZE, fromEPSG4326} from '../../../../src/ol/proj/epsg3857.js';
+import {
+  HALF_SIZE,
+  MAX_SAFE_Y,
+  fromEPSG4326,
+} from '../../../../src/ol/proj/epsg3857.js';
 import {
   addCommon,
   clearAllProjections,
@@ -24,11 +28,11 @@ describe('ol/proj/epsg3857', function () {
         },
         {
           g: [-180, -90],
-          m: [-HALF_SIZE, -HALF_SIZE],
+          m: [-HALF_SIZE, -MAX_SAFE_Y],
         },
         {
           g: [180, 90],
-          m: [HALF_SIZE, HALF_SIZE],
+          m: [HALF_SIZE, MAX_SAFE_Y],
         },
         {
           g: [-111.0429, 45.677],
@@ -47,7 +51,7 @@ describe('ol/proj/epsg3857', function () {
     it('does not produce unexpected results for string coordinates', function () {
       const transformed = fromEPSG4326(['180', '90']);
       expect(transformed[0]).to.roughlyEqual(HALF_SIZE, 1e-5);
-      expect(transformed[1]).to.roughlyEqual(HALF_SIZE, 1e-5);
+      expect(transformed[1]).to.roughlyEqual(MAX_SAFE_Y, 1e-5);
     });
   });
 


### PR DESCRIPTION
Although the validity extent of EPSG:3857 in y direction only ranges from ~-85 to ~85 degrees, lower/higher values can be handled. To avoid geometries getting corrupted topologically when transforming values from high/low latitudes, we can clamp to the lowest/highest safe value instead of the validity extent.

Improves (but does not fix) #11672.