### PR TITLE
Write the correct SRS code in EsriJSON

### DIFF
--- a/examples/vector-esri-edit.js
+++ b/examples/vector-esri-edit.js
@@ -15,9 +15,8 @@ import {fromLonLat} from '../src/ol/proj.js';
 import {tile as tileStrategy} from '../src/ol/loadingstrategy.js';
 
 const serviceUrl =
-  'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/' +
-  'services/PDX_Pedestrian_Districts/FeatureServer/';
-const layer = '0';
+  'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Wildfire/FeatureServer/';
+const layer = '2';
 
 const esrijsonFormat = new EsriJSON();
 
@@ -102,8 +101,8 @@ const map = new Map({
   layers: [raster, vector],
   target: document.getElementById('map'),
   view: new View({
-    center: fromLonLat([-122.619, 45.512]),
-    zoom: 12,
+    center: fromLonLat([-110.875, 37.345]),
+    zoom: 5,
   }),
 });
 
@@ -123,13 +122,13 @@ const dirty = {};
 selected.on('add', function (evt) {
   const feature = evt.element;
   feature.on('change', function (evt) {
-    dirty[evt.target.getId()] = true;
+    dirty[evt.target.get('objectid')] = true;
   });
 });
 
 selected.on('remove', function (evt) {
   const feature = evt.element;
-  const fid = feature.getId();
+  const fid = feature.get('objectid');
   if (dirty[fid] === true) {
     const payload =
       '[' +
@@ -139,7 +138,7 @@ selected.on('remove', function (evt) {
       ']';
     const url = serviceUrl + layer + '/updateFeatures';
     $.post(url, {f: 'json', features: payload}).done(function (data) {
-      const result = JSON.parse(data);
+      const result = typeof data === 'string' ? JSON.parse(data) : data;
       if (result.updateResults && result.updateResults.length > 0) {
         if (result.updateResults[0].success !== true) {
           const error = result.updateResults[0].error;
@@ -162,11 +161,10 @@ draw.on('drawend', function (evt) {
     ']';
   const url = serviceUrl + layer + '/addFeatures';
   $.post(url, {f: 'json', features: payload}).done(function (data) {
-    const result = JSON.parse(data);
+    const result = typeof data === 'string' ? JSON.parse(data) : data;
     if (result.addResults && result.addResults.length > 0) {
       if (result.addResults[0].success === true) {
-        feature.setId(result.addResults[0]['objectId']);
-        vectorSource.clear();
+        feature.set('objectid', result.addResults[0]['objectId']);
       } else {
         const error = result.addResults[0].error;
         alert(error.description + ' (' + error.code + ')');

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -207,16 +207,14 @@ class EsriJSON extends JSONFeature {
     const geometry = feature.getGeometry();
     if (geometry) {
       object['geometry'] = writeGeometry(geometry, opt_options);
-      if (opt_options && opt_options.featureProjection) {
+      const projection =
+        opt_options &&
+        (opt_options.dataProjection || opt_options.featureProjection);
+      if (projection) {
         object['geometry'][
           'spatialReference'
         ] = /** @type {EsriJSONSpatialReferenceWkid} */ ({
-          wkid: Number(
-            getProjection(opt_options.featureProjection)
-              .getCode()
-              .split(':')
-              .pop()
-          ),
+          wkid: Number(getProjection(projection).getCode().split(':').pop()),
         });
       }
       delete properties[feature.getGeometryName()];

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -1797,5 +1797,17 @@ describe('ol.format.EsriJSON', function () {
         );
       });
     });
+
+    it('does not add the projection inside the geometry when neither featurProjection nor dataProjection are set', function () {
+      const str = JSON.stringify(data);
+      const array = format.readFeatures(str);
+      const esrijson = format.writeFeaturesObject(array);
+      esrijson.features.forEach(function (feature, i) {
+        expect(feature.geometry.spatialReference).to.be(undefined);
+        expect(feature.geometry.paths[0]).to.eql(
+          array[i].getGeometry().getCoordinates()
+        );
+      });
+    });
   });
 });

--- a/test/spec/ol/format/esrijson.test.js
+++ b/test/spec/ol/format/esrijson.test.js
@@ -1763,15 +1763,38 @@ describe('ol.format.EsriJSON', function () {
       expect(esrijson.attributes).to.eql({});
     });
 
-    it('adds the projection inside the geometry correctly', function () {
+    it('adds the projection inside the geometry correctly when featureProjection is set', function () {
       const str = JSON.stringify(data);
       const array = format.readFeatures(str);
       const esrijson = format.writeFeaturesObject(array, {
-        featureProjection: 'EPSG:4326',
+        featureProjection: 'EPSG:3857',
       });
-      esrijson.features.forEach(function (feature) {
+      esrijson.features.forEach(function (feature, i) {
+        const spatialReference = feature.geometry.spatialReference;
+        expect(Number(spatialReference.wkid)).to.equal(3857);
+        expect(feature.geometry.paths[0]).to.eql(
+          array[i].getGeometry().getCoordinates()
+        );
+      });
+    });
+
+    it('adds the projection inside the geometry correctly when dataProjection is set', function () {
+      const str = JSON.stringify(data);
+      const array = format.readFeatures(str);
+      const esrijson = format.writeFeaturesObject(array, {
+        dataProjection: 'EPSG:4326',
+        featureProjection: 'EPSG:3857',
+      });
+      esrijson.features.forEach(function (feature, i) {
         const spatialReference = feature.geometry.spatialReference;
         expect(Number(spatialReference.wkid)).to.equal(4326);
+        expect(feature.geometry.paths[0]).to.eql(
+          array[i]
+            .getGeometry()
+            .clone()
+            .transform('EPSG:3857', 'EPSG:4326')
+            .getCoordinates()
+        );
       });
     });
   });


### PR DESCRIPTION
The previous behavior was incorrect, because the `featureProjection` ist the projection the features are in, whereas `dataProjection` is the projection of the serialized EsriJSON. So the correct behavior is to get the `wkid` from the `dataProjection` if it is set, and fall back to the `featureProjection`, in which case the features will not be transformed. 

Fixes #11734.