### PR TITLE
Fix: Check for layer extent in CanvasLayerRenderer.getDataAtPixel 

### DIFF
--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -9,13 +9,14 @@ import {
   compose as composeTransform,
   create as createTransform,
 } from '../../transform.js';
-import {createCanvasContext2D} from '../../dom.js';
 import {
+  containsCoordinate,
   getBottomLeft,
   getBottomRight,
   getTopLeft,
   getTopRight,
 } from '../../extent.js';
+import {createCanvasContext2D} from '../../dom.js';
 import {rotateAtOffset} from '../../render/canvas.js';
 
 /**
@@ -283,6 +284,20 @@ class CanvasLayerRenderer extends LayerRenderer {
       pixel.slice()
     );
     const context = this.context;
+
+    const layer = this.getLayer();
+    const layerExtent = layer.getExtent();
+    if (layerExtent) {
+      const renderCoordinate = applyTransform(
+        frameState.pixelToCoordinateTransform,
+        pixel.slice()
+      );
+
+      /** get only data inside of the layer extent */
+      if (!containsCoordinate(layerExtent, renderCoordinate)) {
+        return null;
+      }
+    }
 
     let data;
     try {


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
## Current behavior

If the [CanvasLayerRenderer](https://github.com/openlayers/openlayers/blob/v6.4.3/src/ol/renderer/canvas/Layer.js#L301) gets cross-origin image data, it returns an empty array so `map.forEachLayerAtPixel` will detect a layer  even if it is clicked outside of the layer extent.

Fixes #10099


## New behavior
The `CanvasLayerRenderer` checks for each pixel if it is in the layer extent, when not it will return `null` in `getDataAtPixel`.