### PR TITLE
Wfs bbox per feature type

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -47,7 +47,7 @@ The default `geometryFunction` can only handle `ol/geom/Point` geometries.
 
 ### 11
 
-`options.featureTypes` should be an Array.
+`options.featureTypes` must be an Array.
 
 ### 12
 

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -473,42 +473,40 @@ class WFS extends XMLFeature {
     node.setAttribute('service', 'WFS');
     node.setAttribute('version', this.version_);
     let filter;
-    if (options) {
-      if (options.handle) {
-        node.setAttribute('handle', options.handle);
-      }
-      if (options.outputFormat) {
-        node.setAttribute('outputFormat', options.outputFormat);
-      }
-      if (options.maxFeatures !== undefined) {
-        node.setAttribute('maxFeatures', String(options.maxFeatures));
-      }
-      if (options.resultType) {
-        node.setAttribute('resultType', options.resultType);
-      }
-      if (options.startIndex !== undefined) {
-        node.setAttribute('startIndex', String(options.startIndex));
-      }
-      if (options.count !== undefined) {
-        node.setAttribute('count', String(options.count));
-      }
-      if (options.viewParams !== undefined) {
-        node.setAttribute('viewParams', options.viewParams);
-      }
-      filter = options.filter;
-      if (options.bbox) {
-        assert(options.geometryName, 12); // `options.geometryName` must also be provided when `options.bbox` is set
-        const bbox = bboxFilter(
-          /** @type {string} */ (options.geometryName),
-          options.bbox,
-          options.srsName
-        );
-        if (filter) {
-          // if bbox and filter are both set, combine the two into a single filter
-          filter = andFilter(filter, bbox);
-        } else {
-          filter = bbox;
-        }
+    if (options.handle) {
+      node.setAttribute('handle', options.handle);
+    }
+    if (options.outputFormat) {
+      node.setAttribute('outputFormat', options.outputFormat);
+    }
+    if (options.maxFeatures !== undefined) {
+      node.setAttribute('maxFeatures', String(options.maxFeatures));
+    }
+    if (options.resultType) {
+      node.setAttribute('resultType', options.resultType);
+    }
+    if (options.startIndex !== undefined) {
+      node.setAttribute('startIndex', String(options.startIndex));
+    }
+    if (options.count !== undefined) {
+      node.setAttribute('count', String(options.count));
+    }
+    if (options.viewParams !== undefined) {
+      node.setAttribute('viewParams', options.viewParams);
+    }
+    filter = options.filter;
+    if (options.bbox) {
+      assert(options.geometryName, 12); // `options.geometryName` must also be provided when `options.bbox` is set
+      const bbox = bboxFilter(
+        /** @type {string} */ (options.geometryName),
+        options.bbox,
+        options.srsName
+      );
+      if (filter) {
+        // if bbox and filter are both set, combine the two into a single filter
+        filter = andFilter(filter, bbox);
+      } else {
+        filter = bbox;
       }
     }
     node.setAttributeNS(

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -143,7 +143,8 @@ const TRANSACTION_SERIALIZERS = {
  * @property {number} [count] Number of features to retrieve when paging. This is a
  * WFS 2.0 feature backported to WFS 1.1.0 by some Web Feature Services. Please note that some
  * Web Feature Services have repurposed `maxfeatures` instead.
- * @property {import("../extent.js").Extent} [bbox] Extent to use for the BBOX filter.
+ * @property {import("../extent.js").Extent} [bbox] Extent to use for the BBOX filter. The `geometryName`
+ * option must be set.
  * @property {import("./filter/Filter.js").default} [filter] Filter condition. See
  * {@link module:ol/format/Filter} for more information.
  * @property {string} [resultType] Indicates what response should be returned,

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -316,6 +316,59 @@ describe('ol.format.WFS', function () {
       expect(serialized.firstElementChild).to.xmleql(parse(text));
     });
 
+    it('creates one BBOX filter per feature type', function () {
+      const textQuery1 =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+        '    typeName="topp:states_1" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+        '    <ogc:BBOX>' +
+        '      <ogc:PropertyName>the_geom_1</ogc:PropertyName>' +
+        '      <gml:Envelope xmlns:gml="http://www.opengis.net/gml" ' +
+        '          srsName="urn:ogc:def:crs:EPSG::4326">' +
+        '        <gml:lowerCorner>1 2</gml:lowerCorner>' +
+        '        <gml:upperCorner>3 4</gml:upperCorner>' +
+        '      </gml:Envelope>' +
+        '    </ogc:BBOX>' +
+        '  </ogc:Filter>' +
+        '</wfs:Query>';
+      const textQuery2 =
+        '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +
+        '    typeName="topp:states_2" srsName="urn:ogc:def:crs:EPSG::4326" ' +
+        '    xmlns:topp="http://www.openplans.org/topp">' +
+        '  <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">' +
+        '    <ogc:BBOX>' +
+        '      <ogc:PropertyName>the_geom_2</ogc:PropertyName>' +
+        '      <gml:Envelope xmlns:gml="http://www.opengis.net/gml" ' +
+        '          srsName="urn:ogc:def:crs:EPSG::4326">' +
+        '        <gml:lowerCorner>5 6</gml:lowerCorner>' +
+        '        <gml:upperCorner>7 8</gml:upperCorner>' +
+        '      </gml:Envelope>' +
+        '    </ogc:BBOX>' +
+        '  </ogc:Filter>' +
+        '</wfs:Query>';
+      const serialized = new WFS().writeGetFeature({
+        srsName: 'urn:ogc:def:crs:EPSG::4326',
+        featureNS: 'http://www.openplans.org/topp',
+        featurePrefix: 'topp',
+        featureTypes: [
+          {
+            name: 'states_1',
+            geometryName: 'the_geom_1',
+            bbox: [1, 2, 3, 4],
+          },
+          {
+            name: 'states_2',
+            geometryName: 'the_geom_2',
+            bbox: [5, 6, 7, 8],
+          },
+        ],
+      });
+      expect(serialized.children.length).to.equal(2);
+      expect(serialized.firstElementChild).to.xmleql(parse(textQuery1));
+      expect(serialized.lastElementChild).to.xmleql(parse(textQuery2));
+    });
+
     it('creates a property filter', function () {
       const text =
         '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +


### PR DESCRIPTION
Fixes #11187 

Add a possibility to provide one specific bbox per feature type
on WFS writeGetFeature. This option results to one query node
per featureTypesBbox item. One query node, for one feature type,
will have a specific bbox filter and every query node will share
the same others filters (if a filter option is defined).

Also improve the doc for `WFS writeGetFeature bbox` option and remove a useless `if` in the same method. 