### PR TITLE
Include LICENSE.md in built package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "npm run serve-examples",
     "serve-examples": "webpack serve --config examples/webpack/config.js --mode development --watch",
     "build-examples": "webpack --config examples/webpack/config.js --mode production",
-    "build-package": "npm run transpile && npm run copy-css && node tasks/prepare-package && shx cp README.md build/ol",
+    "build-package": "npm run transpile && npm run copy-css && node tasks/prepare-package",
     "build-index": "npm run build-package && node tasks/generate-index",
     "build-legacy": "shx rm -rf build && npm run build-index && webpack --config config/webpack-config-legacy-build.js && cleancss --source-map src/ol/ol.css -o build/legacy/ol.css",
     "build-site": "npm run build-examples && npm run apidoc && mkdir -p build/site && cp site/index.html build/site && mv build/apidoc build/site/apidoc && mv build/examples build/site/examples",

--- a/tasks/prepare-package.js
+++ b/tasks/prepare-package.js
@@ -23,3 +23,13 @@ fs.writeFileSync(
   JSON.stringify(pkg, null, 2),
   'utf-8'
 );
+
+// copy in readme and license files
+fs.copyFileSync(
+  path.resolve(__dirname, '../README.md'),
+  path.join(buildDir, 'README.md')
+);
+fs.copyFileSync(
+  path.resolve(__dirname, '../LICENSE.md'),
+  path.join(buildDir, 'LICENSE.md')
+);


### PR DESCRIPTION
Copy `README.md` and `LICENSE.md` when preparing package. These files are useful for tools that inspect `node_modules` for dependency details.

For instance, resolves this warning when running [`license-webpack-plugin`](https://github.com/xz64/license-webpack-plugin):
`WARNING in license-webpack-plugin: could not find any license file for ol. Use the licenseTextOverrides option to add the license text if desired.`