### PR TITLE
Add fetch and TextDecoder to polyfill list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.wh
 
 For older browsers and platforms (Internet Explorer, Android 4.x, iOS v12 and older, Safari v12 and older), polyfills may be needed for the following browser features:
 
+* [`fetch`](https://caniuse.com/#feat=fetch): Available from [polyfill.io](https://polyfill.io/).
 * [`requestAnimationFrame`](https://caniuse.com/#feat=requestanimationframe): Available from [polyfill.io](https://polyfill.io/).
 * [`element.prototype.classList` (`add`/`remove`)](https://caniuse.com/#feat=classlist): Available from [polyfill.io](https://polyfill.io/).
 * [`URL` API](https://caniuse.com/#feat=url): Available from [polyfill.io](https://polyfill.io/).
+* [`TextDecoder`](https://caniuse.com/#feat=textencoder): Available from [polyfill.io](https://polyfill.io/).
 * [Pointer events](https://caniuse.com/#feat=pointer): Use [elm-pep](https://npmjs.com/package/elm-pep) (lightweight) or [@openlayers/pepjs](https://npmjs.com/package/@openlayers/pepjs) (for really, really old browsers).
 
 ## Documentation


### PR DESCRIPTION
#11723 updated the examples template and tutorials but omitted to update the README

#10996 added fetch to the library (previously only needed for examples).
#11723 uses TextDecoder under some conditions.
