### PR TITLE
Document that snapTolerance must be greater than 0

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -48,7 +48,7 @@ import {squaredDistance as squaredCoordinateDistance} from '../coordinate.js';
  * @property {number} [dragVertexDelay=500] Delay in milliseconds after pointerdown
  * before the current vertex can be dragged to its exact position.
  * @property {number} [snapTolerance=12] Pixel distance for snapping to the
- * drawing finish.
+ * drawing finish. Must be greater than `0`.
  * @property {boolean} [stopClick=false] Stop click, singleclick, and
  * doubleclick events from firing during drawing.
  * @property {number} [maxPoints] The number of points that can be drawn before


### PR DESCRIPTION
~A `snapTolerance` of `0` is a falsey value, so it won't be set on the instance. This pull request fixes that.~

*Edit*: A `snapTolerance` of `0` would not work, and it also would not be set on the instance because when a falsey value is provided, the default of `12` will be used. So we should just document that the value must be greater than `0`.