### PR TITLE
Update TMS tileUrlFunction example in ol/source/XYZ documentation

### DIFF
--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -62,7 +62,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * ```js
  *  tileUrlFunction: function(coordinate) {
  *    return 'http://mapserver.com/' + coordinate[0] + '/' +
- *      coordinate[1] + '/' + (-tileCoord[2] - 1) + '.png';
+ *      coordinate[1] + '/' + (-coordinate[2] - 1) + '.png';
  *  }
  * ```
  * @api

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -57,15 +57,14 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * Google grid where `x` 0 and `y` 0 are in the top left. Grids like
  * TMS where `x` 0 and `y` 0 are in the bottom left can be used by
  * using the `{-y}` placeholder in the URL template, so long as the
- * source does not have a custom tile grid. In this case,
- * {@link module:ol/source/TileImage} can be used with a `tileUrlFunction`
- * such as:
- *
+ * source does not have a custom tile grid. In this case
+ * a `tileUrlFunction` can be used, such as:
+ * ```js
  *  tileUrlFunction: function(coordinate) {
  *    return 'http://mapserver.com/' + coordinate[0] + '/' +
- *        coordinate[1] + '/' + coordinate[2] + '.png';
- *    }
- *
+ *      coordinate[1] + '/' + (-tileCoord[2] - 1) + '.png';
+ *  }
+ * ```
  * @api
  */
 class XYZ extends TileImage {


### PR DESCRIPTION
The custom TMS `tileUrlFunction` example had not been updated to reflect the y coordinate change made in v6.0.0.  The reference to using `ol/source/TileImage` seems outdated as `ol/source/XYZ` also supports a `tileUrlFunction`.
