### PR TITLE
Use Mode.LINE_STRING in Draw interaction for Circle geometries

### DIFF
--- a/examples/draw-shapes.html
+++ b/examples/draw-shapes.html
@@ -9,18 +9,19 @@ docs: >
   achieved by using `type: 'Circle'` type with a `geometryFunction` that creates
   a 4-sided regular polygon instead of a circle. Box drawing uses `type: 'Circle'`
   with a `geometryFunction` that creates a box-shaped polygon instead of a
-  circle.  Star drawing uses a custom geometry function that coverts a circle
-  into a start using the center and radius provided by the draw interaction.
+  circle. Star drawing uses a custom geometry function that converts a circle
+  into a star using the center and radius provided by the draw interaction.
 tags: "draw, edit, freehand, vector"
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">
-  <label for="type">Shape type &nbsp;</label>
-  <select id="type">
+  <label for="type">Shape type: &nbsp;</label>
+  <select class="form-control mr-2 mb-2 mt-2" id="type">
     <option value="Circle">Circle</option>
     <option value="Square">Square</option>
     <option value="Box">Box</option>
     <option value="Star">Star</option>
     <option value="None">None</option>
   </select>
+  <input class="form-control mr-2 mb-2 mt-2" type="button" value="Undo" id="undo">
 </form>

--- a/examples/draw-shapes.js
+++ b/examples/draw-shapes.js
@@ -43,28 +43,30 @@ function addInteraction() {
     } else if (value === 'Star') {
       value = 'Circle';
       geometryFunction = function (coordinates, geometry) {
-        const center = coordinates[0];
-        const last = coordinates[1];
-        const dx = center[0] - last[0];
-        const dy = center[1] - last[1];
-        const radius = Math.sqrt(dx * dx + dy * dy);
-        const rotation = Math.atan2(dy, dx);
-        const newCoordinates = [];
-        const numPoints = 12;
-        for (let i = 0; i < numPoints; ++i) {
-          const angle = rotation + (i * 2 * Math.PI) / numPoints;
-          const fraction = i % 2 === 0 ? 1 : 0.5;
-          const offsetX = radius * fraction * Math.cos(angle);
-          const offsetY = radius * fraction * Math.sin(angle);
-          newCoordinates.push([center[0] + offsetX, center[1] + offsetY]);
+        if (coordinates.length) {
+          const center = coordinates[0];
+          const last = coordinates[coordinates.length - 1];
+          const dx = center[0] - last[0];
+          const dy = center[1] - last[1];
+          const radius = Math.sqrt(dx * dx + dy * dy);
+          const rotation = Math.atan2(dy, dx);
+          const newCoordinates = [];
+          const numPoints = 12;
+          for (let i = 0; i < numPoints; ++i) {
+            const angle = rotation + (i * 2 * Math.PI) / numPoints;
+            const fraction = i % 2 === 0 ? 1 : 0.5;
+            const offsetX = radius * fraction * Math.cos(angle);
+            const offsetY = radius * fraction * Math.sin(angle);
+            newCoordinates.push([center[0] + offsetX, center[1] + offsetY]);
+          }
+          newCoordinates.push(newCoordinates[0].slice());
+          if (!geometry) {
+            geometry = new Polygon([newCoordinates]);
+          } else {
+            geometry.setCoordinates([newCoordinates]);
+          }
+          return geometry;
         }
-        newCoordinates.push(newCoordinates[0].slice());
-        if (!geometry) {
-          geometry = new Polygon([newCoordinates]);
-        } else {
-          geometry.setCoordinates([newCoordinates]);
-        }
-        return geometry;
       };
     }
     draw = new Draw({
@@ -83,5 +85,9 @@ typeSelect.onchange = function () {
   map.removeInteraction(draw);
   addInteraction();
 };
+
+document.getElementById('undo').addEventListener('click', function () {
+  draw.removeLastPoint();
+});
 
 addInteraction();

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -841,9 +841,7 @@ class Draw extends PointerInteraction {
       geometry.getType() === GeometryType.POLYGON &&
       this.mode_ !== Mode.POLYGON
     ) {
-      this.createOrUpdateCustomSketchLine_(
-        /** @type {Polygon} */ (geometry)
-      );
+      this.createOrUpdateCustomSketchLine_(/** @type {Polygon} */ (geometry));
     } else if (this.sketchLineCoords_) {
       const sketchLineGeom = this.sketchLine_.getGeometry();
       sketchLineGeom.setCoordinates(this.sketchLineCoords_);
@@ -919,9 +917,7 @@ class Draw extends PointerInteraction {
       }
       this.geometryFunction_(coordinates, geometry, projection);
       if (geometry.getType() === GeometryType.POLYGON && this.sketchLine_) {
-        this.createOrUpdateCustomSketchLine_(
-          /** @type {Polygon} */ (geometry)
-        );
+        this.createOrUpdateCustomSketchLine_(/** @type {Polygon} */ (geometry));
       }
     } else if (this.mode_ === Mode.POLYGON) {
       coordinates = /** @type {PolyCoordType} */ (this.sketchCoords_)[0];

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -1349,6 +1349,33 @@ describe('ol.interaction.Draw', function () {
       const draw = new Draw({
         source: source,
         type: 'Circle',
+        geometryFunction: createRegularPolygon(4),
+      });
+      map.addInteraction(draw);
+
+      // first point
+      simulateEvent('pointermove', 0, 0);
+      simulateEvent('pointerdown', 0, 0);
+      simulateEvent('pointerup', 0, 0);
+
+      // finish on second point
+      simulateEvent('pointermove', 20, 20);
+      simulateEvent('pointerdown', 20, 20);
+      simulateEvent('pointerup', 20, 20);
+
+      const features = source.getFeatures();
+      const geometry = features[0].getGeometry();
+      expect(geometry).to.be.a(Polygon);
+      const coordinates = geometry.getCoordinates();
+      expect(coordinates[0].length).to.eql(5);
+      expect(coordinates[0][0][0]).to.roughlyEqual(20, 1e-9);
+      expect(coordinates[0][0][1]).to.roughlyEqual(-20, 1e-9);
+    });
+
+    it('creates a regular polygon at specified angle', function () {
+      const draw = new Draw({
+        source: source,
+        type: 'Circle',
         geometryFunction: createRegularPolygon(4, Math.PI / 4),
       });
       map.addInteraction(draw);
@@ -1370,6 +1397,33 @@ describe('ol.interaction.Draw', function () {
       expect(coordinates[0].length).to.eql(5);
       expect(coordinates[0][0][0]).to.roughlyEqual(20, 1e-9);
       expect(coordinates[0][0][1]).to.roughlyEqual(20, 1e-9);
+    });
+
+    it('creates a regular polygon at specified 0 angle', function () {
+      const draw = new Draw({
+        source: source,
+        type: 'Circle',
+        geometryFunction: createRegularPolygon(4, 0),
+      });
+      map.addInteraction(draw);
+
+      // first point
+      simulateEvent('pointermove', 0, 0);
+      simulateEvent('pointerdown', 0, 0);
+      simulateEvent('pointerup', 0, 0);
+
+      // finish on second point
+      simulateEvent('pointermove', 20, 20);
+      simulateEvent('pointerdown', 20, 20);
+      simulateEvent('pointerup', 20, 20);
+
+      const features = source.getFeatures();
+      const geometry = features[0].getGeometry();
+      expect(geometry).to.be.a(Polygon);
+      const coordinates = geometry.getCoordinates();
+      expect(coordinates[0].length).to.eql(5);
+      expect(coordinates[0][0][0]).to.roughlyEqual(28.2842712474619, 1e-9);
+      expect(coordinates[0][0][1]).to.roughlyEqual(0, 1e-9);
     });
 
     it('creates a regular polygon in Circle mode in a user projection', function () {


### PR DESCRIPTION
Fixes #11713

Use `Mode.LINE_STRING` with a default `maxPoints` of 2 when the type is `Circle`.  This allows use of `removeLastPoint`.
Update all geometry functions to handle empty or single coordinates which may result from that.
