### PR TITLE
Fix typo that prevents Rotate icon from indicating the view rotation

### DIFF
--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -52,7 +52,7 @@ class Rotate extends Control {
     const compassClassName =
       options.compassClassName !== undefined
         ? options.compassClassName
-        : 'ol-comapss';
+        : 'ol-compass';
 
     /**
      * @type {HTMLElement}


### PR DESCRIPTION
This fixes a regression, see https://github.com/openlayers/openlayers/pull/11403#issuecomment-731720562.