### PR TITLE
Add padding option for View

### DIFF
--- a/examples/center.html
+++ b/examples/center.html
@@ -11,6 +11,11 @@ docs: >
   view's <code>centerOn</code> method is used to position a coordinate (Lausanne)
   at a specific pixel location (the center of the black box).
   <p>Use <code>Alt+Shift+Drag</code> to rotate the map.</p>
+  <p><b>Note:</b> This example does not shift the view center. So the zoom 
+  controls and rotating the map will still use the center of the viewport as anchor.
+  To shift the whole view based on a padding, use the `padding` option on the view,
+  as shown in the <a href="view-padding.html">view-padding.html</a> example.
+  </p>
 tags: "center, rotation, openstreetmap"
 ---
 <div class="mapcontainer">

--- a/examples/view-padding.css
+++ b/examples/view-padding.css
@@ -1,0 +1,54 @@
+.mapcontainer {
+  position: relative;
+  margin-bottom: 20px;
+}
+.map {
+  width: 1000px;
+  height: 600px;
+}
+.map .ol-zoom {
+  top: 178px;
+  left: 158px;
+}
+.map .ol-rotate {
+  top: 178px;
+  right: 58px;
+}
+.map .ol-attribution,
+.map .ol-attribution.ol-uncollapsible {
+  bottom: 30px;
+  right: 50px;
+}
+.padding-top {
+  position: absolute;
+  top: 0;
+  left: 0px;
+  width: 1000px;
+  height: 170px;
+  background: rgba(255, 255, 255, 0.5);
+}
+.padding-left {
+  position: absolute;
+  top: 170px;
+  left: 0;
+  width: 150px;
+  height: 400px;
+  background: rgba(255, 255, 255, 0.5);
+}
+.padding-right {
+  position: absolute;
+  top: 170px;
+  left: 950px;
+  width: 50px;
+  height: 400px;
+  background: rgba(255, 255, 255, 0.5);
+}
+.padding-bottom {
+  position: absolute;
+  top: 570px;
+  left: 0px;
+  width: 1000px;
+  height: 30px;
+  background: rgba(255, 255, 255, 0.5);
+}
+

--- a/examples/view-padding.html
+++ b/examples/view-padding.html
@@ -1,0 +1,23 @@
+---
+layout: example.html
+title: View Padding
+shortdesc: This example demonstrates the use of the view's padding option.
+docs: >
+  This example demonstrates how a map's view can be configured to accommodate
+  for viewport space covered by other elements.
+  If the map viewport is partially covered with other content (overlays) along
+  its edges, the `padding` option allows to shift the center of the viewport away from
+  that content. The shifted viewport center will also be the anchor for zooming in and
+  out with the Zoom controls, and for rotating.
+  <p>Use <code>Alt+Shift+Drag</code> to rotate the map.</p>
+tags: "center, padding, view, shift"
+---
+<div class="mapcontainer">
+  <div id="map" class="map"></div>
+  <div class="padding-top"></div>
+  <div class="padding-left"></div>
+  <div class="padding-right"></div>
+  <div class="padding-bottom"></div>
+</div>
+<button id="zoomtoswitzerland">Zoom to Switzerland</button>
+<button id="centerlausanne">Center on Lausanne</button>

--- a/examples/view-padding.js
+++ b/examples/view-padding.js
@@ -1,0 +1,73 @@
+import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
+import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
+import {fromLonLat} from '../src/ol/proj.js';
+
+/** @type {VectorSource<import("../src/ol/geom/SimpleGeometry.js").default>} */
+const source = new VectorSource({
+  url: 'data/geojson/switzerland.geojson',
+  format: new GeoJSON(),
+});
+const style = new Style({
+  fill: new Fill({
+    color: 'rgba(255, 255, 255, 0.6)',
+  }),
+  stroke: new Stroke({
+    color: '#319FD3',
+    width: 1,
+  }),
+  image: new CircleStyle({
+    radius: 5,
+    fill: new Fill({
+      color: 'rgba(255, 255, 255, 0.6)',
+    }),
+    stroke: new Stroke({
+      color: '#319FD3',
+      width: 1,
+    }),
+  }),
+});
+const vectorLayer = new VectorLayer({
+  source: source,
+  style: style,
+});
+const view = new View({
+  center: fromLonLat([6.6339863, 46.5193823]),
+  padding: [170, 50, 30, 150],
+  zoom: 6,
+});
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+    vectorLayer,
+  ],
+  target: 'map',
+  view: view,
+});
+
+const zoomtoswitzerland = document.getElementById('zoomtoswitzerland');
+zoomtoswitzerland.addEventListener(
+  'click',
+  function () {
+    const feature = source.getFeatures()[0];
+    const polygon = feature.getGeometry();
+    view.fit(polygon);
+  },
+  false
+);
+
+const centerlausanne = document.getElementById('centerlausanne');
+centerlausanne.addEventListener(
+  'click',
+  function () {
+    const feature = source.getFeatures()[1];
+    const point = feature.getGeometry();
+    view.setCenter(point.getCoordinates());
+  },
+  false
+);

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -4,7 +4,7 @@
 import {clamp} from './math.js';
 
 /**
- * @typedef {function((import("./coordinate.js").Coordinate|undefined), number, import("./size.js").Size, boolean=): (import("./coordinate.js").Coordinate|undefined)} Type
+ * @typedef {function((import("./coordinate.js").Coordinate|undefined), number, import("./size.js").Size, boolean=, Array<number>=): (import("./coordinate.js").Coordinate|undefined)} Type
  */
 
 /**
@@ -21,16 +21,19 @@ export function createExtent(extent, onlyCenter, smooth) {
      * @param {number} resolution Resolution.
      * @param {import("./size.js").Size} size Viewport size; unused if `onlyCenter` was specified.
      * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
+     * @param {Array<number>=} opt_centerShift Shift between map center and viewport center.
      * @return {import("./coordinate.js").Coordinate|undefined} Center.
      */
-    function (center, resolution, size, opt_isMoving) {
+    function (center, resolution, size, opt_isMoving, opt_centerShift) {
       if (center) {
         const viewWidth = onlyCenter ? 0 : size[0] * resolution;
         const viewHeight = onlyCenter ? 0 : size[1] * resolution;
-        let minX = extent[0] + viewWidth / 2;
-        let maxX = extent[2] - viewWidth / 2;
-        let minY = extent[1] + viewHeight / 2;
-        let maxY = extent[3] - viewHeight / 2;
+        const shiftX = opt_centerShift ? opt_centerShift[0] : 0;
+        const shiftY = opt_centerShift ? opt_centerShift[1] : 0;
+        let minX = extent[0] + viewWidth / 2 + shiftX;
+        let maxX = extent[2] - viewWidth / 2 + shiftX;
+        let minY = extent[1] + viewHeight / 2 + shiftY;
+        let maxY = extent[3] - viewHeight / 2 + shiftY;
 
         // note: when zooming out of bounds, min and max values for x and y may
         // end up inverted (min > max); this has to be accounted for

--- a/test/spec/ol/view.test.js
+++ b/test/spec/ol/view.test.js
@@ -1660,6 +1660,32 @@ describe('ol.View', function () {
     });
   });
 
+  describe('#getViewportSizeMinusPadding_()', function () {
+    let map, target;
+    beforeEach(function () {
+      target = document.createElement('div');
+      target.style.width = '200px';
+      target.style.height = '150px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+      });
+    });
+    afterEach(function () {
+      map.setTarget(null);
+      document.body.removeChild(target);
+    });
+    it('same as getViewportSize_ when no padding is set', function () {
+      const size = map.getView().getViewportSizeMinusPadding_();
+      expect(size).to.eql(map.getView().getViewportSize_());
+    });
+    it('correctly updates when the padding is changed', function () {
+      map.getView().padding = [1, 2, 3, 4];
+      const size = map.getView().getViewportSizeMinusPadding_();
+      expect(size).to.eql([194, 146]);
+    });
+  });
+
   describe('fit', function () {
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalCancelAnimationFrame = window.cancelAnimationFrame;
@@ -1773,6 +1799,14 @@ describe('ol.View', function () {
     it('fits correctly to the extent', function () {
       view.fit([1000, 1000, 2000, 2000], {size: [200, 200]});
       expect(view.getResolution()).to.be(5);
+      expect(view.getCenter()[0]).to.be(1500);
+      expect(view.getCenter()[1]).to.be(1500);
+    });
+    it('fits correctly to the extent when a padding is configured', function () {
+      view.padding = [100, 0, 0, 100];
+      view.setViewportSize([200, 200]);
+      view.fit([1000, 1000, 2000, 2000]);
+      expect(view.getResolution()).to.be(10);
       expect(view.getCenter()[0]).to.be(1500);
       expect(view.getCenter()[1]).to.be(1500);
     });
@@ -2155,6 +2189,23 @@ describe('ol.View', function () {
       center = view.getCenter();
       expect(center[0]).to.roughlyEqual(0, 1e-10);
       expect(center[1]).to.roughlyEqual(0, 1e-10);
+    });
+  });
+
+  describe('#getState', function () {
+    let view;
+    beforeEach(function () {
+      view = new View({
+        center: [0, 0],
+        resolutions: [1],
+        zoom: 0,
+      });
+      view.setViewportSize([100, 100]);
+    });
+    it('Correctly shifts the viewport center when a padding is set', function () {
+      view.padding = [50, 0, 0, 50];
+      const state = view.getState();
+      expect(state.center).to.eql([-25, 25]);
     });
   });
 });


### PR DESCRIPTION
In an application that covers the left half of the map viewport almost entirely with a collapsible overlay element, I needed a way to fit the map to elements so they are not covered by that overlay. I was able to handle that with `View.fit()` with a `padding`. But In addition, the app uses the History API and adds the map's center and zoom to the URL. This is what is neither covered well by `fit()` with a `padding`, nor by using the `centerOn()` method. I wanted something where I just set the `padding` and don't need to worry about how to fit or center anything.

This pull request adds what I came up with:
```js
const view = new View({
  //...
  padding: [0, 0, 0, 200];
});
```
My initial configuration is for the case where the overlay with a width of 200px is expanded. Everything on the map will be centered so it won't be covered by the overlay, because the viewport center is shifted so it is in the center of the remaining visible area.

Now when I collapse the overlay, all I need to do is
```js
view.padding[3] = 0;
```
Subsequent operations that center the map will use the center of the viewport again.
