### PR TITLE
Improve documentation of geometry rotation

### DIFF
--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -227,7 +227,7 @@ class Circle extends SimpleGeometry {
   /**
    * Rotate the geometry around a given coordinate. This modifies the geometry
    * coordinates in place.
-   * @param {number} angle Rotation angle in radians.
+   * @param {number} angle Rotation angle in counter-clockwise radians.
    * @param {import("../coordinate.js").Coordinate} anchor The rotation center.
    * @api
    */

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -470,7 +470,7 @@ export function fromExtent(extent) {
  * @param {import("./Circle.js").default} circle Circle geometry.
  * @param {number=} opt_sides Number of sides of the polygon. Default is 32.
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in
- *     radians. Default is 0.
+ *     counter-clockwise radians. 0 means East. Default is 0.
  * @return {Polygon} Polygon geometry.
  * @api
  */
@@ -500,7 +500,7 @@ export function fromCircle(circle, opt_sides, opt_angle) {
  * @param {import("../coordinate.js").Coordinate} center Center of the regular polygon.
  * @param {number} radius Radius of the regular polygon.
  * @param {number=} opt_angle Start angle for the first vertex of the polygon in
- *     radians. Default is 0.
+ *     counter-clockwise radians. 0 means East. Default is 0.
  */
 export function makeRegular(polygon, center, radius, opt_angle) {
   const flatCoordinates = polygon.getFlatCoordinates();

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -217,7 +217,7 @@ class SimpleGeometry extends Geometry {
   /**
    * Rotate the geometry around a given coordinate. This modifies the geometry
    * coordinates in place.
-   * @param {number} angle Rotation angle in radians.
+   * @param {number} angle Rotation angle in counter-clockwise radians.
    * @param {import("../coordinate.js").Coordinate} anchor The rotation center.
    * @api
    */


### PR DESCRIPTION
Fixes #11751

Updates the documentation of geometry rotation which has not already be done in #11753

Further changes for consistency with style rotation are probably not desirable as rotation is geometry is justifiably different and is associated with transforms and polygon winding.
