### PR TITLE
Modify interaction developer experience improvements

### DIFF
--- a/examples/modify-icon.html
+++ b/examples/modify-icon.html
@@ -1,0 +1,10 @@
+---
+layout: example.html
+title: Icon modification
+shortdesc: Example using a Modify interaction to edit an icon.
+docs: >
+  The icon on this map can be dragged to modify its location.
+  <p>The Modify interaction can be configured with a `layer` option. With this option, hit detection will be used to determine the modification candidate.</p>
+tags: "vector, modify, icon, marker"
+---
+<div id="map" class="map"></div>

--- a/examples/modify-icon.js
+++ b/examples/modify-icon.js
@@ -1,0 +1,67 @@
+import Feature from '../src/ol/Feature.js';
+import Map from '../src/ol/Map.js';
+import Point from '../src/ol/geom/Point.js';
+import TileJSON from '../src/ol/source/TileJSON.js';
+import VectorSource from '../src/ol/source/Vector.js';
+import View from '../src/ol/View.js';
+import {Icon, Style} from '../src/ol/style.js';
+import {Modify} from '../src/ol/interaction.js';
+import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
+
+const iconFeature = new Feature({
+  geometry: new Point([0, 0]),
+  name: 'Null Island',
+  population: 4000,
+  rainfall: 500,
+});
+
+const iconStyle = new Style({
+  image: new Icon({
+    anchor: [0.5, 46],
+    anchorXUnits: 'fraction',
+    anchorYUnits: 'pixels',
+    src: 'data/icon.png',
+  }),
+});
+
+iconFeature.setStyle(iconStyle);
+
+const vectorSource = new VectorSource({
+  features: [iconFeature],
+});
+
+const vectorLayer = new VectorLayer({
+  source: vectorSource,
+});
+
+const rasterLayer = new TileLayer({
+  source: new TileJSON({
+    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+    crossOrigin: '',
+  }),
+});
+
+const target = document.getElementById('map');
+const map = new Map({
+  layers: [rasterLayer, vectorLayer],
+  target: target,
+  view: new View({
+    center: [0, 0],
+    zoom: 3,
+  }),
+});
+
+const modify = new Modify({
+  layer: vectorLayer,
+  style: function () {}, // do not render the modification vertex
+});
+modify.on(['modifystart', 'modifyend'], function (evt) {
+  target.style.cursor = evt.type === 'modifystart' ? 'grabbing' : 'pointer';
+});
+map.on('pointermove', function (evt) {
+  if (!evt.dragging) {
+    target.style.cursor = map.hasFeatureAtPixel(evt.pixel) ? 'pointer' : '';
+  }
+});
+
+map.addInteraction(modify);

--- a/examples/modify-icon.js
+++ b/examples/modify-icon.js
@@ -52,8 +52,8 @@ const map = new Map({
 });
 
 const modify = new Modify({
-  layer: vectorLayer,
-  style: function () {}, // do not render the modification vertex
+  hitDetection: vectorLayer,
+  source: vectorSource,
 });
 modify.on(['modifystart', 'modifyend'], function (evt) {
   target.style.cursor = evt.type === 'modifystart' ? 'grabbing' : 'pointer';

--- a/examples/modify-icon.js
+++ b/examples/modify-icon.js
@@ -58,10 +58,9 @@ const modify = new Modify({
 modify.on(['modifystart', 'modifyend'], function (evt) {
   target.style.cursor = evt.type === 'modifystart' ? 'grabbing' : 'pointer';
 });
-map.on('pointermove', function (evt) {
-  if (!evt.dragging) {
-    target.style.cursor = map.hasFeatureAtPixel(evt.pixel) ? 'pointer' : '';
-  }
+const overlaySource = modify.getOverlay().getSource();
+overlaySource.on(['addfeature', 'removefeature'], function (evt) {
+  target.style.cursor = evt.type === 'addfeature' ? 'pointer' : '';
 });
 
 map.addInteraction(modify);

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -170,13 +170,15 @@ export class ModifyEvent extends Event {
  * the `features` option.  The interaction must be constructed with either a
  * `source`, `features` or `layer` option.
  *
- * When configured with a `source` or `features`, the modification object (for
- * point geometries the point, for linestring or polygon geometries an existing
- * vertex or a new vertex along a segment) is determined by geometric proximity to
- * the pointer location. When configured with a `layer`, hit detection will be
- * used to determine the feature that will be modified. This is the preferred way
- * when the visual representation of the features subject to modification is much
- * different from their geometry (e.g. icons with an offset).
+ * When configured with a `source` or `features`, Cartesian distance from the
+ * pointer is used to determine all features that will be modified. This is the
+ * preferred mode for modifying polygons or linestrings with shared edges or
+ * vertices that have to be modified together to maintain topology.
+ *
+ * When configured with a `layer`, pointer hit detection is used to determine the
+ * topmost feature that will be modified. This is the preferred mode for modifying
+ * points when the visual representation is much different from
+ * their geometry (e.g. large icons or icons with an offset).
  *
  * By default, the interaction will allow deletion of vertices when the `alt`
  * key is pressed.  To configure the interaction with a different condition

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -120,7 +120,7 @@ const ModifyEventType = {
  * features to modify.  If a vector source is not provided, a feature collection
  * must be provided with the `features` option.
  * @property {boolean|import("../layer/BaseVector").default} [hitDetection] When configured, point
- * features will considered for modification based on their visual appearance, instead of being within
+ * features will be considered for modification based on their visual appearance, instead of being within
  * the `pixelTolerance` from the pointer location. When a {@link module:ol/layer/BaseVector} is
  * provided, only the rendered representation of the features on that layer will be considered.
  * @property {Collection<Feature>} [features]

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1163,8 +1163,8 @@ class Modify extends PointerInteraction {
         const vertexSegments = {};
         vertexSegments[getUid(closestSegment)] = true;
 
-        this.delta_[0] = hitPointGeometry ? vertex[0] - pixelCoordinate[0] : 0;
-        this.delta_[1] = hitPointGeometry ? vertex[1] - pixelCoordinate[1] : 0;
+        this.delta_[0] = vertex[0] - pixelCoordinate[0];
+        this.delta_[1] = vertex[1] - pixelCoordinate[1];
         if (
           node.geometry.getType() === GeometryType.CIRCLE &&
           node.index === CIRCLE_CIRCUMFERENCE_INDEX

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -253,7 +253,7 @@ class Modify extends PointerInteraction {
     this.ignoreNextSingleClick_ = false;
 
     /**
-     * @type {Array<Feature>}
+     * @type {Collection<Feature>}
      * @private
      */
     this.featuresBeingModified_ = null;
@@ -414,12 +414,12 @@ class Modify extends PointerInteraction {
    */
   willModifyFeatures_(evt, segments) {
     if (!this.featuresBeingModified_) {
-      this.featuresBeingModified_ = [];
-      const features = this.featuresBeingModified_;
+      this.featuresBeingModified_ = new Collection();
+      const features = this.featuresBeingModified_.getArray();
       for (let i = 0, ii = segments.length; i < ii; ++i) {
         const feature = segments[i][0].feature;
         if (features.indexOf(feature) === -1) {
-          features.push(feature);
+          this.featuresBeingModified_.push(feature);
         }
       }
 
@@ -1079,7 +1079,7 @@ class Modify extends PointerInteraction {
       this.dispatchEvent(
         new ModifyEvent(
           ModifyEventType.MODIFYEND,
-          new Collection(this.featuresBeingModified_),
+          this.featuresBeingModified_,
           evt
         )
       );
@@ -1302,7 +1302,7 @@ class Modify extends PointerInteraction {
       this.dispatchEvent(
         new ModifyEvent(
           ModifyEventType.MODIFYEND,
-          new Collection(this.featuresBeingModified_),
+          this.featuresBeingModified_,
           evt
         )
       );

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -108,7 +108,7 @@ const ModifyEventType = {
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
  * @property {import("../style/Style.js").StyleLike} [style]
- * Style used for the modification point. For linestrings and polygons, this will
+ * Style used for the modification point or vertex. For linestrings and polygons, this will
  * be the affected vertex, for circles a point along the circle, and for points the actual
  * point. If not configured, the default edit style is used (see {@link module:ol/style}).
  * When using a style function, the point feature passed to the function will have a `features`
@@ -505,7 +505,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * Get the overlay layer that this interaction renders sketch features to.
+   * Get the overlay layer that this interaction renders the modification point or vertex to.
    * @return {VectorLayer} Overlay layer.
    * @api
    */

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1113,7 +1113,7 @@ class Modify extends PointerInteraction {
       );
     };
 
-    let box, hitPointGeometry;
+    let nodes, hitPointGeometry;
     if (this.hitDetection_) {
       const layerFilter =
         typeof this.hitDetection_ === 'object'
@@ -1125,25 +1125,32 @@ class Modify extends PointerInteraction {
           geometry = geometry || feature.getGeometry();
           if (geometry.getType() === GeometryType.POINT) {
             hitPointGeometry = geometry;
-            box = hitPointGeometry.getExtent();
+            const coordinate = geometry.getCoordinates();
+            nodes = [
+              {
+                feature,
+                geometry,
+                segment: [coordinate, coordinate],
+              },
+            ];
           }
           return true;
         },
         {layerFilter}
       );
     }
-    if (!box) {
+    if (!nodes) {
       const viewExtent = fromUserExtent(
         createExtent(pixelCoordinate, tempExtent),
         projection
       );
       const buffer = map.getView().getResolution() * this.pixelTolerance_;
-      box = toUserExtent(
+      const box = toUserExtent(
         bufferExtent(viewExtent, buffer, tempExtent),
         projection
       );
+      nodes = this.rBush_.getInExtent(box);
     }
-    const nodes = this.rBush_.getInExtent(box);
 
     if (nodes && nodes.length > 0) {
       const node = nodes.sort(sortByDistance)[0];

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -426,7 +426,7 @@ class Modify extends PointerInteraction {
       this.dispatchEvent(
         new ModifyEvent(
           ModifyEventType.MODIFYSTART,
-          new Collection(features),
+          this.featuresBeingModified_,
           evt
         )
       );

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -195,6 +195,55 @@ describe('ol.interaction.Modify', function () {
       expect(rbushEntries.length).to.be(1);
       expect(rbushEntries[0].feature).to.be(feature);
     });
+
+    it('accepts a layer for modification features', function () {
+      const feature = new Feature(new Point([0, 0]));
+      const source = new VectorSource({features: [feature]});
+      const layer = new VectorLayer({source: source});
+      const modify = new Modify({layer: layer});
+      const rbushEntries = modify.rBush_.getAll();
+      expect(rbushEntries.length).to.be(1);
+      expect(rbushEntries[0].feature).to.be(feature);
+      expect(modify.layer_).to.be(layer);
+    });
+
+    it('accepts a layer in addition to a features collection', function () {
+      const feature = new Feature(new Point([0, 0]));
+      const source = new VectorSource({features: [feature]});
+      const layer = new VectorLayer({source: source});
+      const features = new Collection([new Feature(new Point([1, 1]))]);
+      const modify = new Modify({layer: layer, features: features});
+      const rbushEntries = modify.rBush_.getAll();
+      expect(rbushEntries.length).to.be(1);
+      expect(rbushEntries[0].feature).to.be(features.item(0));
+      expect(modify.layer_).to.be(layer);
+    });
+
+    it('accepts a layer in addition to a features collection', function () {
+      const feature = new Feature(new Point([0, 0]));
+      const source = new VectorSource({features: [feature]});
+      const layer = new VectorLayer({source: source});
+      const features = new Collection([new Feature(new Point([1, 1]))]);
+      const modify = new Modify({layer: layer, features: features});
+      const rbushEntries = modify.rBush_.getAll();
+      expect(rbushEntries.length).to.be(1);
+      expect(rbushEntries[0].feature).to.be(features.item(0));
+      expect(modify.layer_).to.be(layer);
+    });
+
+    it('accepts a layer in addition to a source', function () {
+      const feature = new Feature(new Point([0, 0]));
+      const source = new VectorSource({features: [feature]});
+      const layer = new VectorLayer({source: source});
+      const candidateSource = new VectorSource({
+        features: [new Feature(new Point([1, 1]))],
+      });
+      const modify = new Modify({layer: layer, source: candidateSource});
+      const rbushEntries = modify.rBush_.getAll();
+      expect(rbushEntries.length).to.be(1);
+      expect(rbushEntries[0].feature).to.be(candidateSource.getFeatures()[0]);
+      expect(modify.layer_).to.be(layer);
+    });
   });
 
   describe('vertex deletion', function () {

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -562,6 +562,7 @@ describe('ol.interaction.Modify', function () {
     let modify, feature, events;
 
     beforeEach(function () {
+      features.push(new Feature(new Point([12, 34])));
       modify = new Modify({
         features: new Collection(features),
       });

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -1084,7 +1084,7 @@ describe('ol.interaction.Modify', function () {
       simulateEvent('pointerdrag', 30, -5, null, 0);
       simulateEvent('pointerup', 30, -5, null, 0);
 
-      expect(circleFeature.getGeometry().getRadius()).to.roughlyEqual(25, 1e9);
+      expect(circleFeature.getGeometry().getRadius()).to.roughlyEqual(25, 1e-9);
       expect(circleFeature.getGeometry().getCenter()).to.eql([5, 5]);
 
       // Increase radius along y axis

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -498,7 +498,7 @@ describe('ol.interaction.Modify', function () {
       simulateEvent('pointerdrag', 30, -5, null, 0);
       simulateEvent('pointerup', 30, -5, null, 0);
 
-      expect(circleFeature.getGeometry().getRadius()).to.equal(25);
+      expect(circleFeature.getGeometry().getRadius()).to.roughlyEqual(25, 0.1);
       expect(circleFeature.getGeometry().getCenter()).to.eql([5, 5]);
 
       // Increase radius along y axis
@@ -508,7 +508,7 @@ describe('ol.interaction.Modify', function () {
       simulateEvent('pointerdrag', 5, -35, null, 0);
       simulateEvent('pointerup', 5, -35, null, 0);
 
-      expect(circleFeature.getGeometry().getRadius()).to.equal(30);
+      expect(circleFeature.getGeometry().getRadius()).to.roughlyEqual(30, 0.1);
       expect(circleFeature.getGeometry().getCenter()).to.eql([5, 5]);
     });
 
@@ -553,7 +553,7 @@ describe('ol.interaction.Modify', function () {
         .getGeometry()
         .clone()
         .transform(userProjection, viewProjection);
-      expect(geometry2.getRadius()).to.roughlyEqual(25, 1e-9);
+      expect(geometry2.getRadius()).to.roughlyEqual(25, 0.1);
       expect(geometry2.getCenter()).to.eql([5, 5]);
 
       // Increase radius along y axis
@@ -567,7 +567,7 @@ describe('ol.interaction.Modify', function () {
         .getGeometry()
         .clone()
         .transform(userProjection, viewProjection);
-      expect(geometry3.getRadius()).to.roughlyEqual(30, 1e-9);
+      expect(geometry3.getRadius()).to.roughlyEqual(30, 0.1);
       expect(geometry3.getCenter()).to.eql([5, 5]);
     });
   });
@@ -1084,7 +1084,7 @@ describe('ol.interaction.Modify', function () {
       simulateEvent('pointerdrag', 30, -5, null, 0);
       simulateEvent('pointerup', 30, -5, null, 0);
 
-      expect(circleFeature.getGeometry().getRadius()).to.equal(25);
+      expect(circleFeature.getGeometry().getRadius()).to.roughlyEqual(25, 1e9);
       expect(circleFeature.getGeometry().getCenter()).to.eql([5, 5]);
 
       // Increase radius along y axis

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -942,8 +942,8 @@ describe('ol.interaction.Modify', function () {
     });
   });
 
-  describe('#setActive', function () {
-    it('removes the vertexFeature of deactivation', function () {
+  describe('Vertex feature', function () {
+    it('tracks features and removes the vertexFeature on deactivation', function () {
       const modify = new Modify({
         features: new Collection(features),
       });
@@ -952,6 +952,7 @@ describe('ol.interaction.Modify', function () {
 
       simulateEvent('pointermove', 10, -20, null, 0);
       expect(modify.vertexFeature_).to.not.be(null);
+      expect(modify.vertexFeature_.get('features').length).to.be(1);
 
       modify.setActive(false);
       expect(modify.vertexFeature_).to.be(null);


### PR DESCRIPTION
Working with the Modify interaction in an application, I noticed several flaws regarding developer experience:

* When modifying points with a style that is different from a circle with 10px radius, it is hard to grab the symbol for dragging because the vertex selection is geometry based. I would expect being able to grab the point for dragging anywhere (like it can currently be done with the Translate interaction). This could easily be achieved by adding hit detection.
* When using the `modifystart` and `modifyend` events, the `features` in the event object are all features on the modify `source`. But I would expect the features to be only those actually being modified.
* When configuring a `style` for the interaction, the vertex feature has no indication about which feature(s) it belongs to. So it is impossible to do conditional styling (e.g. only render a drag vertex for lines, not for points). I'd expect the feature to have a `features` property, so I can apply conditional styling based on the features the vertex belongs to.

This pull request fixes these flaws.

To take advantage of hit detection for points, the `Modify` interaction has to be configured with the new `layer` option.

Fixes #7404 
Replaces #8871
Fixes #8242 (thanks to the added hit detection, modifystart/modifyend can now be used)