### PR TITLE
Enable drawing MultiPoint geometry with more than one point

### DIFF
--- a/examples/draw-features.html
+++ b/examples/draw-features.html
@@ -14,6 +14,7 @@ tags: "draw, edit, freehand, vector"
   <label for="type">Geometry type: &nbsp;</label>
   <select class="form-control mr-2 mb-2 mt-2" id="type">
     <option value="Point">Point</option>
+    <option value="MultiPoint">MultiPoint</option>
     <option value="LineString">LineString</option>
     <option value="Polygon">Polygon</option>
     <option value="Circle">Circle</option>

--- a/examples/draw-features.js
+++ b/examples/draw-features.js
@@ -29,9 +29,17 @@ let draw; // global so we can remove it later
 function addInteraction() {
   const value = typeSelect.value;
   if (value !== 'None') {
+    let maxPoints;
+    if (value === 'MultiPoint') {
+      // By default MultiPoint drawing casts a single Point
+      // as a MultiPoint geometry. Override this to allow
+      // the user to choose when to finish drawing.
+      maxPoints = Infinity;
+    }
     draw = new Draw({
       source: source,
       type: typeSelect.value,
+      maxPoints: maxPoints,
     });
     map.addInteraction(draw);
   }

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -297,6 +297,73 @@ describe('ol.interaction.Draw', function () {
     });
   });
 
+  describe('drawing multipoints with more than one point', function () {
+    let draw;
+
+    beforeEach(function () {
+      draw = new Draw({
+        source: source,
+        type: 'MultiPoint',
+        maxPoints: 3,
+      });
+      map.addInteraction(draw);
+    });
+
+    it('finishes on first point', function () {
+      simulateEvent('pointermove', 30, 15);
+      simulateEvent('pointerdown', 30, 15);
+      simulateEvent('pointerup', 30, 15);
+      simulateEvent('pointerdown', 30, 15);
+      simulateEvent('pointerup', 30, 15);
+      const features = source.getFeatures();
+      expect(features).to.have.length(1);
+      const geometry = features[0].getGeometry();
+      expect(geometry).to.be.a(MultiPoint);
+      expect(geometry.getCoordinates()).to.eql([[30, -15]]);
+    });
+
+    it('finishes on a subsequent point', function () {
+      simulateEvent('pointermove', 30, 15);
+      simulateEvent('pointerdown', 30, 15);
+      simulateEvent('pointerup', 30, 15);
+      simulateEvent('pointermove', 15, 30);
+      simulateEvent('pointerdown', 15, 30);
+      simulateEvent('pointerup', 15, 30);
+      simulateEvent('pointerdown', 15, 30);
+      simulateEvent('pointerup', 15, 30);
+      simulateEvent('pointermove', 30, 30);
+      const features = source.getFeatures();
+      expect(features).to.have.length(1);
+      const geometry = features[0].getGeometry();
+      expect(geometry).to.be.a(MultiPoint);
+      expect(geometry.getCoordinates()).to.eql([
+        [30, -15],
+        [15, -30],
+      ]);
+    });
+
+    it('finishes at maximum point', function () {
+      simulateEvent('pointermove', 30, 15);
+      simulateEvent('pointerdown', 30, 15);
+      simulateEvent('pointerup', 30, 15);
+      simulateEvent('pointermove', 15, 30);
+      simulateEvent('pointerdown', 15, 30);
+      simulateEvent('pointerup', 15, 30);
+      simulateEvent('pointermove', 30, 30);
+      simulateEvent('pointerdown', 30, 30);
+      simulateEvent('pointerup', 30, 30);
+      const features = source.getFeatures();
+      expect(features).to.have.length(1);
+      const geometry = features[0].getGeometry();
+      expect(geometry).to.be.a(MultiPoint);
+      expect(geometry.getCoordinates()).to.eql([
+        [30, -15],
+        [15, -30],
+        [30, -30],
+      ]);
+    });
+  });
+
   describe('drawing linestrings', function () {
     let draw;
 


### PR DESCRIPTION
Currently the Draw interaction casts a single Point as a MultiPoint geometry.  This change enables MultiPoint geometry with more than one point to be drawn, while keeping the existing behaviour as the default for backward compatibility.

Add MultiPoint to the Draw Features example.

Add tests for MultiPoint drawing when maxPoints is set at more than one.
