### PR TITLE
No need to adjust hitTolerance for pixel ratio twice

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,20 @@
 ## Upgrade notes
 
+### Next version
+
+#### Units of the `hitTolerance` option fixed
+
+Previously, the `hitTolerance` option of the map's `getFeaturesAtPixel()`, `forEachFeatureAtPixel()` and `hasFeatureAtPixel()` methods behaved differntly depending on the `devicePixelRatio` (or the `pixelRatio` of the map). Now this is fixed, the `hitTolerance`'s units are css pixels.
+
+If your application adjusts for that with code like
+```js
+{ hitTolerance: 10 / devicePixelRatio, }
+```
+you'll have to change that code to
+```js
+{ hitTolerance: 10, }
+```
+
 ### v6.4.0
 
 #### Pointer events polyfill removed

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,7 +4,7 @@
 
 #### Units of the `hitTolerance` option fixed
 
-Previously, the `hitTolerance` option of the map's `getFeaturesAtPixel()`, `forEachFeatureAtPixel()` and `hasFeatureAtPixel()` methods behaved differntly depending on the `devicePixelRatio` (or the `pixelRatio` of the map). Now this is fixed, the `hitTolerance`'s units are css pixels.
+Previously, the `hitTolerance` option of the map's `getFeaturesAtPixel()`, `forEachFeatureAtPixel()` and `hasFeatureAtPixel()` methods behaved differntly depending on the `devicePixelRatio` (or the `pixelRatio` of the map), because the original value was internally multiplied by the device pixel ratio twice instead of just once. Now this is fixed. **Note**: The `hitTolerance`'s units are css pixels. The documentation was updated to reflect this.
 
 If your application adjusts for that with code like
 ```js

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -75,7 +75,7 @@ import {removeNode} from './dom.js';
  * {@link module:ol/layer/Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
  * will be tested for features. By default, all visible layers will be tested.
- * @property {number} [hitTolerance=0] Hit-detection tolerance in pixels. Pixels
+ * @property {number} [hitTolerance=0] Hit-detection tolerance in css pixels. Pixels
  * inside the radius around the given position will be checked for features.
  * @property {boolean} [checkWrapped=true] Check-Wrapped Will check for for wrapped geometries inside the range of
  *   +/- 1 world width. Works only if a projection is used that can be wrapped.
@@ -559,9 +559,7 @@ class PluggableMap extends BaseObject {
     const coordinate = this.getCoordinateFromPixelInternal(pixel);
     opt_options = opt_options !== undefined ? opt_options : {};
     const hitTolerance =
-      opt_options.hitTolerance !== undefined
-        ? opt_options.hitTolerance * this.frameState_.pixelRatio
-        : 0;
+      opt_options.hitTolerance !== undefined ? opt_options.hitTolerance : 0;
     const layerFilter =
       opt_options.layerFilter !== undefined ? opt_options.layerFilter : TRUE;
     const checkWrapped = opt_options.checkWrapped !== false;
@@ -624,9 +622,7 @@ class PluggableMap extends BaseObject {
     }
     const options = opt_options || {};
     const hitTolerance =
-      options.hitTolerance !== undefined
-        ? options.hitTolerance * this.frameState_.pixelRatio
-        : 0;
+      options.hitTolerance !== undefined ? options.hitTolerance : 0;
     const layerFilter = options.layerFilter || TRUE;
     return this.renderer_.forEachLayerAtPixel(
       pixel,
@@ -654,9 +650,7 @@ class PluggableMap extends BaseObject {
     const layerFilter =
       opt_options.layerFilter !== undefined ? opt_options.layerFilter : TRUE;
     const hitTolerance =
-      opt_options.hitTolerance !== undefined
-        ? opt_options.hitTolerance * this.frameState_.pixelRatio
-        : 0;
+      opt_options.hitTolerance !== undefined ? opt_options.hitTolerance : 0;
     const checkWrapped = opt_options.checkWrapped !== false;
     return this.renderer_.hasFeatureAtCoordinate(
       coordinate,


### PR DESCRIPTION
I think the behavior of the `hitTolerance` option of `Map#getFeaturesAtPixel()` and friends is buggy. Its units should be css pixels, not canvas pixels, so users don't have to configure different behavior depending on the device pixel ratio. This is what I mean:

devicePixelRatio === 2:
![Nov-27-2020 12-31-55](https://user-images.githubusercontent.com/211514/100444933-91968100-30ac-11eb-976a-ba16fd4438b9.gif)

devicePixelRatio === 1:
![Nov-27-2020 12-30-46](https://user-images.githubusercontent.com/211514/100444829-69a71d80-30ac-11eb-8089-5549df9fd40b.gif)

As you can see, the tolerance is different, and I would expect it to always be the same as the area preview at the bottom.
