### PR TITLE
Add a cancel event to the DragBox interaction

### DIFF
--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -53,6 +53,13 @@ const DragBoxEventType = {
    * @api
    */
   BOXEND: 'boxend',
+
+  /**
+   * Triggered upon drag box canceled.
+   * @event DragBoxEvent#boxcancel
+   * @api
+   */
+  BOXCANCEL: 'boxcancel',
 };
 
 /**
@@ -192,22 +199,21 @@ class DragBox extends PointerInteraction {
   handleUpEvent(mapBrowserEvent) {
     this.box_.setMap(null);
 
-    if (
-      this.boxEndCondition_(
-        mapBrowserEvent,
-        this.startPixel_,
-        mapBrowserEvent.pixel
-      )
-    ) {
+    const completeBox = this.boxEndCondition_(
+      mapBrowserEvent,
+      this.startPixel_,
+      mapBrowserEvent.pixel
+    );
+    if (completeBox) {
       this.onBoxEnd(mapBrowserEvent);
-      this.dispatchEvent(
-        new DragBoxEvent(
-          DragBoxEventType.BOXEND,
-          mapBrowserEvent.coordinate,
-          mapBrowserEvent
-        )
-      );
     }
+    this.dispatchEvent(
+      new DragBoxEvent(
+        completeBox ? DragBoxEventType.BOXEND : DragBoxEventType.BOXCANCEL,
+        mapBrowserEvent.coordinate,
+        mapBrowserEvent
+      )
+    );
     return false;
   }
 


### PR DESCRIPTION
Currently there is only a boxstart and boxend event but when the box is canceled it is silent.

This adds a boxcancel event in the case where no boxend event is dispatched.

I have an overlay in the map and on boxstart I hide the overlay because when the mouse is above the overlay the event is not passed through to the map. When the interaction is finished it should become visible again, but this is currently possible because of the missing event.