### PR TITLE
Pass geometry to forEachFeatureAtPixel callback

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -538,7 +538,7 @@ class PluggableMap extends BaseObject {
    * callback with each intersecting feature. Layers included in the detection can
    * be configured through the `layerFilter` option in `opt_options`.
    * @param {import("./pixel.js").Pixel} pixel Pixel.
-   * @param {import("./renderer/vector.js").FeatureCallback<T>} callback Feature callback. The callback will be
+   * @param {function(import("./Feature.js").FeatureLike, import("./layer/Layer.js").default, import("./geom/SimpleGeometry.js").default): T} callback Feature callback. The callback will be
    *     called with two arguments. The first argument is one
    *     {@link module:ol/Feature feature} or
    *     {@link module:ol/render/Feature render feature} at the pixel, the second is

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -538,8 +538,7 @@ class PluggableMap extends BaseObject {
    * callback with each intersecting feature. Layers included in the detection can
    * be configured through the `layerFilter` option in `opt_options`.
    * @param {import("./pixel.js").Pixel} pixel Pixel.
-   * @param {function(this: S, import("./Feature.js").FeatureLike,
-   *     import("./layer/Layer.js").default): T} callback Feature callback. The callback will be
+   * @param {import("./renderer/vector.js").FeatureCallback<T>} callback Feature callback. The callback will be
    *     called with two arguments. The first argument is one
    *     {@link module:ol/Feature feature} or
    *     {@link module:ol/render/Feature render feature} at the pixel, the second is

--- a/src/ol/render/canvas/Builder.js
+++ b/src/ol/render/canvas/Builder.js
@@ -355,19 +355,18 @@ class CanvasBuilder extends VectorContext {
    * @param {import("../../Feature.js").FeatureLike} feature Feature.
    */
   beginGeometry(geometry, feature) {
-    const extent = geometry.getExtent();
     this.beginGeometryInstruction1_ = [
       CanvasInstruction.BEGIN_GEOMETRY,
       feature,
       0,
-      extent,
+      geometry,
     ];
     this.instructions.push(this.beginGeometryInstruction1_);
     this.beginGeometryInstruction2_ = [
       CanvasInstruction.BEGIN_GEOMETRY,
       feature,
       0,
-      extent,
+      geometry,
     ];
     this.hitDetectionInstructions.push(this.beginGeometryInstruction2_);
   }

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -161,7 +161,7 @@ class ExecutorGroup {
    * @param {number} resolution Resolution.
    * @param {number} rotation Rotation.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../../Feature.js").FeatureLike): T} callback Feature callback.
+   * @param {import("./Executor.js").FeatureCallback<T>} callback Feature callback.
    * @param {Array<import("../../Feature.js").FeatureLike>} declutteredFeatures Decluttered features.
    * @return {T|undefined} Callback result.
    * @template T
@@ -225,9 +225,10 @@ class ExecutorGroup {
 
     /**
      * @param {import("../../Feature.js").FeatureLike} feature Feature.
+     * @param {import("../../geom/SimpleGeometry.js").default} geometry Geometry.
      * @return {?} Callback result.
      */
-    function featureCallback(feature) {
+    function featureCallback(feature, geometry) {
       const imageData = context.getImageData(0, 0, contextSize, contextSize)
         .data;
       for (let i = 0; i < contextSize; i++) {
@@ -243,7 +244,7 @@ class ExecutorGroup {
                 ) ||
                 declutteredFeatures.indexOf(feature) !== -1
               ) {
-                result = callback(feature);
+                result = callback(feature, geometry);
               }
               if (result) {
                 return result;

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -105,7 +105,7 @@ class LayerRenderer extends Observable {
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default): T} callback Feature callback.
+   * @param {import("./vector.js").FeatureCallback<T>} callback Feature callback.
    * @return {T|void} Callback result.
    * @template T
    */

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -64,8 +64,7 @@ class MapRenderer extends Disposable {
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
    * @param {boolean} checkWrapped Check for wrapped geometries.
-   * @param {function(this: S, import("../Feature.js").FeatureLike,
-   *     import("../layer/Layer.js").default): T} callback Feature callback.
+   * @param {import("./vector.js").FeatureCallback<T>} callback Feature callback.
    * @param {S} thisArg Value to use as `this` when executing `callback`.
    * @param {function(this: U, import("../layer/Layer.js").default): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function
@@ -92,10 +91,11 @@ class MapRenderer extends Disposable {
      * @param {boolean} managed Managed layer.
      * @param {import("../Feature.js").FeatureLike} feature Feature.
      * @param {import("../layer/Layer.js").default} layer Layer.
+     * @param {import("../geom/Geometry.js").default} geometry Geometry.
      * @return {?} Callback result.
      */
-    function forEachFeatureAtCoordinate(managed, feature, layer) {
-      return callback.call(thisArg, feature, managed ? layer : null);
+    function forEachFeatureAtCoordinate(managed, feature, layer, geometry) {
+      return callback.call(thisArg, feature, managed ? layer : null, geometry);
     }
 
     const projection = viewState.projection;

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -194,7 +194,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
    * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../../Feature.js").FeatureLike, import("../../layer/Layer.js").default): T} callback Feature callback.
+   * @param {import("../vector.js").FeatureCallback<T>} callback Feature callback.
    * @return {T|void} Callback result.
    * @template T
    */

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -406,7 +406,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../../Feature.js").FeatureLike, import("../../layer/Layer.js").default): T} callback Feature callback.
+   * @param {import("../vector.js").FeatureCallback<T>} callback Feature callback.
    * @return {T|void} Callback result.
    * @template T
    */
@@ -423,13 +423,14 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
       /**
        * @param {import("../../Feature.js").FeatureLike} feature Feature.
+       * @param {import("../../geom/SimpleGeometry.js").default} geometry Geometry.
        * @return {?} Callback result.
        */
-      const featureCallback = function (feature) {
+      const featureCallback = function (feature, geometry) {
         const key = getUid(feature);
         if (!(key in features)) {
           features[key] = true;
-          return callback(feature, layer);
+          return callback(feature, layer, geometry);
         }
       };
 

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -380,7 +380,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../../Feature.js").FeatureLike, import("../../layer/Layer.js").default): T} callback Feature callback.
+   * @param {import("../vector.js").FeatureCallback<T>} callback Feature callback.
    * @return {T|void} Callback result.
    * @template T
    */
@@ -432,9 +432,10 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
               hitTolerance,
               /**
                * @param {import("../../Feature.js").FeatureLike} feature Feature.
+               * @param {import("../../geom/SimpleGeometry.js").default} geometry Geometry.
                * @return {?} Callback result.
                */
-              function (feature) {
+              function (feature, geometry) {
                 if (tileContainsCoordinate) {
                   let key = feature.getId();
                   if (key === undefined) {
@@ -442,7 +443,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
                   }
                   if (!(key in features)) {
                     features[key] = true;
-                    return callback(feature, layer);
+                    return callback(feature, layer, geometry);
                   }
                 }
               },

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -7,6 +7,11 @@ import ImageState from '../ImageState.js';
 import {getUid} from '../util.js';
 
 /**
+ * Feature callback. The callback will be called with three arguments. The first
+ * argument is one {@link module:ol/Feature feature} or {@link module:ol/render/Feature render feature}
+ * at the pixel, the second is the {@link module:ol/layer/Layer layer} of the feature and will be null for
+ * unmanaged layers. The third is the {@link module:ol/geom/SimpleGeometry} of the feature. For features
+ * with a GeometryCollection geometry, it will be the first detected geometry from the collection.
  * @template T
  * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default, import("../geom/SimpleGeometry.js").default): T} FeatureCallback
  */

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -7,6 +7,11 @@ import ImageState from '../ImageState.js';
 import {getUid} from '../util.js';
 
 /**
+ * @template T
+ * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default, import("../geom/SimpleGeometry.js").default): T} FeatureCallback
+ */
+
+/**
  * Tolerance for geometry simplification in device pixels.
  * @type {number}
  */

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -597,7 +597,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../../Feature.js").FeatureLike, import("../../layer/Layer.js").default): T} callback Feature callback.
+   * @param {import("../vector.js").FeatureCallback<T>} callback Feature callback.
    * @return {T|void} Callback result.
    * @template T
    */
@@ -621,7 +621,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     const source = this.getLayer().getSource();
     const feature = source.getFeatureByUid(uid);
     if (feature) {
-      return callback(feature, this.getLayer());
+      return callback(feature, this.getLayer(), null);
     }
   }
 


### PR DESCRIPTION
Working on #11769, I realized that when editing a geometry collection, it is useful to not only get the feature that a hit was detected on, but also the exact geometry from the collection. Since this information is available at the time a hit is detected, this change is only about passing that information all the way to the map's `forEachFeatureAtPixel()` method.