### PR TITLE
Fix attributions links for WMS layers from swisstopo

### DIFF
--- a/examples/reprojection.js
+++ b/examples/reprojection.js
@@ -92,8 +92,8 @@ layers['wms4326'] = new TileLayer({
 layers['wms21781'] = new TileLayer({
   source: new TileWMS({
     attributions:
-      '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-      'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
+      '© <a href="https://shop.swisstopo.admin.ch/en/products/maps/national/lk1000"' +
+      'target="_blank">Pixelmap 1:1000000 / geo.admin.ch</a>',
     crossOrigin: 'anonymous',
     params: {
       'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -53,8 +53,8 @@ const layers = [
       url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions:
-        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-        'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
+        '© <a href="https://shop.swisstopo.admin.ch/en/products/maps/national/lk1000"' +
+        'target="_blank">Pixelmap 1:1000000 / geo.admin.ch</a>',
       params: {
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
         'FORMAT': 'image/jpeg',
@@ -68,9 +68,9 @@ const layers = [
       url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions:
-        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-        'en/home.html">National parks / geo.admin.ch</a>',
-      params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
+        '© <a href="https://www.hydrodaten.admin.ch/en/notes-on-the-flood-alert-maps.html"' +
+        'target="_blank">Flood Alert / geo.admin.ch</a>',
+      params: {'LAYERS': 'ch.bafu.hydroweb-warnkarte_national'},
       serverType: 'mapserver',
     }),
   }),

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -42,8 +42,8 @@ const layers = [
       url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions:
-        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-        'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
+        '© <a href="https://shop.swisstopo.admin.ch/en/products/maps/national/lk1000"' +
+        'target="_blank">Pixelmap 1:1000000 / geo.admin.ch</a>',
       params: {
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
         'FORMAT': 'image/jpeg',
@@ -57,9 +57,9 @@ const layers = [
       url: 'https://wms.geo.admin.ch/',
       crossOrigin: 'anonymous',
       attributions:
-        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-        'en/home.html">National parks / geo.admin.ch</a>',
-      params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
+        '© <a href="https://www.hydrodaten.admin.ch/en/notes-on-the-flood-alert-maps.html"' +
+        'target="_blank">Flood Alert / geo.admin.ch</a>',
+      params: {'LAYERS': 'ch.bafu.hydroweb-warnkarte_national'},
       serverType: 'mapserver',
     }),
   }),

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -9,8 +9,8 @@ const layers = [
   new TileLayer({
     source: new TileWMS({
       attributions:
-        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-        'en/home.html">Pixelmap 1:1000000 / geo.admin.ch</a>',
+        '© <a href="https://shop.swisstopo.admin.ch/en/products/maps/national/lk1000"' +
+        'target="_blank">Pixelmap 1:1000000 / geo.admin.ch</a>',
       crossOrigin: 'anonymous',
       params: {
         'LAYERS': 'ch.swisstopo.pixelkarte-farbe-pk1000.noscale',
@@ -22,10 +22,10 @@ const layers = [
   new ImageLayer({
     source: new ImageWMS({
       attributions:
-        '© <a href="http://www.geo.admin.ch/internet/geoportal/' +
-        'en/home.html">National parks / geo.admin.ch</a>',
+        '© <a href="https://www.hydrodaten.admin.ch/en/notes-on-the-flood-alert-maps.html"' +
+        'target="_blank">Flood Alert / geo.admin.ch</a>',
       crossOrigin: 'anonymous',
-      params: {'LAYERS': 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung'},
+      params: {'LAYERS': 'ch.bafu.hydroweb-warnkarte_national'},
       serverType: 'mapserver',
       url: 'https://wms.geo.admin.ch/',
     }),


### PR DESCRIPTION
fixes #11766

The attribution link is now the layer description page at Swisstopo. Because the "National parks" layer has no English page, I've changed it to "Flood Alert" layer.