### PR TITLE
Set default projection axis as neu in WMTS source

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -443,7 +443,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   }
 
   const wrapX = false;
-  const switchOriginXY = projection.getAxisOrientation().substr(0, 2) == 'ne';
+  const switchOriginXY = (projection.getAxisOrientation() || 'neu').substr(0, 2) === 'ne';
 
   let matrix = matrixSetObj.TileMatrix[0];
 


### PR DESCRIPTION
This is the small change that should resolve the issue with default axis orientation for WMTS source #11795