### PR TITLE
Fix removeLastPoint when removing last point

### DIFF
--- a/examples/draw-shapes.js
+++ b/examples/draw-shapes.js
@@ -43,30 +43,28 @@ function addInteraction() {
     } else if (value === 'Star') {
       value = 'Circle';
       geometryFunction = function (coordinates, geometry) {
-        if (coordinates.length) {
-          const center = coordinates[0];
-          const last = coordinates[coordinates.length - 1];
-          const dx = center[0] - last[0];
-          const dy = center[1] - last[1];
-          const radius = Math.sqrt(dx * dx + dy * dy);
-          const rotation = Math.atan2(dy, dx);
-          const newCoordinates = [];
-          const numPoints = 12;
-          for (let i = 0; i < numPoints; ++i) {
-            const angle = rotation + (i * 2 * Math.PI) / numPoints;
-            const fraction = i % 2 === 0 ? 1 : 0.5;
-            const offsetX = radius * fraction * Math.cos(angle);
-            const offsetY = radius * fraction * Math.sin(angle);
-            newCoordinates.push([center[0] + offsetX, center[1] + offsetY]);
-          }
-          newCoordinates.push(newCoordinates[0].slice());
-          if (!geometry) {
-            geometry = new Polygon([newCoordinates]);
-          } else {
-            geometry.setCoordinates([newCoordinates]);
-          }
-          return geometry;
+        const center = coordinates[0];
+        const last = coordinates[coordinates.length - 1];
+        const dx = center[0] - last[0];
+        const dy = center[1] - last[1];
+        const radius = Math.sqrt(dx * dx + dy * dy);
+        const rotation = Math.atan2(dy, dx);
+        const newCoordinates = [];
+        const numPoints = 12;
+        for (let i = 0; i < numPoints; ++i) {
+          const angle = rotation + (i * 2 * Math.PI) / numPoints;
+          const fraction = i % 2 === 0 ? 1 : 0.5;
+          const offsetX = radius * fraction * Math.cos(angle);
+          const offsetY = radius * fraction * Math.sin(angle);
+          newCoordinates.push([center[0] + offsetX, center[1] + offsetY]);
         }
+        newCoordinates.push(newCoordinates[0].slice());
+        if (!geometry) {
+          geometry = new Polygon([newCoordinates]);
+        } else {
+          geometry.setCoordinates([newCoordinates]);
+        }
+        return geometry;
       };
     }
     draw = new Draw({

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -1047,18 +1047,17 @@ class Draw extends PointerInteraction {
     }
 
     // Remove last coordinate from sketch drawing (this coordinate follows cursor position)
-    const ending = sketchCoords.pop();
+    sketchCoords.pop();
 
     // Append coordinate list
     for (let i = 0; i < coordinates.length; i++) {
       this.addToDrawing_(coordinates[i]);
     }
 
-    // Duplicate last coordinate for sketch drawing
+    const ending = coordinates[coordinates.length - 1];
+    // Duplicate last coordinate for sketch drawing (cursor position)
     this.addToDrawing_(ending);
-    this.modifyDrawing_(
-      this.downPx_ ? this.getMap().getCoordinateFromPixel(this.downPx_) : ending
-    );
+    this.modifyDrawing_(ending);
   }
 
   /**


### PR DESCRIPTION
This pull request fixes an issue with the Draw interaction's `removeLastPoint` method. Previously, when no vertex of a polygon or linestring was left to undo, it took two more calls of `removeLastPoint()` to abort the drawing. Now it only takes one more, which I think is the expected behavior.

This issue can be seen in the draw-features.html example, when drawing a polygon or linestring and repeatedly clicking undo to get rid of the entire geometry.