### PR TITLE
Modify fix vertex insertion

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1097,14 +1097,16 @@ class Modify extends PointerInteraction {
           for (let i = 1, ii = nodes.length; i < ii; ++i) {
             const segment = nodes[i].segment;
             if (
-              ((coordinatesEqual(closestSegment[0], segment[0]) &&
+              (coordinatesEqual(closestSegment[0], segment[0]) &&
                 coordinatesEqual(closestSegment[1], segment[1])) ||
-                (coordinatesEqual(closestSegment[0], segment[1]) &&
-                  coordinatesEqual(closestSegment[1], segment[0]))) &&
-              !(getUid(nodes[i].geometry) in geometries)
+              (coordinatesEqual(closestSegment[0], segment[1]) &&
+                coordinatesEqual(closestSegment[1], segment[0]))
             ) {
-              geometries[getUid(nodes[i].geometry)] = true;
-              vertexSegments[getUid(segment)] = true;
+              const geometryUid = getUid(nodes[i].geometry);
+              if (!(geometryUid in geometries)) {
+                geometries[geometryUid] = true;
+                vertexSegments[getUid(segment)] = true;
+              }
             } else {
               break;
             }

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -423,6 +423,37 @@ describe('ol.interaction.Modify', function () {
 
       expect(lineFeature.getGeometry().getCoordinates().length).to.equal(5);
     });
+    it('inserts one vertex into both linestrings with duplicate segments each', function () {
+      const lineFeature1 = new Feature(
+        new LineString([
+          [-10, -10],
+          [10, 10],
+          [-10, -10],
+        ])
+      );
+      const lineFeature2 = new Feature(
+        new LineString([
+          [10, 10],
+          [-10, -10],
+          [10, 10],
+        ])
+      );
+      features.length = 0;
+      features.push(lineFeature1, lineFeature2);
+
+      const modify = new Modify({
+        features: new Collection(features),
+      });
+      map.addInteraction(modify);
+
+      // Click on line
+      simulateEvent('pointermove', 0, 0, null, 0);
+      simulateEvent('pointerdown', 0, 0, null, 0);
+      simulateEvent('pointerup', 0, 0, null, 0);
+
+      expect(lineFeature1.getGeometry().getCoordinates().length).to.be(4);
+      expect(lineFeature2.getGeometry().getCoordinates().length).to.be(4);
+    });
   });
 
   describe('circle modification', function () {


### PR DESCRIPTION
If there are multiple same segments it should only insert one vertex per geometry for all features.
If one feature had a duplicate segment this blocked the insertion of a vertex for other features because the loop was left.

I'm not quite sure if the correct fix is this or if the break should simply be removed.
