### PR TITLE
Better getPointResolution default when no transform available

### DIFF
--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -4,6 +4,7 @@ import Projection from '../src/ol/proj/Projection.js';
 import TileWMS from '../src/ol/source/TileWMS.js';
 import View from '../src/ol/View.js';
 import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
+import {ScaleLine, defaults as defaultControls} from '../src/ol/control.js';
 
 const layers = [
   new TileLayer({
@@ -37,12 +38,20 @@ const layers = [
 // projection object. Requesting tiles only needs the code together with a
 // tile grid of Cartesian coordinates; it does not matter how those
 // coordinates relate to latitude or longitude.
+// With no transforms available projection units must be assumed to represent
+// true distances. In the case of local projections this may be a sufficiently
+// close approximation for a meaningful (if not 100% accurate) ScaleLine control.
 const projection = new Projection({
   code: 'EPSG:21781',
   units: 'm',
 });
 
 const map = new Map({
+  controls: defaultControls().extend([
+    new ScaleLine({
+      units: 'metric',
+    }),
+  ]),
   layers: layers,
   target: 'map',
   view: new View({

--- a/examples/wms-no-proj.js
+++ b/examples/wms-no-proj.js
@@ -38,20 +38,18 @@ const layers = [
 // projection object. Requesting tiles only needs the code together with a
 // tile grid of Cartesian coordinates; it does not matter how those
 // coordinates relate to latitude or longitude.
+//
 // With no transforms available projection units must be assumed to represent
 // true distances. In the case of local projections this may be a sufficiently
 // close approximation for a meaningful (if not 100% accurate) ScaleLine control.
+
 const projection = new Projection({
   code: 'EPSG:21781',
   units: 'm',
 });
 
 const map = new Map({
-  controls: defaultControls().extend([
-    new ScaleLine({
-      units: 'metric',
-    }),
-  ]),
+  controls: defaultControls().extend([new ScaleLine()]),
   layers: layers,
   target: 'map',
   view: new View({

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -212,20 +212,25 @@ export function getPointResolution(projection, resolution, point, opt_units) {
         projection,
         get('EPSG:4326')
       );
-      let vertices = [
-        point[0] - resolution / 2,
-        point[1],
-        point[0] + resolution / 2,
-        point[1],
-        point[0],
-        point[1] - resolution / 2,
-        point[0],
-        point[1] + resolution / 2,
-      ];
-      vertices = toEPSG4326(vertices, vertices, 2);
-      const width = getDistance(vertices.slice(0, 2), vertices.slice(2, 4));
-      const height = getDistance(vertices.slice(4, 6), vertices.slice(6, 8));
-      pointResolution = (width + height) / 2;
+      if (toEPSG4326 === identityTransform && units !== Units.DEGREES) {
+        // no transform is available
+        pointResolution = resolution * projection.getMetersPerUnit();
+      } else {
+        let vertices = [
+          point[0] - resolution / 2,
+          point[1],
+          point[0] + resolution / 2,
+          point[1],
+          point[0],
+          point[1] - resolution / 2,
+          point[0],
+          point[1] + resolution / 2,
+        ];
+        vertices = toEPSG4326(vertices, vertices, 2);
+        const width = getDistance(vertices.slice(0, 2), vertices.slice(2, 4));
+        const height = getDistance(vertices.slice(4, 6), vertices.slice(6, 8));
+        pointResolution = (width + height) / 2;
+      }
       const metersPerUnit = opt_units
         ? METERS_PER_UNIT[opt_units]
         : projection.getMetersPerUnit();

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -415,18 +415,9 @@ describe('ol.proj', function () {
         code: 'foo',
         units: 'ft',
       });
-      let pointResolution = getPointResolution(
-        projection,
-        2,
-        [0, 0]
-      );
+      let pointResolution = getPointResolution(projection, 2, [0, 0]);
       expect(pointResolution).to.be(2);
-      pointResolution = getPointResolution(
-        projection,
-        2,
-        [0, 0],
-        'm'
-      );
+      pointResolution = getPointResolution(projection, 2, [0, 0], 'm');
       expect(pointResolution).to.be(0.6096);
     });
   });

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -410,6 +410,25 @@ describe('ol.proj', function () {
       );
       expect(pointResolution).to.be(1);
     });
+    it('returns the nominal resolution for projections without transforms', function () {
+      const projection = new Projection({
+        code: 'foo',
+        units: 'ft',
+      });
+      let pointResolution = getPointResolution(
+        projection,
+        2,
+        [0, 0]
+      );
+      expect(pointResolution).to.be(2);
+      pointResolution = getPointResolution(
+        projection,
+        2,
+        [0, 0],
+        'm'
+      );
+      expect(pointResolution).to.be(0.6096);
+    });
   });
 
   describe('Proj4js integration', function () {


### PR DESCRIPTION
The default getPointResolution function does not give a meaningful result when proj4 is not used and there is no EPSG:4326 transform defined (as can be seen from the scalebar in https://codesandbox.io/s/wild-resonance-9350t) as the default identity transform is only meaningful when both projections units are degrees.  This change is equivalent to having specified
`getPointResolution: function (resolution) { return resolution; }`
in the Projection options in that situation

Added a ScaleLine to the **WMS without Projection** example as it is now meaningful, although it may lack the 100% accuracy of the **Single Image WMS with Proj4js** or **Custom Tiled WMS** examples.
