### PR TITLE
Add es6 modules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ See the following examples for more detail on bundling OpenLayers with your appl
  * Using [Webpack](https://github.com/openlayers/ol-webpack)
  * Using [Parcel](https://github.com/openlayers/ol-parcel)
  * Using [Browserify](https://github.com/openlayers/ol-browserify)
+ * Using [ES6 modules](https://github.com/openlayers/ol-parcel-es6)
 
 ## Sponsors
 


### PR DESCRIPTION
Fixes #11236 

I've finally got working instructions for creating ES6 modules, and would like to propose adding them to the documentation.

First step would be to copy https://github.com/Dreamsorcerer/ol-parcel-es6 to https://github.com/openlayers/ol-parcel-es6

Then this link can be merged in.

Note there are some details that I'll update as upstream bugs are resolved (such as minify is broken, and we need nightly parcel until there's a beta-2 release).