### PR TITLE
Use tilegrid extent as default attributionExtent for TileJSON

### DIFF
--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -171,10 +171,11 @@ class TileJSON extends TileImage {
       extent = applyTransform(tileJSON['bounds'], transform);
     }
 
+    const gridExtent = extentFromProjection(sourceProjection);
     const minZoom = tileJSON['minzoom'] || 0;
     const maxZoom = tileJSON['maxzoom'] || 22;
     const tileGrid = createXYZ({
-      extent: extentFromProjection(sourceProjection),
+      extent: gridExtent,
       maxZoom: maxZoom,
       minZoom: minZoom,
       tileSize: this.tileSize_,
@@ -184,9 +185,7 @@ class TileJSON extends TileImage {
     this.tileUrlFunction = createFromTemplates(tileJSON['tiles'], tileGrid);
 
     if (tileJSON['attribution'] !== undefined && !this.getAttributions()) {
-      const attributionExtent =
-        extent !== undefined ? extent : epsg4326Projection.getExtent();
-
+      const attributionExtent = extent !== undefined ? extent : gridExtent;
       this.setAttributions(function (frameState) {
         if (intersects(attributionExtent, frameState.extent)) {
           return [tileJSON['attribution']];

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -435,10 +435,11 @@ class UTFGrid extends TileSource {
       extent = applyTransform(tileJSON['bounds'], transform);
     }
 
+    const gridExtent = extentFromProjection(sourceProjection);
     const minZoom = tileJSON['minzoom'] || 0;
     const maxZoom = tileJSON['maxzoom'] || 22;
     const tileGrid = createXYZ({
-      extent: extentFromProjection(sourceProjection),
+      extent: gridExtent,
       maxZoom: maxZoom,
       minZoom: minZoom,
     });
@@ -455,9 +456,7 @@ class UTFGrid extends TileSource {
     this.tileUrlFunction_ = createFromTemplates(grids, tileGrid);
 
     if (tileJSON['attribution'] !== undefined) {
-      const attributionExtent =
-        extent !== undefined ? extent : epsg4326Projection.getExtent();
-
+      const attributionExtent = extent !== undefined ? extent : gridExtent;
       this.setAttributions(function (frameState) {
         if (intersects(attributionExtent, frameState.extent)) {
           return [tileJSON['attribution']];


### PR DESCRIPTION
Fixes #11846

Use a more appropriate default extent.

This does not attempt to handle reprojection issues mentioned in #11846 as transforms involving global extents and local projections could be invalid, and conflicts between reprojection and attributions also seem to affect BingMaps sources, so these would be best dealt with as a separate issue.
