### PR TITLE
Correct documented event names for VectorSourceEvent

### DIFF
--- a/src/ol/source/VectorEventType.js
+++ b/src/ol/source/VectorEventType.js
@@ -37,21 +37,21 @@ export default {
 
   /**
    * Triggered when features starts loading.
-   * @event module:ol/source/Vector.VectorSourceEvent#featureloadstart
+   * @event module:ol/source/Vector.VectorSourceEvent#featuresloadstart
    * @api
    */
   FEATURESLOADSTART: 'featuresloadstart',
 
   /**
    * Triggered when features finishes loading.
-   * @event module:ol/source/Vector.VectorSourceEvent#featureloadend
+   * @event module:ol/source/Vector.VectorSourceEvent#featuresloadend
    * @api
    */
   FEATURESLOADEND: 'featuresloadend',
 
   /**
    * Triggered if feature loading results in an error.
-   * @event module:ol/source/Vector.VectorSourceEvent#featureloaderror
+   * @event module:ol/source/Vector.VectorSourceEvent#featuresloaderror
    * @api
    */
   FEATURESLOADERROR: 'featuresloaderror',


### PR DESCRIPTION
An `s`is missing in the event name documentation.