### PR TITLE
Do not fire duplicate postrender events

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1140,6 +1140,7 @@ class PluggableMap extends BaseObject {
     if (!targetElement) {
       if (this.renderer_) {
         clearTimeout(this.postRenderTimeoutHandle_);
+        this.postRenderTimeoutHandle_ = undefined;
         this.postRenderFunctions_.length = 0;
         this.renderer_.dispose();
         this.renderer_ = null;
@@ -1438,10 +1439,12 @@ class PluggableMap extends BaseObject {
 
     this.dispatchEvent(new MapEvent(MapEventType.POSTRENDER, this, frameState));
 
-    this.postRenderTimeoutHandle_ = setTimeout(
-      this.handlePostRender.bind(this),
-      0
-    );
+    if (!this.postRenderTimeoutHandle_) {
+      this.postRenderTimeoutHandle_ = setTimeout(() => {
+        this.postRenderTimeoutHandle_ = undefined;
+        this.handlePostRender();
+      }, 0);
+    }
   }
 
   /**


### PR DESCRIPTION
Multiple `rendercomplete` may be fired when the `setTimout` for `handlePostRender` does not run immediatly between two animation frames or `renderSync` is called.

Instead of the order of function calls for `PluggableMap` being 
`renderFrame_` -> `handlePostRender` -> `renderFrame_` -> `handlePostRender` 
it may be 
`renderFrame_` -> `renderFrame_` -> `handlePostRender` -> `handlePostRender`

With this PR no more than one `handlePostRender` will occur between any two `renderFrame_` calls.