### PR TITLE
Use ol/array#includes instead of Array.prototype.includes()

### DIFF
--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -3,6 +3,7 @@
  */
 
 import {assert} from '../asserts.js';
+import {includes} from '../array.js';
 
 /**
  * @typedef {Object} PreferredOptions
@@ -245,10 +246,10 @@ function generateVersion3Options(iiifInfo) {
       iiifInfo.imageInfo.preferredFormats.length > 0
         ? iiifInfo.imageInfo.preferredFormats
             .filter(function (format) {
-              return ['jpg', 'png', 'gif'].includes(format);
+              return includes(['jpg', 'png', 'gif'], format);
             })
             .reduce(function (acc, format) {
-              return acc === undefined && formats.includes(format)
+              return acc === undefined && includes(formats, format)
                 ? format
                 : acc;
             }, undefined)
@@ -456,16 +457,16 @@ class IIIFInfo {
       sizes: imageOptions.sizes,
       format:
         options.format !== undefined &&
-        imageOptions.formats.includes(options.format)
+        includes(imageOptions.formats, options.format)
           ? options.format
           : imageOptions.preferredFormat !== undefined
           ? imageOptions.preferredFormat
           : 'jpg',
       supports: imageOptions.supports,
       quality:
-        options.quality && imageOptions.qualities.includes(options.quality)
+        options.quality && includes(imageOptions.qualities, options.quality)
           ? options.quality
-          : imageOptions.qualities.includes('native')
+          : includes(imageOptions.qualities, 'native')
           ? 'native'
           : 'default',
       resolutions: Array.isArray(imageOptions.resolutions)

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -9,6 +9,7 @@ import {DEFAULT_TILE_SIZE} from '../tilegrid/common.js';
 import {Versions} from '../format/IIIFInfo.js';
 import {assert} from '../asserts.js';
 import {getTopLeft} from '../extent.js';
+import {includes} from '../array.js';
 import {toSize} from '../size.js';
 
 /**
@@ -111,11 +112,11 @@ class IIIF extends TileImage {
     const supportsArbitraryTiling =
       supports != undefined &&
       Array.isArray(supports) &&
-      (supports.includes('regionByPx') || supports.includes('regionByPct')) &&
-      (supports.includes('sizeByWh') ||
-        supports.includes('sizeByH') ||
-        supports.includes('sizeByW') ||
-        supports.includes('sizeByPct'));
+      (includes(supports, 'regionByPx') || includes(supports, 'regionByPct')) &&
+      (includes(supports, 'sizeByWh') ||
+        includes(supports, 'sizeByH') ||
+        includes(supports, 'sizeByW') ||
+        includes(supports, 'sizeByPct'));
 
     let tileWidth, tileHeight, maxZoom;
 
@@ -270,10 +271,10 @@ class IIIF extends TileImage {
           regionParam = 'full';
         } else if (
           !supportsArbitraryTiling ||
-          supports.includes('regionByPx')
+          includes(supports, 'regionByPx')
         ) {
           regionParam = regionX + ',' + regionY + ',' + regionW + ',' + regionH;
-        } else if (supports.includes('regionByPct')) {
+        } else if (includes(supports, 'regionByPct')) {
           const pctX = formatPercentage((regionX / width) * 100),
             pctY = formatPercentage((regionY / height) * 100),
             pctW = formatPercentage((regionW / width) * 100),
@@ -282,16 +283,16 @@ class IIIF extends TileImage {
         }
         if (
           version == Versions.VERSION3 &&
-          (!supportsArbitraryTiling || supports.includes('sizeByWh'))
+          (!supportsArbitraryTiling || includes(supports, 'sizeByWh'))
         ) {
           sizeParam = sizeW + ',' + sizeH;
-        } else if (!supportsArbitraryTiling || supports.includes('sizeByW')) {
+        } else if (!supportsArbitraryTiling || includes(supports, 'sizeByW')) {
           sizeParam = sizeW + ',';
-        } else if (supports.includes('sizeByH')) {
+        } else if (includes(supports, 'sizeByH')) {
           sizeParam = ',' + sizeH;
-        } else if (supports.includes('sizeByWh')) {
+        } else if (includes(supports, 'sizeByWh')) {
           sizeParam = sizeW + ',' + sizeH;
-        } else if (supports.includes('sizeByPct')) {
+        } else if (includes(supports, 'sizeByPct')) {
           sizeParam = 'pct:' + formatPercentage(100 / scale);
         }
       } else {


### PR DESCRIPTION
Fixes browser compatibility in the IIIF Image API example which currently doesn't work with IE and perhaps some other old browsers.
