### PR TITLE
Fix examples build for ie11

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ For older browsers and platforms (Internet Explorer, Android 4.x, iOS v12 and ol
 * [`element.prototype.classList` (`add`/`remove`)](https://caniuse.com/#feat=classlist): Available from [polyfill.io](https://polyfill.io/).
 * [`URL` API](https://caniuse.com/#feat=url): Available from [polyfill.io](https://polyfill.io/).
 * [`TextDecoder`](https://caniuse.com/#feat=textencoder): Available from [polyfill.io](https://polyfill.io/).
+* [`Number.isInteger`](https://caniuse.com/#feat=isInteger): Available from [polyfill.io](https://polyfill.io/).
 * [Pointer events](https://caniuse.com/#feat=pointer): Use [elm-pep](https://npmjs.com/package/elm-pep) (lightweight) or [pepjs](https://npmjs.com/package/pepjs) (for really, really old browsers).
 
 ## Documentation

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -68,7 +68,7 @@
     <link rel="stylesheet" href="./css/ol.css" type="text/css">
     <link rel="stylesheet" href="./resources/layout.css" type="text/css">
     <script src="https://unpkg.com/elm-pep"></script>
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL,TextDecoder"></script>
+    <script src="https://cdn.polyfill.io/v3/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,URL,TextDecoder,Number.isInteger"></script>
     {{{ extraHead.local }}}
     {{{ css.tag }}}
     <title>{{ title }}</title>

--- a/examples/webpack/config.js
+++ b/examples/webpack/config.js
@@ -27,18 +27,31 @@ module.exports = {
         test: /^((?!es2015-)[\s\S])*\.js$/,
         use: {
           loader: 'buble-loader',
+          options: {
+            transforms: {
+              dangerousForOf: true,
+            },
+          },
         },
         include: [
           path.join(__dirname, '..', '..', 'src'),
           path.join(__dirname, '..'),
+          path.join(
+            __dirname,
+            '..',
+            '..',
+            'node_modules',
+            '@mapbox',
+            'mapbox-gl-style-spec'
+          ),
         ],
       },
       {
         test: /\.js$/,
         use: {
-          loader: path.join(__dirname, './worker-loader.js'),
+          loader: path.join(__dirname, 'worker-loader.js'),
         },
-        include: [path.join(__dirname, '../../src/ol/worker')],
+        include: [path.join(__dirname, '..', '..', 'src', 'ol', 'worker')],
       },
     ],
   },


### PR DESCRIPTION
The examples work now with ie11 and the spread operator is gone from the legacy build.

I added `Number.isInteger` to the polyfills because that function is not available in ie11.

Building the examples takes twice as long now and I have to say that I am not at all an webpack expert...