### PR TITLE
Update Mapbox-gl Layer example to mapbox-gl-js version 1.13.0 and add note about why an old version is used

### DIFF
--- a/examples/mapbox-layer.html
+++ b/examples/mapbox-layer.html
@@ -3,12 +3,14 @@ layout: example.html
 title: Mapbox-gl Layer
 shortdesc: Example of a Mapbox-gl-js layer integration.
 docs: >
-  Show how to add a mapbox-gl-js layer in an openlayers map. **Note**: Make sure to get your own API key at https://www.maptiler.com/cloud/ when using this example. No map will be visible when the API key has expired.
+  Show how to add a mapbox-gl-js layer in an OpenLayers map.
+  **Note**: Make sure to get your own API key at https://www.maptiler.com/cloud/ when using this example. No map will be visible when the API key has expired.
+  mapbox-gl-js version 1.13.0 is used in this example as later versions require a Mapbox access token and are not compatible with older browsers.
 tags: "simple, mapbox, vector, tiles, maptiler"
 experimental: true
 resources:
-  - https://unpkg.com/mapbox-gl@1.11.1/dist/mapbox-gl.js
-  - https://unpkg.com/mapbox-gl@1.11.1/dist/mapbox-gl.css
+  - https://cdnjs.cloudflare.com/ajax/libs/mapbox-gl/1.13.0/mapbox-gl.js
+  - https://cdnjs.cloudflare.com/ajax/libs/mapbox-gl/1.13.0/mapbox-gl.css
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB
     value: Get your own API key at https://www.maptiler.com/cloud/


### PR DESCRIPTION
mapbox-gl-js version 2.x is definitely not compatible with IE and also requires a Mapbox access token even when the source is not hosted by Mapbox, so I have updated to the final compatible version with a note about why the version is used.