### PR TITLE
Hit lines even if they are dashed

### DIFF
--- a/src/ol/render/canvas/LineStringBuilder.js
+++ b/src/ol/render/canvas/LineStringBuilder.js
@@ -6,6 +6,7 @@ import CanvasInstruction, {
   beginPathInstruction,
   strokeInstruction,
 } from './Instruction.js';
+import {defaultLineDash, defaultLineDashOffset} from '../canvas.js';
 
 class CanvasLineStringBuilder extends CanvasBuilder {
   /**
@@ -67,8 +68,8 @@ class CanvasLineStringBuilder extends CanvasBuilder {
         state.lineCap,
         state.lineJoin,
         state.miterLimit,
-        state.lineDash,
-        state.lineDashOffset,
+        defaultLineDash,
+        defaultLineDashOffset,
       ],
       beginPathInstruction
     );

--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -74,6 +74,7 @@ export function createHitDetectionImageData(
       const stroke = style.getStroke();
       if (stroke) {
         stroke.setColor(color);
+        stroke.setLineDash(null);
       }
       style.setText(undefined);
       const image = originalStyle.getImage();


### PR DESCRIPTION
I think the expected hit detection behavior is to consider lines hit even if they are dashed.

This change makes it so we ignore any line dash (as we do with color) when doing hit detection in both `map.forEachFeatureAtPixel()` and `layer.getFeatures()`.  The new tests fail without the source changes.

Fixes #11805.