### PR TITLE
Throw an error if shaders fail to compile or program fails to link

### DIFF
--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -81,15 +81,6 @@ class WebGLLayerRenderer extends LayerRenderer {
   }
 
   /**
-   * Will return the last shader compilation errors. If no error happened, will return null;
-   * @return {string|null} Errors, or null if last compilation was successful
-   * @api
-   */
-  getShaderCompileErrors() {
-    return this.helper.getShaderCompileErrors();
-  }
-
-  /**
    * @param {import("../../render/EventType.js").default} type Event type.
    * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
    * @private

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -46,7 +46,14 @@ const FRAGMENT_SHADER = `
     gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
   }`;
 
-describe('ol.webgl.WebGLHelper', function () {
+const INVALID_FRAGMENT_SHADER = `
+  precision mediump float;
+
+  void main(void) {
+    gl_FragColor = vec4(oops, 1.0, 1.0, 1.0);
+  }`;
+
+describe('ol/webgl/WebGLHelper', function () {
   describe('constructor', function () {
     describe('without an argument', function () {
       let h;
@@ -177,25 +184,22 @@ describe('ol.webgl.WebGLHelper', function () {
     });
 
     describe('invalid shader compiling', function () {
-      let h;
-      let p;
-      beforeEach(function () {
-        h = new WebGLHelper();
-
-        p = h.getProgram(FRAGMENT_SHADER, INVALID_VERTEX_SHADER);
-        h.useProgram(p);
+      it('throws for an invalid vertex shader', function () {
+        const helper = new WebGLHelper();
+        expect(() =>
+          helper.getProgram(FRAGMENT_SHADER, INVALID_VERTEX_SHADER)
+        ).to.throwException(
+          /Vertex shader compilation failed: ERROR: 0:10: 'bla' : syntax error/
+        );
       });
 
-      it('has saved the program', function () {
-        expect(h.currentProgram_).to.eql(p);
-      });
-
-      it('has shader compilation errors', function () {
-        expect(h.shaderCompileErrors_).to.not.eql(null);
-      });
-
-      it('cannot find the uniform location', function () {
-        expect(h.getUniformLocation('u_test')).to.eql(null);
+      it('throws for an invalid fragment shader', function () {
+        const helper = new WebGLHelper();
+        expect(() =>
+          helper.getProgram(INVALID_FRAGMENT_SHADER, VERTEX_SHADER)
+        ).to.throwException(
+          /Fragment shader compliation failed: ERROR: 0:5: 'oops' : undeclared identifier/
+        );
       });
     });
 
@@ -354,7 +358,7 @@ describe('ol.webgl.WebGLHelper', function () {
         uniform float u_test;
 
         void main(void) {
-          gl_Position = vec4(u_test, a_test, 0.0, 1.0);
+          gl_Position = vec4(u_test, attr3, 0.0, 1.0);
         }`
         )
       );


### PR DESCRIPTION
Currently, if GL shader compilation or program linking fails, nothing happens (and the user would have to figure out that they need to add a call to `layer.getShaderCompileErrors()` and log the output).  Instead, we should fail early and in an obvious way when either shader compilation fails or program linking fails.