### PR TITLE
Fix WFS writeFilter

### DIFF
--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -1328,7 +1328,7 @@ function writeTimeInstant(node, time) {
  * @api
  */
 export function writeFilter(filter, version) {
-  const child = createElementNS(OGCNS[version], 'Filter');
+  const child = createElementNS(getFilterNS(version), 'Filter');
   const context = {
     node: child,
   };

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -1323,11 +1323,12 @@ function writeTimeInstant(node, time) {
  * Encode filter as WFS `Filter` and return the Node.
  *
  * @param {import("./filter/Filter.js").default} filter Filter.
- * @param {string} version Version.
+ * @param {string} opt_version WFS version. If not provided defaults to '1.1.0'
  * @return {Node} Result.
  * @api
  */
-export function writeFilter(filter, version) {
+export function writeFilter(filter, opt_version) {
+  const version = opt_version || '1.1.0';
   const child = createElementNS(getFilterNS(version), 'Filter');
   const context = {
     node: child,

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1457,20 +1457,33 @@ describe('ol.format.WFS', function () {
   });
 
   describe('when writing out a WFS Filter', function () {
-    it('creates a filter', function () {
-      const text =
-        '<Filter xmlns="http://www.opengis.net/ogc">' +
-        '  <And>' +
-        '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
-        '      <PropertyName>name</PropertyName>' +
-        '      <Literal>Mississippi*</Literal>' +
-        '    </PropertyIsLike>' +
-        '    <PropertyIsEqualTo>' +
-        '      <PropertyName>waterway</PropertyName>' +
-        '      <Literal>riverbank</Literal>' +
-        '    </PropertyIsEqualTo>' +
-        '  </And>' +
-        '</Filter>';
+    const wfs1Filter =
+    '<Filter xmlns="http://www.opengis.net/ogc">' +
+    '  <And>' +
+    '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+    '      <PropertyName>name</PropertyName>' +
+    '      <Literal>Mississippi*</Literal>' +
+    '    </PropertyIsLike>' +
+    '    <PropertyIsEqualTo>' +
+    '      <PropertyName>waterway</PropertyName>' +
+    '      <Literal>riverbank</Literal>' +
+    '    </PropertyIsEqualTo>' +
+    '  </And>' +
+    '</Filter>';
+    const wfs2Filter =
+    '<Filter xmlns="http://www.opengis.net/fes/2.0">' +
+    '  <And>' +
+    '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+    '      <ValueReference>name</ValueReference>' +
+    '      <Literal>Mississippi*</Literal>' +
+    '    </PropertyIsLike>' +
+    '    <PropertyIsEqualTo>' +
+    '      <ValueReference>waterway</ValueReference>' +
+    '      <Literal>riverbank</Literal>' +
+    '    </PropertyIsEqualTo>' +
+    '  </And>' +
+    '</Filter>';
+    it('creates a WFS 1.x.x filter', function () {
       const serialized = writeFilter(
         andFilter(
           likeFilter('name', 'Mississippi*'),
@@ -1478,7 +1491,17 @@ describe('ol.format.WFS', function () {
         ),
         '1.1.0'
       );
-      expect(serialized).to.xmleql(parse(text));
+      expect(serialized).to.xmleql(parse(wfs1Filter));
+    });
+    it('creates a WFS 2.x.x filter', function () {
+      const serialized = writeFilter(
+        andFilter(
+          likeFilter('name', 'Mississippi*'),
+          equalToFilter('waterway', 'riverbank')
+        ),
+        '2.0.0'
+      );
+      expect(serialized).to.xmleql(parse(wfs2Filter));
     });
   });
 

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1493,6 +1493,15 @@ describe('ol.format.WFS', function () {
       );
       expect(serialized).to.xmleql(parse(wfs1Filter));
     });
+    it('defaults to creating a WFS 1.x.x filter if no version specified', function () {
+      const serialized = writeFilter(
+        andFilter(
+          likeFilter('name', 'Mississippi*'),
+          equalToFilter('waterway', 'riverbank')
+        )
+      );
+      expect(serialized).to.xmleql(parse(wfs1Filter));
+    });
     it('creates a WFS 2.x.x filter', function () {
       const serialized = writeFilter(
         andFilter(

--- a/test/spec/ol/format/wfs.test.js
+++ b/test/spec/ol/format/wfs.test.js
@@ -1458,31 +1458,31 @@ describe('ol.format.WFS', function () {
 
   describe('when writing out a WFS Filter', function () {
     const wfs1Filter =
-    '<Filter xmlns="http://www.opengis.net/ogc">' +
-    '  <And>' +
-    '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
-    '      <PropertyName>name</PropertyName>' +
-    '      <Literal>Mississippi*</Literal>' +
-    '    </PropertyIsLike>' +
-    '    <PropertyIsEqualTo>' +
-    '      <PropertyName>waterway</PropertyName>' +
-    '      <Literal>riverbank</Literal>' +
-    '    </PropertyIsEqualTo>' +
-    '  </And>' +
-    '</Filter>';
+      '<Filter xmlns="http://www.opengis.net/ogc">' +
+      '  <And>' +
+      '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+      '      <PropertyName>name</PropertyName>' +
+      '      <Literal>Mississippi*</Literal>' +
+      '    </PropertyIsLike>' +
+      '    <PropertyIsEqualTo>' +
+      '      <PropertyName>waterway</PropertyName>' +
+      '      <Literal>riverbank</Literal>' +
+      '    </PropertyIsEqualTo>' +
+      '  </And>' +
+      '</Filter>';
     const wfs2Filter =
-    '<Filter xmlns="http://www.opengis.net/fes/2.0">' +
-    '  <And>' +
-    '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
-    '      <ValueReference>name</ValueReference>' +
-    '      <Literal>Mississippi*</Literal>' +
-    '    </PropertyIsLike>' +
-    '    <PropertyIsEqualTo>' +
-    '      <ValueReference>waterway</ValueReference>' +
-    '      <Literal>riverbank</Literal>' +
-    '    </PropertyIsEqualTo>' +
-    '  </And>' +
-    '</Filter>';
+      '<Filter xmlns="http://www.opengis.net/fes/2.0">' +
+      '  <And>' +
+      '    <PropertyIsLike wildCard="*" singleChar="." escapeChar="!">' +
+      '      <ValueReference>name</ValueReference>' +
+      '      <Literal>Mississippi*</Literal>' +
+      '    </PropertyIsLike>' +
+      '    <PropertyIsEqualTo>' +
+      '      <ValueReference>waterway</ValueReference>' +
+      '      <Literal>riverbank</Literal>' +
+      '    </PropertyIsEqualTo>' +
+      '  </And>' +
+      '</Filter>';
     it('creates a WFS 1.x.x filter', function () {
       const serialized = writeFilter(
         andFilter(


### PR DESCRIPTION
Following an upgrade to ol v6.5.0 we (@AstunTechnology) had a number of tests fail in a project due to the addition of the mandatory `version` argument to `ol/format/WFS~writeFilter`. While investigating I found that `writeFilter` doesn't currently support writing WFS 2.0.0 filters due to the wrong namespace being assigned to the filter child node.

This PR:
* Adds support for writing WFS 2.0.0 filters
* Makes the `version` argument optional, defaulting to WFS 1.1.0
* Adds tests for writing a WFS 2.0.0 filter and calling `writeFilter` without a `opt_version` argument

The reason for making the `version` argument optional is to avoid v6.5.x introducing a breaking change to the existing API which I think would strictly trigger a major version release according to semver rules.