### PR TITLE
Pass the renderer function to the cloned style

### DIFF
--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -219,6 +219,7 @@ class Style {
       geometry: geometry,
       fill: this.getFill() ? this.getFill().clone() : undefined,
       image: this.getImage() ? this.getImage().clone() : undefined,
+      renderer: this.getRenderer() ? this.getRenderer() : undefined,
       stroke: this.getStroke() ? this.getStroke().clone() : undefined,
       text: this.getText() ? this.getText().clone() : undefined,
       zIndex: this.getZIndex(),

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -219,7 +219,7 @@ class Style {
       geometry: geometry,
       fill: this.getFill() ? this.getFill().clone() : undefined,
       image: this.getImage() ? this.getImage().clone() : undefined,
-      renderer: this.getRenderer() ? this.getRenderer() : undefined,
+      renderer: this.getRenderer(),
       stroke: this.getStroke() ? this.getStroke().clone() : undefined,
       text: this.getText() ? this.getText().clone() : undefined,
       zIndex: this.getZIndex(),

--- a/test/spec/ol/style/style.test.js
+++ b/test/spec/ol/style/style.test.js
@@ -68,9 +68,7 @@ describe('ol.style.Style', function () {
       expect(original.getImage().getRadius()).to.eql(
         clone.getImage().getRadius()
       );
-      expect(original.getRenderer().toString()).to.eql(
-        clone.getRenderer().toString()
-      );
+      expect(original.getRenderer()).to.eql(clone.getRenderer());
       expect(original.getStroke().getColor()).to.eql(
         clone.getStroke().getColor()
       );
@@ -102,7 +100,6 @@ describe('ol.style.Style', function () {
       expect(original.getGeometry()).not.to.be(clone.getGeometry());
       expect(original.getFill()).not.to.be(clone.getFill());
       expect(original.getImage()).not.to.be(clone.getImage());
-      expect(original.getRenderer()).not.to.be(clone.getRenderer());
       expect(original.getStroke()).not.to.be(clone.getStroke());
       expect(original.getText()).not.to.be(clone.getText());
 
@@ -123,9 +120,7 @@ describe('ol.style.Style', function () {
       expect(original.getImage().getScale()).not.to.eql(
         clone.getImage().getScale()
       );
-      expect(original.getRenderer().toString()).not.to.eql(
-        clone.getRenderer().toString()
-      );
+      expect(original.getRenderer()).not.to.eql(clone.getRenderer());
       expect(original.getStroke().getColor()).not.to.eql(
         clone.getStroke().getColor()
       );

--- a/test/spec/ol/style/style.test.js
+++ b/test/spec/ol/style/style.test.js
@@ -48,6 +48,10 @@ describe('ol.style.Style', function () {
         image: new CircleStyle({
           radius: 5,
         }),
+        renderer: function (pixelCoordinates, state) {
+          const geometry = state.geometry.clone();
+          geometry.setCoordinates(pixelCoordinates);
+        },
         stroke: new Stroke({
           color: '#319FD3',
         }),
@@ -63,6 +67,9 @@ describe('ol.style.Style', function () {
       expect(original.getFill().getColor()).to.eql(clone.getFill().getColor());
       expect(original.getImage().getRadius()).to.eql(
         clone.getImage().getRadius()
+      );
+      expect(original.getRenderer().toString()).to.eql(
+        clone.getRenderer().toString()
       );
       expect(original.getStroke().getColor()).to.eql(
         clone.getStroke().getColor()
@@ -80,6 +87,10 @@ describe('ol.style.Style', function () {
         image: new CircleStyle({
           radius: 5,
         }),
+        renderer: function (pixelCoordinates, state) {
+          const geometry = state.geometry.clone();
+          geometry.setCoordinates(pixelCoordinates);
+        },
         stroke: new Stroke({
           color: '#319FD3',
         }),
@@ -91,12 +102,16 @@ describe('ol.style.Style', function () {
       expect(original.getGeometry()).not.to.be(clone.getGeometry());
       expect(original.getFill()).not.to.be(clone.getFill());
       expect(original.getImage()).not.to.be(clone.getImage());
+      expect(original.getRenderer()).not.to.be(clone.getRenderer());
       expect(original.getStroke()).not.to.be(clone.getStroke());
       expect(original.getText()).not.to.be(clone.getText());
 
       clone.getGeometry().setCoordinates([1, 1, 1]);
       clone.getFill().setColor('#012345');
       clone.getImage().setScale(2);
+      clone.setRenderer(function (pixelCoordinates, state) {
+        return;
+      });
       clone.getStroke().setColor('#012345');
       clone.getText().setText('other');
       expect(original.getGeometry().getCoordinates()).not.to.eql(
@@ -107,6 +122,9 @@ describe('ol.style.Style', function () {
       );
       expect(original.getImage().getScale()).not.to.eql(
         clone.getImage().getScale()
+      );
+      expect(original.getRenderer().toString()).not.to.eql(
+        clone.getRenderer().toString()
       );
       expect(original.getStroke().getColor()).not.to.eql(
         clone.getStroke().getColor()


### PR DESCRIPTION
Addresses Issue #11860.

Makes Style.clone() more thorough by passing the renderer function to the new Style object created by the clone function.