### PR TITLE
Handle null geometry in TopoJSON

### DIFF
--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -368,18 +368,18 @@ function readFeatureFromGeometry(
   name,
   opt_options
 ) {
-  let geometry;
+  let geometry = null;
   const type = object.type;
-  const geometryReader = GEOMETRY_READERS[type];
-  if (type === 'Point' || type === 'MultiPoint') {
-    geometry = geometryReader(object, scale, translate);
-  } else {
-    geometry = geometryReader(object, arcs);
+  if (type) {
+    const geometryReader = GEOMETRY_READERS[type];
+    if (type === 'Point' || type === 'MultiPoint') {
+      geometry = geometryReader(object, scale, translate);
+    } else {
+      geometry = geometryReader(object, arcs);
+    }
+    geometry = transformGeometryWithOptions(geometry, false, opt_options);
   }
-  const feature = new Feature();
-  feature.setGeometry(
-    transformGeometryWithOptions(geometry, false, opt_options)
-  );
+  const feature = new Feature({geometry: geometry});
   if (object.id !== undefined) {
     feature.setId(object.id);
   }

--- a/test/spec/ol/format/topojson.test.js
+++ b/test/spec/ol/format/topojson.test.js
@@ -48,6 +48,19 @@ const zeroId = {
   },
 };
 
+const nullGeometry = {
+  type: 'Topology',
+  objects: {
+    foobar: {
+      type: null,
+      properties: {
+        prop0: 'value0',
+      },
+      id: 533,
+    },
+  },
+};
+
 describe('ol.format.TopoJSON', function () {
   let format;
   before(function () {
@@ -92,6 +105,17 @@ describe('ol.format.TopoJSON', function () {
       const feature = features[0];
       expect(feature).to.be.a(Feature);
       expect(feature.getId()).to.be(0);
+    });
+
+    it('can read a feature with null geometry', function () {
+      const features = format.readFeaturesFromObject(nullGeometry);
+      expect(features).to.have.length(1);
+
+      const feature = features[0];
+      expect(feature).to.be.a(Feature);
+      expect(feature.getGeometry()).to.be(null);
+      expect(feature.getId()).to.be(533);
+      expect(feature.get('prop0')).to.be('value0');
     });
   });
 


### PR DESCRIPTION
Fixes #11910

Handle features will null geometry type similar to features will null geometry in GeoJSON.