### PR TITLE
Mention unit of radius for Polygon.circular()

### DIFF
--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -413,7 +413,7 @@ export default Polygon;
  * Create an approximation of a circle on the surface of a sphere.
  * @param {import("../coordinate.js").Coordinate} center Center (`[lon, lat]` in degrees).
  * @param {number} radius The great-circle distance from the center to
- *     the polygon vertices.
+ *     the polygon vertices in meters.
  * @param {number=} opt_n Optional number of vertices for the resulting
  *     polygon. Default is `32`.
  * @param {number=} opt_sphereRadius Optional radius for the sphere (defaults to


### PR DESCRIPTION
Radius was using an unknown unit. This makes it clear that it will be interpreted as meters.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
