### PR TITLE
Circle geometry and circular polygon comparison example

### DIFF
--- a/examples/circle-comparison.html
+++ b/examples/circle-comparison.html
@@ -1,0 +1,21 @@
+---
+layout: example.html
+title: Circle Comparison
+shortdesc: Comparison of circle geomtry and a circular polygon
+docs: >
+  A circle geometry created via `ol/geom/Circle` will use the unit of the coordinate
+  reference system for the radius. Except for local projections projection units cannot
+  accurately represent true distances across the extent of a projection as the relative
+  scale or point resolution can vary considerably, especially for global projections such
+  as web mercator. A circle with a radius of 1000 km in projection units is shown in red,
+  and another with 1000 km radius adjusted for point resolution is shown in green.
+
+  Adjustment for point resolution is sufficient for a small radius, but with a larger
+  radius the point resolution can also vary within the radius, so a circle on the
+  Earth's surface will not be a circle geometry on a flat projection. To overcome this
+  `ol/geom/Polygon` provides the `circular` method to create a circle approximation
+  based on spherical geometry. A polygon with a geodesics great-circle radius of 1000 km
+  is shown in blue.
+tags: "circle, projection, scale, geometry, sphere"
+---
+<div id="map" class="map"></div>

--- a/examples/circle-comparison.js
+++ b/examples/circle-comparison.js
@@ -6,7 +6,7 @@ import {Fill, Stroke, Style} from '../src/ol/style.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {circular} from '../src/ol/geom/Polygon.js';
-import {fromLonLat, getPointResolution} from '../src/ol/proj.js'
+import {fromLonLat, getPointResolution} from '../src/ol/proj.js';
 
 const centerLonLat = [8.495833, 53.915222];
 const center3857 = fromLonLat(centerLonLat, 'EPSG:3857');

--- a/examples/circle-comparison.js
+++ b/examples/circle-comparison.js
@@ -1,0 +1,93 @@
+import Feature from '../src/ol/Feature.js';
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import {Circle} from '../src/ol/geom.js';
+import {Fill, Stroke, Style} from '../src/ol/style.js';
+import {OSM, Vector as VectorSource} from '../src/ol/source.js';
+import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
+import {circular} from '../src/ol/geom/Polygon.js';
+import {fromLonLat, getPointResolution} from '../src/ol/proj.js'
+
+const centerLonLat = [8.495833, 53.915222];
+const center3857 = fromLonLat(centerLonLat, 'EPSG:3857');
+const radius = 1000000; // 1000 km
+
+// circle feature using projection unit meters
+const circleFeature1 = new Feature({
+  geometry: new Circle(
+    center3857, // coordinates in EPSG:3857
+    radius // radius in projection units
+  ),
+});
+
+// circle feature with radius adjusted for point resolution
+const circleFeature2 = new Feature({
+  geometry: new Circle(
+    center3857, // coordinates in EPSG:3857
+    radius / getPointResolution('EPSG:3857', 1, center3857)
+  ),
+});
+
+// the circle calculated with spherical geometry
+const circleFeatureSpherical = new Feature({
+  geometry: new circular(
+    centerLonLat, // same location as lon lat
+    radius, // great-circle radius in meters
+    128 // vertices of the resulting polygon
+  ).transform('EPSG:4326', 'EPSG:3857'),
+});
+
+circleFeature1.setStyle(
+  new Style({
+    stroke: new Stroke({
+      color: 'red',
+      width: 3,
+    }),
+    fill: new Fill({
+      color: 'rgba(255, 0, 0, 0.2)',
+    }),
+  })
+);
+
+circleFeature2.setStyle(
+  new Style({
+    stroke: new Stroke({
+      color: 'green',
+      width: 3,
+    }),
+    fill: new Fill({
+      color: 'rgba(0, 255, 0, 0.2)',
+    }),
+  })
+);
+
+circleFeatureSpherical.setStyle(
+  new Style({
+    stroke: new Stroke({
+      color: 'blue',
+      width: 3,
+    }),
+    fill: new Fill({
+      color: 'rgba(0, 0, 255, 0.2)',
+    }),
+  })
+);
+
+new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+      visible: true,
+    }),
+    new VectorLayer({
+      source: new VectorSource({
+        features: [circleFeature1, circleFeature2, circleFeatureSpherical],
+      }),
+    }),
+  ],
+  target: 'map',
+  view: new View({
+    center: center3857,
+    zoom: 4,
+  }),
+});


### PR DESCRIPTION
Replaces #11926

Add a circle geometry and circular polygon comparison example.  This builds on #11926 by adding a circle geometry adjusted for point resolution and revising the description to avoid terms such as fake and metric.
