### PR TITLE
Handle view rotation in d3 Integration example

### DIFF
--- a/examples/d3.js
+++ b/examples/d3.js
@@ -50,10 +50,13 @@ class CanvasLayer extends Layer {
     const scale = r / frameState.viewState.resolution;
 
     const center = toLonLat(getCenter(frameState.extent), projection);
+    const angle = (-frameState.viewState.rotation * 180) / Math.PI;
+
     d3Projection
       .scale(scale)
       .center(center)
-      .translate([width / 2, height / 2]);
+      .translate([width / 2, height / 2])
+      .angle(angle);
 
     d3Path = d3Path.projection(d3Projection);
     d3Path(this.features);


### PR DESCRIPTION
Fixes #11964

Use d3 projection `.angle()` method to rotate rendered output with the view rotation.
