### PR TITLE
Simplify popup positioning in Icon Scale example

### DIFF
--- a/examples/icon-scale.js
+++ b/examples/icon-scale.js
@@ -98,7 +98,6 @@ const popup = new Overlay({
   element: element,
   positioning: 'bottom-center',
   stopEvent: false,
-  offset: [0, -50],
 });
 map.addOverlay(popup);
 
@@ -109,8 +108,7 @@ map.on('click', function (evt) {
   });
   $(element).popover('dispose');
   if (feature) {
-    const coordinates = feature.getGeometry().getCoordinates();
-    popup.setPosition(coordinates);
+    popup.setPosition(evt.coordinate);
     $(element).popover({
       placement: 'top',
       html: true,
@@ -123,11 +121,11 @@ map.on('click', function (evt) {
 
 // change mouse cursor when over marker
 map.on('pointermove', function (e) {
-  if (e.dragging) {
-    $(element).popover('dispose');
-    return;
-  }
   const pixel = map.getEventPixel(e.originalEvent);
   const hit = map.hasFeatureAtPixel(pixel);
   map.getTarget().style.cursor = hit ? 'pointer' : '';
+});
+// Close the popup when the map is moved
+map.on('movestart', function () {
+  $(element).popover('dispose');
 });


### PR DESCRIPTION
The Icon Scale example uses popups to indicate which feature has been detected when clicked.  These were based on the Icon Symbolizer example and suffer the same issues with wrapping and Bootstrap update which were fixed in #11954