### PR TITLE
jsdoc linting

### DIFF
--- a/config/jsdoc/api/plugins/inline-options.js
+++ b/config/jsdoc/api/plugins/inline-options.js
@@ -1,5 +1,5 @@
 /**
- * @filedesc
+ * @fileoverview
  * Inlines option params from typedefs
  */
 

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -190,9 +190,9 @@ function generateSourceFiles(sourceFiles) {
  * for display purposes. This function mutates the original arrays.
  *
  * @private
- * @param {Array<module:jsdoc/doclet.Doclet>} doclets - The array of classes and functions to
+ * @param {Array<module:jsdoc/doclet.Doclet>} doclets The array of classes and functions to
  * check.
- * @param {Array<module:jsdoc/doclet.Doclet>} modules - The array of module doclets to search.
+ * @param {Array<module:jsdoc/doclet.Doclet>} modules The array of module doclets to search.
  */
 function attachModuleSymbols(doclets, modules) {
   const symbols = {};

--- a/examples/image-load-events.js
+++ b/examples/image-load-events.js
@@ -6,7 +6,7 @@ import View from '../src/ol/View.js';
 /**
  * Renders a progress bar.
  * @param {HTMLElement} el The target element.
- * @constructor
+ * @class
  */
 function Progress(el) {
   this.el = el;

--- a/examples/tile-load-events.js
+++ b/examples/tile-load-events.js
@@ -6,7 +6,7 @@ import XYZ from '../src/ol/source/XYZ.js';
 /**
  * Renders a progress bar.
  * @param {HTMLElement} el The target element.
- * @constructor
+ * @class
  */
 function Progress(el) {
   this.el = el;

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -329,7 +329,7 @@ class ScaleLine extends Control {
    * @param {number} width The current width of the scalebar.
    * @param {number} scale The current scale.
    * @param {string} suffix The suffix to append to the scale text.
-   * @returns {string} The stringified HTML of the scalebar.
+   * @return {string} The stringified HTML of the scalebar.
    */
   createScaleBar(width, scale, suffix) {
     const mapScale =
@@ -400,9 +400,9 @@ class ScaleLine extends Control {
 
   /**
    * Creates a marker at given position
-   * @param {string} position - The position, absolute or relative
-   * @param {number} i - The iterator
-   * @returns {string} The stringified div containing the marker
+   * @param {string} position The position, absolute or relative
+   * @param {number} i The iterator
+   * @return {string} The stringified div containing the marker
    */
   createMarker(position, i) {
     const top = position === 'absolute' ? 3 : -10;
@@ -421,12 +421,12 @@ class ScaleLine extends Control {
 
   /**
    * Creates the label for a marker marker at given position
-   * @param {number} i - The iterator
-   * @param {number} width - The width the scalebar will currently use
-   * @param {boolean} isLast - Flag indicating if we add the last step text
-   * @param {number} scale - The current scale for the whole scalebar
-   * @param {string} suffix - The suffix for the scale
-   * @returns {string} The stringified div containing the step text
+   * @param {number} i The iterator
+   * @param {number} width The width the scalebar will currently use
+   * @param {boolean} isLast Flag indicating if we add the last step text
+   * @param {number} scale The current scale for the whole scalebar
+   * @param {string} suffix The suffix for the scale
+   * @return {string} The stringified div containing the step text
    */
   createStepText(i, width, isLast, scale, suffix) {
     const length =

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -72,7 +72,7 @@ export function replaceNode(newNode, oldNode) {
 
 /**
  * @param {Node} node The node to remove.
- * @returns {Node} The node that was removed or null.
+ * @return {Node} The node that was removed or null.
  */
 export function removeNode(node) {
   return node && node.parentNode ? node.parentNode.removeChild(node) : null;

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -356,7 +356,7 @@ class GML2 extends GMLBase {
 
   /**
    * @param {string} namespaceURI XML namespace.
-   * @returns {Element} coordinates node.
+   * @return {Element} coordinates node.
    * @private
    */
   createCoordinatesNode_(namespaceURI) {

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -327,7 +327,7 @@ class IIIFInfo {
   }
 
   /**
-   * @returns {Versions} Major IIIF version.
+   * @return {Versions} Major IIIF version.
    * @api
    */
   getImageApiVersion() {
@@ -364,7 +364,7 @@ class IIIFInfo {
 
   /**
    * @param {Versions} version Optional IIIF image API version
-   * @returns {string} Compliance level as it appears in the IIIF image information
+   * @return {string} Compliance level as it appears in the IIIF image information
    * response.
    */
   getComplianceLevelEntryFromProfile(version) {
@@ -407,7 +407,7 @@ class IIIFInfo {
 
   /**
    * @param {Versions} version Optional IIIF image API version
-   * @returns {string} Compliance level, on of 'level0', 'level1' or 'level2' or undefined
+   * @return {string} Compliance level, on of 'level0', 'level1' or 'level2' or undefined
    */
   getComplianceLevelFromProfile(version) {
     const complianceLevel = this.getComplianceLevelEntryFromProfile(version);
@@ -419,7 +419,7 @@ class IIIFInfo {
   }
 
   /**
-   * @returns {SupportedFeatures} Image formats, qualities and region / size calculation
+   * @return {SupportedFeatures} Image formats, qualities and region / size calculation
    * methods that are supported by the IIIF service.
    */
   getComplianceLevelSupportedFeatures() {
@@ -436,7 +436,7 @@ class IIIFInfo {
 
   /**
    * @param {PreferredOptions=} opt_preferredOptions Optional options for preferred format and quality.
-   * @returns {import("../source/IIIF.js").Options} IIIF tile source ready constructor options.
+   * @return {import("../source/IIIF.js").Options} IIIF tile source ready constructor options.
    * @api
    */
   getTileSourceOptions(opt_preferredOptions) {

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -814,7 +814,7 @@ function writeOgcFidFilter(node, fid, objectStack) {
 /**
  * @param {string|undefined} featurePrefix The prefix of the feature.
  * @param {string} featureType The type of the feature.
- * @returns {string} The value of the typeName property.
+ * @return {string} The value of the typeName property.
  */
 function getTypeName(featurePrefix, featureType) {
   featurePrefix = featurePrefix ? featurePrefix : FEATURE_PREFIX;

--- a/src/ol/format/filter.js
+++ b/src/ol/format/filter.js
@@ -26,7 +26,7 @@ import Within from './filter/Within.js';
  * Create a logical `<And>` operator between two or more filter conditions.
  *
  * @param {...import("./filter/Filter.js").default} conditions Filter conditions.
- * @returns {!And} `<And>` operator.
+ * @return {!And} `<And>` operator.
  * @api
  */
 export function and(conditions) {
@@ -38,7 +38,7 @@ export function and(conditions) {
  * Create a logical `<Or>` operator between two or more filter conditions.
  *
  * @param {...import("./filter/Filter.js").default} conditions Filter conditions.
- * @returns {!Or} `<Or>` operator.
+ * @return {!Or} `<Or>` operator.
  * @api
  */
 export function or(conditions) {
@@ -50,7 +50,7 @@ export function or(conditions) {
  * Represents a logical `<Not>` operator for a filter condition.
  *
  * @param {!import("./filter/Filter.js").default} condition Filter condition.
- * @returns {!Not} `<Not>` operator.
+ * @return {!Not} `<Not>` operator.
  * @api
  */
 export function not(condition) {
@@ -65,7 +65,7 @@ export function not(condition) {
  * @param {!import("../extent.js").Extent} extent Extent.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!Bbox} `<BBOX>` operator.
+ * @return {!Bbox} `<BBOX>` operator.
  * @api
  */
 export function bbox(geometryName, extent, opt_srsName) {
@@ -80,7 +80,7 @@ export function bbox(geometryName, extent, opt_srsName) {
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!Contains} `<Contains>` operator.
+ * @return {!Contains} `<Contains>` operator.
  * @api
  */
 export function contains(geometryName, geometry, opt_srsName) {
@@ -95,7 +95,7 @@ export function contains(geometryName, geometry, opt_srsName) {
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!Intersects} `<Intersects>` operator.
+ * @return {!Intersects} `<Intersects>` operator.
  * @api
  */
 export function intersects(geometryName, geometry, opt_srsName) {
@@ -110,7 +110,7 @@ export function intersects(geometryName, geometry, opt_srsName) {
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!Disjoint} `<Disjoint>` operator.
+ * @return {!Disjoint} `<Disjoint>` operator.
  * @api
  */
 export function disjoint(geometryName, geometry, opt_srsName) {
@@ -125,7 +125,7 @@ export function disjoint(geometryName, geometry, opt_srsName) {
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!Within} `<Within>` operator.
+ * @return {!Within} `<Within>` operator.
  * @api
  */
 export function within(geometryName, geometry, opt_srsName) {
@@ -142,7 +142,7 @@ export function within(geometryName, geometry, opt_srsName) {
  * @param {!string} unit Unit.
  * @param {string=} opt_srsName SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
- * @returns {!DWithin} `<DWithin>` operator.
+ * @return {!DWithin} `<DWithin>` operator.
  * @api
  */
 export function dwithin(geometryName, geometry, distance, unit, opt_srsName) {
@@ -155,7 +155,7 @@ export function dwithin(geometryName, geometry, distance, unit, opt_srsName) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!EqualTo} `<PropertyIsEqualTo>` operator.
+ * @return {!EqualTo} `<PropertyIsEqualTo>` operator.
  * @api
  */
 export function equalTo(propertyName, expression, opt_matchCase) {
@@ -168,7 +168,7 @@ export function equalTo(propertyName, expression, opt_matchCase) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!NotEqualTo} `<PropertyIsNotEqualTo>` operator.
+ * @return {!NotEqualTo} `<PropertyIsNotEqualTo>` operator.
  * @api
  */
 export function notEqualTo(propertyName, expression, opt_matchCase) {
@@ -180,7 +180,7 @@ export function notEqualTo(propertyName, expression, opt_matchCase) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!LessThan} `<PropertyIsLessThan>` operator.
+ * @return {!LessThan} `<PropertyIsLessThan>` operator.
  * @api
  */
 export function lessThan(propertyName, expression) {
@@ -192,7 +192,7 @@ export function lessThan(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
+ * @return {!LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
  * @api
  */
 export function lessThanOrEqualTo(propertyName, expression) {
@@ -204,7 +204,7 @@ export function lessThanOrEqualTo(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!GreaterThan} `<PropertyIsGreaterThan>` operator.
+ * @return {!GreaterThan} `<PropertyIsGreaterThan>` operator.
  * @api
  */
 export function greaterThan(propertyName, expression) {
@@ -216,7 +216,7 @@ export function greaterThan(propertyName, expression) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} expression The value to compare.
- * @returns {!GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
+ * @return {!GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
  * @api
  */
 export function greaterThanOrEqualTo(propertyName, expression) {
@@ -228,7 +228,7 @@ export function greaterThanOrEqualTo(propertyName, expression) {
  * is null.
  *
  * @param {!string} propertyName Name of the context property to compare.
- * @returns {!IsNull} `<PropertyIsNull>` operator.
+ * @return {!IsNull} `<PropertyIsNull>` operator.
  * @api
  */
 export function isNull(propertyName) {
@@ -242,7 +242,7 @@ export function isNull(propertyName) {
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!number} lowerBoundary The lower bound of the range.
  * @param {!number} upperBoundary The upper bound of the range.
- * @returns {!IsBetween} `<PropertyIsBetween>` operator.
+ * @return {!IsBetween} `<PropertyIsBetween>` operator.
  * @api
  */
 export function between(propertyName, lowerBoundary, upperBoundary) {
@@ -262,7 +262,7 @@ export function between(propertyName, lowerBoundary, upperBoundary) {
  * @param {string=} opt_escapeChar Escape character which can be used to escape
  *    the pattern characters. Default is '!'.
  * @param {boolean=} opt_matchCase Case-sensitive?
- * @returns {!IsLike} `<PropertyIsLike>` operator.
+ * @return {!IsLike} `<PropertyIsLike>` operator.
  * @api
  */
 export function like(
@@ -289,7 +289,7 @@ export function like(
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!string} begin The begin date in ISO-8601 format.
  * @param {!string} end The end date in ISO-8601 format.
- * @returns {!During} `<During>` operator.
+ * @return {!During} `<During>` operator.
  * @api
  */
 export function during(propertyName, begin, end) {

--- a/src/ol/format/filter/Filter.js
+++ b/src/ol/format/filter/Filter.js
@@ -23,7 +23,7 @@ class Filter {
 
   /**
    * The XML tag name for a filter.
-   * @returns {!string} Name.
+   * @return {!string} Name.
    */
   getTagName() {
     return this.tagName_;

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -6,7 +6,7 @@ import {equals as arrayEquals} from './array.js';
 
 /**
  * Always returns true.
- * @returns {boolean} true.
+ * @return {boolean} true.
  */
 export function TRUE() {
   return true;
@@ -14,7 +14,7 @@ export function TRUE() {
 
 /**
  * Always returns false.
- * @returns {boolean} false.
+ * @return {boolean} false.
  */
 export function FALSE() {
   return false;

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -188,7 +188,7 @@ class Extent extends PointerInteraction {
   /**
    * @param {import("../pixel.js").Pixel} pixel cursor location
    * @param {import("../PluggableMap.js").default} map map
-   * @returns {import("../coordinate.js").Coordinate|null} snapped vertex on extent
+   * @return {import("../coordinate.js").Coordinate|null} snapped vertex on extent
    * @private
    */
   snapToVertex_(pixel, map) {
@@ -245,7 +245,7 @@ class Extent extends PointerInteraction {
 
   /**
    * @param {import("../extent.js").Extent} extent extent
-   * @returns {Feature} extent as featrue
+   * @return {Feature} extent as featrue
    * @private
    */
   createOrUpdateExtentFeature_(extent) {
@@ -271,7 +271,7 @@ class Extent extends PointerInteraction {
 
   /**
    * @param {import("../coordinate.js").Coordinate} vertex location of feature
-   * @returns {Feature} vertex as feature
+   * @return {Feature} vertex as feature
    * @private
    */
   createOrUpdatePointerFeature_(vertex) {
@@ -471,7 +471,7 @@ function getDefaultPointerStyleFunction() {
 
 /**
  * @param {import("../coordinate.js").Coordinate} fixedPoint corner that will be unchanged in the new extent
- * @returns {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent} event handler
+ * @return {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent} event handler
  */
 function getPointHandler(fixedPoint) {
   return function (point) {
@@ -482,7 +482,7 @@ function getPointHandler(fixedPoint) {
 /**
  * @param {import("../coordinate.js").Coordinate} fixedP1 first corner that will be unchanged in the new extent
  * @param {import("../coordinate.js").Coordinate} fixedP2 second corner that will be unchanged in the new extent
- * @returns {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent|null} event handler
+ * @return {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent|null} event handler
  */
 function getEdgeHandler(fixedP1, fixedP2) {
   if (fixedP1[0] == fixedP2[0]) {
@@ -500,7 +500,7 @@ function getEdgeHandler(fixedP1, fixedP2) {
 
 /**
  * @param {import("../extent.js").Extent} extent extent
- * @returns {Array<Array<import("../coordinate.js").Coordinate>>} extent line segments
+ * @return {Array<Array<import("../coordinate.js").Coordinate>>} extent line segments
  */
 function getSegments(extent) {
   return [

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -277,7 +277,7 @@ class Select extends Interaction {
 
   /**
    * Returns the Hit-detection tolerance.
-   * @returns {number} Hit tolerance in pixels.
+   * @return {number} Hit tolerance in pixels.
    * @api
    */
   getHitTolerance() {

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -320,7 +320,7 @@ class Translate extends PointerInteraction {
 
   /**
    * Returns the Hit-detection tolerance.
-   * @returns {number} Hit tolerance in pixels.
+   * @return {number} Hit tolerance in pixels.
    * @api
    */
   getHitTolerance() {

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -32,10 +32,6 @@ import {listen, unlistenByKey} from '../events.js';
  * visible.
  * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
  * be visible.
- * @property {number} [minZoom] The minimum view zoom level (exclusive) above which this layer will be
- * visible.
- * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
- * be visible.
  * @property {Array<import("./Base.js").default>|import("../Collection.js").default<import("./Base.js").default>} [layers] Child layers.
  */
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -560,7 +560,7 @@ export function clearUserProjection() {
  * Get the projection for coordinates supplied from and returned by API methods.
  * Note that this method is not yet a part of the stable API.  Support for user
  * projections is not yet complete and should be considered experimental.
- * @returns {?Projection} The user projection (or null if not set).
+ * @return {?Projection} The user projection (or null if not set).
  */
 export function getUserProjection() {
   return userProjection;
@@ -580,7 +580,7 @@ export function useGeographic() {
  * is set, the original coordinate is returned.
  * @param {Array<number>} coordinate Input coordinate.
  * @param {ProjectionLike} sourceProjection The input coordinate projection.
- * @returns {Array<number>} The input coordinate in the user projection.
+ * @return {Array<number>} The input coordinate in the user projection.
  */
 export function toUserCoordinate(coordinate, sourceProjection) {
   if (!userProjection) {
@@ -594,7 +594,7 @@ export function toUserCoordinate(coordinate, sourceProjection) {
  * is set, the original coordinate is returned.
  * @param {Array<number>} coordinate Input coordinate.
  * @param {ProjectionLike} destProjection The destination projection.
- * @returns {Array<number>} The input coordinate transformed.
+ * @return {Array<number>} The input coordinate transformed.
  */
 export function fromUserCoordinate(coordinate, destProjection) {
   if (!userProjection) {
@@ -608,7 +608,7 @@ export function fromUserCoordinate(coordinate, destProjection) {
  * is set, the original extent is returned.
  * @param {import("./extent.js").Extent} extent Input extent.
  * @param {ProjectionLike} sourceProjection The input extent projection.
- * @returns {import("./extent.js").Extent} The input extent in the user projection.
+ * @return {import("./extent.js").Extent} The input extent in the user projection.
  */
 export function toUserExtent(extent, sourceProjection) {
   if (!userProjection) {
@@ -622,7 +622,7 @@ export function toUserExtent(extent, sourceProjection) {
  * is set, the original extent is returned.
  * @param {import("./extent.js").Extent} extent Input extent.
  * @param {ProjectionLike} destProjection The destination projection.
- * @returns {import("./extent.js").Extent} The input extent transformed.
+ * @return {import("./extent.js").Extent} The input extent transformed.
  */
 export function fromUserExtent(extent, destProjection) {
   if (!userProjection) {

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -84,7 +84,7 @@ export function toContext(context, opt_options) {
 /**
  * Gets a vector context for drawing to the event's canvas.
  * @param {import("./render/Event.js").default} event Render event.
- * @returns {CanvasImmediateRenderer} Vector context.
+ * @return {CanvasImmediateRenderer} Vector context.
  * @api
  */
 export function getVectorContext(event) {
@@ -121,7 +121,7 @@ export function getVectorContext(event) {
  * @param {import("./render/Event.js").default} event Render event.
  * @param {import("./pixel.js").Pixel} pixel CSS pixel relative to the top-left
  * corner of the map viewport.
- * @returns {import("./pixel.js").Pixel} Pixel on the event's canvas context.
+ * @return {import("./pixel.js").Pixel} Pixel on the event's canvas context.
  * @api
  */
 export function getRenderPixel(event, pixel) {

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -352,7 +352,7 @@ export function measureTextWidth(font, text) {
  * @param {string} font The font.
  * @param {string} text The text to measure.
  * @param {Object<string, number>} cache A lookup of cached widths by text.
- * @returns {number} The text width.
+ * @return {number} The text width.
  */
 export function measureAndCacheTextWidth(font, text, cache) {
   if (text in cache) {

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -379,7 +379,7 @@ const circlePixelIndexArrayCache = {};
  * ordered by how close they are to the center.
  * A cache is used to increase performance.
  * @param {number} radius Radius.
- * @returns {Array<number>} An array with indexes within a circle.
+ * @return {Array<number>} An array with indexes within a circle.
  */
 export function getPixelIndexArray(radius) {
   if (circlePixelIndexArrayCache[radius] !== undefined) {

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -179,6 +179,12 @@ export function calculateSourceExtentResolution(
 }
 
 /**
+ * @typedef {Object} ImageExtent
+ * @property {import("./extent.js").Extent} extent
+ * @property {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement} image
+ */
+
+/**
  * Renders the source data into new canvas based on the triangulation.
  *
  * @param {number} width Width of the canvas.
@@ -188,11 +194,8 @@ export function calculateSourceExtentResolution(
  * @param {import("./extent.js").Extent} sourceExtent Extent of the data source.
  * @param {number} targetResolution Target resolution.
  * @param {import("./extent.js").Extent} targetExtent Target extent.
- * @param {import("./reproj/Triangulation.js").default} triangulation
- * Calculated triangulation.
- * @param {Array<{extent: import("./extent.js").Extent,
- *                 image: (HTMLCanvasElement|HTMLImageElement|HTMLVideoElement)}>} sources
- * Array of sources.
+ * @param {import("./reproj/Triangulation.js").default} triangulation Calculated triangulation.
+ * @param {Array<ImageExtent>} sources Array of sources.
  * @param {number} gutter Gutter of the sources.
  * @param {boolean=} opt_renderEdges Render reprojection edges.
  * @param {object=} opt_contextOptions Properties to set on the canvas context.

--- a/src/ol/string.js
+++ b/src/ol/string.js
@@ -6,7 +6,7 @@
  * @param {number} number Number to be formatted
  * @param {number} width The desired width
  * @param {number=} opt_precision Precision of the output string (i.e. number of decimal places)
- * @returns {string} Formatted string
+ * @return {string} Formatted string
  */
 export function padNumber(number, width, opt_precision) {
   const numberString =
@@ -22,7 +22,7 @@ export function padNumber(number, width, opt_precision) {
  * Adapted from https://github.com/omichelsen/compare-versions/blob/master/index.js
  * @param {string|number} v1 First version
  * @param {string|number} v2 Second version
- * @returns {number} Value
+ * @return {number} Value
  */
 export function compareVersions(v1, v2) {
   const s1 = ('' + v1).split('.');

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -163,6 +163,7 @@ class ImageStyle {
   /**
    * Get the image pixel ratio.
    * @param {number} pixelRatio Pixel ratio.
+   * @return {number} Pixel ratio.
    */
   getPixelRatio(pixelRatio) {
     return 1;

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -160,10 +160,10 @@ class ImageStyle {
     return abstract();
   }
 
-  /*
+  /**
    * Get the image pixel ratio.
    * @param {number} pixelRatio Pixel ratio.
-   * */
+   */
   getPixelRatio(pixelRatio) {
     return 1;
   }

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -243,6 +243,7 @@ class RegularShape extends ImageStyle {
   /**
    * Get the image pixel ratio.
    * @param {number} pixelRatio Pixel ratio.
+   * @return {number} Pixel ratio.
    */
   getPixelRatio(pixelRatio) {
     return pixelRatio;

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -240,10 +240,10 @@ class RegularShape extends ImageStyle {
     return this.canvas_[pixelRatio || 1];
   }
 
-  /*
+  /**
    * Get the image pixel ratio.
    * @param {number} pixelRatio Pixel ratio.
-   * */
+   */
   getPixelRatio(pixelRatio) {
     return pixelRatio;
   }
@@ -339,7 +339,7 @@ class RegularShape extends ImageStyle {
   unlistenImageChange(listener) {}
 
   /**
-   * @returns {RenderOptions}  The render options
+   * @return {RenderOptions}  The render options
    * @protected
    */
   createRenderOptions() {

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -110,7 +110,7 @@ export const Operators = {};
  * Returns the possible types for a given value (each type being a binary flag)
  * To test a value use e.g. `getValueType(v) & ValueTypes.BOOLEAN`
  * @param {ExpressionValue} value Value
- * @returns {ValueTypes|number} Type or types inferred from the value
+ * @return {ValueTypes|number} Type or types inferred from the value
  */
 export function getValueType(value) {
   if (typeof value === 'number') {
@@ -175,7 +175,7 @@ export function isTypeUnique(valueType) {
 /**
  * Will return the number as a float with a dot separator, which is required by GLSL.
  * @param {number} v Numerical value.
- * @returns {string} The value as string.
+ * @return {string} The value as string.
  */
 export function numberToGlsl(v) {
   const s = v.toString();
@@ -185,7 +185,7 @@ export function numberToGlsl(v) {
 /**
  * Will return the number array as a float with a dot separator, concatenated with ', '.
  * @param {Array<number>} array Numerical values array.
- * @returns {string} The array as a vector, e. g.: `vec3(1.0, 2.0, 3.0)`.
+ * @return {string} The array as a vector, e. g.: `vec3(1.0, 2.0, 3.0)`.
  */
 export function arrayToGlsl(array) {
   if (array.length < 2 || array.length > 4) {
@@ -201,7 +201,7 @@ export function arrayToGlsl(array) {
  * @param {string|import("../color.js").Color} color Color either in string format or [r, g, b, a] array format,
  * with RGB components in the 0..255 range and the alpha component in the 0..1 range.
  * Note that the final array will always have 4 components.
- * @returns {string} The color expressed in the `vec4(1.0, 1.0, 1.0, 1.0)` form.
+ * @return {string} The color expressed in the `vec4(1.0, 1.0, 1.0, 1.0)` form.
  */
 export function colorToGlsl(color) {
   const array = asArray(color).slice();
@@ -219,7 +219,7 @@ export function colorToGlsl(color) {
  * Returns a stable equivalent number for the string literal.
  * @param {ParsingContext} context Parsing context
  * @param {string} string String literal value
- * @returns {number} Number equivalent
+ * @return {number} Number equivalent
  */
 export function getStringNumberEquivalent(context, string) {
   if (context.stringLiteralsMap[string] === undefined) {
@@ -235,7 +235,7 @@ export function getStringNumberEquivalent(context, string) {
  * converted to be a GLSL-compatible string.
  * @param {ParsingContext} context Parsing context
  * @param {string} string String literal value
- * @returns {string} GLSL-compatible string containing a number
+ * @return {string} GLSL-compatible string containing a number
  */
 export function stringToGlsl(context, string) {
   return numberToGlsl(getStringNumberEquivalent(context, string));
@@ -247,7 +247,7 @@ export function stringToGlsl(context, string) {
  * @param {ParsingContext} context Parsing context
  * @param {ExpressionValue} value Value
  * @param {ValueTypes|number} [typeHint] Hint for the expected final type (can be several types combined)
- * @returns {string} GLSL-compatible output
+ * @return {string} GLSL-compatible output
  */
 export function expressionToGlsl(context, value, typeHint) {
   // operator

--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -119,7 +119,7 @@ class WebGLArrayBuffer {
 /**
  * Returns a typed array constructor based on the given buffer type
  * @param {number} type Buffer type, either ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER.
- * @returns {Float32ArrayConstructor|Uint32ArrayConstructor} The typed array class to use for this buffer.
+ * @return {Float32ArrayConstructor|Uint32ArrayConstructor} The typed array class to use for this buffer.
  */
 export function getArrayClassForType(type) {
   switch (type) {

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -963,7 +963,7 @@ class WebGLHelper extends Disposable {
 /**
  * Compute a stride in bytes based on a list of attributes
  * @param {Array<AttributeDescription>} attributes Ordered list of attributes
- * @returns {number} Stride, ie amount of values for each vertex in the vertex buffer
+ * @return {number} Stride, ie amount of values for each vertex in the vertex buffer
  * @api
  */
 export function computeAttributesStride(attributes) {
@@ -978,7 +978,7 @@ export function computeAttributesStride(attributes) {
 /**
  * Computes the size in byte of an attribute type.
  * @param {AttributeType} type Attribute type
- * @returns {number} The size in bytes
+ * @return {number} The size in bytes
  */
 function getByteSizeFromType(type) {
   switch (type) {

--- a/src/ol/webgl/PostProcessingPass.js
+++ b/src/ol/webgl/PostProcessingPass.js
@@ -285,7 +285,7 @@ class WebGLPostProcessingPass {
   }
 
   /**
-   * @returns {WebGLFramebuffer} Frame buffer
+   * @return {WebGLFramebuffer} Frame buffer
    * @api
    */
   getFrameBuffer() {

--- a/src/ol/webgl/RenderTarget.js
+++ b/src/ol/webgl/RenderTarget.js
@@ -125,7 +125,7 @@ class WebGLRenderTarget {
    * If x and/or y are outside of existing data, an array filled with 0 is returned.
    * @param {number} x Pixel coordinate
    * @param {number} y Pixel coordinate
-   * @returns {Uint8Array} Integer array with one color value (4 components)
+   * @return {Uint8Array} Integer array with one color value (4 components)
    * @api
    */
   readPixel(x, y) {

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -223,35 +223,35 @@ export class ShaderBuilder {
   }
 
   /**
-   * @returns {string} Previously set size expression
+   * @return {string} Previously set size expression
    */
   getSizeExpression() {
     return this.sizeExpression;
   }
 
   /**
-   * @returns {string} Previously set symbol offset expression
+   * @return {string} Previously set symbol offset expression
    */
   getOffsetExpression() {
     return this.offsetExpression;
   }
 
   /**
-   * @returns {string} Previously set color expression
+   * @return {string} Previously set color expression
    */
   getColorExpression() {
     return this.colorExpression;
   }
 
   /**
-   * @returns {string} Previously set texture coordinate expression
+   * @return {string} Previously set texture coordinate expression
    */
   getTextureCoordinateExpression() {
     return this.texCoordExpression;
   }
 
   /**
-   * @returns {string} Previously set fragment discard expression
+   * @return {string} Previously set fragment discard expression
    */
   getFragmentDiscardExpression() {
     return this.discardExpression;
@@ -272,7 +272,7 @@ export class ShaderBuilder {
    *
    * @param {boolean} [forHitDetection] If true, the shader will be modified to include hit detection variables
    * (namely, hit color with encoded feature id).
-   * @returns {string} The full shader as a string.
+   * @return {string} The full shader as a string.
    */
   getSymbolVertexShader(forHitDetection) {
     const offsetMatrix = this.rotateWithView
@@ -363,7 +363,7 @@ ${varyings
    *
    * @param {boolean} [forHitDetection] If true, the shader will be modified to include hit detection variables
    * (namely, hit color with encoded feature id).
-   * @returns {string} The full shader as a string.
+   * @return {string} The full shader as a string.
    */
   getSymbolFragmentShader(forHitDetection) {
     const hitDetectionBypass = forHitDetection
@@ -421,7 +421,7 @@ ${hitDetectionBypass}
  * {@link module:ol/renderer/webgl/PointsLayer~WebGLPointsLayerRenderer}.
  *
  * @param {import("../style/LiteralStyle").LiteralStyle} style Literal style.
- * @returns {StyleParseResult} Result containing shader params, attributes and uniforms.
+ * @return {StyleParseResult} Result containing shader params, attributes and uniforms.
  */
 export function parseLiteralStyle(style) {
   const symbStyle = style.symbol;

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -64,8 +64,6 @@ function formatSymbolExport(symbol, namespaces, imports) {
 /**
  * Generate export code given a list symbol names.
  * @param {Array<Object>} symbols List of symbols.
- * @param {Object<string, string>} namespaces Already defined namespaces.
- * @param {Array<string>} imports List of all imports.
  * @return {string} Export code.
  */
 function generateExports(symbols) {

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -332,10 +332,15 @@
   }
 
   /**
+   * @typedef {Object} xmleqlOptions
+   * @property {boolean} [includeWhiteSpace]
+   * @property {boolean} [ignoreElementOrder]
+   */
+
+  /**
    * Checks if the XML document sort of equals another XML document.
    * @param {Object} obj The other object.
-   * @param {{includeWhiteSpace: (boolean|undefined),
-   *     ignoreElementOrder: (boolean|undefined)}=} options The options.
+   * @param {xmleqlOptions} [options] The options.
    * @return {expect.Assertion} The assertion.
    */
   expect.Assertion.prototype.xmleql = function (obj, options) {


### PR DESCRIPTION
I used `eslint-plugin-jsdoc` to harmonize the jsdoc in the code base. I decided to replace `@returns` by `@return` because it is used way more.