### PR TITLE
More consistent JSDoc syntax

### DIFF
--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -52,7 +52,7 @@ class ZoomSlider extends Control {
     });
 
     /**
-     * @type {!Array.<import("../events.js").EventsKey>}
+     * @type {!Array<import("../events.js").EventsKey>}
      * @private
      */
     this.dragListenerKeys_ = [];

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -130,7 +130,7 @@ export class SelectEvent extends Event {
 
 /**
  * Original feature styles to reset to when features are no longer selected.
- * @type {Object.<number, import("../style/Style.js").default|Array.<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction>}
+ * @type {Object<number, import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction>}
  */
 const originalFeatureStyles = {};
 
@@ -216,7 +216,7 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {import("../style/Style.js").default|Array.<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction|null}
+     * @type {import("../style/Style.js").default|Array<import("../style/Style.js").default>|import("../style/Style.js").StyleFunction|null}
      */
     this.style_ =
       options.style !== undefined ? options.style : getDefaultStyleFunction();

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -32,13 +32,13 @@ export const WebGLWorkerMessageType = {
  * the main canvas that will then be sampled up (useful for saving resource on blur steps).
  * @property {string} [vertexShader] Vertex shader source
  * @property {string} [fragmentShader] Fragment shader source
- * @property {Object.<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process step
+ * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process step
  */
 
 /**
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the canvas element.
- * @property {Object.<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
+ * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
  * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
  */
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -54,7 +54,7 @@ import {listen, unlistenByKey} from '../../events.js';
  * @property {string} fragmentShader Fragment shader source, mandatory.
  * @property {string} [hitVertexShader] Vertex shader source for hit detection rendering.
  * @property {string} [hitFragmentShader] Fragment shader source for hit detection rendering.
- * @property {Object.<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
+ * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
  * Please note that `u_texture` is reserved for the main texture slot.
  * @property {Array<import("./Layer").PostProcessesOptions>} [postProcesses] Post-processes definitions
  */

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -223,7 +223,7 @@ export class Processor extends Disposable {
 
   /**
    * Run operation on input data.
-   * @param {Array.<Array|ImageData>} inputs Array of pixels or image data
+   * @param {Array<Array|ImageData>} inputs Array of pixels or image data
    *     (depending on the operation type).
    * @param {Object} meta A user data object.  This is passed to all operations
    *     and must be serializable.

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -92,12 +92,12 @@ export const AttributeType = {
  * the main canvas which will then be sampled up (useful for saving resource on blur steps).
  * @property {string} [vertexShader] Vertex shader source
  * @property {string} [fragmentShader] Fragment shader source
- * @property {Object.<string,UniformValue>} [uniforms] Uniform definitions for the post process step
+ * @property {Object<string,UniformValue>} [uniforms] Uniform definitions for the post process step
  */
 
 /**
  * @typedef {Object} Options
- * @property {Object.<string,UniformValue>} [uniforms] Uniform definitions; property names must match the uniform
+ * @property {Object<string,UniformValue>} [uniforms] Uniform definitions; property names must match the uniform
  * names in the provided or default shaders.
  * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
  */
@@ -311,13 +311,13 @@ class WebGLHelper extends Disposable {
 
     /**
      * @private
-     * @type {Object.<string, WebGLUniformLocation>}
+     * @type {Object<string, WebGLUniformLocation>}
      */
     this.uniformLocations_ = {};
 
     /**
      * @private
-     * @type {Object.<string, number>}
+     * @type {Object<string, number>}
      */
     this.attribLocations_ = {};
 

--- a/src/ol/webgl/PostProcessingPass.js
+++ b/src/ol/webgl/PostProcessingPass.js
@@ -37,7 +37,7 @@ const DEFAULT_FRAGMENT_SHADER = `
  * the main canvas that will then be sampled up (useful for saving resource on blur steps).
  * @property {string} [vertexShader] Vertex shader source
  * @property {string} [fragmentShader] Fragment shader source
- * @property {Object.<string,import("./Helper").UniformValue>} [uniforms] Uniform definitions for the post process step
+ * @property {Object<string,import("./Helper").UniformValue>} [uniforms] Uniform definitions for the post process step
  */
 
 /**

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -408,7 +408,7 @@ ${hitDetectionBypass}
 /**
  * @typedef {Object} StyleParseResult
  * @property {ShaderBuilder} builder Shader builder pre-configured according to a given style
- * @property {Object.<string,import("./Helper").UniformValue>} uniforms Uniform definitions.
+ * @property {Object<string,import("./Helper").UniformValue>} uniforms Uniform definitions.
  * @property {Array<import("../renderer/webgl/PointsLayer").CustomAttribute>} attributes Attribute descriptions.
  */
 
@@ -522,7 +522,7 @@ export function parseLiteralStyle(style) {
     builder.setFragmentDiscardExpression(`!${parsedFilter}`);
   }
 
-  /** @type {Object.<string,import("../webgl/Helper").UniformValue>} */
+  /** @type {Object<string,import("../webgl/Helper").UniformValue>} */
   const uniforms = {};
 
   // define one uniform per variable

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -332,7 +332,7 @@
   }
 
   /**
-   * @typedef {Object} xmleqlOptions
+   * @typedef {Object} XMLEqlOptions
    * @property {boolean} [includeWhiteSpace]
    * @property {boolean} [ignoreElementOrder]
    */
@@ -340,7 +340,7 @@
   /**
    * Checks if the XML document sort of equals another XML document.
    * @param {Object} obj The other object.
-   * @param {xmleqlOptions} [options] The options.
+   * @param {XMLEqlOptions} [options] The options.
    * @return {expect.Assertion} The assertion.
    */
   expect.Assertion.prototype.xmleql = function (obj, options) {


### PR DESCRIPTION
Following up on #11975, this adds a bit more consistency with our JSDoc syntax.

 * Arrays use `Array<ItemType>` instead of `Array.<ItemType>`
 * Objects use `Object<KeyType, ValueType>` instead of `Object.<KeyType, ValueType>`
 * All custom types are UpperCamelCase