### PR TITLE
Add snapToPointer option

### DIFF
--- a/examples/modify-icon.html
+++ b/examples/modify-icon.html
@@ -4,7 +4,7 @@ title: Icon modification
 shortdesc: Example using a Modify interaction to edit an icon.
 docs: >
   The icon on this map can be dragged to modify its location.
-  <p>The Modify interaction can be configured with a `layer` option. With this option, hit detection will be used to determine the modification candidate.</p>
+  <p>The Modify interaction can be configured with a `hitDetection` option. With this option, the modification candidate will not be determined by the `pixelTolerance`, but match the visual appearance of the geometry.</p>
 tags: "vector, modify, icon, marker"
 ---
 <div id="map" class="map"></div>

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -128,6 +128,9 @@ const ModifyEventType = {
  * provided, a vector source must be provided with the `source` option.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
  * overlay.
+ * @property {boolean} [snapToPointer=false] The vertex, point or segment being modified snaps to the
+ * pointer coordinate when clicked within the `pixelTolerance`. Setting this to `true` is recommended
+ * when the `Snap` interaction is used and the source geometry is not a snap target.
  */
 
 /**
@@ -386,6 +389,11 @@ class Modify extends PointerInteraction {
      * @type {Array<number>}
      */
     this.delta_ = [0, 0];
+
+    /**
+     * @private
+     */
+    this.snapToPointer_ = options.snapToPointer || false;
   }
 
   /**
@@ -1163,8 +1171,10 @@ class Modify extends PointerInteraction {
         const vertexSegments = {};
         vertexSegments[getUid(closestSegment)] = true;
 
-        this.delta_[0] = vertex[0] - pixelCoordinate[0];
-        this.delta_[1] = vertex[1] - pixelCoordinate[1];
+        if (!this.snapToPointer_) {
+          this.delta_[0] = vertex[0] - pixelCoordinate[0];
+          this.delta_[1] = vertex[1] - pixelCoordinate[1];
+        }
         if (
           node.geometry.getType() === GeometryType.CIRCLE &&
           node.index === CIRCLE_CIRCUMFERENCE_INDEX

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -128,9 +128,8 @@ const ModifyEventType = {
  * provided, a vector source must be provided with the `source` option.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
  * overlay.
- * @property {boolean} [snapToPointer=false] The vertex, point or segment being modified snaps to the
- * pointer coordinate when clicked within the `pixelTolerance`. Setting this to `true` is recommended
- * when the `Snap` interaction is used and the source geometry is not a snap target.
+ * @property {boolean} [snapToPointer=!hitDetection] The vertex, point or segment being modified snaps to the
+ * pointer coordinate when clicked within the `pixelTolerance`.
  */
 
 /**
@@ -393,7 +392,10 @@ class Modify extends PointerInteraction {
     /**
      * @private
      */
-    this.snapToPointer_ = options.snapToPointer || false;
+    this.snapToPointer_ =
+      options.snapToPointer === undefined
+        ? !this.hitDetection_
+        : options.snapToPointer;
   }
 
   /**

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -208,6 +208,11 @@ describe('ol.interaction.Modify', function () {
       expect(rbushEntries[0].feature).to.be(feature);
       expect(modify.hitDetection_).to.be(layer);
     });
+
+    it('accepts a snapToPointer option', function () {
+      const modify = new Modify({source: source, snapToPointer: true});
+      expect(modify.snapToPointer_).to.be(true);
+    });
   });
 
   describe('vertex deletion', function () {
@@ -1038,6 +1043,37 @@ describe('ol.interaction.Modify', function () {
       expect(modify.vertexFeature_.get('geometries')[0]).to.eql(
         pointFeature.getGeometry()
       );
+    });
+
+    it('snaps to pointer when snapToPointer is true', function () {
+      const modify = new Modify({
+        snapToPointer: true,
+        source: source,
+      });
+      map.addInteraction(modify);
+      source.clear();
+      const pointFeature = new Feature(new Point([0, 0]));
+      source.addFeature(pointFeature);
+      map.renderSync();
+      simulateEvent('pointerdown', 2, 2, null, 0);
+      simulateEvent('pointerdrag', 2, 2, null, 0);
+      simulateEvent('pointerup', 2, 2, null, 0);
+      expect(pointFeature.getGeometry().getCoordinates()).to.eql([2, -2]);
+    });
+
+    it('does not snap to pointer by default', function () {
+      const modify = new Modify({
+        source: source,
+      });
+      map.addInteraction(modify);
+      source.clear();
+      const pointFeature = new Feature(new Point([0, 0]));
+      source.addFeature(pointFeature);
+      map.renderSync();
+      simulateEvent('pointerdown', 2, 2, null, 0);
+      simulateEvent('pointerdrag', 2, 2, null, 0);
+      simulateEvent('pointerup', 2, 2, null, 0);
+      expect(pointFeature.getGeometry().getCoordinates()).to.eql([0, 0]);
     });
   });
 

--- a/test/spec/ol/interaction/modify.test.js
+++ b/test/spec/ol/interaction/modify.test.js
@@ -1045,9 +1045,8 @@ describe('ol.interaction.Modify', function () {
       );
     });
 
-    it('snaps to pointer when snapToPointer is true', function () {
+    it('snaps to pointer by default', function () {
       const modify = new Modify({
-        snapToPointer: true,
         source: source,
       });
       map.addInteraction(modify);
@@ -1061,9 +1060,10 @@ describe('ol.interaction.Modify', function () {
       expect(pointFeature.getGeometry().getCoordinates()).to.eql([2, -2]);
     });
 
-    it('does not snap to pointer by default', function () {
+    it('does not snap to pointer when snapToPointer is false', function () {
       const modify = new Modify({
         source: source,
+        snapToPointer: false,
       });
       map.addInteraction(modify);
       source.clear();


### PR DESCRIPTION
Fixes #11976.

This pull request adds a `snapToPointer` option to the `Modify` interaction. When set to `true`, the interaction behaves like it did before #11769 when a point, vertex or segment is clicked within the `pixelTolerance`: The point, vertex or segment will snap to the pointer position.