### PR TITLE
Jsdoc types syntax

### DIFF
--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 /**
  * Publish hook for the JSDoc template.  Writes to JSON stdout.
- * @param {function} data The root of the Taffy DB containing doclet records.
+ * @param {Function} data The root of the Taffy DB containing doclet records.
  * @param {Object} opts Options.
  * @return {Promise} A promise that resolves when writing is complete.
  */

--- a/examples/custom-controls.js
+++ b/examples/custom-controls.js
@@ -10,7 +10,7 @@ import {Control, defaults as defaultControls} from '../src/ol/control.js';
 
 class RotateNorthControl extends Control {
   /**
-   * @param {Object=} opt_options Control options.
+   * @param {Object} [opt_options] Control options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -22,8 +22,8 @@ const Property = {
 export class CollectionEvent extends Event {
   /**
    * @param {import("./CollectionEventType.js").default} type Type.
-   * @param {*=} opt_element Element.
-   * @param {number=} opt_index The index of the added or removed element.
+   * @param {*} [opt_element] Element.
+   * @param {number} [opt_index] The index of the added or removed element.
    */
   constructor(type, opt_element, opt_index) {
     super(type);
@@ -65,8 +65,8 @@ export class CollectionEvent extends Event {
  */
 class Collection extends BaseObject {
   /**
-   * @param {Array<T>=} opt_array Array.
-   * @param {Options=} opt_options Collection options.
+   * @param {Array<T>} [opt_array] Array.
+   * @param {Options} [opt_options] Collection options.
    */
   constructor(opt_array, opt_options) {
     super();
@@ -277,7 +277,7 @@ class Collection extends BaseObject {
   /**
    * @private
    * @param {T} elem Element.
-   * @param {number=} opt_except Optional index to ignore.
+   * @param {number} [opt_except] Optional index to ignore.
    */
   assertUnique_(elem, opt_except) {
     for (let i = 0, ii = this.array_.length; i < ii; ++i) {

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -61,7 +61,7 @@ import {listen, unlistenByKey} from './events.js';
  */
 class Feature extends BaseObject {
   /**
-   * @param {Geometry|Object<string, *>=} opt_geometryOrProperties
+   * @param {Geometry|Object<string, *>} [opt_geometryOrProperties]
    *     You may pass a Geometry object directly, or an object literal containing
    *     properties. If you pass an object literal, you may include a Geometry
    *     associated with a `geometry` key.
@@ -240,7 +240,7 @@ class Feature extends BaseObject {
    * single style object, an array of styles, or a function that takes a
    * resolution and returns an array of styles. To unset the feature style, call
    * `setStyle()` without arguments or a falsey value.
-   * @param {import("./style/Style.js").StyleLike=} opt_style Style for this feature.
+   * @param {import("./style/Style.js").StyleLike} [opt_style] Style for this feature.
    * @api
    * @fires module:ol/events/Event~BaseEvent#event:change
    */

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -86,7 +86,7 @@ class GeolocationError extends BaseEvent {
  */
 class Geolocation extends BaseObject {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/ImageCanvas.js
+++ b/src/ol/ImageCanvas.js
@@ -19,7 +19,7 @@ class ImageCanvas extends ImageBase {
    * @param {number} resolution Resolution.
    * @param {number} pixelRatio Pixel ratio.
    * @param {HTMLCanvasElement} canvas Canvas.
-   * @param {Loader=} opt_loader Optional loader function to
+   * @param {Loader} [opt_loader] Optional loader function to
    *     support asynchronous canvas drawing.
    */
   constructor(extent, resolution, pixelRatio, canvas, opt_loader) {
@@ -58,7 +58,7 @@ class ImageCanvas extends ImageBase {
 
   /**
    * Handle async drawing complete.
-   * @param {Error=} err Any error during drawing.
+   * @param {Error} [err] Any error during drawing.
    * @private
    */
   handleLoad_(err) {

--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -13,7 +13,7 @@ class ImageTile extends Tile {
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
-   * @param {import("./Tile.js").Options=} opt_options Tile options.
+   * @param {import("./Tile.js").Options} [opt_options] Tile options.
    */
   constructor(
     tileCoord,

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -14,8 +14,8 @@ class MapBrowserEvent extends MapEvent {
    * @param {string} type Event type.
    * @param {import("./PluggableMap.js").default} map Map.
    * @param {EVENT} originalEvent Original event.
-   * @param {boolean=} opt_dragging Is the map currently being dragged?
-   * @param {?import("./PluggableMap.js").FrameState=} opt_frameState Frame state.
+   * @param {boolean} [opt_dragging] Is the map currently being dragged?
+   * @param {?import("./PluggableMap.js").FrameState} [opt_frameState] Frame state.
    */
   constructor(type, map, originalEvent, opt_dragging, opt_frameState) {
     super(type, map, opt_frameState);

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -13,7 +13,7 @@ import {listen, unlistenByKey} from './events.js';
 class MapBrowserEventHandler extends EventTarget {
   /**
    * @param {import("./PluggableMap.js").default} map The map with the viewport to listen to events on.
-   * @param {number=} moveTolerance The minimal distance the pointer must travel to trigger a move.
+   * @param {number} [moveTolerance] The minimal distance the pointer must travel to trigger a move.
    */
   constructor(map, moveTolerance) {
     super(map);

--- a/src/ol/MapEvent.js
+++ b/src/ol/MapEvent.js
@@ -12,7 +12,7 @@ class MapEvent extends Event {
   /**
    * @param {string} type Event type.
    * @param {import("./PluggableMap.js").default} map Map.
-   * @param {?import("./PluggableMap.js").FrameState=} opt_frameState Frame state.
+   * @param {?import("./PluggableMap.js").FrameState} [opt_frameState] Frame state.
    */
   constructor(type, map, opt_frameState) {
     super(type);

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -82,7 +82,7 @@ export class ObjectEvent extends Event {
  */
 class BaseObject extends Observable {
   /**
-   * @param {Object<string, *>=} opt_values An object with key-value pairs.
+   * @param {Object<string, *>} [opt_values] An object with key-value pairs.
    */
   constructor(opt_values) {
     super();
@@ -159,7 +159,7 @@ class BaseObject extends Observable {
    * Sets a value.
    * @param {string} key Key name.
    * @param {*} value Value.
-   * @param {boolean=} opt_silent Update without triggering an event.
+   * @param {boolean} [opt_silent] Update without triggering an event.
    * @api
    */
   set(key, value, opt_silent) {
@@ -179,7 +179,7 @@ class BaseObject extends Observable {
    * Sets a collection of key-value pairs.  Note that this changes any existing
    * properties and adds new ones (it does not remove any existing properties).
    * @param {Object<string, *>} values Values.
-   * @param {boolean=} opt_silent Update without triggering an event.
+   * @param {boolean} [opt_silent] Update without triggering an event.
    * @api
    */
   setProperties(values, opt_silent) {
@@ -203,7 +203,7 @@ class BaseObject extends Observable {
   /**
    * Unsets a property.
    * @param {string} key Key name.
-   * @param {boolean=} opt_silent Unset without triggering an event.
+   * @param {boolean} [opt_silent] Unset without triggering an event.
    * @api
    */
   unset(key, opt_silent) {

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -409,7 +409,7 @@ class Overlay extends BaseObject {
   /**
    * Pan the map so that the overlay is entirely visible in the current viewport
    * (if necessary).
-   * @param {PanIntoViewOptions=} opt_panIntoViewOptions Options for the pan action
+   * @param {PanIntoViewOptions} [opt_panIntoViewOptions] Options for the pan action
    * @api
    */
   panIntoView(opt_panIntoViewOptions) {

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -545,7 +545,7 @@ class PluggableMap extends BaseObject {
    *     the {@link module:ol/layer/Layer layer} of the feature and will be null for
    *     unmanaged layers. To stop detection, callback functions can return a
    *     truthy value.
-   * @param {AtPixelOptions=} opt_options Optional options.
+   * @param {AtPixelOptions} [opt_options] Optional options.
    * @return {T|undefined} Callback result, i.e. the return value of last
    * callback execution, or the first truthy callback return value.
    * @template S,T
@@ -577,7 +577,7 @@ class PluggableMap extends BaseObject {
   /**
    * Get all features that intersect a pixel on the viewport.
    * @param {import("./pixel.js").Pixel} pixel Pixel.
-   * @param {AtPixelOptions=} opt_options Optional options.
+   * @param {AtPixelOptions} [opt_options] Optional options.
    * @return {Array<import("./Feature.js").FeatureLike>} The detected features or
    * an empty array if none were found.
    * @api
@@ -609,7 +609,7 @@ class PluggableMap extends BaseObject {
    *     [R, G, B, A] pixel values (0 - 255) and will be `null` for layer types
    *     that do not currently support this argument. To stop detection, callback
    *     functions can return a truthy value.
-   * @param {AtPixelOptions=} opt_options Configuration options.
+   * @param {AtPixelOptions} [opt_options] Configuration options.
    * @return {T|undefined} Callback result, i.e. the return value of last
    * callback execution, or the first truthy callback return value.
    * @template S,T
@@ -636,7 +636,7 @@ class PluggableMap extends BaseObject {
    * Detect if features intersect a pixel on the viewport. Layers included in the
    * detection can be configured through `opt_layerFilter`.
    * @param {import("./pixel.js").Pixel} pixel Pixel.
-   * @param {AtPixelOptions=} opt_options Optional options.
+   * @param {AtPixelOptions} [opt_options] Optional options.
    * @return {boolean} Is there a feature at the given pixel?
    * @api
    */
@@ -968,7 +968,7 @@ class PluggableMap extends BaseObject {
 
   /**
    * @param {UIEvent} browserEvent Browser event.
-   * @param {string=} opt_type Type.
+   * @param {string} [opt_type] Type.
    */
   handleBrowserEvent(browserEvent, opt_type) {
     const type = opt_type || browserEvent.type;

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -76,7 +76,7 @@ class Tile extends EventTarget {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("./TileState.js").default} state State.
-   * @param {Options=} opt_options Tile options.
+   * @param {Options} [opt_options] Tile options.
    */
   constructor(tileCoord, state, opt_options) {
     super();

--- a/src/ol/TileRange.js
+++ b/src/ol/TileRange.js
@@ -136,7 +136,7 @@ class TileRange {
  * @param {number} maxX Maximum X.
  * @param {number} minY Minimum Y.
  * @param {number} maxY Maximum Y.
- * @param {TileRange=} tileRange TileRange.
+ * @param {TileRange} [tileRange] TileRange.
  * @return {TileRange} Tile range.
  */
 export function createOrUpdate(minX, maxX, minY, maxY, tileRange) {

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -11,7 +11,7 @@ class VectorTile extends Tile {
    * @param {string} src Data source url.
    * @param {import("./format/Feature.js").default} format Feature format.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
-   * @param {import("./Tile.js").Options=} opt_options Tile options.
+   * @param {import("./Tile.js").Options} [opt_options] Tile options.
    */
   constructor(tileCoord, state, src, format, tileLoadFunction, opt_options) {
     super(tileCoord, state, opt_options);

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -290,7 +290,7 @@ const DEFAULT_MIN_ZOOM = 0;
  */
 class View extends BaseObject {
   /**
-   * @param {ViewOptions=} opt_options View options.
+   * @param {ViewOptions} [opt_options] View options.
    */
   constructor(opt_options) {
     super();
@@ -838,7 +838,7 @@ class View extends BaseObject {
   /**
    * Returns the current viewport size.
    * @private
-   * @param {number=} opt_rotation Take into account the rotation of the viewport when giving the size
+   * @param {number} [opt_rotation] Take into account the rotation of the viewport when giving the size
    * @return {import("./size.js").Size} Viewport size or `[100, 100]` when no viewport is found.
    */
   getViewportSize_(opt_rotation) {
@@ -862,7 +862,7 @@ class View extends BaseObject {
    * to avoid performance hit and layout reflow.
    * This should be done on map size change.
    * Note: the constraints are not resolved during an animation to avoid stopping it
-   * @param {import("./size.js").Size=} opt_size Viewport size; if undefined, [100, 100] is assumed
+   * @param {import("./size.js").Size} [opt_size] Viewport size; if undefined, [100, 100] is assumed
    */
   setViewportSize(opt_size) {
     this.viewportSize_ = Array.isArray(opt_size)
@@ -912,7 +912,7 @@ class View extends BaseObject {
   }
 
   /**
-   * @param {Array<number>=} opt_hints Destination array.
+   * @param {Array<number>} [opt_hints] Destination array.
    * @return {Array<number>} Hint.
    */
   getHints(opt_hints) {
@@ -930,7 +930,7 @@ class View extends BaseObject {
    * The size is the pixel dimensions of the box into which the calculated extent
    * should fit. In most cases you want to get the extent of the entire map,
    * that is `map.getSize()`.
-   * @param {import("./size.js").Size=} opt_size Box pixel size. If not provided, the size
+   * @param {import("./size.js").Size} [opt_size] Box pixel size. If not provided, the size
    * of the map that uses this view will be used.
    * @return {import("./extent.js").Extent} Extent.
    * @api
@@ -941,7 +941,7 @@ class View extends BaseObject {
   }
 
   /**
-   * @param {import("./size.js").Size=} opt_size Box pixel size. If not provided,
+   * @param {import("./size.js").Size} [opt_size] Box pixel size. If not provided,
    * the map's last known viewport size will be used.
    * @return {import("./extent.js").Extent} Extent.
    */
@@ -1056,7 +1056,7 @@ class View extends BaseObject {
   /**
    * Get the resolution for a provided extent (in map units) and size (in pixels).
    * @param {import("./extent.js").Extent} extent Extent.
-   * @param {import("./size.js").Size=} opt_size Box pixel size.
+   * @param {import("./size.js").Size} [opt_size] Box pixel size.
    * @return {number} The resolution at which the provided extent will render at
    *     the given size.
    * @api
@@ -1071,7 +1071,7 @@ class View extends BaseObject {
   /**
    * Get the resolution for a provided extent (in map units) and size (in pixels).
    * @param {import("./extent.js").Extent} extent Extent.
-   * @param {import("./size.js").Size=} opt_size Box pixel size.
+   * @param {import("./size.js").Size} [opt_size] Box pixel size.
    * @return {number} The resolution at which the provided extent will render at
    *     the given size.
    */
@@ -1085,7 +1085,7 @@ class View extends BaseObject {
   /**
    * Return a function that returns a value between 0 and 1 for a
    * resolution. Exponential scaling is assumed.
-   * @param {number=} opt_power Power.
+   * @param {number} [opt_power] Power.
    * @return {function(number): number} Resolution for value function.
    */
   getResolutionForValueFunction(opt_power) {
@@ -1118,7 +1118,7 @@ class View extends BaseObject {
   /**
    * Return a function that returns a resolution for a value between
    * 0 and 1. Exponential scaling is assumed.
-   * @param {number=} opt_power Power.
+   * @param {number} [opt_power] Power.
    * @return {function(number): number} Value for resolution function.
    */
   getValueForResolutionFunction(opt_power) {
@@ -1141,7 +1141,7 @@ class View extends BaseObject {
   /**
    * Returns the size of the viewport minus padding.
    * @private
-   * @param {number=} opt_rotation Take into account the rotation of the viewport when giving the size
+   * @param {number} [opt_rotation] Take into account the rotation of the viewport when giving the size
    * @return {import("./size.js").Size} Viewport size reduced by the padding.
    */
   getViewportSizeMinusPadding_(opt_rotation) {
@@ -1261,7 +1261,7 @@ class View extends BaseObject {
    * Takes care of the map angle.
    * @param {import("./geom/SimpleGeometry.js").default|import("./extent.js").Extent} geometryOrExtent The geometry or
    *     extent to fit the view to.
-   * @param {FitOptions=} opt_options Options.
+   * @param {FitOptions} [opt_options] Options.
    * @api
    */
   fit(geometryOrExtent, opt_options) {
@@ -1300,7 +1300,7 @@ class View extends BaseObject {
 
   /**
    * @param {import("./geom/SimpleGeometry.js").default} geometry The geometry.
-   * @param {FitOptions=} opt_options Options.
+   * @param {FitOptions} [opt_options] Options.
    */
   fitInternal(geometry, opt_options) {
     const options = opt_options || {};
@@ -1474,7 +1474,7 @@ class View extends BaseObject {
    * Multiply the view resolution by a ratio, optionally using an anchor. Any resolution
    * constraint will apply.
    * @param {number} ratio The ratio to apply on the view resolution.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The origin of the transformation.
    * @api
    */
   adjustResolution(ratio, opt_anchor) {
@@ -1487,7 +1487,7 @@ class View extends BaseObject {
    * Multiply the view resolution by a ratio, optionally using an anchor. Any resolution
    * constraint will apply.
    * @param {number} ratio The ratio to apply on the view resolution.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The origin of the transformation.
    */
   adjustResolutionInternal(ratio, opt_anchor) {
     const isMoving = this.getAnimating() || this.getInteracting();
@@ -1511,7 +1511,7 @@ class View extends BaseObject {
    * Adds a value to the view zoom level, optionally using an anchor. Any resolution
    * constraint will apply.
    * @param {number} delta Relative value to add to the zoom level.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The origin of the transformation.
    * @api
    */
   adjustZoom(delta, opt_anchor) {
@@ -1522,7 +1522,7 @@ class View extends BaseObject {
    * Adds a value to the view rotation, optionally using an anchor. Any rotation
    * constraint will apply.
    * @param {number} delta Relative value to add to the zoom rotation, in radians.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The rotation center.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The rotation center.
    * @api
    */
   adjustRotation(delta, opt_anchor) {
@@ -1534,7 +1534,7 @@ class View extends BaseObject {
 
   /**
    * @param {number} delta Relative value to add to the zoom rotation, in radians.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The rotation center.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The rotation center.
    */
   adjustRotationInternal(delta, opt_anchor) {
     const isMoving = this.getAnimating() || this.getInteracting();
@@ -1614,8 +1614,8 @@ class View extends BaseObject {
    * Recompute rotation/resolution/center based on target values.
    * Note: we have to compute rotation first, then resolution and center considering that
    * parameters can influence one another in case a view extent constraint is present.
-   * @param {boolean=} opt_doNotCancelAnims Do not cancel animations.
-   * @param {boolean=} opt_forceMoving Apply constraints as if the view is moving.
+   * @param {boolean} [opt_doNotCancelAnims] Do not cancel animations.
+   * @param {boolean} [opt_forceMoving] Apply constraints as if the view is moving.
    * @private
    */
   applyTargetState_(opt_doNotCancelAnims, opt_forceMoving) {
@@ -1671,9 +1671,9 @@ class View extends BaseObject {
    * This is typically done on interaction end.
    * Note: calling this with a duration of 0 will apply the constrained values straight away,
    * without animation.
-   * @param {number=} opt_duration The animation duration in ms.
-   * @param {number=} opt_resolutionDirection Which direction to zoom.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
+   * @param {number} [opt_duration] The animation duration in ms.
+   * @param {number} [opt_resolutionDirection] Which direction to zoom.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The origin of the transformation.
    */
   resolveConstraints(opt_duration, opt_resolutionDirection, opt_anchor) {
     const duration = opt_duration !== undefined ? opt_duration : 200;
@@ -1747,9 +1747,9 @@ class View extends BaseObject {
   /**
    * Notify the View that an interaction has ended. The view state will be resolved
    * to a stable one if needed (depending on its constraints).
-   * @param {number=} opt_duration Animation duration in ms.
-   * @param {number=} opt_resolutionDirection Which direction to zoom.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
+   * @param {number} [opt_duration] Animation duration in ms.
+   * @param {number} [opt_resolutionDirection] Which direction to zoom.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The origin of the transformation.
    * @api
    */
   endInteraction(opt_duration, opt_resolutionDirection, opt_anchor) {
@@ -1761,9 +1761,9 @@ class View extends BaseObject {
   /**
    * Notify the View that an interaction has ended. The view state will be resolved
    * to a stable one if needed (depending on its constraints).
-   * @param {number=} opt_duration Animation duration in ms.
-   * @param {number=} opt_resolutionDirection Which direction to zoom.
-   * @param {import("./coordinate.js").Coordinate=} opt_anchor The origin of the transformation.
+   * @param {number} [opt_duration] Animation duration in ms.
+   * @param {number} [opt_resolutionDirection] Which direction to zoom.
+   * @param {import("./coordinate.js").Coordinate} [opt_anchor] The origin of the transformation.
    */
   endInteractionInternal(opt_duration, opt_resolutionDirection, opt_anchor) {
     this.setHint(ViewHint.INTERACTING, -1);
@@ -1774,7 +1774,7 @@ class View extends BaseObject {
   /**
    * Get a valid position for the view center according to the current constraints.
    * @param {import("./coordinate.js").Coordinate|undefined} targetCenter Target center position.
-   * @param {number=} opt_targetResolution Target resolution. If not supplied, the current one will be used.
+   * @param {number} [opt_targetResolution] Target resolution. If not supplied, the current one will be used.
    * This is useful to guess a valid center position at a different zoom level.
    * @return {import("./coordinate.js").Coordinate|undefined} Valid center position.
    */
@@ -1790,7 +1790,7 @@ class View extends BaseObject {
   /**
    * Get a valid zoom level according to the current view constraints.
    * @param {number|undefined} targetZoom Target zoom.
-   * @param {number=} [opt_direction=0] Indicate which resolution should be used
+   * @param {number} [opt_direction=0] Indicate which resolution should be used
    * by a renderer if the view resolution does not match any resolution of the tile source.
    * If 0, the nearest resolution will be used. If 1, the nearest lower resolution
    * will be used. If -1, the nearest higher resolution will be used.
@@ -1806,7 +1806,7 @@ class View extends BaseObject {
   /**
    * Get a valid resolution according to the current view constraints.
    * @param {number|undefined} targetResolution Target resolution.
-   * @param {number=} [opt_direction=0] Indicate which resolution should be used
+   * @param {number} [opt_direction=0] Indicate which resolution should be used
    * by a renderer if the view resolution does not match any resolution of the tile source.
    * If 0, the nearest resolution will be used. If 1, the nearest lower resolution
    * will be used. If -1, the nearest higher resolution will be used.

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -8,7 +8,7 @@
  *
  * @param {Array<*>} haystack Items to search through.
  * @param {*} needle The item to look for.
- * @param {Function=} opt_comparator Comparator function.
+ * @param {Function} [opt_comparator] Comparator function.
  * @return {number} The index of the item if found, -1 if not.
  */
 export function binarySearch(haystack, needle, opt_comparator) {
@@ -222,8 +222,8 @@ export function findIndex(arr, func) {
 
 /**
  * @param {Array<*>} arr The array to test.
- * @param {Function=} opt_func Comparison function.
- * @param {boolean=} opt_strict Strictly sorted (default false).
+ * @param {Function} [opt_func] Comparison function.
+ * @param {boolean} [opt_strict] Strictly sorted (default false).
  * @return {boolean} Return index.
  */
 export function isSorted(arr, opt_func, opt_strict) {

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -20,8 +20,8 @@ export function createExtent(extent, onlyCenter, smooth) {
      * @param {import("./coordinate.js").Coordinate|undefined} center Center.
      * @param {number} resolution Resolution.
      * @param {import("./size.js").Size} size Viewport size; unused if `onlyCenter` was specified.
-     * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
-     * @param {Array<number>=} opt_centerShift Shift between map center and viewport center.
+     * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
+     * @param {Array<number>} [opt_centerShift] Shift between map center and viewport center.
      * @return {import("./coordinate.js").Coordinate|undefined} Center.
      */
     function (center, resolution, size, opt_isMoving, opt_centerShift) {
@@ -69,7 +69,7 @@ export function createExtent(extent, onlyCenter, smooth) {
 }
 
 /**
- * @param {import("./coordinate.js").Coordinate=} center Center.
+ * @param {import("./coordinate.js").Coordinate} [center] Center.
  * @return {import("./coordinate.js").Coordinate|undefined} Center.
  */
 export function none(center) {

--- a/src/ol/control.js
+++ b/src/ol/control.js
@@ -41,7 +41,7 @@ export {default as ZoomToExtent} from './control/ZoomToExtent.js';
  * * {@link module:ol/control/Rotate~Rotate}
  * * {@link module:ol/control/Attribution~Attribution}
  *
- * @param {DefaultsOptions=} opt_options
+ * @param {DefaultsOptions} [opt_options]
  * Defaults options.
  * @return {Collection<import("./control/Control.js").default>}
  * Controls.

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -46,7 +46,7 @@ import {removeChildren, replaceNode} from '../dom.js';
  */
 class Attribution extends Control {
   /**
-   * @param {Options=} opt_options Attribution options.
+   * @param {Options} [opt_options] Attribution options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -70,7 +70,7 @@ const FullScreenEventType = {
  */
 class FullScreen extends Control {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -54,7 +54,7 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  */
 class MousePosition extends Control {
   /**
-   * @param {Options=} opt_options Mouse position options.
+   * @param {Options} [opt_options] Mouse position options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -74,7 +74,7 @@ class ControlledMap extends PluggableMap {
  */
 class OverviewMap extends Control {
   /**
-   * @param {Options=} opt_options OverviewMap options.
+   * @param {Options} [opt_options] OverviewMap options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/Rotate.js
+++ b/src/ol/control/Rotate.js
@@ -33,7 +33,7 @@ import {easeOut} from '../easing.js';
  */
 class Rotate extends Control {
   /**
-   * @param {Options=} opt_options Rotate options.
+   * @param {Options} [opt_options] Rotate options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -73,7 +73,7 @@ const DEFAULT_DPI = 25.4 / 0.28;
  */
 class ScaleLine extends Control {
   /**
-   * @param {Options=} opt_options Scale line options.
+   * @param {Options} [opt_options] Scale line options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/Zoom.js
+++ b/src/ol/control/Zoom.js
@@ -33,7 +33,7 @@ import {easeOut} from '../easing.js';
  */
 class Zoom extends Control {
   /**
-   * @param {Options=} opt_options Zoom options.
+   * @param {Options} [opt_options] Zoom options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -41,7 +41,7 @@ const Direction = {
  */
 class ZoomSlider extends Control {
   /**
-   * @param {Options=} opt_options Zoom slider options.
+   * @param {Options} [opt_options] Zoom slider options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/control/ZoomToExtent.js
+++ b/src/ol/control/ZoomToExtent.js
@@ -27,7 +27,7 @@ import {fromExtent as polygonFromExtent} from '../geom/Polygon.js';
  */
 class ZoomToExtent extends Control {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -135,7 +135,7 @@ export function closestOnSegment(coordinate, segment) {
  *     var out = stringifyFunc(coord);
  *     // out is now '7.85, 47.98'
  *
- * @param {number=} opt_fractionDigits The number of digits to include
+ * @param {number} [opt_fractionDigits] The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {CoordinateFormat} Coordinate format.
  * @api
@@ -155,7 +155,7 @@ export function createStringXY(opt_fractionDigits) {
 /**
  * @param {string} hemispheres Hemispheres.
  * @param {number} degrees Degrees.
- * @param {number=} opt_fractionDigits The number of digits to include
+ * @param {number} [opt_fractionDigits] The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} String.
  */
@@ -219,7 +219,7 @@ export function degreesToStringHDMS(hemispheres, degrees, opt_fractionDigits) {
  * @param {Coordinate} coordinate Coordinate.
  * @param {string} template A template string with `{x}` and `{y}` placeholders
  *     that will be replaced by first and second coordinate values.
- * @param {number=} opt_fractionDigits The number of digits to include
+ * @param {number} [opt_fractionDigits] The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} Formatted coordinate.
  * @api
@@ -354,7 +354,7 @@ export function squaredDistanceToSegment(coordinate, segment) {
  *     // out is now '47° 58′ 60.0″ N 7° 50′ 60.0″ E'
  *
  * @param {Coordinate} coordinate Coordinate.
- * @param {number=} opt_fractionDigits The number of digits to include
+ * @param {number} [opt_fractionDigits] The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} Hemisphere, degrees, minutes and seconds.
  * @api
@@ -391,7 +391,7 @@ export function toStringHDMS(coordinate, opt_fractionDigits) {
  *     // out is now '7.8, 48.0'
  *
  * @param {Coordinate} coordinate Coordinate.
- * @param {number=} opt_fractionDigits The number of digits to include
+ * @param {number} [opt_fractionDigits] The number of digits to include
  *    after the decimal point. Default is `0`.
  * @return {string} XY.
  * @api
@@ -422,7 +422,7 @@ export function wrapX(coordinate, projection) {
 /**
  * @param {Coordinate} coordinate Coordinate.
  * @param {import("./proj/Projection.js").default} projection Projection.
- * @param {number=} opt_sourceExtentWidth Width of the source extent.
+ * @param {number} [opt_sourceExtentWidth] Width of the source extent.
  * @return {number} Offset in world widths.
  */
 export function getWorldsAway(coordinate, projection, opt_sourceExtentWidth) {

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -7,9 +7,9 @@ import {WORKER_OFFSCREEN_CANVAS} from './has.js';
 //FIXME Move this function to the canvas module
 /**
  * Create an html canvas element and returns its 2d context.
- * @param {number=} opt_width Canvas width.
- * @param {number=} opt_height Canvas height.
- * @param {Array<HTMLCanvasElement>=} opt_canvasPool Canvas pool to take existing canvas from.
+ * @param {number} [opt_width] Canvas width.
+ * @param {number} [opt_height] Canvas height.
+ * @param {Array<HTMLCanvasElement>} [opt_canvasPool] Canvas pool to take existing canvas from.
  * @return {CanvasRenderingContext2D} The context.
  */
 export function createCanvasContext2D(opt_width, opt_height, opt_canvasPool) {

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -39,9 +39,9 @@ import {clear} from './obj.js';
  * @param {import("./events/Target.js").EventTargetLike} target Event target.
  * @param {string} type Event type.
  * @param {ListenerFunction} listener Listener.
- * @param {Object=} opt_this Object referenced by the `this` keyword in the
+ * @param {Object} [opt_this] Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
- * @param {boolean=} opt_once If true, add the listener as one-off listener.
+ * @param {boolean} [opt_once] If true, add the listener as one-off listener.
  * @return {EventsKey} Unique key for the listener.
  */
 export function listen(target, type, listener, opt_this, opt_once) {
@@ -80,7 +80,7 @@ export function listen(target, type, listener, opt_this, opt_once) {
  * @param {import("./events/Target.js").EventTargetLike} target Event target.
  * @param {string} type Event type.
  * @param {ListenerFunction} listener Listener.
- * @param {Object=} opt_this Object referenced by the `this` keyword in the
+ * @param {Object} [opt_this] Object referenced by the `this` keyword in the
  *     listener. Default is the `target`.
  * @return {EventsKey} Key for unlistenByKey.
  */

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -27,7 +27,7 @@ import {clear} from '../obj.js';
  */
 class Target extends Disposable {
   /**
-   * @param {*=} opt_target Default event target for dispatched events.
+   * @param {*} [opt_target] Default event target for dispatched events.
    */
   constructor(opt_target) {
     super();
@@ -147,7 +147,7 @@ class Target extends Disposable {
   }
 
   /**
-   * @param {string=} opt_type Type. If not provided,
+   * @param {string} [opt_type] Type. If not provided,
    *     `true` will be returned if this event target has any listeners.
    * @return {boolean} Has listeners.
    */

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -29,7 +29,7 @@ export function boundingExtent(coordinates) {
 /**
  * @param {Array<number>} xs Xs.
  * @param {Array<number>} ys Ys.
- * @param {Extent=} opt_extent Destination extent.
+ * @param {Extent} [opt_extent] Destination extent.
  * @private
  * @return {Extent} Extent.
  */
@@ -45,7 +45,7 @@ function _boundingExtentXYs(xs, ys, opt_extent) {
  * Return extent increased by the provided value.
  * @param {Extent} extent Extent.
  * @param {number} value The amount by which the extent should be buffered.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  * @api
  */
@@ -70,7 +70,7 @@ export function buffer(extent, value, opt_extent) {
  * Creates a clone of an extent.
  *
  * @param {Extent} extent Extent to clone.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} The clone.
  */
 export function clone(extent, opt_extent) {
@@ -202,7 +202,7 @@ export function createEmpty() {
  * @param {number} minY Minimum Y.
  * @param {number} maxX Maximum X.
  * @param {number} maxY Maximum Y.
- * @param {Extent=} opt_extent Destination extent.
+ * @param {Extent} [opt_extent] Destination extent.
  * @return {Extent} Extent.
  */
 export function createOrUpdate(minX, minY, maxX, maxY, opt_extent) {
@@ -219,7 +219,7 @@ export function createOrUpdate(minX, minY, maxX, maxY, opt_extent) {
 
 /**
  * Create a new empty extent or make the provided one empty.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  */
 export function createOrUpdateEmpty(opt_extent) {
@@ -228,7 +228,7 @@ export function createOrUpdateEmpty(opt_extent) {
 
 /**
  * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  */
 export function createOrUpdateFromCoordinate(coordinate, opt_extent) {
@@ -239,7 +239,7 @@ export function createOrUpdateFromCoordinate(coordinate, opt_extent) {
 
 /**
  * @param {Array<import("./coordinate.js").Coordinate>} coordinates Coordinates.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  */
 export function createOrUpdateFromCoordinates(coordinates, opt_extent) {
@@ -252,7 +252,7 @@ export function createOrUpdateFromCoordinates(coordinates, opt_extent) {
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  */
 export function createOrUpdateFromFlatCoordinates(
@@ -268,7 +268,7 @@ export function createOrUpdateFromFlatCoordinates(
 
 /**
  * @param {Array<Array<import("./coordinate.js").Coordinate>>} rings Rings.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  */
 export function createOrUpdateFromRings(rings, opt_extent) {
@@ -521,7 +521,7 @@ export function getEnlargedArea(extent1, extent2) {
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
  * @param {import("./size.js").Size} size Size.
- * @param {Extent=} opt_extent Destination extent.
+ * @param {Extent} [opt_extent] Destination extent.
  * @return {Extent} Extent.
  */
 export function getForViewAndSize(
@@ -582,7 +582,7 @@ export function getIntersectionArea(extent1, extent2) {
  * Get the intersection of two extents.
  * @param {Extent} extent1 Extent 1.
  * @param {Extent} extent2 Extent 2.
- * @param {Extent=} opt_extent Optional extent to populate with intersection.
+ * @param {Extent} [opt_extent] Optional extent to populate with intersection.
  * @return {Extent} Intersecting extent.
  * @api
  */
@@ -691,7 +691,7 @@ export function isEmpty(extent) {
 
 /**
  * @param {Extent} extent Extent.
- * @param {Extent=} opt_extent Extent.
+ * @param {Extent} [opt_extent] Extent.
  * @return {Extent} Extent.
  */
 export function returnOrUpdate(extent, opt_extent) {
@@ -788,8 +788,8 @@ export function intersectsSegment(extent, start, end) {
  * @param {Extent} extent Extent.
  * @param {import("./proj.js").TransformFunction} transformFn Transform function.
  * Called with `[minX, minY, maxX, maxY]` extent coordinates.
- * @param {Extent=} opt_extent Destination extent.
- * @param {number=} opt_stops Number of stops per side used for the transform.
+ * @param {Extent} [opt_extent] Destination extent.
+ * @param {number} [opt_stops] Number of stops per side used for the transform.
  * By default only the corners are used.
  * @return {Extent} Extent.
  * @api

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -136,9 +136,9 @@ export function xhr(url, format) {
    * @param {import("./extent.js").Extent} extent Extent.
    * @param {number} resolution Resolution.
    * @param {import("./proj/Projection.js").default} projection Projection.
-   * @param {function(): void=} success Success
+   * @param {function(): void} [success] Success
    *      Function called when loading succeeded.
-   * @param {function(): void=} failure Failure
+   * @param {function(): void} [failure] Failure
    *      Function called when loading failed.
    * @this {import("./source/Vector").default}
    */

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -78,7 +78,7 @@ GEOMETRY_WRITERS[GeometryType.MULTI_POLYGON] = writeMultiPolygonGeometry;
  */
 class EsriJSON extends JSONFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -95,8 +95,8 @@ class EsriJSON extends JSONFeature {
 
   /**
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
-   * @param {string=} opt_idField Name of the field where to get the id from.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
+   * @param {string} [opt_idField] Name of the field where to get the id from.
    * @protected
    * @return {import("../Feature.js").default} Feature.
    */
@@ -120,7 +120,7 @@ class EsriJSON extends JSONFeature {
 
   /**
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<Feature>} Features.
    */
@@ -148,7 +148,7 @@ class EsriJSON extends JSONFeature {
 
   /**
    * @param {EsriJSONGeometry} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -180,7 +180,7 @@ class EsriJSON extends JSONFeature {
    * Encode a geometry as a EsriJSON object.
    *
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {EsriJSONGeometry} Object.
    * @api
    */
@@ -192,7 +192,7 @@ class EsriJSON extends JSONFeature {
    * Encode a feature as a esriJSON Feature object.
    *
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {Object} Object.
    * @api
    */
@@ -231,7 +231,7 @@ class EsriJSON extends JSONFeature {
    * Encode an array of features as a EsriJSON object.
    *
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {EsriJSONFeatureSet} EsriJSON Object.
    * @api
    */
@@ -249,7 +249,7 @@ class EsriJSON extends JSONFeature {
 
 /**
  * @param {EsriJSONGeometry} object Object.
- * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
  * @return {import("../geom/Geometry.js").default} Geometry.
  */
 function readGeometry(object, opt_options) {
@@ -429,7 +429,7 @@ function readPolygonGeometry(object) {
 
 /**
  * @param {import("../geom/Point.js").default} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONPoint} EsriJSON geometry.
  */
 function writePointGeometry(geometry, opt_options) {
@@ -481,7 +481,7 @@ function getHasZM(geometry) {
 
 /**
  * @param {import("../geom/LineString.js").default} lineString Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONPolyline} EsriJSON geometry.
  */
 function writeLineStringGeometry(lineString, opt_options) {
@@ -497,7 +497,7 @@ function writeLineStringGeometry(lineString, opt_options) {
 
 /**
  * @param {import("../geom/Polygon.js").default} polygon Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONPolygon} EsriJSON geometry.
  */
 function writePolygonGeometry(polygon, opt_options) {
@@ -514,7 +514,7 @@ function writePolygonGeometry(polygon, opt_options) {
 
 /**
  * @param {import("../geom/MultiLineString.js").default} multiLineString Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONPolyline} EsriJSON geometry.
  */
 function writeMultiLineStringGeometry(multiLineString, opt_options) {
@@ -528,7 +528,7 @@ function writeMultiLineStringGeometry(multiLineString, opt_options) {
 
 /**
  * @param {import("../geom/MultiPoint.js").default} multiPoint Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONMultipoint} EsriJSON geometry.
  */
 function writeMultiPointGeometry(multiPoint, opt_options) {
@@ -542,7 +542,7 @@ function writeMultiPointGeometry(multiPoint, opt_options) {
 
 /**
  * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONPolygon} EsriJSON geometry.
  */
 function writeMultiPolygonGeometry(geometry, opt_options) {
@@ -563,7 +563,7 @@ function writeMultiPolygonGeometry(geometry, opt_options) {
 
 /**
  * @param {import("../geom/Geometry.js").default} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {EsriJSONGeometry} EsriJSON geometry.
  */
 function writeGeometry(geometry, opt_options) {

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -81,7 +81,7 @@ class FeatureFormat {
   /**
    * Adds the data projection to the read options.
    * @param {Document|Element|Object|string} source Source.
-   * @param {ReadOptions=} opt_options Options.
+   * @param {ReadOptions} [opt_options] Options.
    * @return {ReadOptions|undefined} Options.
    * @protected
    */
@@ -139,7 +139,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Element|Object|string} source Source.
-   * @param {ReadOptions=} opt_options Read options.
+   * @param {ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").FeatureLike} Feature.
    */
   readFeature(source, opt_options) {
@@ -151,7 +151,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Element|ArrayBuffer|Object|string} source Source.
-   * @param {ReadOptions=} opt_options Read options.
+   * @param {ReadOptions} [opt_options] Read options.
    * @return {Array<import("../Feature.js").FeatureLike>} Features.
    */
   readFeatures(source, opt_options) {
@@ -163,7 +163,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Element|Object|string} source Source.
-   * @param {ReadOptions=} opt_options Read options.
+   * @param {ReadOptions} [opt_options] Read options.
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometry(source, opt_options) {
@@ -186,7 +186,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {WriteOptions=} opt_options Write options.
+   * @param {WriteOptions} [opt_options] Write options.
    * @return {string} Result.
    */
   writeFeature(feature, opt_options) {
@@ -198,7 +198,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {WriteOptions=} opt_options Write options.
+   * @param {WriteOptions} [opt_options] Write options.
    * @return {string} Result.
    */
   writeFeatures(features, opt_options) {
@@ -210,7 +210,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {WriteOptions=} opt_options Write options.
+   * @param {WriteOptions} [opt_options] Write options.
    * @return {string} Result.
    */
   writeGeometry(geometry, opt_options) {
@@ -223,7 +223,7 @@ export default FeatureFormat;
 /**
  * @param {import("../geom/Geometry.js").default} geometry Geometry.
  * @param {boolean} write Set to true for writing, false for reading.
- * @param {(WriteOptions|ReadOptions)=} opt_options Options.
+ * @param {WriteOptions|ReadOptions} [opt_options] Options.
  * @return {import("../geom/Geometry.js").default} Transformed geometry.
  */
 export function transformGeometryWithOptions(geometry, write, opt_options) {
@@ -277,7 +277,7 @@ export function transformGeometryWithOptions(geometry, write, opt_options) {
 
 /**
  * @param {import("../extent.js").Extent} extent Extent.
- * @param {ReadOptions=} opt_options Read options.
+ * @param {ReadOptions} [opt_options] Read options.
  * @return {import("../extent.js").Extent} Transformed extent.
  */
 export function transformExtentWithOptions(extent, opt_options) {

--- a/src/ol/format/GML.js
+++ b/src/ol/format/GML.js
@@ -9,7 +9,7 @@ import GML3 from './GML3.js';
  * version 3.1.1.
  * Currently only supports GML 3.1.1 Simple Features profile.
  *
- * @param {import("./GMLBase.js").Options=} opt_options
+ * @param {import("./GMLBase.js").Options} [opt_options]
  *     Optional configuration object.
  * @api
  */
@@ -20,7 +20,7 @@ const GML = GML3;
  *
  * @function
  * @param {Array<import("../Feature.js").default>} features Features.
- * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
  * @return {string} Result.
  * @api
  */
@@ -31,7 +31,7 @@ GML.prototype.writeFeatures;
  *
  * @function
  * @param {Array<import("../Feature.js").default>} features Features.
- * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
  * @return {Node} Node.
  * @api
  */

--- a/src/ol/format/GML2.js
+++ b/src/ol/format/GML2.js
@@ -49,7 +49,7 @@ const MULTIGEOMETRY_TO_MEMBER_NODENAME = {
  */
 class GML2 extends GMLBase {
   /**
-   * @param {import("./GMLBase.js").Options=} opt_options Optional configuration object.
+   * @param {import("./GMLBase.js").Options} [opt_options] Optional configuration object.
    */
   constructor(opt_options) {
     const options =
@@ -170,7 +170,7 @@ class GML2 extends GMLBase {
    * @const
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
-   * @param {string=} opt_nodeName Node name.
+   * @param {string} [opt_nodeName] Node name.
    * @return {Element|undefined} Node.
    * @private
    */
@@ -434,7 +434,7 @@ class GML2 extends GMLBase {
   /**
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
-   * @param {string=} opt_nodeName Node name.
+   * @param {string} [opt_nodeName] Node name.
    * @return {Node} Node.
    * @private
    */
@@ -476,8 +476,8 @@ class GML2 extends GMLBase {
 
   /**
    * @param {Array<number>} point Point geometry.
-   * @param {string=} opt_srsName Optional srsName
-   * @param {boolean=} opt_hasZ whether the geometry has a Z coordinate (is 3D) or not.
+   * @param {string} [opt_srsName] Optional srsName
+   * @param {boolean} [opt_hasZ] whether the geometry has a Z coordinate (is 3D) or not.
    * @return {string} The coords string.
    * @private
    */
@@ -636,7 +636,7 @@ class GML2 extends GMLBase {
    * @const
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
-   * @param {string=} opt_nodeName Node name.
+   * @param {string} [opt_nodeName] Node name.
    * @return {Node|undefined} Node.
    * @private
    */

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -62,7 +62,7 @@ const MULTIGEOMETRY_TO_MEMBER_NODENAME = {
  */
 class GML3 extends GMLBase {
   /**
-   * @param {import("./GMLBase.js").Options=} opt_options Optional configuration object.
+   * @param {import("./GMLBase.js").Options} [opt_options] Optional configuration object.
    */
   constructor(opt_options) {
     const options =
@@ -466,8 +466,8 @@ class GML3 extends GMLBase {
 
   /**
    * @param {Array<number>} point Point geometry.
-   * @param {string=} opt_srsName Optional srsName
-   * @param {boolean=} opt_hasZ whether the geometry has a Z coordinate (is 3D) or not.
+   * @param {string} [opt_srsName] Optional srsName
+   * @param {boolean} [opt_hasZ] whether the geometry has a Z coordinate (is 3D) or not.
    * @return {string} The coords string.
    * @private
    */
@@ -573,7 +573,7 @@ class GML3 extends GMLBase {
   /**
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
-   * @param {string=} opt_nodeName Node name.
+   * @param {string} [opt_nodeName] Node name.
    * @return {Node} Node.
    * @private
    */
@@ -920,7 +920,7 @@ class GML3 extends GMLBase {
    * @const
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
-   * @param {string=} opt_nodeName Node name.
+   * @param {string} [opt_nodeName] Node name.
    * @return {Node|undefined} Node.
    * @private
    */
@@ -936,7 +936,7 @@ class GML3 extends GMLBase {
    * @const
    * @param {*} value Value.
    * @param {Array<*>} objectStack Object stack.
-   * @param {string=} opt_nodeName Node name.
+   * @param {string} [opt_nodeName] Node name.
    * @return {Element|undefined} Node.
    * @private
    */
@@ -968,7 +968,7 @@ class GML3 extends GMLBase {
    * Encode a geometry in GML 3.1.1 Simple Features.
    *
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @return {Node} Node.
    * @api
    */
@@ -995,7 +995,7 @@ class GML3 extends GMLBase {
    * Encode an array of features in the GML 3.1.1 format as an XML node.
    *
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @return {Element} Node.
    * @api
    */
@@ -1169,7 +1169,7 @@ GML3.prototype.SEGMENTS_PARSERS = {
  *
  * @function
  * @param {Array<import("../Feature.js").default>} features Features.
- * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
  * @return {string} Result.
  * @api
  */

--- a/src/ol/format/GML32.js
+++ b/src/ol/format/GML32.js
@@ -14,7 +14,7 @@ import {writeStringTextNode} from '../format/xsd.js';
  */
 class GML32 extends GML3 {
   /**
-   * @param {import("./GMLBase.js").Options=} opt_options Optional configuration object.
+   * @param {import("./GMLBase.js").Options} [opt_options] Optional configuration object.
    */
   constructor(opt_options) {
     const options = /** @type {import("./GMLBase.js").Options} */ (opt_options

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -93,7 +93,7 @@ const ONLY_WHITESPACE_RE = /^[\s\xa0]*$/;
  */
 class GMLBase extends XMLFeature {
   /**
-   * @param {Options=} opt_options Optional configuration object.
+   * @param {Options} [opt_options] Optional configuration object.
    */
   constructor(opt_options) {
     super();
@@ -532,7 +532,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @protected
    * @return {import("../geom/Geometry.js").default|import("../extent.js").Extent} Geometry.
    */
@@ -546,7 +546,7 @@ class GMLBase extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -131,7 +131,7 @@ const GPX_SERIALIZERS = makeStructureNS(NAMESPACE_URIS, {
  */
 class GPX extends XMLFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -170,7 +170,7 @@ class GPX extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromNode(node, opt_options) {
@@ -193,7 +193,7 @@ class GPX extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {
@@ -221,7 +221,7 @@ class GPX extends XMLFeature {
    * as tracks (`<trk>`).
    *
    * @param {Array<Feature>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @return {Node} Node.
    * @api
    */
@@ -508,7 +508,7 @@ const GEOMETRY_TYPE_TO_NODENAME = {
 /**
  * @param {*} value Value.
  * @param {Array<*>} objectStack Object stack.
- * @param {string=} opt_nodeName Node name.
+ * @param {string} [opt_nodeName] Node name.
  * @return {Node|undefined} Node.
  */
 function GPX_NODE_FACTORY(value, objectStack, opt_nodeName) {
@@ -557,7 +557,7 @@ function appendCoordinate(flatCoordinates, layoutOptions, node, values) {
  *
  * @param {LayoutOptions} layoutOptions Layout options.
  * @param {Array<number>} flatCoordinates Flat coordinates.
- * @param {Array<number>=} ends Ends.
+ * @param {Array<number>} [ends] Ends.
  * @return {import("../geom/GeometryLayout.js").default} Layout.
  */
 function applyLayoutOptions(layoutOptions, flatCoordinates, ends) {

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -51,7 +51,7 @@ import {transformGeometryWithOptions} from './Feature.js';
  */
 class GeoJSON extends JSONFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -86,7 +86,7 @@ class GeoJSON extends JSONFeature {
 
   /**
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../Feature.js").default} Feature.
    */
@@ -129,7 +129,7 @@ class GeoJSON extends JSONFeature {
 
   /**
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<Feature>} Features.
    */
@@ -154,7 +154,7 @@ class GeoJSON extends JSONFeature {
 
   /**
    * @param {GeoJSONGeometry} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -188,7 +188,7 @@ class GeoJSON extends JSONFeature {
    * Encode a feature as a GeoJSON Feature object.
    *
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {GeoJSONFeature} Object.
    * @api
    */
@@ -230,7 +230,7 @@ class GeoJSON extends JSONFeature {
    * Encode an array of features as a GeoJSON object.
    *
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {GeoJSONFeatureCollection} GeoJSON Object.
    * @api
    */
@@ -250,7 +250,7 @@ class GeoJSON extends JSONFeature {
    * Encode a geometry as a GeoJSON object.
    *
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {GeoJSONGeometry|GeoJSONGeometryCollection} Object.
    * @api
    */
@@ -261,7 +261,7 @@ class GeoJSON extends JSONFeature {
 
 /**
  * @param {GeoJSONGeometry|GeoJSONGeometryCollection} object Object.
- * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
  * @return {import("../geom/Geometry.js").default} Geometry.
  */
 function readGeometry(object, opt_options) {
@@ -321,7 +321,7 @@ function readGeometry(object, opt_options) {
 
 /**
  * @param {GeoJSONGeometryCollection} object Object.
- * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
  * @return {GeometryCollection} Geometry collection.
  */
 function readGeometryCollectionGeometry(object, opt_options) {
@@ -387,7 +387,7 @@ function readPolygonGeometry(object) {
 
 /**
  * @param {import("../geom/Geometry.js").default} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeGeometry(geometry, opt_options) {
@@ -462,7 +462,7 @@ function writeGeometry(geometry, opt_options) {
 
 /**
  * @param {GeometryCollection} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometryCollection} GeoJSON geometry collection.
  */
 function writeGeometryCollectionGeometry(geometry, opt_options) {
@@ -479,7 +479,7 @@ function writeGeometryCollectionGeometry(geometry, opt_options) {
 
 /**
  * @param {LineString} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeLineStringGeometry(geometry, opt_options) {
@@ -491,7 +491,7 @@ function writeLineStringGeometry(geometry, opt_options) {
 
 /**
  * @param {MultiLineString} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeMultiLineStringGeometry(geometry, opt_options) {
@@ -503,7 +503,7 @@ function writeMultiLineStringGeometry(geometry, opt_options) {
 
 /**
  * @param {MultiPoint} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeMultiPointGeometry(geometry, opt_options) {
@@ -515,7 +515,7 @@ function writeMultiPointGeometry(geometry, opt_options) {
 
 /**
  * @param {MultiPolygon} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writeMultiPolygonGeometry(geometry, opt_options) {
@@ -531,7 +531,7 @@ function writeMultiPolygonGeometry(geometry, opt_options) {
 
 /**
  * @param {Point} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writePointGeometry(geometry, opt_options) {
@@ -543,7 +543,7 @@ function writePointGeometry(geometry, opt_options) {
 
 /**
  * @param {Polygon} geometry Geometry.
- * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+ * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
  * @return {GeoJSONGeometry} GeoJSON geometry.
  */
 function writePolygonGeometry(geometry, opt_options) {

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -62,7 +62,7 @@ const NEWLINE_RE = /\r\n|\r|\n/;
  */
 class IGC extends TextFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -86,7 +86,7 @@ class IGC extends TextFeature {
   /**
    * @protected
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromText(text, opt_options) {
@@ -166,7 +166,7 @@ class IGC extends TextFeature {
 
   /**
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<Feature>} Features.
    */

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -435,7 +435,7 @@ class IIIFInfo {
   }
 
   /**
-   * @param {PreferredOptions=} opt_preferredOptions Optional options for preferred format and quality.
+   * @param {PreferredOptions} [opt_preferredOptions] Optional options for preferred format and quality.
    * @return {import("../source/IIIF.js").Options} IIIF tile source ready constructor options.
    * @api
    */

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -30,7 +30,7 @@ class JSONFeature extends FeatureFormat {
    * read a feature collection.
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").default} Feature.
    * @api
    */
@@ -46,7 +46,7 @@ class JSONFeature extends FeatureFormat {
    * collection.
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
@@ -60,7 +60,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../Feature.js").default} Feature.
    */
@@ -71,7 +71,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<import("../Feature.js").default>} Features.
    */
@@ -83,7 +83,7 @@ class JSONFeature extends FeatureFormat {
    * Read a geometry.
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../geom/Geometry.js").default} Geometry.
    * @api
    */
@@ -97,7 +97,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -130,7 +130,7 @@ class JSONFeature extends FeatureFormat {
    * Encode a feature as string.
    *
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded feature.
    * @api
    */
@@ -141,7 +141,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {Object} Object.
    */
   writeFeatureObject(feature, opt_options) {
@@ -152,7 +152,7 @@ class JSONFeature extends FeatureFormat {
    * Encode an array of features as string.
    *
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded features.
    * @api
    */
@@ -163,7 +163,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {Object} Object.
    */
   writeFeaturesObject(features, opt_options) {
@@ -174,7 +174,7 @@ class JSONFeature extends FeatureFormat {
    * Encode a geometry as string.
    *
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded geometry.
    * @api
    */
@@ -185,7 +185,7 @@ class JSONFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {Object} Object.
    */
   writeGeometryObject(geometry, opt_options) {

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -427,7 +427,7 @@ function defaultIconUrlFunction(href) {
  */
 class KML extends XMLFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -624,7 +624,7 @@ class KML extends XMLFeature {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromNode(node, opt_options) {
@@ -644,7 +644,7 @@ class KML extends XMLFeature {
   /**
    * @protected
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {
@@ -886,7 +886,7 @@ class KML extends XMLFeature {
    * MultiPoints, MultiLineStrings, and MultiPolygons are output as MultiGeometries.
    *
    * @param {Array<Feature>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @return {Node} Node.
    * @api
    */
@@ -2403,7 +2403,7 @@ const DOCUMENT_SERIALIZERS = makeStructureNS(NAMESPACE_URIS, {
  * @const
  * @param {*} value Value.
  * @param {Array<*>} objectStack Object stack.
- * @param {string=} opt_nodeName Node name.
+ * @param {string} [opt_nodeName] Node name.
  * @return {Node|undefined} Node.
  */
 const DOCUMENT_NODE_FACTORY = function (value, objectStack, opt_nodeName) {
@@ -2492,7 +2492,7 @@ const ICON_SERIALIZERS = makeStructureNS(
  * @const
  * @param {*} value Value.
  * @param {Array<*>} objectStack Object stack.
- * @param {string=} opt_nodeName Node name.
+ * @param {string} [opt_nodeName] Node name.
  * @return {Node|undefined} Node.
  */
 const GX_NODE_FACTORY = function (value, objectStack, opt_nodeName) {
@@ -2731,7 +2731,7 @@ const GEOMETRY_TYPE_TO_NODENAME = {
  * @const
  * @param {*} value Value.
  * @param {Array<*>} objectStack Object stack.
- * @param {string=} opt_nodeName Node name.
+ * @param {string} [opt_nodeName] Node name.
  * @return {Node|undefined} Node.
  */
 const GEOMETRY_NODE_FACTORY = function (value, objectStack, opt_nodeName) {

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -38,12 +38,12 @@ import {linearRingIsClockwise} from '../geom/flat/orient.js';
  * @classdesc
  * Feature format for reading data in the Mapbox MVT format.
  *
- * @param {Options=} opt_options Options.
+ * @param {Options} [opt_options] Options.
  * @api
  */
 class MVT extends FeatureFormat {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -260,7 +260,7 @@ class MVT extends FeatureFormat {
    * Read all features.
    *
    * @param {ArrayBuffer} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {Array<import("../Feature.js").FeatureLike>} Features.
    * @api
    */

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -60,7 +60,7 @@ class OSMXML extends XMLFeature {
   /**
    * @protected
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -35,7 +35,7 @@ import {transformGeometryWithOptions} from './Feature.js';
  */
 class Polyline extends TextFeature {
   /**
-   * @param {Options=} opt_options Optional configuration object.
+   * @param {Options} [opt_options] Optional configuration object.
    */
   constructor(opt_options) {
     super();
@@ -65,7 +65,7 @@ class Polyline extends TextFeature {
   /**
    * @protected
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromText(text, opt_options) {
@@ -75,7 +75,7 @@ class Polyline extends TextFeature {
 
   /**
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<Feature>} Features.
    */
@@ -86,7 +86,7 @@ class Polyline extends TextFeature {
 
   /**
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -111,7 +111,7 @@ class Polyline extends TextFeature {
 
   /**
    * @param {import("../Feature.js").default} feature Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -127,7 +127,7 @@ class Polyline extends TextFeature {
 
   /**
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -137,7 +137,7 @@ class Polyline extends TextFeature {
 
   /**
    * @param {LineString} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -163,7 +163,7 @@ class Polyline extends TextFeature {
  *
  * @param {Array<number>} numbers A list of n-dimensional points.
  * @param {number} stride The number of dimension of the points in the list.
- * @param {number=} opt_factor The factor by which the numbers will be
+ * @param {number} [opt_factor] The factor by which the numbers will be
  *     multiplied. The remaining decimal places will get rounded away.
  *     Default is `1e5`.
  * @return {string} The encoded string.
@@ -197,7 +197,7 @@ export function encodeDeltas(numbers, stride, opt_factor) {
  * @param {string} encoded An encoded string.
  * @param {number} stride The number of dimension of the points in the
  *     encoded string.
- * @param {number=} opt_factor The factor by which the resulting numbers will
+ * @param {number} [opt_factor] The factor by which the resulting numbers will
  *     be divided. Default is `1e5`.
  * @return {Array<number>} A list of n-dimensional points.
  * @api
@@ -231,7 +231,7 @@ export function decodeDeltas(encoded, stride, opt_factor) {
  * Attention: This function will modify the passed array!
  *
  * @param {Array<number>} numbers A list of floating point numbers.
- * @param {number=} opt_factor The factor by which the numbers will be
+ * @param {number} [opt_factor] The factor by which the numbers will be
  *     multiplied. The remaining decimal places will get rounded away.
  *     Default is `1e5`.
  * @return {string} The encoded string.
@@ -250,7 +250,7 @@ export function encodeFloats(numbers, opt_factor) {
  * Decode a list of floating point numbers from an encoded string
  *
  * @param {string} encoded An encoded string.
- * @param {number=} opt_factor The factor by which the result will be divided.
+ * @param {number} [opt_factor] The factor by which the result will be divided.
  *     Default is `1e5`.
  * @return {Array<number>} A list of floating point numbers.
  * @api

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -29,7 +29,7 @@ class TextFeature extends FeatureFormat {
    * Read the feature from the source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").default} Feature.
    * @api
    */
@@ -43,7 +43,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../Feature.js").default} Feature.
    */
@@ -55,7 +55,7 @@ class TextFeature extends FeatureFormat {
    * Read the features from the source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
@@ -69,7 +69,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<import("../Feature.js").default>} Features.
    */
@@ -81,7 +81,7 @@ class TextFeature extends FeatureFormat {
    * Read the geometry from the source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../geom/Geometry.js").default} Geometry.
    * @api
    */
@@ -95,7 +95,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -127,7 +127,7 @@ class TextFeature extends FeatureFormat {
    * Encode a feature as a string.
    *
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded feature.
    * @api
    */
@@ -138,7 +138,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {import("../Feature.js").default} feature Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -150,7 +150,7 @@ class TextFeature extends FeatureFormat {
    * Encode an array of features as string.
    *
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded features.
    * @api
    */
@@ -161,7 +161,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -173,7 +173,7 @@ class TextFeature extends FeatureFormat {
    * Write a single geometry.
    *
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Geometry.
    * @api
    */
@@ -184,7 +184,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -56,7 +56,7 @@ import {transformGeometryWithOptions} from './Feature.js';
  */
 class TopoJSON extends JSONFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -85,7 +85,7 @@ class TopoJSON extends JSONFeature {
 
   /**
    * @param {Object} object Object.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<Feature>} Features.
    */
@@ -318,7 +318,7 @@ function readMultiPolygonGeometry(object, arcs) {
  * @param {string|undefined} property Property to set the `GeometryCollection`'s parent
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
- * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
  * @return {Array<Feature>} Array of features.
  */
 function readFeaturesFromGeometryCollection(
@@ -356,7 +356,7 @@ function readFeaturesFromGeometryCollection(
  * @param {string|undefined} property Property to set the `GeometryCollection`'s parent
  *     object to.
  * @param {string} name Name of the `Topology`'s child object.
- * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+ * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
  * @return {Feature} Feature.
  */
 function readFeatureFromGeometry(

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -266,7 +266,7 @@ const DEFAULT_VERSION = '1.1.0';
  */
 class WFS extends XMLFeature {
   /**
-   * @param {Options=} opt_options Optional configuration object.
+   * @param {Options} [opt_options] Optional configuration object.
    */
   constructor(opt_options) {
     super();
@@ -325,7 +325,7 @@ class WFS extends XMLFeature {
   /**
    * @protected
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {
@@ -563,9 +563,9 @@ class WFS extends XMLFeature {
    *
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../extent.js").Extent} extent Extent.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
-   * @param {import("./filter/Filter.js").default=} opt_filter Filter condition.
+   * @param {import("./filter/Filter.js").default} [opt_filter] Filter condition.
    * @return {import("./filter/Filter.js").default} The filter.
    */
   combineBboxAndFilter(geometryName, extent, opt_srsName, opt_filter) {

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -117,7 +117,7 @@ class Lexer {
 
   /**
    * @param {string} c Character.
-   * @param {boolean=} opt_decimal Whether the string number
+   * @param {boolean} [opt_decimal] Whether the string number
    *     contains a dot, i.e. is a decimal number.
    * @return {boolean} Whether the character is numeric.
    * @private
@@ -604,7 +604,7 @@ class Parser {
  */
 class WKT extends TextFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -636,7 +636,7 @@ class WKT extends TextFeature {
   /**
    * @protected
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromText(text, opt_options) {
@@ -651,7 +651,7 @@ class WKT extends TextFeature {
 
   /**
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {Array<Feature>} Features.
    */
@@ -677,7 +677,7 @@ class WKT extends TextFeature {
 
   /**
    * @param {string} text Text.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -692,7 +692,7 @@ class WKT extends TextFeature {
 
   /**
    * @param {import("../Feature.js").default} feature Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -706,7 +706,7 @@ class WKT extends TextFeature {
 
   /**
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */
@@ -724,7 +724,7 @@ class WKT extends TextFeature {
 
   /**
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @protected
    * @return {string} Text.
    */

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -33,7 +33,7 @@ const layerIdentifier = '_layer';
  */
 class WMSGetFeatureInfo extends XMLFeature {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -151,7 +151,7 @@ class WMSGetFeatureInfo extends XMLFeature {
   /**
    * @protected
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -37,7 +37,7 @@ class XMLFeature extends FeatureFormat {
    * Read a single feature.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../Feature.js").default} Feature.
    * @api
    */
@@ -62,7 +62,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Document} doc Document.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromDocument(doc, opt_options) {
@@ -76,7 +76,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromNode(node, opt_options) {
@@ -87,7 +87,7 @@ class XMLFeature extends FeatureFormat {
    * Read all features from a feature collection.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
@@ -112,7 +112,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Document} doc Document.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @protected
    * @return {Array<import("../Feature.js").default>} Features.
    */
@@ -133,7 +133,7 @@ class XMLFeature extends FeatureFormat {
   /**
    * @abstract
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @protected
    * @return {Array<import("../Feature.js").default>} Features.
    */
@@ -145,7 +145,7 @@ class XMLFeature extends FeatureFormat {
    * Read a single geometry from a source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Read options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
   readGeometry(source, opt_options) {
@@ -169,7 +169,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Document} doc Document.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -179,7 +179,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Element} node Node.
-   * @param {import("./Feature.js").ReadOptions=} opt_options Options.
+   * @param {import("./Feature.js").ReadOptions} [opt_options] Options.
    * @protected
    * @return {import("../geom/Geometry.js").default} Geometry.
    */
@@ -229,7 +229,7 @@ class XMLFeature extends FeatureFormat {
    * Encode a feature as string.
    *
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded feature.
    */
   writeFeature(feature, opt_options) {
@@ -239,7 +239,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @protected
    * @return {Node} Node.
    */
@@ -251,7 +251,7 @@ class XMLFeature extends FeatureFormat {
    * Encode an array of features as string.
    *
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Result.
    * @api
    */
@@ -262,7 +262,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {Array<import("../Feature.js").default>} features Features.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @return {Node} Node.
    */
   writeFeaturesNode(features, opt_options) {
@@ -273,7 +273,7 @@ class XMLFeature extends FeatureFormat {
    * Encode a geometry as string.
    *
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Write options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Write options.
    * @return {string} Encoded geometry.
    */
   writeGeometry(geometry, opt_options) {
@@ -283,7 +283,7 @@ class XMLFeature extends FeatureFormat {
 
   /**
    * @param {import("../geom/Geometry.js").default} geometry Geometry.
-   * @param {import("./Feature.js").WriteOptions=} opt_options Options.
+   * @param {import("./Feature.js").WriteOptions} [opt_options] Options.
    * @return {Node} Node.
    */
   writeGeometryNode(geometry, opt_options) {

--- a/src/ol/format/filter.js
+++ b/src/ol/format/filter.js
@@ -63,7 +63,7 @@ export function not(condition) {
  *
  * @param {!string} geometryName Geometry name to use.
  * @param {!import("../extent.js").Extent} extent Extent.
- * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ * @param {string} [opt_srsName] SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
  * @return {!Bbox} `<BBOX>` operator.
  * @api
@@ -78,7 +78,7 @@ export function bbox(geometryName, extent, opt_srsName) {
  *
  * @param {!string} geometryName Geometry name to use.
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
- * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ * @param {string} [opt_srsName] SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
  * @return {!Contains} `<Contains>` operator.
  * @api
@@ -93,7 +93,7 @@ export function contains(geometryName, geometry, opt_srsName) {
  *
  * @param {!string} geometryName Geometry name to use.
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
- * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ * @param {string} [opt_srsName] SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
  * @return {!Intersects} `<Intersects>` operator.
  * @api
@@ -108,7 +108,7 @@ export function intersects(geometryName, geometry, opt_srsName) {
  *
  * @param {!string} geometryName Geometry name to use.
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
- * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ * @param {string} [opt_srsName] SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
  * @return {!Disjoint} `<Disjoint>` operator.
  * @api
@@ -123,7 +123,7 @@ export function disjoint(geometryName, geometry, opt_srsName) {
  *
  * @param {!string} geometryName Geometry name to use.
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
- * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ * @param {string} [opt_srsName] SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
  * @return {!Within} `<Within>` operator.
  * @api
@@ -140,7 +140,7 @@ export function within(geometryName, geometry, opt_srsName) {
  * @param {!import("../geom/Geometry.js").default} geometry Geometry.
  * @param {!number} distance Distance.
  * @param {!string} unit Unit.
- * @param {string=} opt_srsName SRS name. No srsName attribute will be
+ * @param {string} [opt_srsName] SRS name. No srsName attribute will be
  *    set on geometries when this is not provided.
  * @return {!DWithin} `<DWithin>` operator.
  * @api
@@ -154,7 +154,7 @@ export function dwithin(geometryName, geometry, distance, unit, opt_srsName) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
- * @param {boolean=} opt_matchCase Case-sensitive?
+ * @param {boolean} [opt_matchCase] Case-sensitive?
  * @return {!EqualTo} `<PropertyIsEqualTo>` operator.
  * @api
  */
@@ -167,7 +167,7 @@ export function equalTo(propertyName, expression, opt_matchCase) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!(string|number)} expression The value to compare.
- * @param {boolean=} opt_matchCase Case-sensitive?
+ * @param {boolean} [opt_matchCase] Case-sensitive?
  * @return {!NotEqualTo} `<PropertyIsNotEqualTo>` operator.
  * @api
  */
@@ -255,13 +255,13 @@ export function between(propertyName, lowerBoundary, upperBoundary) {
  *
  * @param {!string} propertyName Name of the context property to compare.
  * @param {!string} pattern Text pattern.
- * @param {string=} opt_wildCard Pattern character which matches any sequence of
+ * @param {string} [opt_wildCard] Pattern character which matches any sequence of
  *    zero or more string characters. Default is '*'.
- * @param {string=} opt_singleChar pattern character which matches any single
+ * @param {string} [opt_singleChar] pattern character which matches any single
  *    string character. Default is '.'.
- * @param {string=} opt_escapeChar Escape character which can be used to escape
+ * @param {string} [opt_escapeChar] Escape character which can be used to escape
  *    the pattern characters. Default is '!'.
- * @param {boolean=} opt_matchCase Case-sensitive?
+ * @param {boolean} [opt_matchCase] Case-sensitive?
  * @return {!IsLike} `<PropertyIsLike>` operator.
  * @api
  */

--- a/src/ol/format/filter/Bbox.js
+++ b/src/ol/format/filter/Bbox.js
@@ -14,7 +14,7 @@ class Bbox extends Filter {
   /**
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../../extent.js").Extent} extent Extent.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be set
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be set
    * on geometries when this is not provided.
    */
   constructor(geometryName, extent, opt_srsName) {

--- a/src/ol/format/filter/ComparisonBinary.js
+++ b/src/ol/format/filter/ComparisonBinary.js
@@ -15,7 +15,7 @@ class ComparisonBinary extends Comparison {
    * @param {!string} tagName The XML tag name for this filter.
    * @param {!string} propertyName Name of the context property to compare.
    * @param {!(string|number)} expression The value to compare.
-   * @param {boolean=} opt_matchCase Case-sensitive?
+   * @param {boolean} [opt_matchCase] Case-sensitive?
    */
   constructor(tagName, propertyName, expression, opt_matchCase) {
     super(tagName, propertyName);

--- a/src/ol/format/filter/Contains.js
+++ b/src/ol/format/filter/Contains.js
@@ -13,7 +13,7 @@ class Contains extends Spatial {
   /**
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
   constructor(geometryName, geometry, opt_srsName) {

--- a/src/ol/format/filter/DWithin.js
+++ b/src/ol/format/filter/DWithin.js
@@ -15,7 +15,7 @@ class DWithin extends Spatial {
    * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
    * @param {!number} distance Distance.
    * @param {!string} unit Unit.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
   constructor(geometryName, geometry, distance, unit, opt_srsName) {

--- a/src/ol/format/filter/Disjoint.js
+++ b/src/ol/format/filter/Disjoint.js
@@ -13,7 +13,7 @@ class Disjoint extends Spatial {
   /**
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
   constructor(geometryName, geometry, opt_srsName) {

--- a/src/ol/format/filter/EqualTo.js
+++ b/src/ol/format/filter/EqualTo.js
@@ -12,7 +12,7 @@ class EqualTo extends ComparisonBinary {
   /**
    * @param {!string} propertyName Name of the context property to compare.
    * @param {!(string|number)} expression The value to compare.
-   * @param {boolean=} opt_matchCase Case-sensitive?
+   * @param {boolean} [opt_matchCase] Case-sensitive?
    */
   constructor(propertyName, expression, opt_matchCase) {
     super('PropertyIsEqualTo', propertyName, expression, opt_matchCase);

--- a/src/ol/format/filter/Intersects.js
+++ b/src/ol/format/filter/Intersects.js
@@ -13,7 +13,7 @@ class Intersects extends Spatial {
   /**
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
   constructor(geometryName, geometry, opt_srsName) {

--- a/src/ol/format/filter/IsLike.js
+++ b/src/ol/format/filter/IsLike.js
@@ -13,13 +13,13 @@ class IsLike extends Comparison {
    * [constructor description]
    * @param {!string} propertyName Name of the context property to compare.
    * @param {!string} pattern Text pattern.
-   * @param {string=} opt_wildCard Pattern character which matches any sequence of
+   * @param {string} [opt_wildCard] Pattern character which matches any sequence of
    *    zero or more string characters. Default is '*'.
-   * @param {string=} opt_singleChar pattern character which matches any single
+   * @param {string} [opt_singleChar] pattern character which matches any single
    *    string character. Default is '.'.
-   * @param {string=} opt_escapeChar Escape character which can be used to escape
+   * @param {string} [opt_escapeChar] Escape character which can be used to escape
    *    the pattern characters. Default is '!'.
-   * @param {boolean=} opt_matchCase Case-sensitive?
+   * @param {boolean} [opt_matchCase] Case-sensitive?
    */
   constructor(
     propertyName,

--- a/src/ol/format/filter/NotEqualTo.js
+++ b/src/ol/format/filter/NotEqualTo.js
@@ -12,7 +12,7 @@ class NotEqualTo extends ComparisonBinary {
   /**
    * @param {!string} propertyName Name of the context property to compare.
    * @param {!(string|number)} expression The value to compare.
-   * @param {boolean=} opt_matchCase Case-sensitive?
+   * @param {boolean} [opt_matchCase] Case-sensitive?
    */
   constructor(propertyName, expression, opt_matchCase) {
     super('PropertyIsNotEqualTo', propertyName, expression, opt_matchCase);

--- a/src/ol/format/filter/Spatial.js
+++ b/src/ol/format/filter/Spatial.js
@@ -16,7 +16,7 @@ class Spatial extends Filter {
    * @param {!string} tagName The XML tag name for this filter.
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
   constructor(tagName, geometryName, geometry, opt_srsName) {

--- a/src/ol/format/filter/Within.js
+++ b/src/ol/format/filter/Within.js
@@ -13,7 +13,7 @@ class Within extends Spatial {
   /**
    * @param {!string} geometryName Geometry name to use.
    * @param {!import("../../geom/Geometry.js").default} geometry Geometry.
-   * @param {string=} opt_srsName SRS name. No srsName attribute will be
+   * @param {string} [opt_srsName] SRS name. No srsName attribute will be
    *    set on geometries when this is not provided.
    */
   constructor(geometryName, geometry, opt_srsName) {

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -18,8 +18,8 @@ class Circle extends SimpleGeometry {
    * @param {!import("../coordinate.js").Coordinate} center Center.
    *     For internal use, flat coordinates in combination with `opt_layout` and no
    *     `opt_radius` are also accepted.
-   * @param {number=} opt_radius Radius.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {number} [opt_radius] Radius.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    */
   constructor(center, opt_radius, opt_layout) {
     super();
@@ -189,7 +189,7 @@ class Circle extends SimpleGeometry {
    * number) of the circle.
    * @param {!import("../coordinate.js").Coordinate} center Center.
    * @param {number} radius Radius.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCenterAndRadius(center, radius, opt_layout) {

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -135,7 +135,7 @@ class Geometry extends BaseObject {
    * Return the closest point of the geometry to the passed point as
    * {@link module:ol/coordinate~Coordinate coordinate}.
    * @param {import("../coordinate.js").Coordinate} point Point.
-   * @param {import("../coordinate.js").Coordinate=} opt_closestPoint Closest point.
+   * @param {import("../coordinate.js").Coordinate} [opt_closestPoint] Closest point.
    * @return {import("../coordinate.js").Coordinate} Closest point.
    * @api
    */
@@ -168,7 +168,7 @@ class Geometry extends BaseObject {
 
   /**
    * Get the extent of the geometry.
-   * @param {import("../extent.js").Extent=} opt_extent Extent.
+   * @param {import("../extent.js").Extent} [opt_extent] Extent.
    * @return {import("../extent.js").Extent} extent Extent.
    * @api
    */
@@ -200,8 +200,8 @@ class Geometry extends BaseObject {
    * coordinates in place.
    * @abstract
    * @param {number} sx The scaling factor in the x-direction.
-   * @param {number=} opt_sy The scaling factor in the y-direction (defaults to sx).
-   * @param {import("../coordinate.js").Coordinate=} opt_anchor The scale origin (defaults to the center
+   * @param {number} [opt_sy] The scaling factor in the y-direction (defaults to sx).
+   * @param {import("../coordinate.js").Coordinate} [opt_anchor] The scale origin (defaults to the center
    *     of the geometry extent).
    * @api
    */

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -20,7 +20,7 @@ import {listen, unlistenByKey} from '../events.js';
  */
 class GeometryCollection extends Geometry {
   /**
-   * @param {Array<Geometry>=} opt_geometries Geometries.
+   * @param {Array<Geometry>} [opt_geometries] Geometries.
    */
   constructor(opt_geometries) {
     super();
@@ -255,8 +255,8 @@ class GeometryCollection extends Geometry {
    * coordinates in place.
    * @abstract
    * @param {number} sx The scaling factor in the x-direction.
-   * @param {number=} opt_sy The scaling factor in the y-direction (defaults to sx).
-   * @param {import("../coordinate.js").Coordinate=} opt_anchor The scale origin (defaults to the center
+   * @param {number} [opt_sy] The scaling factor in the y-direction (defaults to sx).
+   * @param {import("../coordinate.js").Coordinate} [opt_anchor] The scale origin (defaults to the center
    *     of the geometry extent).
    * @api
    */

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -25,7 +25,7 @@ class LineString extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -163,7 +163,7 @@ class LineString extends SimpleGeometry {
    * return the last coordinate.
    *
    * @param {number} m M.
-   * @param {boolean=} opt_extrapolate Extrapolate. Default is `false`.
+   * @param {boolean} [opt_extrapolate] Extrapolate. Default is `false`.
    * @return {import("../coordinate.js").Coordinate} Coordinate.
    * @api
    */
@@ -204,7 +204,7 @@ class LineString extends SimpleGeometry {
    * The `fraction` is a number between 0 and 1, where 0 is the start of the
    * linestring and 1 is the end.
    * @param {number} fraction Fraction.
-   * @param {import("../coordinate.js").Coordinate=} opt_dest Optional coordinate whose values will
+   * @param {import("../coordinate.js").Coordinate} [opt_dest] Optional coordinate whose values will
    *     be modified. If not provided, a new coordinate will be returned.
    * @return {import("../coordinate.js").Coordinate} Coordinate of the interpolated point.
    * @api
@@ -293,7 +293,7 @@ class LineString extends SimpleGeometry {
   /**
    * Set the coordinates of the linestring.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -22,7 +22,7 @@ class LinearRing extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -167,7 +167,7 @@ class LinearRing extends SimpleGeometry {
   /**
    * Set the coordinates of the linear ring.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -28,8 +28,8 @@ class MultiLineString extends SimpleGeometry {
    * @param {Array<Array<import("../coordinate.js").Coordinate>|LineString>|Array<number>} coordinates
    *     Coordinates or LineString geometries. (For internal use, flat coordinates in
    *     combination with `opt_layout` and `opt_ends` are also accepted.)
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
-   * @param {Array<number>=} opt_ends Flat coordinate ends for internal use.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
+   * @param {Array<number>} [opt_ends] Flat coordinate ends for internal use.
    */
   constructor(coordinates, opt_layout, opt_ends) {
     super();
@@ -165,8 +165,8 @@ class MultiLineString extends SimpleGeometry {
    * LineStrings.
    *
    * @param {number} m M.
-   * @param {boolean=} opt_extrapolate Extrapolate. Default is `false`.
-   * @param {boolean=} opt_interpolate Interpolate. Default is `false`.
+   * @param {boolean} [opt_extrapolate] Extrapolate. Default is `false`.
+   * @param {boolean} [opt_interpolate] Interpolate. Default is `false`.
    * @return {import("../coordinate.js").Coordinate} Coordinate.
    * @api
    */
@@ -332,7 +332,7 @@ class MultiLineString extends SimpleGeometry {
   /**
    * Set the coordinates of the multilinestring.
    * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
-   * @param {GeometryLayout=} opt_layout Layout.
+   * @param {GeometryLayout} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -20,7 +20,7 @@ class MultiPoint extends SimpleGeometry {
   /**
    * @param {Array<import("../coordinate.js").Coordinate>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -181,7 +181,7 @@ class MultiPoint extends SimpleGeometry {
   /**
    * Set the coordinates of the multipoint.
    * @param {!Array<import("../coordinate.js").Coordinate>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -35,8 +35,8 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * @param {Array<Array<Array<import("../coordinate.js").Coordinate>>|Polygon>|Array<number>} coordinates Coordinates.
    *     For internal use, flat coordinates in combination with `opt_layout` and `opt_endss` are also accepted.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
-   * @param {Array<Array<number>>=} opt_endss Array of ends for internal use with flat coordinates.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
+   * @param {Array<Array<number>>} [opt_endss] Array of ends for internal use with flat coordinates.
    */
   constructor(coordinates, opt_layout, opt_endss) {
     super();
@@ -236,7 +236,7 @@ class MultiPolygon extends SimpleGeometry {
    * Get the coordinate array for this geometry.  This array has the structure
    * of a GeoJSON coordinate array for multi-polygons.
    *
-   * @param {boolean=} opt_right Orient coordinates according to the right-hand
+   * @param {boolean} [opt_right] Orient coordinates according to the right-hand
    *     rule (counter-clockwise for exterior and clockwise for interior rings).
    *     If `false`, coordinates will be oriented according to the left-hand rule
    *     (clockwise for exterior and counter-clockwise for interior rings).
@@ -449,7 +449,7 @@ class MultiPolygon extends SimpleGeometry {
   /**
    * Set the coordinates of the multipolygon.
    * @param {!Array<Array<Array<import("../coordinate.js").Coordinate>>>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -16,7 +16,7 @@ import {squaredDistance as squaredDx} from '../math.js';
 class Point extends SimpleGeometry {
   /**
    * @param {import("../coordinate.js").Coordinate} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    */
   constructor(coordinates, opt_layout) {
     super();
@@ -100,7 +100,7 @@ class Point extends SimpleGeometry {
 
   /**
    * @param {!Array<*>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -35,8 +35,8 @@ class Polygon extends SimpleGeometry {
    *     an array of vertices' coordinates where the first coordinate and the last are
    *     equivalent. (For internal use, flat coordinates in combination with
    *     `opt_layout` and `opt_ends` are also accepted.)
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
-   * @param {Array<number>=} opt_ends Ends (for internal use with flat coordinates).
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
+   * @param {Array<number>} [opt_ends] Ends (for internal use with flat coordinates).
    */
   constructor(coordinates, opt_layout, opt_ends) {
     super();
@@ -198,7 +198,7 @@ class Polygon extends SimpleGeometry {
    * Get the coordinate array for this geometry.  This array has the structure
    * of a GeoJSON coordinate array for polygons.
    *
-   * @param {boolean=} opt_right Orient coordinates according to the right-hand
+   * @param {boolean} [opt_right] Orient coordinates according to the right-hand
    *     rule (counter-clockwise for exterior and clockwise for interior rings).
    *     If `false`, coordinates will be oriented according to the left-hand rule
    *     (clockwise for exterior and counter-clockwise for interior rings).
@@ -387,7 +387,7 @@ class Polygon extends SimpleGeometry {
   /**
    * Set the coordinates of the polygon.
    * @param {!Array<Array<import("../coordinate.js").Coordinate>>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    * @api
    */
   setCoordinates(coordinates, opt_layout) {
@@ -414,9 +414,9 @@ export default Polygon;
  * @param {import("../coordinate.js").Coordinate} center Center (`[lon, lat]` in degrees).
  * @param {number} radius The great-circle distance from the center to
  *     the polygon vertices in meters.
- * @param {number=} opt_n Optional number of vertices for the resulting
+ * @param {number} [opt_n] Optional number of vertices for the resulting
  *     polygon. Default is `32`.
- * @param {number=} opt_sphereRadius Optional radius for the sphere (defaults to
+ * @param {number} [opt_sphereRadius] Optional radius for the sphere (defaults to
  *     the Earth's mean radius using the WGS84 ellipsoid).
  * @return {Polygon} The "circular" polygon.
  * @api
@@ -468,8 +468,8 @@ export function fromExtent(extent) {
 /**
  * Create a regular polygon from a circle.
  * @param {import("./Circle.js").default} circle Circle geometry.
- * @param {number=} opt_sides Number of sides of the polygon. Default is 32.
- * @param {number=} opt_angle Start angle for the first vertex of the polygon in
+ * @param {number} [opt_sides] Number of sides of the polygon. Default is 32.
+ * @param {number} [opt_angle] Start angle for the first vertex of the polygon in
  *     counter-clockwise radians. 0 means East. Default is 0.
  * @return {Polygon} Polygon geometry.
  * @api
@@ -499,7 +499,7 @@ export function fromCircle(circle, opt_sides, opt_angle) {
  * @param {Polygon} polygon Polygon geometry.
  * @param {import("../coordinate.js").Coordinate} center Center of the regular polygon.
  * @param {number} radius Radius of the regular polygon.
- * @param {number=} opt_angle Start angle for the first vertex of the polygon in
+ * @param {number} [opt_angle] Start angle for the first vertex of the polygon in
  *     counter-clockwise radians. 0 means East. Default is 0.
  */
 export function makeRegular(polygon, center, radius, opt_angle) {

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -164,7 +164,7 @@ class SimpleGeometry extends Geometry {
   /**
    * @abstract
    * @param {!Array<*>} coordinates Coordinates.
-   * @param {import("./GeometryLayout.js").default=} opt_layout Layout.
+   * @param {import("./GeometryLayout.js").default} [opt_layout] Layout.
    */
   setCoordinates(coordinates, opt_layout) {
     abstract();
@@ -242,8 +242,8 @@ class SimpleGeometry extends Geometry {
    * Scale the geometry (with an optional origin).  This modifies the geometry
    * coordinates in place.
    * @param {number} sx The scaling factor in the x-direction.
-   * @param {number=} opt_sy The scaling factor in the y-direction (defaults to sx).
-   * @param {import("../coordinate.js").Coordinate=} opt_anchor The scale origin (defaults to the center
+   * @param {number} [opt_sy] The scaling factor in the y-direction (defaults to sx).
+   * @param {import("../coordinate.js").Coordinate} [opt_anchor] The scale origin (defaults to the center
    *     of the geometry extent).
    * @api
    */
@@ -333,7 +333,7 @@ export function getStrideForLayout(layout) {
 /**
  * @param {SimpleGeometry} simpleGeometry Simple geometry.
  * @param {import("../transform.js").Transform} transform Transform.
- * @param {Array<number>=} opt_dest Destination.
+ * @param {Array<number>} [opt_dest] Destination.
  * @return {Array<number>} Transformed flat coordinates.
  */
 export function transformGeom2D(simpleGeometry, transform, opt_dest) {

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -138,7 +138,7 @@ export function multiArrayMaxSquaredDelta(
  * @param {number} y Y.
  * @param {Array<number>} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
- * @param {Array<number>=} opt_tmpPoint Temporary point object.
+ * @param {Array<number>} [opt_tmpPoint] Temporary point object.
  * @return {number} Minimum squared distance.
  */
 export function assignClosestPoint(
@@ -251,7 +251,7 @@ export function assignClosestPoint(
  * @param {number} y Y.
  * @param {Array<number>} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
- * @param {Array<number>=} opt_tmpPoint Temporary point object.
+ * @param {Array<number>} [opt_tmpPoint] Temporary point object.
  * @return {number} Minimum squared distance.
  */
 export function assignClosestArrayPoint(
@@ -299,7 +299,7 @@ export function assignClosestArrayPoint(
  * @param {number} y Y.
  * @param {Array<number>} closestPoint Closest point.
  * @param {number} minSquaredDistance Minimum squared distance.
- * @param {Array<number>=} opt_tmpPoint Temporary point object.
+ * @param {Array<number>} [opt_tmpPoint] Temporary point object.
  * @return {number} Minimum squared distance.
  */
 export function assignClosestMultiArrayPoint(

--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -43,7 +43,7 @@ export function deflateCoordinates(
  * @param {number} offset Offset.
  * @param {Array<Array<import("../../coordinate.js").Coordinate>>} coordinatess Coordinatess.
  * @param {number} stride Stride.
- * @param {Array<number>=} opt_ends Ends.
+ * @param {Array<number>} [opt_ends] Ends.
  * @return {Array<number>} Ends.
  */
 export function deflateCoordinatesArray(
@@ -74,7 +74,7 @@ export function deflateCoordinatesArray(
  * @param {number} offset Offset.
  * @param {Array<Array<Array<import("../../coordinate.js").Coordinate>>>} coordinatesss Coordinatesss.
  * @param {number} stride Stride.
- * @param {Array<Array<number>>=} opt_endss Endss.
+ * @param {Array<Array<number>>} [opt_endss] Endss.
  * @return {Array<Array<number>>} Endss.
  */
 export function deflateMultiCoordinatesArray(

--- a/src/ol/geom/flat/flip.js
+++ b/src/ol/geom/flat/flip.js
@@ -7,8 +7,8 @@
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {Array<number>=} opt_dest Destination.
- * @param {number=} opt_destOffset Destination offset.
+ * @param {Array<number>} [opt_dest] Destination.
+ * @param {number} [opt_destOffset] Destination offset.
  * @return {Array<number>} Flat coordinates.
  */
 export function flipXY(

--- a/src/ol/geom/flat/inflate.js
+++ b/src/ol/geom/flat/inflate.js
@@ -7,7 +7,7 @@
  * @param {number} offset Offset.
  * @param {number} end End.
  * @param {number} stride Stride.
- * @param {Array<import("../../coordinate.js").Coordinate>=} opt_coordinates Coordinates.
+ * @param {Array<import("../../coordinate.js").Coordinate>} [opt_coordinates] Coordinates.
  * @return {Array<import("../../coordinate.js").Coordinate>} Coordinates.
  */
 export function inflateCoordinates(
@@ -31,7 +31,7 @@ export function inflateCoordinates(
  * @param {number} offset Offset.
  * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {Array<Array<import("../../coordinate.js").Coordinate>>=} opt_coordinatess Coordinatess.
+ * @param {Array<Array<import("../../coordinate.js").Coordinate>>} [opt_coordinatess] Coordinatess.
  * @return {Array<Array<import("../../coordinate.js").Coordinate>>} Coordinatess.
  */
 export function inflateCoordinatesArray(
@@ -63,7 +63,7 @@ export function inflateCoordinatesArray(
  * @param {number} offset Offset.
  * @param {Array<Array<number>>} endss Endss.
  * @param {number} stride Stride.
- * @param {Array<Array<Array<import("../../coordinate.js").Coordinate>>>=} opt_coordinatesss
+ * @param {Array<Array<Array<import("../../coordinate.js").Coordinate>>>} [opt_coordinatesss]
  *     Coordinatesss.
  * @return {Array<Array<Array<import("../../coordinate.js").Coordinate>>>} Coordinatesss.
  */

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -13,7 +13,7 @@ import {numberSafeCompareFunction} from '../../array.js';
  * @param {number} stride Stride.
  * @param {Array<number>} flatCenters Flat centers.
  * @param {number} flatCentersOffset Flat center offset.
- * @param {Array<number>=} opt_dest Destination.
+ * @param {Array<number>} [opt_dest] Destination.
  * @return {Array<number>} Destination point as XYM coordinate, where M is the
  * length of the horizontal intersection that the point belongs to.
  */

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -10,8 +10,8 @@ import {lerp} from '../../math.js';
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {number} fraction Fraction.
- * @param {Array<number>=} opt_dest Destination.
- * @param {number=} opt_dimension Destination dimension (default is `2`)
+ * @param {Array<number>} [opt_dest] Destination.
+ * @param {number} [opt_dimension] Destination dimension (default is `2`)
  * @return {Array<number>} Destination.
  */
 export function interpolatePoint(

--- a/src/ol/geom/flat/orient.js
+++ b/src/ol/geom/flat/orient.js
@@ -38,7 +38,7 @@ export function linearRingIsClockwise(flatCoordinates, offset, end, stride) {
  * @param {number} offset Offset.
  * @param {Array<number>} ends Array of end indexes.
  * @param {number} stride Stride.
- * @param {boolean=} opt_right Test for right-hand orientation
+ * @param {boolean} [opt_right] Test for right-hand orientation
  *     (counter-clockwise exterior ring and clockwise interior rings).
  * @return {boolean} Rings are correctly oriented.
  */
@@ -81,7 +81,7 @@ export function linearRingsAreOriented(
  * @param {number} offset Offset.
  * @param {Array<Array<number>>} endss Array of array of end indexes.
  * @param {number} stride Stride.
- * @param {boolean=} opt_right Test for right-hand orientation
+ * @param {boolean} [opt_right] Test for right-hand orientation
  *     (counter-clockwise exterior ring and clockwise interior rings).
  * @return {boolean} Rings are correctly oriented.
  */
@@ -116,7 +116,7 @@ export function linearRingssAreOriented(
  * @param {number} offset Offset.
  * @param {Array<number>} ends Ends.
  * @param {number} stride Stride.
- * @param {boolean=} opt_right Follow the right-hand rule for orientation.
+ * @param {boolean} [opt_right] Follow the right-hand rule for orientation.
  * @return {number} End.
  */
 export function orientLinearRings(
@@ -157,7 +157,7 @@ export function orientLinearRings(
  * @param {number} offset Offset.
  * @param {Array<Array<number>>} endss Array of array of end indexes.
  * @param {number} stride Stride.
- * @param {boolean=} opt_right Follow the right-hand rule for orientation.
+ * @param {boolean} [opt_right] Follow the right-hand rule for orientation.
  * @return {number} End.
  */
 export function orientLinearRingsArray(

--- a/src/ol/geom/flat/simplify.js
+++ b/src/ol/geom/flat/simplify.js
@@ -36,7 +36,7 @@ import {squaredDistance, squaredSegmentDistance} from '../../math.js';
  * @param {number} stride Stride.
  * @param {number} squaredTolerance Squared tolerance.
  * @param {boolean} highQuality Highest quality.
- * @param {Array<number>=} opt_simplifiedFlatCoordinates Simplified flat
+ * @param {Array<number>} [opt_simplifiedFlatCoordinates] Simplified flat
  *     coordinates.
  * @return {Array<number>} Simplified line string.
  */

--- a/src/ol/geom/flat/transform.js
+++ b/src/ol/geom/flat/transform.js
@@ -8,7 +8,7 @@
  * @param {number} end End.
  * @param {number} stride Stride.
  * @param {import("../../transform.js").Transform} transform Transform.
- * @param {Array<number>=} opt_dest Destination.
+ * @param {Array<number>} [opt_dest] Destination.
  * @return {Array<number>} Transformed coordinates.
  */
 export function transform2D(
@@ -40,7 +40,7 @@ export function transform2D(
  * @param {number} stride Stride.
  * @param {number} angle Angle.
  * @param {Array<number>} anchor Rotation anchor point.
- * @param {Array<number>=} opt_dest Destination.
+ * @param {Array<number>} [opt_dest] Destination.
  * @return {Array<number>} Transformed coordinates.
  */
 export function rotate(
@@ -82,7 +82,7 @@ export function rotate(
  * @param {number} sx Scale factor in the x-direction.
  * @param {number} sy Scale factor in the y-direction.
  * @param {Array<number>} anchor Scale anchor point.
- * @param {Array<number>=} opt_dest Destination.
+ * @param {Array<number>} [opt_dest] Destination.
  * @return {Array<number>} Transformed coordinates.
  */
 export function scale(
@@ -121,7 +121,7 @@ export function scale(
  * @param {number} stride Stride.
  * @param {number} deltaX Delta X.
  * @param {number} deltaY Delta Y.
- * @param {Array<number>=} opt_dest Destination.
+ * @param {Array<number>} [opt_dest] Destination.
  * @return {Array<number>} Transformed coordinates.
  */
 export function translate(

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -75,7 +75,7 @@ export {default as Translate} from './interaction/Translate.js';
  * * {@link module:ol/interaction/MouseWheelZoom~MouseWheelZoom}
  * * {@link module:ol/interaction/DragZoom~DragZoom}
  *
- * @param {DefaultsOptions=} opt_options Defaults options.
+ * @param {DefaultsOptions} [opt_options] Defaults options.
  * @return {import("./Collection.js").default<import("./interaction/Interaction.js").default>}
  * A collection of interactions to be used with the {@link module:ol/Map~Map}
  * constructor's `interactions` option.

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -17,7 +17,7 @@ import MapBrowserEventType from '../MapBrowserEventType.js';
  */
 class DoubleClickZoom extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -45,8 +45,8 @@ export class DragAndDropEvent extends Event {
   /**
    * @param {DragAndDropEventType} type Type.
    * @param {File} file File.
-   * @param {Array<import("../Feature.js").default>=} opt_features Features.
-   * @param {import("../proj/Projection.js").default=} opt_projection Projection.
+   * @param {Array<import("../Feature.js").default>} [opt_features] Features.
+   * @param {import("../proj/Projection.js").default} [opt_projection] Projection.
    */
   constructor(type, file, opt_features, opt_projection) {
     super(type);
@@ -88,7 +88,7 @@ export class DragAndDropEvent extends Event {
  */
 class DragAndDrop extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -107,7 +107,7 @@ export class DragBoxEvent extends Event {
  */
 class DragBox extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -34,7 +34,7 @@ import {
  */
 class DragPan extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super({

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -30,7 +30,7 @@ import {disable} from '../rotationconstraint.js';
  */
 class DragRotate extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -26,7 +26,7 @@ import {mouseOnly, shiftKeyOnly} from '../events/condition.js';
  */
 class DragRotateAndZoom extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -38,7 +38,7 @@ import {shiftKeyOnly} from '../events/condition.js';
  */
 class DragZoom extends DragBox {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -1140,9 +1140,9 @@ function getDefaultStyleFunction() {
  * Create a `geometryFunction` for `type: 'Circle'` that will create a regular
  * polygon with a user specified number of sides and start angle instead of a
  * `import("../geom/Circle.js").Circle` geometry.
- * @param {number=} opt_sides Number of sides of the regular polygon.
+ * @param {number} [opt_sides] Number of sides of the regular polygon.
  *     Default is 32.
- * @param {number=} opt_angle Angle of the first point in counter-clockwise
+ * @param {number} [opt_angle] Angle of the first point in counter-clockwise
  *     radians. 0 means East.
  *     Default is the angle defined by the heading from the center of the
  *     regular polygon to the current pointer position.

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -85,7 +85,7 @@ export class ExtentEvent extends Event {
  */
 class Extent extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -31,7 +31,7 @@ import {easeOut, linear} from '../easing.js';
  */
 class Interaction extends BaseObject {
   /**
-   * @param {InteractionOptions=} opt_options Options.
+   * @param {InteractionOptions} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
@@ -102,7 +102,7 @@ class Interaction extends BaseObject {
 /**
  * @param {import("../View.js").default} view View.
  * @param {import("../coordinate.js").Coordinate} delta Delta.
- * @param {number=} opt_duration Duration.
+ * @param {number} [opt_duration] Duration.
  */
 export function pan(view, delta, opt_duration) {
   const currentCenter = view.getCenterInternal();
@@ -119,8 +119,8 @@ export function pan(view, delta, opt_duration) {
 /**
  * @param {import("../View.js").default} view View.
  * @param {number} delta Delta from previous zoom level.
- * @param {import("../coordinate.js").Coordinate=} opt_anchor Anchor coordinate in the user projection.
- * @param {number=} opt_duration Duration.
+ * @param {import("../coordinate.js").Coordinate} [opt_anchor] Anchor coordinate in the user projection.
+ * @param {number} [opt_duration] Duration.
  */
 export function zoomByDelta(view, delta, opt_anchor, opt_duration) {
   const currentZoom = view.getZoom();

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -34,7 +34,7 @@ import {rotate as rotateCoordinate} from '../coordinate.js';
  */
 class KeyboardPan extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -30,7 +30,7 @@ import {targetNotEditable} from '../events/condition.js';
  */
 class KeyboardZoom extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1100,7 +1100,7 @@ class Modify extends PointerInteraction {
   /**
    * @param {import("../pixel.js").Pixel} pixel Pixel
    * @param {import("../PluggableMap.js").default} map Map.
-   * @param {import("../coordinate.js").Coordinate=} opt_coordinate The pixel Coordinate.
+   * @param {import("../coordinate.js").Coordinate} [opt_coordinate] The pixel Coordinate.
    * @private
    */
   handlePointerAtPixel_(pixel, map, opt_coordinate) {

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -41,7 +41,7 @@ export const Mode = {
  */
 class MouseWheelZoom extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -22,7 +22,7 @@ import {disable} from '../rotationconstraint.js';
  */
 class PinchRotate extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -19,7 +19,7 @@ import {FALSE} from '../functions.js';
  */
 class PinchZoom extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -45,7 +45,7 @@ import {getValues} from '../obj.js';
  */
 class PointerInteraction extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -151,7 +151,7 @@ const originalFeatureStyles = {};
  */
 class Select extends Interaction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -95,7 +95,7 @@ const tempSegment = [];
  */
 class Snap extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -200,7 +200,7 @@ class Snap extends PointerInteraction {
   /**
    * Add a feature to the collection of features that we may snap to.
    * @param {import("../Feature.js").default} feature Feature.
-   * @param {boolean=} opt_listen Whether to listen to the feature change or not
+   * @param {boolean} [opt_listen] Whether to listen to the feature change or not
    *     Defaults to `true`.
    * @api
    */
@@ -322,7 +322,7 @@ class Snap extends PointerInteraction {
   /**
    * Remove a feature from the collection of features that we may snap to.
    * @param {import("../Feature.js").default} feature Feature
-   * @param {boolean=} opt_unlisten Whether to unlisten to the feature change
+   * @param {boolean} [opt_unlisten] Whether to unlisten to the feature change
    *     or not. Defaults to `true`.
    * @api
    */

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -115,7 +115,7 @@ export class TranslateEvent extends Event {
  */
 class Translate extends PointerInteraction {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -95,7 +95,7 @@ class BaseLayer extends BaseObject {
    * This method is not meant to be called by layers or layer renderers because the state
    * is incorrect if the layer is included in a layer group.
    *
-   * @param {boolean=} opt_managed Layer is managed.
+   * @param {boolean} [opt_managed] Layer is managed.
    * @return {import("./Layer.js").State} Layer state.
    */
   getLayerState(opt_managed) {
@@ -124,7 +124,7 @@ class BaseLayer extends BaseObject {
 
   /**
    * @abstract
-   * @param {Array<import("./Layer.js").default>=} opt_array Array of layers (to be
+   * @param {Array<import("./Layer.js").default>} [opt_array] Array of layers (to be
    *     modified in place).
    * @return {Array<import("./Layer.js").default>} Array of layers.
    */
@@ -134,7 +134,7 @@ class BaseLayer extends BaseObject {
 
   /**
    * @abstract
-   * @param {Array<import("./Layer.js").State>=} opt_states Optional list of layer
+   * @param {Array<import("./Layer.js").State>} [opt_states] Optional list of layer
    *     states (to be modified in place).
    * @return {Array<import("./Layer.js").State>} List of layer states.
    */

--- a/src/ol/layer/BaseImage.js
+++ b/src/ol/layer/BaseImage.js
@@ -43,7 +43,7 @@ import Layer from './Layer.js';
  */
 class BaseImageLayer extends Layer {
   /**
-   * @param {Options=} opt_options Layer options.
+   * @param {Options} [opt_options] Layer options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -48,7 +48,7 @@ import {assign} from '../obj.js';
  */
 class BaseTileLayer extends Layer {
   /**
-   * @param {Options=} opt_options Tile layer options.
+   * @param {Options} [opt_options] Tile layer options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -76,7 +76,7 @@ const Property = {
  */
 class BaseVectorLayer extends Layer {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
@@ -241,7 +241,7 @@ class BaseVectorLayer extends Layer {
    * so only features that have their own styles will be rendered in the layer. Call
    * `setStyle()` without arguments to reset to the default style. See
    * {@link module:ol/style} for information on the default style.
-   * @param {(import("../style/Style.js").StyleLike|null)=} opt_style Layer style.
+   * @param {import("../style/Style.js").StyleLike|null} [opt_style] Layer style.
    * @api
    */
   setStyle(opt_style) {

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -177,7 +177,7 @@ const INTERVALS = [
  */
 class Graticule extends VectorLayer {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -53,7 +53,7 @@ const Property = {
  */
 class LayerGroup extends BaseLayer {
   /**
-   * @param {Options=} opt_options Layer options.
+   * @param {Options} [opt_options] Layer options.
    */
   constructor(opt_options) {
     const options = opt_options || {};
@@ -193,7 +193,7 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * @param {Array<import("./Layer.js").default>=} opt_array Array of layers (to be modified in place).
+   * @param {Array<import("./Layer.js").default>} [opt_array] Array of layers (to be modified in place).
    * @return {Array<import("./Layer.js").default>} Array of layers.
    */
   getLayersArray(opt_array) {
@@ -205,7 +205,7 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * @param {Array<import("./Layer.js").State>=} opt_states Optional list of layer states (to be modified in place).
+   * @param {Array<import("./Layer.js").State>} [opt_states] Optional list of layer states (to be modified in place).
    * @return {Array<import("./Layer.js").State>} List of layer states.
    */
   getLayerStatesArray(opt_states) {

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -66,7 +66,7 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  */
 class Heatmap extends VectorLayer {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -18,7 +18,7 @@ import CanvasImageLayerRenderer from '../renderer/canvas/ImageLayer.js';
  */
 class ImageLayer extends BaseImageLayer {
   /**
-   * @param {import("./BaseImage.js").Options=} opt_options Layer options.
+   * @param {import("./BaseImage.js").Options} [opt_options] Layer options.
    */
   constructor(opt_options) {
     super(opt_options);

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -140,7 +140,7 @@ class Layer extends BaseLayer {
   }
 
   /**
-   * @param {Array<import("./Layer.js").default>=} opt_array Array of layers (to be modified in place).
+   * @param {Array<import("./Layer.js").default>} [opt_array] Array of layers (to be modified in place).
    * @return {Array<import("./Layer.js").default>} Array of layers.
    */
   getLayersArray(opt_array) {
@@ -150,7 +150,7 @@ class Layer extends BaseLayer {
   }
 
   /**
-   * @param {Array<import("./Layer.js").State>=} opt_states Optional list of layer states (to be modified in place).
+   * @param {Array<import("./Layer.js").State>} [opt_states] Optional list of layer states (to be modified in place).
    * @return {Array<import("./Layer.js").State>} List of layer states.
    */
   getLayerStatesArray(opt_states) {

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -18,7 +18,7 @@ import CanvasTileLayerRenderer from '../renderer/canvas/TileLayer.js';
  */
 class TileLayer extends BaseTileLayer {
   /**
-   * @param {import("./BaseTile.js").Options=} opt_options Tile layer options.
+   * @param {import("./BaseTile.js").Options} [opt_options] Tile layer options.
    */
   constructor(opt_options) {
     super(opt_options);

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -17,7 +17,7 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  */
 class VectorLayer extends BaseVectorLayer {
   /**
-   * @param {import("./BaseVector.js").Options=} opt_options Options.
+   * @param {import("./BaseVector.js").Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super(opt_options);

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -57,7 +57,7 @@ import {assign} from '../obj.js';
  */
 class VectorImageLayer extends BaseVectorLayer {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -76,13 +76,13 @@ import {assign} from '../obj.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @param {Options=} opt_options Options.
+ * @param {Options} [opt_options] Options.
  * @extends {BaseVectorLayer<import("../source/VectorTile.js").default>}
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/net.js
+++ b/src/ol/net.js
@@ -10,8 +10,8 @@ import {getUid} from './util.js';
  * @param {string} url Request url. A 'callback' query parameter will be
  *     appended.
  * @param {Function} callback Callback on success.
- * @param {function()=} opt_errback Callback on error.
- * @param {string=} opt_callbackParam Custom query parameter for the JSONP
+ * @param {Function} [opt_errback] Callback on error.
+ * @param {string} [opt_callbackParam] Custom query parameter for the JSONP
  *     callback. Default is 'callback'.
  */
 export function jsonp(url, callback, opt_errback, opt_callbackParam) {

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -99,8 +99,8 @@ export {Projection};
 
 /**
  * @param {Array<number>} input Input coordinate array.
- * @param {Array<number>=} opt_output Output array of coordinate values.
- * @param {number=} opt_dimension Dimension.
+ * @param {Array<number>} [opt_output] Output array of coordinate values.
+ * @param {number} [opt_dimension] Dimension.
  * @return {Array<number>} Output coordinate array (new array, same coordinate
  *     values).
  */
@@ -119,8 +119,8 @@ export function cloneTransform(input, opt_output, opt_dimension) {
 
 /**
  * @param {Array<number>} input Input coordinate array.
- * @param {Array<number>=} opt_output Output array of coordinate values.
- * @param {number=} opt_dimension Dimension.
+ * @param {Array<number>} [opt_output] Output array of coordinate values.
+ * @param {number} [opt_dimension] Dimension.
  * @return {Array<number>} Input coordinate array (same array as input).
  */
 export function identityTransform(input, opt_output, opt_dimension) {
@@ -182,7 +182,7 @@ export function get(projectionLike) {
  * @param {ProjectionLike} projection The projection.
  * @param {number} resolution Nominal resolution in projection units.
  * @param {import("./coordinate.js").Coordinate} point Point to find adjusted resolution at.
- * @param {import("./proj/Units.js").default=} opt_units Units to get the point resolution in.
+ * @param {import("./proj/Units.js").default} [opt_units] Units to get the point resolution in.
  * Default is the projection's units.
  * @return {number} Point resolution.
  * @api
@@ -321,8 +321,8 @@ export function createTransformFromCoordinateTransform(coordTransform) {
   return (
     /**
      * @param {Array<number>} input Input.
-     * @param {Array<number>=} opt_output Output.
-     * @param {number=} opt_dimension Dimension.
+     * @param {Array<number>} [opt_output] Output.
+     * @param {number} [opt_dimension] Dimension.
      * @return {Array<number>} Output.
      */
     function (input, opt_output, opt_dimension) {
@@ -380,7 +380,7 @@ export function addCoordinateTransforms(source, destination, forward, inverse) {
  * Transforms a coordinate from longitude/latitude to a different projection.
  * @param {import("./coordinate.js").Coordinate} coordinate Coordinate as longitude and latitude, i.e.
  *     an array with longitude as 1st and latitude as 2nd element.
- * @param {ProjectionLike=} opt_projection Target projection. The
+ * @param {ProjectionLike} [opt_projection] Target projection. The
  *     default is Web Mercator, i.e. 'EPSG:3857'.
  * @return {import("./coordinate.js").Coordinate} Coordinate projected to the target projection.
  * @api
@@ -396,7 +396,7 @@ export function fromLonLat(coordinate, opt_projection) {
 /**
  * Transforms a coordinate to longitude/latitude.
  * @param {import("./coordinate.js").Coordinate} coordinate Projected coordinate.
- * @param {ProjectionLike=} opt_projection Projection of the coordinate.
+ * @param {ProjectionLike} [opt_projection] Projection of the coordinate.
  *     The default is Web Mercator, i.e. 'EPSG:3857'.
  * @return {import("./coordinate.js").Coordinate} Coordinate as longitude and latitude, i.e. an array
  *     with longitude as 1st and latitude as 2nd element.
@@ -502,7 +502,7 @@ export function transform(coordinate, source, destination) {
  * @param {import("./extent.js").Extent} extent The extent to transform.
  * @param {ProjectionLike} source Source projection-like.
  * @param {ProjectionLike} destination Destination projection-like.
- * @param {number=} opt_stops Number of stops per side used for the transform.
+ * @param {number} [opt_stops] Number of stops per side used for the transform.
  * By default only the corners are used.
  * @return {import("./extent.js").Extent} The transformed extent.
  * @api

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -78,8 +78,8 @@ export const PROJECTIONS = [
  * Transformation from EPSG:4326 to EPSG:3857.
  *
  * @param {Array<number>} input Input array of coordinate values.
- * @param {Array<number>=} opt_output Output array of coordinate values.
- * @param {number=} opt_dimension Dimension (default is `2`).
+ * @param {Array<number>} [opt_output] Output array of coordinate values.
+ * @param {number} [opt_dimension] Dimension (default is `2`).
  * @return {Array<number>} Output array of coordinate values.
  */
 export function fromEPSG4326(input, opt_output, opt_dimension) {
@@ -111,8 +111,8 @@ export function fromEPSG4326(input, opt_output, opt_dimension) {
  * Transformation from EPSG:3857 to EPSG:4326.
  *
  * @param {Array<number>} input Input array of coordinate values.
- * @param {Array<number>=} opt_output Output array of coordinate values.
- * @param {number=} opt_dimension Dimension (default is `2`).
+ * @param {Array<number>} [opt_output] Output array of coordinate values.
+ * @param {number} [opt_dimension] Dimension (default is `2`).
  * @return {Array<number>} Output array of coordinate values.
  */
 export function toEPSG4326(input, opt_output, opt_dimension) {

--- a/src/ol/proj/epsg4326.js
+++ b/src/ol/proj/epsg4326.js
@@ -37,7 +37,7 @@ export const METERS_PER_UNIT = (Math.PI * RADIUS) / 180;
 class EPSG4326Projection extends Projection {
   /**
    * @param {string} code Code.
-   * @param {string=} opt_axisOrientation Axis orientation.
+   * @param {string} [opt_axisOrientation] Axis orientation.
    */
   constructor(code, opt_axisOrientation) {
     super({

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -61,7 +61,7 @@ import {getTransformFromProjections, getUserProjection} from './proj.js';
  * ```
  *
  * @param {CanvasRenderingContext2D} context Canvas context.
- * @param {ToContextOptions=} opt_options Options.
+ * @param {ToContextOptions} [opt_options] Options.
  * @return {CanvasImmediateRenderer} Canvas Immediate.
  * @api
  */

--- a/src/ol/render/Event.js
+++ b/src/ol/render/Event.js
@@ -7,10 +7,10 @@ import Event from '../events/Event.js';
 class RenderEvent extends Event {
   /**
    * @param {import("./EventType.js").default} type Type.
-   * @param {import("../transform.js").Transform=} opt_inversePixelTransform Transform for
+   * @param {import("../transform.js").Transform} [opt_inversePixelTransform] Transform for
    *     CSS pixels to rendered pixels.
-   * @param {import("../PluggableMap.js").FrameState=} opt_frameState Frame state.
-   * @param {?CanvasRenderingContext2D=} opt_context Context.
+   * @param {import("../PluggableMap.js").FrameState} [opt_frameState] Frame state.
+   * @param {?CanvasRenderingContext2D} [opt_context] Context.
    */
   constructor(type, opt_inversePixelTransform, opt_frameState, opt_context) {
     super(type);

--- a/src/ol/render/VectorContext.js
+++ b/src/ol/render/VectorContext.js
@@ -100,13 +100,13 @@ class VectorContext {
 
   /**
    * @param {import("../style/Image.js").default} imageStyle Image style.
-   * @param {import("../render/canvas.js").DeclutterImageWithText=} opt_declutterImageWithText Shared data for combined decluttering with a text style.
+   * @param {import("../render/canvas.js").DeclutterImageWithText} [opt_declutterImageWithText] Shared data for combined decluttering with a text style.
    */
   setImageStyle(imageStyle, opt_declutterImageWithText) {}
 
   /**
    * @param {import("../style/Text.js").default} textStyle Text style.
-   * @param {import("../render/canvas.js").DeclutterImageWithText=} opt_declutterImageWithText Shared data for combined decluttering with an image style.
+   * @param {import("../render/canvas.js").DeclutterImageWithText} [opt_declutterImageWithText] Shared data for combined decluttering with an image style.
    */
   setTextStyle(textStyle, opt_declutterImageWithText) {}
 }

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -595,10 +595,10 @@ class Executor {
    * @param {import("../../transform.js").Transform} transform Transform.
    * @param {Array<*>} instructions Instructions array.
    * @param {boolean} snapToPixel Snap point symbols and text to integer pixels.
-   * @param {FeatureCallback<T>=} opt_featureCallback Feature callback.
-   * @param {import("../../extent.js").Extent=} opt_hitExtent Only check
+   * @param {FeatureCallback<T>} [opt_featureCallback] Feature callback.
+   * @param {import("../../extent.js").Extent} [opt_hitExtent] Only check
    *     features that intersect this extent.
-   * @param {import("rbush").default=} opt_declutterTree Declutter tree.
+   * @param {import("rbush").default} [opt_declutterTree] Declutter tree.
    * @return {T|undefined} Callback result.
    * @template T
    */
@@ -1141,7 +1141,7 @@ class Executor {
    * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {boolean} snapToPixel Snap point symbols and text to integer pixels.
-   * @param {import("rbush").default=} opt_declutterTree Declutter tree.
+   * @param {import("rbush").default} [opt_declutterTree] Declutter tree.
    */
   execute(
     context,
@@ -1168,8 +1168,8 @@ class Executor {
    * @param {CanvasRenderingContext2D} context Context.
    * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
-   * @param {FeatureCallback<T>=} opt_featureCallback Feature callback.
-   * @param {import("../../extent.js").Extent=} opt_hitExtent Only check
+   * @param {FeatureCallback<T>} [opt_featureCallback] Feature callback.
+   * @param {import("../../extent.js").Extent} [opt_hitExtent] Only check
    *     features that intersect this extent.
    * @return {T|undefined} Callback result.
    * @template T

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -38,7 +38,7 @@ class ExecutorGroup {
    * @param {boolean} overlaps The executor group can have overlapping geometries.
    * @param {!Object<string, !Object<import("./BuilderType.js").default, import("../canvas.js").SerializableInstructions>>} allInstructions
    * The serializable instructions.
-   * @param {number=} opt_renderBuffer Optional rendering buffer.
+   * @param {number} [opt_renderBuffer] Optional rendering buffer.
    */
   constructor(
     maxExtent,
@@ -312,9 +312,9 @@ class ExecutorGroup {
    * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
    * @param {boolean} snapToPixel Snap point symbols and test to integer pixel.
-   * @param {Array<import("./BuilderType.js").default>=} opt_builderTypes Ordered replay types to replay.
+   * @param {Array<import("./BuilderType.js").default>} [opt_builderTypes] Ordered replay types to replay.
    *     Default is {@link module:ol/render/replay~ORDER}
-   * @param {import("rbush").default=} opt_declutterTree Declutter tree.
+   * @param {import("rbush").default} [opt_declutterTree] Declutter tree.
    */
   execute(
     context,

--- a/src/ol/render/canvas/ImageBuilder.js
+++ b/src/ol/render/canvas/ImageBuilder.js
@@ -234,7 +234,7 @@ class CanvasImageBuilder extends CanvasBuilder {
 
   /**
    * @param {import("../../style/Image.js").default} imageStyle Image style.
-   * @param {Object=} opt_sharedData Shared data.
+   * @param {Object} [opt_sharedData] Shared data.
    */
   setImageStyle(imageStyle, opt_sharedData) {
     const anchor = imageStyle.getAnchor();

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -46,8 +46,8 @@ class CanvasImmediateRenderer extends VectorContext {
    * @param {import("../../extent.js").Extent} extent Extent.
    * @param {import("../../transform.js").Transform} transform Transform.
    * @param {number} viewRotation View rotation.
-   * @param {number=} opt_squaredTolerance Optional squared tolerance for simplification.
-   * @param {import("../../proj.js").TransformFunction=} opt_userTransform Transform from user to view projection.
+   * @param {number} [opt_squaredTolerance] Optional squared tolerance for simplification.
+   * @param {import("../../proj.js").TransformFunction} [opt_userTransform] Transform from user to view projection.
    */
   constructor(
     context,

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -484,7 +484,7 @@ class CanvasTextBuilder extends CanvasBuilder {
 
   /**
    * @param {import("../../style/Text.js").default} textStyle Text style.
-   * @param {Object=} opt_sharedData Shared data.
+   * @param {Object} [opt_sharedData] Shared data.
    */
   setTextStyle(textStyle, opt_sharedData) {
     let textState, fillState, strokeState;

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -576,7 +576,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    * @param {import("../../extent.js").Extent} extent Extent.
    * @param {number} currentZ Current Z.
    * @param {number} preload Load low resolution tiles up to 'preload' levels.
-   * @param {function(import("../../Tile.js").default)=} opt_tileCallback Tile callback.
+   * @param {function(import("../../Tile.js").default):void} [opt_tileCallback] Tile callback.
    * @protected
    */
   manageTilePyramid(

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -156,7 +156,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
   /**
    * @param {ExecutorGroup} executorGroup Executor group.
    * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
-   * @param {import("rbush").default=} opt_declutterTree Declutter tree.
+   * @param {import("rbush").default} [opt_declutterTree] Declutter tree.
    */
   renderWorlds(executorGroup, frameState, opt_declutterTree) {
     const extent = frameState.extent;
@@ -716,8 +716,8 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @param {number} squaredTolerance Squared render tolerance.
    * @param {import("../../style/Style.js").default|Array<import("../../style/Style.js").default>} styles The style or array of styles.
    * @param {import("../../render/canvas/BuilderGroup.js").default} builderGroup Builder group.
-   * @param {import("../../proj.js").TransformFunction=} opt_transform Transform from user to view projection.
-   * @param {import("../../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+   * @param {import("../../proj.js").TransformFunction} [opt_transform] Transform from user to view projection.
+   * @param {import("../../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
    * @return {boolean} `true` if an image is loading.
    */
   renderFeature(

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -787,7 +787,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
    * @param {number} squaredTolerance Squared tolerance.
    * @param {import("../../style/Style.js").default|Array<import("../../style/Style.js").default>} styles The style or array of styles.
    * @param {import("../../render/canvas/BuilderGroup.js").default} builderGroup Replay group.
-   * @param {import("../../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder group for decluttering.
+   * @param {import("../../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder group for decluttering.
    * @return {boolean} `true` if an image is loading.
    */
   renderFeature(

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -72,7 +72,7 @@ export function getTolerance(resolution, pixelRatio) {
  * @param {import("../geom/Circle.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").default} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderCircleGeometry(
   builderGroup,
@@ -109,7 +109,7 @@ function renderCircleGeometry(
  * @param {number} squaredTolerance Squared tolerance.
  * @param {function(import("../events/Event.js").default): void} listener Listener function.
  * @param {import("../proj.js").TransformFunction} [opt_transform] Transform from user to view projection.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  * @return {boolean} `true` if style is loading.
  */
 export function renderFeature(
@@ -154,7 +154,7 @@ export function renderFeature(
  * @param {import("../style/Style.js").default} style Style.
  * @param {number} squaredTolerance Squared tolerance.
  * @param {import("../proj.js").TransformFunction} [opt_transform] Optional transform function.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderFeatureInternal(
   replayGroup,
@@ -214,7 +214,7 @@ function renderGeometry(replayGroup, geometry, style, feature) {
  * @param {import("../geom/GeometryCollection.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").default} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderGeometryCollectionGeometry(
   replayGroup,
@@ -242,7 +242,7 @@ function renderGeometryCollectionGeometry(
  * @param {import("../geom/LineString.js").default|import("../render/Feature.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").FeatureLike} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderLineStringGeometry(
   builderGroup,
@@ -276,7 +276,7 @@ function renderLineStringGeometry(
  * @param {import("../geom/MultiLineString.js").default|import("../render/Feature.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").FeatureLike} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderMultiLineStringGeometry(
   builderGroup,
@@ -310,7 +310,7 @@ function renderMultiLineStringGeometry(
  * @param {import("../geom/MultiPolygon.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").default} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderMultiPolygonGeometry(
   builderGroup,
@@ -345,7 +345,7 @@ function renderMultiPolygonGeometry(
  * @param {import("../geom/Point.js").default|import("../render/Feature.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").FeatureLike} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderPointGeometry(
   builderGroup,
@@ -389,7 +389,7 @@ function renderPointGeometry(
  * @param {import("../geom/MultiPoint.js").default|import("../render/Feature.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").FeatureLike} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderMultiPointGeometry(
   builderGroup,
@@ -433,7 +433,7 @@ function renderMultiPointGeometry(
  * @param {import("../geom/Polygon.js").default|import("../render/Feature.js").default} geometry Geometry.
  * @param {import("../style/Style.js").default} style Style.
  * @param {import("../Feature.js").FeatureLike} feature Feature.
- * @param {import("../render/canvas/BuilderGroup.js").default=} opt_declutterBuilderGroup Builder for decluttering.
+ * @param {import("../render/canvas/BuilderGroup.js").default} [opt_declutterBuilderGroup] Builder for decluttering.
  */
 function renderPolygonGeometry(
   builderGroup,

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -51,7 +51,7 @@ export const WebGLWorkerMessageType = {
 class WebGLLayerRenderer extends LayerRenderer {
   /**
    * @param {LayerType} layer Layer.
-   * @param {Options=} [opt_options] Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(layer, opt_options) {
     super(layer);

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -197,8 +197,8 @@ export function calculateSourceExtentResolution(
  * @param {import("./reproj/Triangulation.js").default} triangulation Calculated triangulation.
  * @param {Array<ImageExtent>} sources Array of sources.
  * @param {number} gutter Gutter of the sources.
- * @param {boolean=} opt_renderEdges Render reprojection edges.
- * @param {object=} opt_contextOptions Properties to set on the canvas context.
+ * @param {boolean} [opt_renderEdges] Render reprojection edges.
+ * @param {object} [opt_contextOptions] Properties to set on the canvas context.
  * @return {HTMLCanvasElement} Canvas with reprojected data.
  */
 export function render(

--- a/src/ol/reproj/Image.js
+++ b/src/ol/reproj/Image.js
@@ -32,7 +32,7 @@ class ReprojImage extends ImageBase {
    * @param {number} pixelRatio Pixel ratio.
    * @param {FunctionType} getImageFunction
    *     Function returning source images (extent, resolution, pixelRatio).
-   * @param {object=} opt_contextOptions Properties to set on the canvas context.
+   * @param {object} [opt_contextOptions] Properties to set on the canvas context.
    */
   constructor(
     sourceProj,

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -37,9 +37,9 @@ class ReprojTile extends Tile {
    * @param {number} gutter Gutter of the source tiles.
    * @param {FunctionType} getTileFunction
    *     Function returning source tiles (z, x, y, pixelRatio).
-   * @param {number=} opt_errorThreshold Acceptable reprojection error (in px).
-   * @param {boolean=} opt_renderEdges Render reprojection edges.
-   * @param {object=} opt_contextOptions Properties to set on the canvas context.
+   * @param {number} [opt_errorThreshold] Acceptable reprojection error (in px).
+   * @param {boolean} [opt_renderEdges] Render reprojection edges.
+   * @param {object} [opt_contextOptions] Properties to set on the canvas context.
    */
   constructor(
     sourceProj,

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -64,9 +64,9 @@ function getSmoothClampedResolution(resolution, maxResolution, minResolution) {
 
 /**
  * @param {Array<number>} resolutions Resolutions.
- * @param {boolean=} opt_smooth If true, the view will be able to slightly exceed resolution limits. Default: true.
- * @param {import("./extent.js").Extent=} opt_maxExtent Maximum allowed extent.
- * @param {boolean=} opt_showFullExtent If true, allows us to show the full extent. Default: false.
+ * @param {boolean} [opt_smooth] If true, the view will be able to slightly exceed resolution limits. Default: true.
+ * @param {import("./extent.js").Extent} [opt_maxExtent] Maximum allowed extent.
+ * @param {boolean} [opt_showFullExtent] If true, allows us to show the full extent. Default: false.
  * @return {Type} Zoom function.
  */
 export function createSnapToResolutions(
@@ -80,7 +80,7 @@ export function createSnapToResolutions(
      * @param {number|undefined} resolution Resolution.
      * @param {number} direction Direction.
      * @param {import("./size.js").Size} size Viewport size.
-     * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
+     * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
      * @return {number|undefined} Resolution.
      */
     function (resolution, direction, size, opt_isMoving) {
@@ -125,10 +125,10 @@ export function createSnapToResolutions(
 /**
  * @param {number} power Power.
  * @param {number} maxResolution Maximum resolution.
- * @param {number=} opt_minResolution Minimum resolution.
- * @param {boolean=} opt_smooth If true, the view will be able to slightly exceed resolution limits. Default: true.
- * @param {import("./extent.js").Extent=} opt_maxExtent Maximum allowed extent.
- * @param {boolean=} opt_showFullExtent If true, allows us to show the full extent. Default: false.
+ * @param {number} [opt_minResolution] Minimum resolution.
+ * @param {boolean} [opt_smooth] If true, the view will be able to slightly exceed resolution limits. Default: true.
+ * @param {import("./extent.js").Extent} [opt_maxExtent] Maximum allowed extent.
+ * @param {boolean} [opt_showFullExtent] If true, allows us to show the full extent. Default: false.
  * @return {Type} Zoom function.
  */
 export function createSnapToPower(
@@ -144,7 +144,7 @@ export function createSnapToPower(
      * @param {number|undefined} resolution Resolution.
      * @param {number} direction Direction.
      * @param {import("./size.js").Size} size Viewport size.
-     * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
+     * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
      * @return {number|undefined} Resolution.
      */
     function (resolution, direction, size, opt_isMoving) {
@@ -195,9 +195,9 @@ export function createSnapToPower(
 /**
  * @param {number} maxResolution Max resolution.
  * @param {number} minResolution Min resolution.
- * @param {boolean=} opt_smooth If true, the view will be able to slightly exceed resolution limits. Default: true.
- * @param {import("./extent.js").Extent=} opt_maxExtent Maximum allowed extent.
- * @param {boolean=} opt_showFullExtent If true, allows us to show the full extent. Default: false.
+ * @param {boolean} [opt_smooth] If true, the view will be able to slightly exceed resolution limits. Default: true.
+ * @param {import("./extent.js").Extent} [opt_maxExtent] Maximum allowed extent.
+ * @param {boolean} [opt_showFullExtent] If true, allows us to show the full extent. Default: false.
  * @return {Type} Zoom function.
  */
 export function createMinMaxResolution(
@@ -212,7 +212,7 @@ export function createMinMaxResolution(
      * @param {number|undefined} resolution Resolution.
      * @param {number} direction Direction.
      * @param {import("./size.js").Size} size Viewport size.
-     * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
+     * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
      * @return {number|undefined} Resolution.
      */
     function (resolution, direction, size, opt_isMoving) {

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -40,7 +40,7 @@ export function createSnapToN(n) {
   return (
     /**
      * @param {number|undefined} rotation Rotation.
-     * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
+     * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
      * @return {number|undefined} Rotation.
      */
     function (rotation, opt_isMoving) {
@@ -59,7 +59,7 @@ export function createSnapToN(n) {
 }
 
 /**
- * @param {number=} opt_tolerance Tolerance.
+ * @param {number} [opt_tolerance] Tolerance.
  * @return {Type} Rotation constraint.
  */
 export function createSnapToZero(opt_tolerance) {
@@ -67,7 +67,7 @@ export function createSnapToZero(opt_tolerance) {
   return (
     /**
      * @param {number|undefined} rotation Rotation.
-     * @param {boolean=} opt_isMoving True if an interaction or animation is in progress.
+     * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
      * @return {number|undefined} Rotation.
      */
     function (rotation, opt_isMoving) {

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -12,7 +12,7 @@
  * Returns a buffered size.
  * @param {Size} size Size.
  * @param {number} num The amount by which to buffer.
- * @param {Size=} opt_size Optional reusable size array.
+ * @param {Size} [opt_size] Optional reusable size array.
  * @return {Size} The buffered size.
  */
 export function buffer(size, num, opt_size) {
@@ -37,7 +37,7 @@ export function hasArea(size) {
  * Returns a size scaled by a ratio. The result will be an array of integers.
  * @param {Size} size Size.
  * @param {number} ratio Ratio.
- * @param {Size=} opt_size Optional reusable size array.
+ * @param {Size} [opt_size] Optional reusable size array.
  * @return {Size} The scaled size.
  */
 export function scale(size, ratio, opt_size) {
@@ -54,7 +54,7 @@ export function scale(size, ratio, opt_size) {
  * `Size` array.
  * (meaning: non-square),
  * @param {number|Size} size Width and height.
- * @param {Size=} opt_size Optional reusable size array.
+ * @param {Size} [opt_size] Optional reusable size array.
  * @return {Size} Size.
  * @api
  */

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -92,7 +92,7 @@ class Cluster extends VectorSource {
 
   /**
    * Remove all features from the source.
-   * @param {boolean=} opt_fast Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#removefeature} events.
+   * @param {boolean} [opt_fast] Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#removefeature} events.
    * @api
    */
   clear(opt_fast) {

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -60,7 +60,7 @@ function formatPercentage(percentage) {
  */
 class IIIF extends TileImage {
   /**
-   * @param {Options=} opt_options Tile source options. Use {@link import("../format/IIIFInfo.js").IIIFInfo}
+   * @param {Options} [opt_options] Tile source options. Use {@link import("../format/IIIFInfo.js").IIIFInfo}
    * to parse Image API service information responses into constructor options.
    * @api
    */

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -50,7 +50,7 @@ import {containsExtent, getHeight, getWidth} from '../extent.js';
  */
 class ImageArcGISRest extends ImageSource {
   /**
-   * @param {Options=} opt_options Image ArcGIS Rest Options.
+   * @param {Options} [opt_options] Image ArcGIS Rest Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -52,7 +52,7 @@ import {
  */
 class ImageCanvasSource extends ImageSource {
   /**
-   * @param {Options=} opt_options ImageCanvas options.
+   * @param {Options} [opt_options] ImageCanvas options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -62,7 +62,7 @@ const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
  */
 class ImageWMS extends ImageSource {
   /**
-   * @param {Options=} [opt_options] ImageWMS options.
+   * @param {Options} [opt_options] ImageWMS options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -48,7 +48,7 @@ export const ATTRIBUTION =
  */
 class OSM extends XYZ {
   /**
-   * @param {Options=} [opt_options] Open Street Map options.
+   * @param {Options} [opt_options] Open Street Map options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -597,7 +597,7 @@ class RasterSource extends ImageSource {
   /**
    * Set the operation.
    * @param {Operation} operation New operation.
-   * @param {Object=} opt_lib Functions that will be available to operations run
+   * @param {Object} [opt_lib] Functions that will be available to operations run
    *     in a worker.
    * @api
    */

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -291,7 +291,7 @@ class TileSource extends Source {
    * is outside the resolution and extent range of the tile grid, `null` will be
    * returned.
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {import("../proj/Projection.js").default=} opt_projection Projection.
+   * @param {import("../proj/Projection.js").default} [opt_projection] Projection.
    * @return {import("../tilecoord.js").TileCoord} Tile coordinate to be passed to the tileUrlFunction or
    *     null if no tile URL should be created for the passed `tileCoord`.
    */

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -62,7 +62,7 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  */
 class TileArcGISRest extends TileImage {
   /**
-   * @param {Options=} opt_options Tile ArcGIS Rest options.
+   * @param {Options} [opt_options] Tile ArcGIS Rest options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -101,7 +101,7 @@ class LabeledTile extends Tile {
  */
 class TileDebug extends XYZ {
   /**
-   * @param {Options=} opt_options Debug tile options.
+   * @param {Options} [opt_options] Debug tile options.
    */
   constructor(opt_options) {
     /**

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -77,7 +77,7 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  */
 class TileWMS extends TileImage {
   /**
-   * @param {Options=} [opt_options] Tile WMS options.
+   * @param {Options} [opt_options] Tile WMS options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : /** @type {Options} */ ({});

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -132,7 +132,7 @@ export class CustomTile extends Tile {
    * for given coordinate (or `null` if not yet loaded).
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {function(*): void} callback Callback.
-   * @param {boolean=} opt_request If `true` the callback is always async.
+   * @param {boolean} [opt_request] If `true` the callback is always async.
    *                               The tile data is requested if not yet loaded.
    */
   forDataAtCoordinate(coordinate, callback, opt_request) {
@@ -378,7 +378,7 @@ class UTFGrid extends TileSource {
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
    * @param {function(*): void} callback Callback.
-   * @param {boolean=} opt_request If `true` the callback is always async.
+   * @param {boolean} [opt_request] If `true` the callback is always async.
    *                               The tile data is requested if not yet loaded.
    * @api
    */

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -162,7 +162,7 @@ class UrlTile extends TileSource {
   /**
    * Set the tile URL function of the source.
    * @param {import("../Tile.js").UrlFunction} tileUrlFunction Tile URL function.
-   * @param {string=} key Optional new tile key for the source.
+   * @param {string} [key] Optional new tile key for the source.
    * @api
    */
   setTileUrlFunction(tileUrlFunction, key) {

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -39,8 +39,8 @@ import {xhr} from '../featureloader.js';
 export class VectorSourceEvent extends Event {
   /**
    * @param {string} type Type.
-   * @param {import("../Feature.js").default<Geometry>=} opt_feature Feature.
-   * @param {Array<import("../Feature.js").default<Geometry>>=} opt_features Features.
+   * @param {import("../Feature.js").default<Geometry>} [opt_feature] Feature.
+   * @param {Array<import("../Feature.js").default<Geometry>>} [opt_features] Features.
    */
   constructor(type, opt_feature, opt_features) {
     super(type);
@@ -165,7 +165,7 @@ export class VectorSourceEvent extends Event {
  */
 class VectorSource extends Source {
   /**
-   * @param {Options=} opt_options Vector source options.
+   * @param {Options} [opt_options] Vector source options.
    */
   constructor(opt_options) {
     const options = opt_options || {};
@@ -500,7 +500,7 @@ class VectorSource extends Source {
 
   /**
    * Remove all features from the source.
-   * @param {boolean=} opt_fast Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#removefeature} events.
+   * @param {boolean} [opt_fast] Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#removefeature} events.
    * @api
    */
   clear(opt_fast) {
@@ -712,7 +712,7 @@ class VectorSource extends Source {
    * This method is not available when the source is configured with
    * `useSpatialIndex` set to `false`.
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @param {function(import("../Feature.js").default<Geometry>):boolean=} opt_filter Feature filter function.
+   * @param {function(import("../Feature.js").default<Geometry>):boolean} [opt_filter] Feature filter function.
    *     The filter function will receive one argument, the {@link module:ol/Feature feature}
    *     and it should return a boolean value. By default, no filtering is made.
    * @return {import("../Feature.js").default<Geometry>} Closest feature.
@@ -771,7 +771,7 @@ class VectorSource extends Source {
    *
    * This method is not available when the source is configured with
    * `useSpatialIndex` set to `false`.
-   * @param {import("../extent.js").Extent=} opt_extent Destination extent. If provided, no new extent
+   * @param {import("../extent.js").Extent} [opt_extent] Destination extent. If provided, no new extent
    *     will be created. Instead, that extent's coordinates will be overwritten.
    * @return {import("../extent.js").Extent} Extent.
    * @api

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -69,7 +69,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  */
 class XYZ extends TileImage {
   /**
-   * @param {Options=} opt_options XYZ options.
+   * @param {Options} [opt_options] XYZ options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -29,7 +29,7 @@ export class CustomTile extends ImageTile {
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
    * @param {import("../Tile.js").LoadFunction} tileLoadFunction Tile load function.
-   * @param {import("../Tile.js").Options=} opt_options Tile options.
+   * @param {import("../Tile.js").Options} [opt_options] Tile options.
    */
   constructor(
     tileSize,

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -27,7 +27,7 @@ export const DEFAULT_RADIUS = 6371008.8;
  * Get the great circle distance (in meters) between two geographic coordinates.
  * @param {Array} c1 Starting coordinate.
  * @param {Array} c2 Ending coordinate.
- * @param {number=} opt_radius The sphere radius to use.  Defaults to the Earth's
+ * @param {number} [opt_radius] The sphere radius to use.  Defaults to the Earth's
  *     mean radius using the WGS84 ellipsoid.
  * @return {number} The great circle distance between the points (in meters).
  * @api
@@ -67,7 +67,7 @@ function getLengthInternal(coordinates, radius) {
  * the sum of all rings.  For points, the length is zero.  For multi-part
  * geometries, the length is the sum of the length of each part.
  * @param {import("./geom/Geometry.js").default} geometry A geometry.
- * @param {SphereMetricOptions=} opt_options Options for the
+ * @param {SphereMetricOptions} [opt_options] Options for the
  * length calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  * You can change this by providing a `projection` option.
  * @return {number} The spherical length (in meters).
@@ -161,7 +161,7 @@ function getAreaInternal(coordinates, radius) {
  * Get the spherical area of a geometry.  This is the area (in meters) assuming
  * that polygon edges are segments of great circles on a sphere.
  * @param {import("./geom/Geometry.js").default} geometry A geometry.
- * @param {SphereMetricOptions=} opt_options Options for the area
+ * @param {SphereMetricOptions} [opt_options] Options for the area
  *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
  *     You can change this by providing a `projection` option.
  * @return {number} The spherical area (in square meters).
@@ -225,7 +225,7 @@ export function getArea(geometry, opt_options) {
  * @param {number} distance The great-circle distance between the origin
  *     point and the target point.
  * @param {number} bearing The bearing (in radians).
- * @param {number=} opt_radius The sphere radius to use.  Defaults to the Earth's
+ * @param {number} [opt_radius] The sphere radius to use.  Defaults to the Earth's
  *     mean radius using the WGS84 ellipsoid.
  * @return {import("./coordinate.js").Coordinate} The target point.
  */

--- a/src/ol/string.js
+++ b/src/ol/string.js
@@ -5,7 +5,7 @@
 /**
  * @param {number} number Number to be formatted
  * @param {number} width The desired width
- * @param {number=} opt_precision Precision of the output string (i.e. number of decimal places)
+ * @param {number} [opt_precision] Precision of the output string (i.e. number of decimal places)
  * @return {string} Formatted string
  */
 export function padNumber(number, width, opt_precision) {

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -23,7 +23,7 @@ import {assert} from '../asserts.js';
  */
 class LRUCache {
   /**
-   * @param {number=} opt_highWaterMark High water mark.
+   * @param {number} [opt_highWaterMark] High water mark.
    */
   constructor(opt_highWaterMark) {
     /**
@@ -100,7 +100,7 @@ class LRUCache {
 
   /**
    * @param {string} key Key.
-   * @param {*=} opt_options Options (reserverd for subclasses).
+   * @param {*} [opt_options] Options (reserverd for subclasses).
    * @return {T} Value.
    */
   get(key, opt_options) {

--- a/src/ol/structs/LinkedList.js
+++ b/src/ol/structs/LinkedList.js
@@ -15,7 +15,7 @@
  */
 class LinkedList {
   /**
-   * @param {boolean=} opt_circular The last item is connected to the first one,
+   * @param {boolean} [opt_circular] The last item is connected to the first one,
    * and the first item to the last one. Default is true.
    */
   constructor(opt_circular) {

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -24,7 +24,7 @@ import {isEmpty} from '../obj.js';
  */
 class RBush {
   /**
-   * @param {number=} opt_maxEntries Max entries.
+   * @param {number} [opt_maxEntries] Max entries.
    */
   constructor(opt_maxEntries) {
     /**
@@ -198,7 +198,7 @@ class RBush {
   }
 
   /**
-   * @param {import("../extent.js").Extent=} opt_extent Extent.
+   * @param {import("../extent.js").Extent} [opt_extent] Extent.
    * @return {import("../extent.js").Extent} Extent.
    */
   getExtent(opt_extent) {

--- a/src/ol/style/Circle.js
+++ b/src/ol/style/Circle.js
@@ -25,7 +25,7 @@ import RegularShape from './RegularShape.js';
  */
 class CircleStyle extends RegularShape {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};

--- a/src/ol/style/Fill.js
+++ b/src/ol/style/Fill.js
@@ -16,7 +16,7 @@
  */
 class Fill {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -53,7 +53,7 @@ import {getUid} from '../util.js';
  */
 class Icon extends ImageStyle {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -27,7 +27,7 @@
  */
 class Stroke {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -147,7 +147,7 @@ import {assert} from '../asserts.js';
  */
 class Style {
   /**
-   * @param {Options=} opt_options Style options.
+   * @param {Options} [opt_options] Style options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -50,7 +50,7 @@ const DEFAULT_FILL_COLOR = '#333';
  */
 class Text {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     const options = opt_options || {};

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -274,9 +274,9 @@ export function expressionToGlsl(context, value, typeHint) {
     (valueType & ValueTypes.COLOR) > 0 &&
     (typeHint === undefined || typeHint == ValueTypes.COLOR)
   ) {
-    return colorToGlsl(/** @type {number[]|string} */ (value));
+    return colorToGlsl(/** @type {Array<number> | string} */ (value));
   } else if ((valueType & ValueTypes.NUMBER_ARRAY) > 0) {
-    return arrayToGlsl(/** @type {number[]} */ (value));
+    return arrayToGlsl(/** @type {Array<number>} */ (value));
   }
 }
 
@@ -652,7 +652,7 @@ Operators['color'] = {
     assertArgsMinCount(args, 3);
     assertArgsMaxCount(args, 4);
     assertNumbers(args);
-    const array = /** @type {number[]} */ (args);
+    const array = /** @type {Array<number>} */ (args);
     if (args.length === 3) {
       array.push(1);
     }

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -13,7 +13,7 @@
  * @param {number} z Z.
  * @param {number} x X.
  * @param {number} y Y.
- * @param {TileCoord=} opt_tileCoord Tile coordinate.
+ * @param {TileCoord} [opt_tileCoord] Tile coordinate.
  * @return {TileCoord} Tile coordinate.
  */
 export function createOrUpdate(z, x, y, opt_tileCoord) {

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -53,11 +53,11 @@ export function wrapX(tileGrid, tileCoord, projection) {
 
 /**
  * @param {import("./extent.js").Extent} extent Extent.
- * @param {number=} opt_maxZoom Maximum zoom level (default is
+ * @param {number} [opt_maxZoom] Maximum zoom level (default is
  *     DEFAULT_MAX_ZOOM).
- * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
+ * @param {number|import("./size.js").Size} [opt_tileSize] Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {import("./extent/Corner.js").default=} opt_corner Extent corner (default is `'top-left'`).
+ * @param {import("./extent/Corner.js").default} [opt_corner] Extent corner (default is `'top-left'`).
  * @return {!TileGrid} TileGrid instance.
  */
 export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
@@ -87,7 +87,7 @@ export function createForExtent(extent, opt_maxZoom, opt_tileSize, opt_corner) {
 
 /**
  * Creates a tile grid with a standard XYZ tiling scheme.
- * @param {XYZOptions=} opt_options Tile grid options.
+ * @param {XYZOptions} [opt_options] Tile grid options.
  * @return {!TileGrid} Tile grid instance.
  * @api
  */
@@ -113,11 +113,11 @@ export function createXYZ(opt_options) {
 /**
  * Create a resolutions array from an extent.  A zoom factor of 2 is assumed.
  * @param {import("./extent.js").Extent} extent Extent.
- * @param {number=} opt_maxZoom Maximum zoom level (default is
+ * @param {number} [opt_maxZoom] Maximum zoom level (default is
  *     DEFAULT_MAX_ZOOM).
- * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
+ * @param {number|import("./size.js").Size} [opt_tileSize] Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {number=} opt_maxResolution Resolution at level zero.
+ * @param {number} [opt_maxResolution] Resolution at level zero.
  * @return {!Array<number>} Resolutions array.
  */
 function resolutionsFromExtent(
@@ -149,11 +149,11 @@ function resolutionsFromExtent(
 
 /**
  * @param {import("./proj.js").ProjectionLike} projection Projection.
- * @param {number=} opt_maxZoom Maximum zoom level (default is
+ * @param {number} [opt_maxZoom] Maximum zoom level (default is
  *     DEFAULT_MAX_ZOOM).
- * @param {number|import("./size.js").Size=} opt_tileSize Tile size (default uses
+ * @param {number|import("./size.js").Size} [opt_tileSize] Tile size (default uses
  *     DEFAULT_TILE_SIZE).
- * @param {import("./extent/Corner.js").default=} opt_corner Extent corner (default is `'top-left'`).
+ * @param {import("./extent/Corner.js").default} [opt_corner] Extent corner (default is `'top-left'`).
  * @return {!TileGrid} TileGrid instance.
  */
 export function createForProjection(

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -222,8 +222,8 @@ class TileGrid {
   /**
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {function(number, import("../TileRange.js").default): boolean} callback Callback.
-   * @param {import("../TileRange.js").default=} opt_tileRange Temporary import("../TileRange.js").default object.
-   * @param {import("../extent.js").Extent=} opt_extent Temporary import("../extent.js").Extent object.
+   * @param {import("../TileRange.js").default} [opt_tileRange] Temporary import("../TileRange.js").default object.
+   * @param {import("../extent.js").Extent} [opt_extent] Temporary import("../extent.js").Extent object.
    * @return {boolean} Callback succeeded.
    */
   forEachTileCoordParentTileRange(
@@ -323,8 +323,8 @@ class TileGrid {
 
   /**
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {import("../TileRange.js").default=} opt_tileRange Temporary import("../TileRange.js").default object.
-   * @param {import("../extent.js").Extent=} opt_extent Temporary import("../extent.js").Extent object.
+   * @param {import("../TileRange.js").default} [opt_tileRange] Temporary import("../TileRange.js").default object.
+   * @param {import("../extent.js").Extent} [opt_extent] Temporary import("../extent.js").Extent object.
    * @return {import("../TileRange.js").default} Tile range.
    */
   getTileCoordChildTileRange(tileCoord, opt_tileRange, opt_extent) {
@@ -354,7 +354,7 @@ class TileGrid {
    * Get the extent for a tile range.
    * @param {number} z Integer zoom level.
    * @param {import("../TileRange.js").default} tileRange Tile range.
-   * @param {import("../extent.js").Extent=} opt_extent Temporary import("../extent.js").Extent object.
+   * @param {import("../extent.js").Extent} [opt_extent] Temporary import("../extent.js").Extent object.
    * @return {import("../extent.js").Extent} Extent.
    */
   getTileRangeExtent(z, tileRange, opt_extent) {
@@ -372,7 +372,7 @@ class TileGrid {
    * Get a tile range for the given extent and integer zoom level.
    * @param {import("../extent.js").Extent} extent Extent.
    * @param {number} z Integer zoom level.
-   * @param {import("../TileRange.js").default=} opt_tileRange Temporary tile range object.
+   * @param {import("../TileRange.js").default} [opt_tileRange] Temporary tile range object.
    * @return {import("../TileRange.js").default} Tile range.
    */
   getTileRangeForExtentAndZ(extent, z, opt_tileRange) {
@@ -408,7 +408,7 @@ class TileGrid {
    * Get the extent of a tile coordinate.
    *
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
-   * @param {import("../extent.js").Extent=} opt_extent Temporary extent object.
+   * @param {import("../extent.js").Extent} [opt_extent] Temporary extent object.
    * @return {import("../extent.js").Extent} Extent.
    * @api
    */
@@ -430,7 +430,7 @@ class TileGrid {
    *
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} resolution Resolution.
-   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Destination import("../tilecoord.js").TileCoord object.
+   * @param {import("../tilecoord.js").TileCoord} [opt_tileCoord] Destination import("../tilecoord.js").TileCoord object.
    * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @api
    */
@@ -453,7 +453,7 @@ class TileGrid {
    * @param {boolean} reverseIntersectionPolicy Instead of letting edge
    *     intersections go to the higher tile coordinate, let edge intersections
    *     go to the lower tile coordinate.
-   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Temporary import("../tilecoord.js").TileCoord object.
+   * @param {import("../tilecoord.js").TileCoord} [opt_tileCoord] Temporary import("../tilecoord.js").TileCoord object.
    * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @private
    */
@@ -498,7 +498,7 @@ class TileGrid {
    * @param {boolean} reverseIntersectionPolicy Instead of letting edge
    *     intersections go to the higher tile coordinate, let edge intersections
    *     go to the lower tile coordinate.
-   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Temporary import("../tilecoord.js").TileCoord object.
+   * @param {import("../tilecoord.js").TileCoord} [opt_tileCoord] Temporary import("../tilecoord.js").TileCoord object.
    * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @private
    */
@@ -529,7 +529,7 @@ class TileGrid {
    * Get a tile coordinate given a map coordinate and zoom level.
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {number} z Zoom level.
-   * @param {import("../tilecoord.js").TileCoord=} opt_tileCoord Destination import("../tilecoord.js").TileCoord object.
+   * @param {import("../tilecoord.js").TileCoord} [opt_tileCoord] Destination import("../tilecoord.js").TileCoord object.
    * @return {import("../tilecoord.js").TileCoord} Tile coordinate.
    * @api
    */
@@ -583,7 +583,7 @@ class TileGrid {
 
   /**
    * @param {number} resolution Resolution.
-   * @param {number=} opt_direction If 0, the nearest resolution will be used.
+   * @param {number} [opt_direction] If 0, the nearest resolution will be used.
    *     If 1, the nearest lower resolution will be used. If -1, the nearest
    *     higher resolution will be used. Default is 0.
    * @return {number} Z.

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -90,9 +90,9 @@ export default WMTSTileGrid;
  * optional TileMatrixSetLimits.
  * @param {Object} matrixSet An object representing a matrixSet in the
  *     capabilities document.
- * @param {import("../extent.js").Extent=} opt_extent An optional extent to restrict the tile
+ * @param {import("../extent.js").Extent} [opt_extent] An optional extent to restrict the tile
  *     ranges the server provides.
- * @param {Array<Object>=} opt_matrixLimits An optional object representing
+ * @param {Array<Object>} [opt_matrixLimits] An optional object representing
  *     the available matrices for tileGrid.
  * @return {WMTSTileGrid} WMTS tileGrid instance.
  * @api

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -85,7 +85,7 @@ const CONTEXT_IDS = ['experimental-webgl', 'webgl', 'webkit-3d', 'moz-webgl'];
 
 /**
  * @param {HTMLCanvasElement} canvas Canvas.
- * @param {Object=} opt_attributes Attributes.
+ * @param {Object} [opt_attributes] Attributes.
  * @return {WebGLRenderingContext} WebGL rendering context.
  */
 export function getContext(canvas, opt_attributes) {

--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -35,7 +35,7 @@ export const BufferUsage = {
 class WebGLArrayBuffer {
   /**
    * @param {number} type Buffer type, either ARRAY_BUFFER or ELEMENT_ARRAY_BUFFER.
-   * @param {number=} opt_usage Intended usage, either `STATIC_DRAW`, `STREAM_DRAW` or `DYNAMIC_DRAW`.
+   * @param {number} [opt_usage] Intended usage, either `STATIC_DRAW`, `STREAM_DRAW` or `DYNAMIC_DRAW`.
    * Default is `DYNAMIC_DRAW`.
    */
   constructor(type, opt_usage) {

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -105,7 +105,7 @@ export const AttributeType = {
 /**
  * @typedef {Object} UniformInternalDescription
  * @property {string} name Name
- * @property {UniformValue=} value Value
+ * @property {UniformValue} [value] Value
  * @property {WebGLTexture} [texture] Texture
  * @private
  */
@@ -238,7 +238,7 @@ export const AttributeType = {
  */
 class WebGLHelper extends Disposable {
   /**
-   * @param {Options=} opt_options Options.
+   * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -106,7 +106,7 @@ export function parse(xml) {
  * Make an array extender function for extending the array at the top of the
  * object stack.
  * @param {function(this: T, Node, Array<*>): (Array<*>|undefined)} valueReader Value reader.
- * @param {T=} opt_this The object to use as `this` in `valueReader`.
+ * @param {T} [opt_this] The object to use as `this` in `valueReader`.
  * @return {Parser} Parser.
  * @template T
  */
@@ -136,7 +136,7 @@ export function makeArrayExtender(valueReader, opt_this) {
  * Make an array pusher function for pushing to the array at the top of the
  * object stack.
  * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
- * @param {T=} opt_this The object to use as `this` in `valueReader`.
+ * @param {T} [opt_this] The object to use as `this` in `valueReader`.
  * @return {Parser} Parser.
  * @template T
  */
@@ -166,7 +166,7 @@ export function makeArrayPusher(valueReader, opt_this) {
  * Make an object stack replacer function for replacing the object at the
  * top of the stack.
  * @param {function(this: T, Node, Array<*>): *} valueReader Value reader.
- * @param {T=} opt_this The object to use as `this` in `valueReader`.
+ * @param {T} [opt_this] The object to use as `this` in `valueReader`.
  * @return {Parser} Parser.
  * @template T
  */
@@ -193,8 +193,8 @@ export function makeReplacer(valueReader, opt_this) {
  * Make an object property pusher function for adding a property to the
  * object at the top of the stack.
  * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
- * @param {string=} opt_property Property.
- * @param {T=} opt_this The object to use as `this` in `valueReader`.
+ * @param {string} [opt_property] Property.
+ * @param {T} [opt_this] The object to use as `this` in `valueReader`.
  * @return {Parser} Parser.
  * @template T
  */
@@ -232,8 +232,8 @@ export function makeObjectPropertyPusher(valueReader, opt_property, opt_this) {
 /**
  * Make an object property setter function.
  * @param {function(this: T, Element, Array<*>): *} valueReader Value reader.
- * @param {string=} opt_property Property.
- * @param {T=} opt_this The object to use as `this` in `valueReader`.
+ * @param {string} [opt_property] Property.
+ * @param {T} [opt_this] The object to use as `this` in `valueReader`.
  * @return {Parser} Parser.
  * @template T
  */
@@ -266,7 +266,7 @@ export function makeObjectPropertySetter(valueReader, opt_property, opt_this) {
  * designated parent. The parent is the `node` of the
  * {@link module:ol/xml~NodeStackItem} at the top of the `objectStack`.
  * @param {function(this: T, Node, V, Array<*>): void} nodeWriter Node writer.
- * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
+ * @param {T} [opt_this] The object to use as `this` in `nodeWriter`.
  * @return {Serializer} Serializer.
  * @template T, V
  */
@@ -294,7 +294,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
  * geometry writer, which could be reused for writing MultiLineString
  * geometries.
  * @param {function(this: T, Element, V, Array<*>): void} nodeWriter Node writer.
- * @param {T=} opt_this The object to use as `this` in `nodeWriter`.
+ * @param {T} [opt_this] The object to use as `this` in `nodeWriter`.
  * @return {Serializer} Serializer.
  * @template T, V
  */
@@ -317,10 +317,10 @@ export function makeArraySerializer(nodeWriter, opt_this) {
  * {@link module:ol/xml~serialize} or {@link module:ol/xml~pushSerializeAndPop} as node names,
  * or a fixed node name. The namespace of the created nodes can either be fixed,
  * or the parent namespace will be used.
- * @param {string=} opt_nodeName Fixed node name which will be used for all
+ * @param {string} [opt_nodeName] Fixed node name which will be used for all
  *     created nodes. If not provided, the 3rd argument to the resulting node
  *     factory needs to be provided and will be the nodeName.
- * @param {string=} opt_namespaceURI Fixed namespace URI which will be used for
+ * @param {string} [opt_namespaceURI] Fixed namespace URI which will be used for
  *     all created nodes. If not provided, the namespace of the parent node will
  *     be used.
  * @return {function(*, Array<*>, string=): (Node|undefined)} Node factory.
@@ -331,7 +331,7 @@ export function makeSimpleNodeFactory(opt_nodeName, opt_namespaceURI) {
     /**
      * @param {*} value Value.
      * @param {Array<*>} objectStack Object stack.
-     * @param {string=} opt_nodeName Node name.
+     * @param {string} [opt_nodeName] Node name.
      * @return {Node} Node.
      */
     function (value, objectStack, opt_nodeName) {
@@ -386,7 +386,7 @@ export function makeSequence(object, orderedKeys) {
  * values are version specific.
  * @param {Array<string>} namespaceURIs Namespace URIs.
  * @param {T} structure Structure.
- * @param {Object<string, T>=} opt_structureNS Namespaced structure to add to.
+ * @param {Object<string, T>} [opt_structureNS] Namespaced structure to add to.
  * @return {Object<string, T>} Namespaced structure.
  * @template T
  */
@@ -408,7 +408,7 @@ export function makeStructureNS(namespaceURIs, structure, opt_structureNS) {
  *     Parsers by namespace.
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @param {*=} opt_this The object to use as `this`.
+ * @param {*} [opt_this] The object to use as `this`.
  */
 export function parseNode(parsersNS, node, objectStack, opt_this) {
   let n;
@@ -430,7 +430,7 @@ export function parseNode(parsersNS, node, objectStack, opt_this) {
  *     Parsers by namespace.
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
- * @param {*=} opt_this The object to use as `this`.
+ * @param {*} [opt_this] The object to use as `this`.
  * @return {T} Object.
  * @template T
  */
@@ -459,12 +459,12 @@ export function pushParseAndPop(
  * @param {Array<*>} values Values to serialize. An example would be an array
  *     of {@link module:ol/Feature~Feature} instances.
  * @param {Array<*>} objectStack Node stack.
- * @param {Array<string>=} opt_keys Keys of the `values`. Will be passed to the
+ * @param {Array<string>} [opt_keys] Keys of the `values`. Will be passed to the
  *     `nodeFactory`. This is used for serializing object literals where the
  *     node name relates to the property key. The array length of `opt_keys` has
  *     to match the length of `values`. For serializing a sequence, `opt_keys`
  *     determines the order of the sequence.
- * @param {T=} opt_this The object to use as `this` for the node factory and
+ * @param {T} [opt_this] The object to use as `this` for the node factory and
  *     serializers.
  * @template T
  */
@@ -512,12 +512,12 @@ export function serialize(
  * @param {Array<*>} values Values to serialize. An example would be an array
  *     of {@link module:ol/Feature~Feature} instances.
  * @param {Array<*>} objectStack Node stack.
- * @param {Array<string>=} opt_keys Keys of the `values`. Will be passed to the
+ * @param {Array<string>} [opt_keys] Keys of the `values`. Will be passed to the
  *     `nodeFactory`. This is used for serializing object literals where the
  *     node name relates to the property key. The array length of `opt_keys` has
  *     to match the length of `values`. For serializing a sequence, `opt_keys`
  *     determines the order of the sequence.
- * @param {T=} opt_this The object to use as `this` for the node factory and
+ * @param {T} [opt_this] The object to use as `this` for the node factory and
  *     serializers.
  * @return {O|undefined} Object.
  * @template O, T

--- a/test/spec/ol/interaction/draw.test.js
+++ b/test/spec/ol/interaction/draw.test.js
@@ -75,8 +75,8 @@ describe('ol.interaction.Draw', function () {
    * @param {string} type Event type.
    * @param {number} x Horizontal offset from map center.
    * @param {number} y Vertical offset from map center.
-   * @param {boolean=} opt_shiftKey Shift key is pressed.
-   * @param {boolean=} opt_pointerId Pointer id.
+   * @param {boolean} [opt_shiftKey] Shift key is pressed.
+   * @param {boolean} [opt_pointerId] Pointer id.
    * @return {module:ol/MapBrowserEvent} The simulated event.
    */
   function simulateEvent(type, x, y, opt_shiftKey, opt_pointerId = 0) {

--- a/test/spec/ol/interaction/extent.test.js
+++ b/test/spec/ol/interaction/extent.test.js
@@ -41,7 +41,7 @@ describe('ol.interaction.Extent', function () {
    * @param {string} type Event type.
    * @param {number} x Horizontal offset from map center.
    * @param {number} y Vertical offset from map center.
-   * @param {boolean=} opt_shiftKey Shift key is pressed.
+   * @param {boolean} [opt_shiftKey] Shift key is pressed.
    * @param {number} button The mouse button.
    */
   function simulateEvent(type, x, y, opt_shiftKey, button) {

--- a/test/spec/ol/interaction/select.test.js
+++ b/test/spec/ol/interaction/select.test.js
@@ -92,7 +92,7 @@ describe('ol.interaction.Select', function () {
    * @param {string} type Event type.
    * @param {number} x Horizontal offset from map center.
    * @param {number} y Vertical offset from map center.
-   * @param {boolean=} opt_shiftKey Shift key is pressed.
+   * @param {boolean} [opt_shiftKey] Shift key is pressed.
    */
   function simulateEvent(type, x, y, opt_shiftKey) {
     const viewport = map.getViewport();

--- a/test/spec/ol/interaction/translate.test.js
+++ b/test/spec/ol/interaction/translate.test.js
@@ -62,7 +62,7 @@ describe('ol.interaction.Translate', function () {
    * @param {string} type Event type.
    * @param {number} x Horizontal offset from map center.
    * @param {number} y Vertical offset from map center.
-   * @param {boolean=} opt_shiftKey Shift key is pressed.
+   * @param {boolean} [opt_shiftKey] Shift key is pressed.
    */
   function simulateEvent(type, x, y, opt_shiftKey) {
     const viewport = map.getViewport();

--- a/test/spec/ol/renderer/canvas/builder.test.js
+++ b/test/spec/ol/renderer/canvas/builder.test.js
@@ -29,8 +29,8 @@ describe('ol.render.canvas.BuilderGroup', function () {
 
     /**
      * @param {BuilderGroup} builder The builder to get instructions from.
-     * @param {number=} pixelRatio The pixel ratio.
-     * @param {boolean=} overlaps Whether there is overlaps.
+     * @param {number} [pixelRatio] The pixel ratio.
+     * @param {boolean} [overlaps] Whether there is overlaps.
      */
     function execute(builder, pixelRatio, overlaps) {
       const executor = new ExecutorGroup(

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -63,8 +63,8 @@
 
   /**
    * Assert value is within some tolerance of a number.
-   * @param {Number} n Number.
-   * @param {Number} tol Tolerance.
+   * @param {number} n Number.
+   * @param {number} tol Tolerance.
    * @return {expect.Assertion} The assertion.
    */
   expect.Assertion.prototype.roughlyEqual = function (n, tol) {
@@ -455,7 +455,7 @@
    * @param {ol.PluggableMap} map A map using the canvas renderer.
    * @param {string} referenceImage Path to the reference image.
    * @param {number} tolerance The accepted mismatch tolerance.
-   * @param {function} done A callback to indicate that the test is done.
+   * @param {Function} done A callback to indicate that the test is done.
    */
   global.expectResemble = function (map, referenceImage, tolerance, done) {
     map.render();


### PR DESCRIPTION
With these commits the `check-types` and `check-syntax` rules of `eslint-plugin-jsdoc` pass.

The first commit contains some type changes and second commit only replaces the `{type=} name` syntax with `{type} [name]`.