### PR TITLE
Correct pixel ratio descriptions

### DIFF
--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -15,8 +15,8 @@ import {
  * A function returning the canvas element (`{HTMLCanvasElement}`)
  * used by the source as an image. The arguments passed to the function are:
  * {@link module:ol/extent~Extent} the image extent, `{number}` the image resolution,
- * `{number}` the device pixel ratio, {@link module:ol/size~Size} the image size, and
- * {@link module:ol/proj/Projection} the image projection. The canvas returned by
+ * `{number}` the pixel ratio of the map, {@link module:ol/size~Size} the image size,
+ * and {@link module:ol/proj/Projection} the image projection. The canvas returned by
  * this function is cached by the source. The this keyword inside the function
  * references the {@link module:ol/source/ImageCanvas}.
  *
@@ -30,8 +30,8 @@ import {
  * @property {FunctionType} [canvasFunction] Canvas function.
  * The function returning the canvas element used by the source
  * as an image. The arguments passed to the function are: `{import("../extent.js").Extent}` the
- * image extent, `{number}` the image resolution, `{number}` the device pixel
- * ratio, `{import("../size.js").Size}` the image size, and `{import("../proj/Projection.js").Projection}` the image
+ * image extent, `{number}` the image resolution, `{number}` the pixel ratio of the map,
+ * `{import("../size.js").Size}` the image size, and `{import("../proj/Projection.js").Projection}` the image
  * projection. The canvas returned by this function is cached by the source. If
  * the value returned by the function is later changed then
  * `changed` should be called on the source for the source to

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -323,7 +323,7 @@ class Icon extends ImageStyle {
   /**
    * Get the pixel ratio.
    * @param {number} pixelRatio Pixel ratio.
-   * @return {number} The pixel ration of the image.
+   * @return {number} The pixel ratio of the image.
    * @api
    */
   getPixelRatio(pixelRatio) {


### PR DESCRIPTION
Fixes #11983

Corrects the description which was causing confusion in #11983 and a typo in the description of pixel ratio for icons,
