### PR TITLE
Fix some typings in format and format/WKT

### DIFF
--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -67,15 +67,15 @@ class FeatureFormat {
   constructor() {
     /**
      * @protected
-     * @type {import("../proj/Projection.js").default}
+     * @type {import("../proj/Projection.js").default|undefined}
      */
-    this.dataProjection = null;
+    this.dataProjection = undefined;
 
     /**
      * @protected
-     * @type {import("../proj/Projection.js").default}
+     * @type {import("../proj/Projection.js").default|undefined}
      */
-    this.defaultFeatureProjection = null;
+    this.defaultFeatureProjection = undefined;
   }
 
   /**
@@ -175,7 +175,7 @@ class FeatureFormat {
    *
    * @abstract
    * @param {Document|Element|Object|string} source Source.
-   * @return {import("../proj/Projection.js").default} Projection.
+   * @return {import("../proj/Projection.js").default|undefined} Projection.
    */
   readProjection(source) {
     return abstract();

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -107,7 +107,7 @@ class TextFeature extends FeatureFormat {
    * Read the projection from the source.
    *
    * @param {Document|Element|Object|string} source Source.
-   * @return {import("../proj/Projection.js").default} Projection.
+   * @return {import("../proj/Projection.js").default|undefined} Projection.
    * @api
    */
   readProjection(source) {
@@ -117,7 +117,7 @@ class TextFeature extends FeatureFormat {
   /**
    * @param {string} text Text.
    * @protected
-   * @return {import("../proj/Projection.js").default} Projection.
+   * @return {import("../proj/Projection.js").default|undefined} Projection.
    */
   readProjectionFromText(text) {
     return this.dataProjection;

--- a/test/spec/ol/format/wkt.test.js
+++ b/test/spec/ol/format/wkt.test.js
@@ -9,7 +9,7 @@ describe('ol.format.WKT', function () {
   describe('#readProjectionFromText', function () {
     it('returns the default projection', function () {
       const projection = format.readProjectionFromText('POINT(1 2)');
-      expect(projection).to.be(null);
+      expect(projection).to.be(undefined);
     });
   });
 


### PR DESCRIPTION
I turned on `strictNullChecks` for the tsc to find issues in the openlayers code. I looked at the wkt format in particular and fixed some types here.

The `EMPTY` geometry handling was causing some problems because some functions would return `null`. I checked the OGC specifications and figured out that `EMPTY` can only occur immediately after a geometry type. This way I was able to move these checks out of the functions and into `parseGeometry_`.
