### PR TITLE
Improve measure example ux

### DIFF
--- a/examples/measure.css
+++ b/examples/measure.css
@@ -7,6 +7,8 @@
   opacity: 0.7;
   white-space: nowrap;
   font-size: 12px;
+  cursor: default;
+  user-select: none;
 }
 .ol-tooltip-measure {
   opacity: 1;

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -248,6 +248,8 @@ function createMeasureTooltip() {
     element: measureTooltipElement,
     offset: [0, -15],
     positioning: 'bottom-center',
+    stopEvent: false,
+    insertFirst: false,
   });
   map.addOverlay(measureTooltip);
 }


### PR DESCRIPTION
- Pass click events on measure tooltips through to the map
- Put the tooltip for  the currently drawn geometry on top
- Disable text selection in the tooltips so clicking to draw does not select