### PR TITLE
Update links to external resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to OpenLayers.  Please see the project'
 
 ## Asking Questions
 
-Please ask questions about using the library on [Stack Overflow using the tag 'openlayers'](http://stackoverflow.com/questions/tagged/openlayers).
+Please ask questions about using the library on [Stack Overflow using the tag 'openlayers'](https://stackoverflow.com/questions/tagged/openlayers).
 
 When you want to get involved and discuss new features or changes, please use [the mailing list](https://groups.google.com/forum/#!forum/openlayers-dev).
 
@@ -68,12 +68,12 @@ easily-understandable chunks.  Any individual commit should not add more than
 one new class or one new function.  Do not submit commits that change thousands
 of lines or that contain more than one distinct logical change.  Trivial
 commits, e.g. to fix lint errors, should be merged into the commit that
-introduced the error.  See the [Atomic Commit Convention on Wikipedia](http://en.wikipedia.org/wiki/Atomic_commit#Atomic_Commit_Convention) for more detail.
+introduced the error.  See the [Atomic Commit Convention on Wikipedia](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_Commit_Convention) for more detail.
 
 `git apply --patch` and `git rebase` can help you create a clean commit
 history.
-[Reviewboard.org](http://www.reviewboard.org/docs/codebase/dev/git/clean-commits/)
-and [Pro GIT](http://git-scm.com/book/en/Git-Tools-Rewriting-History) have
+[Reviewboard.org](https://www.reviewboard.org/docs/codebase/dev/git/clean-commits/)
+and [Pro GIT](https://git-scm.com/book/en/Git-Tools-Rewriting-History) have
 explain how to use them.
 
 
@@ -81,7 +81,7 @@ explain how to use them.
 
 Commit messages should be short, begin with a verb in the imperative, and
 contain no trailing punctuation. We follow
-http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 for the formatting of commit messages.
 
 Git commit message should look like:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -10,7 +10,7 @@ You will obviously start by
 The minimum requirements are:
 
 * Git
-* [Node.js](http://nodejs.org/) (version 8 and above)
+* [Node.js](https://nodejs.org/) (version 8 and above)
 
 The executables `git` and `node` should be in your `PATH`.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ TypeScript users may want to use a [third-party types package](https://github.co
 
 ## Supported Browsers
 
-OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/). This includes Chrome, Firefox, Safari and Edge.
+OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](https://262.ecma-international.org/5.1/). This includes Chrome, Firefox, Safari and Edge.
 
 For older browsers and platforms (Internet Explorer, Android 4.x, iOS v12 and older, Safari v12 and older), polyfills may be needed for the following browser features:
 
@@ -134,7 +134,7 @@ Please see our guide on [contributing](CONTRIBUTING.md) if you're interested in 
 
 ## Community
 
-- Need help? Find it on [Stack Overflow using the tag 'openlayers'](http://stackoverflow.com/questions/tagged/openlayers)
+- Need help? Find it on [Stack Overflow using the tag 'openlayers'](https://stackoverflow.com/questions/tagged/openlayers)
 - Follow [@openlayers](https://twitter.com/openlayers) on Twitter
 
 ![Test Status](https://github.com/openlayers/openlayers/workflows/Test/badge.svg)

--- a/config/jsdoc/api/plugins/markdown.js
+++ b/config/jsdoc/api/plugins/markdown.js
@@ -1,7 +1,7 @@
 /**
  * Modified from JSDoc's plugins/markdown and lib/jsdoc/util/markdown modules
  * (see https://github.com/jsdoc3/jsdoc/), which are licensed under the Apache 2
- * license (see http://www.apache.org/licenses/LICENSE-2.0).
+ * license (see https://www.apache.org/licenses/LICENSE-2.0).
  *
  * This version does not protect http(s) urls from being turned into links, and
  * works around an issue with `~` characters in module paths by escaping them.

--- a/config/jsdoc/api/readme.md
+++ b/config/jsdoc/api/readme.md
@@ -1,6 +1,6 @@
 # API Documentation
 
-This directory contains configuration (`conf.json`), static content (`index.md`), template (`template/`) and plugins (`plugins/`) for the [JSDoc3](http://usejsdoc.org/) API generator.
+This directory contains configuration (`conf.json`), static content (`index.md`), template (`template/`) and plugins (`plugins/`) for the [JSDoc3](https://jsdoc.app/) API generator.
 
 ## Documenting the source code
 

--- a/config/jsdoc/api/template/README.md
+++ b/config/jsdoc/api/template/README.md
@@ -1,3 +1,3 @@
 This template is based on the [Jaguar](https://github.com/davidshimjs/jaguarjs/tree/master/docs/templates/jaguar) template. [JaguarJS](https://github.com/davidshimjs/jaguarjs) is licensed under the [LGPL license](https://github.com/davidshimjs/jaguarjs/tree/master/LICENSE).
 
-The default template for JSDoc 3 uses: [the Taffy Database library](http://taffydb.com/) and the [Underscore Template library](http://documentcloud.github.com/underscore/#template).
+The default template for JSDoc 3 uses: [the Taffy Database library](https://taffydb.com/) and the [Underscore Template library](https://underscorejs.org/#template).

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -322,7 +322,7 @@ function buildNav(members) {
 }
 
 /**
- * @param {Object} taffyData See <http://taffydb.com/>.
+ * @param {Object} taffyData See {@link https://taffydb.com/}.
  * @param {Object} opts Options.
  * @param {Object} tutorials Tutorials.
  */

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -7,7 +7,7 @@ layout: doc.hbs
 
 Certain questions arise more often than others when users ask for help. This
 document tries to list some of the common questions that frequently get asked,
-e.g. on [Stack Overflow](http://stackoverflow.com/questions/tagged/openlayers).
+e.g. on [Stack Overflow](https://stackoverflow.com/questions/tagged/openlayers).
 
 If you think a question (and naturally its answer) should be added here, feel
 free to ping us or to send a pull request enhancing this document.
@@ -198,8 +198,8 @@ for English, `en`, as a mnemonic: East before North.
 So you want to center your map on a certain place on the earth and obviously you
 need to have its coordinates for this. Let's assume you want your map centered
 on Schladming, a beautiful place in Austria. Head over to the wikipedia
-page for [Schladming](http://en.wikipedia.org/wiki/Schladming). In the top-right
-corner there is a link to [GeoHack](http://tools.wmflabs.org/geohack/geohack.php?pagename=Schladming&params=47_23_39_N_13_41_21_E_type:city(4565)_region:AT-6),
+page for [Schladming](https://en.wikipedia.org/wiki/Schladming). In the top-right
+corner there is a link to [GeoHack](https://geohack.toolforge.org/geohack.php?pagename=Schladming&params=47_23_39_N_13_41_21_E_type:city(4565)_region:AT-6),
 which effectively tells you the coordinates are:
 
     WGS84:

--- a/doc/index.hbs
+++ b/doc/index.hbs
@@ -19,4 +19,4 @@ We have put together a document that lists [Frequently Asked Questions (FAQ)](fa
 
 # More questions?
 
-If you cannot find an answer in the documentation or the FAQ, you can search [Stack Overflow](http://stackoverflow.com/questions/tagged/openlayers). If you cannot find an answer there, ask a new question there, using the tag 'openlayers'.
+If you cannot find an answer in the documentation or the FAQ, you can search [Stack Overflow](https://stackoverflow.com/questions/tagged/openlayers). If you cannot find an answer there, ask a new question there, using the tag 'openlayers'.

--- a/doc/quickstart.hbs
+++ b/doc/quickstart.hbs
@@ -78,7 +78,7 @@ The first part is to include the JavaScript library. For the purpose of this tut
   <div id="map" class="map"></div>
 ```
 
-The map in the application is contained in a [`<div>` HTML element](http://en.wikipedia.org/wiki/Span_and_div). Through this `<div>` the map properties like width, height and border can be controlled through CSS. Here's the CSS element used to make the map 400 pixels high and as wide as the browser window.
+The map in the application is contained in a [`<div>` HTML element](https://en.wikipedia.org/wiki/Span_and_div). Through this `<div>` the map properties like width, height and border can be controlled through CSS. Here's the CSS element used to make the map 400 pixels high and as wide as the browser window.
 
 ```xml
   <style>

--- a/doc/tutorials/background.md
+++ b/doc/tutorials/background.md
@@ -19,7 +19,7 @@ OpenLayers is available as [`ol` npm package](https://npmjs.com/package/ol), whi
 
 By default, OpenLayers uses a performance optimized Canvas renderer.
 
-OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, [polyfills](http://polyfill.io), the application bundle needs to be transpiled (e.g. using [Babel](https://babeljs.io)) and bundled with polyfills for `fetch`, `requestAnimationFrame`, `Element.prototype.classList`, `URL`, `TextDecoder` and `Number.isInteger`.
+OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](https://262.ecma-international.org/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, [polyfills](https://polyfill.io/), the application bundle needs to be transpiled (e.g. using [Babel](https://babeljs.io/)) and bundled with polyfills for `fetch`, `requestAnimationFrame`, `Element.prototype.classList`, `URL`, `TextDecoder` and `Number.isInteger`.
 
 The library is intended for use on both desktop/laptop and mobile devices, and supports pointer and touch interactions.
 

--- a/doc/tutorials/raster-reprojection.md
+++ b/doc/tutorials/raster-reprojection.md
@@ -27,7 +27,7 @@ var map = new Map({
     new TileLayer({
       source: new TileWMS({
         projection: 'EPSG:4326', //HERE IS THE DATA SOURCE PROJECTION
-        url: 'http://demo.boundlessgeo.com/geoserver/wms',
+        url: 'https://ahocevar.com/geoserver/wms',
         params: {
           'LAYERS': 'ne:NE1_HR_LC_SR_W_DR'
         }

--- a/examples/animated-gif.html
+++ b/examples/animated-gif.html
@@ -4,7 +4,7 @@ title: Animated GIF
 shortdesc: Example of using an animated GIF as an icon.
 docs: >
   Example of using an animated GIF as an icon.
-  Animation is achieved using the <a href="http://themadcreator.github.io/gifler/" target="_blank">Gifler</a> library.
+  Animation is achieved using the <a href="https://themadcreator.github.io/gifler/" target="_blank">Gifler</a> library.
 tags: "animation, vector, style, icon, gif"
 resources:
   - https://unpkg.com/gifler@0.1.0/gifler.min.js

--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -7,7 +7,7 @@ docs: >
 tags: "bing, bing-maps"
 cloak:
   - key: ApTJzdkyN1DdFKkRAE6QIDtzihNaf6IWJsT-nQ_2eMoO4PN__0Tzhl2-WgJtXFSp
-    value: Your Bing Maps Key from http://www.bingmapsportal.com/ here
+    value: Your Bing Maps Key from https://www.bingmapsportal.com/ here
 ---
  <div id="map" class="map"></div>
  <select id="layer-select">

--- a/examples/flight-animation.html
+++ b/examples/flight-animation.html
@@ -7,8 +7,8 @@ docs: >
   animate flights. A great circle arc between two airports is calculated using
   <a href="https://github.com/springmeyer/arc.js">arc.js</a> and then the flight
   paths are animated with <b>postrender</b>. The flight data is provided by
-  <a href="http://openflights.org/data.html">OpenFlights</a> (a simplified data
-  set from the <a href="https://www.mapbox.com/mapbox.js/example/v1.0.0/animating-flight-paths/">
+  <a href="https://openflights.org/data.html">OpenFlights</a> (a simplified data
+  set from the <a href="https://docs.mapbox.com/mapbox.js/example/v1.0.0/animating-flight-paths/">
   Mapbox.js documentation</a> is used).
 tags: "animation, vector, feature, flights, arc"
 resources:

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -34,7 +34,7 @@ const flightsSource = new VectorSource({
   wrapX: false,
   attributions:
     'Flight data by ' +
-    '<a href="http://openflights.org/data.html">OpenFlights</a>,',
+    '<a href="https://openflights.org/data.html">OpenFlights</a>,',
   loader: function () {
     const url = 'data/openflights/flights.json';
     fetch(url)

--- a/examples/full-screen-drag-rotate-and-zoom.html
+++ b/examples/full-screen-drag-rotate-and-zoom.html
@@ -4,7 +4,7 @@ title: Full Screen Drag, Rotate, and Zoom
 shortdesc: Example of drag rotate and zoom control with full screen effect.
 docs: >
   <p>Hold down <code>Shift+Drag</code> to rotate and zoom.  Click the button in the top right corner to go full screen.  Then do the <code>Shift+Drag</code> thing again.</p>
-  <p>If there is no button on the map, your browser does not support the <a href="http://caniuse.com/#feat=fullscreen">Full Screen API</a>.</p>
+  <p>If there is no button on the map, your browser does not support the <a href="https://caniuse.com/fullscreen">Full Screen API</a>.</p>
 tags: "full-screen, drag, rotate, zoom, xyz, maptiler"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB

--- a/examples/full-screen-source.html
+++ b/examples/full-screen-source.html
@@ -4,7 +4,7 @@ title: Full Screen Control with extended source element
 shortdesc: Example of a full screen control with a source option definition.
 docs: >
   <p>Click the control in the top right corner to go full screen.  Click it again to exit full screen.</p>
-  <p>If there is no button on the map, your browser does not support the <a href="http://caniuse.com/#feat=fullscreen">Full Screen API</a>.</p>
+  <p>If there is no button on the map, your browser does not support the <a href="https://caniuse.com/fullscreen">Full Screen API</a>.</p>
 tags: "full-screen, source, fullScreenSource, osm, osm-maps"
 ---
 <div id="fullscreen" class="fullscreen">

--- a/examples/full-screen.html
+++ b/examples/full-screen.html
@@ -4,7 +4,7 @@ title: Full Screen Control
 shortdesc: Example of a full screen control.
 docs: >
   <p>Click the control in the top right corner to go full screen.  Click it again to exit full screen.</p>
-  <p>If there is no button on the map, your browser does not support the <a href="http://caniuse.com/#feat=fullscreen">Full Screen API</a>.</p>
+  <p>If there is no button on the map, your browser does not support the <a href="https://caniuse.com/fullscreen">Full Screen API</a>.</p>
 tags: "full-screen, xyz, maptiler"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB

--- a/examples/here-maps.js
+++ b/examples/here-maps.js
@@ -60,7 +60,7 @@ for (i = 0, ii = hereLayers.length; i < ii; ++i) {
           'Map Tiles &copy; ' +
           new Date().getFullYear() +
           ' ' +
-          '<a href="http://developer.here.com" target="_blank">HERE</a>',
+          '<a href="https://developer.here.com/" target="_blank">HERE</a>',
       }),
     })
   );

--- a/examples/igc.html
+++ b/examples/igc.html
@@ -7,7 +7,7 @@ docs: >
 tags: "complex-geometry, closest-feature, igc, opencyclemap"
 cloak:
   - key: 0e6fc415256d4fbb9b5166a718591d71
-    value: Your API key from http://www.thunderforest.com/docs/apikeys/ here
+    value: Your API key from https://www.thunderforest.com/docs/apikeys/ here
 
 ---
 <div id="map" class="map"></div>

--- a/examples/localized-openstreetmap.html
+++ b/examples/localized-openstreetmap.html
@@ -3,11 +3,11 @@ layout: example.html
 title: Localized OpenStreetMap
 shortdesc: Example of a localized OpenStreetMap map with a custom tile server and a custom attribution.
 docs: >
-  <p>The base layer is <a href="https://www.opencyclemap.org/">OpenCycleMap</a> with an overlay from <a href="http://www.openseamap.org/">OpenSeaMap</a>.
+  <p>The base layer is <a href="https://www.opencyclemap.org/">OpenCycleMap</a> with an overlay from <a href="https://www.openseamap.org/">OpenSeaMap</a>.
 tags: "localized-openstreetmap, openseamap, openstreetmap"
 cloak:
   - key: 0e6fc415256d4fbb9b5166a718591d71
-    value: Your API key from http://www.thunderforest.com/docs/apikeys/ here
+    value: Your API key from https://www.thunderforest.com/docs/apikeys/ here
 
 ---
 <div id="map" class="map"></div>

--- a/examples/localized-openstreetmap.js
+++ b/examples/localized-openstreetmap.js
@@ -18,7 +18,7 @@ const openCycleMapLayer = new TileLayer({
 const openSeaMapLayer = new TileLayer({
   source: new OSM({
     attributions: [
-      'All maps © <a href="http://www.openseamap.org/">OpenSeaMap</a>',
+      'All maps © <a href="https://www.openseamap.org/">OpenSeaMap</a>',
       ATTRIBUTION,
     ],
     opaque: false,

--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -4,8 +4,8 @@ title: Full-Screen Mobile
 shortdesc: Example of a full screen map.
 tags: "fullscreen, geolocation, mobile"
 cloak:
-  - key: ApTJzdkyN1DdFKkRAE6QIDtzihNaf6IWJsT-nQ_2eMoO4PN__0Tzhl2-WgJtXFSp 
-    value: Your Bing Maps Key from http://www.bingmapsportal.com/ here
+  - key: ApTJzdkyN1DdFKkRAE6QIDtzihNaf6IWJsT-nQ_2eMoO4PN__0Tzhl2-WgJtXFSp
+    value: Your Bing Maps Key from https://www.bingmapsportal.com/ here
 ---
 <!doctype html>
 <html lang="en">

--- a/examples/overlay.html
+++ b/examples/overlay.html
@@ -13,7 +13,7 @@ resources:
 <div id="map" class="map"></div>
 <div style="display: none;">
   <!-- Clickable label for Vienna -->
-  <a class="overlay" id="vienna" target="_blank" href="http://en.wikipedia.org/wiki/Vienna">Vienna</a>
+  <a class="overlay" id="vienna" target="_blank" href="https://en.wikipedia.org/wiki/Vienna">Vienna</a>
   <div id="marker" title="Marker"></div>
   <!-- Popup -->
   <div id="popup" title="Welcome to OpenLayers"></div>

--- a/examples/overviewmap-custom.html
+++ b/examples/overviewmap-custom.html
@@ -7,7 +7,7 @@ docs: >
 tags: "overview, overviewmap"
 cloak:
   - key: 0e6fc415256d4fbb9b5166a718591d71
-    value: Your API key from http://www.thunderforest.com/docs/apikeys/ here
+    value: Your API key from https://www.thunderforest.com/docs/apikeys/ here
 
 ---
 <div id="map" class="map"></div>

--- a/examples/permalink.html
+++ b/examples/permalink.html
@@ -6,7 +6,7 @@ docs: >
   In this example the <a href="https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history"
   target="_blank">HTML 5 History API</a> is used to update the browser URL
   with the current zoom-level, center and rotation when the map is moved.
-  Note that the History API is not supported in <a href="http://caniuse.com/#feat=history"
+  Note that the History API is not supported in <a href="https://caniuse.com/history"
   target="_blank">all browsers</a>, one might consider to use a <a
   href="https://github.com/Modernizr/Modernizr/wiki/HTML5-Cross-Browser-Polyfills#html5-history-api-pushstate-replacestate-popstate"
   target="_blank">a polyfill</a>.

--- a/examples/preload.html
+++ b/examples/preload.html
@@ -7,7 +7,7 @@ docs: >
 tags: "preload, bing"
 cloak:
   - key: ApTJzdkyN1DdFKkRAE6QIDtzihNaf6IWJsT-nQ_2eMoO4PN__0Tzhl2-WgJtXFSp
-    value: Your Bing Maps Key from http://www.bingmapsportal.com/ here
+    value: Your Bing Maps Key from https://www.bingmapsportal.com/ here
 ---
 <div id="map1" class="map"></div>
 <div id="map2" class="map"></div>

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -13,7 +13,7 @@ docs: >
   <p>
     In this case, a single tiled source of imagery is used as input.
     For each pixel, the Vegetation Greenness Index
-    (<a href="http://www.tandfonline.com/doi/abs/10.1080/10106040108542184#.Vb90ITBViko">VGI</a>)
+    (<a href="https://www.tandfonline.com/doi/abs/10.1080/10106040108542184#.Vb90ITBViko">VGI</a>)
     is calculated from the input pixels.  A second operation colors
     those pixels based on a threshold value (values above the
     threshold are green and those below are transparent).

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,6 +1,6 @@
 # Code examples
 
-The `.html` files in this folder are built by applying the templates in the `templates` folder. Examples have [YAML front-matter](http://www.metalsmith.io) headers with the following properties:
+The `.html` files in this folder are built by applying the templates in the `templates` folder. Examples have [YAML front-matter](https://metalsmith.io/) headers with the following properties:
 
 * layout: The template from the `templates` directory to use for this example
 * title: The title of the example

--- a/examples/resources/mapbox-streets-v6-style.js
+++ b/examples/resources/mapbox-streets-v6-style.js
@@ -1,5 +1,5 @@
 // Styles for the mapbox-streets-v6 vector tile data set. Loosely based on
-// http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6.json
+// https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v6/
 
 function createMapboxStreetsV6Style(Style, Fill, Stroke, Icon, Text) {
   var fill = new Fill({color: ''});

--- a/examples/static-image.html
+++ b/examples/static-image.html
@@ -4,7 +4,7 @@ title: Static Image
 shortdesc: Example of a static image layer.
 docs: >
   <p>
-    This example uses a <a href="http://xkcd.com/256/">static image</a>
+    This example uses a <a href="https://xkcd.com/256/">static image</a>
     as a layer source.  The map view is configured with a custom
     projection that translates image coordinates directly into map
     coordinates.

--- a/examples/static-image.js
+++ b/examples/static-image.js
@@ -19,7 +19,7 @@ const map = new Map({
   layers: [
     new ImageLayer({
       source: new Static({
-        attributions: '© <a href="http://xkcd.com/license.html">xkcd</a>',
+        attributions: '© <a href="https://xkcd.com/license.html">xkcd</a>',
         url: 'https://imgs.xkcd.com/comics/online_communities.png',
         projection: projection,
         imageExtent: extent,

--- a/examples/tissot.html
+++ b/examples/tissot.html
@@ -3,7 +3,7 @@ layout: example.html
 title: Tissot Indicatrix
 shortdesc: Draw Tissot's indicatrices on maps.
 docs: >
-  Example of [Tissot indicatrix](http://en.wikipedia.org/wiki/Tissot's_indicatrix) maps. The map on the top is an `EPSG:4326` map. The one on the bottom is `EPSG:3857`.
+  Example of [Tissot indicatrix](https://en.wikipedia.org/wiki/Tissot's_indicatrix) maps. The map on the top is an `EPSG:4326` map. The one on the bottom is `EPSG:3857`.
 tags: "tissot, circle"
 ---
 <h4>EPSG:4326</h4>

--- a/examples/turf.html
+++ b/examples/turf.html
@@ -3,7 +3,7 @@ layout: example.html
 title: turf.js
 shortdesc: Example on how to use turf.js with OpenLayers.
 docs: >
-  Example showing the integration of <a href="http://turfjs.org">turf.js</a>
+  Example showing the integration of <a href="https://turfjs.org/">turf.js</a>
   with OpenLayers. The turf.js function <code>along</code> is used to
   display a marker every 200 meters along a street.
 tags: "vector, turfjs, along, distance"

--- a/examples/utfgrid.html
+++ b/examples/utfgrid.html
@@ -4,7 +4,7 @@ title: UTFGrid
 shortdesc: This example shows how to read data from a UTFGrid source.
 docs: >
   <p>Point to a country to see its name and flag.</p>
-  Tiles made with <a href="http://tilemill.com">TileMill</a>. Hosting on <a href="mapbox.com">mapbox.com</a> or with open-source <a href="https://github.com/klokantech/tileserver-php/">TileServer</a>.
+  Tiles made with <a href="https://tilemill-project.github.io/tilemill/">TileMill</a>. Hosting on <a href="https://www.mapbox.com/">mapbox.com</a> or with open-source <a href="https://github.com/maptiler/tileserver-php">TileServer</a>.
 tags: "utfgrid, tilejson"
 cloak:
   - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2pzbmg0Nmk5MGF5NzQzbzRnbDNoeHJrbiJ9.7_-_gL8ur7ZtEiNwRfCy7Q

--- a/examples/vector-labels.js
+++ b/examples/vector-labels.js
@@ -234,7 +234,7 @@ String.prototype.trunc =
     return this.length > n ? this.substr(0, n - 1) + '...' : this.substr(0);
   };
 
-// http://stackoverflow.com/questions/14484787/wrap-text-in-javascript
+// https://stackoverflow.com/questions/14484787/wrap-text-in-javascript
 function stringDivider(str, width, spaceReplacer) {
   if (str.length > width) {
     let p = width;

--- a/examples/vector-osm.html
+++ b/examples/vector-osm.html
@@ -3,7 +3,7 @@ layout: example.html
 title: OSM XML
 shortdesc: Example of using the OSM XML source.
 docs: >
- OSM XML vector data is loaded dynamically from a the [Overpass API](http://overpass-api.de) using a bbox strategy. Note that panning and zooming will eventually lead to "Too many requests" errors from the Overpass API.
+ OSM XML vector data is loaded dynamically from a the [Overpass API](https://overpass-api.de/) using a bbox strategy. Note that panning and zooming will eventually lead to "Too many requests" errors from the Overpass API.
 tags: "vector, osmxml, loading, server, strategy, bbox, maptiler"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -94,7 +94,7 @@ const map = new Map({
 
 /*
  * Swiss projection transform functions downloaded from
- * http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/software/products/skripts.html
+ * https://www.swisstopo.admin.ch/en/knowledge-facts/surveying-geodesy/reference-systems/map-projections.html
  */
 
 // Convert WGS lat/long (° dec) to CH y
@@ -107,7 +107,7 @@ function WGStoCHy(lat, lng) {
   lat = DEGtoSEC(lat);
   lng = DEGtoSEC(lng);
 
-  // Axiliary values (% Bern)
+  // Axillary values (% Bern)
   const lat_aux = (lat - 169028.66) / 10000;
   const lng_aux = (lng - 26782.5) / 10000;
 
@@ -132,7 +132,7 @@ function WGStoCHx(lat, lng) {
   lat = DEGtoSEC(lat);
   lng = DEGtoSEC(lng);
 
-  // Axiliary values (% Bern)
+  // Axillary values (% Bern)
   const lat_aux = (lat - 169028.66) / 10000;
   const lng_aux = (lng - 26782.5) / 10000;
 
@@ -150,8 +150,8 @@ function WGStoCHx(lat, lng) {
 
 // Convert CH y/x to WGS lat
 function CHtoWGSlat(y, x) {
-  // Converts militar to civil and  to unit = 1000km
-  // Axiliary values (% Bern)
+  // Converts military to civil and to unit = 1000km
+  // Axillary values (% Bern)
   const y_aux = (y - 600000) / 1000000;
   const x_aux = (x - 200000) / 1000000;
 
@@ -172,8 +172,8 @@ function CHtoWGSlat(y, x) {
 
 // Convert CH y/x to WGS long
 function CHtoWGSlng(y, x) {
-  // Converts militar to civil and  to unit = 1000km
-  // Axiliary values (% Bern)
+  // Converts military to civil and to unit = 1000km
+  // Axillary values (% Bern)
   const y_aux = (y - 600000) / 1000000;
   const x_aux = (x - 200000) / 1000000;
 

--- a/examples/wmts-dimensions.html
+++ b/examples/wmts-dimensions.html
@@ -3,7 +3,7 @@ layout: example.html
 title: WMTS Tile Transitions
 shortdesc: Example of smooth tile transitions when changing the dimension of a WMTS layer.
 docs: >
-  Demonstrates smooth reloading of layers when changing a dimension continuously. The demonstration layer is a global sea-level computation (flooding computation from <a href="http://scalgo.com">SCALGO</a>, underlying data from <a href="https://cgiarcsi.community/data/srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>) where cells that are flooded if the sea-level rises to more than <em>x</em> m are colored blue. The user selects the sea-level dimension using a slider.
+  Demonstrates smooth reloading of layers when changing a dimension continuously. The demonstration layer is a global sea-level computation (flooding computation from <a href="https://scalgo.com/">SCALGO</a>, underlying data from <a href="https://cgiarcsi.community/data/srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>) where cells that are flooded if the sea-level rises to more than <em>x</em> m are colored blue. The user selects the sea-level dimension using a slider.
 tags: "wmts, parameter, transition"
 ---
 <div id="map" class="map"></div>

--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -42,7 +42,7 @@ const ign_source = new WMTS({
   tileGrid: tileGrid,
   style: 'normal',
   attributions:
-    '<a href="http://www.ign.fr" target="_blank">' +
+    '<a href="https://www.ign.fr/" target="_blank">' +
     '<img src="https://wxs.ign.fr/static/logos/IGN/IGN.gif" title="Institut national de l\'' +
     'information géographique et forestière" alt="IGN"></a>',
 });

--- a/examples/xyz.html
+++ b/examples/xyz.html
@@ -7,7 +7,7 @@ docs: >
 tags: "xyz"
 cloak:
   - key: 0e6fc415256d4fbb9b5166a718591d71
-    value: Your API key from http://www.thunderforest.com/docs/apikeys/ here
+    value: Your API key from https://www.thunderforest.com/docs/apikeys/ here
 
 ---
 <div id="map" class="map"></div>

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -56,7 +56,7 @@ class GeolocationError extends BaseEvent {
  * @property {boolean} [tracking=false] Start Tracking right after
  * instantiation.
  * @property {PositionOptions} [trackingOptions] Tracking options.
- * See http://www.w3.org/TR/geolocation-API/#position_options_interface.
+ * See https://www.w3.org/TR/geolocation-API/#position_options_interface.
  * @property {import("./proj.js").ProjectionLike} [projection] The projection the position
  * is reported in.
  */
@@ -64,7 +64,7 @@ class GeolocationError extends BaseEvent {
 /**
  * @classdesc
  * Helper class for providing HTML5 Geolocation capabilities.
- * The [Geolocation API](http://www.w3.org/TR/geolocation-API/)
+ * The [Geolocation API](https://www.w3.org/TR/geolocation-API/)
  * is used to locate a user's position.
  *
  * To get notified of position changes, register a listener for the generic
@@ -324,10 +324,10 @@ class Geolocation extends BaseObject {
 
   /**
    * Get the tracking options.
-   * See http://www.w3.org/TR/geolocation-API/#position-options.
+   * See https://www.w3.org/TR/geolocation-API/#position-options.
    * @return {PositionOptions|undefined} PositionOptions as defined by
    *     the [HTML5 Geolocation spec
-   *     ](http://www.w3.org/TR/geolocation-API/#position_options_interface).
+   *     ](https://www.w3.org/TR/geolocation-API/#position_options_interface).
    * @observable
    * @api
    */

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -61,7 +61,7 @@ const FullScreenEventType = {
  * element introduced using this parameter will be displayed in full screen.
  *
  * When in full screen mode, a close button is shown to exit full screen mode.
- * The [Fullscreen API](http://www.w3.org/TR/fullscreen/) is used to
+ * The [Fullscreen API](https://www.w3.org/TR/fullscreen/) is used to
  * toggle the map in full screen mode.
  *
  * @fires FullScreenEventType#enterfullscreen

--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -63,7 +63,7 @@ export const CLASS_CONTROL = 'ol-control';
 export const CLASS_COLLAPSED = 'ol-collapsed';
 
 /**
- * From http://stackoverflow.com/questions/10135697/regex-to-parse-any-css-font
+ * From https://stackoverflow.com/questions/10135697/regex-to-parse-any-css-font
  * @type {RegExp}
  */
 const fontRegEx = new RegExp(

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -248,7 +248,7 @@ export const mouseOnly = function (mapBrowserEvent) {
   const pointerEvent = /** @type {import("../MapBrowserEvent").default} */ (mapBrowserEvent)
     .originalEvent;
   assert(pointerEvent !== undefined, 56); // mapBrowserEvent must originate from a pointer event
-  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
   return pointerEvent.pointerType == 'mouse';
 };
 
@@ -263,7 +263,7 @@ export const touchOnly = function (mapBrowserEvent) {
   const pointerEvt = /** @type {import("../MapBrowserEvent").default} */ (mapBrowserEvent)
     .originalEvent;
   assert(pointerEvt !== undefined, 56); // mapBrowserEvent must originate from a pointer event
-  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
   return pointerEvt.pointerType === 'touch';
 };
 
@@ -278,14 +278,14 @@ export const penOnly = function (mapBrowserEvent) {
   const pointerEvt = /** @type {import("../MapBrowserEvent").default} */ (mapBrowserEvent)
     .originalEvent;
   assert(pointerEvt !== undefined, 56); // mapBrowserEvent must originate from a pointer event
-  // see http://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
+  // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
   return pointerEvt.pointerType === 'pen';
 };
 
 /**
  * Return `true` if the event originates from a primary pointer in
  * contact with the surface or if the left mouse button is pressed.
- * See http://www.w3.org/TR/pointerevents/#button-states.
+ * See https://www.w3.org/TR/pointerevents/#button-states.
  *
  * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
  * @return {boolean} True if the event originates from a primary pointer.

--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -43,7 +43,7 @@ const PARSERS = makeStructureNS(NAMESPACE_URIS, {
 /**
  * @classdesc
  * Feature format for reading data in the
- * [OSMXML format](http://wiki.openstreetmap.org/wiki/OSM_XML).
+ * [OSMXML format](https://wiki.openstreetmap.org/wiki/OSM_XML).
  *
  * @api
  */

--- a/src/ol/format/readme.md
+++ b/src/ol/format/readme.md
@@ -124,7 +124,7 @@ In the above there are many common operations, like setting the property of the 
 
 ### Putting it all together
 
-With the above, you should be able to read through the [source code to `ol/format/GPX`](https://github.com/openlayers/openlayers/blob/main/src/ol/format/gpxformat.js) and get a feel for how it works. Start from the bottom of the file and work upwards. It's also useful to have [an example GPX file](http://www.topografix.com/fells_loop.gpx) and [the GPX specification](http://www.topografix.com/GPX/1/1/) to hand.
+With the above, you should be able to read through the [source code to `ol/format/GPX`](https://github.com/openlayers/openlayers/blob/main/src/ol/format/gpxformat.js) and get a feel for how it works. Start from the bottom of the file and work upwards. It's also useful to have [an example GPX file](https://openlayers.org/en/latest/examples/data/fells_loop.gpx) and [the GPX specification](https://www.topografix.com/GPX/1/1/) to hand.
 
 ### Handling errors
 

--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -55,7 +55,7 @@ export function linearRingContainsXY(
   x,
   y
 ) {
-  // http://geomalgorithms.com/a03-_inclusion.html
+  // https://geomalgorithms.com/a03-_inclusion.html
   // Copyright 2000 softSurfer, 2012 Dan Sunday
   // This code may be freely used and modified for any purpose
   // providing that this copyright notice is included with it.

--- a/src/ol/geom/flat/orient.js
+++ b/src/ol/geom/flat/orient.js
@@ -14,8 +14,8 @@ import {coordinates as reverseCoordinates} from './reverse.js';
  * @return {boolean} Is clockwise.
  */
 export function linearRingIsClockwise(flatCoordinates, offset, end, stride) {
-  // http://tinyurl.com/clockwise-method
-  // https://github.com/OSGeo/gdal/blob/trunk/gdal/ogr/ogrlinearring.cpp
+  // https://stackoverflow.com/q/1165647/clockwise-method#1165943
+  // https://github.com/OSGeo/gdal/blob/master/gdal/ogr/ogrlinearring.cpp
   let edge = 0;
   let x1 = flatCoordinates[end - stride];
   let y1 = flatCoordinates[end - stride + 1];

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -51,7 +51,7 @@ const TOS_ATTRIBUTION =
  * @property {number} [cacheSize] Initial tile cache size. Will auto-grow to hold at least the number of tiles in the viewport.
  * @property {boolean} [hidpi=false] If `true` hidpi tiles will be requested.
  * @property {string} [culture='en-us'] Culture code.
- * @property {string} key Bing Maps API key. Get yours at http://www.bingmapsportal.com/.
+ * @property {string} key Bing Maps API key. Get yours at https://www.bingmapsportal.com/.
  * @property {string} imagerySet Type of imagery.
  * @property {boolean} [imageSmoothing=true] Enable image smoothing.
  * @property {number} [maxZoom=21] Max zoom. Default is what's advertized by the BingMaps service.

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -25,7 +25,7 @@ import {containsExtent, getHeight, getWidth} from '../extent.js';
  * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
  * `IMAGE` by default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`, and `IMAGESR`
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
- * {@link http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/}
+ * {@link https://developers.arcgis.com/rest/services-reference/export-map.htm}
  * for further reference.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -23,7 +23,7 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  * default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`,
  * and `IMAGESR` will be set dynamically. Set `LAYERS` to
  * override the default service layer visibility. See
- * http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/
+ * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
  * the image from the remote server.

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -37,7 +37,7 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  * ignored. If you control the WMS service it is recommended to address
  * "artifacts at tile edges" issues by properly configuring the WMS service. For
  * example, MapServer has a `tile_map_edge_buffer` configuration parameter for
- * this. See http://mapserver.org/output/tile_mode.html.
+ * this. See https://mapserver.org/output/tile_mode.html.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
  * the image from the remote server.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.

--- a/src/ol/structs/PriorityQueue.js
+++ b/src/ol/structs/PriorityQueue.js
@@ -16,8 +16,8 @@ export const DROP = Infinity;
  * The implementation is inspired from the Closure Library's Heap class and
  * Python's heapq module.
  *
- * See http://closure-library.googlecode.com/svn/docs/closure_goog_structs_heap.js.source.html
- * and http://hg.python.org/cpython/file/2.7/Lib/heapq.py.
+ * See https://github.com/google/closure-library/blob/master/closure/goog/structs/heap.js
+ * and https://hg.python.org/cpython/file/2.7/Lib/heapq.py.
  *
  * @template T
  */

--- a/test/README.md
+++ b/test/README.md
@@ -22,7 +22,7 @@ This will run tests in Chrome.  If you do not have Chrome installed, you can run
 
     npm test -- --browsers Firefox
 
-To run tests in other browsers, you need to install [additional Karma launchers](http://karma-runner.github.io/1.0/config/browsers.html).
+To run tests in other browsers, you need to install [additional Karma launchers](https://karma-runner.github.io/1.0/config/browsers.html).
 
 To run the tests continuously:
 

--- a/test/spec/ol/proj.test.js
+++ b/test/spec/ol/proj.test.js
@@ -273,7 +273,7 @@ describe('ol.proj', function () {
   });
 
   describe('transform from 4326 to 3857 (Alastaira)', function () {
-    // http://alastaira.wordpress.com/2011/01/23/the-google-maps-bing-maps-spherical-mercator-projection/
+    // https://alastaira.wordpress.com/2011/01/23/the-google-maps-bing-maps-spherical-mercator-projection/
 
     it('returns expected value using ol.proj.transform', function () {
       const point = transform(
@@ -297,7 +297,7 @@ describe('ol.proj', function () {
   });
 
   describe('transform from 3857 to 4326 (Alastaira)', function () {
-    // http://alastaira.wordpress.com/2011/01/23/the-google-maps-bing-maps-spherical-mercator-projection/
+    // https://alastaira.wordpress.com/2011/01/23/the-google-maps-bing-maps-spherical-mercator-projection/
 
     it('returns expected value using ol.proj.transform', function () {
       const point = transform(

--- a/test/spec/ol/proj/epsg3857.test.js
+++ b/test/spec/ol/proj/epsg3857.test.js
@@ -57,7 +57,7 @@ describe('ol/proj/epsg3857', function () {
 
   describe('getPointResolution', function () {
     it('returns the correct point scale at the equator', function () {
-      // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
+      // @see https://docs.microsoft.com/en-us/bingmaps/articles/understanding-scale-and-resolution
       const epsg3857 = getProjection('EPSG:3857');
       const resolution = 19.11;
       const point = [0, 0];
@@ -68,7 +68,7 @@ describe('ol/proj/epsg3857', function () {
     });
 
     it('returns the correct point scale at the latitude of Toronto', function () {
-      // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
+      // @see https://docs.microsoft.com/en-us/bingmaps/articles/understanding-scale-and-resolution
       const epsg3857 = getProjection('EPSG:3857');
       const epsg4326 = getProjection('EPSG:4326');
       const resolution = 19.11;
@@ -80,7 +80,7 @@ describe('ol/proj/epsg3857', function () {
     });
 
     it('returns the correct point scale at various latitudes', function () {
-      // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
+      // @see https://docs.microsoft.com/en-us/bingmaps/articles/understanding-scale-and-resolution
       const epsg3857 = getProjection('EPSG:3857');
       const epsg4326 = getProjection('EPSG:4326');
       const resolution = 19.11;

--- a/test/spec/ol/structs/rbush.test.js
+++ b/test/spec/ol/structs/rbush.test.js
@@ -160,7 +160,7 @@ describe('ol.structs.RBush', function () {
 
       it('can remove objects in random order', function () {
         let i, ii, j;
-        // http://en.wikipedia.org/wiki/Random_permutation
+        // https://en.wikipedia.org/wiki/Random_permutation
         const indexes = [];
         for (i = 0, ii = objs.length; i < ii; ++i) {
           j = Math.floor(Math.random() * (i + 1));

--- a/test/spec/ol/tilegrid/tilegrid.test.js
+++ b/test/spec/ol/tilegrid/tilegrid.test.js
@@ -674,7 +674,7 @@ describe('ol.tilegrid.TileGrid', function () {
     });
 
     it('returns the correct resolution at the equator', function () {
-      // @see http://msdn.microsoft.com/en-us/library/aa940990.aspx
+      // @see https://docs.microsoft.com/en-us/bingmaps/articles/understanding-scale-and-resolution
       expect(tileGrid.getResolution(0)).to.roughlyEqual(156543.04, 1e-2);
       expect(tileGrid.getResolution(1)).to.roughlyEqual(78271.52, 1e-2);
       expect(tileGrid.getResolution(2)).to.roughlyEqual(39135.76, 1e-2);

--- a/test/test-extensions.js
+++ b/test/test-extensions.js
@@ -260,7 +260,7 @@
         // we do not care about the difference between an empty string and
         // null for namespaceURI some tests will fail in IE9 otherwise
         // see also
-        // http://msdn.microsoft.com/en-us/library/ff460650(v=vs.85).aspx
+        // https://docs.microsoft.com/en-us/openspecs/ie_standards/ms-dom2c/d6ad7f24-25f4-4ab0-a36b-32ddc08f413c
         if (
           (node1Attr[name].namespaceURI || null) !==
           (node2Attr[name].namespaceURI || null)


### PR DESCRIPTION
Most links are simply changed to https but some of them have a different url.

The links below no longer work and I couldn't find a new version:
- ~http://demo.boundlessgeo.com/geoserver/wms~
- ~http://tilemill.com~
- http://www.swisstopo.admin.ch/internet/swisstopo/en/home/products/software/products/skripts.html
- ~http://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6.json~
- ~https://www.openplans.org/topp~
- ~https://www.topografix.com/fells_loop.gpx~
- ~http://mapserver.org~
- ~http://my.zoomify.info/~