### PR TITLE
allow customized url for bing maps

### DIFF
--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -162,13 +162,14 @@ class BingMaps extends TileImage {
      */
     this.imagerySet_ = options.imagerySet;
 
-    const url = options.url ? options.url : 
-      ('https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
-      this.imagerySet_ +
-      '?uriScheme=https&include=ImageryProviders&key=' +
-      this.apiKey_ +
-      '&c=' +
-      this.culture_);
+    const url = options.url
+      ? options.url
+      : "https://dev.virtualearth.net/REST/v1/Imagery/Metadata/" +
+        this.imagerySet_ +
+        "?uriScheme=https&include=ImageryProviders&key=" +
+        this.apiKey_ +
+        "&c=" +
+        this.culture_;
 
     requestJSONP(
       url,

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -66,6 +66,7 @@ const TOS_ATTRIBUTION =
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
+ * @property {string} url customized url for bing map to avoid key pass around
  */
 
 /**
@@ -161,13 +162,13 @@ class BingMaps extends TileImage {
      */
     this.imagerySet_ = options.imagerySet;
 
-    const url =
-      'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
+    const url = options.url ? options.url : 
+      ('https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
       this.imagerySet_ +
       '?uriScheme=https&include=ImageryProviders&key=' +
       this.apiKey_ +
       '&c=' +
-      this.culture_;
+      this.culture_);
 
     requestJSONP(
       url,

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -164,11 +164,11 @@ class BingMaps extends TileImage {
 
     const url = options.url
       ? options.url
-      : "https://dev.virtualearth.net/REST/v1/Imagery/Metadata/" +
+      : 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
         this.imagerySet_ +
-        "?uriScheme=https&include=ImageryProviders&key=" +
+        '?uriScheme=https&include=ImageryProviders&key=' +
         this.apiKey_ +
-        "&c=" +
+        '&c=' +
         this.culture_;
 
     requestJSONP(


### PR DESCRIPTION
hi, we need to have an option to change the target URL for bing map in case we want to protect the key behind User Authentication (in case we don't want to set the api secret directly in code, when openlayer send request, we want the request send to a proxy, then the proxy will set the api key), currently there is no way to change the bing map url.