### PR TITLE
Always use same order for renderedTiles

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -415,8 +415,10 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         );
         if (clips && !inTransition) {
           context.restore();
+          this.renderedTiles.unshift(tile);
+        } else {
+          this.renderedTiles.push(tile);
         }
-        this.renderedTiles.push(tile);
         this.updateUsedTiles(frameState.usedTiles, tileSource, tile);
       }
     }


### PR DESCRIPTION
Depending on whether a tile layer uses redraw and tile transitions or clipping higher resolution tiles out of lower resolution tiles, the order of `renderedTiles` is different. This breaks clipping higher resolution tiles out of lower resolution tiles for vector tiles when vector render mode is used, which results in flickering and overlapping geometries from different zoom levels. This can be seen in the `vector-tile-selection` example:

![Feb-10-2021 21-32-01](https://user-images.githubusercontent.com/211514/107568585-805b0c00-6be7-11eb-8a94-2e6b3c545248.gif)

With this pull request, clipping works correctly: https://deploy-preview-12019--ol-site.netlify.app/examples/vector-tile-selection.html
