### PR TITLE
Fix WebGL buffer deletion

### DIFF
--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -410,8 +410,8 @@ class WebGLHelper extends Disposable {
     const gl = this.getGL();
     const bufferKey = getUid(buf);
     const bufferCacheEntry = this.bufferCache_[bufferKey];
-    if (!gl.isContextLost()) {
-      gl.deleteBuffer(bufferCacheEntry.buffer);
+    if (bufferCacheEntry && !gl.isContextLost()) {
+      gl.deleteBuffer(bufferCacheEntry.webGlBuffer);
     }
     delete this.bufferCache_[bufferKey];
   }

--- a/test/spec/ol/webgl/helper.test.js
+++ b/test/spec/ol/webgl/helper.test.js
@@ -1,11 +1,13 @@
+import WebGLArrayBuffer from '../../../../src/ol/webgl/Buffer.js';
 import WebGLHelper, {DefaultUniform} from '../../../../src/ol/webgl/Helper.js';
-import {FLOAT} from '../../../../src/ol/webgl.js';
+import {ARRAY_BUFFER, FLOAT, STATIC_DRAW} from '../../../../src/ol/webgl.js';
 import {
   create as createTransform,
   rotate as rotateTransform,
   scale as scaleTransform,
   translate as translateTransform,
 } from '../../../../src/ol/transform.js';
+import {getUid} from '../../../../src/ol/util.js';
 
 const VERTEX_SHADER = `
   precision mediump float;
@@ -237,6 +239,20 @@ describe('ol/webgl/WebGLHelper', function () {
         expect(given.map((val) => val.toFixed(15))).to.eql(
           expected.map((val) => val.toFixed(15))
         );
+      });
+    });
+
+    describe('deleteBuffer()', function () {
+      it('can be called to free up buffer resources', function () {
+        const helper = new WebGLHelper();
+        const buffer = new WebGLArrayBuffer(ARRAY_BUFFER, STATIC_DRAW);
+        buffer.fromArray([0, 1, 2, 3]);
+        helper.flushBufferData(buffer);
+        const bufferKey = getUid(buffer);
+        expect(helper.bufferCache_).to.have.property(bufferKey);
+
+        helper.deleteBuffer(buffer);
+        expect(helper.bufferCache_).to.not.have.property(bufferKey);
       });
     });
 


### PR DESCRIPTION
The WebGL helper's `deleteBuffer()` method would previously throw since it was trying to call `gl.deleteBuffer()` with an object that is not a [`WebGLBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLBuffer).

This was part of #12008.  I'm pulling out small changes to make review easier.
