### PR TITLE
Allow source projection to be set after construction

### DIFF
--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -51,10 +51,10 @@ class Source extends BaseObject {
     super();
 
     /**
-     * @private
+     * @protected
      * @type {import("../proj/Projection.js").default}
      */
-    this.projection_ = getProjection(options.projection);
+    this.projection = getProjection(options.projection);
 
     /**
      * @private
@@ -113,7 +113,7 @@ class Source extends BaseObject {
    * @api
    */
   getProjection() {
-    return this.projection_;
+    return this.projection;
   }
 
   /**


### PR DESCRIPTION
It is useful to be able to create a source that is not immediately "ready" after construction.  The TileJSON source is an example that configures itself asynchronously before setting its state to ready.  In the case of the TileJSON source, the tile grid, tile URL function, attributions, and other properties are not known at construction.

This change adds the source projection to the list of things that can be set after construction.  I added a `setProjection` method to provide the convenience of being able to pass a projection id instead of a `Projection` instance.  But we could also rename the `projection_` property to `projection` and make that protected instead of private if we want (this would be consistent with `tileGrid` and other post-construction-settable properties.

This was part of #12008. I'm pulling out small changes to make review easier.