### PR TITLE
Avoid collisions between user variables and internal names in WebGL shaders

### DIFF
--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -378,6 +378,15 @@ Operators['get'] = {
   },
 };
 
+/**
+ * Get the uniform name given a variable name.
+ * @param {string} variableName The variable name.
+ * @return {string} The uniform name.
+ */
+export function uniformNameForVariable(variableName) {
+  return 'u_var_' + variableName;
+}
+
 Operators['var'] = {
   getReturnType: function (args) {
     return ValueTypes.ANY;
@@ -389,7 +398,7 @@ Operators['var'] = {
     if (context.variables.indexOf(value) === -1) {
       context.variables.push(value);
     }
-    return `u_${value}`;
+    return uniformNameForVariable(value);
   },
 };
 

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -7,6 +7,7 @@ import {
   ValueTypes,
   expressionToGlsl,
   getStringNumberEquivalent,
+  uniformNameForVariable,
 } from '../style/expressions.js';
 
 /**
@@ -527,8 +528,9 @@ export function parseLiteralStyle(style) {
 
   // define one uniform per variable
   fragContext.variables.forEach(function (varName) {
-    builder.addUniform(`float u_${varName}`);
-    uniforms[`u_${varName}`] = function () {
+    const uniformName = uniformNameForVariable(varName);
+    builder.addUniform(`float ${uniformName}`);
+    uniforms[uniformName] = function () {
       if (!style.variables || style.variables[varName] === undefined) {
         throw new Error(
           `The following variable is missing from the style: ${varName}`

--- a/test/spec/ol/style/expressions.test.js
+++ b/test/spec/ol/style/expressions.test.js
@@ -7,6 +7,7 @@ import {
   isTypeUnique,
   numberToGlsl,
   stringToGlsl,
+  uniformNameForVariable,
 } from '../../../../src/ol/style/expressions.js';
 
 describe('ol.style.expressions', function () {
@@ -211,7 +212,9 @@ describe('ol.style.expressions', function () {
 
     it('correctly converts expressions to GLSL', function () {
       expect(expressionToGlsl(context, ['get', 'myAttr'])).to.eql('a_myAttr');
-      expect(expressionToGlsl(context, ['var', 'myValue'])).to.eql('u_myValue');
+      expect(expressionToGlsl(context, ['var', 'myValue'])).to.eql(
+        uniformNameForVariable('myValue')
+      );
       expect(expressionToGlsl(context, ['time'])).to.eql('u_time');
       expect(expressionToGlsl(context, ['zoom'])).to.eql('u_zoom');
       expect(expressionToGlsl(context, ['resolution'])).to.eql('u_resolution');


### PR DESCRIPTION
Currently, when users supply `variables` in a WebGL layer's style, we serialize the variable names as uniforms by prefixing them with `u_`.  This means that user supplied variables will collide with the uniforms that we use internally - so variable names like `time`, `resolution`, `zoom`, etc. would cause problems.

This change proposes that we prefix user supplied variables with `u_var_` when creating uniform names.  This will avoid conflicts with uniforms that we use internally (as long as we remember not to name them `u_var_something`.

This was part of #12008. I'm pulling out small changes to make review easier.

PS - We should do the same with feature attributes that get encoded as attributes in a vertex shader, but I'm not taking that on here.