### PR TITLE
Remove watch option from webpack serve script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "npm run test-spec && npm run test-rendering -- --force",
     "karma": "karma start test/karma.config.js",
     "start": "npm run serve-examples",
-    "serve-examples": "webpack serve --config examples/webpack/config.js --mode development --watch",
+    "serve-examples": "webpack serve --config examples/webpack/config.js --mode development",
     "build-examples": "webpack --config examples/webpack/config.js --mode production",
     "build-package": "npm run transpile && npm run copy-css && node tasks/prepare-package",
     "build-index": "npm run build-package && node tasks/generate-index",


### PR DESCRIPTION
With a fresh install of the dependencies (`npm ci`) I have the following error when running the development server:
```shell
$ npm run start 

> ol@6.5.1-dev start /home/fredj/code/openlayers
> npm run serve-examples


> ol@6.5.1-dev serve-examples /home/fredj/code/openlayers
> webpack serve --config examples/webpack/config.js --mode development --watch

[webpack-cli] Error: Unknown option '--watch'
[webpack-cli] Run 'webpack --help' to see available commands and options
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! ol@6.5.1-dev serve-examples: `webpack serve --config examples/webpack/config.js --mode development --watch`
...
```
`--watch` is no longer a valid option and it can be omitted when using [webpack-dev-server](https://webpack.js.org/configuration/watch/#watch)


