### PR TITLE
Update / fix links to external ressources

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.wh
 
 For older browsers and platforms (Internet Explorer, Android 4.x, iOS v12 and older, Safari v12 and older), polyfills may be needed for the following browser features:
 
-* [`fetch`](https://caniuse.com/#feat=fetch): Available from [polyfill.io](https://polyfill.io/).
-* [`requestAnimationFrame`](https://caniuse.com/#feat=requestanimationframe): Available from [polyfill.io](https://polyfill.io/).
-* [`element.prototype.classList` (`add`/`remove`)](https://caniuse.com/#feat=classlist): Available from [polyfill.io](https://polyfill.io/).
-* [`URL` API](https://caniuse.com/#feat=url): Available from [polyfill.io](https://polyfill.io/).
-* [`TextDecoder`](https://caniuse.com/#feat=textencoder): Available from [polyfill.io](https://polyfill.io/).
-* [`Number.isInteger`](https://caniuse.com/#feat=isInteger): Available from [polyfill.io](https://polyfill.io/).
-* [Pointer events](https://caniuse.com/#feat=pointer): Use [elm-pep](https://npmjs.com/package/elm-pep) (lightweight) or [pepjs](https://npmjs.com/package/pepjs) (for really, really old browsers).
+* [`fetch`](https://caniuse.com/fetch): Available from [polyfill.io](https://polyfill.io/).
+* [`requestAnimationFrame`](https://caniuse.com/requestanimationframe): Available from [polyfill.io](https://polyfill.io/).
+* [`element.prototype.classList` (`add`/`remove`)](https://caniuse.com/classlist): Available from [polyfill.io](https://polyfill.io/).
+* [`URL` API](https://caniuse.com/url): Available from [polyfill.io](https://polyfill.io/).
+* [`TextDecoder`](https://caniuse.com/textencoder): Available from [polyfill.io](https://polyfill.io/).
+* [`Number.isInteger`](https://caniuse.com/isInteger): Available from [polyfill.io](https://polyfill.io/).
+* [Pointer events](https://caniuse.com/pointer): Use [elm-pep](https://npmjs.com/package/elm-pep) (lightweight) or [pepjs](https://npmjs.com/package/pepjs) (for really, really old browsers).
 
 ## Documentation
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -75,7 +75,7 @@ import {register} from 'ol/proj/proj4';
 import {get as getProjection} from 'ol/proj';
 
 // To use other projections, you have to register the projection in OpenLayers.
-// This can easily be done with [https://proj4js.org](proj4)
+// This can easily be done with [http://proj4js.org/](proj4)
 //
 // By default OpenLayers does not know about the EPSG:21781 (Swiss) projection.
 // So we create a projection instance for EPSG:21781 and pass it to

--- a/examples/sea-level.html
+++ b/examples/sea-level.html
@@ -5,7 +5,7 @@ shortdesc: Render sea level at different elevations
 docs: >
   <p>
     This example uses a <code>ol/source/Raster</code> with
-    <a href="https://www.mapbox.com/blog/terrain-rgb/">Mapbox Terrain-RGB tiles</a>
+    <a href="https://blog.mapbox.com/styling-mapbox-terrain-rgb-c75d1cd71471">Mapbox Terrain-RGB tiles</a>
     to "flood" areas below the elevation shown on the sea level slider.
   </p>
   <p>

--- a/src/ol/format/readme.md
+++ b/src/ol/format/readme.md
@@ -124,7 +124,7 @@ In the above there are many common operations, like setting the property of the 
 
 ### Putting it all together
 
-With the above, you should be able to read through the [source code to `ol/format/GPX`](https://github.com/openlayers/openlayers/blob/main/src/ol/format/gpxformat.js) and get a feel for how it works. Start from the bottom of the file and work upwards. It's also useful to have [an example GPX file](https://openlayers.org/en/latest/examples/data/fells_loop.gpx) and [the GPX specification](https://www.topografix.com/GPX/1/1/) to hand.
+With the above, you should be able to read through the [source code to `ol/format/GPX`](https://github.com/openlayers/openlayers/blob/main/src/ol/format/GPX.js) and get a feel for how it works. Start from the bottom of the file and work upwards. It's also useful to have [an example GPX file](https://openlayers.org/en/latest/examples/data/fells_loop.gpx) and [the GPX specification](https://www.topografix.com/GPX/1/1/) to hand.
 
 ### Handling errors
 

--- a/src/ol/sphere.js
+++ b/src/ol/sphere.js
@@ -129,7 +129,7 @@ export function getLength(geometry, opt_options) {
 /**
  * Returns the spherical area for a list of coordinates.
  *
- * [Reference](https://trs-new.jpl.nasa.gov/handle/2014/40409)
+ * [Reference](https://trs.jpl.nasa.gov/handle/2014/40409)
  * Robert. G. Chamberlain and William H. Duquette, "Some Algorithms for
  * Polygons on a Sphere", JPL Publication 07-03, Jet Propulsion
  * Laboratory, Pasadena, CA, June 2007


### PR DESCRIPTION
I found a few more links that needed to be updated.

proj4js.org actually is not reachable by https.