### PR TITLE
Fix kml-timezone example tooltip

### DIFF
--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -82,11 +82,7 @@ const displayFeatureInfo = function (pixel) {
     return feature;
   });
   if (feature) {
-    info
-      .tooltip('hide')
-      .attr('data-original-title', feature.get('name'))
-      .tooltip('fixTitle')
-      .tooltip('show');
+    info.attr('data-original-title', feature.get('name')).tooltip('show');
   } else {
     info.tooltip('hide');
   }


### PR DESCRIPTION
The tooltip did not work at all for https://openlayers.org/en/latest/examples/kml-timezones.html