### PR TITLE
Change IGN WMTS example to use PLANIGNV2 layer 

### DIFF
--- a/examples/wmts-ign.js
+++ b/examples/wmts-ign.js
@@ -19,7 +19,7 @@ const matrixIds = [];
 const proj3857 = getProjection('EPSG:3857');
 const maxResolution = getWidth(proj3857.getExtent()) / 256;
 
-for (let i = 0; i < 18; i++) {
+for (let i = 0; i < 20; i++) {
   matrixIds[i] = i.toString();
   resolutions[i] = maxResolution / Math.pow(2, i);
 }
@@ -31,13 +31,13 @@ const tileGrid = new WMTSTileGrid({
 });
 
 // For more information about the IGN API key see
-// https://geoservices.ign.fr/blog/2018/09/06/acces_geoportail_sans_compte.html
+// https://geoservices.ign.fr/blog/2021/01/29/Maj_Cles_Geoservices.html
 
 const ign_source = new WMTS({
   url: 'https://wxs.ign.fr/choisirgeoportail/geoportail/wmts',
-  layer: 'GEOGRAPHICALGRIDSYSTEMS.MAPS',
+  layer: 'GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2',
   matrixSet: 'PM',
-  format: 'image/jpeg',
+  format: 'image/png',
   projection: 'EPSG:3857',
   tileGrid: tileGrid,
   style: 'normal',


### PR DESCRIPTION
Support of the `pratique` and `choisirgeoportail` keys has changed again https://geoservices.ign.fr/blog/2021/01/29/Maj_Cles_Geoservices.html and neither now support the `GEOGRAPHICALGRIDSYSTEMS.MAPS` layer.  While `GEOGRAPHICALGRIDSYSTEMS.MAPS` remains supported by free personal keys obtained (temporarily) via https://www.sphinxonline.com/surveyserver/s/etudesmk/Geoservices_2021/questionnaire.htm#1 these require security settings such as referer which would make them unsuitable for users editing the example in codesandbox, so it seems appropriate to use the new `GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2` layer instead.
