### PR TITLE
Fix broken url/description of ImageArcGISRest documentation

### DIFF
--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -25,7 +25,7 @@ import {containsExtent, getHeight, getWidth} from '../extent.js';
  * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
  * `IMAGE` by default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`, and `IMAGESR`
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
- * {@link https://developers.arcgis.com/rest/services-reference/export-map.htm}
+ * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,


### PR DESCRIPTION
This pull request fix issue #12087.

`npm run apidocs` is successful finished.

![ImageArcGISRest-fix-broken-link](https://user-images.githubusercontent.com/3016561/110154145-316a5600-7de4-11eb-92f5-20e3749b8187.PNG)
