### PR TITLE
Load less tiles when low on frame budget

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -18,11 +18,7 @@ import RenderEventType from './render/EventType.js';
 import TileQueue, {getTilePriority} from './TileQueue.js';
 import View from './View.js';
 import ViewHint from './ViewHint.js';
-import {
-  DEVICE_PIXEL_RATIO,
-  IMAGE_DECODE,
-  PASSIVE_EVENT_LISTENERS,
-} from './has.js';
+import {DEVICE_PIXEL_RATIO, PASSIVE_EVENT_LISTENERS} from './has.js';
 import {TRUE} from './functions.js';
 import {
   apply as applyTransform,
@@ -1047,8 +1043,7 @@ class PluggableMap extends BaseObject {
       if (frameState) {
         const hints = frameState.viewHints;
         if (hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING]) {
-          const lowOnFrameBudget =
-            !IMAGE_DECODE && Date.now() - frameState.time > 8;
+          const lowOnFrameBudget = Date.now() - frameState.time > 8;
           maxTotalLoading = lowOnFrameBudget ? 0 : 8;
           maxNewLoads = lowOnFrameBudget ? 0 : 2;
         }


### PR DESCRIPTION
Because the logic for determining how many new tiles to queue is used for both image and vector tile layers, it makes no sense to include `IMAGE_DECODE` in the check. `Image.prototype.decode` does not help for loading vector tiles. Also, even for image tile layers with `Image.prototype.decode` support, it is a good idea to load less tiles when low on frame budget.

This pull request improves perceived zooming performance on vector tile layers, because more zoom levels are skipped during zoom animations.

Maybe improves or fixes #12136.