### PR TITLE
Fix offscreen-canvas example

### DIFF
--- a/examples/offscreen-canvas.worker.js
+++ b/examples/offscreen-canvas.worker.js
@@ -144,7 +144,9 @@ worker.addEventListener('message', (event) => {
       renderer.renderFrame(frameState, canvas);
     }
   });
-  layers.forEach((layer) => layer.renderDeclutter(frameState));
+  layers.forEach(
+    (layer) => layer.getRenderer().context && layer.renderDeclutter(frameState)
+  );
   if (tileQueue.getTilesLoading() < maxTotalLoading) {
     tileQueue.reprioritize();
     tileQueue.loadMoreTiles(maxTotalLoading, maxNewLoads);


### PR DESCRIPTION
After the recent VectorTile layer changes (#12018 or #12037) we may not have a context yet when the worker in the example calls renderDeclutter. This pull request fixes that.