### PR TITLE
VectorSource#getFeatures() consistently returns a new array

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -653,7 +653,7 @@ class VectorSource extends Source {
   }
 
   /**
-   * Get all snapshot of the features currently on the source in random order. The returned array
+   * Get a snapshot of the features currently on the source in random order. The returned array
    * is a copy, the features are references to the features in the source.
    * @return {Array<import("../Feature.js").default<Geometry>>} Features.
    * @api

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -653,14 +653,15 @@ class VectorSource extends Source {
   }
 
   /**
-   * Get all features on the source in random order.
+   * Get all snapshot of the features currently on the source in random order. The returned array
+   * is a copy, the features are references to the features in the source.
    * @return {Array<import("../Feature.js").default<Geometry>>} Features.
    * @api
    */
   getFeatures() {
     let features;
     if (this.featuresCollection_) {
-      features = this.featuresCollection_.getArray();
+      features = this.featuresCollection_.getArray().slice(0);
     } else if (this.featuresRtree_) {
       features = this.featuresRtree_.getAll();
       if (!isEmpty(this.nullGeometryFeatures_)) {
@@ -700,7 +701,7 @@ class VectorSource extends Source {
     if (this.featuresRtree_) {
       return this.featuresRtree_.getInExtent(extent);
     } else if (this.featuresCollection_) {
-      return this.featuresCollection_.getArray();
+      return this.featuresCollection_.getArray().slice(0);
     } else {
       return [];
     }

--- a/test/spec/ol/source/vector.test.js
+++ b/test/spec/ol/source/vector.test.js
@@ -143,6 +143,18 @@ describe('ol.source.Vector', function () {
         expect(feature).to.be(features[0]);
       });
     });
+
+    describe('#getFeatures', function () {
+      it('does not return the internal array when useSpatialIndex is false', function () {
+        const noSpatialIndexSource = new VectorSource({
+          useSpatialIndex: false,
+          features: vectorSource.getFeatures(),
+        });
+        expect(noSpatialIndexSource.getFeatures()).to.not.be(
+          noSpatialIndexSource.getFeaturesCollection().getArray()
+        );
+      });
+    });
   });
 
   describe('clear and refresh', function () {


### PR DESCRIPTION
I just stumbled across an issue where I had a `Vector` source configured with `useSpatialIndex: false`. When such a source is used as `source` of a `Modify` interaction, the interaction will modify the array of the source's features `Collection`, bringing the collection out of sync with its `length`.

To avoid such issues, we should document what is returned by `VectorSource#getFeatures()`, and make sure we don't return the internal array of the features `Collection`.