### PR TITLE
Link to GitHub sponsors page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [openlayers] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
 open_collective: openlayers
 ko_fi: # Replace with a single Ko-fi username

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ OpenLayers appreciates contributions of all kinds.  We especially want to thank 
 > We love Openlayers and it forms a core part of our platform.
 > https://pozi.com/ https://app.pozi.com/
 
-See our [Open Collective](https://opencollective.com/openlayers/contribute/sponsors-214/checkout) page if you too are interested in becoming a regular sponsor.
+See our [GitHub sponsors page](https://github.com/sponsors/openlayers) or [Open Collective](https://opencollective.com/openlayers/contribute/sponsors-214/checkout) if you too are interested in becoming a regular sponsor.
 
 ## IntelliSense support and type checking for VS Code
 


### PR DESCRIPTION
This will link the ❤️   Sponsor button for this repo to our GitHub [sponsors profile page](https://github.com/sponsors/openlayers).