### PR TITLE
Refresh available examples before each compilation

### DIFF
--- a/examples/webpack/config.js
+++ b/examples/webpack/config.js
@@ -6,20 +6,19 @@ const path = require('path');
 
 const src = path.join(__dirname, '..');
 
-const examples = fs
-  .readdirSync(src)
-  .filter((name) => /^(?!index).*\.html$/.test(name))
-  .map((name) => name.replace(/\.html$/, ''));
-
-const entry = {};
-examples.forEach((example) => {
-  entry[example] = `./${example}.js`;
-});
-
 module.exports = {
   context: src,
   target: 'web',
-  entry: entry,
+  entry: () => {
+    const entry = {};
+    fs.readdirSync(src)
+      .filter((name) => /^(?!index).*\.html$/.test(name))
+      .map((name) => name.replace(/\.html$/, ''))
+      .forEach((example) => {
+        entry[example] = `./${example}.js`;
+      });
+    return entry;
+  },
   stats: 'minimal',
   module: {
     rules: [


### PR DESCRIPTION
This makes it possible to pickup new examples and prevents compilation
errors when an example is removed. This is especially handy when switching
branches. Otherwise the dev server has to be restarted each time.