### PR TITLE
Allow private class members to be mangled

### DIFF
--- a/config/webpack-config-legacy-build.js
+++ b/config/webpack-config-legacy-build.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const TerserPlugin = require('terser-webpack-plugin');
+
 module.exports = {
   entry: './build/index.js',
   devtool: 'source-map',
@@ -29,6 +31,16 @@ module.exports = {
     alias: {
       ol: path.resolve('./build/ol'),
     },
+  },
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          // Mangle private members convention with underscore suffix
+          mangle: {properties: {regex: /_$/}},
+        },
+      }),
+    ],
   },
   output: {
     path: path.resolve('./build/legacy'),

--- a/examples/webpack/config.js
+++ b/examples/webpack/config.js
@@ -61,6 +61,10 @@ module.exports = {
         // Do not minify examples that inject code into workers
         exclude: [/(color-manipulation|region-growing|raster)\.js/],
         extractComments: false,
+        terserOptions: {
+          // Mangle private members convention with underscore suffix
+          mangle: {properties: {regex: /_$/}},
+        },
       }),
     ],
     runtimeChunk: {


### PR DESCRIPTION
Openlayers classes use an underscore suffix convention to mark class members as private. These are undocumented implementation details and presumably unsafe for code outside the class to rely on.

Allowing javascript minimisation to change these names gives 5% bundle size reduction to the library.

See terser docs on [mangling property names](https://github.com/terser/terser#cli-mangling-property-names---mangle-props) and [mange options](https://github.com/terser/terser#mangle-properties-options).

<details>
<summary>Before/after size comparisons.</summary>

For common examples bundle:

    929K build/examples/common.js
    877K build/examples/common.js

After `gzip -9`:

    246K build/examples/common.js.gz
    241K build/examples/common.js.gz

And for legacy bundle:

    985K build/legacy/ol.js
    932K build/legacy/ol.js 
</details>

I've not exhaustively tested all examples, but from grep for `'_ '` only `examples/custom-interactions.js` touches properties with an underscore suffix, and it's its own class.

This might be considered an api change, as it has some potential to break library users (if they're not building from the module sources themselves, and are poking around class internals), so may be worth a specific version bump of some kind.

Motivation for proposing this, is have been using this exact build setup when importing and building `ol` and having the same behaviour upstream makes the guarantee it'll work going forwards a bit stronger.