### PR TITLE
MapBrowserEvent#preventDefault() behaves the same as with native events

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -201,7 +201,7 @@ class MapBrowserEventHandler extends Target {
     // to 0).
     // See http://www.w3.org/TR/pointerevents/#button-states
     // We only fire click, singleclick, and doubleclick if nobody has called
-    // event.stopPropagation() or event.preventDefault().
+    // event.preventDefault().
     if (
       this.emulateClicks_ &&
       !newEvent.defaultPrevented &&

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -204,7 +204,7 @@ class MapBrowserEventHandler extends Target {
     // event.stopPropagation() or event.preventDefault().
     if (
       this.emulateClicks_ &&
-      !newEvent.propagationStopped &&
+      !newEvent.defaultPrevented &&
       !this.dragging_ &&
       this.isMouseActionButton_(pointerEvent)
     ) {

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -23,6 +23,11 @@ class BaseEvent {
     this.propagationStopped;
 
     /**
+     * @type {boolean}
+     */
+    this.defaultPrevented;
+
+    /**
      * The event type.
      * @type {string}
      * @api
@@ -38,11 +43,12 @@ class BaseEvent {
   }
 
   /**
-   * Stop event propagation.
+   * Prevent default. This means that no emulated `click`, `singleclick` or `doubleclick` events
+   * will be fired.
    * @api
    */
   preventDefault() {
-    this.propagationStopped = true;
+    this.defaultPrevented = true;
   }
 
   /**

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -650,7 +650,7 @@ class Draw extends PointerInteraction {
     }
 
     if (!pass && this.stopClick_) {
-      event.stopPropagation();
+      event.preventDefault();
     }
     return pass;
   }

--- a/test/spec/ol/events/event.test.js
+++ b/test/spec/ol/events/event.test.js
@@ -16,10 +16,10 @@ describe('ol.events.Event', function () {
   });
 
   describe('#preventDefault', function () {
-    it('sets the propagationStopped flag', function () {
+    it('sets the defaultPrevented flag', function () {
       const event = new Event('foo');
       event.preventDefault();
-      expect(event.propagationStopped).to.be(true);
+      expect(event.defaultPrevented).to.be(true);
     });
     it('does the same as #stopPropagation', function () {
       const event = new Event('foo');

--- a/test/spec/ol/events/eventtarget.test.js
+++ b/test/spec/ol/events/eventtarget.test.js
@@ -105,10 +105,10 @@ describe('ol.events.EventTarget', function () {
       eventTarget.dispatchEvent('foo');
       expect(called).to.eql([1, 2]);
     });
-    it('stops propagation when listeners call preventDefault()', function () {
+    it('stops propagation when listeners call stopPropagation()', function () {
       eventTarget.addEventListener('foo', function (evt) {
         spy2();
-        evt.preventDefault();
+        evt.stopPropagation();
       });
       eventTarget.addEventListener('foo', spy1);
       eventTarget.dispatchEvent('foo');


### PR DESCRIPTION
Previously, calling `preventDefault()` on a `MapBrowserEvent` meant the same as calling `stopPropagation()`. But with the emulated `click`, `singleclick` and `doubleclick` events in the `MapBrowserEventHandler`, we have something very similar as native browser event handlers, so it makes sense to distinguish between `preventDefault()` and `stopPropagation()`.

Fixes #12171 and fixes #12161.