### PR TITLE
Ignore empty gx:coord elements in KML files

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -65,7 +65,7 @@ import {transformGeometryWithOptions} from './Feature.js';
 
 /**
  * @typedef {Object} GxTrackObject
- * @property {Array<number>} flatCoordinates Flat coordinates.
+ * @property {Array<Array<number>>} coordinates Coordinates.
  * @property {Array<number>} whens Whens.
  */
 
@@ -1466,7 +1466,7 @@ function gxCoordParser(node, objectStack) {
   const gxTrackObject =
     /** @type {GxTrackObject} */
     (objectStack[objectStack.length - 1]);
-  const flatCoordinates = gxTrackObject.flatCoordinates;
+  const coordinates = gxTrackObject.coordinates;
   const s = getAllTextContent(node, false);
   const re = /^\s*([+\-]?\d+(?:\.\d*)?(?:e[+\-]?\d*)?)\s+([+\-]?\d+(?:\.\d*)?(?:e[+\-]?\d*)?)\s+([+\-]?\d+(?:\.\d*)?(?:e[+\-]?\d*)?)\s*$/i;
   const m = re.exec(s);
@@ -1474,9 +1474,9 @@ function gxCoordParser(node, objectStack) {
     const x = parseFloat(m[1]);
     const y = parseFloat(m[2]);
     const z = parseFloat(m[3]);
-    flatCoordinates.push(x, y, z, 0);
+    coordinates.push([x, y, z]);
   } else {
-    flatCoordinates.push(0, 0, 0, 0);
+    coordinates.push([]);
   }
 }
 
@@ -1530,7 +1530,7 @@ const GX_TRACK_PARSERS = makeStructureNS(
 function readGxTrack(node, objectStack) {
   const gxTrackObject = pushParseAndPop(
     /** @type {GxTrackObject} */ ({
-      flatCoordinates: [],
+      coordinates: [],
       whens: [],
     }),
     GX_TRACK_PARSERS,
@@ -1540,14 +1540,22 @@ function readGxTrack(node, objectStack) {
   if (!gxTrackObject) {
     return undefined;
   }
-  const flatCoordinates = gxTrackObject.flatCoordinates;
+  const flatCoordinates = [];
+  const coordinates = gxTrackObject.coordinates;
   const whens = gxTrackObject.whens;
   for (
-    let i = 0, ii = Math.min(flatCoordinates.length, whens.length);
+    let i = 0, ii = Math.min(coordinates.length, whens.length);
     i < ii;
     ++i
   ) {
-    flatCoordinates[4 * i + 3] = whens[i];
+    if (coordinates[i].length == 3) {
+      flatCoordinates.push(
+        coordinates[i][0],
+        coordinates[i][1],
+        coordinates[i][2],
+        whens[i]
+      );
+    }
   }
   return new LineString(flatCoordinates, GeometryLayout.XYZM);
 }

--- a/test/browser/spec/ol/format/kml.test.js
+++ b/test/browser/spec/ol/format/kml.test.js
@@ -1603,9 +1603,11 @@ describe('ol.format.KML', function () {
             '      <when>2014-01-06T19:38:55Z</when>' +
             '      <when>2014-01-06T19:39:03Z</when>' +
             '      <when>2014-01-06T19:39:10Z</when>' +
+            '      <when>2014-01-06T19:39:17Z</when>' +
             '      <gx:coord>8.1 46.1 1909.9</gx:coord>' +
             '      <gx:coord>8.2 46.2 1925.2</gx:coord>' +
             '      <gx:coord>8.3 46.3 1926.2</gx:coord>' +
+            '      <gx:coord/>' +
             '    </gx:Track>' +
             '  </Placemark>' +
             '</kml>';


### PR DESCRIPTION
This pull request changes the KML parser so that empty gx:coord elements are handled. Fixes #12113.