### PR TITLE
Prevent TypeScript Compiler from erroring out due to lib checks

### DIFF
--- a/config/tsconfig-build.json
+++ b/config/tsconfig-build.json
@@ -51,11 +51,12 @@
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": false                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSources": false,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "skipLibCheck": true
   },
   "include": [
     "../build/ol/src/**/*.js"


### PR DESCRIPTION
Fixes a build issue when running `npm run build-package` caused by dependencies:
```
node_modules/@types/eslint/index.d.ts:302:41 - error TS2724: '"/Users/ahocevar/projects/openlayers/node_modules/@types/estree/index"' has no exported member named 'ChainExpression'. Did you mean 'ThisExpression'?

302         ChainExpression?: (node: ESTree.ChainExpression & NodeParentExtension) => void;
                                            ~~~~~~~~~~~~~~~

node_modules/@types/eslint/index.d.ts:325:42 - error TS2694: Namespace '"/Users/ahocevar/projects/openlayers/node_modules/@types/estree/index"' has no exported member 'ImportExpression'.

325         ImportExpression?: (node: ESTree.ImportExpression & NodeParentExtension) => void;
                                             ~~~~~~~~~~~~~~~~


Found 2 errors.
```