### PR TITLE
Move tolerance should not increase with higher pixel ratio

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -7,7 +7,7 @@ import MapBrowserEvent from './MapBrowserEvent.js';
 import MapBrowserEventType from './MapBrowserEventType.js';
 import PointerEventType from './pointer/EventType.js';
 import Target from './events/Target.js';
-import {DEVICE_PIXEL_RATIO, PASSIVE_EVENT_LISTENERS} from './has.js';
+import {PASSIVE_EVENT_LISTENERS} from './has.js';
 import {VOID} from './functions.js';
 import {listen, unlistenByKey} from './events.js';
 
@@ -54,9 +54,7 @@ class MapBrowserEventHandler extends Target {
      * @type {number}
      * @private
      */
-    this.moveTolerance_ = moveTolerance
-      ? moveTolerance * DEVICE_PIXEL_RATIO
-      : DEVICE_PIXEL_RATIO;
+    this.moveTolerance_ = moveTolerance === undefined ? 1 : moveTolerance;
 
     /**
      * The most recent "down" type event (or null if none have occurred).


### PR DESCRIPTION
Browsers already handle the scaling, no need to multiply this again.
This now also allows setting a moveTolerance of zero which was not
possible before. In the isMoving_ method the condition is
distance > tolerance so this will work.
https://github.com/openlayers/openlayers/blob/7a2f87caca9ddc1912d910f56eb5637445fc11f6/src/ol/MapBrowserEventHandler.js#L358-L365

Maybe the move tolerance should default to `0` instead of `1`?

To test this:
1. Load a page with a map then set the zoom level to a high value like 500%.
2. Drag the map, should take about 5 screenpixel until the map moves, pixel ratio was 1 form page load
3. Reload the page
4. Drag again, now it takes 25px because the pixel ratio was set to 5 on page load