### PR TITLE
Use proxy url as interim fix for mixed content in the MapGuide example

### DIFF
--- a/examples/mapguide-untiled.js
+++ b/examples/mapguide-untiled.js
@@ -4,7 +4,7 @@ import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 
 const mdf = 'Library://Samples/Sheboygan/Maps/Sheboygan.MapDefinition';
-const agentUrl = 'http://138.197.230.93:8008/mapguide/mapagent/mapagent.fcgi?';
+const agentUrl = 'https://mikenunn.net/mapguide/mapagent/mapagent.fcgi?';
 const bounds = [
   -87.865114442365922,
   43.665065564837931,


### PR DESCRIPTION
Fixes #12233

Keeps the example working in modern browsers until @jumpinjackie is able to update the demo server to an https domain.
