### PR TITLE
Avoid naming required checks with a changing version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,11 @@ env:
 
 jobs:
   pretest:
-    name: Pre-Test (Node ${{ matrix.node }} / ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Pre-Test
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        node:
-          - 16
 
     steps:
       - name: Clone Repository
@@ -31,7 +26,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -53,16 +48,11 @@ jobs:
         run: npm run pretest
 
   spec:
-    name: Spec (Node ${{ matrix.node }} / ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Spec
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        node:
-          - 16
 
     steps:
       - name: Clone Repository
@@ -71,7 +61,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -93,16 +83,11 @@ jobs:
         run: npm run test-spec
 
   build:
-    name: Build (Node ${{ matrix.node }} / ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Build (Node 16 / ubuntu-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        node:
-          - 16
 
     steps:
       - name: Clone Repository
@@ -111,7 +96,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -133,16 +118,11 @@ jobs:
         run: npm run build-package
 
   rendering:
-    name: Rendering (Node ${{ matrix.node }} / ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Rendering
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        node:
-          - 16
 
     steps:
       - name: Clone Repository
@@ -151,7 +131,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16
 
       - name: Determine Cache Directory
         id: npm-cache


### PR DESCRIPTION
Our CI Jobs (workflow actions, whatever) are named with a combination of the os and Node version.  This would be useful if we wanted to ensure that our tests pass on a matrix of os and Node version.  However, we only test on a single os and Node version.  When we update the version of Node where we want to run tests (e.g. #12247), we also have to change the name of all the required checks for branch protection.  If this project were primarily used on Node, this could make sense.  For this project, it ends up being a hassle because all outstanding pull requests need to be rebased.

If we want to require that all pull requests are updated before being merged, we can configure that.  But we don't require that currently.