### PR TITLE
Update the name of the build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm run test-spec
 
   build:
-    name: Build (Node 16 / ubuntu-latest
+    name: Build
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
#12248 left us with an odd name for the build job.  This corrects that.