### PR TITLE
Do not set projection extent in WMTS optionsFromCapabilities

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -502,10 +502,6 @@ export function optionsFromCapabilities(wmtsCap, config) {
       wgs84BoundingBox[2] === wgs84ProjectionExtent[2];
   }
 
-  if (projection.getExtent() === null) {
-    projection.setExtent(extent);
-  }
-
   const tileGrid = createFromCapabilitiesMatrixSet(
     matrixSetObj,
     extent,


### PR DESCRIPTION
Fixes #11738
Replaces #11792

Leave setting projection extents to the application.
