### PR TITLE
Use lowercase module names for modules without a default export

### DIFF
--- a/src/ol/format/OWS.js
+++ b/src/ol/format/OWS.js
@@ -8,7 +8,7 @@ import {
   makeStructureNS,
   pushParseAndPop,
 } from '../xml.js';
-import {readHref} from './XLink.js';
+import {readHref} from './xlink.js';
 import {readString} from './xsd.js';
 
 /**

--- a/src/ol/format/WMSCapabilities.js
+++ b/src/ol/format/WMSCapabilities.js
@@ -17,7 +17,7 @@ import {
   readNonNegativeIntegerString,
   readString,
 } from './xsd.js';
-import {readHref} from './XLink.js';
+import {readHref} from './xlink.js';
 
 /**
  * @const

--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -12,7 +12,7 @@ import {
   pushParseAndPop,
 } from '../xml.js';
 import {readDecimal, readNonNegativeInteger, readString} from './xsd.js';
-import {readHref} from './XLink.js';
+import {readHref} from './xlink.js';
 
 /**
  * @const

--- a/src/ol/format/xlink.js
+++ b/src/ol/format/xlink.js
@@ -1,5 +1,5 @@
 /**
- * @module ol/format/XLink
+ * @module ol/format/xlink
  */
 
 /**

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -8,7 +8,7 @@ import {parseLiteralStyle} from '../webgl/ShaderBuilder.js';
 
 /**
  * @typedef {Object} Options
- * @property {import('../style/LiteralStyle.js').LiteralStyle} style Literal style to apply to the layer features.
+ * @property {import('../style/literal.js').LiteralStyle} style Literal style to apply to the layer features.
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.

--- a/src/ol/style/literal.js
+++ b/src/ol/style/literal.js
@@ -1,7 +1,7 @@
 /**
- * Literal Style objects differ from standard styles in that they cannot
+ * Literal style objects differ from standard styles in that they cannot
  * be functions and are made up of simple objects instead of classes.
- * @module ol/style/LiteralStyle
+ * @module ol/style/literal
  */
 
 /**

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -414,14 +414,14 @@ ${hitDetectionBypass}
  */
 
 /**
- * Parses a {@link import("../style/LiteralStyle").LiteralStyle} object and returns a {@link ShaderBuilder}
+ * Parses a {@link import("../style/literal").LiteralStyle} object and returns a {@link ShaderBuilder}
  * object that has been configured according to the given style, as well as `attributes` and `uniforms`
  * arrays to be fed to the `WebGLPointsRenderer` class.
  *
  * Also returns `uniforms` and `attributes` properties as expected by the
  * {@link module:ol/renderer/webgl/PointsLayer~WebGLPointsLayerRenderer}.
  *
- * @param {import("../style/LiteralStyle").LiteralStyle} style Literal style.
+ * @param {import("../style/literal").LiteralStyle} style Literal style.
  * @return {StyleParseResult} Result containing shader params, attributes and uniforms.
  */
 export function parseLiteralStyle(style) {


### PR DESCRIPTION
The convention in the library is to use lowercase module names where we have modules without a default export.  The `ol/format/XLink.js` and `ol/style/LiteralStyle.js` modules were exceptions to this.