### PR TITLE
Lint the index file after generating the legacy build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
         run: npm run build-package
 
       - name: Generate the Legacy Build
-        run: npm run build-legacy
+        run: npm run build-legacy && npx eslint --fix build/index.js
 
   rendering:
     name: Rendering


### PR DESCRIPTION
After the changes in #12266, we have a clean enough `build/index.js` that it should pass ESLint aside from the order of imports.  The `--fix` flag will reorder imports, but ESLint will fail if there are any unused variables or other cruft.  This isn't a full test of the legacy build, but it should at least catch more issues generating the legacy build.