### PR TITLE
Fix JSDoc generated links

### DIFF
--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -87,7 +87,7 @@ class BaseObject extends Observable {
   constructor(opt_values) {
     super();
 
-    // Call {@link module:ol/util~getUid} to ensure that the order of objects' ids is
+    // Call {@link module:ol/util.getUid} to ensure that the order of objects' ids is
     // the same as the order in which they were created.  This also helps to
     // ensure that object properties are always added in the same order, which
     // helps many JavaScript engines generate faster code.

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -61,7 +61,7 @@ import {outerHeight, outerWidth, removeChildren, removeNode} from './dom.js';
  * milliseconds.
  * @property {function(number):number} [easing] The easing function to use. Can
  * be one from {@link module:ol/easing} or a custom function.
- * Default is {@link module:ol/easing~inAndOut}.
+ * Default is {@link module:ol/easing.inAndOut}.
  */
 
 /**

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -91,12 +91,12 @@ import {removeNode} from './dom.js';
  * @typedef {Object} MapOptions
  * @property {Collection<import("./control/Control.js").default>|Array<import("./control/Control.js").default>} [controls]
  * Controls initially added to the map. If not specified,
- * {@link module:ol/control~defaults} is used.
+ * {@link module:ol/control.defaults} is used.
  * @property {number} [pixelRatio=window.devicePixelRatio] The ratio between
  * physical pixels and device-independent pixels (dips) on the device.
  * @property {Collection<import("./interaction/Interaction.js").default>|Array<import("./interaction/Interaction.js").default>} [interactions]
  * Interactions that are initially added to the map. If not specified,
- * {@link module:ol/interaction~defaults} is used.
+ * {@link module:ol/interaction.defaults} is used.
  * @property {HTMLElement|Document|string} [keyboardEventTarget] The element to
  * listen to keyboard events on. This determines when the `KeyboardPan` and
  * `KeyboardZoom` interactions trigger. For example, if this option is set to

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -91,7 +91,7 @@ import {fromExtent as polygonFromExtent} from './geom/Polygon.js';
  * @property {number} [duration] The duration of the animation in milliseconds.
  * By default, there is no animation to the target extent.
  * @property {function(number):number} [easing] The easing function used during
- * the animation (defaults to {@link module:ol/easing~inAndOut}).
+ * the animation (defaults to {@link module:ol/easing.inAndOut}).
  * The function will be called for each frame with a number representing a
  * fraction of the animation's duration.  The function should return a number
  * between 0 and 1 representing the progress toward the destination state.
@@ -197,7 +197,7 @@ import {fromExtent as polygonFromExtent} from './geom/Polygon.js';
  * during a rotation or resolution animation.
  * @property {number} [duration=1000] The duration of the animation in milliseconds.
  * @property {function(number):number} [easing] The easing function used
- * during the animation (defaults to {@link module:ol/easing~inAndOut}).
+ * during the animation (defaults to {@link module:ol/easing.inAndOut}).
  * The function will be called for each frame with a number representing a
  * fraction of the animation's duration.  The function should return a number
  * between 0 and 1 representing the progress toward the destination state.

--- a/src/ol/easing.js
+++ b/src/ol/easing.js
@@ -44,7 +44,7 @@ export function linear(t) {
 
 /**
  * Start slow, speed up, and at the very end slow down again.  This has the
- * same general behavior as {@link module:ol/easing~inAndOut}, but the final
+ * same general behavior as {@link module:ol/easing.inAndOut}, but the final
  * slowdown is delayed.
  * @param {number} t Input between 0 and 1.
  * @return {number} Output between 0 and 1.

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -34,7 +34,7 @@ import {clear} from './obj.js';
  * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * This function efficiently binds a `listener` to a `this` object, and returns
- * a key for use with {@link module:ol/events~unlistenByKey}.
+ * a key for use with {@link module:ol/events.unlistenByKey}.
  *
  * @param {import("./events/Target.js").EventTargetLike} target Event target.
  * @param {string} type Event type.
@@ -70,10 +70,10 @@ export function listen(target, type, listener, opt_this, opt_once) {
  *
  * This function efficiently binds a `listener` as self-unregistering listener
  * to a `this` object, and returns a key for use with
- * {@link module:ol/events~unlistenByKey} in case the listener needs to be
+ * {@link module:ol/events.unlistenByKey} in case the listener needs to be
  * unregistered before it is called.
  *
- * When {@link module:ol/events~listen} is called with the same arguments after this
+ * When {@link module:ol/events.listen} is called with the same arguments after this
  * function, the self-unregistering listener will be turned into a permanent
  * listener.
  *
@@ -93,7 +93,7 @@ export function listenOnce(target, type, listener, opt_this) {
  * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html
  *
  * The argument passed to this function is the key returned from
- * {@link module:ol/events~listen} or {@link module:ol/events~listenOnce}.
+ * {@link module:ol/events.listen} or {@link module:ol/events.listenOnce}.
  *
  * @param {EventsKey} key The key.
  */

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -24,7 +24,7 @@ import {linearRingIsClockwise} from '../geom/flat/orient.js';
 /**
  * @typedef {Object} Options
  * @property {import("../Feature.js").FeatureClass} [featureClass] Class for features returned by
- * {@link module:ol/format/MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
+ * {@link module:ol/format/MVT~MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
  * support at the cost of decreased rendering performance. The default is
  * {@link module:ol/render/Feature~RenderFeature}, which is optimized for rendering and hit detection.
  * @property {string} [geometryName='geometry'] Geometry name to use when creating features.

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -21,7 +21,7 @@ import {
  * @typedef {Object} Options
  * @property {import("../events/condition.js").Condition} [condition] A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
- * Default is {@link module:ol/events/condition~noModifierKeys} and {@link module:ol/events/condition~primaryAction}.
+ * Default is {@link module:ol/events/condition.noModifierKeys} and {@link module:ol/events/condition.primaryAction}.
  * @property {boolean} [onFocusOnly=false] When the map's target has a `tabindex` attribute set,
  * the interaction will only handle events when the map has the focus.
  * @property {import("../Kinetic.js").default} [kinetic] Kinetic inertia to apply to the pan.

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -15,7 +15,7 @@ import {disable} from '../rotationconstraint.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that takes an
  * {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean
  * to indicate whether that event should be handled.
- * Default is {@link module:ol/events/condition~altShiftKeysOnly}.
+ * Default is {@link module:ol/events/condition.altShiftKeysOnly}.
  * @property {number} [duration=250] Animation duration in milliseconds.
  */
 

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -9,7 +9,7 @@ import {mouseOnly, shiftKeyOnly} from '../events/condition.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
- * Default is {@link module:ol/events/condition~shiftKeyOnly}.
+ * Default is {@link module:ol/events/condition.shiftKeyOnly}.
  * @property {number} [duration=400] Animation duration in milliseconds.
  */
 

--- a/src/ol/interaction/DragZoom.js
+++ b/src/ol/interaction/DragZoom.js
@@ -12,7 +12,7 @@ import {shiftKeyOnly} from '../events/condition.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
- * Default is {@link module:ol/events/condition~shiftKeyOnly}.
+ * Default is {@link module:ol/events/condition.shiftKeyOnly}.
  * @property {number} [duration=200] Animation duration in milliseconds.
  * @property {boolean} [out=false] Use interaction for zooming out.
  * @property {number} [minArea=64] The minimum area of the box in pixel, this value is used by the parent default

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -70,7 +70,7 @@ import {squaredDistance as squaredCoordinateDistance} from '../coordinate.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
- * By default {@link module:ol/events/condition~noModifierKeys}, i.e. a click,
+ * By default {@link module:ol/events/condition.noModifierKeys}, i.e. a click,
  * adds a vertex or deactivates freehand drawing.
  * @property {boolean} [freehand=false] Operate in freehand mode for lines,
  * polygons, and circles.  This makes the interaction always operate in freehand
@@ -79,7 +79,7 @@ import {squaredDistance as squaredCoordinateDistance} from '../coordinate.js';
  * Condition that activates freehand drawing for lines and polygons. This
  * function takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and
  * returns a boolean to indicate whether that event should be handled. The
- * default is {@link module:ol/events/condition~shiftKeyOnly}, meaning that the
+ * default is {@link module:ol/events/condition.shiftKeyOnly}, meaning that the
  * Shift key activates freehand drawing.
  * @property {boolean} [wrapX=false] Wrap the world horizontally on the sketch
  * overlay.

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -26,7 +26,7 @@ import {toUserExtent} from '../proj.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
- * Default is {@link module:ol/events/condition~always}.
+ * Default is {@link module:ol/events/condition.always}.
  * @property {import("../extent.js").Extent} [extent] Initial extent. Defaults to no
  * initial extent.
  * @property {import("../style/Style.js").StyleLike} [boxStyle]

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -12,8 +12,8 @@ import {rotate as rotateCoordinate} from '../coordinate.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
- * {@link module:ol/events/condition~noModifierKeys} and
- * {@link module:ol/events/condition~targetNotEditable}.
+ * {@link module:ol/events/condition.noModifierKeys} and
+ * {@link module:ol/events/condition.targetNotEditable}.
  * @property {number} [duration=100] Animation duration in milliseconds.
  * @property {number} [pixelDelta=128] The amount of pixels to pan on each key
  * press.

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -11,7 +11,7 @@ import {targetNotEditable} from '../events/condition.js';
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
- * {@link module:ol/events/condition~targetNotEditable}.
+ * {@link module:ol/events/condition.targetNotEditable}.
  * @property {number} [delta=1] The zoom level delta on each key press.
  */
 

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -95,16 +95,16 @@ const ModifyEventType = {
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event will be considered to add or move a
  * vertex to the sketch. Default is
- * {@link module:ol/events/condition~primaryAction}.
+ * {@link module:ol/events/condition.primaryAction}.
  * @property {import("../events/condition.js").Condition} [deleteCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. By default,
- * {@link module:ol/events/condition~singleClick} with
- * {@link module:ol/events/condition~altKeyOnly} results in a vertex deletion.
+ * {@link module:ol/events/condition.singleClick} with
+ * {@link module:ol/events/condition.altKeyOnly} results in a vertex deletion.
  * @property {import("../events/condition.js").Condition} [insertVertexCondition] A
  * function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and
  * returns a boolean to indicate whether a new vertex should be added to the sketch
- * features. Default is {@link module:ol/events/condition~always}.
+ * features. Default is {@link module:ol/events/condition.always}.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
  * @property {import("../style/Style.js").StyleLike} [style]

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -20,7 +20,7 @@ export const Mode = {
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. Default is
- * {@link module:ol/events/condition~always}.
+ * {@link module:ol/events/condition.always}.
  * @property {boolean} [onFocusOnly=false] When the map's target has a `tabindex` attribute set,
  * the interaction will only handle events when the map has the focus.
  * @property {number} [maxDelta=1] Maximum mouse wheel delta.

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -38,13 +38,13 @@ const SelectEventType = {
  * @property {import("../events/condition.js").Condition} [addCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
- * By default, this is {@link module:ol/events/condition~never}. Use this if you
+ * By default, this is {@link module:ol/events/condition.never}. Use this if you
  * want to use different events for add and remove instead of `toggle`.
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. This is the event
  * for the selected features as a whole. By default, this is
- * {@link module:ol/events/condition~singleClick}. Clicking on a feature selects that
+ * {@link module:ol/events/condition.singleClick}. Clicking on a feature selects that
  * feature and removes any that were in the selection. Clicking outside any
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
@@ -63,13 +63,13 @@ const SelectEventType = {
  * @property {import("../events/condition.js").Condition} [removeCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled.
- * By default, this is {@link module:ol/events/condition~never}. Use this if you
+ * By default, this is {@link module:ol/events/condition.never}. Use this if you
  * want to use different events for add and remove instead of `toggle`.
  * @property {import("../events/condition.js").Condition} [toggleCondition] A function
  * that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. This is in addition
  * to the `condition` event. By default,
- * {@link module:ol/events/condition~shiftKeyOnly}, i.e. pressing `shift` as
+ * {@link module:ol/events/condition.shiftKeyOnly}, i.e. pressing `shift` as
  * well as the `condition` event, adds that feature to the current selection if
  * it is not currently selected, and removes it if it is. See `add` and `remove`
  * if you want to use different events instead of a toggle.

--- a/src/ol/layer/BaseImage.js
+++ b/src/ol/layer/BaseImage.js
@@ -26,7 +26,7 @@ import Layer from './Layer.js';
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link import("../PluggableMap.js").default#addLayer map.addLayer()}.
  * @property {ImageSourceType} [source] Source for this layer.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -31,7 +31,7 @@ import {assign} from '../obj.js';
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link import("../PluggableMap.js").default#addLayer map.addLayer()}.
  * @property {boolean} [useInterimTilesOnError=true] Use interim tiles on error.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -39,7 +39,7 @@ import {
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link import("../PluggableMap.js").default#addLayer map.addLayer()}.
  * @property {boolean} [declutter=false] Declutter images and text. Decluttering is applied to all
  * image and text styles of all Vector and VectorTile layers that have set this to `true`. The priority
  * is defined by the z-index of the layer, the `zIndex` of the style and the render order of features.

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -36,7 +36,7 @@ import {listen, unlistenByKey} from '../events.js';
  * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
  * be visible.
  * @property {SourceType} [source] Source for this layer.  If not provided to the constructor,
- * the source can be set by calling {@link module:ol/layer/Layer#setSource layer.setSource(source)} after
+ * the source can be set by calling {@link module:ol/layer/Layer~Layer#setSource layer.setSource(source)} after
  * construction.
  * @property {import("../PluggableMap.js").default} [map] Map.
  * @property {RenderFunction} [render] Render function. Takes the frame state as input and is expected to return an
@@ -69,7 +69,7 @@ import {listen, unlistenByKey} from '../events.js';
  * Layers group together those properties that pertain to how the data is to be
  * displayed, irrespective of the source of that data.
  *
- * Layers are usually added to a map with {@link module:ol/Map#addLayer}. Components
+ * Layers are usually added to a map with {@link import("../PluggableMap.js").default#addLayer map.addLayer()}. Components
  * like {@link module:ol/interaction/Select~Select} use unmanaged layers
  * internally. These unmanaged layers are associated with the map using
  * {@link module:ol/layer/Layer~Layer#setMap} instead.
@@ -77,7 +77,7 @@ import {listen, unlistenByKey} from '../events.js';
  * A generic `change` event is fired when the state of the source changes.
  *
  * Please note that for performance reasons several layers might get rendered to
- * the same HTML element, which will cause {@link module:ol/Map~Map#forEachLayerAtPixel} to
+ * the same HTML element, which will cause {@link import("../PluggableMap.js").default#forEachLayerAtPixel map.forEachLayerAtPixel()} to
  * give false positives. To avoid this, apply different `className` properties to the
  * layers at creation time.
  *
@@ -237,12 +237,12 @@ class Layer extends BaseLayer {
   /**
    * Sets the layer to be rendered on top of other layers on a map. The map will
    * not manage this layer in its layers collection, and the callback in
-   * {@link module:ol/Map#forEachLayerAtPixel} will receive `null` as layer. This
+   * {@link module:ol/Map~Map#forEachLayerAtPixel} will receive `null` as layer. This
    * is useful for temporary layers. To remove an unmanaged layer from the map,
    * use `#setMap(null)`.
    *
    * To add the layer to a map and have it managed by the map, use
-   * {@link module:ol/Map#addLayer} instead.
+   * {@link module:ol/Map~Map#addLayer} instead.
    * @param {import("../PluggableMap.js").default} map Map.
    * @api
    */

--- a/src/ol/layer/MapboxVector.js
+++ b/src/ol/layer/MapboxVector.js
@@ -202,7 +202,7 @@ const SourceType = {
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link import("../PluggableMap.js").default#addLayer map.addLayer()}.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting
  * will have a performance impact for large amounts of vector data. When set to `false`, batches

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -35,12 +35,13 @@ import {assign} from '../obj.js';
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link import("../PluggableMap.js").default#addLayer map.addLayer()}.
  * @property {boolean} [declutter=false] Declutter images and text on this layer. The priority is defined
  * by the `zIndex` of the style and the render order of features. Higher z-index means higher priority.
  * Within the same z-index, a feature rendered before another has higher priority.
  * @property {import("../style/Style.js").StyleLike} [style] Layer style. See
- * {@link module:ol/style} for default style which will be used if this is not defined.
+ * {@link import("../style/Style.js").default the style docs} for the default style that will be used if
+ * this is not defined.
  * @property {number} [imageRatio=1] Ratio by which the rendered extent should be larger than the
  * viewport extent. A larger ratio avoids cut images during panning, but will cause a decrease in performance.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -46,14 +46,15 @@ import {assign} from '../obj.js';
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link import("../PluggableMap.js").default#addLayer map.addLayer()}.
  * @property {boolean} [declutter=false] Declutter images and text. Decluttering is applied to all
  * image and text styles of all Vector and VectorTile layers that have set this to `true`. The priority
  * is defined by the z-index of the layer, the `zIndex` of the style and the render order of features.
  * Higher z-index means higher priority. Within the same z-index, a feature rendered before another has
  * higher priority.
  * @property {import("../style/Style.js").StyleLike} [style] Layer style. See
- * {@link module:ol/style} for default style which will be used if this is not defined.
+ * {@link import("../style/Style.js").default the style docs} for the default style that will be used if
+ * this is not defined.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting
  * will have a performance impact for large amounts of vector data. When set to `false`, batches
@@ -69,7 +70,7 @@ import {assign} from '../obj.js';
 /**
  * @classdesc
  * Layer for vector tile data that is rendered client-side.
- * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject BaseObject}
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
@@ -134,7 +135,7 @@ class VectorTileLayer extends BaseVectorLayer {
    * when a hit was detected, or it will be empty.
    *
    * The hit detection algorithm used for this method is optimized for performance, but is less
-   * accurate than the one used in {@link import("../PluggableMap.js").default#getFeaturesAtPixel}: Text
+   * accurate than the one used in {@link import("../PluggableMap.js").default#getFeaturesAtPixel map.getFeaturesAtPixel()}: Text
    * is not considered, and icons are only represented by their bounding box instead of the exact
    * image.
    *

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -42,15 +42,15 @@
  * `get('EPSG:1234').setExtent(extent)`.
  *
  * In addition to Proj4js support, any transform functions can be added with
- * {@link module:ol/proj~addCoordinateTransforms}. To use this, you must first create
+ * {@link module:ol/proj.addCoordinateTransforms}. To use this, you must first create
  * a {@link module:ol/proj/Projection} object for the new projection and add it with
- * {@link module:ol/proj~addProjection}. You can then add the forward and inverse
- * functions with {@link module:ol/proj~addCoordinateTransforms}. See
+ * {@link module:ol/proj.addProjection}. You can then add the forward and inverse
+ * functions with {@link module:ol/proj.addCoordinateTransforms}. See
  * examples/wms-custom-proj for an example of this.
  *
  * Note that if no transforms are needed and you only need to define the
  * projection, just add a {@link module:ol/proj/Projection} with
- * {@link module:ol/proj~addProjection}. See examples/wms-no-proj for an example of
+ * {@link module:ol/proj.addProjection}. See examples/wms-no-proj for an example of
  * this.
  */
 import Projection from './proj/Projection.js';
@@ -480,7 +480,7 @@ export function getTransform(source, destination) {
  * Transforms a coordinate from source projection to destination projection.
  * This returns a new coordinate (and does not modify the original).
  *
- * See {@link module:ol/proj~transformExtent} for extent transformation.
+ * See {@link module:ol/proj.transformExtent} for extent transformation.
  * See the transform method of {@link module:ol/geom/Geometry~Geometry} and its
  * subclasses for geometry transforms.
  *

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -30,7 +30,7 @@ import {METERS_PER_UNIT} from './Units.js';
  * and options use {@link module:ol/proj~ProjectionLike} which means the simple string
  * code will suffice.
  *
- * You can use {@link module:ol/proj~get} to retrieve the object for a particular
+ * You can use {@link module:ol/proj.get} to retrieve the object for a particular
  * projection.
  *
  * The library includes definitions for `EPSG:4326` and `EPSG:3857`, together
@@ -45,7 +45,7 @@ import {METERS_PER_UNIT} from './Units.js';
  *
  * If you use [proj4js](https://github.com/proj4js/proj4js), aliases can
  * be added using `proj4.defs()`. After all required projection definitions are
- * added, call the {@link module:ol/proj/proj4~register} function.
+ * added, call the {@link module:ol/proj/proj4.register} function.
  *
  * @api
  */
@@ -249,7 +249,7 @@ class Projection {
   }
 
   /**
-   * Set the getPointResolution function (see {@link module:ol/proj~getPointResolution}
+   * Set the getPointResolution function (see {@link module:ol/proj.getPointResolution}
    * for this projection.
    * @param {function(number, import("../coordinate.js").Coordinate):number} func Function
    * @api

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -17,9 +17,9 @@ import {METERS_PER_UNIT} from './Units.js';
  * @property {import("../extent.js").Extent} [worldExtent] The world extent for the SRS.
  * @property {function(number, import("../coordinate.js").Coordinate):number} [getPointResolution]
  * Function to determine resolution at a point. The function is called with a
- * `{number}` view resolution and an `{import("../coordinate.js").Coordinate}` as arguments, and returns
- * the `{number}` resolution in projection units at the passed coordinate. If this is `undefined`,
- * the default {@link module:ol/proj#getPointResolution} function will be used.
+ * `number` view resolution and a {@link module:ol/coordinate~Coordinate Coordinate} as arguments, and returns
+ * the `number` resolution in projection units at the passed coordinate. If this is `undefined`,
+ * the default {@link module:ol/proj.getPointResolution getPointResolution()} function will be used.
  */
 
 /**

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -159,7 +159,7 @@ export const checkedFonts = new BaseObject();
 
 /**
  * The label cache for text rendering. To change the default cache size of 2048
- * entries, use {@link module:ol/structs/LRUCache#setSize}.
+ * entries, use {@link module:ol/structs/LRUCache~LRUCache#setSize cache.setSize()}.
  * Deprecated - there is no label cache any more.
  * @type {?}
  * @api

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -32,11 +32,11 @@ import {transformGeom2D} from '../../geom/SimpleGeometry.js';
 
 /**
  * @classdesc
- * A concrete subclass of {@link module:ol/render/VectorContext} that implements
+ * A concrete subclass of {@link module:ol/render/VectorContext VectorContext} that implements
  * direct rendering of features and geometries to an HTML5 Canvas context.
  * Instances of this class are created internally by the library and
  * provided to application code as vectorContext member of the
- * {@link module:ol/render/Event~RenderEvent} object associated with postcompose, precompose and
+ * {@link module:ol/render/Event~RenderEvent RenderEvent} object associated with postcompose, precompose and
  * render events emitted by layers and maps.
  */
 class CanvasImmediateRenderer extends VectorContext {
@@ -541,7 +541,7 @@ class CanvasImmediateRenderer extends VectorContext {
 
   /**
    * Render a geometry into the canvas.  Call
-   * {@link module:ol/render/canvas/Immediate#setStyle} first to set the rendering style.
+   * {@link module:ol/render/canvas/Immediate~CanvasImmediateRenderer#setStyle renderer.setStyle()} first to set the rendering style.
    *
    * @param {import("../../geom/Geometry.js").default|import("../Feature.js").default} geometry The geometry to render.
    * @api
@@ -597,7 +597,7 @@ class CanvasImmediateRenderer extends VectorContext {
    * Render a feature into the canvas.  Note that any `zIndex` on the provided
    * style will be ignored - features are rendered immediately in the order that
    * this method is called.  If you need `zIndex` support, you should be using an
-   * {@link module:ol/layer/Vector~VectorLayer} instead.
+   * {@link module:ol/layer/Vector~VectorLayer VectorLayer} instead.
    *
    * @param {import("../../Feature.js").default} feature Feature.
    * @param {import("../../style/Style.js").default} style Style.

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -500,7 +500,7 @@ class VectorSource extends Source {
 
   /**
    * Remove all features from the source.
-   * @param {boolean} [opt_fast] Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#removefeature} events.
+   * @param {boolean} [opt_fast] Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#event:removefeature removefeature} events.
    * @api
    */
   clear(opt_fast) {

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -116,12 +116,12 @@ export class VectorSourceEvent extends Event {
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
  * stroke operations.
  * @property {LoadingStrategy} [strategy] The loading strategy to use.
- * By default an {@link module:ol/loadingstrategy~all}
+ * By default an {@link module:ol/loadingstrategy.all}
  * strategy is used, a one-off strategy which loads all features at once.
  * @property {string|import("../featureloader.js").FeatureUrlFunction} [url]
  * Setting this option instructs the source to load features using an XHR loader
- * (see {@link module:ol/featureloader~xhr}). Use a `string` and an
- * {@link module:ol/loadingstrategy~all} for a one-off download of all features from
+ * (see {@link module:ol/featureloader.xhr}). Use a `string` and an
+ * {@link module:ol/loadingstrategy.all} for a one-off download of all features from
  * the given URL. Use a {@link module:ol/featureloader~FeatureUrlFunction} to generate the url with
  * other loading strategies.
  * Requires `format` to be set as well.

--- a/src/ol/source/VectorEventType.js
+++ b/src/ol/source/VectorEventType.js
@@ -29,7 +29,7 @@ export default {
 
   /**
    * Triggered when a feature is removed from the source.
-   * See {@link module:ol/source/Vector#clear source.clear()} for exceptions.
+   * See {@link module:ol/source/Vector~VectorSource#clear source.clear()} for exceptions.
    * @event module:ol/source/Vector.VectorSourceEvent#removefeature
    * @api
    */

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -4,8 +4,8 @@
 import {extend} from './array.js';
 
 /**
- * When using {@link module:ol/xml~makeChildAppender} or
- * {@link module:ol/xml~makeSimpleNodeFactory}, the top `objectStack` item needs
+ * When using {@link module:ol/xml.makeChildAppender} or
+ * {@link module:ol/xml.makeSimpleNodeFactory}, the top `objectStack` item needs
  * to have this structure.
  * @typedef {Object} NodeStackItem
  * @property {Node} node Node.
@@ -288,7 +288,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
 
 /**
  * Create a serializer that calls the provided `nodeWriter` from
- * {@link module:ol/xml~serialize}. This can be used by the parent writer to have the
+ * {@link module:ol/xml.serialize}. This can be used by the parent writer to have the
  * 'nodeWriter' called with an array of values when the `nodeWriter` was
  * designed to serialize a single item. An example would be a LineString
  * geometry writer, which could be reused for writing MultiLineString
@@ -314,7 +314,7 @@ export function makeArraySerializer(nodeWriter, opt_this) {
 
 /**
  * Create a node factory which can use the `opt_keys` passed to
- * {@link module:ol/xml~serialize} or {@link module:ol/xml~pushSerializeAndPop} as node names,
+ * {@link module:ol/xml.serialize} or {@link module:ol/xml.pushSerializeAndPop} as node names,
  * or a fixed node name. The namespace of the created nodes can either be fixed,
  * or the parent namespace will be used.
  * @param {string} [opt_nodeName] Fixed node name which will be used for all
@@ -353,16 +353,16 @@ export function makeSimpleNodeFactory(opt_nodeName, opt_namespaceURI) {
 
 /**
  * A node factory that creates a node using the parent's `namespaceURI` and the
- * `nodeName` passed by {@link module:ol/xml~serialize} or
- * {@link module:ol/xml~pushSerializeAndPop} to the node factory.
+ * `nodeName` passed by {@link module:ol/xml.serialize} or
+ * {@link module:ol/xml.pushSerializeAndPop} to the node factory.
  * @const
  * @type {function(*, Array<*>, string=): (Node|undefined)}
  */
 export const OBJECT_PROPERTY_NODE_FACTORY = makeSimpleNodeFactory();
 
 /**
- * Create an array of `values` to be used with {@link module:ol/xml~serialize} or
- * {@link module:ol/xml~pushSerializeAndPop}, where `orderedKeys` has to be provided as
+ * Create an array of `values` to be used with {@link module:ol/xml.serialize} or
+ * {@link module:ol/xml.pushSerializeAndPop}, where `orderedKeys` has to be provided as
  * `opt_key` argument.
  * @param {Object<string, *>} object Key-value pairs for the sequence. Keys can
  *     be a subset of the `orderedKeys`.


### PR DESCRIPTION
This fixes links to named exports.

**Before** (broken links to things like `module:ol/control~defaults` in fuchsia)
![image](https://user-images.githubusercontent.com/41094/117711339-58505a00-b190-11eb-98c2-822e569f9aa4.png)

**After** (working links in cyan)
![image](https://user-images.githubusercontent.com/41094/117711390-6ef6b100-b190-11eb-99c0-35e9a0e5f949.png)
