### PR TITLE
Do not require PointerEvent constructor

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -8,6 +8,7 @@ import MapBrowserEventType from './MapBrowserEventType.js';
 import PointerEventType from './pointer/EventType.js';
 import Target from './events/Target.js';
 import {DEVICE_PIXEL_RATIO, PASSIVE_EVENT_LISTENERS} from './has.js';
+import {VOID} from './functions.js';
 import {listen, unlistenByKey} from './events.js';
 
 class MapBrowserEventHandler extends Target {
@@ -244,11 +245,12 @@ class MapBrowserEventHandler extends Target {
     );
     this.dispatchEvent(newEvent);
 
-    this.down_ = new PointerEvent(pointerEvent.type, pointerEvent);
-    Object.defineProperty(this.down_, 'target', {
-      writable: false,
-      value: pointerEvent.target,
-    });
+    // Store a copy of the down event
+    this.down_ = /** @type {PointerEvent} */ ({});
+    for (const property in pointerEvent) {
+      const value = pointerEvent[property];
+      this.down_[property] = typeof value === 'function' ? VOID : value;
+    }
 
     if (this.dragListenerKeys_.length === 0) {
       const doc = this.map_.getOwnerDocument();


### PR DESCRIPTION
Fixes #12226.

It is enough for the `down_` member in `MapBrowserEventHandler` to hold a copy of all properties of the original down event. The `preventDefault` and `stopPropagation` functions (and other functions on the event copy, if any) can be noop, because the event has been handled already.