### PR TITLE
Fix confusing import in Mapbox Style example

### DIFF
--- a/examples/mapbox-style.js
+++ b/examples/mapbox-style.js
@@ -1,7 +1,7 @@
 import FullScreen from '../src/ol/control/FullScreen.js';
-import apply from 'ol-mapbox-style';
+import olms from 'ol-mapbox-style';
 
-apply(
+olms(
   'map',
   'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB'
 ).then(function (map) {


### PR DESCRIPTION
Importing the default `olms` as `apply` is likely to be confused with importing `{apply}`.  Anyone doing so (e.g. with legacy build) would still get a map but no FullScreen control as the result would not support the `.then()` method.
