### PR TITLE
Fix Vector Tile Selection example on old browsers

### DIFF
--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -86,7 +86,7 @@ map.on(['click', 'pointermove'], function (event) {
     }
     const fid = feature.getId();
 
-    if (selectElement.value.startsWith('singleselect')) {
+    if (selectElement.value.indexOf('singleselect') === 0) {
       selection = {};
     }
     // add selected feature to lookup


### PR DESCRIPTION
Replace `string.startsWith(x)` with fully supported `string.indexOf(x) === 0` 
