### PR TITLE
Correct .split() calls to only split numeric srid for ArcgisRest

### DIFF
--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -242,7 +242,7 @@ class ImageArcGISRest extends ImageSource {
     // ArcGIS Server only wants the numeric portion of the projection ID.
     // (if there is no numeric portion the entire projection code must
     // form a valid ArcGIS SpatialReference definition).
-    const srid = projection.getCode().split(/:(?=\d+$)/)).pop();
+    const srid = projection.getCode().split(/:(?=\d+$)/).pop();
 
     params['SIZE'] = size[0] + ',' + size[1];
     params['BBOX'] = extent.join(',');

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -28,6 +28,8 @@ import {containsExtent, getHeight, getWidth} from '../extent.js';
  * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.
+ * The projection code must contain a numeric end portion separated by :
+ * or the entire code must form a valid ArcGIS SpatialReference definition.
  * @property {number} [ratio=1.5] Ratio. `1` means image requests are the size of the map viewport,
  * `2` means twice the size of the map viewport, and so on.
  * @property {Array<number>} [resolutions] Resolutions. If specified, requests will be made for
@@ -238,7 +240,9 @@ class ImageArcGISRest extends ImageSource {
    */
   getRequestUrl_(extent, size, pixelRatio, projection, params) {
     // ArcGIS Server only wants the numeric portion of the projection ID.
-    const srid = projection.getCode().split(':').pop();
+    // (if there is no numeric portion the entire projection code must
+    // form a valid ArcGIS SpatialReference definition).
+    const srid = projection.getCode().split(/:(?=\d+$)/)).pop();
 
     params['SIZE'] = size[0] + ',' + size[1];
     params['BBOX'] = extent.join(',');

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -242,7 +242,10 @@ class ImageArcGISRest extends ImageSource {
     // ArcGIS Server only wants the numeric portion of the projection ID.
     // (if there is no numeric portion the entire projection code must
     // form a valid ArcGIS SpatialReference definition).
-    const srid = projection.getCode().split(/:(?=\d+$)/).pop();
+    const srid = projection
+      .getCode()
+      .split(/:(?=\d+$)/)
+      .pop();
 
     params['SIZE'] = size[0] + ',' + size[1];
     params['BBOX'] = extent.join(',');

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -154,7 +154,10 @@ class TileArcGISRest extends TileImage {
     // ArcGIS Server only wants the numeric portion of the projection ID.
     // (if there is no numeric portion the entire projection code must
     // form a valid ArcGIS SpatialReference definition).
-    const srid = projection.getCode().split(/:(?=\d+$)/).pop();
+    const srid = projection
+      .getCode()
+      .split(/:(?=\d+$)/)
+      .pop();
 
     params['SIZE'] = tileSize[0] + ',' + tileSize[1];
     params['BBOX'] = tileExtent.join(',');

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -33,6 +33,8 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  * extent, the grid will be based on that; if not, a grid based on a global
  * extent with origin at 0,0 will be used.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.
+ * The projection code must contain a numeric end portion separated by :
+ * or the entire code must form a valid ArcGIS SpatialReference definition.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
  * Higher values can increase reprojection performance, but decrease precision.
  * @property {import("../Tile.js").LoadFunction} [tileLoadFunction] Optional function to load a tile given a URL.
@@ -150,7 +152,9 @@ class TileArcGISRest extends TileImage {
     }
 
     // ArcGIS Server only wants the numeric portion of the projection ID.
-    const srid = projection.getCode().split(':').pop();
+    // (if there is no numeric portion the entire projection code must
+    // form a valid ArcGIS SpatialReference definition).
+    const srid = projection.getCode().split(/:(?=\d+$)/).pop();
 
     params['SIZE'] = tileSize[0] + ',' + tileSize[1];
     params['BBOX'] = tileExtent.join(',');


### PR DESCRIPTION
Fixes #12377

Ensuring the split only works for numeric srid has the advantage that the projection code can be set to a custom Arcgis SpatialReference definition (which would contain a `:`) without it being broken.
