### PR TITLE
Ensure VectorSource getUrl() corresponds to last setUrl()

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -1054,6 +1054,7 @@ class VectorSource extends Source {
    */
   setUrl(url) {
     assert(this.format_, 7); // `format` must be set when `url` is set
+    this.url_ = url;
     this.setLoader(xhr(url, this.format_));
   }
 }


### PR DESCRIPTION
Fixes #12046

Might be useful if someone needs to keep track of multiple sources which are being dynamically updated.