### PR TITLE
Replace getChangeEventType() with add/removeChangeListener methods

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/Feature
  */
-import BaseObject, {getChangeEventType} from './Object.js';
+import BaseObject from './Object.js';
 import EventType from './events/EventType.js';
 import {assert} from './asserts.js';
 import {listen, unlistenByKey} from './events.js';
@@ -100,10 +100,7 @@ class Feature extends BaseObject {
      */
     this.geometryChangeKey_ = null;
 
-    this.addEventListener(
-      getChangeEventType(this.geometryName_),
-      this.handleGeometryChanged_
-    );
+    this.addChangeListener(this.geometryName_, this.handleGeometryChanged_);
 
     if (opt_geometryOrProperties) {
       if (
@@ -274,15 +271,9 @@ class Feature extends BaseObject {
    * @api
    */
   setGeometryName(name) {
-    this.removeEventListener(
-      getChangeEventType(this.geometryName_),
-      this.handleGeometryChanged_
-    );
+    this.removeChangeListener(this.geometryName_, this.handleGeometryChanged_);
     this.geometryName_ = name;
-    this.addEventListener(
-      getChangeEventType(this.geometryName_),
-      this.handleGeometryChanged_
-    );
+    this.addChangeListener(this.geometryName_, this.handleGeometryChanged_);
     this.handleGeometryChanged_();
   }
 }

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -2,7 +2,7 @@
  * @module ol/Geolocation
  */
 import BaseEvent from './events/Event.js';
-import BaseObject, {getChangeEventType} from './Object.js';
+import BaseObject from './Object.js';
 import EventType from './events/EventType.js';
 import {circular as circularPolygon} from './geom/Polygon.js';
 import {
@@ -112,14 +112,8 @@ class Geolocation extends BaseObject {
      */
     this.watchId_ = undefined;
 
-    this.addEventListener(
-      getChangeEventType(Property.PROJECTION),
-      this.handleProjectionChanged_
-    );
-    this.addEventListener(
-      getChangeEventType(Property.TRACKING),
-      this.handleTrackingChanged_
-    );
+    this.addChangeListener(Property.PROJECTION, this.handleProjectionChanged_);
+    this.addChangeListener(Property.TRACKING, this.handleTrackingChanged_);
 
     if (options.projection !== undefined) {
       this.setProjection(options.projection);

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -149,10 +149,26 @@ class BaseObject extends Observable {
    */
   notify(key, oldValue) {
     let eventType;
-    eventType = getChangeEventType(key);
+    eventType = `change:${key}`;
     this.dispatchEvent(new ObjectEvent(eventType, key, oldValue));
     eventType = ObjectEventType.PROPERTYCHANGE;
     this.dispatchEvent(new ObjectEvent(eventType, key, oldValue));
+  }
+
+  /**
+   * @param {string} key Key name.
+   * @param {import("./events.js").Listener} listener Listener.
+   */
+  addChangeListener(key, listener) {
+    this.addEventListener(`change:${key}`, listener);
+  }
+
+  /**
+   * @param {string} key Key name.
+   * @param {import("./events.js").Listener} listener Listener.
+   */
+  removeChangeListener(key, listener) {
+    this.removeEventListener(`change:${key}`, listener);
   }
 
   /**
@@ -218,21 +234,6 @@ class BaseObject extends Observable {
       }
     }
   }
-}
-
-/**
- * @type {Object<string, string>}
- */
-const changeEventTypeCache = {};
-
-/**
- * @param {string} key Key name.
- * @return {string} Change name.
- */
-export function getChangeEventType(key) {
-  return changeEventTypeCache.hasOwnProperty(key)
-    ? changeEventTypeCache[key]
-    : (changeEventTypeCache[key] = 'change:' + key);
 }
 
 export default BaseObject;

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/Overlay
  */
-import BaseObject, {getChangeEventType} from './Object.js';
+import BaseObject from './Object.js';
 import MapEventType from './MapEventType.js';
 import OverlayPositioning from './OverlayPositioning.js';
 import {CLASS_SELECTABLE} from './css.js';
@@ -176,26 +176,11 @@ class Overlay extends BaseObject {
      */
     this.mapPostrenderListenerKey = null;
 
-    this.addEventListener(
-      getChangeEventType(Property.ELEMENT),
-      this.handleElementChanged
-    );
-    this.addEventListener(
-      getChangeEventType(Property.MAP),
-      this.handleMapChanged
-    );
-    this.addEventListener(
-      getChangeEventType(Property.OFFSET),
-      this.handleOffsetChanged
-    );
-    this.addEventListener(
-      getChangeEventType(Property.POSITION),
-      this.handlePositionChanged
-    );
-    this.addEventListener(
-      getChangeEventType(Property.POSITIONING),
-      this.handlePositioningChanged
-    );
+    this.addChangeListener(Property.ELEMENT, this.handleElementChanged);
+    this.addChangeListener(Property.MAP, this.handleMapChanged);
+    this.addChangeListener(Property.OFFSET, this.handleOffsetChanged);
+    this.addChangeListener(Property.POSITION, this.handlePositionChanged);
+    this.addChangeListener(Property.POSITIONING, this.handlePositioningChanged);
 
     if (options.element !== undefined) {
       this.setElement(options.element);

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/PluggableMap
  */
-import BaseObject, {getChangeEventType} from './Object.js';
+import BaseObject from './Object.js';
 import Collection from './Collection.js';
 import CollectionEventType from './CollectionEventType.js';
 import EventType from './events/EventType.js';
@@ -345,22 +345,13 @@ class PluggableMap extends BaseObject {
       this.handleTileChange_.bind(this)
     );
 
-    this.addEventListener(
-      getChangeEventType(MapProperty.LAYERGROUP),
+    this.addChangeListener(
+      MapProperty.LAYERGROUP,
       this.handleLayerGroupChanged_
     );
-    this.addEventListener(
-      getChangeEventType(MapProperty.VIEW),
-      this.handleViewChanged_
-    );
-    this.addEventListener(
-      getChangeEventType(MapProperty.SIZE),
-      this.handleSizeChanged_
-    );
-    this.addEventListener(
-      getChangeEventType(MapProperty.TARGET),
-      this.handleTargetChanged_
-    );
+    this.addChangeListener(MapProperty.VIEW, this.handleViewChanged_);
+    this.addChangeListener(MapProperty.SIZE, this.handleSizeChanged_);
+    this.addChangeListener(MapProperty.TARGET, this.handleTargetChanged_);
 
     // setProperties will trigger the rendering of the map if the map
     // is "defined" already.

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -4,7 +4,6 @@
 
 import Control from './Control.js';
 import EventType from '../pointer/EventType.js';
-import {getChangeEventType} from '../Object.js';
 import {
   get as getProjection,
   getTransformFromProjections,
@@ -69,10 +68,7 @@ class MousePosition extends Control {
       target: options.target,
     });
 
-    this.addEventListener(
-      getChangeEventType(PROJECTION),
-      this.handleProjectionChanged_
-    );
+    this.addChangeListener(PROJECTION, this.handleProjectionChanged_);
 
     if (options.coordinateFormat) {
       this.setCoordinateFormat(options.coordinateFormat);

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -20,7 +20,6 @@ import {
   getTopLeft,
   scaleFromCenter,
 } from '../extent.js';
-import {getChangeEventType} from '../Object.js';
 import {listen, listenOnce} from '../events.js';
 import {fromExtent as polygonFromExtent} from '../geom/Polygon.js';
 import {replaceNode} from '../dom.js';
@@ -348,8 +347,8 @@ class OverviewMap extends Control {
       this.ovmap_.setView(newView);
     }
 
-    view.addEventListener(
-      getChangeEventType(ViewProperty.ROTATION),
+    view.addChangeListener(
+      ViewProperty.ROTATION,
       this.boundHandleRotationChanged_
     );
     // Sync once with the new view
@@ -362,8 +361,8 @@ class OverviewMap extends Control {
    * @private
    */
   unbindView_(view) {
-    view.removeEventListener(
-      getChangeEventType(ViewProperty.ROTATION),
+    view.removeChangeListener(
+      ViewProperty.ROTATION,
       this.boundHandleRotationChanged_
     );
   }

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -6,7 +6,6 @@ import ProjUnits from '../proj/Units.js';
 import {CLASS_UNSELECTABLE} from '../css.js';
 import {METERS_PER_UNIT, getPointResolution} from '../proj.js';
 import {assert} from '../asserts.js';
-import {getChangeEventType} from '../Object.js';
 
 /**
  * @type {string}
@@ -131,10 +130,7 @@ class ScaleLine extends Control {
      */
     this.renderedHTML_ = '';
 
-    this.addEventListener(
-      getChangeEventType(UNITS_PROP),
-      this.handleUnitsChanged_
-    );
+    this.addChangeListener(UNITS_PROP, this.handleUnitsChanged_);
 
     this.setUnits(options.units || Units.METRIC);
 

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -29,7 +29,6 @@ import {
 } from '../extent.js';
 import {createEditingStyle} from '../style/Style.js';
 import {fromUserCoordinate, getUserProjection} from '../proj.js';
-import {getChangeEventType} from '../Object.js';
 import {squaredDistance as squaredCoordinateDistance} from '../coordinate.js';
 
 /**
@@ -477,10 +476,7 @@ class Draw extends PointerInteraction {
         : shiftKeyOnly;
     }
 
-    this.addEventListener(
-      getChangeEventType(InteractionProperty.ACTIVE),
-      this.updateState_
-    );
+    this.addChangeListener(InteractionProperty.ACTIVE, this.updateState_);
   }
 
   /**

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -7,7 +7,6 @@ import InteractionProperty from './Property.js';
 import PointerInteraction from './Pointer.js';
 import {TRUE} from '../functions.js';
 import {always} from '../events/condition.js';
-import {getChangeEventType} from '../Object.js';
 import {includes} from '../array.js';
 
 /**
@@ -192,8 +191,8 @@ class Translate extends PointerInteraction {
      */
     this.lastFeature_ = null;
 
-    this.addEventListener(
-      getChangeEventType(InteractionProperty.ACTIVE),
+    this.addChangeListener(
+      InteractionProperty.ACTIVE,
       this.handleActiveChanged_
     );
   }

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -9,7 +9,6 @@ import ObjectEventType from '../ObjectEventType.js';
 import SourceState from '../source/State.js';
 import {assert} from '../asserts.js';
 import {assign, clear} from '../obj.js';
-import {getChangeEventType} from '../Object.js';
 import {getIntersection} from '../extent.js';
 import {getUid} from '../util.js';
 import {listen, unlistenByKey} from '../events.js';
@@ -77,10 +76,7 @@ class LayerGroup extends BaseLayer {
      */
     this.listenerKeys_ = {};
 
-    this.addEventListener(
-      getChangeEventType(Property.LAYERS),
-      this.handleLayersChanged_
-    );
+    this.addChangeListener(Property.LAYERS, this.handleLayersChanged_);
 
     if (layers) {
       if (Array.isArray(layers)) {

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -6,7 +6,6 @@ import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
 import {assign} from '../obj.js';
 import {clamp} from '../math.js';
 import {createCanvasContext2D} from '../dom.js';
-import {getChangeEventType} from '../Object.js';
 
 /**
  * @typedef {Object} Options
@@ -86,10 +85,7 @@ class Heatmap extends VectorLayer {
      */
     this.gradient_ = null;
 
-    this.addEventListener(
-      getChangeEventType(Property.GRADIENT),
-      this.handleGradientChanged_
-    );
+    this.addChangeListener(Property.GRADIENT, this.handleGradientChanged_);
 
     this.setGradient(options.gradient ? options.gradient : DEFAULT_GRADIENT);
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -8,7 +8,6 @@ import RenderEventType from '../render/EventType.js';
 import SourceState from '../source/State.js';
 import {assert} from '../asserts.js';
 import {assign} from '../obj.js';
-import {getChangeEventType} from '../Object.js';
 import {listen, unlistenByKey} from '../events.js';
 
 /**
@@ -130,8 +129,8 @@ class Layer extends BaseLayer {
       this.setMap(options.map);
     }
 
-    this.addEventListener(
-      getChangeEventType(LayerProperty.SOURCE),
+    this.addChangeListener(
+      LayerProperty.SOURCE,
       this.handleSourcePropertyChange_
     );
 


### PR DESCRIPTION
Although the reason for #12412 is probably a Terser problem (which I was unable to isolate), I think we can make an improvement, which also makes that problem go away. I see no reason for caching event types, and instead of having to use the `getChangeEventType()` function, I like it better to have dedicated `addChangeListener()` and `removeChangeListener()` methods.