### PR TITLE
Fix layer render extent when it is not at all in view

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -187,10 +187,10 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
       const opacity = layerState.opacity;
       let previousAlpha;
       if (opacity !== 1) {
-        previousAlpha = this.context.globalAlpha;
-        this.context.globalAlpha = opacity;
+        previousAlpha = context.globalAlpha;
+        context.globalAlpha = opacity;
       }
-      this.context.drawImage(
+      context.drawImage(
         img,
         0,
         0,
@@ -202,7 +202,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
         Math.round(dh)
       );
       if (opacity !== 1) {
-        this.context.globalAlpha = previousAlpha;
+        context.globalAlpha = previousAlpha;
       }
     }
     this.postRender(context, frameState);

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -17,7 +17,6 @@ import {
   getTopRight,
 } from '../../extent.js';
 import {createCanvasContext2D} from '../../dom.js';
-import {rotateAtOffset} from '../../render/canvas.js';
 
 /**
  * @abstract
@@ -128,38 +127,6 @@ class CanvasLayerRenderer extends LayerRenderer {
       this.container = container;
       this.context = context;
     }
-  }
-
-  /**
-   * @param {CanvasRenderingContext2D} context Context.
-   * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
-   * @param {import("../../extent.js").Extent} extent Clip extent.
-   * @protected
-   */
-  clip(context, frameState, extent) {
-    const pixelRatio = frameState.pixelRatio;
-    const halfWidth = (frameState.size[0] * pixelRatio) / 2;
-    const halfHeight = (frameState.size[1] * pixelRatio) / 2;
-    const rotation = frameState.viewState.rotation;
-    const topLeft = getTopLeft(extent);
-    const topRight = getTopRight(extent);
-    const bottomRight = getBottomRight(extent);
-    const bottomLeft = getBottomLeft(extent);
-
-    applyTransform(frameState.coordinateToPixelTransform, topLeft);
-    applyTransform(frameState.coordinateToPixelTransform, topRight);
-    applyTransform(frameState.coordinateToPixelTransform, bottomRight);
-    applyTransform(frameState.coordinateToPixelTransform, bottomLeft);
-
-    context.save();
-    rotateAtOffset(context, -rotation, halfWidth, halfHeight);
-    context.beginPath();
-    context.moveTo(topLeft[0] * pixelRatio, topLeft[1] * pixelRatio);
-    context.lineTo(topRight[0] * pixelRatio, topRight[1] * pixelRatio);
-    context.lineTo(bottomRight[0] * pixelRatio, bottomRight[1] * pixelRatio);
-    context.lineTo(bottomLeft[0] * pixelRatio, bottomLeft[1] * pixelRatio);
-    context.clip();
-    rotateAtOffset(context, rotation, halfWidth, halfHeight);
   }
 
   /**

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -280,17 +280,19 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
     // clipped rendering if layer extent is set
     let clipped = false;
+    let render = true;
     if (layerState.extent && this.clipping) {
       const layerExtent = fromUserExtent(layerState.extent, projection);
-      clipped =
-        !containsExtent(layerExtent, frameState.extent) &&
-        intersectsExtent(layerExtent, frameState.extent);
+      render = intersectsExtent(layerExtent, frameState.extent);
+      clipped = render && !containsExtent(layerExtent, frameState.extent);
       if (clipped) {
         this.clipUnrotated(context, frameState, layerExtent);
       }
     }
 
-    this.renderWorlds(replayGroup, frameState);
+    if (render) {
+      this.renderWorlds(replayGroup, frameState);
+    }
 
     if (clipped) {
       context.restore();


### PR DESCRIPTION
Fixes #11651 for `ol/layer/Vector` and `ol/layer/Image`.

Also removes `ol/renderer/canvas/Layer#clip` which wasn't  used anywhere.