### PR TITLE
Allow multiple LinearRings per innerBoundaryIs

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -2206,7 +2206,9 @@ function lodParser(node, objectStack) {
  */
 // @ts-ignore
 const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(NAMESPACE_URIS, {
-  'LinearRing': makeReplacer(readFlatLinearRing),
+  // KML spec only allows one LinearRing  per innerBoundaryIs, but Google Earth
+  // allows multiple, so we parse multiple here too.
+  'LinearRing': makeArrayPusher(readFlatLinearRing),
 });
 
 /**
@@ -2214,18 +2216,17 @@ const INNER_BOUNDARY_IS_PARSERS = makeStructureNS(NAMESPACE_URIS, {
  * @param {Array<*>} objectStack Object stack.
  */
 function innerBoundaryIsParser(node, objectStack) {
-  /** @type {Array<number>|undefined} */
-  const flatLinearRing = pushParseAndPop(
-    undefined,
+  const innerBoundaryFlatLinearRings = pushParseAndPop(
+    /** @type {Array<Array<number>>} */ ([]),
     INNER_BOUNDARY_IS_PARSERS,
     node,
     objectStack
   );
-  if (flatLinearRing) {
+  if (innerBoundaryFlatLinearRings.length > 0) {
     const flatLinearRings =
       /** @type {Array<Array<number>>} */
       (objectStack[objectStack.length - 1]);
-    flatLinearRings.push(flatLinearRing);
+    flatLinearRings.push(...innerBoundaryFlatLinearRings);
   }
 }
 

--- a/test/browser/spec/ol/format/kml.test.js
+++ b/test/browser/spec/ol/format/kml.test.js
@@ -980,6 +980,55 @@ describe('ol.format.KML', function () {
           ]);
         });
 
+        it('can read multiple LinearRings from one innerBoundaryIs', function () {
+          const text = `
+            <kml xmlns="http://earth.google.com/kml/2.2">
+              <Placemark>
+                <Polygon>
+                  <innerBoundaryIs>
+                    <LinearRing>
+                      <coordinates>1,1,0 1,2,0 2,2,0 2,1,0</coordinates>
+                    </LinearRing>
+                    <LinearRing>
+                      <coordinates>3,3,0 3,4,0 4,4,0 4,3,0</coordinates>
+                    </LinearRing>
+                  </innerBoundaryIs>
+                  <outerBoundaryIs>
+                    <LinearRing>
+                      <coordinates>0,0,1 0,5,1 5,5,2 5,0,3</coordinates>
+                    </LinearRing>
+                  </outerBoundaryIs>
+                </Polygon>
+              </Placemark>
+            </kml>`;
+          const fs = format.readFeatures(text);
+          expect(fs).to.have.length(1);
+          const f = fs[0];
+          expect(f).to.be.an(Feature);
+          const g = f.getGeometry();
+          expect(g).to.be.an(Polygon);
+          expect(g.getCoordinates()).to.eql([
+            [
+              [0, 0, 1],
+              [0, 5, 1],
+              [5, 5, 2],
+              [5, 0, 3],
+            ],
+            [
+              [1, 1, 0],
+              [1, 2, 0],
+              [2, 2, 0],
+              [2, 1, 0],
+            ],
+            [
+              [3, 3, 0],
+              [3, 4, 0],
+              [4, 4, 0],
+              [4, 3, 0],
+            ],
+          ]);
+        });
+
         it('can write complex Polygon geometries', function () {
           const layout = 'XYZ';
           const polygon = new Polygon(


### PR DESCRIPTION
Fixes #12407

Allows multiple LinearRing nodes per innerBoundaryIs, not allowed by spec, but Google Earth will read it too.