### PR TITLE
Consistent use of quotes in example description

### DIFF
--- a/examples/vector-tile-selection.html
+++ b/examples/vector-tile-selection.html
@@ -8,8 +8,8 @@ docs: >
     By changing the action type to "Multi Select" you can select multiple features at a time. With "Single Select on hover",
     features will be higlighted when the pointer is above them.
   </p><p>
-    The selection layer is configured with `renderMode: 'vector'` for better performance on frequent redraws,
-    i.e. when 'Single select on hover' is selected.
+    The selection layer is configured with <code>renderMode: 'vector'</code> for better performance on frequent redraws,
+    i.e. when "Single Select on hover" is selected.
   </p>
 tags: "vector tiles, selection"
 ---


### PR DESCRIPTION
I presume the backtick quotes were intended to format as code, but this does not work inside `<p></p>`

Also replace one set of single quotes with double for consistency (and consistent use of capitals) when referring to action types.
